### PR TITLE
[codex] Handle Codex completed turn item pagination

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -69,6 +69,8 @@ _DIAGNOSTIC_TEXT_MAX_CHARS = 1000
 _RPC_TRACE_MAX_ENTRIES = 80
 _ROLLUP_EVENT_TYPES_MAX = 24
 _LOG_EXCERPT_MAX_ROWS = 20
+_TURN_ITEMS_PAGE_LIMIT = 200
+_TURN_ITEMS_MAX_PAGES = 20
 _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
@@ -626,8 +628,7 @@ class CodexManagedSessionRuntime:
         return state
 
     @staticmethod
-    def _assistant_text_from_turn_payload(turn_payload: Mapping[str, Any]) -> str:
-        items = turn_payload.get("items")
+    def _assistant_text_from_items(items: Any) -> str:
         if not isinstance(items, list):
             return ""
         for item in reversed(items):
@@ -639,6 +640,10 @@ class CodexManagedSessionRuntime:
             if isinstance(text, str) and text.strip():
                 return text.strip()
         return ""
+
+    @classmethod
+    def _assistant_text_from_turn_payload(cls, turn_payload: Mapping[str, Any]) -> str:
+        return cls._assistant_text_from_items(turn_payload.get("items"))
 
     @classmethod
     def _extract_assistant_text(
@@ -1746,6 +1751,8 @@ class CodexManagedSessionRuntime:
         state: CodexSessionRuntimeState,
         thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
+        client: CodexAppServerRpcClient | None = None,
+        vendor_thread_id: str | None = None,
     ) -> _CompletedTurnInspection:
         assistant_text = self._extract_assistant_text(
             thread_payload,
@@ -1753,6 +1760,14 @@ class CodexManagedSessionRuntime:
         )
         if assistant_text:
             return _CompletedTurnInspection(assistant_text=assistant_text)
+        if client is not None and vendor_thread_id:
+            assistant_text = self._assistant_text_from_turn_items_list(
+                client=client,
+                vendor_thread_id=vendor_thread_id,
+                vendor_turn_id=vendor_turn_id,
+            )
+            if assistant_text:
+                return _CompletedTurnInspection(assistant_text=assistant_text)
         vendor_thread_path = self._resolved_rollout_path(
             state=state,
             thread_payload=thread_payload,
@@ -1766,6 +1781,38 @@ class CodexManagedSessionRuntime:
             assistant_text=rollout_scan.assistant_text,
             rollout_scan=rollout_scan,
         )
+
+    def _assistant_text_from_turn_items_list(
+        self,
+        *,
+        client: CodexAppServerRpcClient,
+        vendor_thread_id: str,
+        vendor_turn_id: str,
+    ) -> str:
+        cursor: str | None = None
+        assistant_text = ""
+        for _ in range(_TURN_ITEMS_MAX_PAGES):
+            params: dict[str, Any] = {
+                "threadId": vendor_thread_id,
+                "turnId": vendor_turn_id,
+                "limit": _TURN_ITEMS_PAGE_LIMIT,
+                "sortDirection": "asc",
+            }
+            if cursor:
+                params["cursor"] = cursor
+            try:
+                response = client.request("thread/turns/items/list", params)
+            except RuntimeError:
+                return ""
+
+            text = self._assistant_text_from_items(response.get("data"))
+            if text:
+                assistant_text = text
+            next_cursor = response.get("nextCursor")
+            if not isinstance(next_cursor, str) or not next_cursor.strip():
+                return assistant_text
+            cursor = next_cursor.strip()
+        return assistant_text
 
     def _assistant_text_for_completed_turn(
         self,
@@ -2089,6 +2136,8 @@ class CodexManagedSessionRuntime:
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=active_turn_id,
+                client=client,
+                vendor_thread_id=state.vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
         if status == "completed" and not assistant_text:
@@ -2267,6 +2316,8 @@ class CodexManagedSessionRuntime:
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=vendor_turn_id,
+                client=client,
+                vendor_thread_id=vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
             if not assistant_text:

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1803,7 +1803,7 @@ class CodexManagedSessionRuntime:
             try:
                 response = client.request("thread/turns/items/list", params)
             except RuntimeError:
-                return ""
+                return assistant_text
 
             text = self._assistant_text_from_items(response.get("data"))
             if text:

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -19,6 +19,7 @@ def write_fake_app_server(
     start_thread_id: str = "vendor-thread-1",
     start_thread_path: str | None = "/tmp/vendor-thread-1.jsonl",
     rollout_entries_on_read: list[dict] | None = None,
+    items_list_assistant_text: str | None = None,
     skill_outcome_path: Path | str | None = None,
     skill_outcome_payload: dict | str | None = None,
     steer_record_path: Path | None = None,
@@ -58,6 +59,7 @@ ASSISTANT_TEXT = __ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
 THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
 ROLLOUT_ENTRIES_ON_READ = __ROLLOUT_ENTRIES_ON_READ__
+ITEMS_LIST_ASSISTANT_TEXT = __ITEMS_LIST_ASSISTANT_TEXT__
 SKILL_OUTCOME_PATH = __SKILL_OUTCOME_PATH__
 SKILL_OUTCOME_PAYLOAD = __SKILL_OUTCOME_PAYLOAD__
 SKILL_OUTCOME_PAYLOAD_IS_RAW = __SKILL_OUTCOME_PAYLOAD_IS_RAW__
@@ -212,6 +214,27 @@ __COMPLETION_BLOCK__
             "result": {"status": "running"},
         }) + "\\n")
         sys.stdout.flush()
