### PR TITLE
Track managed secret usage in settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,8 @@ Key diagnostics:
 - Python 3.12 (existing MoonMind runtime); no new module files are added for this one-shot run. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (353-transition-mm658-in-progress)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, existing managed runtime launcher/strategy stack, existing task contract runtime command metadata (356-runtime-command-rendering)
 - No new persistent storage; use existing task input snapshot data, `AgentExecutionRequest` payload fields/parameters, workflow history, and launcher diagnostics (356-runtime-command-rendering)
+- Python 3.12; TypeScript/React for Mission Control UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal runtime helpers, React, TanStack Query, Vitest, Testing Library, `httpx` (001-secretref-settings-integration)
+- Existing `settings_overrides`, managed secret/provider-profile rows, and artifact/runtime metadata only; no new persistent storage planned (001-secretref-settings-integration)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -252,6 +252,8 @@ Key diagnostics:
 - Python 3.12 (existing MoonMind runtime); no new module files are added for this one-shot run. + Existing trusted Jira tool registry (`moonmind/mcp/jira_tool_registry.py`), `JiraToolService` (`moonmind/integrations/jira/tool.py`), `redact_sensitive_text` / `SecretRedactor` redaction helpers. (353-transition-mm658-in-progress)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, existing managed runtime launcher/strategy stack, existing task contract runtime command metadata (356-runtime-command-rendering)
 - No new persistent storage; use existing task input snapshot data, `AgentExecutionRequest` payload fields/parameters, workflow history, and launcher diagnostics (356-runtime-command-rendering)
+- Python 3.12; TypeScript/React for Mission Control UI + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal runtime helpers, React, TanStack Query, Vitest, Testing Library, `httpx` (001-secretref-settings-integration)
+- Existing `settings_overrides`, managed secret/provider-profile rows, and artifact/runtime metadata only; no new persistent storage planned (001-secretref-settings-integration)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/secrets.py
+++ b/api_service/api/routers/secrets.py
@@ -1,5 +1,6 @@
 import structlog
 from typing import Any
+from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -20,6 +21,17 @@ from moonmind.utils.logging import redact_sensitive_payload
 logger = structlog.get_logger(__name__)
 
 router = APIRouter()
