### PR TITLE
MM-709 Wire broken-reference state and launch blocking for disabled SecretRefs

### DIFF
--- a/api_service/api/routers/secrets.py
+++ b/api_service/api/routers/secrets.py
@@ -16,7 +16,10 @@ from api_service.api.schemas import (
 )
 from api_service.db.models import SecretStatus
 from api_service.services.secrets import SecretsService
+from api_service.services.settings_catalog import settings_permissions_for_user
 from moonmind.utils.logging import redact_sensitive_payload
+
+_STATUS_CHANGE_PERMISSIONS = frozenset({"secrets.disable", "secrets.rotate"})
 
 logger = structlog.get_logger(__name__)
 
@@ -126,8 +129,23 @@ async def update_secret_status(
     db: AsyncSession = Depends(get_async_session),
     user: Any = Depends(get_current_user()),
 ) -> SecretMetadataResponse:
+    permissions = settings_permissions_for_user(user)
+    if not permissions & _STATUS_CHANGE_PERMISSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Missing required secrets.disable or secrets.rotate permission "
+                "to change managed secret status."
+            ),
+        )
     new_status = SecretStatus(request.status)
-    secret = await SecretsService.set_status(db, slug, new_status)
+    secret = await SecretsService.set_status(
+        db,
+        slug,
+        new_status,
+        actor_user_id=_uuid_attr(getattr(user, "id", None)),
+        workspace_id=_uuid_attr(getattr(user, "workspace_id", None)),
+    )
     if not secret:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Secret not found"

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -6,7 +6,12 @@ from uuid import UUID
 from sqlalchemy import and_, or_, select, Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_service.db.models import ManagedSecret, SecretStatus, SettingsOverride
+from api_service.db.models import (
+    ManagedSecret,
+    SecretStatus,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -81,9 +86,22 @@ class SecretsService:
 
     @classmethod
     async def set_status(
-        cls, db: AsyncSession, slug: str, status: SecretStatus
+        cls,
+        db: AsyncSession,
+        slug: str,
+        status: SecretStatus,
+        *,
+        actor_user_id: UUID | None = None,
+        workspace_id: UUID | None = None,
+        reason: str | None = None,
+        request_id: str | None = None,
     ) -> ManagedSecret | None:
-        """Change the status of an existing secret."""
+        """Change the status of an existing secret and record an audit event.
+
+        The audit event captures the lifecycle transition without exposing
+        plaintext or ciphertext; ``redacted=True`` enforces that contract at
+        the storage layer.
+        """
         result = await db.execute(select(ManagedSecret).where(ManagedSecret.slug == slug))
         secret = result.scalar_one_or_none()
 
@@ -91,11 +109,33 @@ class SecretsService:
             logger.warning("secret_not_found_for_status_change", slug=slug)
             return None
 
+        previous_status = (
+            secret.status.value
+            if isinstance(secret.status, SecretStatus)
+            else str(secret.status)
+        )
+        new_status = status.value if isinstance(status, SecretStatus) else str(status)
+
         secret.status = status
         secret.updated_at = datetime.now(timezone.utc)
+        db.add(
+            SettingsAuditEvent(
+                event_type="secrets.status.changed",
+                key=f"secrets.{slug}",
+                scope="system",
+                workspace_id=workspace_id or _DEFAULT_SETTINGS_SUBJECT_ID,
+                user_id=_DEFAULT_SETTINGS_SUBJECT_ID,
+                actor_user_id=actor_user_id,
+                old_value_json={"status": previous_status},
+                new_value_json={"status": new_status},
+                redacted=True,
+                reason=reason,
+                request_id=request_id,
+            )
+        )
         await db.commit()
         await db.refresh(secret)
-        logger.info("secret_status_changed", slug=slug, new_status=status.value)
+        logger.info("secret_status_changed", slug=slug, new_status=new_status)
         return secret
 
     @classmethod

--- a/frontend/src/components/secrets/SecretManager.test.tsx
+++ b/frontend/src/components/secrets/SecretManager.test.tsx
@@ -132,4 +132,97 @@ describe('SecretManager', () => {
     expect(await screen.findByText('Workspace setting integrations.github.token_ref')).toBeTruthy();
     expect(screen.queryByText('ghp_usage_plaintext')).toBeNull();
   });
+
+  it('shows a Re-enable action and broken-reference indicator for disabled secrets when the user can re-enable', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        slug: 'github-pat-main',
+        secretRef: 'db://github-pat-main',
+        status: 'active',
+        details: {},
+        createdAt: '2026-04-28T00:00:00Z',
+        updatedAt: '2026-04-28T00:00:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const onNotice = vi.fn();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SecretManager
+          secrets={[
+            {
+              slug: 'github-pat-main',
+              secretRef: 'db://github-pat-main',
+              status: 'disabled',
+              details: {},
+              createdAt: '2026-04-28T00:00:00Z',
+              updatedAt: '2026-04-28T00:00:00Z',
+              usages: [
+                {
+                  consumerType: 'setting_override',
+                  objectName: 'Workspace setting integrations.github.token_ref',
+                  reference: 'db://github-pat-main',
+                  scope: 'workspace',
+                  settingKey: 'integrations.github.token_ref',
+                },
+              ],
+            },
+          ]}
+          onNotice={onNotice}
+          queryClient={queryClient}
+          permissions={new Set(['secrets.disable'])}
+        />
+      </QueryClientProvider>,
+    );
+
+    // Broken-reference indicator appears next to the dependent setting
+    expect(screen.getAllByText(/broken reference/i).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-enable github-pat-main' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/secrets/github-pat-main/status',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ status: 'active' }),
+        }),
+      );
+    });
+    expect(onNotice).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'ok' }),
+    );
+  });
+
+  it('hides the Re-enable action when the user lacks the required permission', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SecretManager
+          secrets={[
+            {
+              slug: 'github-pat-main',
+              secretRef: 'db://github-pat-main',
+              status: 'disabled',
+              details: {},
+              createdAt: '2026-04-28T00:00:00Z',
+              updatedAt: '2026-04-28T00:00:00Z',
+            },
+          ]}
+          onNotice={vi.fn()}
+          queryClient={queryClient}
+          permissions={new Set()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByRole('button', { name: /re-enable github-pat-main/i })).toBeNull();
+  });
 });

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -35,9 +35,32 @@ interface SecretManagerProps {
   secrets: SecretMetadata[];
   onNotice: (notice: { level: 'ok' | 'error'; text: string } | null) => void;
   queryClient: QueryClient;
+  permissions?: ReadonlySet<string>;
 }
 
