### PR TITLE
MM-663 Change application semantics with apply modes and reload events

### DIFF
--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Literal
 from uuid import UUID
 
@@ -324,6 +324,7 @@ class EffectiveSettingValue(BaseModel):
 class EffectiveSettingsResponse(BaseModel):
     scope: SettingScope
     values: dict[str, EffectiveSettingValue]
+    change_events: list["SettingsChangeEvent"] = Field(default_factory=list)
 
 
 class SettingsValidationResponse(BaseModel):
@@ -384,6 +385,7 @@ class SettingsAuditRead(BaseModel):
     event_type: str
     key: str
     scope: str
+    source: str | None = None
     actor_user_id: UUID | None = None
     old_value: Any = None
     new_value: Any = None
@@ -399,6 +401,18 @@ class SettingsAuditRead(BaseModel):
 
 class SettingsAuditResponse(BaseModel):
     items: list[SettingsAuditRead]
+
+
+class SettingsChangeEvent(BaseModel):
+    event_type: Literal["setting_changed"] = "setting_changed"
+    key: str
+    scope: SettingScope
+    source: str
+    apply_mode: SettingApplyMode
+    actor_user_id: UUID | None = None
+    changed_at: datetime
+    affected_systems: list[str] = Field(default_factory=list)
+    refresh_targets: list[str] = Field(default_factory=list)
 
 
 class SettingsRecentChange(BaseModel):
@@ -1043,7 +1057,11 @@ class SettingsCatalogService:
             override_value=None,
             source=metadata["source"],
             source_explanation=metadata["source_explanation"],
-            **self._activation_metadata(entry, value),
+            **self._activation_metadata(
+                entry,
+                value,
+                pending_activation=override_present,
+            ),
             options=[
                 SettingOption(value=value, label=label)
                 for value, label in entry.options
@@ -1119,7 +1137,11 @@ class SettingsCatalogService:
             scope=scope,
             value=value,
             **self._effective_metadata(entry, value, source, override_present, diagnostics),
-            **self._activation_metadata(entry, value),
+            **self._activation_metadata(
+                entry,
+                value,
+                pending_activation=override_present,
+            ),
             value_version=version,
             diagnostics=diagnostics,
         )
@@ -1181,7 +1203,11 @@ class SettingsCatalogService:
                 scope=scope,
                 value=data[0],
                 **self._effective_metadata(entry, data[0], data[1], data[3], diagnostics),
-                **self._activation_metadata(entry, data[0]),
+                **self._activation_metadata(
+                    entry,
+                    data[0],
+                    pending_activation=data[3],
+                ),
                 value_version=data[2],
                 diagnostics=diagnostics,
             )
@@ -1618,10 +1644,13 @@ class SettingsCatalogService:
         if pre_persistence_issues:
             raise SettingsValidationError(pre_persistence_issues)
 
+        changed_at = datetime.now(timezone.utc)
+        change_events: list[SettingsChangeEvent] = []
         for key, value in validated.items():
             entry = entries[key]
             row = current_rows.get((scope, key))
             old_value = row.value_json if row is not None else None
+            source = f"{scope}_override"
             if row is None:
                 row = SettingsOverride(
                     scope=scope,
@@ -1639,11 +1668,25 @@ class SettingsCatalogService:
             self._session.add(
                 self._audit_event(
                     entry,
-                    event_type="settings.override.updated",
+                    event_type="setting_changed",
                     scope=scope,
                     old_value=old_value,
                     new_value=value,
                     reason=reason,
+                )
+            )
+            change_events.append(
+                SettingsChangeEvent(
+                    key=entry.key,
+                    scope=scope,
+                    source=source,
+                    apply_mode=entry.apply_mode,
+                    actor_user_id=(
+                        self._user_id if self._user_id != _DEFAULT_SUBJECT_ID else None
+                    ),
+                    changed_at=changed_at,
+                    affected_systems=list(entry.applies_to),
+                    refresh_targets=self._refresh_targets_for_entry(entry),
                 )
             )
 
@@ -1694,7 +1737,11 @@ class SettingsCatalogService:
                 value_version=data[2],
                 diagnostics=diagnostics,
             )
