### PR TITLE
MM-703 process tracker proposal decisions

### DIFF
--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -668,6 +668,45 @@ async def inspect_proposal_delivery(
         ) from exc
     return _serialize_proposal(proposal)
 
+
+@router.post("/{proposal_id}/redeliver", response_model=TaskProposalModel)
+async def redeliver_proposal(
+    *,
+    proposal_id: UUID,
+    service: TaskProposalService = Depends(_get_service),
+    _user: User = Depends(get_current_user()),
+) -> TaskProposalModel:
+    try:
+        proposal = await service.redeliver_proposal(proposal_id=proposal_id)
+    except TaskProposalValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_request", "message": str(exc)},
+        ) from exc
+    except TaskProposalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "proposal_not_found", "message": str(exc)},
+        ) from exc
+    return _serialize_proposal(proposal)
+
+
+@router.post("/{proposal_id}/sync", response_model=TaskProposalModel)
+async def sync_proposal_delivery(
+    *,
+    proposal_id: UUID,
+    service: TaskProposalService = Depends(_get_service),
+    _user: User = Depends(get_current_user()),
+) -> TaskProposalModel:
+    try:
+        proposal = await service.sync_proposal_delivery(proposal_id=proposal_id)
+    except TaskProposalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "proposal_not_found", "message": str(exc)},
+        ) from exc
+    return _serialize_proposal(proposal)
+
 @router.post("/{proposal_id}/dismiss", response_model=TaskProposalModel)
 async def dismiss_proposal(
     *,

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -51,6 +51,18 @@ async def _get_service(
     return get_task_proposal_service(session)
 
 
+def _require_proposal_recovery_admin(user: User) -> None:
+    if bool(getattr(user, "is_superuser", False)):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "proposal_recovery_forbidden",
+            "message": "Only administrators can run proposal recovery actions.",
+        },
+    )
+
+
 def _build_task_preview(
     task_request: dict[str, object],
 ) -> TaskProposalTaskPreview | None:
@@ -674,8 +686,9 @@ async def redeliver_proposal(
     *,
     proposal_id: UUID,
     service: TaskProposalService = Depends(_get_service),
-    _user: User = Depends(get_current_user()),
+    user: User = Depends(get_current_user()),
 ) -> TaskProposalModel:
+    _require_proposal_recovery_admin(user)
     try:
         proposal = await service.redeliver_proposal(proposal_id=proposal_id)
     except TaskProposalValidationError as exc:
@@ -696,10 +709,16 @@ async def sync_proposal_delivery(
     *,
     proposal_id: UUID,
     service: TaskProposalService = Depends(_get_service),
-    _user: User = Depends(get_current_user()),
+    user: User = Depends(get_current_user()),
 ) -> TaskProposalModel:
+    _require_proposal_recovery_admin(user)
     try:
         proposal = await service.sync_proposal_delivery(proposal_id=proposal_id)
+    except TaskProposalValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_request", "message": str(exc)},
+        ) from exc
     except TaskProposalError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1684,6 +1684,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/proposals/{proposal_id}/redeliver": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Redeliver Proposal */