+    elif method == "thread/turns/items/list":
+        turn_items = []
+        if turn_completed and ITEMS_LIST_ASSISTANT_TEXT is not None:
+            turn_items = [
+                {
+                    "type": "agentMessage",
+                    "id": "msg-list-1",
+                    "text": ITEMS_LIST_ASSISTANT_TEXT,
+                    "phase": "final_answer",
+                    "memoryCitation": None,
+                }
+            ]
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "data": turn_items,
+                "nextCursor": None,
+                "backwardsCursor": None,
+            },
+        }) + "\\n")
+        sys.stdout.flush()
     elif method == "thread/read":
         thread_id = message["params"]["threadId"]
         if START_THREAD_PATH and ROLLOUT_ENTRIES_ON_READ:
@@ -316,6 +339,7 @@ __COMPLETION_BLOCK__
         .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
         .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
         .replace("__ROLLOUT_ENTRIES_ON_READ__", repr(rollout_entries_on_read or []))
+        .replace("__ITEMS_LIST_ASSISTANT_TEXT__", repr(items_list_assistant_text))
         .replace(
             "__SKILL_OUTCOME_PATH__",
             repr(str(skill_outcome_path) if skill_outcome_path is not None else ""),

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -3111,3 +3111,79 @@ def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch,
 
     with pytest.raises(RuntimeError, match="MOONMIND_SESSION_IMAGE_REF is required"):
         _run_ready()
+
+
+def _make_runtime_for_turn_items_test(tmp_path: Path) -> CodexManagedSessionRuntime:
+    request = launch_request(tmp_path)
+    return CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+    )
+
+
+class _StubTurnItemsClient:
+    def __init__(self, responses: list[object]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def request(self, method: str, params: dict[str, object]) -> dict[str, object]:
+        assert method == "thread/turns/items/list"
+        self.calls.append(dict(params))
+        if not self._responses:
+            raise AssertionError("no remaining stubbed responses")
+        next_value = self._responses.pop(0)
+        if isinstance(next_value, Exception):
+            raise next_value
+        return next_value  # type: ignore[return-value]
+
+
+def test_assistant_text_from_turn_items_list_preserves_partial_pages_on_runtime_error(
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime_for_turn_items_test(tmp_path)
+    client = _StubTurnItemsClient(
+        responses=[
+            {
+                "data": [
+                    {
+                        "type": "agentMessage",
+                        "id": "msg-1",
+                        "text": "partial assistant text",
+                        "phase": "final_answer",
+                    }
+                ],
+                "nextCursor": "cursor-2",
+            },
+            RuntimeError("transport closed"),
+        ]
+    )
+
+    result = runtime._assistant_text_from_turn_items_list(
+        client=client,  # type: ignore[arg-type]
+        vendor_thread_id="thread-1",
+        vendor_turn_id="turn-1",
+    )
+
+    assert result == "partial assistant text"
+    assert len(client.calls) == 2
+
+
+def test_assistant_text_from_turn_items_list_returns_empty_when_first_page_fails(
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime_for_turn_items_test(tmp_path)
+    client = _StubTurnItemsClient(responses=[RuntimeError("transport closed")])
+
+    result = runtime._assistant_text_from_turn_items_list(
+        client=client,  # type: ignore[arg-type]
+        vendor_thread_id="thread-1",
+        vendor_turn_id="turn-1",
+    )
+
+    assert result == ""
+    assert len(client.calls) == 1

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -479,6 +479,56 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
     assert stderr_path.exists()
     assert "turn failed:" in stderr_path.read_text(encoding="utf-8")
 
+
+def test_runtime_send_turn_reads_completed_assistant_items_from_item_list(
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="",
+        items_list_assistant_text="OK",
+    )
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.metadata["assistantText"] == "OK"
+    assert "turnFailureEvidence" not in response.metadata
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == "OK"
+    assert handle.metadata["lastTurnStatus"] == "completed"
+
+
 def test_runtime_send_turn_accepts_item_completed_notification_contract(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Fetch completed Codex turn items through `thread/turns/items/list` when `thread/read` does not include assistant text.
- Keep the existing rollout scan fallback for older or failing item-list calls.
- Add fake app-server support and regression coverage for completed turns whose assistant output is only available from the item-list endpoint.

## Root Cause
Codex app-server v2 can return completed turn summaries without loaded assistant items. MoonMind only inspected the `thread/read` turn payload and rollout files, so valid completed turns could be misclassified as `codex app-server turn/completed produced no assistant output`.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
  - Python target: 59 passed
  - Frontend phase: 21 files passed, 358 passed, 232 skipped