-        return EffectiveSettingsResponse(scope=scope, values=values)
+        return EffectiveSettingsResponse(
+            scope=scope,
+            values=values,
+            change_events=change_events,
+        )
 
     async def reset_override(
         self,
@@ -1719,7 +1766,7 @@ class SettingsCatalogService:
             self._session.add(
                 self._audit_event(
                     entry,
-                    event_type="settings.override.reset",
+                    event_type="setting_changed",
                     scope=scope,
                     old_value=old_value,
                     new_value=None,
@@ -2044,6 +2091,19 @@ class SettingsCatalogService:
             "requires_process_restart": entry.requires_process_restart,
             "applies_to": list(entry.applies_to),
         }
+
+    def _refresh_targets_for_entry(self, entry: SettingRegistryEntry) -> list[str]:
+        targets = {"settings_catalog"}
+        applies_to = set(entry.applies_to)
+        if "task_creation" in applies_to:
+            targets.add("task_creation_defaults")
+        if "provider_profiles" in applies_to:
+            targets.add("provider_profile_manager")
+        if entry.apply_mode == "worker_reload" or entry.requires_reload:
+            targets.add("worker_reloaders")
+        if "operations" in applies_to or entry.apply_mode == "manual_operation":
+            targets.add("operational_controls")
+        return sorted(targets)
 
     def _resolve_value(self, entry: SettingRegistryEntry) -> tuple[Any, str]:
         if self._is_operator_locked(entry):
@@ -3914,6 +3974,7 @@ class SettingsCatalogService:
             event_type=row.event_type,
             key=row.key,
             scope=row.scope,
+            source=f"{row.scope}_override" if row.new_value_json is not None else "inherited",
             actor_user_id=row.actor_user_id,
             old_value=old_value,
             new_value=new_value,

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -1668,7 +1668,7 @@ class SettingsCatalogService:
             self._session.add(
                 self._audit_event(
                     entry,
-                    event_type="setting_changed",
+                    event_type="settings.override.updated",
                     scope=scope,
                     old_value=old_value,
                     new_value=value,
@@ -1766,7 +1766,7 @@ class SettingsCatalogService:
             self._session.add(
                 self._audit_event(
                     entry,
-                    event_type="setting_changed",
+                    event_type="settings.override.reset",
                     scope=scope,
                     old_value=old_value,
                     new_value=None,
@@ -3974,7 +3974,11 @@ class SettingsCatalogService:
             event_type=row.event_type,
             key=row.key,
             scope=row.scope,
-            source=f"{row.scope}_override" if row.new_value_json is not None else "inherited",
+            source=(
+                f"{row.scope}_override"
+                if row.event_type != "settings.override.reset"
+                else "inherited"
+            ),
             actor_user_id=row.actor_user_id,
             old_value=old_value,
             new_value=new_value,

--- a/tests/integration/api/test_settings_overrides_contract.py
+++ b/tests/integration/api/test_settings_overrides_contract.py
@@ -93,6 +93,15 @@ async def test_settings_override_contract_round_trips_and_resets(
     assert workspace.json()["values"]["integrations.github.token_ref"]["source"] == (
         "workspace_override"
     )
+    workspace_event = workspace.json()["change_events"][0]
+    assert workspace_event["event_type"] == "setting_changed"
+    assert workspace_event["key"] == "integrations.github.token_ref"
+    assert workspace_event["scope"] == "workspace"
+    assert workspace_event["source"] == "workspace_override"
+    assert workspace_event["apply_mode"] == "next_launch"
+    assert workspace_event["affected_systems"] == ["github", "integrations"]
+    assert workspace_event["refresh_targets"] == ["settings_catalog"]
+    assert workspace_event["changed_at"]
     assert user.status_code == 200
     assert user.json()["values"]["integrations.github.token_ref"]["source"] == (
         "user_override"

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -2279,13 +2279,108 @@ async def test_audit_entries_expose_apply_mode_and_affected_systems(
             permissions={"settings.audit.read"},
         )
 
-    assert entries[0].event_type == "settings.override.updated"
+    assert entries[0].event_type == "setting_changed"
     assert entries[0].key == "workflow.default_publish_mode"
     assert entries[0].scope == "workspace"
+    assert entries[0].source == "workspace_override"
     assert entries[0].apply_mode == "next_task"
     assert entries[0].affected_systems == ["task_creation", "publishing"]
     assert entries[0].validation_outcome == "accepted"
     assert entries[0].created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_overrides_returns_setting_changed_event_with_refresh_targets(
+    settings_session_maker,
+):
+    async with settings_session_maker() as settings_session:
+        entry_type = SettingsCatalogService(env={})._registry[0].__class__
+        service = SettingsCatalogService(
+            env={},
+            session=settings_session,
+            user_id=uuid4(),
+            registry=(
+                entry_type(
+                    key="test.provider_profile",
+                    title="Provider Profile",
+                    category="Test",
+                    section="user-workspace",
+                    value_type="string",
+                    ui="provider_profile_picker",
+                    scopes=("workspace",),
+                    default_value="profile-default",
+                    order=1,
+                    apply_mode="next_launch",
+                    applies_to=(
+                        "task_creation",
+                        "workflow_runtime",
+                        "provider_profiles",
+                    ),
+                ),
+            ),
+        )
+
+        response = await service.apply_overrides(
+            scope="workspace",
+            changes={"test.provider_profile": "profile-main"},
+            expected_versions={"test.provider_profile": 1},
+        )
+
+    event = response.change_events[0]
+    assert event.event_type == "setting_changed"
+    assert event.key == "test.provider_profile"
+    assert event.scope == "workspace"
+    assert event.source == "workspace_override"
+    assert event.apply_mode == "next_launch"
+    assert event.actor_user_id is not None
+    assert event.changed_at is not None
+    assert event.affected_systems == [
+        "task_creation",
+        "workflow_runtime",
+        "provider_profiles",
+    ]
+    assert event.refresh_targets == [
+        "provider_profile_manager",
+        "settings_catalog",
+        "task_creation_defaults",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_catalog_keeps_reload_setting_pending_until_reload(
+    settings_session_maker,
+):
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(env={}, session=settings_session)
+        await service.apply_overrides(
+            scope="workspace",
+            changes={"skills.policy_mode": "allowlist"},
+            expected_versions={"skills.policy_mode": 1},
+        )
+
+        catalog = await service.catalog_async(
+            section="user-workspace",
+            scope="workspace",
+        )
+        effective = await service.effective_value_async(
+            "skills.policy_mode",
+            scope="workspace",
+        )
+
+    skill_policy = next(
+        item
+        for item in catalog.categories["Skills"]
+        if item.key == "skills.policy_mode"
+    )
+    assert skill_policy.apply_mode == "worker_reload"
+    assert skill_policy.activation_state == "pending_reload"
+    assert skill_policy.active is False
+    assert skill_policy.pending_value == "allowlist"
+    assert skill_policy.affected_process_or_worker == "workflow_runtime, skills"
+    assert skill_policy.completion_guidance == "Reload affected workers to activate this value."
+    assert effective.activation_state == "pending_reload"
+    assert effective.active is False
+    assert effective.pending_value == "allowlist"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -2279,7 +2279,7 @@ async def test_audit_entries_expose_apply_mode_and_affected_systems(
             permissions={"settings.audit.read"},
         )
 
-    assert entries[0].event_type == "setting_changed"
+    assert entries[0].event_type == "settings.override.updated"
     assert entries[0].key == "workflow.default_publish_mode"
     assert entries[0].scope == "workspace"
     assert entries[0].source == "workspace_override"
@@ -2287,6 +2287,39 @@ async def test_audit_entries_expose_apply_mode_and_affected_systems(
     assert entries[0].affected_systems == ["task_creation", "publishing"]
     assert entries[0].validation_outcome == "accepted"
     assert entries[0].created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_audit_source_preserves_intentional_null_override(settings_session_maker):
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(env={}, session=settings_session)
+        await service.apply_overrides(
+            scope="user",
+            changes={"integrations.github.token_ref": None},
+            expected_versions={"integrations.github.token_ref": 1},
+        )
+
+        updated_entries = await service.list_audit_events(
+            permissions={"settings.audit.read"},
+        )
+
+        await service.reset_override(
+            "integrations.github.token_ref",
+            scope="user",
+        )
+        reset_entries = await service.list_audit_events(
+            permissions={"settings.audit.read"},
+        )
+
+    assert updated_entries[0].event_type == "settings.override.updated"
+    assert updated_entries[0].source == "user_override"
+    assert updated_entries[0].new_value is None
+    reset_entry = next(
+        entry
+        for entry in reset_entries
+        if entry.event_type == "settings.override.reset"
+    )
+    assert reset_entry.source == "inherited"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Implements MM-663 settings apply mode semantics and structured `setting_changed` event payloads.
- Preserves pending activation metadata for reload/restart-delayed settings.
- Adds service and API contract coverage for change events and refresh targets.

## Jira

- Issue: MM-663

## MoonSpec

- Active feature path: `specs/001-settings-apply-modes`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests run

- `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest -q tests/integration/api/test_settings_overrides_contract.py -q --tb=short`

## Remaining risks

- None identified in post-remediation MoonSpec verification.