-export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerProps) {
+const _RE_ENABLE_PERMISSIONS = ['secrets.disable', 'secrets.rotate'];
+const _BROKEN_REFERENCE_STATUSES = new Set([
+  'disabled',
+  'rotated',
+  'deleted',
+  'invalid',
+  'missing',
+]);
+
+function isBrokenReferenceStatus(status: string | undefined): boolean {
+  return Boolean(status) && _BROKEN_REFERENCE_STATUSES.has(String(status));
+}
+
+export function SecretManager({
+  secrets,
+  onNotice,
+  queryClient,
+  permissions,
+}: SecretManagerProps) {
+  const grantedPermissions = permissions ?? new Set<string>();
+  const canChangeStatus = _RE_ENABLE_PERMISSIONS.some((permission) =>
+    grantedPermissions.has(permission),
+  );
   const [slug, setSlug] = useState('');
   const [plaintext, setPlaintext] = useState('');
   const [isEditing, setIsEditing] = useState(false);
@@ -150,6 +173,33 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     onError: (error: Error) => onNotice({ level: 'error', text: error.message }),
   });
 
+  const setStatusOp = useMutation({
+    mutationFn: async ({
+      slug: nextSlug,
+      status,
+    }: {
+      slug: string;
+      status: 'active' | 'disabled';
+    }) => {
+      const response = await fetch(`/api/v1/secrets/${nextSlug}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({}));
+        throw new Error(errorPayload.detail || 'Failed to change secret status');
+      }
+      return response.json();
+    },
+    onSuccess: (_data, variables) => {
+      const verb = variables.status === 'active' ? 're-enabled' : 'disabled';
+      onNotice({ level: 'ok', text: `Secret ${verb}.` });
+      queryClient.invalidateQueries({ queryKey: ['secrets'] });
+    },
+    onError: (error: Error) => onNotice({ level: 'error', text: error.message }),
+  });
+
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!slug) {
@@ -173,16 +223,31 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
   };
 
   const renderStatus = (status: string) => {
-    if (status === 'active') {
-      return <span className="badge badge-success">Active</span>;
-    }
-    if (status === 'disabled') {
-      return <span className="badge badge-warning">Disabled</span>;
-    }
-    if (status === 'rotated') {
-      return <span className="badge badge-neutral">Rotated</span>;
-    }
-    return <span className="badge badge-error">{formatStatusLabel(status)}</span>;
+    const isBroken = isBrokenReferenceStatus(status);
+    const primaryBadge =
+      status === 'active' ? (
+        <span className="badge badge-success">Active</span>
+      ) : status === 'disabled' ? (
+        <span className="badge badge-warning">Disabled</span>
+      ) : status === 'rotated' ? (
+        <span className="badge badge-neutral">Rotated</span>
+      ) : (
+        <span className="badge badge-error">{formatStatusLabel(status)}</span>
+      );
+    return (
+      <div className="flex flex-wrap items-center gap-1">
+        {primaryBadge}
+        {isBroken ? (
+          <span
+            className="badge badge-error"
+            aria-label={`Broken reference: ${status}`}
+            title="Dependent settings and profiles will fail launches until this secret is active again."
+          >
+            Broken reference
+          </span>
+        ) : null}
+      </div>
+    );
   };
 
   const copySecretRef = async (secretRef: string) => {
@@ -223,6 +288,7 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
     const usages = loadedUsage?.usages ?? secret.usages ?? [];
     const usageError = usageErrorBySlug[secret.slug];
     const usageLoaded = Boolean(loadedUsage || secret.usages);
+    const isBroken = isBrokenReferenceStatus(secret.status);
 
     if (usageError) {
       return <span className="text-xs text-red-600 dark:text-red-400">{usageError}</span>;
@@ -249,8 +315,19 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
       <ul className="space-y-2">
         {usages.map((usage) => (
           <li key={`${usage.consumerType}:${usage.objectName}:${usage.reference}`}>
-            <div className="text-xs font-medium text-slate-700 dark:text-slate-200">
-              {usage.objectName}
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="text-xs font-medium text-slate-700 dark:text-slate-200">
+                {usage.objectName}
+              </div>
+              {isBroken ? (
+                <span
+                  className="badge badge-error"
+                  aria-label={`Broken reference for ${usage.objectName}`}
+                  title="Launches that bind this secret are blocked until it is active."
+                >
+                  Broken reference
+                </span>
+              ) : null}
             </div>
             <code className="mt-1 inline-block rounded bg-slate-100 px-2 py-1 text-xs text-slate-800 dark:bg-slate-900 dark:text-slate-100">
               {usage.reference}
@@ -345,6 +422,22 @@ export function SecretManager({ secrets, onNotice, queryClient }: SecretManagerP
                           >
                             Rotate
                           </button>
+                          {secret.status === 'disabled' && canChangeStatus ? (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setStatusOp.mutate({
+                                  slug: secret.slug,
+                                  status: 'active',
+                                })
+                              }
+                              disabled={setStatusOp.isPending}
+                              className="btn btn-sm btn-outline"
+                              aria-label={`Re-enable ${secret.slug}`}
+                            >
+                              Re-enable
+                            </button>
+                          ) : null}
                           <button
                             type="button"
                             onClick={() => {

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -517,6 +517,16 @@ describe('GeneratedSettingsSection', () => {
     expect(screen.queryByText('Default Publish Mode')).toBeNull();
   });
 
+  it('renders a Broken reference indicator on rows whose secret_ref is unresolved', async () => {
+    renderWithClient(<GeneratedSettingsSection />);
+
+    expect(await screen.findByText('Default Publish Mode')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Search settings'), { target: { value: 'github' } });
+    expect(screen.getByText('GitHub Token Reference')).toBeTruthy();
+    expect(screen.getAllByText(/broken reference/i).length).toBeGreaterThan(0);
+  });
+
   it('resets overrides through the reset route and supports discard', async () => {
     renderWithClient(<GeneratedSettingsSection />);
 

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -295,6 +295,16 @@ function reloadBadges(descriptor: SettingDescriptor): string[] {
   return badges;
 }
 
+function hasBrokenSecretRef(descriptor: SettingDescriptor): boolean {
+  return descriptor.diagnostics.some(
+    (diagnostic) =>
+      diagnostic.code === 'unresolved_secret_ref' ||
+      diagnostic.code === 'secret_ref_unresolved' ||
+      diagnostic.code === 'invalid_secret_ref' ||
+      diagnostic.code.startsWith('broken_reference_'),
+  );
+}
+
 function canReset(descriptor: SettingDescriptor, scope: SettingScope): boolean {
   return (
     (scope === 'workspace' && descriptor.source === 'workspace_override') ||
@@ -633,6 +643,15 @@ export function GeneratedSettingsSection() {
                           {badge}
                         </span>
                       ))}
+                      {hasBrokenSecretRef(descriptor) ? (
+                        <span
+                          className="rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-800 dark:bg-rose-900/40 dark:text-rose-200"
+                          aria-label={`Broken reference for ${descriptor.title}`}
+                          title="Launches will be blocked until the referenced secret is active."
+                        >
+                          Broken reference
+                        </span>
+                      ) : null}
                     </div>
                     {descriptor.description ? (
                       <p className="text-sm text-slate-600 dark:text-slate-400">{descriptor.description}</p>

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -340,6 +340,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
               secrets={secretsData?.items ?? []}
               onNotice={setNotice}
               queryClient={queryClient}
+              permissions={settingsPermissions}
             />
           )}
         </div>

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -965,9 +965,18 @@ class ManagedRuntimeLauncher:
         from moonmind.workflows.adapters.secret_boundary import SecretResolverBoundary
         
         # Resolve secrets async up-front so the async materializer can access them.
-        from moonmind.workflows.temporal.runtime.managed_api_key_resolve import resolve_managed_api_key_reference
+        from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+            assert_managed_secret_refs_active_for_launch,
+            resolve_managed_api_key_reference,
+        )
+        profile_secret_refs = getattr(profile, "secret_refs", None) or {}
+        # Refuse to materialize the runtime when any managed SecretRef is
+        # disabled, revoked, or missing. Plaintext is never read or surfaced.
+        await assert_managed_secret_refs_active_for_launch(
+            profile_secret_refs.values()
+        )
         resolved_secrets = {}
-        for ref_key, secret_name in (getattr(profile, "secret_refs", None) or {}).items():
+        for ref_key, secret_name in profile_secret_refs.items():
             resolved_secrets[ref_key] = await resolve_managed_api_key_reference(secret_name)
 
         class AsyncDictSecretResolver(SecretResolverBoundary):

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 from sqlalchemy import select
 
@@ -327,8 +328,142 @@ async def resolve_managed_api_key_reference(
         if vault_resolver_instance is not None:
             await vault_resolver_instance.aclose()
 
+@dataclass(frozen=True)
+class BrokenSecretRef:
+    """Describes a managed SecretRef that cannot be used for launch.
+
+    The diagnostic is intentionally metadata-only; no plaintext, ciphertext, or
+    decryption error detail is surfaced. ``status`` is the managed secret
+    lifecycle state ("missing", "disabled", "rotated", "deleted", "invalid").
+    """
+
+    secret_ref: str
+    slug: str
+    status: str
+    diagnostic_code: str
+    message: str
+
+
+class SecretRefLaunchBlockedError(ValueError):
+    """Raised when one or more managed SecretRefs are not active for launch."""
+
+    def __init__(self, broken: list[BrokenSecretRef]) -> None:
+        self.broken = list(broken)
+        descriptions = "; ".join(
+            f"{item.secret_ref}={item.status}" for item in self.broken
+        )
+        super().__init__(
+            "Refusing to launch: managed SecretRefs are not active: "
+            f"{descriptions}"
+        )
+
+
+async def inspect_managed_secret_refs_for_launch(
+    refs: Iterable[str],
+) -> list[BrokenSecretRef]:
+    """Inspect managed (``db://``) SecretRefs and return any broken references.
+
+    Only ``db://`` refs are inspected here; ``env://``, ``exec://``, and
+    ``vault://`` validation is left to the regular resolver. Plaintext is never
+    read or returned.
+    """
+
+    candidates: list[tuple[str, str]] = []
+    seen_slugs: set[str] = set()
+    for ref in refs:
+        if not isinstance(ref, str):
+            continue
+        stripped = ref.strip()
+        if not stripped or not stripped.startswith("db://"):
+            continue
+        slug = stripped.removeprefix("db://").strip()
+        if not slug or slug in seen_slugs:
+            continue
+        seen_slugs.add(slug)
+        candidates.append((stripped, slug))
+
+    if not candidates:
+        return []
+
+    from api_service.db.base import async_session_maker
+    from api_service.db.models import ManagedSecret, SecretStatus
+
+    try:
+        async with async_session_maker() as session:
+            result = await session.execute(
+                select(ManagedSecret.slug, ManagedSecret.status).where(
+                    ManagedSecret.slug.in_([slug for _, slug in candidates])
+                )
+            )
+            statuses_by_slug: dict[str, str] = {}
+            for slug, status in result.all():
+                statuses_by_slug[slug] = (
+                    status.value if isinstance(status, SecretStatus) else str(status)
+                )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        # Cannot reach the managed-secret store (e.g. unit tests without a DB
+        # fixture, transient connection issue). Skip the pre-flight check;
+        # the resolver itself will still surface a typed failure when it
+        # attempts to read the secret.
+        logger.warning(
+            "Skipping managed SecretRef readiness check; managed secret store "
+            "unreachable.",
+            exc_info=True,
+        )
+        return []
+
+    active_value = SecretStatus.ACTIVE.value
+    issues: list[BrokenSecretRef] = []
+    for secret_ref, slug in candidates:
+        status = statuses_by_slug.get(slug)
+        if status is None:
+            issues.append(
+                BrokenSecretRef(
+                    secret_ref=secret_ref,
+                    slug=slug,
+                    status="missing",
+                    diagnostic_code="broken_reference_missing",
+                    message=(
+                        f"Managed secret '{slug}' is missing; restore it or "
+                        "update the reference."
+                    ),
+                )
+            )
+            continue
+        if status != active_value:
+            issues.append(
+                BrokenSecretRef(
+                    secret_ref=secret_ref,
+                    slug=slug,
+                    status=status,
+                    diagnostic_code=f"broken_reference_{status}",
+                    message=(
+                        f"Managed secret '{slug}' is {status}; re-enable it "
+                        "before launching."
+                    ),
+                )
+            )
+    return issues
+
+
+async def assert_managed_secret_refs_active_for_launch(
+    refs: Iterable[str],
+) -> None:
+    """Raise SecretRefLaunchBlockedError if any managed SecretRef is not active."""
+
+    issues = await inspect_managed_secret_refs_for_launch(refs)
+    if issues:
+        raise SecretRefLaunchBlockedError(issues)
+
+
 __all__ = [
+    "BrokenSecretRef",
+    "SecretRefLaunchBlockedError",
+    "assert_managed_secret_refs_active_for_launch",
     "build_github_credential_descriptor_for_launch",
+    "inspect_managed_secret_refs_for_launch",
     "resolve_github_token_for_launch",
     "resolve_managed_api_key_reference",
     "resolve_managed_github_token_from_store",

--- a/tests/unit/api/test_secrets_api.py
+++ b/tests/unit/api/test_secrets_api.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from api_service.api.routers.secrets import router
@@ -11,8 +12,36 @@ app = FastAPI()
 app.include_router(router, prefix="/api/v1/secrets")
 
 mock_db_session = AsyncMock()
+
+# Resolve the cached current-user dependency once so overrides target the same
+# callable that FastAPI sees when the router was imported with
+# Depends(get_current_user()).
+_CURRENT_USER_DEP = get_current_user()
+
+
+def _superuser():
+    return SimpleNamespace(
+        id=None, workspace_id=None, is_superuser=True, settings_permissions=set()
+    )
+
+
+def _user_without_permissions():
+    return SimpleNamespace(
+        id=None, workspace_id=None, is_superuser=False, settings_permissions=set()
+    )
+
+
+def _user_with_disable_only():
+    return SimpleNamespace(
+        id=None,
+        workspace_id=None,
+        is_superuser=False,
+        settings_permissions={"secrets.disable"},
+    )
+
+
 app.dependency_overrides[get_async_session] = lambda: mock_db_session
-app.dependency_overrides[get_current_user] = lambda: lambda: None
+app.dependency_overrides[_CURRENT_USER_DEP] = _superuser
 
 client = TestClient(app)
 
@@ -223,3 +252,53 @@ def test_secret_usage_endpoint_redacts_missing_secret_diagnostics(
     assert resp.json()["diagnostics"][0]["message"] == (
         "Managed secret is missing; token=[REDACTED]"
     )
+
+
+def _restore_superuser_dep():
+    app.dependency_overrides[_CURRENT_USER_DEP] = _superuser
+
+
+def test_update_secret_status_denied_without_disable_or_rotate_permissions(
+    mock_secrets_service,
+):
+    app.dependency_overrides[_CURRENT_USER_DEP] = _user_without_permissions
+    try:
+        resp = client.put(
+            "/api/v1/secrets/TEST_API_KEY/status",
+            json={"status": "active"},
+        )
+    finally:
+        _restore_superuser_dep()
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "secrets.disable" in body["detail"] or "secrets.rotate" in body["detail"]
+    mock_secrets_service.set_status.assert_not_called()
+
+
+def test_update_secret_status_allows_re_enable_with_disable_permission(
+    mock_secrets_service,
+):
+    from api_service.db.models import ManagedSecret
+    from datetime import datetime
+
+    mock_secret = ManagedSecret(
+        slug="TEST_API_KEY",
+        status="active",
+        details={},
+        created_at=datetime.utcnow(),
+    )
+    mock_secrets_service.set_status.return_value = mock_secret
+
+    app.dependency_overrides[_CURRENT_USER_DEP] = _user_with_disable_only
+    try:
+        resp = client.put(
+            "/api/v1/secrets/TEST_API_KEY/status",
+            json={"status": "active"},
+        )
+    finally:
+        _restore_superuser_dep()
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "active"
+    mock_secrets_service.set_status.assert_awaited()

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -80,17 +80,61 @@ async def test_rotate_secret(mock_db_session):
 async def test_set_status_secret(mock_db_session):
     slug = "test-secret"
     existing_secret = ManagedSecret(slug=slug, ciphertext="old", status=SecretStatus.ACTIVE)
-    
+
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = existing_secret
-    
+
     async def mock_execute(*args, **kwargs):
         return mock_result
-        
+
     mock_db_session.execute.side_effect = mock_execute
-    
+
     disabled = await SecretsService.set_status(mock_db_session, slug, SecretStatus.DISABLED)
     assert disabled.status == SecretStatus.DISABLED
+
+
+@pytest.mark.asyncio
+async def test_set_status_records_audit_event(mock_db_session):
+    from api_service.db.models import SettingsAuditEvent
+
+    slug = "test-secret"
+    existing_secret = ManagedSecret(slug=slug, ciphertext="old", status=SecretStatus.ACTIVE)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = existing_secret
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    actor_id = uuid4()
+    workspace_id = uuid4()
+
+    await SecretsService.set_status(
+        mock_db_session,
+        slug,
+        SecretStatus.DISABLED,
+        actor_user_id=actor_id,
+        workspace_id=workspace_id,
+        reason="rotation cadence",
+    )
+
+    audit_calls = [
+        call.args[0]
+        for call in mock_db_session.add.call_args_list
+        if call.args and isinstance(call.args[0], SettingsAuditEvent)
+    ]
+    assert audit_calls, "Expected SettingsAuditEvent to be persisted for status change"
+    event = audit_calls[0]
+    assert event.event_type == "secrets.status.changed"
+    assert event.actor_user_id == actor_id
+    assert event.workspace_id == workspace_id
+    assert event.redacted is True
+    assert event.old_value_json == {"status": "active"}
+    assert event.new_value_json == {"status": "disabled"}
+    assert event.reason == "rotation cadence"
+    assert event.key == f"secrets.{slug}"
 
 @pytest.mark.asyncio
 async def test_get_secret(mock_db_session):

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -8,6 +8,10 @@ from types import SimpleNamespace
 import pytest
 
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    BrokenSecretRef,
+    SecretRefLaunchBlockedError,
+    assert_managed_secret_refs_active_for_launch,
+    inspect_managed_secret_refs_for_launch,
     resolve_github_token_for_launch,
     resolve_managed_api_key_reference,
     resolve_managed_github_token_from_store,
@@ -210,3 +214,153 @@ async def test_resolve_github_token_for_launch_propagates_cancellation_from_stor
 
     with pytest.raises(asyncio.CancelledError):
         await resolve_github_token_for_launch({})
+
+
+class _FakeStatusResult:
+    def __init__(self, rows: list[tuple[str, str]]) -> None:
+        self._rows = list(rows)
+
+    def all(self) -> list[tuple[str, str]]:
+        return list(self._rows)
+
+
+class _FakeStatusSession:
+    def __init__(self, statuses_by_slug: dict[str, str | None]) -> None:
+        self._statuses = dict(statuses_by_slug)
+        self.queried_slugs: list[tuple[str, ...]] = []
+
+    async def execute(self, query) -> _FakeStatusResult:
+        compiled = query.compile()
+        params = compiled.params
+        slugs_collected: list[str] = []
+        for key, value in params.items():
+            if not key.startswith("slug_"):
+                continue
+            if isinstance(value, str):
+                slugs_collected.append(value)
+            elif isinstance(value, (list, tuple, set)):
+                slugs_collected.extend(
+                    item for item in value if isinstance(item, str)
+                )
+        slugs = tuple(sorted(slugs_collected))
+        self.queried_slugs.append(slugs)
+        rows = [
+            (slug, status)
+            for slug, status in self._statuses.items()
+            if slug in slugs and status is not None
+        ]
+        return _FakeStatusResult(rows)
+
+
+class _FakeStatusSessionMaker:
+    def __init__(self, session: _FakeStatusSession) -> None:
+        self._session = session
+        self.calls = 0
+
+    def __call__(self) -> _FakeAsyncSessionCtx:
+        self.calls += 1
+        return _FakeAsyncSessionCtx(self._session)
+
+
+async def test_inspect_managed_secret_refs_returns_empty_for_only_env_refs() -> None:
+    issues = await inspect_managed_secret_refs_for_launch(
+        ["env://OPENAI_API_KEY", "vault://kv/data/foo#bar"]
+    )
+    assert issues == []
+
+
+async def test_inspect_managed_secret_refs_flags_missing_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeStatusSession(statuses_by_slug={})
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker",
+        _FakeStatusSessionMaker(session),
+    )
+
+    issues = await inspect_managed_secret_refs_for_launch(
+        ["db://missing-slug"]
+    )
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert isinstance(issue, BrokenSecretRef)
+    assert issue.secret_ref == "db://missing-slug"
+    assert issue.slug == "missing-slug"
+    assert issue.status == "missing"
+    assert issue.diagnostic_code == "broken_reference_missing"
+
+
+async def test_inspect_managed_secret_refs_flags_disabled_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeStatusSession(statuses_by_slug={"github-pat-main": "disabled"})
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker",
+        _FakeStatusSessionMaker(session),
+    )
+
+    issues = await inspect_managed_secret_refs_for_launch(
+        ["db://github-pat-main"]
+    )
+
+    assert len(issues) == 1
+    assert issues[0].status == "disabled"
+    assert issues[0].diagnostic_code == "broken_reference_disabled"
+
+
+async def test_inspect_managed_secret_refs_ignores_active_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeStatusSession(statuses_by_slug={"ok-secret": "active"})
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker",
+        _FakeStatusSessionMaker(session),
+    )
+
+    issues = await inspect_managed_secret_refs_for_launch(
+        ["db://ok-secret", "env://OPENAI_API_KEY"]
+    )
+
+    assert issues == []
+
+
+async def test_assert_managed_secret_refs_raises_launch_blocked_for_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeStatusSession(
+        statuses_by_slug={
+            "claude-key": "disabled",
+            "openai-key": "active",
+        }
+    )
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker",
+        _FakeStatusSessionMaker(session),
+    )
+
+    with pytest.raises(SecretRefLaunchBlockedError) as exc_info:
+        await assert_managed_secret_refs_active_for_launch(
+            ["db://claude-key", "db://openai-key"]
+        )
+
+    error = exc_info.value
+    assert len(error.broken) == 1
+    assert error.broken[0].secret_ref == "db://claude-key"
+    assert error.broken[0].status == "disabled"
+    assert "claude-key" in str(error)
+    assert "disabled" in str(error)
+
+
+async def test_assert_managed_secret_refs_noop_for_all_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeStatusSession(statuses_by_slug={"ok-key": "active"})
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker",
+        _FakeStatusSessionMaker(session),
+    )
+
+    await assert_managed_secret_refs_active_for_launch(
+        ["db://ok-key", "env://ALSO_OK"]
+    )


### PR DESCRIPTION
## Summary

Implements MM-709: Wire broken-reference state and launch blocking when SecretRefs become disabled or revoked, and surface a re-enable action.

- **Jira issue**: [MM-709](https://moonladder.atlassian.net/browse/MM-709)
- **Active MoonSpec feature path**: Jira-orchestrated; no `specs/<feature>/spec.md` exists in this repository. Verification source: trusted Jira tool payload for `MM-709` (`moonmind.jira.get_issue`). Source design reference: `docs/Security/SettingsSystem.md` §6.1, §13.5, §13.6, §14, §22(1), §22(2), §22(13), §27.2 (DESIGN-REQ-012/-013/-026/-027/-028/-029/-030/-031).
- **Verification verdict**: `FULLY_IMPLEMENTED` (HIGH confidence) — moonspec-verify post-remediation report.

## Changes

- **Backend launch readiness** — `moonmind/workflows/temporal/runtime/managed_api_key_resolve.py` adds `BrokenSecretRef`, `SecretRefLaunchBlockedError`, `inspect_managed_secret_refs_for_launch`, and `assert_managed_secret_refs_active_for_launch`; wired into the activity-boundary launcher at `moonmind/workflows/temporal/runtime/launcher.py`. Disabled/revoked SecretRefs now refuse to materialize the runtime with a metadata-only diagnostic.
- **Re-enable workflow** — `api_service/api/routers/secrets.py` and `api_service/services/secrets.py` permission-gate the status change behind `secrets.disable` / `secrets.rotate` and emit a redacted `SettingsAuditEvent` (`event_type="secrets.status.changed"`).
- **Frontend broken-reference indicators** — `frontend/src/components/secrets/SecretManager.tsx` shows a broken-reference badge on the secret status and on each dependent usage row, plus a permission-gated re-enable action for disabled secrets. `frontend/src/components/settings/GeneratedSettingsSection.tsx` renders a broken-reference state on any setting whose SecretRef is unresolved/invalid. `frontend/src/entrypoints/settings.tsx` threads `settingsPermissions` through.
- **No-plaintext-readback contract preserved** — audit events are `redacted=True`; diagnostics expose only slug + status; no ciphertext or plaintext traverses any new surface.

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_secrets.py tests/unit/api/test_secrets_api.py tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py` → **PASS** (45 passed; 6 pre-existing deprecation warnings).
- Frontend Vitest full suite (chained by `./tools/test_unit.sh`) → **PASS** (367 passed / 232 skipped / 0 failed across 21 test files).
- Targeted runtime coverage in `tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py` covers active / disabled / missing / mixed SecretRef states for the new launch-readiness contract.

Not run for this gate: `./tools/test_unit.sh` (no args, full suite) and `./tools/test_integration.sh` (compose-backed `integration_ci`). No MM-709 behavior depends on a new integration surface beyond the unit-tested resolver.

## Remaining risks

- `ProviderProfilesManager.tsx` does not render its own per-row broken-reference badge; operationally this is covered by (a) `SecretManager`'s primary + per-usage broken-reference indicators, and (b) the launcher's pre-flight check that refuses to materialize any runtime bound to a broken SecretRef. Spec's "Already Implemented Evidence" treats usage enumeration as met for the prior story scope, and provider-profile per-row visuals are not listed as MM-709 remaining work.
- `inspect_managed_secret_refs_for_launch` fails-soft when the DB is briefly unreachable; the resolver still refuses the launch, preserving fail-fast at the runtime boundary. Worth monitoring if DB-unavailability becomes a common operational shape.
- Optional follow-up (non-blocking): extend `list_secret_usage` to enumerate `consumerType: 'provider_profile'` so the SecretManager's usage list surfaces provider-profile dependencies explicitly.

## Test plan

- [x] Python unit (targeted): secrets service + secrets API + managed-api-key resolver
- [x] Frontend Vitest full suite
- [ ] Pre-merge: rerun `./tools/test_unit.sh` (full) and `./tools/test_integration.sh` (`integration_ci`) in CI

[MM-709]: https://moonladder.atlassian.net/browse/MM-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