### PR TITLE
[codex] Fix managed session epoch reset observability

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -970,15 +970,19 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         )
         await self._attach_runtime_handles(
             {
+                "sessionEpoch": handle.session_state.session_epoch,
                 "containerId": handle.session_state.container_id,
                 "threadId": handle.session_state.thread_id,
+                "activeTurnId": handle.session_state.active_turn_id,
             }
         )
         await self._signal_control_action(
             action="clear_session",
             reason=reason,
+            session_epoch=handle.session_state.session_epoch,
             container_id=handle.session_state.container_id,
             thread_id=handle.session_state.thread_id,
+            active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
 
@@ -1335,6 +1339,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         *,
         action: str,
         reason: str | None,
+        session_epoch: int | None = None,
         container_id: str | None,
         thread_id: str | None,
         active_turn_id: str | None = None,
@@ -1342,6 +1347,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         payload: dict[str, Any] = {"action": action}
         if reason is not None:
             payload["reason"] = reason
+        if session_epoch is not None:
+            payload["sessionEpoch"] = session_epoch
         if container_id is not None:
             payload["containerId"] = container_id
         if thread_id is not None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -279,6 +279,36 @@ class MoonMindRunWorkflow:
             )
             return logging.LoggerAdapter(logging.getLogger(__name__), extra=extra)
 
+    @staticmethod
+    def _operator_failure_summary(exc: BaseException) -> str:
+        """Return the most actionable bounded message from a nested failure chain."""
+
+        generic_messages = {
+            "Activity task failed",
+            "Child Workflow execution failed",
+            "Workflow execution failed",
+            "activity failed",
+        }
+        messages: list[str] = []
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            message = str(current).strip()
+            if message:
+                messages.append(message)
+            next_exc = getattr(current, "cause", None)
+            if not isinstance(next_exc, BaseException):
+                next_exc = current.__cause__
+            current = next_exc
+
+        for message in reversed(messages):
+            if message and message not in generic_messages:
+                return message[:1000]
+        if messages:
+            return messages[-1][:1000]
+        return exc.__class__.__name__
+
     def __init__(self) -> None:
         self._state = STATE_INITIALIZING
         self._owner_type: Optional[str] = None
@@ -2428,15 +2458,16 @@ class MoonMindRunWorkflow:
                 non_retryable=True,
             ) from exc
         except Exception as exc:
+            failure_summary = self._operator_failure_summary(exc)
             await self._run_finalizing_stage(
-                parameters=parameters, status="failed", error=str(exc)
+                parameters=parameters, status="failed", error=failure_summary
             )
             self._close_status = CLOSE_STATUS_FAILED
-            self._set_state(STATE_FAILED, summary=str(exc))
+            self._set_state(STATE_FAILED, summary=failure_summary)
             await self._record_terminal_state(
                 state=STATE_FAILED,
                 close_status=CLOSE_STATUS_FAILED,
-                summary=str(exc),
+                summary=failure_summary,
                 error_category="execution_error",
             )
             raise

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -285,28 +285,34 @@ class MoonMindRunWorkflow:
 
         generic_messages = {
             "Activity task failed",
+            "Activity error",
             "Child Workflow execution failed",
+            "Child workflow execution failed",
             "Workflow execution failed",
             "activity failed",
         }
-        messages: list[str] = []
-        seen: set[int] = set()
+        generic_types = (
+            exceptions.ActivityError,
+            exceptions.ChildWorkflowError,
+        )
+        chain: list[tuple[BaseException, str]] = []
         current: BaseException | None = exc
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
+        for _ in range(20):
+            if current is None:
+                break
             message = str(current).strip()
             if message:
-                messages.append(message)
+                chain.append((current, message))
             next_exc = getattr(current, "cause", None)
             if not isinstance(next_exc, BaseException):
                 next_exc = current.__cause__
             current = next_exc
 
-        for message in reversed(messages):
-            if message and message not in generic_messages:
+        for exc_obj, message in reversed(chain):
+            if message not in generic_messages and not isinstance(exc_obj, generic_types):
                 return message[:1000]
