### PR TITLE
MM-701 Generate validated proposal delivery records

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3128,6 +3128,22 @@ class TemporalProposalActivities:
             ctx = _wrap()
 
         async with ctx as service:
+            if service is not None and origin and not workflow_id:
+                error = "origin.workflow_id is required for workflow proposal submission"
+                return {
+                    "generated_count": generated_count,
+                    "submitted_count": 0,
+                    "deliveredCount": 0,
+                    "validationErrors": [
+                        {"code": "proposal_validation_error", "message": error}
+                    ],
+                    "deliveryFailures": [],
+                    "externalLinks": [],
+                    "dedupUpdates": [],
+                    "errors": [error],
+                    "delivery_decisions": [],
+                }
+
             for candidate in candidates:
                 if not isinstance(candidate, Mapping):
                     errors.append("skipped non-object candidate")
@@ -3162,6 +3178,35 @@ class TemporalProposalActivities:
                 if isinstance(payload_node, Mapping):
                     target_repo = str(payload_node.get("repository") or "").strip()
 
+                original_runtime_mode = ""
+                if isinstance(task_create_request, Mapping):
+                    original_payload = task_create_request.get("payload")
+                    if isinstance(original_payload, Mapping):
+                        original_task = original_payload.get("task")
+                        if isinstance(original_task, Mapping):
+                            original_runtime = original_task.get("runtime")
+                            if isinstance(original_runtime, Mapping):
+                                original_runtime_mode = str(
+                                    original_runtime.get("mode") or ""
+                                ).strip()
+                stamped_runtime_mode = ""
+                if isinstance(payload_node, Mapping):
+                    stamped_task = payload_node.get("task")
+                    if isinstance(stamped_task, Mapping):
+                        stamped_runtime = stamped_task.get("runtime")
+                        if isinstance(stamped_runtime, Mapping):
+                            stamped_runtime_mode = str(
+                                stamped_runtime.get("mode") or ""
+                            ).strip()
+                default_runtime_value = (
+                    default_runtime if isinstance(default_runtime, str) else None
+                )
+                default_runtime_applied = bool(
+                    default_runtime_value
+                    and stamped_runtime_mode == default_runtime_value
+                    and not original_runtime_mode
+                )
+
                 tags = [
                     str(tag or "").strip().lower()
                     for tag in (candidate.get("tags") or [])
@@ -3169,6 +3214,10 @@ class TemporalProposalActivities:
                 tags = [tag for tag in tags if tag]
                 category = str(candidate.get("category") or "").strip().lower()
                 severity = str(candidate.get("severity") or "medium").strip().lower()
+                moonmind_tag_matches = sorted(set(tags) & approved_moonmind_tags)
+                moonmind_severity_qualified = effective_policy.severity_meets_floor(
+                    severity
+                )
                 wants_moonmind = (
                     bool(moonmind_repo)
                     and effective_policy.allow_moonmind
@@ -3178,8 +3227,8 @@ class TemporalProposalActivities:
                         or category in {"run_quality", "moonmind_ci"}
                     )
                     and category in {"run_quality", "moonmind_ci"}
-                    and bool(set(tags) & approved_moonmind_tags)
-                    and effective_policy.severity_meets_floor(severity)
+                    and bool(moonmind_tag_matches)
+                    and moonmind_severity_qualified
                 )
 
                 target = "project"
@@ -3227,6 +3276,8 @@ class TemporalProposalActivities:
 
                         origin_source = TaskProposalOriginSource.WORKFLOW
                         origin_metadata = {
+                            "source": "workflow",
+                            "id": workflow_id,
                             "workflow_id": workflow_id,
                             "temporal_run_id": run_id,
                             "trigger_repo": trigger_repo,
@@ -3252,6 +3303,49 @@ class TemporalProposalActivities:
                                 "target": target,
                                 "repository": target_repo,
                                 "workflow_id": workflow_id,
+                                "default_runtime": default_runtime_value,
+                                "default_runtime_applied": default_runtime_applied,
+                                "capacity": {
+                                    "project": {
+                                        "allowed": effective_policy.allow_project,
+                                        "limit": effective_policy.max_items_project,
+                                        "remaining": (
+                                            effective_policy.remaining_project_slots
+                                        ),
+                                        "accepted": (
+                                            effective_policy.max_items_project
+                                            - effective_policy.remaining_project_slots
+                                        ),
+                                    },
+                                    "moonmind": {
+                                        "allowed": effective_policy.allow_moonmind,
+                                        "limit": effective_policy.max_items_moonmind,
+                                        "remaining": (
+                                            effective_policy.remaining_moonmind_slots
+                                        ),
+                                        "accepted": (
+                                            effective_policy.max_items_moonmind
+                                            - effective_policy.remaining_moonmind_slots
+                                        ),
+                                    },
+                                },
+                                "gates": {
+                                    "moonmind": {
+                                        "severity": severity,
+                                        "severity_floor": (
+                                            effective_policy.min_severity_for_moonmind
+                                        ),
+                                        "severity_qualified": (
+                                            moonmind_severity_qualified
+                                        ),
+                                        "approved_tags": moonmind_tag_matches,
+                                        "qualified": wants_moonmind,
+                                    }
+                                },
+                                "delivery": {
+                                    "provider": delivery_provider,
+                                    "metadata": provider_payload,
+                                },
                             },
                         )
                         external_key = getattr(proposal, "external_key", None)

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2828,6 +2828,18 @@ class TemporalProposalActivities:
             payload_node["task"] = {"runtime": {"mode": default_runtime}}
         return stamped_request
 
