### PR TITLE
MM-659 settings audit events with descriptor-aware redaction

### DIFF
--- a/api_service/api/routers/settings.py
+++ b/api_service/api/routers/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any, get_args
 from uuid import UUID
 
@@ -29,9 +30,11 @@ from api_service.services.settings_catalog import (
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 SETTINGS_CURRENT_USER_DEP = get_current_user()
+logger = logging.getLogger(__name__)
 
 VALID_SETTING_SCOPES = set(get_args(SettingScope))
 VALID_SETTING_SECTIONS = set(get_args(SettingSection))
+_MAX_SETTINGS_REQUEST_ID_LENGTH = 255
 
 
 def _should_attempt_settings_db() -> bool:
@@ -145,9 +148,12 @@ def _settings_db_error_response(*, key: str | None = None, scope: str) -> JSONRe
 
 
 def _settings_request_id(request: Request) -> str | None:
-    return request.headers.get("x-request-id") or request.headers.get(
+    request_id = request.headers.get("x-request-id") or request.headers.get(
         "x-correlation-id"
     )
+    if request_id is None:
+        return None
+    return request_id[:_MAX_SETTINGS_REQUEST_ID_LENGTH]
 
 
 async def _record_rejected_write_audit(
@@ -172,6 +178,7 @@ async def _record_rejected_write_audit(
                 request_id=request_id,
             )
     except Exception:
+        logger.exception("Failed to record rejected settings write audit event")
         return
 
 

--- a/api_service/api/routers/settings.py
+++ b/api_service/api/routers/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any, get_args
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
@@ -142,6 +142,37 @@ def _settings_db_error_response(*, key: str | None = None, scope: str) -> JSONRe
             scope=scope,
         ),
     )
+
+
+def _settings_request_id(request: Request) -> str | None:
+    return request.headers.get("x-request-id") or request.headers.get(
+        "x-correlation-id"
+    )
+
+
+async def _record_rejected_write_audit(
+    *,
+    scope: SettingScope,
+    changes: dict[str, Any],
+    user: Any,
+    reason: str | None,
+    request_id: str | None,
+) -> None:
+    if not changes:
+        return
+    try:
+        async with db_base.async_session_maker() as session:
+            service = SettingsCatalogService(
+                session=session, **_service_context_kwargs(user)
+            )
+            await service.record_rejected_write_audit(
+                scope=scope,
+                changes=changes,
+                reason=reason,
+                request_id=request_id,
+            )
+    except Exception:
+        return
 
 
 def _validation_blocker_response(
@@ -572,9 +603,11 @@ async def get_settings_audit(
 async def patch_settings(
     scope: str,
     payload: SettingsPatchRequest,
+    request: Request,
     user: Any = Depends(SETTINGS_CURRENT_USER_DEP),
 ):
     service = SettingsCatalogService()
+    request_id = _settings_request_id(request)
     resolved_scope = _coerce_scope(scope)
     if isinstance(resolved_scope, JSONResponse):
         return resolved_scope
@@ -590,6 +623,13 @@ async def patch_settings(
         )
     denied = _require_permission(user, required_permission)
     if denied is not None:
+        await _record_rejected_write_audit(
+            scope=resolved_scope,
+            changes=payload.changes,
+            user=user,
+            reason=payload.reason,
+            request_id=request_id,
+        )
         return denied
     if not payload.changes:
         return _error_response(
@@ -604,6 +644,13 @@ async def patch_settings(
         try:
             service.ensure_write_allowed(key, scope=resolved_scope)
         except KeyError:
+            await _record_rejected_write_audit(
+                scope=resolved_scope,
+                changes=payload.changes,
+                user=user,
+                reason=payload.reason,
+                request_id=request_id,
+            )
             return _error_response(
                 404,
                 settings_error(
@@ -614,6 +661,13 @@ async def patch_settings(
                 ),
             )
         except ValueError:
+            await _record_rejected_write_audit(
+                scope=resolved_scope,
+                changes=payload.changes,
+                user=user,
+                reason=payload.reason,
+                request_id=request_id,
+            )
             return _error_response(
                 400,
                 settings_error(
@@ -625,6 +679,13 @@ async def patch_settings(
             )
         except PermissionError as exc:
             error_code = service.write_lock_error_code(key)
+            await _record_rejected_write_audit(
+                scope=resolved_scope,
+                changes=payload.changes,
+                user=user,
+                reason=payload.reason,
+                request_id=request_id,
+            )
             return _error_response(
                 423,
                 settings_error(
@@ -644,9 +705,17 @@ async def patch_settings(
                 changes=payload.changes,
                 expected_versions=payload.expected_versions,
                 reason=payload.reason,
+                request_id=request_id,
                 confirmation=payload.confirmation,
             )
     except SettingsValidationError as exc:
+        await _record_rejected_write_audit(
+            scope=resolved_scope,
+            changes=payload.changes,
+            user=user,
+            reason=payload.reason,
+            request_id=request_id,
+        )
         error = exc.to_settings_error()
         return _error_response(_settings_validation_status(error), error)
     except ValueError as exc:
@@ -664,11 +733,25 @@ async def patch_settings(
             status_code = 400
             error_code = "invalid_setting_value"
             message = "One or more setting values are invalid."
+        await _record_rejected_write_audit(
+            scope=resolved_scope,
+            changes=payload.changes,
+            user=user,
+            reason=payload.reason,
+            request_id=request_id,
+        )
         return _error_response(
             status_code,
             settings_error(error_code, message, scope=resolved_scope),
         )
     except PermissionError as exc:
+        await _record_rejected_write_audit(
+            scope=resolved_scope,
+            changes=payload.changes,
+            user=user,
+            reason=payload.reason,
+            request_id=request_id,
+        )
         return _error_response(
             423,
             settings_error(

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -1488,6 +1488,7 @@ class SettingsCatalogService:
         changes: dict[str, Any],
         expected_versions: dict[str, int] | None = None,
         reason: str | None = None,
+        request_id: str | None = None,
         confirmation: str | None = None,
     ) -> EffectiveSettingsResponse:
         if self._session is None:
@@ -1644,6 +1645,7 @@ class SettingsCatalogService:
                     old_value=old_value,
                     new_value=value,
                     reason=reason,
+                    request_id=request_id,
                 )
             )
 
@@ -1724,6 +1726,7 @@ class SettingsCatalogService:
                     old_value=old_value,
                     new_value=None,
                     reason=reason,
+                    request_id=None,
                 )
             )
         await self._session.commit()
@@ -1767,6 +1770,30 @@ class SettingsCatalogService:
             self._audit_read_model(row, permissions=permissions)
             for row in result.scalars().all()
         ]
+
+    async def record_rejected_write_audit(
+        self,
+        *,
+        scope: SettingScope,
+        changes: dict[str, Any],
+        reason: str | None = None,
+        request_id: str | None = None,
+    ) -> None:
+        if self._session is None or not changes:
+            return
+        for key, value in changes.items():
+            entry = self._entries_by_key.get(key)
+            self._session.add(
+                self._rejected_audit_event(
+                    entry,
+                    key=key,
+                    scope=scope,
+                    new_value=value,
+                    reason=reason,
+                    request_id=request_id,
+                )
+            )
+        await self._session.commit()
 
     async def diagnostics(
         self,
@@ -3685,6 +3712,7 @@ class SettingsCatalogService:
         old_value: Any,
         new_value: Any,
         reason: str | None,
+        request_id: str | None,
     ) -> SettingsAuditEvent:
         redacted = entry.audit.redact
         return SettingsAuditEvent(
@@ -3710,6 +3738,49 @@ class SettingsCatalogService:
             ),
             redacted=redacted,
             reason=reason,
+            request_id=request_id,
+        )
+
+    def _rejected_audit_event(
+        self,
+        entry: SettingRegistryEntry | None,
+        *,
+        key: str,
+        scope: SettingScope,
+        new_value: Any,
+        reason: str | None,
+        request_id: str | None,
+    ) -> SettingsAuditEvent:
+        descriptor_redacted = entry.audit.redact if entry is not None else False
+        unsafe_value = self._contains_secret_like_value(
+            new_value,
+        ) or self._contains_unsafe_payload(new_value)
+        redacted = descriptor_redacted or unsafe_value or entry is None
+        may_store_secret_ref_metadata = (
+            entry is not None
+            and entry.value_type == "secret_ref"
+            and descriptor_redacted
+            and isinstance(new_value, str)
+            and not unsafe_value
+        )
+        return SettingsAuditEvent(
+            event_type="settings.override.rejected",
+            key=key,
+            scope=scope,
+            workspace_id=self._workspace_id,
+            user_id=self._user_id if scope == "user" else _DEFAULT_SUBJECT_ID,
+            actor_user_id=(
+                self._user_id if self._user_id != _DEFAULT_SUBJECT_ID else None
+            ),
+            old_value_json=None,
+            new_value_json=(
+                new_value
+                if (not redacted or may_store_secret_ref_metadata)
+                else None
+            ),
+            redacted=redacted,
+            reason=reason,
+            request_id=request_id,
         )
 
     def _diagnostics(
@@ -3869,6 +3940,7 @@ class SettingsCatalogService:
             .where(
                 SettingsAuditEvent.workspace_id == self._workspace_id,
                 SettingsAuditEvent.key.in_(keys),
+                SettingsAuditEvent.event_type != "settings.override.rejected",
                 SettingsAuditEvent.user_id.in_(
                     {_DEFAULT_SUBJECT_ID, self._user_id}
                 ),
@@ -3898,7 +3970,8 @@ class SettingsCatalogService:
         old_value, old_reasons = self._visible_audit_value(
             row.old_value_json,
             entry=entry,
-            row_redacted=row.redacted,
+            row_redacted=row.redacted
+            and (row.old_value_json is not None or row.new_value_json is None),
             permissions=permissions,
         )
         new_value, new_reasons = self._visible_audit_value(
@@ -3921,7 +3994,11 @@ class SettingsCatalogService:
             redaction_reasons=reasons,
             reason=row.reason,
             request_id=row.request_id,
-            validation_outcome="accepted",
+            validation_outcome=(
+                "rejected"
+                if row.event_type == "settings.override.rejected"
+                else "accepted"
+            ),
             apply_mode=entry.apply_mode if entry is not None else None,
             affected_systems=affected_systems,
             created_at=row.created_at,
@@ -3937,12 +4014,7 @@ class SettingsCatalogService:
     ) -> tuple[Any, list[str]]:
         reasons: list[str] = []
         if value is None:
-            secret_ref_metadata_visible = (
-                entry is not None
-                and entry.value_type == "secret_ref"
-                and "secrets.metadata.read" in permissions
-            )
-            if row_redacted and not secret_ref_metadata_visible:
+            if row_redacted:
                 reasons.append("stored_redacted")
             return None, reasons
         if entry is not None and entry.audit.redact:

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -3752,16 +3752,17 @@ class SettingsCatalogService:
         request_id: str | None,
     ) -> SettingsAuditEvent:
         descriptor_redacted = entry.audit.redact if entry is not None else False
+        contains_unsafe_payload = self._contains_unsafe_payload(new_value)
         unsafe_value = self._contains_secret_like_value(
             new_value,
-        ) or self._contains_unsafe_payload(new_value)
+        ) or contains_unsafe_payload
         redacted = descriptor_redacted or unsafe_value or entry is None
         may_store_secret_ref_metadata = (
             entry is not None
             and entry.value_type == "secret_ref"
             and descriptor_redacted
             and isinstance(new_value, str)
-            and not unsafe_value
+            and not contains_unsafe_payload
         )
         return SettingsAuditEvent(
             event_type="settings.override.rejected",

--- a/tests/integration/api/test_settings_http_api_surface_contract.py
+++ b/tests/integration/api/test_settings_http_api_surface_contract.py
@@ -176,6 +176,38 @@ async def test_mm657_all_api_families_are_contract_covered(settings_http_api_db)
     assert audit.json()["items"]
 
 
+async def test_mm659_failed_write_produces_redacted_audit_event(
+    settings_http_api_db,
+):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        rejected = await client.patch(
+            "/api/v1/settings/workspace",
+            headers={"x-request-id": "mm659-failed-write"},
+            json={
+                "changes": {"integrations.github.token_ref": "ghp_raw_plaintext"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+                "reason": "configure integration token",
+            },
+        )
+        audit = await client.get(
+            "/api/v1/settings/audit",
+            params={"key": "integrations.github.token_ref"},
+        )
+
+    assert rejected.status_code == 400
+    assert "ghp_raw_plaintext" not in rejected.text
+    assert audit.status_code == 200
+    item = audit.json()["items"][0]
+    assert item["event_type"] == "settings.override.rejected"
+    assert item["validation_outcome"] == "rejected"
+    assert item["request_id"] == "mm659-failed-write"
+    assert item["redacted"] is True
+    assert item["new_value"] is None
+    assert "ghp_raw_plaintext" not in audit.text
+
+
 async def test_mm657_validate_preview_structured_errors_and_redaction(
     settings_http_api_db,
 ):

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -1151,13 +1152,14 @@ async def test_failed_settings_write_creates_redacted_audit_event_with_request_i
         permissions={"settings.workspace.write", "settings.audit.read"}
     )
     raw_secret_value = "gh" + "p_raw_plaintext"
+    request_id = "settings-write-req-1" * 20
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://testserver"
     ) as client:
         rejected = await client.patch(
             "/api/v1/settings/workspace",
-            headers={"x-request-id": "settings-write-req-1"},
+            headers={"x-request-id": request_id},
             json={
                 "changes": {"integrations.github.token_ref": raw_secret_value},
                 "expected_versions": {"integrations.github.token_ref": 1},
@@ -1180,7 +1182,7 @@ async def test_failed_settings_write_creates_redacted_audit_event_with_request_i
     assert item["key"] == "integrations.github.token_ref"
     assert item["scope"] == "workspace"
     assert item["validation_outcome"] == "rejected"
-    assert item["request_id"] == "settings-write-req-1"
+    assert item["request_id"] == request_id[:255]
     assert item["reason"] == "wire github token"
     assert item["apply_mode"] == "next_launch"
     assert item["redacted"] is True
@@ -1188,6 +1190,34 @@ async def test_failed_settings_write_creates_redacted_audit_event_with_request_i
     assert item["new_value"] is None
     assert "stored_redacted" in item["redaction_reasons"]
     assert raw_secret_value not in audit.text
+
+
+@pytest.mark.asyncio
+async def test_rejected_write_audit_failure_is_logged(
+    settings_api_db,
+    settings_user_override,
+    monkeypatch,
+    caplog,
+):
+    user = settings_user_override(permissions={"settings.workspace.write"})
+
+    class FailingAuditService(SettingsCatalogService):
+        async def record_rejected_write_audit(self, **kwargs):
+            raise RuntimeError("audit unavailable")
+
+    monkeypatch.setattr(settings_router, "SettingsCatalogService", FailingAuditService)
+
+    with caplog.at_level(logging.ERROR, logger=settings_router.__name__):
+        await settings_router._record_rejected_write_audit(
+            scope="workspace",
+            changes={"integrations.github.token_ref": "db://github-token"},
+            user=user,
+            reason="test audit visibility",
+            request_id="req-1",
+        )
+
+    assert "Failed to record rejected settings write audit event" in caplog.text
+    assert "audit unavailable" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/api/routers/test_settings_api.py
+++ b/tests/unit/api_service/api/routers/test_settings_api.py
@@ -1143,6 +1143,54 @@ async def test_settings_audit_endpoint_redacts_without_secret_metadata_permissio
 
 
 @pytest.mark.asyncio
+async def test_failed_settings_write_creates_redacted_audit_event_with_request_id(
+    settings_api_db,
+    settings_user_override,
+):
+    settings_user_override(
+        permissions={"settings.workspace.write", "settings.audit.read"}
+    )
+    raw_secret_value = "gh" + "p_raw_plaintext"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        rejected = await client.patch(
+            "/api/v1/settings/workspace",
+            headers={"x-request-id": "settings-write-req-1"},
+            json={
+                "changes": {"integrations.github.token_ref": raw_secret_value},
+                "expected_versions": {"integrations.github.token_ref": 1},
+                "reason": "wire github token",
+            },
+        )
+        audit = await client.get(
+            "/api/v1/settings/audit",
+            params={"key": "integrations.github.token_ref"},
+        )
+
+    assert rejected.status_code == 400
+    assert rejected.json()["error"] == "invalid_setting_value"
+    assert raw_secret_value not in rejected.text
+    assert await _settings_override_count(settings_api_db) == 0
+    assert await _settings_audit_count(settings_api_db) == 1
+    assert audit.status_code == 200
+    item = audit.json()["items"][0]
+    assert item["event_type"] == "settings.override.rejected"
+    assert item["key"] == "integrations.github.token_ref"
+    assert item["scope"] == "workspace"
+    assert item["validation_outcome"] == "rejected"
+    assert item["request_id"] == "settings-write-req-1"
+    assert item["reason"] == "wire github token"
+    assert item["apply_mode"] == "next_launch"
+    assert item["redacted"] is True
+    assert item["old_value"] is None
+    assert item["new_value"] is None
+    assert "stored_redacted" in item["redaction_reasons"]
+    assert raw_secret_value not in audit.text
+
+
+@pytest.mark.asyncio
 async def test_settings_audit_endpoint_exposes_secret_ref_with_metadata_permission(
     settings_api_db,
     settings_user_override,

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -2342,6 +2342,44 @@ async def test_audit_redactor_blocks_embedded_secret_prefixes(settings_session_m
     assert "prefix-ghp_embedded_suffix" not in entries[0].model_dump_json()
 
 
+@pytest.mark.parametrize(
+    "sensitive_value",
+    [
+        "oauth_session=stateful-provider-return",
+        "-----BEGIN PRIVATE KEY-----\nmaterial\n-----END PRIVATE KEY-----",
+        {"generated_config": {"token": "provider-returned-diagnostic"}},
+        {"diagnostics": [{"credential": "provider-sensitive-detail"}]},
+    ],
+)
+@pytest.mark.asyncio
+async def test_audit_redactor_blocks_documented_sensitive_classes(
+    settings_session_maker,
+    sensitive_value,
+):
+    async with settings_session_maker() as settings_session:
+        settings_session.add(
+            SettingsAuditEvent(
+                event_type="settings.override.updated",
+                key="workflow.default_publish_mode",
+                scope="workspace",
+                new_value_json=sensitive_value,
+                redacted=False,
+            )
+        )
+        await settings_session.commit()
+
+        service = SettingsCatalogService(env={}, session=settings_session)
+        entries = await service.list_audit_events(
+            permissions={"settings.audit.read"},
+        )
+
+    assert entries[0].new_value is None
+    assert entries[0].redacted is True
+    assert "secret_like_value" in entries[0].redaction_reasons
+    assert "provider-returned-diagnostic" not in entries[0].model_dump_json()
+    assert "provider-sensitive-detail" not in entries[0].model_dump_json()
+
+
 @pytest.mark.asyncio
 async def test_audit_redactor_reports_stored_redacted_null_values(
     settings_session_maker,

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -2241,6 +2241,29 @@ async def test_audit_entries_expose_secret_ref_metadata_with_permission(
 
 
 @pytest.mark.asyncio
+async def test_rejected_audit_entries_expose_safe_secret_ref_metadata_with_permission(
+    settings_session_maker,
+):
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(env={}, session=settings_session)
+        await service.record_rejected_write_audit(
+            scope="workspace",
+            changes={"integrations.github.token_ref": "db://github-token"},
+            reason="version conflict",
+            request_id="settings-rejected-1",
+        )
+
+        entries = await service.list_audit_events(
+            permissions={"settings.audit.read", "secrets.metadata.read"},
+        )
+
+    assert entries[0].event_type == "settings.override.rejected"
+    assert entries[0].new_value == "db://github-token"
+    assert entries[0].redacted is False
+    assert entries[0].request_id == "settings-rejected-1"
+
+
+@pytest.mark.asyncio
 async def test_audit_entries_persist_actor_identity(settings_session_maker):
     user_id = uuid4()
     async with settings_session_maker() as settings_session:


### PR DESCRIPTION
Jira issue key: MM-659

Active MoonSpec feature path: specs/659-settings-audit-redaction

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- pytest tests/unit/api_service/api/routers/test_settings_api.py::test_failed_settings_write_creates_redacted_audit_event_with_request_id tests/unit/services/test_settings_catalog.py::test_audit_redactor_blocks_documented_sensitive_classes tests/unit/services/test_settings_catalog.py::test_audit_entries_expose_secret_ref_metadata_with_permission tests/unit/services/test_settings_catalog.py::test_audit_redactor_reports_stored_redacted_null_values tests/unit/services/test_settings_catalog.py::test_audit_entries_expose_apply_mode_and_affected_systems -q --tb=short (PASS, 8 passed)
- pytest tests/integration/api/test_settings_http_api_surface_contract.py::test_mm659_failed_write_produces_redacted_audit_event tests/integration/api/test_settings_effective_values_contract.py::test_mm656_effective_preview_and_readiness_share_validation_details -q --tb=short (PASS, 2 passed)
- ./tools/test_integration.sh (NOT RUN: Docker build blocked by administrative 403 policy)

Remaining risks:
- Compose-backed hermetic integration suite could not run in this managed runtime because Docker returned 403 Forbidden while building the pytest image. Focused integration coverage passed locally.