+
+
+def _uuid_attr(value: Any) -> UUID | None:
+    if isinstance(value, UUID):
+        return value
+    if value is None:
+        return None
+    try:
+        return UUID(str(value))
+    except (TypeError, ValueError):
+        return None
 
 @router.post(
     "",
@@ -149,7 +161,12 @@ async def get_secret_usage(
     db: AsyncSession = Depends(get_async_session),
     user: Any = Depends(get_current_user()),
 ) -> SecretUsageResponse:
-    result = await SecretsService.list_secret_usage(db, slug)
+    result = await SecretsService.list_secret_usage(
+        db,
+        slug,
+        workspace_id=_uuid_attr(getattr(user, "workspace_id", None)),
+        user_id=_uuid_attr(getattr(user, "id", None)),
+    )
     return SecretUsageResponse.model_validate(redact_sensitive_payload(result))
 
 @router.get(

--- a/api_service/api/routers/secrets.py
+++ b/api_service/api/routers/secrets.py
@@ -11,6 +11,7 @@ from api_service.api.schemas import (
     SecretMetadataResponse,
     SecretStatusUpdateRequest,
     SecretUpdateRequest,
+    SecretUsageResponse,
 )
 from api_service.db.models import SecretStatus
 from api_service.services.secrets import SecretsService
@@ -136,6 +137,20 @@ async def delete_secret(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret not found"
         )
+
+@router.get(
+    "/{slug}/usage",
+    response_model=SecretUsageResponse,
+    summary="List redacted consumers of a managed secret",
+    tags=["Secrets"],
+)
+async def get_secret_usage(
+    slug: str,
+    db: AsyncSession = Depends(get_async_session),
+    user: Any = Depends(get_current_user()),
+) -> SecretUsageResponse:
+    result = await SecretsService.list_secret_usage(db, slug)
+    return SecretUsageResponse.model_validate(redact_sensitive_payload(result))
 
 @router.get(
     "/{slug}/validate",

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -598,6 +598,35 @@ class SecretListResponse(BaseModel):
 
     items: list[SecretMetadataResponse] = Field(default_factory=list)
 
+class SecretUsageItemResponse(BaseModel):
+    """Metadata-only reference from a consumer to a managed secret."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    consumer_type: str = Field(..., alias="consumerType")
+    object_name: str = Field(..., alias="objectName")
+    reference: str
+    scope: Optional[str] = None
+    setting_key: Optional[str] = Field(None, alias="settingKey")
+
+class SecretUsageDiagnosticResponse(BaseModel):
+    """Redacted diagnostic surfaced by a secret usage lookup."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    code: str
+    message: str
+    severity: str
+
+class SecretUsageResponse(BaseModel):
+    """Envelope for managed secret usage views."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    secret_ref: str = Field(..., alias="secretRef")
+    usages: list[SecretUsageItemResponse] = Field(default_factory=list)
+    diagnostics: list[SecretUsageDiagnosticResponse] = Field(default_factory=list)
+
 class AgentSkillSummaryResponse(BaseModel):
     """List item representing an agent skill definition."""
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
@@ -685,6 +714,9 @@ __all__ = [
     "SecretStatusUpdateRequest",
     "SecretMetadataResponse",
     "SecretListResponse",
+    "SecretUsageItemResponse",
+    "SecretUsageDiagnosticResponse",
+    "SecretUsageResponse",
     "AgentSkillSummaryResponse",
     "AgentSkillVersionResponse",
     "AgentSkillCreateRequest",

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select, Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_service.db.models import ManagedSecret, SecretStatus
+from api_service.db.models import ManagedSecret, SecretStatus, SettingsOverride
 
 logger = structlog.get_logger(__name__)
 
@@ -130,6 +130,62 @@ class SecretsService:
             )
         )
         return result.all()
+
+    @classmethod
+    async def list_secret_usage(cls, db: AsyncSession, slug: str) -> dict[str, Any]:
+        """List metadata-only consumers for a managed secret reference."""
+        secret_ref = f"db://{slug}"
+        status_result = await db.execute(
+            select(ManagedSecret.status).where(ManagedSecret.slug == slug)
+        )
+        status = status_result.scalar_one_or_none()
+        if status is None:
+            return {
+                "secretRef": secret_ref,
+                "usages": [],
+                "diagnostics": [
+                    {
+                        "code": "secret_ref_unresolved",
+                        "message": "Managed secret is missing.",
+                        "severity": "error",
+                    }
+                ],
+            }
+
+        usage_result = await db.execute(select(SettingsOverride))
+        usages = []
+        for override in usage_result.scalars().all():
+            if not cls._value_references_secret(override.value_json, secret_ref):
+                continue
+            scope = str(override.scope)
+            scope_label = "Workspace" if scope == "workspace" else "User"
+            usages.append(
+                {
+                    "consumerType": "setting_override",
+                    "objectName": f"{scope_label} setting {override.key}",
+                    "reference": secret_ref,
+                    "scope": scope,
+                    "settingKey": override.key,
+                }
+            )
+
+        return {"secretRef": secret_ref, "usages": usages, "diagnostics": []}
+
+    @staticmethod
+    def _value_references_secret(value: Any, secret_ref: str) -> bool:
+        if value == secret_ref:
+            return True
+        if isinstance(value, dict):
+            return any(
+                SecretsService._value_references_secret(item, secret_ref)
+                for item in value.values()
+            )
+        if isinstance(value, list):
+            return any(
+                SecretsService._value_references_secret(item, secret_ref)
+                for item in value
+            )
+        return False
 
     @classmethod
     async def get_secret(cls, db: AsyncSession, slug: str) -> str | None:

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -1,13 +1,16 @@
 import structlog
 from typing import Any, Sequence
 from datetime import datetime, timezone
+from uuid import UUID
 
-from sqlalchemy import select, Row
+from sqlalchemy import and_, or_, select, Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import ManagedSecret, SecretStatus, SettingsOverride
 
 logger = structlog.get_logger(__name__)
+
+_DEFAULT_SETTINGS_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
 
 class SecretsService:
     """Service layer for managing securely encrypted secrets."""
@@ -132,9 +135,18 @@ class SecretsService:
         return result.all()
 
     @classmethod
-    async def list_secret_usage(cls, db: AsyncSession, slug: str) -> dict[str, Any]:
+    async def list_secret_usage(
+        cls,
+        db: AsyncSession,
+        slug: str,
+        *,
+        workspace_id: UUID | None = None,
+        user_id: UUID | None = None,
+    ) -> dict[str, Any]:
         """List metadata-only consumers for a managed secret reference."""
         secret_ref = f"db://{slug}"
+        resolved_workspace_id = workspace_id or _DEFAULT_SETTINGS_SUBJECT_ID
+        resolved_user_id = user_id or _DEFAULT_SETTINGS_SUBJECT_ID
         status_result = await db.execute(
             select(ManagedSecret.status).where(ManagedSecret.slug == slug)
         )
@@ -152,20 +164,38 @@ class SecretsService:
                 ],
             }
 
-        usage_result = await db.execute(select(SettingsOverride))
+        usage_result = await db.execute(
+            select(
+                SettingsOverride.key,
+                SettingsOverride.scope,
+                SettingsOverride.value_json,
+            ).where(
+                SettingsOverride.workspace_id == resolved_workspace_id,
+                or_(
+                    and_(
+                        SettingsOverride.scope == "user",
+                        SettingsOverride.user_id == resolved_user_id,
+                    ),
+                    and_(
+                        SettingsOverride.scope != "user",
+                        SettingsOverride.user_id == _DEFAULT_SETTINGS_SUBJECT_ID,
+                    ),
+                ),
+            )
+        )
         usages = []
-        for override in usage_result.scalars().all():
-            if not cls._value_references_secret(override.value_json, secret_ref):
+        for key, scope, value_json in usage_result:
+            if not cls._value_references_secret(value_json, secret_ref):
                 continue
-            scope = str(override.scope)
+            scope = str(scope)
             scope_label = "Workspace" if scope == "workspace" else "User"
             usages.append(
                 {
                     "consumerType": "setting_override",
-                    "objectName": f"{scope_label} setting {override.key}",
+                    "objectName": f"{scope_label} setting {key}",
                     "reference": secret_ref,
                     "scope": scope,
-                    "settingKey": override.key,
+                    "settingKey": key,
                 }
             )
 

--- a/frontend/src/components/secrets/SecretManager.test.tsx
+++ b/frontend/src/components/secrets/SecretManager.test.tsx
@@ -5,6 +5,7 @@ import { SecretManager } from './SecretManager';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 function renderSecretManager() {
@@ -99,6 +100,36 @@ describe('SecretManager', () => {
 
     expect(screen.getByText('Workspace setting integrations.github.token_ref')).toBeTruthy();
     expect(screen.getAllByText('db://github-pat-main').length).toBeGreaterThan(0);
+    expect(screen.queryByText('ghp_usage_plaintext')).toBeNull();
+  });
+
+  it('loads secret usage on demand from the usage endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        secretRef: 'db://github-pat-main',
+        usages: [
+          {
+            consumerType: 'setting_override',
+            objectName: 'Workspace setting integrations.github.token_ref',
+            reference: 'db://github-pat-main',
+            scope: 'workspace',
+            settingKey: 'integrations.github.token_ref',
+          },
+        ],
+        diagnostics: [],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSecretManager();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View usage' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/secrets/github-pat-main/usage');
+    });
+    expect(await screen.findByText('Workspace setting integrations.github.token_ref')).toBeTruthy();
     expect(screen.queryByText('ghp_usage_plaintext')).toBeNull();
   });
 });

--- a/frontend/src/components/secrets/SecretManager.test.tsx
+++ b/frontend/src/components/secrets/SecretManager.test.tsx
@@ -57,4 +57,48 @@ describe('SecretManager', () => {
       text: 'SecretRef copied.',
     });
   });
+
+  it('shows usage references and consumer names without exposing plaintext', () => {
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+          })
+        }
+      >
+        <SecretManager
+          secrets={[
+            {
+              slug: 'github-pat-main',
+              secretRef: 'db://github-pat-main',
+              status: 'active',
+              details: {},
+              createdAt: '2026-04-28T00:00:00Z',
+              updatedAt: '2026-04-28T00:00:00Z',
+              usages: [
+                {
+                  consumerType: 'setting_override',
+                  objectName: 'Workspace setting integrations.github.token_ref',
+                  reference: 'db://github-pat-main',
+                  scope: 'workspace',
+                  settingKey: 'integrations.github.token_ref',
+                },
+              ],
+            },
+          ]}
+          onNotice={vi.fn()}
+          queryClient={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false } },
+            })
+          }
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText('Workspace setting integrations.github.token_ref')).toBeTruthy();
+    expect(screen.getAllByText('db://github-pat-main').length).toBeGreaterThan(0);
+    expect(screen.queryByText('ghp_usage_plaintext')).toBeNull();
+  });
 });

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -10,6 +10,15 @@ interface SecretMetadata {
   details: Record<string, unknown>;
   createdAt: string;
   updatedAt?: string;
+  usages?: SecretUsage[];
+}
+
+interface SecretUsage {
+  consumerType: string;
+  objectName: string;
+  reference: string;
+  scope?: string;
+  settingKey?: string;
 }
 
 interface SecretManagerProps {
@@ -172,6 +181,28 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     }
   };
 
+  const renderUsages = (secret: SecretMetadata) => {
+    const usages = secret.usages ?? [];
+    if (usages.length === 0) {
+      return <span className="text-xs text-slate-500 dark:text-slate-400">No consumers</span>;
+    }
+
+    return (
+      <ul className="space-y-2">
+        {usages.map((usage) => (
+          <li key={`${usage.consumerType}:${usage.objectName}:${usage.reference}`}>
+            <div className="text-xs font-medium text-slate-700 dark:text-slate-200">
+              {usage.objectName}
+            </div>
+            <code className="mt-1 inline-block rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 dark:bg-slate-900 dark:text-slate-100">
+              {usage.reference}
+            </code>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
   return (
     <div className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
       <div className="border-b border-slate-200 dark:border-slate-800 pb-4">
@@ -194,6 +225,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Secret slug</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">SecretRef</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Status</th>
+                  <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Usage</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Updated</th>
                   <th className="px-2 py-3 font-medium text-slate-600 dark:text-slate-400">Actions</th>
                 </tr>
@@ -201,7 +233,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                 {secrets.length === 0 ? (
                   <tr>
-                    <td className="px-2 py-6 text-slate-500 dark:text-slate-400 italic" colSpan={5}>
+                    <td className="px-2 py-6 text-slate-500 dark:text-slate-400 italic" colSpan={6}>
                       No secrets currently stored.
                     </td>
                   </tr>
@@ -217,6 +249,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
                         </code>
                       </td>
                       <td className="px-2 py-4">{renderStatus(secret.status)}</td>
+                      <td className="px-2 py-4">{renderUsages(secret)}</td>
                       <td className="px-2 py-4 text-xs text-slate-500 dark:text-slate-400">
                         {secret.updatedAt
                           ? new Date(secret.updatedAt).toLocaleString()

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -21,6 +21,16 @@ interface SecretUsage {
   settingKey?: string;
 }
 
+interface SecretUsageResponse {
+  secretRef: string;
+  usages: SecretUsage[];
+  diagnostics?: Array<{
+    code: string;
+    message: string;
+    severity: string;
+  }>;
+}
+
 interface SecretManagerProps {
   secrets: SecretMetadata[];
   onNotice: (notice: { level: 'ok' | 'error'; text: string } | null) => void;
@@ -34,6 +44,9 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
   const [rotatePromptOpen, setRotatePromptOpen] = useState(false);
   const [rotatePromptSlug, setRotatePromptSlug] = useState('');
   const [rotatePromptVal, setRotatePromptVal] = useState('');
+  const [usageBySlug, setUsageBySlug] = useState<Record<string, SecretUsageResponse>>({});
+  const [usageLoadingSlug, setUsageLoadingSlug] = useState<string | null>(null);
+  const [usageErrorBySlug, setUsageErrorBySlug] = useState<Record<string, string>>({});
 
   const createOp = useMutation({
     mutationFn: async ({
@@ -181,8 +194,53 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     }
   };
 
+  const loadUsage = async (targetSlug: string) => {
+    setUsageLoadingSlug(targetSlug);
+    setUsageErrorBySlug((current) => {
+      const next = { ...current };
+      delete next[targetSlug];
+      return next;
+    });
+    try {
+      const response = await fetch(`/api/v1/secrets/${encodeURIComponent(targetSlug)}/usage`);
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        throw new Error(errorPayload.detail || 'Failed to load secret usage');
+      }
+      const usage = (await response.json()) as SecretUsageResponse;
+      setUsageBySlug((current) => ({ ...current, [targetSlug]: usage }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load secret usage';
+      setUsageErrorBySlug((current) => ({ ...current, [targetSlug]: message }));
+      onNotice({ level: 'error', text: message });
+    } finally {
+      setUsageLoadingSlug(null);
+    }
+  };
+
   const renderUsages = (secret: SecretMetadata) => {
-    const usages = secret.usages ?? [];
+    const loadedUsage = usageBySlug[secret.slug];
+    const usages = loadedUsage?.usages ?? secret.usages ?? [];
+    const usageError = usageErrorBySlug[secret.slug];
+    const usageLoaded = Boolean(loadedUsage || secret.usages);
+
+    if (usageError) {
+      return <span className="text-xs text-red-600 dark:text-red-400">{usageError}</span>;
+    }
+
+    if (!usageLoaded) {
+      return (
+        <button
+          type="button"
+          onClick={() => loadUsage(secret.slug)}
+          disabled={usageLoadingSlug === secret.slug}
+          className="btn btn-sm btn-outline"
+        >
+          {usageLoadingSlug === secret.slug ? 'Loading...' : 'View usage'}
+        </button>
+      );
+    }
+
     if (usages.length === 0) {
       return <span className="text-xs text-slate-500 dark:text-slate-400">No consumers</span>;
     }

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -914,6 +914,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/secrets/{slug}/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List redacted consumers of a managed secret */
+        get: operations["get_secret_usage_api_v1_secrets__slug__usage_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/secrets/{slug}/validate": {
         parameters: {
             query?: never;
@@ -6381,6 +6398,46 @@ export interface components {
              */
             plaintext: string;
         };
+        /**
+         * SecretUsageDiagnosticResponse
+         * @description Redacted diagnostic surfaced by a secret usage lookup.
+         */
+        SecretUsageDiagnosticResponse: {
+            /** Code */
+            code: string;
+            /** Message */
+            message: string;
+            /** Severity */
+            severity: string;
+        };
+        /**
+         * SecretUsageItemResponse
+         * @description Metadata-only reference from a consumer to a managed secret.
+         */
+        SecretUsageItemResponse: {
+            /** Consumertype */
+            consumerType: string;
+            /** Objectname */
+            objectName: string;
+            /** Reference */
+            reference: string;
+            /** Scope */
+            scope?: string | null;
+            /** Settingkey */
+            settingKey?: string | null;
+        };
+        /**
+         * SecretUsageResponse
+         * @description Envelope for managed secret usage views.
+         */
+        SecretUsageResponse: {
+            /** Secretref */
+            secretRef: string;
+            /** Usages */
+            usages?: components["schemas"]["SecretUsageItemResponse"][];
+            /** Diagnostics */
+            diagnostics?: components["schemas"]["SecretUsageDiagnosticResponse"][];
+        };
         /** SettingsPatchRequest */
         SettingsPatchRequest: {
             /** Changes */
@@ -9752,6 +9809,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SecretMetadataResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_secret_usage_api_v1_secrets__slug__usage_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SecretUsageResponse"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/utils/logging.py
+++ b/moonmind/utils/logging.py
@@ -21,12 +21,15 @@ _SECRET_ASSIGNMENT_PATTERN = re.compile(
 _AUTHORIZATION_PATTERN = re.compile(
     r"(?i)\b(authorization\s*:\s*)?bearer\s+[A-Za-z0-9._~+/=-]+"
 )
-_PRIVATE_KEY_PATTERN = re.compile(
-    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
-    re.DOTALL,
-)
-_AUTH_PATH_PATTERN = re.compile(
-    r"(?i)(?:/[^\s\"']*)?(?:\.codex|\.claude|codex-auth|claude-auth|gemini-auth|auth-volume)[^\s\"']*"
+_PRIVATE_KEY_BEGIN = "-----BEGIN "
+_PRIVATE_KEY_END = "-----END "
+_AUTH_PATH_MARKERS = (
+    ".codex",
+    ".claude",
+    "codex-auth",
+    "claude-auth",
+    "gemini-auth",
+    "auth-volume",
 )
 _NON_SECRET_SENTINEL_VALUES = frozenset(
     {"true", "false", "none", "null", "yes", "no", "on", "off"}
@@ -75,16 +78,61 @@ def scrub_github_tokens(text: str) -> str:
         return ""
     return _GITHUB_TOKEN_PATTERN.sub("[REDACTED]", text)
 
+def _redact_private_key_blocks(text: str) -> str:
+    redacted = text
+    while True:
+        upper = redacted.upper()
+        begin = upper.find(_PRIVATE_KEY_BEGIN)
+        if begin == -1:
+            return redacted
+        key_suffix = upper.find("PRIVATE KEY-----", begin)
+        if key_suffix == -1:
+            return redacted[:begin] + "[REDACTED_PRIVATE_KEY]"
+        end_marker = upper.find(_PRIVATE_KEY_END, key_suffix)
+        if end_marker == -1:
+            return redacted[:begin] + "[REDACTED_PRIVATE_KEY]"
+        end_suffix = upper.find("PRIVATE KEY-----", end_marker)
+        if end_suffix == -1:
+            return redacted[:begin] + "[REDACTED_PRIVATE_KEY]"
+        end = end_suffix + len("PRIVATE KEY-----")
+        redacted = (
+            redacted[:begin]
+            + "[REDACTED_PRIVATE_KEY]"
+            + redacted[end:]
+        )
+
+def _redact_auth_paths(text: str) -> str:
+    output: list[str] = []
+    index = 0
+    length = len(text)
+    delimiters = set(" \t\r\n\"'")
+    while index < length:
+        if text[index] in delimiters:
+            output.append(text[index])
+            index += 1
+            continue
+        end = index
+        while end < length and text[end] not in delimiters:
+            end += 1
+        token = text[index:end]
+        token_lower = token.lower()
+        if any(marker in token_lower for marker in _AUTH_PATH_MARKERS):
+            output.append("[REDACTED_AUTH_PATH]")
+        else:
+            output.append(token)
+        index = end
+    return "".join(output)
+
 def redact_sensitive_text(text: str | None) -> str:
     """Scrub common credential-shaped values from browser/artifact text."""
 
     if not text:
         return ""
     redacted = scrub_github_tokens(str(text))
-    redacted = _PRIVATE_KEY_PATTERN.sub("[REDACTED_PRIVATE_KEY]", redacted)
+    redacted = _redact_private_key_blocks(redacted)
     redacted = _AUTHORIZATION_PATTERN.sub("[REDACTED_AUTHORIZATION]", redacted)
     redacted = _SECRET_ASSIGNMENT_PATTERN.sub(r"\1=[REDACTED]", redacted)
-    redacted = _AUTH_PATH_PATTERN.sub("[REDACTED_AUTH_PATH]", redacted)
+    redacted = _redact_auth_paths(redacted)
     return redacted
 
 def redact_sensitive_payload(payload: Any, *, key: str | None = None) -> Any:

--- a/tests/integration/api/test_secret_usage_views.py
+++ b/tests/integration/api/test_secret_usage_views.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api_service.auth_providers import get_current_user
 from api_service.db import base as db_base
-from api_service.db.models import Base, ManagedSecret, SecretStatus
+from api_service.db.models import Base, ManagedSecret, SecretStatus, SettingsOverride
 from api_service.main import app
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
@@ -120,3 +120,38 @@ async def test_secret_usage_view_reports_empty_and_missing_without_plaintext(
     assert missing.json()["usages"] == []
     assert missing.json()["diagnostics"][0]["code"] == "secret_ref_unresolved"
     assert "plaintext" not in missing.text
+
+
+async def test_secret_usage_view_excludes_other_workspace_consumers(
+    secret_usage_db,
+):
+    async with secret_usage_db() as session:
+        session.add(
+            ManagedSecret(
+                slug="github-pat-main",
+                ciphertext="ghp_usage_plaintext",
+                status=SecretStatus.ACTIVE,
+                details={},
+            )
+        )
+        session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=uuid4(),
+                key="integrations.github.token_ref",
+                value_json="db://github-pat-main",
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        usage = await client.get("/api/v1/secrets/github-pat-main/usage")
+
+    assert usage.status_code == 200
+    assert usage.json() == {
+        "secretRef": "db://github-pat-main",
+        "usages": [],
+        "diagnostics": [],
+    }

--- a/tests/integration/api/test_secret_usage_views.py
+++ b/tests/integration/api/test_secret_usage_views.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.auth_providers import get_current_user
+from api_service.db import base as db_base
+from api_service.db.models import Base, ManagedSecret, SecretStatus
+from api_service.main import app
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+SETTINGS_USER_DEP = get_current_user()
+
+
+@pytest_asyncio.fixture
+async def secret_usage_db(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/secret-usage.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    original = db_base.async_session_maker
+    db_base.async_session_maker = session_maker
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="secret-usage@example.com",
+        is_superuser=True,
+        settings_permissions={
+            "settings.catalog.read",
+            "settings.effective.read",
+            "settings.workspace.write",
+        },
+        workspace_id=uuid4(),
+    )
+    app.dependency_overrides[SETTINGS_USER_DEP] = lambda: user
+    try:
+        yield session_maker
+    finally:
+        app.dependency_overrides.pop(SETTINGS_USER_DEP, None)
+        db_base.async_session_maker = original
+        await engine.dispose()
+
+
+async def test_secret_usage_view_reports_settings_consumer_without_plaintext(
+    secret_usage_db,
+):
+    async with secret_usage_db() as session:
+        session.add(
+            ManagedSecret(
+                slug="github-pat-main",
+                ciphertext="ghp_usage_plaintext",
+                status=SecretStatus.ACTIVE,
+                details={},
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        stored = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"integrations.github.token_ref": "db://github-pat-main"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+        usage = await client.get("/api/v1/secrets/github-pat-main/usage")
+
+    assert stored.status_code == 200
+    assert usage.status_code == 200
+    body = usage.json()
+    assert body["secretRef"] == "db://github-pat-main"
+    assert body["usages"] == [
+        {
+            "consumerType": "setting_override",
+            "objectName": "Workspace setting integrations.github.token_ref",
+            "reference": "db://github-pat-main",
+            "scope": "workspace",
+            "settingKey": "integrations.github.token_ref",
+        }
+    ]
+    assert "ghp_usage_plaintext" not in usage.text
+
+
+async def test_secret_usage_view_reports_empty_and_missing_without_plaintext(
+    secret_usage_db,
+):
+    async with secret_usage_db() as session:
+        session.add(
+            ManagedSecret(
+                slug="unused-secret",
+                ciphertext="unused_plaintext",
+                status=SecretStatus.ACTIVE,
+                details={},
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        unused = await client.get("/api/v1/secrets/unused-secret/usage")
+        missing = await client.get("/api/v1/secrets/missing-secret/usage")
+
+    assert unused.status_code == 200
+    assert unused.json() == {
+        "secretRef": "db://unused-secret",
+        "usages": [],
+        "diagnostics": [],
+    }
+    assert "unused_plaintext" not in unused.text
+    assert missing.status_code == 200
+    assert missing.json()["secretRef"] == "db://missing-secret"
+    assert missing.json()["usages"] == []
+    assert missing.json()["diagnostics"][0]["code"] == "secret_ref_unresolved"
+    assert "plaintext" not in missing.text

--- a/tests/unit/api/test_secrets_api.py
+++ b/tests/unit/api/test_secrets_api.py
@@ -167,3 +167,59 @@ def test_validate_secret_response_is_redacted(mock_secrets_service):
     assert resp.json()["diagnostics"][0]["message"] == (
         "Managed secret is missing; token=[REDACTED]"
     )
+
+
+def test_secret_usage_endpoint_returns_references_and_object_names_only(
+    mock_secrets_service,
+):
+    raw_secret = "ghp_usage_plaintext"
+    mock_secrets_service.list_secret_usage.return_value = {
+        "secretRef": "db://github-pat-main",
+        "usages": [
+            {
+                "consumerType": "setting_override",
+                "objectName": "Workspace setting integrations.github.token_ref",
+                "reference": "db://github-pat-main",
+                "scope": "workspace",
+                "settingKey": "integrations.github.token_ref",
+            }
+        ],
+        "diagnostics": [],
+    }
+
+    resp = client.get("/api/v1/secrets/github-pat-main/usage")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["secretRef"] == "db://github-pat-main"
+    assert body["usages"][0]["objectName"] == (
+        "Workspace setting integrations.github.token_ref"
+    )
+    assert body["usages"][0]["reference"] == "db://github-pat-main"
+    assert "ciphertext" not in resp.text
+    assert raw_secret not in resp.text
+
+
+def test_secret_usage_endpoint_redacts_missing_secret_diagnostics(
+    mock_secrets_service,
+):
+    raw_secret = "sk-missing-secret"
+    mock_secrets_service.list_secret_usage.return_value = {
+        "secretRef": "db://missing-secret",
+        "usages": [],
+        "diagnostics": [
+            {
+                "code": "secret_ref_unresolved",
+                "message": f"Managed secret is missing; token={raw_secret}",
+                "severity": "error",
+            }
+        ],
+    }
+
+    resp = client.get("/api/v1/secrets/missing-secret/usage")
+
+    assert resp.status_code == 200
+    assert raw_secret not in resp.text
+    assert resp.json()["diagnostics"][0]["message"] == (
+        "Managed secret is missing; token=[REDACTED]"
+    )

--- a/tests/unit/moonmind/utils/test_logging.py
+++ b/tests/unit/moonmind/utils/test_logging.py
@@ -122,6 +122,24 @@ def test_secret_redactor_scrub_sequence():
     result = redactor.scrub_sequence(["This is my_secret", "No secrets"])
     assert result == ["This is ***", "No secrets"]
 
+def test_redact_sensitive_text_redacts_auth_paths_without_regex_backtracking():
+    repeated_path = "/home/app/.codex-auth/" + ("auth-volume/" * 200)
+
+    result = redact_sensitive_payload(f"token=sk-test in {repeated_path}")
+
+    assert result == "token=[REDACTED] in [REDACTED_AUTH_PATH]"
+
+def test_redact_sensitive_text_redacts_private_keys_without_regex_backtracking():
+    private_key = (
+        "prefix -----BEGIN PRIVATE KEY-----"
+        + ("-----BEGIN PRIVATE KEY-----" * 200)
+        + "-----END PRIVATE KEY----- suffix"
+    )
+
+    result = redact_sensitive_payload(private_key)
+
+    assert result == "prefix [REDACTED_PRIVATE_KEY] suffix"
+
 def test_redact_profile_file_templates_redacts_nested_content_fields():
     raw_secret = "sk-template-raw-secret"
 

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import ManagedSecret, SecretStatus
-from api_service.db.models import SettingsOverride
 from api_service.services.secrets import SecretsService
 
 @pytest.fixture
@@ -159,13 +159,9 @@ async def test_list_secret_usage_reports_settings_consumers_without_plaintext(
     secret_status_result = MagicMock()
     secret_status_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
     usage_result = MagicMock()
-    usage_result.scalars.return_value.all.return_value = [
-        SettingsOverride(
-            scope="workspace",
-            key="integrations.github.token_ref",
-            value_json="db://github-pat-main",
-        )
-    ]
+    usage_result.__iter__.return_value = iter(
+        [("integrations.github.token_ref", "workspace", "db://github-pat-main")]
+    )
 
     async def mock_execute(*args, **kwargs):
         return secret_status_result if mock_db_session.execute.call_count == 1 else usage_result
@@ -175,6 +171,8 @@ async def test_list_secret_usage_reports_settings_consumers_without_plaintext(
     result = await SecretsService.list_secret_usage(
         mock_db_session,
         "github-pat-main",
+        workspace_id=uuid4(),
+        user_id=uuid4(),
     )
 
     assert result["secretRef"] == "db://github-pat-main"
@@ -188,6 +186,10 @@ async def test_list_secret_usage_reports_settings_consumers_without_plaintext(
         }
     ]
     assert raw_secret not in repr(result)
+    usage_statement = mock_db_session.execute.call_args_list[1].args[0]
+    assert "settings_overrides.key" in str(usage_statement)
+    assert "settings_overrides.value_json" in str(usage_statement)
+    assert "settings_overrides.workspace_id" in str(usage_statement)
 
 
 @pytest.mark.asyncio
@@ -197,7 +199,7 @@ async def test_list_secret_usage_reports_empty_and_missing_without_plaintext(
     active_result = MagicMock()
     active_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
     empty_usage_result = MagicMock()
-    empty_usage_result.scalars.return_value.all.return_value = []
+    empty_usage_result.__iter__.return_value = iter([])
     missing_result = MagicMock()
     missing_result.scalar_one_or_none.return_value = None
 
@@ -234,6 +236,36 @@ async def test_list_secret_usage_reports_empty_and_missing_without_plaintext(
         }
     ]
     assert "plaintext" not in repr(missing)
+
+
+@pytest.mark.asyncio
+async def test_list_secret_usage_restricts_query_to_caller_scope(mock_db_session):
+    workspace_id = uuid4()
+    user_id = uuid4()
+    active_result = MagicMock()
+    active_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
+    usage_result = MagicMock()
+    usage_result.__iter__.return_value = iter([])
+
+    async def mock_execute(*args, **kwargs):
+        return active_result if mock_db_session.execute.call_count == 1 else usage_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    await SecretsService.list_secret_usage(
+        mock_db_session,
+        "github-pat-main",
+        workspace_id=workspace_id,
+        user_id=user_id,
+    )
+
+    usage_statement = mock_db_session.execute.call_args_list[1].args[0]
+    compiled = usage_statement.compile(compile_kwargs={"literal_binds": True})
+    statement = str(compiled)
+
+    assert workspace_id.hex in statement
+    assert user_id.hex in statement
+    assert UUID("00000000-0000-0000-0000-000000000000").hex in statement
 
 @pytest.mark.asyncio
 async def test_import_from_env(mock_db_session):

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import ManagedSecret, SecretStatus
+from api_service.db.models import SettingsOverride
 from api_service.services.secrets import SecretsService
 
 @pytest.fixture
@@ -148,6 +149,91 @@ async def test_validate_secret_ref_reports_missing_without_plaintext(mock_db_ses
         "message": "Managed secret is missing.",
         "severity": "error",
     }
+
+
+@pytest.mark.asyncio
+async def test_list_secret_usage_reports_settings_consumers_without_plaintext(
+    mock_db_session,
+):
+    raw_secret = "ghp_usage_plaintext"
+    secret_status_result = MagicMock()
+    secret_status_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
+    usage_result = MagicMock()
+    usage_result.scalars.return_value.all.return_value = [
+        SettingsOverride(
+            scope="workspace",
+            key="integrations.github.token_ref",
+            value_json="db://github-pat-main",
+        )
+    ]
+
+    async def mock_execute(*args, **kwargs):
+        return secret_status_result if mock_db_session.execute.call_count == 1 else usage_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    result = await SecretsService.list_secret_usage(
+        mock_db_session,
+        "github-pat-main",
+    )
+
+    assert result["secretRef"] == "db://github-pat-main"
+    assert result["usages"] == [
+        {
+            "consumerType": "setting_override",
+            "objectName": "Workspace setting integrations.github.token_ref",
+            "reference": "db://github-pat-main",
+            "scope": "workspace",
+            "settingKey": "integrations.github.token_ref",
+        }
+    ]
+    assert raw_secret not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_list_secret_usage_reports_empty_and_missing_without_plaintext(
+    mock_db_session,
+):
+    active_result = MagicMock()
+    active_result.scalar_one_or_none.return_value = SecretStatus.ACTIVE
+    empty_usage_result = MagicMock()
+    empty_usage_result.scalars.return_value.all.return_value = []
+    missing_result = MagicMock()
+    missing_result.scalar_one_or_none.return_value = None
+
+    async def active_execute(*args, **kwargs):
+        return active_result if mock_db_session.execute.call_count == 1 else empty_usage_result
+
+    mock_db_session.execute.side_effect = active_execute
+
+    empty = await SecretsService.list_secret_usage(mock_db_session, "unused-secret")
+
+    assert empty == {
+        "secretRef": "db://unused-secret",
+        "usages": [],
+        "diagnostics": [],
+    }
+
+    mock_db_session.execute.reset_mock()
+    mock_db_session.execute.side_effect = None
+
+    async def missing_execute(*args, **kwargs):
+        return missing_result
+
+    mock_db_session.execute.side_effect = missing_execute
+
+    missing = await SecretsService.list_secret_usage(mock_db_session, "missing-secret")
+
+    assert missing["secretRef"] == "db://missing-secret"
+    assert missing["usages"] == []
+    assert missing["diagnostics"] == [
+        {
+            "code": "secret_ref_unresolved",
+            "message": "Managed secret is missing.",
+            "severity": "error",
+        }
+    ]
+    assert "plaintext" not in repr(missing)
 
 @pytest.mark.asyncio
 async def test_import_from_env(mock_db_session):


### PR DESCRIPTION
Adds metadata-only managed secret usage tracking for settings overrides, including the /api/v1/secrets/{slug}/usage endpoint and Mission Control UI support for viewing consumers without exposing plaintext. The usage lookup is scoped to the caller workspace/user context and returns redacted diagnostics.