### PR TITLE
Run Jira Orchestrate for MM-704: Expose proposal delivery status and diagnostics without creating a proposal queue page

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2081,6 +2081,10 @@ def _proposal_outcomes_from_summary(
         if not isinstance(item, Mapping):
             continue
         merge_outcome(item, default_status="updated")
+    for item in proposal_summary.get("deliveryFailures") or []:
+        if not isinstance(item, Mapping):
+            continue
+        merge_outcome(item, default_status="failed")
     return outcomes
 
 

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -409,6 +409,112 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('renders compact proposal delivery diagnostics from execution detail outcomes', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Proposal detail task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'proposals',
+      rawState: 'proposals',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+      proposalSummary: {
+        requested: true,
+        generatedCount: 3,
+        submittedCount: 3,
+        deliveredCount: 1,
+        externalLinks: [],
+        dedupUpdates: [
+          {
+            provider: 'github',
+            externalKey: '42',
+            created: false,
+            duplicateSource: 'existing-open-issue',
+          },
+        ],
+        validationErrors: [
+          { code: 'proposal_validation_error', message: 'proposal skipped: [REDACTED]' },
+        ],
+        deliveryFailures: [
+          { provider: 'jira', code: 'delivery_failed', message: 'delivery failed: [REDACTED]' },
+        ],
+      },
+      proposalOutcomes: [
+        {
+          provider: 'jira',
+          externalKey: 'MM-901',
+          externalUrl: 'https://jira.example/browse/MM-901',
+          deliveryStatus: 'delivered',
+          deliveredAt: '2026-04-09T00:01:00Z',
+          lastSyncedAt: '2026-04-09T00:02:00Z',
+          taskPreview: {
+            repository: 'MoonLadderStudios/MoonMind',
+            runtimeMode: 'codex_cli',
+            publishMode: 'pr',
+            priority: 4,
+            maxAttempts: 2,
+            taskSkills: ['fix-ci'],
+            presetProvenance: 'jira-preset',
+          },
+          promotionResult: {
+            promotedExecutionId: 'mm-promoted-1',
+            promotedExecutionUrl: '/tasks/temporal/mm-promoted-1',
+          },
+        },
+        {
+          provider: 'github',
+          externalKey: '42',
+          deliveryStatus: 'updated',
+          created: false,
+          duplicateSource: 'existing-open-issue',
+        },
+        {
+          provider: 'jira',
+          externalKey: 'MM-902',
+          deliveryStatus: 'failed',
+          message: 'delivery failed: [REDACTED]',
+        },
+      ],
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      const summaryCard = (label: string) => screen.getByText((_, element) => element?.textContent === `${label}:`).closest('.card');
+      expect(screen.getByRole('heading', { name: 'Proposal Outcomes' })).toBeTruthy();
+      expect(summaryCard('Delivered')?.textContent).toContain('1');
+      expect(summaryCard('Updated')?.textContent).toContain('1');
+      expect(summaryCard('Failed')?.textContent).toContain('2');
+      expect(screen.getByText('jira: MM-901')).toBeTruthy();
+      expect(screen.getAllByText('Delivery Status').length).toBeGreaterThan(0);
+      expect(screen.getByText('delivered')).toBeTruthy();
+      expect(screen.getByText('MoonLadderStudios/MoonMind')).toBeTruthy();
+      expect(screen.getByText('Codex CLI')).toBeTruthy();
+      expect(screen.getByText('fix-ci')).toBeTruthy();
+      expect(screen.getByText('jira-preset')).toBeTruthy();
+      expect(screen.getByText('existing-open-issue')).toBeTruthy();
+      expect(screen.getByText('mm-promoted-1')).toBeTruthy();
+      expect(screen.getAllByText('delivery failed: [REDACTED]').length).toBeGreaterThan(0);
+      expect(screen.queryByText(/ghp_secret/i)).toBeNull();
+    });
+  });
+
   it('does not poll terminal task detail surfaces after the initial load', async () => {
     const terminalExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1130,11 +1130,11 @@ function ProposalDeliveryCard({ outcome, index }: { outcome: Record<string, unkn
   const deliveredAt = proposalFieldText(outcome, 'deliveredAt', 'delivered_at');
   const lastSyncedAt = proposalFieldText(outcome, 'lastSyncedAt', 'last_synced_at');
   const duplicateSource = proposalFieldText(outcome, 'duplicateSource', 'duplicate_source');
-  const created = outcome.created;
+  const created = outcome['created'];
   const errorText = proposalErrorText(outcome);
   const taskPreview = proposalNestedRecord(outcome, 'taskPreview', 'task_preview');
   const promotionResult = proposalNestedRecord(outcome, 'promotionResult', 'promotion_result');
-  const taskSkills = proposalStringList(taskPreview.taskSkills ?? taskPreview.task_skills);
+  const taskSkills = proposalStringList(taskPreview['taskSkills'] ?? taskPreview['task_skills']);
   const promotedExecutionId = proposalFieldText(promotionResult, 'promotedExecutionId', 'promoted_execution_id');
   const promotedExecutionUrl = proposalFieldText(promotionResult, 'promotedExecutionUrl', 'promoted_execution_url');
 
@@ -4789,8 +4789,10 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                 <Card label="Generated">{String(proposalSummary.generatedCount ?? 0)}</Card>
                 <Card label="Submitted">{String(proposalSummary.submittedCount ?? 0)}</Card>
                 <Card label="Delivered">{String(proposalSummary.deliveredCount ?? 0)}</Card>
-                <Card label="Updated">{String(proposalSummary.dedupUpdates.length)}</Card>
-                <Card label="Failed">{String(proposalSummary.validationErrors.length + proposalSummary.deliveryFailures.length)}</Card>
+                <Card label="Updated">{String(proposalSummary.dedupUpdates?.length ?? 0)}</Card>
+                <Card label="Failed">
+                  {String((proposalSummary.validationErrors?.length ?? 0) + (proposalSummary.deliveryFailures?.length ?? 0))}
+                </Card>
               </div>
               {proposalSummary.externalLinks.length > 0 ? (
                 <div className="stack">
@@ -4811,38 +4813,38 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   })}
                 </div>
               ) : null}
-              {proposalOutcomes.length > 0 ? (
+              {(proposalOutcomes?.length ?? 0) > 0 ? (
                 <div className="stack">
                   <strong>Delivery Status</strong>
-                  {proposalOutcomes.map((item, index) => (
+                  {proposalOutcomes?.map((item, index) => (
                     <ProposalDeliveryCard
-                      key={`${String(item.provider || 'tracker')}-${String(item.externalKey || item.externalUrl || index)}`}
+                      key={`${String(item['provider'] || 'tracker')}-${String(item['externalKey'] || item['externalUrl'] || index)}`}
                       outcome={item}
                       index={index}
                     />
                   ))}
                 </div>
               ) : null}
-              {proposalSummary.dedupUpdates.length > 0 ? (
-                <p className="small">{proposalSummary.dedupUpdates.length} dedup update(s)</p>
+              {(proposalSummary.dedupUpdates?.length ?? 0) > 0 ? (
+                <p className="small">{proposalSummary.dedupUpdates?.length ?? 0} dedup update(s)</p>
               ) : null}
-              {proposalSummary.validationErrors.length > 0 ? (
+              {(proposalSummary.validationErrors?.length ?? 0) > 0 ? (
                 <div className="stack">
                   <strong>Validation Errors</strong>
-                  {proposalSummary.validationErrors.map((item, index) => {
+                  {proposalSummary.validationErrors?.map((item, index) => {
                     const message = proposalErrorText(item);
                     return (
                       <p key={`validation-error-${index}`} className="small whitespace-pre-wrap">
-                        {message || `${proposalSummary.validationErrors.length} validation error(s)`}
+                        {message || `${proposalSummary.validationErrors?.length ?? 0} validation error(s)`}
                       </p>
                     );
                   })}
                 </div>
               ) : null}
-              {proposalSummary.deliveryFailures.length > 0 ? (
+              {(proposalSummary.deliveryFailures?.length ?? 0) > 0 ? (
                 <div className="stack">
                   <strong>Delivery Failures</strong>
-                  {proposalSummary.deliveryFailures.map((item, index) => {
+                  {proposalSummary.deliveryFailures?.map((item, index) => {
                     const provider = proposalFieldText(item, 'provider') || 'tracker';
                     const message = proposalErrorText(item);
                     return (
@@ -4853,8 +4855,8 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   })}
                 </div>
               ) : null}
-              {proposalOutcomes.length > 0 && !runSummary?.proposals ? (
-                <p className="small">{proposalOutcomes.length} proposal outcome(s) available from execution detail.</p>
+              {(proposalOutcomes?.length ?? 0) > 0 && !runSummary?.proposals ? (
+                <p className="small">{proposalOutcomes?.length ?? 0} proposal outcome(s) available from execution detail.</p>
               ) : null}
             </section>
           ) : null}

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1091,6 +1091,110 @@ function formatWhen(iso: string | null | undefined): string {
   return date.toLocaleString();
 }
 
+function proposalFieldText(row: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = row[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  }
+  return '';
+}
+
+function proposalNestedRecord(row: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
+  for (const key of keys) {
+    const value = row[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  }
+  return {};
+}
+
+function proposalStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item || '').trim()).filter(Boolean);
+}
+
+function proposalErrorText(row: Record<string, unknown>): string {
+  const direct = proposalFieldText(row, 'message', 'sanitizedReason', 'reason');
+  if (direct) return direct;
+  const error = proposalNestedRecord(row, 'error');
+  return proposalFieldText(error, 'message', 'sanitizedReason', 'reason');
+}
+
+function ProposalDeliveryCard({ outcome, index }: { outcome: Record<string, unknown>; index: number }) {
+  const provider = proposalFieldText(outcome, 'provider') || 'tracker';
+  const externalKey = proposalFieldText(outcome, 'externalKey', 'external_key') || `Proposal ${index + 1}`;
+  const externalUrl = proposalFieldText(outcome, 'externalUrl', 'external_url');
+  const deliveryStatus = proposalFieldText(outcome, 'deliveryStatus', 'status') || 'available';
+  const deliveredAt = proposalFieldText(outcome, 'deliveredAt', 'delivered_at');
+  const lastSyncedAt = proposalFieldText(outcome, 'lastSyncedAt', 'last_synced_at');
+  const duplicateSource = proposalFieldText(outcome, 'duplicateSource', 'duplicate_source');
+  const created = outcome.created;
+  const errorText = proposalErrorText(outcome);
+  const taskPreview = proposalNestedRecord(outcome, 'taskPreview', 'task_preview');
+  const promotionResult = proposalNestedRecord(outcome, 'promotionResult', 'promotion_result');
+  const taskSkills = proposalStringList(taskPreview.taskSkills ?? taskPreview.task_skills);
+  const promotedExecutionId = proposalFieldText(promotionResult, 'promotedExecutionId', 'promoted_execution_id');
+  const promotedExecutionUrl = proposalFieldText(promotionResult, 'promotedExecutionUrl', 'promoted_execution_url');
+
+  return (
+    <div className="card">
+      <strong>
+        {externalUrl ? (
+          <a href={externalUrl} target="_blank" rel="noreferrer">
+            {provider}: {externalKey}
+          </a>
+        ) : (
+          `${provider}: ${externalKey}`
+        )}
+      </strong>
+      <div className="td-facts-grid" style={{ marginTop: '0.5rem' }}>
+        <Fact label="Delivery Status">{formatStatusLabel(deliveryStatus)}</Fact>
+        {deliveredAt ? <Fact label="Delivered">{formatWhen(deliveredAt)}</Fact> : null}
+        {lastSyncedAt ? <Fact label="Last Sync">{formatWhen(lastSyncedAt)}</Fact> : null}
+        {created === false ? <Fact label="Dedup">Updated existing issue</Fact> : null}
+        {created === true ? <Fact label="Dedup">Created new issue</Fact> : null}
+        {duplicateSource ? <Fact label="Dedup Source">{duplicateSource}</Fact> : null}
+        {proposalFieldText(taskPreview, 'repository') ? (
+          <Fact label="Repository">
+            <code className="text-xs break-all">{proposalFieldText(taskPreview, 'repository')}</code>
+          </Fact>
+        ) : null}
+        {proposalFieldText(taskPreview, 'runtimeMode', 'runtime_mode') ? (
+          <Fact label="Runtime">{formatRuntimeLabel(proposalFieldText(taskPreview, 'runtimeMode', 'runtime_mode'))}</Fact>
+        ) : null}
+        {proposalFieldText(taskPreview, 'publishMode', 'publish_mode') ? (
+          <Fact label="Publish Mode">{proposalFieldText(taskPreview, 'publishMode', 'publish_mode')}</Fact>
+        ) : null}
+        {proposalFieldText(taskPreview, 'priority') ? (
+          <Fact label="Priority">{proposalFieldText(taskPreview, 'priority')}</Fact>
+        ) : null}
+        {proposalFieldText(taskPreview, 'maxAttempts', 'max_attempts') ? (
+          <Fact label="Max Attempts">{proposalFieldText(taskPreview, 'maxAttempts', 'max_attempts')}</Fact>
+        ) : null}
+        {taskSkills.length > 0 ? <Fact label="Skills">{taskSkills.join(', ')}</Fact> : null}
+        {proposalFieldText(taskPreview, 'skillId', 'skill_id') ? (
+          <Fact label="Skill">{proposalFieldText(taskPreview, 'skillId', 'skill_id')}</Fact>
+        ) : null}
+        {proposalFieldText(taskPreview, 'presetProvenance', 'preset_provenance') ? (
+          <Fact label="Preset">{proposalFieldText(taskPreview, 'presetProvenance', 'preset_provenance')}</Fact>
+        ) : null}
+        {promotedExecutionId ? (
+          <Fact label="Promoted Run">
+            {promotedExecutionUrl ? (
+              <a href={promotedExecutionUrl}>{promotedExecutionId}</a>
+            ) : (
+              <code className="text-xs break-all">{promotedExecutionId}</code>
+            )}
+          </Fact>
+        ) : null}
+      </div>
+      {errorText ? <p className="small whitespace-pre-wrap">{errorText}</p> : null}
+    </div>
+  );
+}
+
 function Card({
   label,
   children,
@@ -4685,6 +4789,8 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                 <Card label="Generated">{String(proposalSummary.generatedCount ?? 0)}</Card>
                 <Card label="Submitted">{String(proposalSummary.submittedCount ?? 0)}</Card>
                 <Card label="Delivered">{String(proposalSummary.deliveredCount ?? 0)}</Card>
+                <Card label="Updated">{String(proposalSummary.dedupUpdates.length)}</Card>
+                <Card label="Failed">{String(proposalSummary.validationErrors.length + proposalSummary.deliveryFailures.length)}</Card>
               </div>
               {proposalSummary.externalLinks.length > 0 ? (
                 <div className="stack">
@@ -4700,19 +4806,52 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                     ) : (
                       <span key={`${provider}-${externalKey}-${index}`} className="small">
                         {provider}: {externalKey}
-                      </span>
+                  </span>
                     );
                   })}
+                </div>
+              ) : null}
+              {proposalOutcomes.length > 0 ? (
+                <div className="stack">
+                  <strong>Delivery Status</strong>
+                  {proposalOutcomes.map((item, index) => (
+                    <ProposalDeliveryCard
+                      key={`${String(item.provider || 'tracker')}-${String(item.externalKey || item.externalUrl || index)}`}
+                      outcome={item}
+                      index={index}
+                    />
+                  ))}
                 </div>
               ) : null}
               {proposalSummary.dedupUpdates.length > 0 ? (
                 <p className="small">{proposalSummary.dedupUpdates.length} dedup update(s)</p>
               ) : null}
               {proposalSummary.validationErrors.length > 0 ? (
-                <p className="small">{proposalSummary.validationErrors.length} validation error(s)</p>
+                <div className="stack">
+                  <strong>Validation Errors</strong>
+                  {proposalSummary.validationErrors.map((item, index) => {
+                    const message = proposalErrorText(item);
+                    return (
+                      <p key={`validation-error-${index}`} className="small whitespace-pre-wrap">
+                        {message || `${proposalSummary.validationErrors.length} validation error(s)`}
+                      </p>
+                    );
+                  })}
+                </div>
               ) : null}
               {proposalSummary.deliveryFailures.length > 0 ? (
-                <p className="small">{proposalSummary.deliveryFailures.length} delivery failure(s)</p>
+                <div className="stack">
+                  <strong>Delivery Failures</strong>
+                  {proposalSummary.deliveryFailures.map((item, index) => {
+                    const provider = proposalFieldText(item, 'provider') || 'tracker';
+                    const message = proposalErrorText(item);
+                    return (
+                      <p key={`delivery-failure-${index}`} className="small whitespace-pre-wrap">
+                        {provider}: {message || 'delivery failed'}
+                      </p>
+                    );
+                  })}
+                </div>
               ) : null}
               {proposalOutcomes.length > 0 && !runSummary?.proposals ? (
                 <p className="small">{proposalOutcomes.length} proposal outcome(s) available from execution detail.</p>

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -51,6 +51,7 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('failed')).toEqual({ className: 'status status-failed' });
     expect(executionStatusPillProps('executing').className).toBe('status status-running is-executing');
     expect(executionStatusPillProps('planning').className).toBe('status status-running is-planning');
+    expect(executionStatusPillProps('proposals')).toEqual({ className: 'status status-running' });
 
     expect(executionStatusPillProps('waiting_on_dependencies')).toEqual({
       className: 'status status-waiting',
@@ -79,5 +80,6 @@ describe('executionStatusPillProps', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-489');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-704');
   });
 });

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -2,7 +2,7 @@ import { formatStatusLabel } from './formatters';
 
 export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   jiraIssue: 'MM-488',
-  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491'],
+  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491', 'MM-704'],
   designRequirements: [
     'DESIGN-REQ-001',
     'DESIGN-REQ-002',
@@ -39,6 +39,7 @@ function executionStatusBaseClasses(key: string): string {
   if (
     key === 'running' ||
     key === 'executing' ||
+    key === 'proposals' ||
     key === 'planning' ||
     key === 'initializing' ||
     key === 'finalizing'

--- a/tests/integration/test_proposal_delivery_status_execution_detail.py
+++ b/tests/integration/test_proposal_delivery_status_execution_detail.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from api_service.api.routers.executions import _serialize_execution
+from api_service.db.models import MoonMindWorkflowState, TemporalWorkflowType
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _proposal_execution_record() -> SimpleNamespace:
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+    return SimpleNamespace(
+        namespace="moonmind",
+        workflow_id="mm:proposal-contract",
+        run_id="run-proposal-contract",
+        workflow_type=TemporalWorkflowType.RUN,
+        state=MoonMindWorkflowState.PROPOSALS,
+        close_status=None,
+        search_attributes={
+            "mm_owner_id": "user-1",
+            "mm_owner_type": "user",
+            "mm_entry": "run",
+            "mm_repo": "MoonLadderStudios/MoonMind",
+        },
+        memo={
+            "title": "Proposal diagnostics",
+            "summary": "Proposal delivery is in progress.",
+            "proposals": {
+                "requested": True,
+                "generatedCount": 3,
+                "submittedCount": 3,
+                "deliveredCount": 1,
+                "validationErrors": [
+                    {
+                        "code": "proposal_validation_error",
+                        "message": "proposal skipped: [REDACTED]",
+                    }
+                ],
+                "deliveryFailures": [
+                    {
+                        "provider": "jira",
+                        "externalKey": "MM-902",
+                        "code": "delivery_failed",
+                        "message": "delivery failed: [REDACTED]",
+                    }
+                ],
+                "externalLinks": [
+                    {
+                        "provider": "jira",
+                        "externalKey": "MM-901",
+                        "externalUrl": "https://jira.example/browse/MM-901",
+                    }
+                ],
+                "dedupUpdates": [
+                    {
+                        "provider": "github",
+                        "externalKey": "42",
+                        "created": False,
+                        "duplicateSource": "existing-open-issue",
+                    }
+                ],
+            },
+        },
+        artifact_refs=[],
+        manifest_ref=None,
+        plan_ref=None,
+        parameters={},
+        paused=False,
+        waiting_reason=None,
+        attention_required=False,
+        created_at=now,
+        started_at=now,
+        updated_at=now,
+        closed_at=None,
+        owner_id="user-1",
+        owner_type="user",
+        entry="run",
+        integration_state=None,
+    )
+
+
+def test_execution_detail_contract_exposes_proposal_delivery_diagnostics() -> None:
+    payload = _serialize_execution(_proposal_execution_record()).model_dump(
+        by_alias=True
+    )
+
+    assert payload["state"] == "proposals"
+    assert payload["rawState"] == "proposals"
+    assert payload["dashboardStatus"] == "running"
+    assert payload["proposalSummary"]["generatedCount"] == 3
+    assert payload["proposalSummary"]["deliveryFailures"][0]["externalKey"] == "MM-902"
+
+    outcomes = {
+        item.get("externalKey"): item for item in payload["proposalOutcomes"]
+    }
+    assert outcomes["MM-901"]["provider"] == "jira"
+    assert outcomes["MM-901"]["deliveryStatus"] == "delivered"
+    assert outcomes["42"]["deliveryStatus"] == "updated"
+    assert outcomes["42"]["created"] is False
+    assert outcomes["MM-902"]["deliveryStatus"] == "failed"
+    assert outcomes["MM-902"]["message"] == "delivery failed: [REDACTED]"
+    assert "ghp_secret" not in repr(payload)

--- a/tests/integration/test_proposal_delivery_status_surfaces.py
+++ b/tests/integration/test_proposal_delivery_status_surfaces.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.test_proposal_delivery_status_execution_detail import (
+    _proposal_execution_record,
+)
+
+from api_service.api.routers.executions import _serialize_execution
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def test_execution_detail_payload_keeps_proposal_review_off_primary_queue() -> None:
+    record = _proposal_execution_record()
+    record.memo["proposals"]["externalLinks"].append(
+        {
+            "provider": "github",
+            "externalKey": "99",
+            "externalUrl": "https://github.example/Moon/Mind/issues/99",
+            "promotionResult": {
+                "promotedExecutionId": "mm-promoted-1",
+                "promotedExecutionUrl": "/tasks/temporal/mm-promoted-1",
+            },
+        }
+    )
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+    serialized = repr(payload).lower()
+
+    assert payload["detailHref"] == "/tasks/mm:proposal-contract"
+    assert "/tasks/proposals" not in serialized
+    assert "/api/proposals" not in serialized
+    assert "/promote" not in serialized
+    assert "/dismiss" not in serialized
+    assert any(
+        item.get("externalUrl") == "https://github.example/Moon/Mind/issues/99"
+        for item in payload["proposalOutcomes"]
+    )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3011,6 +3011,31 @@ def test_serialize_execution_deduplicates_proposal_outcomes_by_external_key() ->
         }
     ]
 
+def test_serialize_execution_includes_failed_proposal_outcomes() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+    record.memo["proposals"] = {
+        "deliveryFailures": [
+            {
+                "provider": "jira",
+                "externalKey": "MM-902",
+                "code": "delivery_failed",
+                "message": "delivery failed: [REDACTED]",
+            }
+        ],
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["proposalOutcomes"] == [
+        {
+            "provider": "jira",
+            "externalKey": "MM-902",
+            "code": "delivery_failed",
+            "message": "delivery failed: [REDACTED]",
+            "deliveryStatus": "failed",
+        }
+    ]
+
 
 def test_serialize_execution_exposes_snake_case_publish_merge_automation() -> None:
     record = _build_execution_record()


### PR DESCRIPTION
Run Jira Orchestrate for MM-704.

Source story: STORY-005.
Source summary: Expose proposal delivery status and diagnostics without creating a proposal queue page.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.