### PR TITLE
[codex] Fix auto skill selector materialization

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -14380,7 +14380,12 @@ describe("Task Create MM-578 Preset expansion", () => {
     expect(
       (
         latestCreateRequest() as {
-          payload?: { task?: { authoredPresets?: Array<Record<string, unknown>> } };
+          payload?: {
+            task?: {
+              authoredPresets?: Array<Record<string, unknown>>;
+              skills?: Record<string, unknown>;
+            };
+          };
         }
       ).payload?.task?.authoredPresets,
     ).toEqual([
@@ -14390,6 +14395,13 @@ describe("Task Create MM-578 Preset expansion", () => {
         includePath: ["mm-578-preset@1.0.0"],
       },
     ]);
+    expect(
+      (
+        latestCreateRequest() as {
+          payload?: { task?: { skills?: Record<string, unknown> } };
+        }
+      ).payload?.task?.skills,
+    ).toBeUndefined();
     expect(
       screen.getByDisplayValue("Keep unresolved MM-578 preset placeholder."),
     ).toBeTruthy();

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7651,12 +7651,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         : cleaned;
     })();
 
-    // Only include task-level agent skill selectors when we have an explicit skill or a template slug.
-    const taskSkillSelectors =
-      hasExplicitSkillSelection(primarySkillId) ||
-      submissionAppliedTemplates.length > 0
-        ? { include: [{ name: effectiveSubmissionSkillId }] }
-        : undefined;
+    // Only include task-level agent skill selectors for real instruction bundles.
+    const taskSkillSelectors = hasExplicitSkillSelection(
+      effectiveSubmissionSkillId,
+    )
+      ? { include: [{ name: effectiveSubmissionSkillId }] }
+      : undefined;
     const submissionAuthoredPresets =
       authoredPresetsFromAppliedTemplates(submissionAppliedTemplates);
 

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -792,6 +792,8 @@ def build_effective_task_skill_selectors(
     include_by_name: dict[str, TaskSkillSelectorExact] = {}
     for source in (task, step):
         for item in (source.include if source is not None else None) or []:
+            if _normalize_skill_id(item.name) == "auto":
+                continue
             include_by_name[item.name] = TaskSkillSelectorExact(
                 name=item.name,
                 version=item.version,

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -1020,6 +1020,38 @@ def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> 
 def test_effective_task_step_skills_returns_none_for_empty_intent() -> None:
     assert build_effective_task_skill_selectors(None, None) is None
 
+def test_effective_task_step_skills_ignores_auto_sentinel_include() -> None:
+    task_skills = TaskExecutionSpec.model_validate(
+        {
+            "repository": "test/repo",
+            "instructions": "execute",
+            "skills": {"include": [{"name": "auto"}]},
+        }
+    ).skills
+
+    assert build_effective_task_skill_selectors(task_skills, None) is None
+
+def test_effective_task_step_skills_drops_auto_without_losing_real_includes() -> None:
+    task_skills = TaskExecutionSpec.model_validate(
+        {
+            "repository": "test/repo",
+            "instructions": "execute",
+            "skills": {
+                "include": [
+                    {"name": "auto"},
+                    {"name": "jira-issue-updater"},
+                ],
+            },
+        }
+    ).skills
+
+    effective = build_effective_task_skill_selectors(task_skills, None)
+
+    assert effective is not None
+    assert [(item.name, item.version) for item in effective.include or []] == [
+        ("jira-issue-updater", None)
+    ]
+
 def test_task_input_attachments_preserve_objective_and_step_targets() -> None:
     """MM-367: objective and step refs remain distinct canonical fields."""
 


### PR DESCRIPTION
## Summary
- Prevent the Create UI from submitting `auto` as an active task-level agent skill selector.
- Harden backend task skill selector merging so API-created payloads also drop the `auto` sentinel before skill snapshot resolution.
- Add backend and frontend regression coverage for the THOR-431 failure mode.

## Root Cause
THOR-431 retry payloads included `skills.include: [{ name: "auto" }]`. `auto` is a sentinel for no explicit skill, but it was resolved as a materialized skill snapshot entry without content, causing runtime launch to fail before Jira issue loading.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py -q`
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`