+        post: operations["redeliver_proposal_api_proposals__proposal_id__redeliver_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/proposals/{proposal_id}/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Proposal Delivery */
+        post: operations["sync_proposal_delivery_api_proposals__proposal_id__sync_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/proposals/{proposal_id}/dismiss": {
         parameters: {
             query?: never;
@@ -11539,6 +11573,68 @@ export interface operations {
         };
     };
     inspect_proposal_delivery_api_proposals__proposal_id__delivery_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskProposalModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    redeliver_proposal_api_proposals__proposal_id__redeliver_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskProposalModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_proposal_delivery_api_proposals__proposal_id__sync_post: {
         parameters: {
             query?: never;
             header?: never;

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -37,6 +37,7 @@ from moonmind.workflows.task_proposals.repositories import (
 )
 from moonmind.workflows.tasks.task_contract import (
     CanonicalTaskPayload,
+    SUPPORTED_EXECUTION_RUNTIMES,
     TaskContractError,
 )
 
@@ -691,6 +692,67 @@ class TaskProposalService:
         proposal.provider_metadata = existing_metadata
         await self._repository.commit()
 
+    async def redeliver_proposal(self, *, proposal_id: UUID) -> TaskProposal:
+        """Retry provider delivery through the trusted delivery adapter."""
+
+        proposal = await self._repository.get_proposal_for_update(proposal_id)
+        if self._delivery_service is None:
+            raise TaskProposalValidationError(
+                "proposal delivery provider is not configured"
+            )
+        await self._deliver_proposal_if_configured(proposal)
+        await self._repository.refresh(proposal)
+        return proposal
+
+    async def sync_proposal_delivery(self, *, proposal_id: UUID) -> TaskProposal:
+        """Refresh delivery audit metadata without changing the executable payload."""
+
+        proposal = await self._repository.get_proposal_for_update(proposal_id)
+        provider_metadata = (
+            dict(getattr(proposal, "provider_metadata", {}))
+            if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
+            else {}
+        )
+        syncer = getattr(self._delivery_service, "sync", None)
+        now = datetime.now(UTC)
+        if callable(syncer):
+            try:
+                result = await syncer(request_from_proposal(proposal))
+            except Exception as exc:  # pragma: no cover - adapter-specific
+                provider_metadata["sync"] = self._scrub_json(
+                    {
+                        "status": "failed",
+                        "errorType": type(exc).__name__,
+                        "sanitizedReason": str(exc),
+                        "syncedAt": now.isoformat(),
+                    }
+                )
+            else:
+                metadata = result if isinstance(result, Mapping) else {}
+                provider_metadata["sync"] = self._scrub_json(
+                    {
+                        "status": "synced",
+                        "syncedAt": now.isoformat(),
+                        **dict(metadata),
+                    }
+                )
+        else:
+            provider_metadata["sync"] = self._scrub_json(
+                {
+                    "status": "inspected",
+                    "syncedAt": now.isoformat(),
+                    "note": (
+                        "trusted provider adapter does not expose a dedicated sync "
+                        "operation"
+                    ),
+                }
+            )
+        proposal.last_synced_at = now
+        proposal.provider_metadata = provider_metadata
+        await self._repository.commit()
+        await self._repository.refresh(proposal)
+        return proposal
+
     async def create_proposal(
         self,
         *,
@@ -1269,6 +1331,14 @@ class TaskProposalService:
             normalized_runtime_mode = self._normalize_proposal_runtime_mode(
                 runtime_mode_override
             )
+            if (
+                not isinstance(normalized_runtime_mode, str)
+                or normalized_runtime_mode not in SUPPORTED_EXECUTION_RUNTIMES
+            ):
+                supported = ", ".join(sorted(SUPPORTED_EXECUTION_RUNTIMES))
+                raise TaskProposalValidationError(
+                    f"runtimeMode must be one of: {supported}"
+                )
             task_node = payload.get("task")
             task = dict(task_node) if isinstance(task_node, Mapping) else {}
             runtime_node = task.get("runtime")

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -695,11 +695,13 @@ class TaskProposalService:
     async def redeliver_proposal(self, *, proposal_id: UUID) -> TaskProposal:
         """Retry provider delivery through the trusted delivery adapter."""
 
-        proposal = await self._repository.get_proposal_for_update(proposal_id)
         if self._delivery_service is None:
             raise TaskProposalValidationError(
                 "proposal delivery provider is not configured"
             )
+        proposal = await self._repository.get_proposal(proposal_id)
+        if proposal is None:
+            raise TaskProposalNotFoundError(str(proposal_id))
         await self._deliver_proposal_if_configured(proposal)
         await self._repository.refresh(proposal)
         return proposal
@@ -707,12 +709,14 @@ class TaskProposalService:
     async def sync_proposal_delivery(self, *, proposal_id: UUID) -> TaskProposal:
         """Refresh delivery audit metadata without changing the executable payload."""
 
-        proposal = await self._repository.get_proposal_for_update(proposal_id)
-        provider_metadata = (
-            dict(getattr(proposal, "provider_metadata", {}))
-            if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
-            else {}
-        )
+        if self._delivery_service is None:
+            raise TaskProposalValidationError(
+                "proposal delivery provider is not configured"
+            )
+        proposal = await self._repository.get_proposal(proposal_id)
+        if proposal is None:
+            raise TaskProposalNotFoundError(str(proposal_id))
+        provider_metadata = dict(proposal.provider_metadata)
         syncer = getattr(self._delivery_service, "sync", None)
         now = datetime.now(UTC)
         if callable(syncer):

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -687,3 +687,51 @@ def test_provider_decision_recovery_inspects_delivery_history(
     assert payload["providerMetadata"]["providerDecisions"][0]["promotedExecutionId"] == (
         "wf-abc-123"
     )
+
+
+def test_redeliver_proposal_endpoint_returns_recovery_record(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    proposal.provider = "github"
+    proposal.external_key = "42"
+    proposal.external_url = "https://github.example/Moon/Repo/issues/42"
+    proposal.provider_metadata = {
+        "delivery": {
+            "status": "delivered",
+            "storedSnapshotNotice": True,
+            "created": False,
+        }
+    }
+    service.redeliver_proposal.return_value = proposal
+
+    response = test_client.post(f"/api/proposals/{proposal.id}/redeliver")
+
+    assert response.status_code == 200
+    service.redeliver_proposal.assert_awaited_once_with(proposal_id=proposal.id)
+    assert response.json()["reviewDelivery"]["status"] == "delivered"
+
+
+def test_sync_proposal_delivery_endpoint_returns_recovery_record(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    proposal.provider = "jira"
+    proposal.external_key = "MM-901"
+    proposal.external_url = "https://jira.example/browse/MM-901"
+    proposal.last_synced_at = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+    proposal.provider_metadata = {
+        "delivery": {"status": "delivered", "storedSnapshotNotice": True},
+        "sync": {"status": "inspected"},
+    }
+    service.sync_proposal_delivery.return_value = proposal
+
+    response = test_client.post(f"/api/proposals/{proposal.id}/sync")
+
+    assert response.status_code == 200
+    service.sync_proposal_delivery.assert_awaited_once_with(proposal_id=proposal.id)
+    payload = response.json()
+    assert payload["reviewDelivery"]["lastSyncedAt"] == "2026-05-17T12:00:00Z"
+    assert payload["providerMetadata"]["sync"]["status"] == "inspected"

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -18,7 +18,10 @@ from moonmind.workflows.task_proposals.models import (
     TaskProposalReviewPriority,
     TaskProposalStatus,
 )
-from moonmind.workflows.task_proposals.service import TaskProposalStatusError
+from moonmind.workflows.task_proposals.service import (
+    TaskProposalStatusError,
+    TaskProposalValidationError,
+)
 
 @pytest.fixture
 def client() -> tuple[TestClient, AsyncMock, AsyncMock]:
@@ -37,7 +40,12 @@ def client() -> tuple[TestClient, AsyncMock, AsyncMock]:
     app.dependency_overrides[_get_service] = _service_override
     app.dependency_overrides[_get_temporal_execution_service] = _execution_service_override
 
-    mock_user = SimpleNamespace(id=uuid4(), email="user@example.com", is_active=True)
+    mock_user = SimpleNamespace(
+        id=uuid4(),
+        email="user@example.com",
+        is_active=True,
+        is_superuser=True,
+    )
 
     async def _user_override():
         return mock_user
@@ -713,6 +721,28 @@ def test_redeliver_proposal_endpoint_returns_recovery_record(
     assert response.json()["reviewDelivery"]["status"] == "delivered"
 
 
+def test_redeliver_proposal_endpoint_requires_admin(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+
+    async def _user_override():
+        return SimpleNamespace(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_superuser=False,
+        )
+
+    test_client.app.dependency_overrides[get_current_user()] = _user_override
+
+    response = test_client.post(f"/api/proposals/{proposal.id}/redeliver")
+
+    assert response.status_code == 403
+    service.redeliver_proposal.assert_not_awaited()
+
+
 def test_sync_proposal_delivery_endpoint_returns_recovery_record(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
@@ -735,3 +765,40 @@ def test_sync_proposal_delivery_endpoint_returns_recovery_record(
     payload = response.json()
     assert payload["reviewDelivery"]["lastSyncedAt"] == "2026-05-17T12:00:00Z"
     assert payload["providerMetadata"]["sync"]["status"] == "inspected"
+
+
+def test_sync_proposal_delivery_endpoint_requires_admin(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+
+    async def _user_override():
+        return SimpleNamespace(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_superuser=False,
+        )
+
+    test_client.app.dependency_overrides[get_current_user()] = _user_override
+
+    response = test_client.post(f"/api/proposals/{proposal.id}/sync")
+
+    assert response.status_code == 403
+    service.sync_proposal_delivery.assert_not_awaited()
+
+
+def test_sync_proposal_delivery_endpoint_returns_validation_errors(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    service.sync_proposal_delivery.side_effect = TaskProposalValidationError(
+        "proposal delivery provider is not configured"
+    )
+
+    response = test_client.post(f"/api/proposals/{proposal.id}/sync")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_request"

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -1178,7 +1178,7 @@ async def test_redeliver_proposal_reuses_trusted_delivery_adapter() -> None:
         delivered_at=None,
         last_synced_at=None,
     )
-    repo.get_proposal_for_update.return_value = record
+    repo.get_proposal.return_value = record
     delivery = _FakeDeliveryService()
     service = TaskProposalService(
         repo,
@@ -1191,6 +1191,7 @@ async def test_redeliver_proposal_reuses_trusted_delivery_adapter() -> None:
     assert updated is record
     assert delivery.requests[0].record_id == str(record.id)
     assert record.provider_metadata["delivery"]["status"] == "delivered"
+    repo.get_proposal_for_update.assert_not_called()
     repo.refresh.assert_awaited_with(record)
 
 
@@ -1218,7 +1219,7 @@ async def test_sync_proposal_delivery_records_recovery_audit_without_adapter_syn
         delivered_at=None,
         last_synced_at=None,
     )
-    repo.get_proposal_for_update.return_value = record
+    repo.get_proposal.return_value = record
     service = TaskProposalService(
         repo,
         redactor=SecretRedactor([], "***"),
@@ -1230,7 +1231,30 @@ async def test_sync_proposal_delivery_records_recovery_audit_without_adapter_syn
     assert updated is record
     assert record.provider_metadata["sync"]["status"] == "inspected"
     assert record.last_synced_at is not None
+    repo.get_proposal_for_update.assert_not_called()
     repo.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_redeliver_proposal_requires_configured_delivery_service() -> None:
+    repo = AsyncMock()
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    with pytest.raises(TaskProposalValidationError):
+        await service.redeliver_proposal(proposal_id=uuid4())
+
+    repo.get_proposal.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_proposal_delivery_requires_configured_delivery_service() -> None:
+    repo = AsyncMock()
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    with pytest.raises(TaskProposalValidationError):
+        await service.sync_proposal_delivery(proposal_id=uuid4())
+
+    repo.get_proposal.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -526,6 +526,40 @@ async def test_promote_proposal_applies_runtime_override() -> None:
 
 
 @pytest.mark.asyncio
+async def test_promote_proposal_rejects_unsupported_runtime_before_commit() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Refactor logic",
+                    "runtime": {"mode": "gemini_cli"},
+                },
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    with pytest.raises(TaskProposalValidationError, match="runtimeMode must be one of"):
+        await service.promote_proposal(
+            proposal_id=proposal.id,
+            promoted_by_user_id=uuid4(),
+            runtime_mode_override="codex_cloud",
+        )
+
+    repo.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_promote_proposal_preserves_preset_provenance() -> None:
     repo = AsyncMock()
     proposal = SimpleNamespace(
@@ -1118,6 +1152,85 @@ async def test_create_proposal_invokes_delivery_and_persists_external_issue() ->
     assert proposal.provider_metadata["delivery"]["marker"] == "moonmind-proposal"
     assert delivery.requests[0].task_snapshot_ref == "artifact://snapshot"
     assert repo.commit.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_redeliver_proposal_reuses_trusted_delivery_adapter() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        provider="github",
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        repository="Moon/Repo",
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        origin_metadata={},
+        provider_metadata={"delivery": {"status": "failed"}},
+        resolved_policy={},
+        task_snapshot_ref="artifact://snapshot",
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+        delivered_at=None,
+        last_synced_at=None,
+    )
+    repo.get_proposal_for_update.return_value = record
+    delivery = _FakeDeliveryService()
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=delivery,
+    )
+
+    updated = await service.redeliver_proposal(proposal_id=record.id)
+
+    assert updated is record
+    assert delivery.requests[0].record_id == str(record.id)
+    assert record.provider_metadata["delivery"]["status"] == "delivered"
+    repo.refresh.assert_awaited_with(record)
+
+
+@pytest.mark.asyncio
+async def test_sync_proposal_delivery_records_recovery_audit_without_adapter_sync() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        provider="jira",
+        external_key="MM-42",
+        external_url="https://jira.example/browse/MM-42",
+        repository="MM",
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        dedup_key="mm:add-tests",
+        dedup_hash="hash",
+        review_priority=TaskProposalReviewPriority.NORMAL,
+        origin_metadata={},
+        provider_metadata={"delivery": {"status": "delivered"}},
+        resolved_policy={},
+        task_snapshot_ref="artifact://snapshot",
+        task_create_request={"payload": {"repository": "Moon/Repo"}},
+        delivered_at=None,
+        last_synced_at=None,
+    )
+    repo.get_proposal_for_update.return_value = record
+    service = TaskProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=object(),
+    )
+
+    updated = await service.sync_proposal_delivery(proposal_id=record.id)
+
+    assert updated is record
+    assert record.provider_metadata["sync"]["status"] == "inspected"
+    assert record.last_synced_at is not None
+    repo.commit.assert_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds safe tracker proposal decision handling for Jira issue MM-703.
- Validates provider decision authenticity, actor policy, idempotency, bounded promotion controls, and stored-snapshot promotion.
- Adds admin recovery endpoints for proposal delivery inspection, redelivery, and sync.

## Jira
- Jira issue key: MM-703

## MoonSpec
- Active feature path: `specs/313-process-tracker-decisions`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- `pytest tests/integration/temporal/test_proposal_review_delivery.py -q` — PASS, 5 passed
- `./tools/test_unit.sh` — PASS, Python 5100 passed, 6 skipped, 1 xpassed, 16 subtests passed; frontend 21 files passed, 364 passed, 232 skipped

## Remaining risks
- None known.
