### PR TITLE
MM-691 Add Docker sidecar runtime profile validation

### DIFF
--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -3,7 +3,10 @@ from .agent_runtime_models import (
     AgentRunHandle,
     AgentRunResult,
     AgentRunStatus,
+    ManagedAgentRuntimeProfile,
     ManagedAgentProviderProfile,
+    ManagedRuntimeWorkloadMode,
+    resolve_managed_runtime_workload_mode,
     is_terminal_agent_run_state,
 )
 from .agent_skill_models import (

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import posixpath
+import re
 from datetime import UTC, datetime
 from typing import Any, Literal, Mapping, NoReturn, get_args
 
@@ -711,15 +713,23 @@ def _image_is_pinned(image: str | None) -> bool:
     return bool(tag) and tag != "latest"
 
 
+def _normalize_posix_path(value: str) -> str:
+    collapsed = re.sub(r"/+", "/", value)
+    return posixpath.normpath(collapsed)
+
+
 def _mounts_host_docker_socket(mounts: list[RuntimeProfileMount]) -> bool:
+    target = "/var/run/docker.sock"
     for mount in mounts:
-        candidates = {
-            str(mount.mount_path or "").strip(),
-            str(mount.source or "").strip(),
-            str(mount.host_path or "").strip(),
-        }
-        if "/var/run/docker.sock" in candidates:
-            return True
+        for candidate in (mount.mount_path, mount.source, mount.host_path):
+            text = str(candidate or "").strip()
+            if not text:
+                continue
+            try:
+                if _normalize_posix_path(text) == target:
+                    return True
+            except (TypeError, ValueError):
+                continue
     return False
 
 
@@ -770,6 +780,16 @@ class ManagedAgentRuntimeProfile(BaseModel):
             if self.agent.docker_client.enabled:
                 raise ValueError(
                     "agent.dockerClient.enabled must be false for no-docker profiles; "
+                    "task instructions cannot raise Docker capability"
+                )
+            if sidecar is not None and sidecar.enabled:
+                raise ValueError(
+                    "dockerSidecar.enabled must be false for no-docker profiles; "
+                    "task instructions cannot raise Docker capability"
+                )
+            if "DOCKER_HOST" in self.agent.env:
+                raise ValueError(
+                    "agent.env.DOCKER_HOST must not be set for no-docker profiles; "
                     "task instructions cannot raise Docker capability"
                 )
             return self

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -573,6 +573,275 @@ class ManagedAgentProviderProfile(BaseModel):
         return self
 
 WorkspaceMode = Literal["tempdir", "shared", "none"]
+ManagedRuntimeWorkloadMode = Literal[
+    "docker-sidecar",
+    "docker-sidecar-rootless",
+    "no-docker",
+]
+
+
+class RuntimeProfileMount(BaseModel):
+    """Declarative mount entry for managed agent runtime profiles."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    name: str | None = None
+    mount_path: str = Field(..., alias="mountPath", min_length=1)
+    source: str | None = None
+    host_path: str | None = Field(None, alias="hostPath")
+
+
+class RuntimeProfileWorkspace(BaseModel):
+    """Workspace declaration shared by agent and sidecar containers."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    volume: str | None = None
+    mount_path: str = Field(..., alias="mountPath", min_length=1)
+    repo_env: str | None = Field(None, alias="repoEnv")
+    lifecycle: Literal["session"] = "session"
+
+
+class RuntimeProfileAgentDockerClient(BaseModel):
+    """Agent-side Docker CLI settings."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    enabled: bool = False
+    compose_plugin: bool = Field(False, alias="composePlugin")
+    daemon_in_agent: bool = Field(False, alias="daemonInAgent")
+
+
+class RuntimeProfileAgent(BaseModel):
+    """Agent container portion of a managed runtime profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    image: str | None = None
+    workspace: RuntimeProfileWorkspace
+    docker_client: RuntimeProfileAgentDockerClient = Field(
+        default_factory=RuntimeProfileAgentDockerClient,
+        alias="dockerClient",
+    )
+    env: dict[str, str] = Field(default_factory=dict)
+    mounts: list[RuntimeProfileMount] = Field(default_factory=list)
+
+
+class RuntimeProfileSidecarSocket(BaseModel):
+    """Docker sidecar Unix socket declaration."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    path: str = Field(..., min_length=1)
+    volume_name: str = Field(..., alias="volumeName", min_length=1)
+
+
+class RuntimeProfileSidecarStorage(BaseModel):
+    """Docker sidecar graph storage declaration."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    volume_name: str = Field(..., alias="volumeName", min_length=1)
+    mount_path: str = Field(..., alias="mountPath", min_length=1)
+    lifecycle: Literal["session"] = "session"
+    daemon_scope: Literal["session", "shared"] = Field("session", alias="daemonScope")
+
+
+class RuntimeProfileSidecarSecurity(BaseModel):
+    """Docker sidecar security policy declaration."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    privileged: bool = False
+    host_docker_socket: Literal["forbidden"] = Field(
+        "forbidden", alias="hostDockerSocket"
+    )
+    moonmind_deployment_secrets: Literal["forbidden"] = Field(
+        "forbidden", alias="moonmindDeploymentSecrets"
+    )
+
+
+class RuntimeProfileDockerSidecar(BaseModel):
+    """Docker sidecar portion of a managed runtime profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    enabled: bool = False
+    mode: Literal["dind", "dind-rootless"] = "dind"
+    image: str | None = None
+    socket: RuntimeProfileSidecarSocket | None = None
+    storage: RuntimeProfileSidecarStorage | None = None
+    workspace: RuntimeProfileWorkspace | None = None
+    security: RuntimeProfileSidecarSecurity = Field(
+        default_factory=RuntimeProfileSidecarSecurity
+    )
+    env: dict[str, str] = Field(default_factory=dict)
+    mounts: list[RuntimeProfileMount] = Field(default_factory=list)
+
+
+class RuntimeProfilePolicy(BaseModel):
+    """Policy declaration for managed agent runtime profile validation."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    host_docker_access: Literal["forbidden"] = Field(
+        "forbidden", alias="hostDockerAccess"
+    )
+    app_container_control_from_session: Literal["forbidden"] = Field(
+        "forbidden", alias="appContainerControlFromSession"
+    )
+    deployment_secrets_in_session: Literal["forbidden"] = Field(
+        "forbidden", alias="deploymentSecretsInSession"
+    )
+    api_container_workload_docker_socket_access: bool = Field(
+        False, alias="apiContainerWorkloadDockerSocketAccess"
+    )
+
+
+def _image_is_pinned(image: str | None) -> bool:
+    text = str(image or "").strip()
+    if not text:
+        return False
+    if "@sha256:" in text:
+        return True
+    last_segment = text.rsplit("/", 1)[-1]
+    if ":" not in last_segment:
+        return False
+    tag = last_segment.rsplit(":", 1)[-1].strip().lower()
+    return bool(tag) and tag != "latest"
+
+
+def _mounts_host_docker_socket(mounts: list[RuntimeProfileMount]) -> bool:
+    for mount in mounts:
+        candidates = {
+            str(mount.mount_path or "").strip(),
+            str(mount.source or "").strip(),
+            str(mount.host_path or "").strip(),
+        }
+        if "/var/run/docker.sock" in candidates:
+            return True
+    return False
+
+
+class ManagedAgentRuntimeProfile(BaseModel):
+    """Validated managed-session runtime profile for Docker sidecar capability."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    workload_mode: ManagedRuntimeWorkloadMode = Field(..., alias="workloadMode")
+    workspace: RuntimeProfileWorkspace
+    agent: RuntimeProfileAgent
+    docker_sidecar: RuntimeProfileDockerSidecar | None = Field(
+        None, alias="dockerSidecar"
+    )
+    resources: dict[str, Any] = Field(default_factory=dict)
+    readiness: dict[str, Any] = Field(default_factory=dict)
+    policy: RuntimeProfilePolicy = Field(default_factory=RuntimeProfilePolicy)
+
+    @model_validator(mode="after")
+    def _validate_runtime_profile(self) -> "ManagedAgentRuntimeProfile":
+        if _contains_sensitive_key(self.agent.env):
+            raise ValueError(
+                "agent.env must not receive deployment credentials or unrelated "
+                "session tokens; credential exposure would leak MoonMind or "
+                "cross-session authority into the workload"
+            )
+        sidecar = self.docker_sidecar
+        if sidecar is not None and _contains_sensitive_key(sidecar.env):
+            raise ValueError(
+                "dockerSidecar.env must not receive deployment credentials or "
+                "unrelated session tokens; credential exposure would leak MoonMind "
+                "or cross-session authority into the workload"
+            )
+        if _mounts_host_docker_socket(self.agent.mounts) or (
+            sidecar is not None and _mounts_host_docker_socket(sidecar.mounts)
+        ):
+            raise ValueError(
+                "host Docker socket must not be mounted; exposing "
+                "/var/run/docker.sock would grant host-level Docker control"
+            )
+        if self.policy.api_container_workload_docker_socket_access:
+            raise ValueError(
+                "API container must not have normal workload Docker socket access; "
+                "workload Docker control belongs to the isolated session sidecar"
+            )
+
+        if self.workload_mode == "no-docker":
+            if self.agent.docker_client.enabled:
+                raise ValueError(
+                    "agent.dockerClient.enabled must be false for no-docker profiles; "
+                    "task instructions cannot raise Docker capability"
+                )
+            return self
+
+        if sidecar is None or not sidecar.enabled:
+            raise ValueError(
+                "dockerSidecar.enabled must be true for Docker-capable profiles; "
+                "otherwise agent Docker commands would have no per-session daemon"
+            )
+        if not self.agent.docker_client.enabled:
+            raise ValueError(
+                "agent.dockerClient.enabled must be true when dockerSidecar.enabled "
+                "is true; otherwise Docker commands cannot reach the sidecar daemon"
+            )
+        if self.agent.docker_client.daemon_in_agent:
+            raise ValueError(
+                "agent.dockerClient.daemonInAgent must be false; running the daemon "
+                "inside the agent breaks sidecar isolation"
+            )
+        if sidecar.socket is None:
+            raise ValueError(
+                "dockerSidecar.socket.path is required; DOCKER_HOST cannot be "
+                "validated without the declared sidecar socket"
+            )
+        expected_docker_host = f"unix://{sidecar.socket.path}"
+        actual_docker_host = str(self.agent.env.get("DOCKER_HOST") or "").strip()
+        if actual_docker_host != expected_docker_host:
+            raise ValueError(
+                "agent.env.DOCKER_HOST must point at dockerSidecar.socket.path; "
+                "otherwise Docker commands may reach the wrong daemon or fail"
+            )
+        sidecar_workspace_path = (
+            sidecar.workspace.mount_path if sidecar.workspace else self.workspace.mount_path
+        )
+        if self.agent.workspace.mount_path != sidecar_workspace_path:
+            raise ValueError(
+                "agent and dockerSidecar workspace mount paths must match; "
+                "otherwise docker run bind mounts resolve against a different "
+                "filesystem path"
+            )
+        if not _image_is_pinned(sidecar.image):
+            raise ValueError(
+                "dockerSidecar.image sidecar image must be pinned to a non-latest "
+                "tag or digest; floating images make launches non-reproducible"
+            )
+        if sidecar.storage is None:
+            raise ValueError(
+                "dockerSidecar.storage is required; the Docker graph volume must be "
+                "declared per session"
+            )
+        if sidecar.storage.daemon_scope != "session":
+            raise ValueError(
+                "Docker daemon scope must be per session; shared daemons can expose "
+                "containers, images, and credentials across sessions or users"
+            )
+        return self
+
+
+def resolve_managed_runtime_workload_mode(
+    profile: ManagedAgentRuntimeProfile,
+    *,
+    task_requested_workload_mode: str | None = None,
+) -> ManagedRuntimeWorkloadMode:
+    """Return profile workload mode and reject task-level capability elevation."""
+
+    requested = str(task_requested_workload_mode or "").strip()
+    if requested and requested != profile.workload_mode:
+        raise ValueError(
+            "task instructions cannot raise Docker capability; workloadMode is "
+            "read from deployment/profile configuration"
+        )
+    return profile.workload_mode
 
 class RuntimeFileTemplate(BaseModel):
     """Path-aware file materialization contract for managed runtime launch."""

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -40,6 +40,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunHandle,
     AgentRunResult,
     AgentRunStatus,
+    ManagedAgentRuntimeProfile,
     ManagedRunRecord,
     ManagedRuntimeProfile,
     TERMINAL_AGENT_RUN_STATES,
@@ -205,6 +206,9 @@ def build_managed_profile_launch_context(
     """Build deterministic launch metadata safe to compute in workflow code."""
 
     del workflow_id  # Reserved for activity-side shaping.
+    runtime_profile = profile.get("runtime_profile") or profile.get("runtimeProfile")
+    if isinstance(runtime_profile, Mapping):
+        ManagedAgentRuntimeProfile.model_validate(runtime_profile)
     credential_source = str(
         profile.get("credential_source") or default_credential_source
     ).strip() or default_credential_source

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -207,7 +207,12 @@ def build_managed_profile_launch_context(
 
     del workflow_id  # Reserved for activity-side shaping.
     runtime_profile = profile.get("runtime_profile") or profile.get("runtimeProfile")
-    if isinstance(runtime_profile, Mapping):
+    if runtime_profile is not None:
+        if not isinstance(runtime_profile, Mapping):
+            raise ValueError(
+                "runtime_profile must be a mapping of profile fields; "
+                "non-object runtime profiles cannot satisfy launch invariants"
+            )
         ManagedAgentRuntimeProfile.model_validate(runtime_profile)
     credential_source = str(
         profile.get("credential_source") or default_credential_source

--- a/tests/integration/schemas/test_managed_runtime_profile_contract.py
+++ b/tests/integration/schemas/test_managed_runtime_profile_contract.py
@@ -1,0 +1,89 @@
+"""Integration coverage for managed runtime profile validation at launch boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.adapters.managed_agent_adapter import (
+    build_managed_profile_launch_context,
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _valid_docker_sidecar_profile() -> dict:
+    return {
+        "workloadMode": "docker-sidecar",
+        "workspace": {
+            "volume": "agent_workspaces",
+            "mountPath": "/work/agent_jobs",
+            "repoEnv": "MOONMIND_REPO_DIR",
+            "lifecycle": "session",
+        },
+        "agent": {
+            "image": "moonmind/managed-agent:2026-05-16",
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "dockerClient": {
+                "enabled": True,
+                "composePlugin": True,
+                "daemonInAgent": False,
+            },
+            "env": {
+                "DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock",
+            },
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+                {"name": "docker-socket", "mountPath": "/var/run/moonmind-docker"},
+            ],
+        },
+        "dockerSidecar": {
+            "enabled": True,
+            "mode": "dind",
+            "image": "docker:27-dind",
+            "socket": {
+                "path": "/var/run/moonmind-docker/docker.sock",
+                "volumeName": "docker-socket",
+            },
+            "storage": {
+                "volumeName": "docker-graph",
+                "mountPath": "/var/lib/docker",
+                "lifecycle": "session",
+                "daemonScope": "session",
+            },
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "security": {
+                "privileged": True,
+                "hostDockerSocket": "forbidden",
+                "moonmindDeploymentSecrets": "forbidden",
+            },
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+                {"name": "docker-socket", "mountPath": "/var/run/moonmind-docker"},
+                {"name": "docker-graph", "mountPath": "/var/lib/docker"},
+            ],
+        },
+        "policy": {
+            "hostDockerAccess": "forbidden",
+            "appContainerControlFromSession": "forbidden",
+            "deploymentSecretsInSession": "forbidden",
+            "apiContainerWorkloadDockerSocketAccess": False,
+        },
+    }
+
+
+def test_launch_context_validates_runtime_profile_before_managed_session_launch() -> None:
+    runtime_profile = _valid_docker_sidecar_profile()
+    runtime_profile["dockerSidecar"]["image"] = "docker:latest"
+
+    with pytest.raises(ValueError, match="sidecar image must be pinned"):
+        build_managed_profile_launch_context(
+            profile={
+                "profile_id": "codex_default",
+                "credential_source": "oauth_volume",
+                "runtime_profile": runtime_profile,
+            },
+            runtime_for_profile="codex_cli",
+            workflow_id="wf-agent-run-1",
+            default_credential_source="oauth_volume",
+        )

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -730,6 +730,82 @@ def test_managed_agent_runtime_profile_rejects_unsafe_sidecar_invariants(
         ManagedAgentRuntimeProfile.model_validate(payload)
 
 
+def _valid_no_docker_profile() -> dict:
+    return {
+        "workloadMode": "no-docker",
+        "workspace": {
+            "volume": "agent_workspaces",
+            "mountPath": "/work/agent_jobs",
+            "lifecycle": "session",
+        },
+        "agent": {
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "dockerClient": {"enabled": False, "daemonInAgent": False},
+            "env": {},
+            "mounts": [{"name": "workspace", "mountPath": "/work/agent_jobs"}],
+        },
+        "policy": {
+            "hostDockerAccess": "forbidden",
+            "appContainerControlFromSession": "forbidden",
+            "deploymentSecretsInSession": "forbidden",
+        },
+    }
+
+
+def test_no_docker_profile_rejects_enabled_sidecar() -> None:
+    payload = _valid_no_docker_profile()
+    payload["dockerSidecar"] = {
+        "enabled": True,
+        "image": "docker:27-dind",
+        "socket": {
+            "path": "/var/run/moonmind-docker/docker.sock",
+            "volumeName": "docker-socket",
+        },
+        "storage": {
+            "volumeName": "docker-graph",
+            "mountPath": "/var/lib/docker",
+            "lifecycle": "session",
+            "daemonScope": "session",
+        },
+        "workspace": {"mountPath": "/work/agent_jobs"},
+    }
+    with pytest.raises(
+        ValidationError,
+        match="dockerSidecar.enabled must be false for no-docker profiles",
+    ):
+        ManagedAgentRuntimeProfile.model_validate(payload)
+
+
+def test_no_docker_profile_rejects_docker_host_env() -> None:
+    payload = _valid_no_docker_profile()
+    payload["agent"]["env"]["DOCKER_HOST"] = "unix:///var/run/moonmind-docker/docker.sock"
+    with pytest.raises(
+        ValidationError,
+        match="agent.env.DOCKER_HOST must not be set for no-docker profiles",
+    ):
+        ManagedAgentRuntimeProfile.model_validate(payload)
+
+
+def test_no_docker_profile_allows_disabled_sidecar() -> None:
+    payload = _valid_no_docker_profile()
+    payload["dockerSidecar"] = {"enabled": False}
+    profile = ManagedAgentRuntimeProfile.model_validate(payload)
+    assert profile.workload_mode == "no-docker"
+    assert profile.docker_sidecar is not None
+    assert profile.docker_sidecar.enabled is False
+
+
+def test_host_docker_socket_check_normalizes_paths() -> None:
+    payload = _valid_docker_sidecar_profile()
+    payload["agent"]["mounts"].append(
+        {"source": "//var/run/docker.sock/", "mountPath": "/host/docker.sock"}
+    )
+    with pytest.raises(
+        ValidationError, match="host Docker socket must not be mounted"
+    ):
+        ManagedAgentRuntimeProfile.model_validate(payload)
+
+
 def test_no_docker_profile_cannot_be_raised_by_task_requested_mode() -> None:
     profile = ManagedAgentRuntimeProfile.model_validate(
         {

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -9,6 +9,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunResult,
     AgentRunStatus,
+    ManagedAgentRuntimeProfile,
     ManagedAgentProviderProfile,
     ManagedRuntimeProfile,
     LiveLogChunk,
@@ -16,6 +17,7 @@ from moonmind.schemas.agent_runtime_models import (
     RuntimeCommandRenderResult,
     extract_durable_retrieval_metadata,
     is_terminal_agent_run_state,
+    resolve_managed_runtime_workload_mode,
 )
 
 def test_agent_execution_request_requires_non_blank_idempotency_key() -> None:
@@ -581,3 +583,178 @@ def test_extract_durable_retrieval_metadata_only_allows_boolean_contract_fields(
         "retrievalContextTruncated": True,
         "retrievalMode": "semantic",
     }
+
+
+def _valid_docker_sidecar_profile() -> dict:
+    return {
+        "workloadMode": "docker-sidecar",
+        "workspace": {
+            "volume": "agent_workspaces",
+            "mountPath": "/work/agent_jobs",
+            "repoEnv": "MOONMIND_REPO_DIR",
+            "lifecycle": "session",
+        },
+        "agent": {
+            "image": "moonmind/managed-agent:2026-05-16",
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "dockerClient": {
+                "enabled": True,
+                "composePlugin": True,
+                "daemonInAgent": False,
+            },
+            "env": {
+                "DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock",
+            },
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+                {"name": "docker-socket", "mountPath": "/var/run/moonmind-docker"},
+            ],
+        },
+        "dockerSidecar": {
+            "enabled": True,
+            "mode": "dind",
+            "image": "docker:27-dind",
+            "socket": {
+                "path": "/var/run/moonmind-docker/docker.sock",
+                "volumeName": "docker-socket",
+            },
+            "storage": {
+                "volumeName": "docker-graph",
+                "mountPath": "/var/lib/docker",
+                "lifecycle": "session",
+                "daemonScope": "session",
+            },
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "security": {
+                "privileged": True,
+                "hostDockerSocket": "forbidden",
+                "moonmindDeploymentSecrets": "forbidden",
+            },
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+                {"name": "docker-socket", "mountPath": "/var/run/moonmind-docker"},
+                {"name": "docker-graph", "mountPath": "/var/lib/docker"},
+            ],
+        },
+        "resources": {
+            "agent": {"cpu": "2", "memory": "4Gi"},
+            "dockerSidecar": {"cpu": "4", "memory": "8Gi"},
+        },
+        "readiness": {
+            "docker": {
+                "required": True,
+                "timeoutSeconds": 60,
+                "intervalSeconds": 2,
+            },
+        },
+        "policy": {
+            "hostDockerAccess": "forbidden",
+            "appContainerControlFromSession": "forbidden",
+            "deploymentSecretsInSession": "forbidden",
+            "apiContainerWorkloadDockerSocketAccess": False,
+        },
+    }
+
+
+def test_managed_agent_runtime_profile_accepts_valid_docker_sidecar_contract() -> None:
+    profile = ManagedAgentRuntimeProfile.model_validate(_valid_docker_sidecar_profile())
+
+    assert profile.workload_mode == "docker-sidecar"
+    assert profile.agent.docker_client.enabled is True
+    assert (
+        profile.agent.env["DOCKER_HOST"]
+        == "unix:///var/run/moonmind-docker/docker.sock"
+    )
+    assert profile.docker_sidecar is not None
+    assert profile.docker_sidecar.image == "docker:27-dind"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda p: p["agent"]["dockerClient"].update({"enabled": False}),
+            "agent.dockerClient.enabled must be true",
+        ),
+        (
+            lambda p: p["agent"]["dockerClient"].update({"daemonInAgent": True}),
+            "daemonInAgent must be false",
+        ),
+        (
+            lambda p: p["agent"]["env"].update(
+                {"DOCKER_HOST": "unix:///tmp/docker.sock"}
+            ),
+            "DOCKER_HOST must point at dockerSidecar.socket.path",
+        ),
+        (
+            lambda p: p["dockerSidecar"]["workspace"].update(
+                {"mountPath": "/mnt/workspace"}
+            ),
+            "workspace mount paths must match",
+        ),
+        (
+            lambda p: p["agent"]["mounts"].append(
+                {"source": "/var/run/docker.sock", "mountPath": "/var/run/docker.sock"}
+            ),
+            "host Docker socket must not be mounted",
+        ),
+        (
+            lambda p: p["agent"]["env"].update({"OPENAI_API_KEY": "secret"}),
+            "must not receive deployment credentials",
+        ),
+        (
+            lambda p: p["policy"].update(
+                {"apiContainerWorkloadDockerSocketAccess": True}
+            ),
+            "API container must not have normal workload Docker socket access",
+        ),
+        (
+            lambda p: p["dockerSidecar"].update({"image": "docker:latest"}),
+            "sidecar image must be pinned",
+        ),
+        (
+            lambda p: p["dockerSidecar"]["storage"].update(
+                {"daemonScope": "shared"}
+            ),
+            "Docker daemon scope must be per session",
+        ),
+    ],
+)
+def test_managed_agent_runtime_profile_rejects_unsafe_sidecar_invariants(
+    mutate, message
+) -> None:
+    payload = _valid_docker_sidecar_profile()
+    mutate(payload)
+
+    with pytest.raises(ValidationError, match=message):
+        ManagedAgentRuntimeProfile.model_validate(payload)
+
+
+def test_no_docker_profile_cannot_be_raised_by_task_requested_mode() -> None:
+    profile = ManagedAgentRuntimeProfile.model_validate(
+        {
+            "workloadMode": "no-docker",
+            "workspace": {
+                "volume": "agent_workspaces",
+                "mountPath": "/work/agent_jobs",
+                "lifecycle": "session",
+            },
+            "agent": {
+                "workspace": {"mountPath": "/work/agent_jobs"},
+                "dockerClient": {"enabled": False, "daemonInAgent": False},
+                "env": {},
+                "mounts": [{"name": "workspace", "mountPath": "/work/agent_jobs"}],
+            },
+            "policy": {
+                "hostDockerAccess": "forbidden",
+                "appContainerControlFromSession": "forbidden",
+                "deploymentSecretsInSession": "forbidden",
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="task instructions cannot raise Docker capability"):
+        resolve_managed_runtime_workload_mode(
+            profile,
+            task_requested_workload_mode="docker-sidecar",
+        )

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -177,6 +177,22 @@ async def test_launch_context_exports_execution_profile_ref() -> None:
         == "codex_cli"
     )
 
+async def test_launch_context_rejects_non_mapping_runtime_profile() -> None:
+    with pytest.raises(
+        ValueError, match="runtime_profile must be a mapping of profile fields"
+    ):
+        build_managed_profile_launch_context(
+            profile={
+                "profile_id": "codex_default",
+                "credential_source": "oauth_volume",
+                "runtime_profile": ["not", "a", "mapping"],
+            },
+            runtime_for_profile="codex_cli",
+            workflow_id="wf-agent-run-1",
+            default_credential_source="oauth_volume",
+        )
+
+
 async def test_launch_context_reserved_execution_profile_keys_cannot_be_overridden() -> None:
     context = build_managed_profile_launch_context(
         profile={


### PR DESCRIPTION
## Jira

- Jira issue key: MM-691

## MoonSpec

- Active feature path: `specs/001-docker-sidecar-profile-validation`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests run

- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS
- `./tools/test_unit.sh tests/unit/schemas/test_agent_runtime_models.py`: PASS (`45 passed`; frontend wrapper `21 passed`, `357 passed`, `232 skipped`)
- `pytest tests/integration/schemas/test_managed_runtime_profile_contract.py -m integration_ci -q`: PASS (`1 passed`)
- `./tools/test_unit.sh`: PASS (`5046 passed, 6 skipped, 1 xpassed, 16 subtests passed`; frontend `21 passed`, `357 passed`, `232 skipped`)

## Remaining risks

- No known blocking risks. Full unit output includes existing deprecation/resource warnings and jsdom canvas `getContext` notices, but all required suites passed.