-        if messages:
-            return messages[-1][:1000]
+        if chain:
+            return chain[-1][1][:1000]
         return exc.__class__.__name__
 
     def __init__(self) -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1445,6 +1445,7 @@ async def test_start_resets_session_once_after_empty_assistant_activity_failure(
     workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
     send_turn_calls: list[Any] = []
     clear_calls: list[Any] = []
+    attach_calls: list[dict[str, Any]] = []
     control_calls: list[dict[str, Any]] = []
     run_store = ManagedRunStore(tmp_path / "managed_runs")
     reset_thread_id = "thread-1:empty-output-reset"
@@ -1523,6 +1524,9 @@ async def test_start_resets_session_once_after_empty_assistant_activity_failure(
     async def _apply_control_action(payload: dict[str, Any]) -> None:
         control_calls.append(payload)
 
+    async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+        attach_calls.append(payload)
+
     adapter = CodexSessionAdapter(
         profile_fetcher=_fake_profiles(
             [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
@@ -1543,7 +1547,7 @@ async def test_start_resets_session_once_after_empty_assistant_activity_failure(
         terminate_remote_session=_async_noop,
         fetch_remote_summary=_fetch_summary,
         publish_remote_artifacts=_publish_artifacts,
-        attach_runtime_handles=_async_noop,
+        attach_runtime_handles=_attach_runtime_handles,
         apply_session_control_action=_apply_control_action,
         workspace_root=str(tmp_path / "agent_jobs"),
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
@@ -1555,7 +1559,19 @@ async def test_start_resets_session_once_after_empty_assistant_activity_failure(
     assert len(send_turn_calls) == 2
     assert len(clear_calls) == 1
     assert send_turn_calls[1].thread_id == reset_thread_id
-    assert any(call["action"] == "clear_session" for call in control_calls)
+    assert {
+        "sessionEpoch": 2,
+        "containerId": "container-1",
+        "threadId": reset_thread_id,
+        "activeTurnId": None,
+    } in attach_calls
+    assert {
+        "action": "clear_session",
+        "reason": "retry_after_empty_assistant_output",
+        "sessionEpoch": 2,
+        "containerId": "container-1",
+        "threadId": reset_thread_id,
+    } in control_calls
     persisted_record = run_store.load(binding.task_run_id)
     result = await adapter.fetch_result(handle.run_id)
     assert persisted_record is not None
@@ -2893,15 +2909,27 @@ async def test_clear_session_rotates_epoch_and_signals_session_workflow(
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
     )
 
-    handle = await adapter.clear_session(binding=binding, new_thread_id="thread-2", reason="reset")
+    handle = await adapter.clear_session(
+        binding=binding,
+        new_thread_id="thread-2",
+        reason="reset",
+    )
 
     assert handle.session_state.session_epoch == 2
     assert handle.session_state.thread_id == "thread-2"
-    assert attach_calls == [{"containerId": "container-1", "threadId": "thread-2"}]
+    assert attach_calls == [
+        {
+            "sessionEpoch": 2,
+            "containerId": "container-1",
+            "threadId": "thread-2",
+            "activeTurnId": None,
+        }
+    ]
     assert control_calls == [
         {
             "action": "clear_session",
             "reason": "reset",
+            "sessionEpoch": 2,
             "containerId": "container-1",
             "threadId": "thread-2",
         }

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -19,6 +19,12 @@ from moonmind.workflows.temporal.workflows.run import (
     MoonMindRunWorkflow,
 )
 
+class _NestedFailure(Exception):
+    def __init__(self, message: str, cause: BaseException | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+
+
 async def fake_execute_activity(activity_name, *args, **kwargs):
     if activity_name == "artifact.read":
         import json
@@ -65,6 +71,22 @@ async def fake_execute_activity(activity_name, *args, **kwargs):
     elif activity_name == "artifact.create":
         return {"artifact_id": "art-123"}, {"url": "test"}
     return {}
+
+
+def test_operator_failure_summary_uses_deep_actionable_cause() -> None:
+    failure = _NestedFailure(
+        "Child Workflow execution failed",
+        _NestedFailure(
+            "Activity task failed",
+            RuntimeError("sessionEpoch does not match the active managed session"),
+        ),
+    )
+
+    assert (
+        MoonMindRunWorkflow._operator_failure_summary(failure)
+        == "sessionEpoch does not match the active managed session"
+    )
+
 
 @pytest.fixture
 def mock_run_environment(monkeypatch):

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -8,6 +8,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
+from temporalio.exceptions import ActivityError
 from temporalio.workflow import ActivityCancellationType
 from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_TASK_QUEUE
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
@@ -81,6 +82,28 @@ def test_operator_failure_summary_uses_deep_actionable_cause() -> None:
             RuntimeError("sessionEpoch does not match the active managed session"),
         ),
     )
+
+    assert (
+        MoonMindRunWorkflow._operator_failure_summary(failure)
+        == "sessionEpoch does not match the active managed session"
+    )
+
+
+def test_operator_failure_summary_skips_temporal_activity_wrapper() -> None:
+    cause = RuntimeError("sessionEpoch does not match the active managed session")
+    try:
+        raise cause
+    except RuntimeError as exc:
+        failure = ActivityError(
+            "Activity error",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="test-worker",
+            activity_type="agent_runtime.session_status",
+            activity_id="activity-1",
+            retry_state=None,
+        )
+        failure.__cause__ = exc
 
     assert (
         MoonMindRunWorkflow._operator_failure_summary(failure)


### PR DESCRIPTION
## Summary
- Carry the advanced `sessionEpoch` and active turn state when Codex session clears are signaled back to the AgentSession workflow.
- Unwrap nested Temporal failure chains so task summaries surface the deepest actionable cause instead of only `Child Workflow execution failed`.
- Tighten regression coverage for empty-assistant-output recovery and parent workflow failure summaries.

## Root Cause
A Codex child run could recover from empty assistant output by clearing the managed session, which advanced the container/store to a new session epoch. The adapter signaled the new container/thread handles back to AgentSession without the new epoch, so the next child loaded a stale locator and failed during `agent_runtime.session_status`.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py`
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3.12 -m py_compile moonmind/workflows/adapters/codex_session_adapter.py moonmind/workflows/temporal/workflows/run.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py`

## Notes
Full `./tools/test_unit.sh` was attempted, but this checkout's `.venv` is Python 3.11 while an existing unit test uses Python 3.12 f-string syntax, causing collection to stop at `tests/unit/services/temporal/runtime/test_managed_session_controller.py:2191` before exercising this patch.