### PR TITLE
[codex] Avoid live polling for terminal task details

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3187,6 +3187,14 @@ async def _load_execution_progress(
         )
         return None, None
 
+
+def _execution_uses_live_workflow_queries(execution: ExecutionModel) -> bool:
+    if execution.workflow_type != "MoonMind.Run":
+        return False
+    if execution.close_status:
+        return False
+    return execution.temporal_status == "running"
+
 async def _load_execution_step_ledger(
     *,
     temporal_client: Client,
@@ -6596,7 +6604,7 @@ async def describe_execution(
     execution = _serialize_execution(record, user=user)
     execution = await _enrich_execution_dependencies(execution, service=service)
     execution = await _hydrate_provider_profile_metadata(execution, session)
-    if execution.workflow_type == "MoonMind.Run":
+    if _execution_uses_live_workflow_queries(execution):
         progress, queried_run_id = await _load_execution_progress(
             temporal_client=temporal_client,
             workflow_id=canonical_workflow_id,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6604,16 +6604,17 @@ async def describe_execution(
     execution = _serialize_execution(record, user=user)
     execution = await _enrich_execution_dependencies(execution, service=service)
     execution = await _hydrate_provider_profile_metadata(execution, session)
-    if _execution_uses_live_workflow_queries(execution):
-        progress, queried_run_id = await _load_execution_progress(
-            temporal_client=temporal_client,
-            workflow_id=canonical_workflow_id,
-        )
-        update: dict[str, object] = {"progress": progress}
-        if queried_run_id:
-            update["run_id"] = queried_run_id
-            update["temporal_run_id"] = queried_run_id
-        execution = execution.model_copy(update=update)
+    if execution.workflow_type == "MoonMind.Run":
+        if _execution_uses_live_workflow_queries(execution):
+            progress, queried_run_id = await _load_execution_progress(
+                temporal_client=temporal_client,
+                workflow_id=canonical_workflow_id,
+            )
+            update: dict[str, object] = {"progress": progress}
+            if queried_run_id:
+                update["run_id"] = queried_run_id
+                update["temporal_run_id"] = queried_run_id
+            execution = execution.model_copy(update=update)
         execution = await _enrich_execution_merge_automation(
             execution,
             temporal_client=temporal_client,

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -409,6 +409,68 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('does not poll terminal task detail surfaces after the initial load', async () => {
+    const terminalExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Terminal task',
+      summary: 'Execution finished',
+      status: 'completed',
+      state: 'succeeded',
+      rawState: 'succeeded',
+      temporalStatus: 'completed',
+      closeStatus: 'COMPLETED',
+      closedAt: '2026-04-09T00:00:05Z',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:05Z',
+      actions: {},
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => terminalExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    const detailSurfaceCalls = () => fetchSpy.mock.calls
+      .map(([input]) => String(input))
+      .filter((url) => (
+        url.includes('/api/executions/test-123?source=temporal') ||
+        url.includes('/api/executions/test-123/steps') ||
+        url.includes('/artifacts')
+      ));
+
+    await waitFor(() => {
+      const urls = detailSurfaceCalls();
+      expect(urls.some((url) => url.includes('/api/executions/test-123?source=temporal'))).toBe(true);
+      expect(urls.some((url) => url.includes('/api/executions/test-123/steps'))).toBe(true);
+      expect(urls.filter((url) => url.includes('/artifacts')).length).toBeGreaterThanOrEqual(2);
+    });
+
+    const callsAfterInitialLoad = detailSurfaceCalls();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(detailSurfaceCalls()).toEqual(callsAfterInitialLoad);
+  });
+
   it('displays original slash instructions and missing runtime command metadata state', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1543,6 +1543,22 @@ const TERMINAL_RUN_STATUSES = new Set([
   'timed_out',
 ]);
 
+function isExecutionTerminal(
+  execution: z.infer<typeof ExecutionDetailSchema> | null | undefined,
+): boolean {
+  if (!execution) {
+    return false;
+  }
+  const lifecycleState = (execution.rawState || execution.state || execution.status || '').toLowerCase();
+  const temporalStatus = (execution.temporalStatus || execution.closeStatus || '').toLowerCase();
+  return Boolean(
+    execution.closedAt ||
+      TERMINAL_STATES.has(lifecycleState) ||
+      TERMINAL_RUN_STATUSES.has(lifecycleState) ||
+      TERMINAL_RUN_STATUSES.has(temporalStatus),
+  );
+}
+
 function usePageVisibility() {
   const [isVisible, setIsVisible] = useState(!document.hidden);
 
@@ -3927,10 +3943,15 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       return ExecutionDetailSchema.parse(await response.json());
     },
     enabled: Boolean(encodedTaskId),
-    refetchInterval: liveUpdates ? detailPoll : false,
+    refetchInterval: (query) => (
+      liveUpdates && !isExecutionTerminal(query.state.data)
+        ? detailPoll
+        : false
+    ),
   });
 
   const execution = detailQuery.data;
+  const isTerminalExecution = isExecutionTerminal(execution);
   const workflowId = execution?.workflowId || execution?.taskId || taskId || '';
   const runId = execution?.temporalRunId || execution?.runId || '';
   const namespace = execution?.namespace || '';
@@ -3973,7 +3994,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     queryKey: ['task-detail-steps', workflowId, execution?.stepsHref],
     queryFn: () => fetchStepLedger(String(execution?.stepsHref || '')),
     enabled: Boolean(execution?.stepsHref),
-    refetchInterval: liveUpdates && execution?.stepsHref ? detailPoll : false,
+    refetchInterval: liveUpdates && execution?.stepsHref && !isTerminalExecution ? detailPoll : false,
   });
   const latestRunId = stepsQuery.data?.runId || runId;
 
@@ -3990,7 +4011,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     enabled:
       Boolean(namespace && workflowId && latestRunId)
       && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
-    refetchInterval: liveUpdates && namespace && workflowId && latestRunId ? detailPoll : false,
+    refetchInterval: liveUpdates && namespace && workflowId && latestRunId && !isTerminalExecution
+      ? detailPoll
+      : false,
   });
 
   const latestReportQuery = useQuery({
@@ -4006,14 +4029,16 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     enabled:
       Boolean(namespace && workflowId && latestRunId)
       && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
-    refetchInterval: liveUpdates && namespace && workflowId && latestRunId ? detailPoll : false,
+    refetchInterval: liveUpdates && namespace && workflowId && latestRunId && !isTerminalExecution
+      ? detailPoll
+      : false,
   });
 
   const runSummaryQuery = useQuery({
     queryKey: ['task-detail-run-summary', summaryArtifactRef],
     queryFn: () => fetchRunSummaryArtifact(payload.apiBase, summaryArtifactRef),
     enabled: Boolean(summaryArtifactRef),
-    refetchInterval: liveUpdates && summaryArtifactRef ? detailPoll : false,
+    refetchInterval: liveUpdates && summaryArtifactRef && !isTerminalExecution ? detailPoll : false,
   });
   const inboundRemediationsQuery = useQuery({
     queryKey: ['task-detail-remediations', workflowId, 'inbound'],
@@ -4374,7 +4399,6 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       },
     );
   };