+    @staticmethod
+    def _task_runtime_mode_from_payload(payload_node: Any) -> str:
+        if not isinstance(payload_node, Mapping):
+            return ""
+        task_node = payload_node.get("task") or {}
+        if not isinstance(task_node, Mapping):
+            return ""
+        runtime_node = task_node.get("runtime") or {}
+        if isinstance(runtime_node, Mapping):
+            runtime_node = runtime_node.get("mode")
+        return str(runtime_node or "").strip()
+
     @classmethod
     def _validate_candidate_task_create_request(
         cls, request: Mapping[str, Any], *, default_runtime: str | None
@@ -3128,7 +3140,7 @@ class TemporalProposalActivities:
             ctx = _wrap()
 
         async with ctx as service:
-            if service is not None and origin and not workflow_id:
+            if origin and not workflow_id:
                 error = "origin.workflow_id is required for workflow proposal submission"
                 return {
                     "generated_count": generated_count,
@@ -3178,26 +3190,12 @@ class TemporalProposalActivities:
                 if isinstance(payload_node, Mapping):
                     target_repo = str(payload_node.get("repository") or "").strip()
 
-                original_runtime_mode = ""
-                if isinstance(task_create_request, Mapping):
-                    original_payload = task_create_request.get("payload")
-                    if isinstance(original_payload, Mapping):
-                        original_task = original_payload.get("task")
-                        if isinstance(original_task, Mapping):
-                            original_runtime = original_task.get("runtime")
-                            if isinstance(original_runtime, Mapping):
-                                original_runtime_mode = str(
-                                    original_runtime.get("mode") or ""
-                                ).strip()
-                stamped_runtime_mode = ""
-                if isinstance(payload_node, Mapping):
-                    stamped_task = payload_node.get("task")
-                    if isinstance(stamped_task, Mapping):
-                        stamped_runtime = stamped_task.get("runtime")
-                        if isinstance(stamped_runtime, Mapping):
-                            stamped_runtime_mode = str(
-                                stamped_runtime.get("mode") or ""
-                            ).strip()
+                original_runtime_mode = self._task_runtime_mode_from_payload(
+                    task_create_request.get("payload")
+                )
+                stamped_runtime_mode = self._task_runtime_mode_from_payload(
+                    payload_node
+                )
                 default_runtime_value = (
                     default_runtime if isinstance(default_runtime, str) else None
                 )

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -164,7 +164,13 @@ async def test_proposal_submit_persists_external_delivery_result() -> None:
     repo = AsyncMock()
     record = _record()
     repo.find_open_duplicate.return_value = None
-    repo.create_proposal.return_value = record
+
+    async def create_record(**kwargs):
+        for key, value in kwargs.items():
+            setattr(record, key, value)
+        return record
+
+    repo.create_proposal.side_effect = create_record
     delivery = _Delivery()
     service = TaskProposalService(
         repo,
@@ -209,6 +215,89 @@ async def test_proposal_submit_persists_external_delivery_result() -> None:
     assert record.external_url == "https://tracker.example/issues/42"
     assert record.provider_metadata["delivery"]["storedSnapshotNotice"] is True
     assert delivery.requests[0].origin_metadata["workflow_id"] == "wf-1"
+    assert delivery.requests[0].origin_metadata["source"] == "workflow"
+    assert delivery.requests[0].origin_metadata["id"] == "wf-1"
+    assert record.resolved_policy["target"] == "project"
+    assert record.resolved_policy["provider"] == "github"
+    assert record.resolved_policy["capacity"]["project"]["accepted"] == 1
+    assert record.resolved_policy["delivery"]["provider"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_proposal_submit_reports_partial_success_and_dedup_update() -> None:
+    repo = AsyncMock()
+    record = _record()
+    record.external_key = "42"
+    record.external_url = "https://tracker.example/issues/42"
+    record.provider_metadata = {
+        "delivery": {
+            "status": "updated",
+            "created": False,
+            "duplicateSource": "existing-open-issue",
+        }
+    }
+    repo.find_open_duplicate.return_value = record
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "[REDACTED]"),
+    )
+    service._emit_notification = AsyncMock()
+
+    async def factory():
+        return service
+
+    activities = TemporalProposalActivities(proposal_service_factory=factory)
+    result = await activities.proposal_submit(
+        {
+            "candidates": [
+                {
+                    "title": "",
+                    "summary": "Missing title",
+                    "taskCreateRequest": {},
+                },
+                {
+                    "title": "Add tests",
+                    "summary": "Add follow-up",
+                    "tags": ["artifact_gap"],
+                    "taskCreateRequest": {
+                        "type": "task",
+                        "payload": {
+                            "repository": "Moon/Repo",
+                            "task": {"instructions": "Add tests"},
+                        },
+                    },
+                },
+            ],
+            "policy": {"delivery": {"provider": "github"}},
+            "origin": {
+                "workflow_id": "wf-1",
+                "temporal_run_id": "run-1",
+                "trigger_repo": "Moon/Repo",
+                "trigger_job_id": "job-1",
+            },
+        }
+    )
+
+    assert result["generated_count"] == 2
+    assert result["submitted_count"] == 1
+    assert result["deliveredCount"] == 1
+    assert result["validationErrors"]
+    assert result["externalLinks"] == [
+        {
+            "provider": "github",
+            "externalKey": "42",
+            "externalUrl": "https://tracker.example/issues/42",
+        }
+    ]
+    assert result["dedupUpdates"] == [
+        {
+            "created": False,
+            "provider": "github",
+            "externalKey": "42",
+            "duplicateSource": "existing-open-issue",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -14,6 +14,7 @@ from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalProposalActivities,
 )
+from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 from moonmind.workflows.task_proposals.models import (
     TaskProposalOriginSource,
     TaskProposalStatus,
@@ -632,6 +633,40 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(meta["trigger_repo"], "org/repo")
         self.assertEqual(meta["trigger_job_id"], "run-1")
 
+    async def test_workflow_origin_metadata_carries_canonical_source_and_id(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix bug",
+                        "summary": "Bug in module X",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {},
+                "origin": {
+                    "workflow_id": "wf-1",
+                    "temporal_run_id": "run-1",
+                    "trigger_repo": "org/repo",
+                    "trigger_job_id": "job-1",
+                },
+            }
+        )
+
+        call_kwargs = mock_service.create_proposal.await_args.kwargs
+        self.assertEqual(call_kwargs["origin_source"], TaskProposalOriginSource.WORKFLOW)
+        self.assertEqual(call_kwargs["origin_external_id"], "wf-1")
+        self.assertEqual(call_kwargs["origin_metadata"]["source"], "workflow")
+        self.assertEqual(call_kwargs["origin_metadata"]["id"], "wf-1")
+        self.assertEqual(call_kwargs["origin_metadata"]["workflow_id"], "wf-1")
+
     async def test_service_failure_recorded(self) -> None:
         mock_service = AsyncMock()
         mock_service.create_proposal.side_effect = RuntimeError("DB down")
@@ -742,6 +777,33 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result["submitted_count"], 1)
         self.assertEqual(result["deliveredCount"], 0)
+
+    async def test_missing_workflow_origin_is_validation_error_before_delivery(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix bug",
+                        "summary": "Bug in module X",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {},
+                "origin": {"temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 0)
+        self.assertEqual(result["validationErrors"][0]["code"], "proposal_validation_error")
+        self.assertIn("workflow_id", result["validationErrors"][0]["message"])
+        mock_service.create_proposal.assert_not_called()
 
 class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
     async def test_default_runtime_stamped_into_candidate(self) -> None:
@@ -1026,6 +1088,8 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             call_kwargs["origin_metadata"],
             {
+                "source": "workflow",
+                "id": "wf-1",
                 "workflow_id": "wf-1",
                 "temporal_run_id": "run-1",
                 "trigger_repo": "org/repo",
@@ -1112,3 +1176,99 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_kwargs["category"], "run_quality")
         self.assertEqual(call_kwargs["tags"], ["loop_detected"])
         self.assertEqual(result["delivery_decisions"][0]["target"], "moonmind")
+
+    async def test_project_target_preserves_candidate_repository(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Project follow-up",
+                        "summary": "Project-scoped cleanup",
+                        "category": "tests",
+                        "tags": ["tests"],
+                        "severity": "high",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {
+                    "targets": ["project", "moonmind"],
+                    "minSeverityForMoonMind": "medium",
+                },
+                "origin": {"workflow_id": "wf-1", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        call_kwargs = mock_service.create_proposal.await_args.kwargs
+        self.assertEqual(
+            call_kwargs["task_create_request"]["payload"]["repository"],
+            "org/repo",
+        )
+        self.assertEqual(call_kwargs["resolved_policy"]["target"], "project")
+        self.assertEqual(result["delivery_decisions"][0]["target"], "project")
+
+    async def test_resolved_policy_records_capacity_gates_and_runtime_decision(
+        self,
+    ) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix loop",
+                        "summary": "Loop detected",
+                        "category": "run_quality",
+                        "tags": ["loop_detected"],
+                        "severity": "high",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {
+                    "targets": ["moonmind"],
+                    "maxItems": {"moonmind": 2},
+                    "minSeverityForMoonMind": "medium",
+                    "defaultRuntime": "codex",
+                    "delivery": {"provider": "jira", "jira": {"projectKey": "MM"}},
+                },
+                "origin": {"workflow_id": "wf-1", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        resolved = mock_service.create_proposal.await_args.kwargs["resolved_policy"]
+        self.assertEqual(resolved["provider"], "jira")
+        self.assertEqual(resolved["target"], "moonmind")
+        self.assertEqual(resolved["repository"], "MoonLadderStudios/MoonMind")
+        self.assertEqual(resolved["default_runtime"], "codex")
+        self.assertTrue(resolved["default_runtime_applied"])
+        self.assertEqual(resolved["capacity"]["moonmind"]["limit"], 2)
+        self.assertEqual(resolved["capacity"]["moonmind"]["accepted"], 1)
+        self.assertEqual(resolved["gates"]["moonmind"]["severity_floor"], "medium")
+        self.assertTrue(resolved["gates"]["moonmind"]["qualified"])
+        self.assertEqual(resolved["delivery"]["provider"], "jira")
+
+
+class TestProposalActivityCatalog(unittest.TestCase):
+    def test_proposal_activity_retry_metadata_is_bounded(self) -> None:
+        catalog = build_default_activity_catalog()
+
+        generate = catalog.resolve_activity("proposal.generate")
+        submit = catalog.resolve_activity("proposal.submit")
+
+        self.assertEqual(generate.retries.max_attempts, 3)
+        self.assertLessEqual(generate.retries.max_interval_seconds, 120)
+        self.assertEqual(submit.retries.max_attempts, 3)
+        self.assertLessEqual(submit.retries.max_interval_seconds, 60)

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -331,6 +331,43 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["submitted_count"], 2)
         self.assertEqual(result["errors"], [])
 
+    async def test_origin_requires_workflow_id_without_service(self) -> None:
+        activities = TemporalProposalActivities()
+
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix bug",
+                        "summary": "There is a bug in module X",
+                        "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {},
+                "origin": {"temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["generated_count"], 1)
+        self.assertEqual(result["submitted_count"], 0)
+        self.assertEqual(result["deliveredCount"], 0)
+        self.assertEqual(
+            result["errors"],
+            ["origin.workflow_id is required for workflow proposal submission"],
+        )
+        self.assertEqual(
+            result["validationErrors"],
+            [
+                {
+                    "code": "proposal_validation_error",
+                    "message": (
+                        "origin.workflow_id is required for workflow proposal "
+                        "submission"
+                    ),
+                }
+            ],
+        )
+
     async def test_valid_skill_tool_candidate_counted_after_contract_validation(self) -> None:
         activities = TemporalProposalActivities()
         candidates = [


### PR DESCRIPTION
Jira issue key: MM-701

Active MoonSpec feature path: `specs/001-proposal-delivery-records`

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- `pytest tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/workflows/task_proposals/test_service.py tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/workflows/test_run_proposals.py -q` — 102 passed
- `pytest tests/integration/temporal/test_proposal_review_delivery.py -q` — 5 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` — Python 5075 passed, 6 skipped, 1 xpassed; frontend 360 passed, 232 skipped

Remaining risks:
- Full Docker hermetic integration CI (`./tools/test_integration.sh`) was environment-blocked before pytest by Docker administrative `403 Forbidden`; focused story integration and full unit verification passed.