-  const isTerminalExecution = TERMINAL_STATES.has(execution?.rawState || execution?.state || '');
   const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
   const canShowEditTask = Boolean(actions?.canUpdateInputs || actions?.canEditForRerun);
   const canFailedStepResume = Boolean(actions?.canResumeFromFailedStep);

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5914,6 +5914,11 @@ def test_describe_execution_skips_live_progress_query_for_terminal_runs() -> Non
             new_callable=AsyncMock,
         ) as load_progress,
         patch(
+            "api_service.api.routers.executions._enrich_execution_merge_automation",
+            new_callable=AsyncMock,
+            side_effect=lambda execution, **_kwargs: execution,
+        ) as enrich_merge_automation,
+        patch(
             "api_service.api.routers.executions._hydrate_execution_report_projection",
             side_effect=passthrough_report_projection,
         ),
@@ -5927,6 +5932,7 @@ def test_describe_execution_skips_live_progress_query_for_terminal_runs() -> Non
     assert payload["closeStatus"] == "failed"
     assert payload["progress"] is None
     load_progress.assert_not_awaited()
+    enrich_merge_automation.assert_awaited_once()
 
 def test_describe_execution_steps_href_uses_configured_detail_endpoint(monkeypatch) -> None:
     monkeypatch.setattr(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5886,6 +5886,48 @@ def test_describe_execution_leaves_progress_null_when_query_fails() -> None:
     assert payload["stepsHref"] == "/api/executions/mm:wf-1/steps"
     assert payload["progress"] is None
 
+def test_describe_execution_skips_live_progress_query_for_terminal_runs() -> None:
+    from api_service.db.models import TemporalExecutionCloseStatus
+
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    record.close_status = TemporalExecutionCloseStatus.FAILED
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        progress={
+            "total": 99,
+            "failed": 99,
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+
+    async def passthrough_report_projection(execution, **_kwargs):
+        return execution
+
+    with (
+        patch(
+            "api_service.api.routers.executions._load_execution_progress",
+            new_callable=AsyncMock,
+        ) as load_progress,
+        patch(
+            "api_service.api.routers.executions._hydrate_execution_report_projection",
+            side_effect=passthrough_report_projection,
+        ),
+        TestClient(app) as test_client,
+    ):
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["temporalStatus"] == "failed"
+    assert payload["closeStatus"] == "failed"
+    assert payload["progress"] is None
+    load_progress.assert_not_awaited()
+
 def test_describe_execution_steps_href_uses_configured_detail_endpoint(monkeypatch) -> None:
     monkeypatch.setattr(
         settings.temporal_dashboard,


### PR DESCRIPTION
## Summary
- Skip optional live Temporal progress queries for terminal `MoonMind.Run` execution detail responses.
- Stop Mission Control task-detail polling for terminal detail, steps, artifacts, report, and summary surfaces after the initial load.
- Add backend and frontend regression coverage for terminal execution behavior.

## Root Cause
Closed task detail pages still queried live workflow progress and kept polling every 2 seconds. Under Temporal workflow task queue pressure, those optional queries could block page loads for already-terminal executions.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `.venv/bin/pytest tests/unit/api/routers/test_executions.py -q -k 'progress or terminal_runs'`\n- `npm run ui:build`\n- Live timing check for `mm:fde6f693-6503-4679-b653-86b2e07db4fb?source=temporal`: 0.57s, 0.19s, 0.20s after API restart.\n\n## Notes\n- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'progress or terminal_runs'` passed the selected backend tests, then continued into the full frontend phase and hit an unrelated reproducible timeout in `frontend/src/entrypoints/tasks-list.test.tsx` for the active column filter chip test. Rerunning that single test reproduced the timeout.