### PR TITLE
Run Jira Orchestrate for MM-710: Wire downstream subscribers to the published setting_changed event stream

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1016,6 +1016,22 @@ async def ensure_provider_profile_managers_started():
     except Exception as e:
         logger.error(f"Error ensuring ProviderProfileManager workflows: {e}", exc_info=True)
 
+def _register_settings_change_subscribers() -> None:
+    """Wire the default SettingsChangePublisher subscribers once per process."""
+
+    try:
+        from api_service.services.settings_change_subscribers import (
+            register_default_subscribers,
+        )
+
+        register_default_subscribers()
+    except Exception as exc:  # noqa: BLE001 — defensive at startup
+        logger.warning(
+            "Failed to register default settings change subscribers: %s",
+            exc,
+        )
+
+
 async def startup_event():
     """Defines the application's startup events."""
     logger.info("Executing application startup events...")
@@ -1031,6 +1047,7 @@ async def startup_event():
     _initialize_contexts(app.state, settings)
     _load_or_create_vector_index(app.state)
     await _initialize_oidc_provider(app)  # OIDC provider init like Keycloak discovery
+    _register_settings_change_subscribers()
     try:
         app.state.retrieval_service = ContextRetrievalService(
             settings=RagRuntimeSettings.from_env()

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1026,6 +1026,7 @@ def _register_settings_change_subscribers() -> None:
 
     try:
         from api_service.services.settings_change_hooks import (
+            make_operational_mode_hook,
             make_provider_profile_refresh_hook,
             make_worker_reload_broadcast_hook,
         )
@@ -1035,6 +1036,9 @@ def _register_settings_change_subscribers() -> None:
 
         worker_reload_logger = logging.getLogger(
             "api_service.settings_change.worker_reload_broadcast"
+        )
+        operational_logger = logging.getLogger(
+            "api_service.settings_change.operational_mode"
         )
 
         async def _structured_worker_reload_broadcaster(payload: dict) -> None:
@@ -1047,11 +1051,20 @@ def _register_settings_change_subscribers() -> None:
                 extra={"settings_worker_reload_broadcast": payload},
             )
 
+        async def _structured_operational_mode_handler(payload: dict) -> None:
+            operational_logger.info(
+                "settings.operational_mode_change",
+                extra={"settings_operational_mode_change": payload},
+            )
+
         register_default_subscribers(
             worker_on_reload=make_worker_reload_broadcast_hook(
                 broadcaster=_structured_worker_reload_broadcaster,
             ),
             provider_profile_on_refresh=make_provider_profile_refresh_hook(),
+            operational_on_refresh=make_operational_mode_hook(
+                handler=_structured_operational_mode_handler,
+            ),
         )
     except Exception as exc:  # noqa: BLE001 — defensive at startup
         logger.warning(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1017,14 +1017,42 @@ async def ensure_provider_profile_managers_started():
         logger.error(f"Error ensuring ProviderProfileManager workflows: {e}", exc_info=True)
 
 def _register_settings_change_subscribers() -> None:
-    """Wire the default SettingsChangePublisher subscribers once per process."""
+    """Wire the default SettingsChangePublisher subscribers once per process.
+
+    Production wiring attaches concrete hooks so worker_reload / next_launch
+    apply modes drive observable cross-process side effects (Temporal signals,
+    structured broadcast log) beyond the in-process intent ledgers.
+    """
 
     try:
+        from api_service.services.settings_change_hooks import (
+            make_provider_profile_refresh_hook,
+            make_worker_reload_broadcast_hook,
+        )
         from api_service.services.settings_change_subscribers import (
             register_default_subscribers,
         )
 
-        register_default_subscribers()
+        worker_reload_logger = logging.getLogger(
+            "api_service.settings_change.worker_reload_broadcast"
+        )
+
+        async def _structured_worker_reload_broadcaster(payload: dict) -> None:
+            # Records a structured INFO event that ops dashboards and worker
+            # health scrapers can observe out-of-process. Real cross-host
+            # broadcast (Redis, Temporal control workflow, etc.) can be plugged
+            # in by replacing this callable.
+            worker_reload_logger.info(
+                "settings.worker_reload_broadcast",
+                extra={"settings_worker_reload_broadcast": payload},
+            )
+
+        register_default_subscribers(
+            worker_on_reload=make_worker_reload_broadcast_hook(
+                broadcaster=_structured_worker_reload_broadcaster,
+            ),
+            provider_profile_on_refresh=make_provider_profile_refresh_hook(),
+        )
     except Exception as exc:  # noqa: BLE001 — defensive at startup
         logger.warning(
             "Failed to register default settings change subscribers: %s",

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -838,10 +838,12 @@ class SettingsCatalogService:
         workspace_id: UUID | None = None,
         user_id: UUID | None = None,
         workspace_policy: SettingsWorkspacePolicy | dict[str, Any] | None = None,
+        change_publisher: "SettingsChangePublisher | None" = None,
     ) -> None:
         self._settings = settings or app_settings
         self._env = env if env is not None else os.environ
         self._migration_rules = migration_rules
+        self._change_publisher = change_publisher
         ledger = _CATALOG_KEY_LEDGER if registry is _REGISTRY else None
         self._settings_registry = SettingsRegistry(
             registry,
@@ -1700,6 +1702,7 @@ class SettingsCatalogService:
         except IntegrityError as exc:
             await self._session.rollback()
             raise ValueError("version_conflict") from exc
+        await self._dispatch_change_events(change_events)
         changed_overrides = {
             (row_scope, changed_key): row
             for (row_scope, changed_key), row in current_rows.items()
@@ -2121,6 +2124,21 @@ class SettingsCatalogService:
             "requires_process_restart": entry.requires_process_restart,
             "applies_to": list(entry.applies_to),
         }
+
+    async def _dispatch_change_events(
+        self, events: list["SettingsChangeEvent"]
+    ) -> None:
+        if not events:
+            return
+        publisher = self._change_publisher
+        if publisher is None:
+            from api_service.services.settings_change_publisher import (
+                get_settings_change_publisher,
+            )
+
+            publisher = get_settings_change_publisher()
+            self._change_publisher = publisher
+        await publisher.publish(events)
 
     def _refresh_targets_for_entry(self, entry: SettingRegistryEntry) -> list[str]:
         targets = {"settings_catalog"}

--- a/api_service/services/settings_change_hooks.py
+++ b/api_service/services/settings_change_hooks.py
@@ -1,0 +1,212 @@
+"""Production hook factories for SettingsChangePublisher default subscribers (MM-710).
+
+The subscribers in ``settings_change_subscribers`` expose optional ``on_reload``
+and ``on_refresh`` callables so that consumers can plug in concrete cross-process
+side effects. This module provides the production-grade implementations:
+
+- ``make_provider_profile_refresh_hook`` -- pushes a ``sync_profiles`` Temporal
+  signal to every registered ``ProviderProfileManager`` workflow so the running
+  manager re-pulls the authoritative profile snapshot from the database when a
+  profile-affecting setting changes.
+- ``make_worker_reload_broadcast_hook`` -- forwards worker reload intents to a
+  caller-supplied broadcaster so apply modes ``worker_reload`` and
+  ``process_restart`` drive observable behavior beyond the in-process intent
+  ledger.
+- ``make_operational_mode_hook`` -- forwards operational refresh intents to a
+  caller-supplied handler so ``manual_operation`` apply mode changes can drive
+  observable operations behavior (alerts, banners, runbooks).
+
+All hooks are defensive: failures are logged structurally but never propagate,
+mirroring the isolation guarantee that ``SettingsChangePublisher._invoke``
+already provides.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from api_service.services.settings_change_subscribers import (
+    OperationalRefreshIntent,
+    ProviderProfileRefreshIntent,
+    WorkerReloadIntent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_PROVIDER_PROFILE_WORKFLOW_ID_PREFIX = "provider-profile-manager"
+
+
+async def _list_runtime_ids_from_db() -> list[str]:
+    """Default runtime-id provider that queries the managed-agent profile table.
+
+    Wrapped in a try/except so callers can use this in startup contexts where
+    the DB may not yet be reachable.
+    """
+
+    try:
+        from sqlalchemy import select
+
+        from api_service.db.base import get_async_session_context
+        from api_service.db.models import ManagedAgentProviderProfile
+
+        async with get_async_session_context() as session:
+            stmt = select(ManagedAgentProviderProfile.runtime_id).distinct()
+            result = await session.execute(stmt)
+            return [str(rid) for rid in result.scalars().all() if rid]
+    except Exception as exc:  # noqa: BLE001 -- intentional defense-in-depth
+        logger.warning(
+            "Failed to list provider-profile runtime ids for refresh hook: %s",
+            exc,
+        )
+        return []
+
+
+async def _default_temporal_client_provider() -> Any:
+    """Default Temporal client provider used in production wiring."""
+
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    adapter = TemporalClientAdapter()
+    return await adapter.get_client()
+
+
+def make_provider_profile_refresh_hook(
+    *,
+    temporal_client_provider: Callable[[], Awaitable[Any]] | None = None,
+    runtime_ids_provider: Callable[[], Awaitable[list[str]]] | None = None,
+) -> Callable[[ProviderProfileRefreshIntent], Awaitable[None]]:
+    """Build an ``on_refresh`` hook that signals every running
+    ``ProviderProfileManager`` workflow with ``sync_profiles`` so the manager
+    re-pulls profile state from the authoritative DB.
+    """
+
+    resolve_client = temporal_client_provider or _default_temporal_client_provider
+    resolve_runtime_ids = runtime_ids_provider or _list_runtime_ids_from_db
+
+    async def _hook(intent: ProviderProfileRefreshIntent) -> None:
+        try:
+            runtime_ids = await resolve_runtime_ids()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ProviderProfileManager refresh hook could not resolve runtime ids: %s",
+                exc,
+            )
+            return
+
+        if not runtime_ids:
+            logger.debug(
+                "ProviderProfileManager refresh hook found no registered runtimes; "
+                "skipping signal for setting %s",
+                intent.key,
+            )
+            return
+
+        try:
+            client = await resolve_client()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "ProviderProfileManager refresh hook could not reach Temporal: %s",
+                exc,
+            )
+            return
+
+        for runtime_id in runtime_ids:
+            workflow_id = f"{_PROVIDER_PROFILE_WORKFLOW_ID_PREFIX}:{runtime_id}"
+            try:
+                handle = client.get_workflow_handle(workflow_id)
+                await handle.signal("sync_profiles", {"profiles": []})
+                logger.info(
+                    "Signaled ProviderProfileManager sync_profiles "
+                    "(runtime_id=%s key=%s apply_mode=%s)",
+                    runtime_id,
+                    intent.key,
+                    intent.apply_mode,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to signal ProviderProfileManager runtime_id=%s "
+                    "for setting %s: %s",
+                    runtime_id,
+                    intent.key,
+                    exc,
+                )
+
+    return _hook
+
+
+def make_worker_reload_broadcast_hook(
+    *,
+    broadcaster: Callable[[dict[str, Any]], Awaitable[None]],
+) -> Callable[[WorkerReloadIntent], Awaitable[None]]:
+    """Build an ``on_reload`` hook that forwards a normalized payload to the
+    given broadcaster.
+
+    Production wiring may publish to a Redis pub/sub topic, a Temporal control
+    workflow, or another out-of-process channel. The hook itself only owns
+    intent-to-payload normalization plus failure isolation, so the publisher
+    contract stays observable even when the broadcaster is degraded.
+    """
+
+    async def _hook(intent: WorkerReloadIntent) -> None:
+        payload = {
+            "intent": intent.intent,
+            "key": intent.key,
+            "scope": intent.scope,
+            "apply_mode": intent.apply_mode,
+            "refresh_target": intent.refresh_target,
+            "affected_systems": tuple(intent.affected_systems),
+            "recorded_at": intent.recorded_at.isoformat(),
+        }
+        try:
+            await broadcaster(payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Worker reload broadcaster failed for setting %s (intent=%s): %s",
+                intent.key,
+                intent.intent,
+                exc,
+            )
+
+    return _hook
+
+
+def make_operational_mode_hook(
+    *,
+    handler: Callable[[dict[str, Any]], Awaitable[None]],
+) -> Callable[[OperationalRefreshIntent], Awaitable[None]]:
+    """Build a callable that forwards a normalized operational refresh payload
+    to the given handler. Production wiring may post alerts, update banners,
+    or trigger a runbook activity.
+    """
+
+    async def _hook(intent: OperationalRefreshIntent) -> None:
+        payload = {
+            "key": intent.key,
+            "scope": intent.scope,
+            "apply_mode": intent.apply_mode,
+            "refresh_target": intent.refresh_target,
+            "affected_systems": tuple(intent.affected_systems),
+            "recorded_at": intent.recorded_at.isoformat(),
+        }
+        try:
+            await handler(payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Operational mode hook handler failed for setting %s "
+                "(apply_mode=%s): %s",
+                intent.key,
+                intent.apply_mode,
+                exc,
+            )
+
+    return _hook
+
+
+__all__ = [
+    "make_operational_mode_hook",
+    "make_provider_profile_refresh_hook",
+    "make_worker_reload_broadcast_hook",
+]

--- a/api_service/services/settings_change_hooks.py
+++ b/api_service/services/settings_change_hooks.py
@@ -23,6 +23,7 @@ already provides.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -113,7 +114,7 @@ def make_provider_profile_refresh_hook(
             )
             return
 
-        for runtime_id in runtime_ids:
+        async def _signal_one(runtime_id: str) -> None:
             workflow_id = f"{_PROVIDER_PROFILE_WORKFLOW_ID_PREFIX}:{runtime_id}"
             try:
                 handle = client.get_workflow_handle(workflow_id)
@@ -133,6 +134,8 @@ def make_provider_profile_refresh_hook(
                     intent.key,
                     exc,
                 )
+
+        await asyncio.gather(*(_signal_one(rid) for rid in runtime_ids))
 
     return _hook
 

--- a/api_service/services/settings_change_publisher.py
+++ b/api_service/services/settings_change_publisher.py
@@ -1,0 +1,137 @@
+"""In-process publisher for SettingsChangeEvent fan-out (MM-710).
+
+This module owns the `SettingsChangePublisher` and the subscriber protocol.
+Subscribers register against one or more ``refresh_target`` strings and receive
+events emitted by ``SettingsCatalogService.apply_overrides`` after the database
+transaction commits.
+
+Per ``specs/360-setting-change-subscribers/contracts/settings_change_publisher.md``:
+
+- registration enforces unique subscriber names and non-empty refresh_targets;
+- dispatch deduplicates per-(event, subscriber) pair across overlapping
+  refresh_targets;
+- subscriber failures are caught and logged structurally, never propagated;
+- events with empty refresh_targets are a no-op dispatch.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Iterable
+from typing import Protocol, runtime_checkable
+
+from api_service.services.settings_catalog import SettingsChangeEvent
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SettingsChangeSubscriber(Protocol):
+    """Callable that consumes ``SettingsChangeEvent`` instances."""
+
+    name: str
+    refresh_targets: frozenset[str]
+
+    async def __call__(self, event: SettingsChangeEvent) -> Awaitable[None] | None:
+        ...  # pragma: no cover - protocol stub
+
+
+class SettingsChangePublisher:
+    """In-process pub/sub keyed by ``refresh_target``."""
+
+    def __init__(self) -> None:
+        self._by_target: dict[str, dict[str, SettingsChangeSubscriber]] = {}
+        self._by_name: dict[str, SettingsChangeSubscriber] = {}
+
+    def register(self, subscriber: SettingsChangeSubscriber) -> None:
+        name = getattr(subscriber, "name", "")
+        if not isinstance(name, str) or not name:
+            raise ValueError("SettingsChangeSubscriber requires a non-empty name")
+        targets = getattr(subscriber, "refresh_targets", None)
+        if not isinstance(targets, frozenset) or not targets:
+            raise ValueError(
+                "SettingsChangeSubscriber requires a non-empty frozenset refresh_targets"
+            )
+        if name in self._by_name:
+            raise ValueError(
+                f"SettingsChangeSubscriber with name '{name}' is already registered"
+            )
+        self._by_name[name] = subscriber
+        for target in targets:
+            self._by_target.setdefault(target, {})[name] = subscriber
+
+    def unregister(self, subscriber_name: str) -> None:
+        if subscriber_name not in self._by_name:
+            return
+        self._by_name.pop(subscriber_name, None)
+        empty_targets: list[str] = []
+        for target, name_map in self._by_target.items():
+            name_map.pop(subscriber_name, None)
+            if not name_map:
+                empty_targets.append(target)
+        for target in empty_targets:
+            self._by_target.pop(target, None)
+
+    def subscribers_for(self, refresh_target: str) -> list[SettingsChangeSubscriber]:
+        return list(self._by_target.get(refresh_target, {}).values())
+
+    async def publish(self, events: Iterable[SettingsChangeEvent]) -> None:
+        for event in events:
+            matched: dict[str, SettingsChangeSubscriber] = {}
+            for target in event.refresh_targets:
+                for name, subscriber in self._by_target.get(target, {}).items():
+                    matched.setdefault(name, subscriber)
+            for name, subscriber in matched.items():
+                await self._invoke(subscriber, event)
+
+    async def _invoke(
+        self, subscriber: SettingsChangeSubscriber, event: SettingsChangeEvent
+    ) -> None:
+        try:
+            result = subscriber(event)
+            if hasattr(result, "__await__"):
+                await result  # type: ignore[func-returns-value]
+        except Exception as exc:  # noqa: BLE001 — structured isolation
+            structured = {
+                "subscriber_name": getattr(subscriber, "name", "<unknown>"),
+                "exception_class": exc.__class__.__name__,
+                "exception_message": str(exc)[:512],
+                "key": event.key,
+                "scope": event.scope,
+                "source": event.source,
+                "apply_mode": event.apply_mode,
+                "refresh_targets": sorted(event.refresh_targets),
+            }
+            logger.error(
+                "settings change subscriber '%s' failed: %s",
+                structured["subscriber_name"],
+                structured["exception_class"],
+                extra={"settings_change_publish": structured},
+            )
+
+
+_default_publisher: SettingsChangePublisher | None = None
+
+
+def get_settings_change_publisher() -> SettingsChangePublisher:
+    """Return the process-wide default publisher singleton."""
+
+    global _default_publisher
+    if _default_publisher is None:
+        _default_publisher = SettingsChangePublisher()
+    return _default_publisher
+
+
+def reset_default_settings_change_publisher() -> None:
+    """Replace the default publisher singleton (test helper)."""
+
+    global _default_publisher
+    _default_publisher = None
+
+
+__all__ = [
+    "SettingsChangePublisher",
+    "SettingsChangeSubscriber",
+    "get_settings_change_publisher",
+    "reset_default_settings_change_publisher",
+]

--- a/api_service/services/settings_change_publisher.py
+++ b/api_service/services/settings_change_publisher.py
@@ -32,8 +32,10 @@ class SettingsChangeSubscriber(Protocol):
     name: str
     refresh_targets: frozenset[str]
 
-    async def __call__(self, event: SettingsChangeEvent) -> Awaitable[None] | None:
-        ...  # pragma: no cover - protocol stub
+    async def __call__(  # pragma: no cover - protocol stub
+        self, event: SettingsChangeEvent
+    ) -> Awaitable[None] | None:
+        """Protocol stub; implementations consume the event."""
 
 
 class SettingsChangePublisher:

--- a/api_service/services/settings_change_subscribers.py
+++ b/api_service/services/settings_change_subscribers.py
@@ -147,11 +147,16 @@ class OperationalControlsSubscriber:
     name = "operational_controls"
     refresh_targets = frozenset({"operational_controls"})
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        on_refresh: Callable[[OperationalRefreshIntent], Awaitable[None]] | None = None,
+    ) -> None:
         self.version: int = 0
         self.pending_intents: deque[OperationalRefreshIntent] = deque(
             maxlen=_LEDGER_MAXLEN
         )
+        self.on_refresh = on_refresh
 
     async def __call__(self, event: SettingsChangeEvent) -> None:
         intent = OperationalRefreshIntent(
@@ -163,6 +168,8 @@ class OperationalControlsSubscriber:
         )
         self.pending_intents.append(intent)
         self.version += 1
+        if self.on_refresh is not None:
+            await self.on_refresh(intent)
 
 
 def register_default_subscribers(
@@ -173,14 +180,18 @@ def register_default_subscribers(
         [ProviderProfileRefreshIntent], Awaitable[None]
     ]
     | None = None,
+    operational_on_refresh: Callable[
+        [OperationalRefreshIntent], Awaitable[None]
+    ]
+    | None = None,
 ) -> None:
     """Register the four default subscribers against *publisher* once.
 
     Optional hooks let production wiring drive observable cross-process side
-    effects (e.g. Temporal signals, worker drain broadcasts) when
-    ``worker_reload`` / ``process_restart`` / ``next_launch`` apply modes are
-    triggered. The hooks default to ``None`` so tests can run with the bare
-    intent-ledger contract.
+    effects (e.g. Temporal signals, worker drain broadcasts, operational
+    alerting) when ``worker_reload`` / ``process_restart`` / ``next_launch`` /
+    ``manual_operation`` apply modes are triggered. The hooks default to
+    ``None`` so tests can run with the bare intent-ledger contract.
     """
 
     target_publisher = publisher or get_settings_change_publisher()
@@ -190,7 +201,7 @@ def register_default_subscribers(
         lambda: ProviderProfileManagerSubscriber(
             on_refresh=provider_profile_on_refresh
         ),
-        OperationalControlsSubscriber,
+        lambda: OperationalControlsSubscriber(on_refresh=operational_on_refresh),
     )
     for factory in factories:
         instance = factory()

--- a/api_service/services/settings_change_subscribers.py
+++ b/api_service/services/settings_change_subscribers.py
@@ -165,21 +165,34 @@ class OperationalControlsSubscriber:
         self.version += 1
 
 
-_DEFAULT_SUBSCRIBER_FACTORIES: tuple[Callable[[], object], ...] = (
-    TaskCreationDefaultsSubscriber,
-    WorkerReloadSubscriber,
-    ProviderProfileManagerSubscriber,
-    OperationalControlsSubscriber,
-)
-
-
 def register_default_subscribers(
     publisher: SettingsChangePublisher | None = None,
+    *,
+    worker_on_reload: Callable[[WorkerReloadIntent], Awaitable[None]] | None = None,
+    provider_profile_on_refresh: Callable[
+        [ProviderProfileRefreshIntent], Awaitable[None]
+    ]
+    | None = None,
 ) -> None:
-    """Register the four default subscribers against *publisher* once."""
+    """Register the four default subscribers against *publisher* once.
+
+    Optional hooks let production wiring drive observable cross-process side
+    effects (e.g. Temporal signals, worker drain broadcasts) when
+    ``worker_reload`` / ``process_restart`` / ``next_launch`` apply modes are
+    triggered. The hooks default to ``None`` so tests can run with the bare
+    intent-ledger contract.
+    """
 
     target_publisher = publisher or get_settings_change_publisher()
-    for factory in _DEFAULT_SUBSCRIBER_FACTORIES:
+    factories: tuple[Callable[[], object], ...] = (
+        TaskCreationDefaultsSubscriber,
+        lambda: WorkerReloadSubscriber(on_reload=worker_on_reload),
+        lambda: ProviderProfileManagerSubscriber(
+            on_refresh=provider_profile_on_refresh
+        ),
+        OperationalControlsSubscriber,
+    )
+    for factory in factories:
         instance = factory()
         name = getattr(instance, "name", None)
         refresh_targets = getattr(instance, "refresh_targets", frozenset())

--- a/api_service/services/settings_change_subscribers.py
+++ b/api_service/services/settings_change_subscribers.py
@@ -1,0 +1,207 @@
+"""Default per-family settings change subscribers (MM-710).
+
+Each subscriber refreshes one consumer family (task creation defaults, worker
+reloaders, the provider profile manager, or operational controls) in response
+to the ``setting_changed`` events emitted by ``SettingsCatalogService``.
+
+The subscribers maintain bounded in-process ledgers so that operators and tests
+can observe that a refresh occurred. Real cross-process side effects
+(worker drains, Temporal signals to the ``ProviderProfileManager`` workflow,
+etc.) are delegated to optional ``on_*`` hooks that downstream wiring can
+attach without modifying the subscriber implementations.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+from api_service.services.settings_catalog import (
+    SettingApplyMode,
+    SettingScope,
+    SettingsChangeEvent,
+)
+from api_service.services.settings_change_publisher import (
+    SettingsChangePublisher,
+    get_settings_change_publisher,
+)
+
+_LEDGER_MAXLEN = 128
+
+
+@dataclass
+class WorkerReloadIntent:
+    intent: Literal["soft_reload", "process_restart"]
+    key: str
+    scope: SettingScope
+    apply_mode: SettingApplyMode
+    refresh_target: str
+    affected_systems: tuple[str, ...]
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class ProviderProfileRefreshIntent:
+    key: str
+    scope: SettingScope
+    apply_mode: SettingApplyMode
+    refresh_target: str
+    affected_systems: tuple[str, ...]
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class OperationalRefreshIntent:
+    key: str
+    scope: SettingScope
+    apply_mode: SettingApplyMode
+    refresh_target: str
+    affected_systems: tuple[str, ...]
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class TaskCreationDefaultsSubscriber:
+    """Tracks task-creation default refreshes triggered by setting changes."""
+
+    name = "task_creation_defaults"
+    refresh_targets = frozenset({"task_creation_defaults"})
+
+    def __init__(self) -> None:
+        self.version: int = 0
+        self.recent_events: deque[SettingsChangeEvent] = deque(maxlen=_LEDGER_MAXLEN)
+
+    async def __call__(self, event: SettingsChangeEvent) -> None:
+        self.version += 1
+        self.recent_events.append(event)
+
+
+class WorkerReloadSubscriber:
+    """Records reload intents the worker fleet should observe."""
+
+    name = "worker_reloaders"
+    refresh_targets = frozenset({"worker_reloaders"})
+
+    def __init__(
+        self,
+        *,
+        on_reload: Callable[[WorkerReloadIntent], Awaitable[None]] | None = None,
+    ) -> None:
+        self.pending_intents: deque[WorkerReloadIntent] = deque(maxlen=_LEDGER_MAXLEN)
+        self.on_reload = on_reload
+
+    async def __call__(self, event: SettingsChangeEvent) -> None:
+        kind: Literal["soft_reload", "process_restart"] = (
+            "process_restart" if event.apply_mode == "process_restart" else "soft_reload"
+        )
+        intent = WorkerReloadIntent(
+            intent=kind,
+            key=event.key,
+            scope=event.scope,
+            apply_mode=event.apply_mode,
+            refresh_target="worker_reloaders",
+            affected_systems=tuple(event.affected_systems),
+        )
+        self.pending_intents.append(intent)
+        if self.on_reload is not None:
+            await self.on_reload(intent)
+
+
+class ProviderProfileManagerSubscriber:
+    """Records provider-profile-manager refresh intents."""
+
+    name = "provider_profile_manager"
+    refresh_targets = frozenset({"provider_profile_manager"})
+
+    def __init__(
+        self,
+        *,
+        on_refresh: Callable[[ProviderProfileRefreshIntent], Awaitable[None]]
+        | None = None,
+    ) -> None:
+        self.version: int = 0
+        self.pending_intents: deque[ProviderProfileRefreshIntent] = deque(
+            maxlen=_LEDGER_MAXLEN
+        )
+        self.on_refresh = on_refresh
+
+    async def __call__(self, event: SettingsChangeEvent) -> None:
+        intent = ProviderProfileRefreshIntent(
+            key=event.key,
+            scope=event.scope,
+            apply_mode=event.apply_mode,
+            refresh_target="provider_profile_manager",
+            affected_systems=tuple(event.affected_systems),
+        )
+        self.pending_intents.append(intent)
+        self.version += 1
+        if self.on_refresh is not None:
+            await self.on_refresh(intent)
+
+
+class OperationalControlsSubscriber:
+    """Records operational-controls refresh intents."""
+
+    name = "operational_controls"
+    refresh_targets = frozenset({"operational_controls"})
+
+    def __init__(self) -> None:
+        self.version: int = 0
+        self.pending_intents: deque[OperationalRefreshIntent] = deque(
+            maxlen=_LEDGER_MAXLEN
+        )
+
+    async def __call__(self, event: SettingsChangeEvent) -> None:
+        intent = OperationalRefreshIntent(
+            key=event.key,
+            scope=event.scope,
+            apply_mode=event.apply_mode,
+            refresh_target="operational_controls",
+            affected_systems=tuple(event.affected_systems),
+        )
+        self.pending_intents.append(intent)
+        self.version += 1
+
+
+_DEFAULT_SUBSCRIBER_FACTORIES: tuple[Callable[[], object], ...] = (
+    TaskCreationDefaultsSubscriber,
+    WorkerReloadSubscriber,
+    ProviderProfileManagerSubscriber,
+    OperationalControlsSubscriber,
+)
+
+
+def register_default_subscribers(
+    publisher: SettingsChangePublisher | None = None,
+) -> None:
+    """Register the four default subscribers against *publisher* once."""
+
+    target_publisher = publisher or get_settings_change_publisher()
+    for factory in _DEFAULT_SUBSCRIBER_FACTORIES:
+        instance = factory()
+        name = getattr(instance, "name", None)
+        refresh_targets = getattr(instance, "refresh_targets", frozenset())
+        if not isinstance(name, str) or not name or not refresh_targets:
+            continue
+        already_registered = any(
+            sub.name == name
+            for target in refresh_targets
+            for sub in target_publisher.subscribers_for(target)
+        )
+        if already_registered:
+            continue
+        target_publisher.register(instance)
+
+
+__all__ = [
+    "OperationalControlsSubscriber",
+    "OperationalRefreshIntent",
+    "ProviderProfileManagerSubscriber",
+    "ProviderProfileRefreshIntent",
+    "TaskCreationDefaultsSubscriber",
+    "WorkerReloadIntent",
+    "WorkerReloadSubscriber",
+    "register_default_subscribers",
+]

--- a/tests/integration/api/test_settings_change_subscribers_contract.py
+++ b/tests/integration/api/test_settings_change_subscribers_contract.py
@@ -22,7 +22,6 @@ from api_service.db import base as db_base
 from api_service.db.models import Base
 from api_service.main import app
 from api_service.services.settings_change_publisher import (
-    SettingsChangePublisher,
     get_settings_change_publisher,
     reset_default_settings_change_publisher,
 )

--- a/tests/integration/api/test_settings_change_subscribers_contract.py
+++ b/tests/integration/api/test_settings_change_subscribers_contract.py
@@ -334,3 +334,159 @@ async def test_secret_ref_setting_change_does_not_publish_secret_payload(
     # The event payload must not include the value being set.
     assert env_alias not in repr(payload.get("source"))
     assert env_alias not in repr(payload.get("key"))
+
+
+@pytest_asyncio.fixture
+async def settings_subscriber_env_with_hooks(tmp_path):
+    """Same hermetic env as ``settings_subscriber_env`` but with the production
+    hook factories wired in. The Temporal client provider is mocked so we can
+    assert observable signaling without touching a live Temporal server.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    from api_service.services.settings_change_hooks import (
+        make_provider_profile_refresh_hook,
+        make_worker_reload_broadcast_hook,
+    )
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/settings-subscribers-hooks.db"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    original_session_maker = db_base.async_session_maker
+    db_base.async_session_maker = session_maker
+
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="settings-subscribers-hooks@example.com",
+        is_superuser=True,
+        settings_permissions={
+            "settings.catalog.read",
+            "settings.effective.read",
+            "settings.user.write",
+            "settings.workspace.write",
+        },
+        workspace_id=uuid4(),
+    )
+    app.dependency_overrides[SETTINGS_USER_DEP] = lambda: user
+
+    reset_default_settings_change_publisher()
+    publisher = get_settings_change_publisher()
+
+    signaled_workflows: list[str] = []
+    signaled_calls: list[tuple[str, dict]] = []
+    fake_client = MagicMock()
+
+    def _handle_for(workflow_id: str):
+        signaled_workflows.append(workflow_id)
+        handle = AsyncMock()
+
+        async def _signal(name: str, payload: dict) -> None:
+            signaled_calls.append((name, payload))
+
+        handle.signal.side_effect = _signal
+        return handle
+
+    fake_client.get_workflow_handle = MagicMock(side_effect=_handle_for)
+
+    runtime_ids = ["claude_code", "codex_cli"]
+
+    provider_hook = make_provider_profile_refresh_hook(
+        temporal_client_provider=AsyncMock(return_value=fake_client),
+        runtime_ids_provider=AsyncMock(return_value=runtime_ids),
+    )
+
+    worker_broadcasts: list[dict] = []
+
+    async def _record_broadcast(payload: dict) -> None:
+        worker_broadcasts.append(payload)
+
+    worker_hook = make_worker_reload_broadcast_hook(
+        broadcaster=_record_broadcast,
+    )
+
+    register_default_subscribers(
+        publisher,
+        worker_on_reload=worker_hook,
+        provider_profile_on_refresh=provider_hook,
+    )
+
+    handle = SimpleNamespace(
+        publisher=publisher,
+        signaled_workflows=signaled_workflows,
+        signaled_calls=signaled_calls,
+        worker_broadcasts=worker_broadcasts,
+        runtime_ids=runtime_ids,
+    )
+    try:
+        yield handle
+    finally:
+        app.dependency_overrides.pop(SETTINGS_USER_DEP, None)
+        db_base.async_session_maker = original_session_maker
+        reset_default_settings_change_publisher()
+        await engine.dispose()
+
+
+async def test_provider_profile_refresh_hook_signals_each_known_runtime_on_patch(
+    settings_subscriber_env_with_hooks,
+):
+    """End-to-end: patching ``workflow.default_provider_profile_ref`` must reach
+    every registered ProviderProfileManager workflow via ``sync_profiles``."""
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_provider_profile_ref": None},
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    assert sorted(settings_subscriber_env_with_hooks.signaled_workflows) == sorted(
+        f"provider-profile-manager:{rid}"
+        for rid in settings_subscriber_env_with_hooks.runtime_ids
+    )
+    assert all(
+        name == "sync_profiles"
+        for name, _ in settings_subscriber_env_with_hooks.signaled_calls
+    )
+    assert len(settings_subscriber_env_with_hooks.signaled_calls) == len(
+        settings_subscriber_env_with_hooks.runtime_ids
+    )
+
+
+async def test_worker_reload_hook_broadcasts_intent_on_patch(
+    settings_subscriber_env_with_hooks,
+):
+    """End-to-end: patching a worker_reload-mode setting must reach the
+    configured broadcaster with the normalized intent payload."""
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"skills.policy_mode": "allowlist"},
+                "expected_versions": {"skills.policy_mode": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    broadcasts = settings_subscriber_env_with_hooks.worker_broadcasts
+    assert len(broadcasts) == 1
+    payload = broadcasts[0]
+    assert payload["intent"] == "soft_reload"
+    assert payload["apply_mode"] == "worker_reload"
+    assert payload["key"] == "skills.policy_mode"
+    assert "workflow_runtime" in payload["affected_systems"]
+    # The Temporal client provider must not be exercised for worker_reload-only
+    # settings: refresh hook is keyed off the provider_profile_manager refresh
+    # target which only fires when applies_to includes provider_profiles.
+    assert settings_subscriber_env_with_hooks.signaled_workflows == []

--- a/tests/integration/api/test_settings_change_subscribers_contract.py
+++ b/tests/integration/api/test_settings_change_subscribers_contract.py
@@ -1,0 +1,336 @@
+"""Integration coverage for the SettingsChangePublisher and its four default
+subscribers (MM-710).
+
+These tests drive the same Settings PATCH endpoint that Mission Control uses,
+then assert observable side effects on the per-family subscriber instances.
+The publisher is isolated per test by resetting the process-wide singleton and
+registering a fresh set of default subscribers against it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.auth_providers import get_current_user
+from api_service.db import base as db_base
+from api_service.db.models import Base
+from api_service.main import app
+from api_service.services.settings_change_publisher import (
+    SettingsChangePublisher,
+    get_settings_change_publisher,
+    reset_default_settings_change_publisher,
+)
+from api_service.services.settings_change_subscribers import (
+    OperationalControlsSubscriber,
+    ProviderProfileManagerSubscriber,
+    TaskCreationDefaultsSubscriber,
+    WorkerReloadSubscriber,
+    register_default_subscribers,
+)
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+SETTINGS_USER_DEP = get_current_user()
+
+
+@pytest_asyncio.fixture
+async def settings_subscriber_env(tmp_path):
+    """Provision a hermetic settings DB, swap in an isolated publisher with the
+    four default subscribers registered, and yield a handle to the subscribers
+    for assertion."""
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/settings-subscribers.db"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    original_session_maker = db_base.async_session_maker
+    db_base.async_session_maker = session_maker
+
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="settings-subscribers@example.com",
+        is_superuser=True,
+        settings_permissions={
+            "settings.catalog.read",
+            "settings.effective.read",
+            "settings.user.write",
+            "settings.workspace.write",
+        },
+        workspace_id=uuid4(),
+    )
+    app.dependency_overrides[SETTINGS_USER_DEP] = lambda: user
+
+    reset_default_settings_change_publisher()
+    publisher = get_settings_change_publisher()
+    register_default_subscribers(publisher)
+
+    handle = SimpleNamespace(
+        session_maker=session_maker,
+        publisher=publisher,
+        task_creation=next(
+            sub
+            for sub in publisher.subscribers_for("task_creation_defaults")
+            if isinstance(sub, TaskCreationDefaultsSubscriber)
+        ),
+        worker_reload=next(
+            sub
+            for sub in publisher.subscribers_for("worker_reloaders")
+            if isinstance(sub, WorkerReloadSubscriber)
+        ),
+        provider_profile=next(
+            sub
+            for sub in publisher.subscribers_for("provider_profile_manager")
+            if isinstance(sub, ProviderProfileManagerSubscriber)
+        ),
+        operational=next(
+            sub
+            for sub in publisher.subscribers_for("operational_controls")
+            if isinstance(sub, OperationalControlsSubscriber)
+        ),
+    )
+
+    try:
+        yield handle
+    finally:
+        app.dependency_overrides.pop(SETTINGS_USER_DEP, None)
+        db_base.async_session_maker = original_session_maker
+        reset_default_settings_change_publisher()
+        await engine.dispose()
+
+
+async def test_task_creation_defaults_subscriber_fires_on_next_task_setting(
+    settings_subscriber_env,
+):
+    start_version = settings_subscriber_env.task_creation.version
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_task_runtime": "claude_code"},
+                "expected_versions": {"workflow.default_task_runtime": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["change_events"][0]["refresh_targets"].count("task_creation_defaults") == 1
+    assert (
+        settings_subscriber_env.task_creation.version == start_version + 1
+    ), "task_creation_defaults subscriber should fire exactly once for a next_task change"
+    latest = settings_subscriber_env.task_creation.recent_events[-1]
+    assert latest.key == "workflow.default_task_runtime"
+    assert latest.apply_mode == "next_task"
+
+
+async def test_worker_reload_subscriber_records_soft_reload_intent_for_worker_reload_mode(
+    settings_subscriber_env,
+):
+    start_count = len(settings_subscriber_env.worker_reload.pending_intents)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"skills.policy_mode": "allowlist"},
+                "expected_versions": {"skills.policy_mode": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    intents = list(settings_subscriber_env.worker_reload.pending_intents)
+    assert len(intents) == start_count + 1
+    intent = intents[-1]
+    assert intent.intent == "soft_reload"
+    assert intent.apply_mode == "worker_reload"
+    assert intent.key == "skills.policy_mode"
+    assert intent.refresh_target == "worker_reloaders"
+    assert "workflow_runtime" in intent.affected_systems
+
+
+async def test_provider_profile_manager_subscriber_fires_on_default_profile_change(
+    settings_subscriber_env,
+):
+    start_version = settings_subscriber_env.provider_profile.version
+    start_count = len(settings_subscriber_env.provider_profile.pending_intents)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_provider_profile_ref": None},
+                "expected_versions": {"workflow.default_provider_profile_ref": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    intents = list(settings_subscriber_env.provider_profile.pending_intents)
+    assert len(intents) == start_count + 1
+    intent = intents[-1]
+    assert intent.key == "workflow.default_provider_profile_ref"
+    assert intent.apply_mode == "next_launch"
+    assert intent.refresh_target == "provider_profile_manager"
+    assert settings_subscriber_env.provider_profile.version == start_version + 1
+
+
+async def test_operational_controls_subscriber_fires_on_operation_mode_change(
+    settings_subscriber_env,
+):
+    start_version = settings_subscriber_env.operational.version
+    start_count = len(settings_subscriber_env.operational.pending_intents)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.operation_mode": "maintenance"},
+                "expected_versions": {"workflow.operation_mode": 1},
+                "confirmation": "I confirm this operation mode change.",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    intents = list(settings_subscriber_env.operational.pending_intents)
+    assert len(intents) == start_count + 1
+    intent = intents[-1]
+    assert intent.key == "workflow.operation_mode"
+    assert intent.apply_mode == "manual_operation"
+    assert intent.refresh_target == "operational_controls"
+    assert settings_subscriber_env.operational.version == start_version + 1
+
+
+async def test_multi_key_patch_fans_out_one_event_per_key(settings_subscriber_env):
+    start_version = settings_subscriber_env.task_creation.version
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {
+                    "workflow.default_task_runtime": "claude_code",
+                    "workflow.default_publish_mode": "branch",
+                },
+                "expected_versions": {
+                    "workflow.default_task_runtime": 1,
+                    "workflow.default_publish_mode": 1,
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["change_events"]) == 2
+    assert settings_subscriber_env.task_creation.version == start_version + 2
+    recorded = list(settings_subscriber_env.task_creation.recent_events)[-2:]
+    keys = {event.key for event in recorded}
+    assert keys == {"workflow.default_task_runtime", "workflow.default_publish_mode"}
+
+
+async def test_subscriber_failure_does_not_change_http_response(
+    settings_subscriber_env,
+):
+    """SCN-6 + SC-003: a failing subscriber does not break the API response and
+    does not prevent other subscribers from running."""
+
+    class _FailingSubscriber:
+        name = "failing_for_test"
+        refresh_targets = frozenset({"task_creation_defaults"})
+
+        def __init__(self) -> None:
+            self.invoked = False
+
+        async def __call__(self, event) -> None:
+            self.invoked = True
+            raise RuntimeError("intentional subscriber failure")
+
+    failing = _FailingSubscriber()
+    settings_subscriber_env.publisher.register(failing)
+    start_version = settings_subscriber_env.task_creation.version
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/workspace",
+            json={
+                "changes": {"workflow.default_task_runtime": "gemini_cli"},
+                "expected_versions": {"workflow.default_task_runtime": 1},
+            },
+        )
+
+    assert response.status_code == 200
+    assert failing.invoked is True
+    assert (
+        settings_subscriber_env.task_creation.version == start_version + 1
+    ), "real subscriber must still fire when a sibling subscriber raised"
+
+
+async def test_secret_ref_setting_change_does_not_publish_secret_payload(
+    settings_subscriber_env,
+):
+    """FR-010: secret values must not appear in published event payloads."""
+
+    captured: list[dict] = []
+
+    class _SnifferSubscriber:
+        name = "secret_sniffer"
+        refresh_targets = frozenset({"settings_catalog"})
+
+        async def __call__(self, event) -> None:
+            captured.append(event.model_dump())
+
+    settings_subscriber_env.publisher.register(_SnifferSubscriber())
+
+    # Use an env-ref name that passes the unsafe-payload heuristics (no secret
+    # prefix); FR-010 covers what fields the published event carries, not how
+    # the validation layer rejects sensitive payloads.
+    env_alias = "MM710_TEST_ENV_TOKEN_REF"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.patch(
+            "/api/v1/settings/user",
+            json={
+                "changes": {"integrations.github.token_ref": f"env://{env_alias}"},
+                "expected_versions": {"integrations.github.token_ref": 1},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured, "expected the sniffer subscriber to receive the event"
+    payload = captured[-1]
+    assert payload["key"] == "integrations.github.token_ref"
+    assert set(payload.keys()) == {
+        "event_type",
+        "key",
+        "scope",
+        "source",
+        "apply_mode",
+        "actor_user_id",
+        "changed_at",
+        "affected_systems",
+        "refresh_targets",
+    }
+    # The event payload must not include the value being set.
+    assert env_alias not in repr(payload.get("source"))
+    assert env_alias not in repr(payload.get("key"))

--- a/tests/unit/services/test_settings_catalog.py
+++ b/tests/unit/services/test_settings_catalog.py
@@ -3293,3 +3293,127 @@ def test_workflow_settings_has_moonmind_expose_metadata():
     assert "skills.policy_mode" in exposed_keys
     assert "skills.canary_percent" in exposed_keys
     assert "live_sessions.default_enabled" in exposed_keys
+
+
+# ---------------------------------------------------------------------------
+# MM-710: SettingsCatalogService.apply_overrides publishes through the
+# SettingsChangePublisher after the database transaction commits.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_overrides_dispatches_change_events_through_injected_publisher(
+    settings_session_maker,
+):
+    from api_service.services.settings_change_publisher import SettingsChangePublisher
+    from api_service.services.settings_catalog import SettingsChangeEvent
+
+    published: list[list[SettingsChangeEvent]] = []
+
+    class _CapturingPublisher(SettingsChangePublisher):
+        async def publish(self, events):  # type: ignore[override]
+            batch = list(events)
+            published.append(batch)
+            await super().publish(batch)
+
+    publisher = _CapturingPublisher()
+
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(
+            env={},
+            session=settings_session,
+            user_id=uuid4(),
+            change_publisher=publisher,
+        )
+        response = await service.apply_overrides(
+            scope="workspace",
+            changes={"workflow.default_task_runtime": "claude_code"},
+            expected_versions={"workflow.default_task_runtime": 1},
+        )
+
+    assert len(published) == 1
+    assert len(published[0]) == 1
+    dispatched = published[0][0]
+    assert dispatched.key == "workflow.default_task_runtime"
+    assert dispatched.scope == "workspace"
+    assert dispatched.source == "workspace_override"
+    assert "task_creation_defaults" in dispatched.refresh_targets
+
+    response_event = response.change_events[0]
+    assert response_event.key == dispatched.key
+    assert response_event.refresh_targets == dispatched.refresh_targets
+
+
+@pytest.mark.asyncio
+async def test_apply_overrides_does_not_dispatch_when_validation_fails(
+    settings_session_maker,
+):
+    from api_service.services.settings_change_publisher import SettingsChangePublisher
+    from api_service.services.settings_catalog import SettingsChangeEvent
+
+    published: list[SettingsChangeEvent] = []
+
+    class _CapturingPublisher(SettingsChangePublisher):
+        async def publish(self, events):  # type: ignore[override]
+            published.extend(events)
+            await super().publish(events)
+
+    publisher = _CapturingPublisher()
+
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(
+            env={},
+            session=settings_session,
+            user_id=uuid4(),
+            change_publisher=publisher,
+        )
+        with pytest.raises(SettingsValidationError):
+            await service.apply_overrides(
+                scope="workspace",
+                changes={"skills.canary_percent": 999},
+                expected_versions={"skills.canary_percent": 1},
+            )
+
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_apply_overrides_fans_out_one_event_per_committed_key(
+    settings_session_maker,
+):
+    """SC-002: a single PATCH committing N settings produces N publish payload entries."""
+
+    from api_service.services.settings_change_publisher import SettingsChangePublisher
+    from api_service.services.settings_catalog import SettingsChangeEvent
+
+    published: list[SettingsChangeEvent] = []
+
+    class _CapturingPublisher(SettingsChangePublisher):
+        async def publish(self, events):  # type: ignore[override]
+            published.extend(events)
+            await super().publish(events)
+
+    publisher = _CapturingPublisher()
+
+    async with settings_session_maker() as settings_session:
+        service = SettingsCatalogService(
+            env={},
+            session=settings_session,
+            user_id=uuid4(),
+            change_publisher=publisher,
+        )
+        await service.apply_overrides(
+            scope="workspace",
+            changes={
+                "workflow.default_task_runtime": "claude_code",
+                "workflow.default_publish_mode": "branch",
+            },
+            expected_versions={
+                "workflow.default_task_runtime": 1,
+                "workflow.default_publish_mode": 1,
+            },
+        )
+
+    assert len(published) == 2
+    keys = {event.key for event in published}
+    assert keys == {"workflow.default_task_runtime", "workflow.default_publish_mode"}

--- a/tests/unit/services/test_settings_change_hooks.py
+++ b/tests/unit/services/test_settings_change_hooks.py
@@ -24,6 +24,7 @@ from api_service.services.settings_change_hooks import (
 )
 from api_service.services.settings_change_publisher import SettingsChangePublisher
 from api_service.services.settings_change_subscribers import (
+    OperationalControlsSubscriber,
     OperationalRefreshIntent,
     ProviderProfileManagerSubscriber,
     ProviderProfileRefreshIntent,
@@ -313,6 +314,26 @@ async def test_register_default_subscribers_wires_worker_reload_hook():
     worker_sub = worker_subs[0]
     assert isinstance(worker_sub, WorkerReloadSubscriber)
     assert worker_sub.on_reload is captured_hook
+
+
+@pytest.mark.asyncio
+async def test_register_default_subscribers_wires_operational_hook():
+    received: list[OperationalRefreshIntent] = []
+
+    async def captured_hook(intent: OperationalRefreshIntent) -> None:
+        received.append(intent)
+
+    publisher = SettingsChangePublisher()
+    register_default_subscribers(
+        publisher,
+        operational_on_refresh=captured_hook,
+    )
+
+    operational_subs = publisher.subscribers_for("operational_controls")
+    assert operational_subs, "expected operational_controls subscriber registered"
+    operational_sub = operational_subs[0]
+    assert isinstance(operational_sub, OperationalControlsSubscriber)
+    assert operational_sub.on_refresh is captured_hook
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_settings_change_hooks.py
+++ b/tests/unit/services/test_settings_change_hooks.py
@@ -1,0 +1,355 @@
+"""Unit tests for production hook factories used by the SettingsChangePublisher
+default subscribers (MM-710).
+
+These hooks turn the subscriber-recorded intents (e.g. ProviderProfileRefreshIntent)
+into concrete cross-process side effects so that ``worker_reload``,
+``next_launch``, and ``manual_operation`` apply modes drive observable behavior
+beyond UI query invalidation.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from api_service.services.settings_change_hooks import (
+    make_operational_mode_hook,
+    make_provider_profile_refresh_hook,
+    make_worker_reload_broadcast_hook,
+)
+from api_service.services.settings_change_publisher import SettingsChangePublisher
+from api_service.services.settings_change_subscribers import (
+    OperationalRefreshIntent,
+    ProviderProfileManagerSubscriber,
+    ProviderProfileRefreshIntent,
+    WorkerReloadIntent,
+    WorkerReloadSubscriber,
+    register_default_subscribers,
+)
+
+
+def _provider_intent(
+    *,
+    key: str = "workflow.default_provider_profile_ref",
+    apply_mode: str = "next_launch",
+    affected_systems: tuple[str, ...] = (
+        "task_creation",
+        "workflow_runtime",
+        "provider_profiles",
+    ),
+) -> ProviderProfileRefreshIntent:
+    return ProviderProfileRefreshIntent(
+        key=key,
+        scope="workspace",
+        apply_mode=apply_mode,
+        refresh_target="provider_profile_manager",
+        affected_systems=affected_systems,
+    )
+
+
+def _worker_intent(
+    *,
+    apply_mode: str = "worker_reload",
+    intent: str = "soft_reload",
+) -> WorkerReloadIntent:
+    return WorkerReloadIntent(
+        intent=intent,
+        key="skills.policy_mode",
+        scope="workspace",
+        apply_mode=apply_mode,
+        refresh_target="worker_reloaders",
+        affected_systems=("workflow_runtime", "skills"),
+    )
+
+
+def _operational_intent(
+    *,
+    apply_mode: str = "manual_operation",
+) -> OperationalRefreshIntent:
+    return OperationalRefreshIntent(
+        key="workflow.operation_mode",
+        scope="workspace",
+        apply_mode=apply_mode,
+        refresh_target="operational_controls",
+        affected_systems=("operations",),
+    )
+
+
+# ---------------------------------------------------------------------------
+# make_provider_profile_refresh_hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_refresh_hook_signals_every_known_runtime():
+    """The on_refresh hook signals sync_profiles on every registered runtime
+    family workflow so any one of them can re-pull from the DB."""
+
+    handle_a = AsyncMock()
+    handle_b = AsyncMock()
+    client = MagicMock()
+    handle_lookup = {
+        "provider-profile-manager:claude_code": handle_a,
+        "provider-profile-manager:codex_cli": handle_b,
+    }
+    client.get_workflow_handle = MagicMock(side_effect=handle_lookup.__getitem__)
+    temporal_client_provider = AsyncMock(return_value=client)
+    runtime_ids_provider = AsyncMock(return_value=["claude_code", "codex_cli"])
+
+    hook = make_provider_profile_refresh_hook(
+        temporal_client_provider=temporal_client_provider,
+        runtime_ids_provider=runtime_ids_provider,
+    )
+
+    await hook(_provider_intent())
+
+    runtime_ids_provider.assert_awaited_once()
+    temporal_client_provider.assert_awaited_once()
+    handle_a.signal.assert_awaited_once_with("sync_profiles", {"profiles": []})
+    handle_b.signal.assert_awaited_once_with("sync_profiles", {"profiles": []})
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_refresh_hook_isolates_failed_runtime_signal(caplog):
+    """A signal failure for one runtime must not stop signaling the others."""
+
+    failing = AsyncMock()
+    failing.signal.side_effect = RuntimeError("temporal unreachable")
+    ok = AsyncMock()
+    client = MagicMock()
+    client.get_workflow_handle = MagicMock(
+        side_effect={
+            "provider-profile-manager:claude_code": failing,
+            "provider-profile-manager:codex_cli": ok,
+        }.__getitem__
+    )
+    hook = make_provider_profile_refresh_hook(
+        temporal_client_provider=AsyncMock(return_value=client),
+        runtime_ids_provider=AsyncMock(return_value=["claude_code", "codex_cli"]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="api_service.services.settings_change_hooks"):
+        await hook(_provider_intent())
+
+    ok.signal.assert_awaited_once()
+    failing.signal.assert_awaited_once()
+    assert any(
+        "claude_code" in record.getMessage() for record in caplog.records
+    ), "expected the failing-runtime warning to be logged"
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_refresh_hook_skips_when_no_runtimes_known():
+    """If no runtime families are registered yet, the hook is a no-op."""
+
+    temporal_client_provider = AsyncMock()
+    hook = make_provider_profile_refresh_hook(
+        temporal_client_provider=temporal_client_provider,
+        runtime_ids_provider=AsyncMock(return_value=[]),
+    )
+
+    await hook(_provider_intent())
+
+    temporal_client_provider.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_refresh_hook_handles_temporal_provider_failure(caplog):
+    """If the Temporal client itself cannot be reached, the hook must swallow
+    the exception (publisher would also isolate, but defense-in-depth)."""
+
+    hook = make_provider_profile_refresh_hook(
+        temporal_client_provider=AsyncMock(side_effect=RuntimeError("no client")),
+        runtime_ids_provider=AsyncMock(return_value=["claude_code"]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="api_service.services.settings_change_hooks"):
+        await hook(_provider_intent())  # must not raise
+
+    assert any(
+        "no client" in record.getMessage() or "ProviderProfileManager" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# make_worker_reload_broadcast_hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_broadcast_hook_invokes_broadcaster_with_intent_payload():
+    seen: list[dict[str, Any]] = []
+
+    async def fake_broadcaster(payload: dict[str, Any]) -> None:
+        seen.append(payload)
+
+    hook = make_worker_reload_broadcast_hook(broadcaster=fake_broadcaster)
+
+    await hook(_worker_intent())
+
+    assert len(seen) == 1
+    payload = seen[0]
+    assert payload["intent"] == "soft_reload"
+    assert payload["key"] == "skills.policy_mode"
+    assert payload["apply_mode"] == "worker_reload"
+    assert payload["scope"] == "workspace"
+    assert "workflow_runtime" in payload["affected_systems"]
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_broadcast_hook_distinguishes_process_restart_payload():
+    seen: list[dict[str, Any]] = []
+
+    async def fake_broadcaster(payload: dict[str, Any]) -> None:
+        seen.append(payload)
+
+    hook = make_worker_reload_broadcast_hook(broadcaster=fake_broadcaster)
+
+    await hook(_worker_intent(apply_mode="process_restart", intent="process_restart"))
+
+    assert seen[0]["intent"] == "process_restart"
+    assert seen[0]["apply_mode"] == "process_restart"
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_broadcast_hook_isolates_broadcaster_failure(caplog):
+    async def angry_broadcaster(payload: dict[str, Any]) -> None:
+        raise RuntimeError("control plane gone")
+
+    hook = make_worker_reload_broadcast_hook(broadcaster=angry_broadcaster)
+
+    with caplog.at_level(logging.WARNING, logger="api_service.services.settings_change_hooks"):
+        await hook(_worker_intent())  # must not raise
+
+    assert any("control plane gone" in record.getMessage() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# make_operational_mode_hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operational_mode_hook_invokes_handler_with_intent_payload():
+    seen: list[dict[str, Any]] = []
+
+    async def fake_handler(payload: dict[str, Any]) -> None:
+        seen.append(payload)
+
+    hook = make_operational_mode_hook(handler=fake_handler)
+
+    await hook(_operational_intent())
+
+    assert len(seen) == 1
+    payload = seen[0]
+    assert payload["key"] == "workflow.operation_mode"
+    assert payload["apply_mode"] == "manual_operation"
+    assert payload["affected_systems"] == ("operations",)
+
+
+@pytest.mark.asyncio
+async def test_operational_mode_hook_isolates_handler_failure(caplog):
+    async def angry_handler(payload: dict[str, Any]) -> None:
+        raise RuntimeError("ops endpoint down")
+
+    hook = make_operational_mode_hook(handler=angry_handler)
+
+    with caplog.at_level(logging.WARNING, logger="api_service.services.settings_change_hooks"):
+        await hook(_operational_intent())  # must not raise
+
+    assert any("ops endpoint down" in record.getMessage() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# register_default_subscribers hook injection contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_default_subscribers_wires_provider_profile_on_refresh():
+    """register_default_subscribers must support injecting a concrete
+    on_refresh hook so production wiring can drive cross-process side effects.
+    """
+
+    received: list[ProviderProfileRefreshIntent] = []
+
+    async def captured_hook(intent: ProviderProfileRefreshIntent) -> None:
+        received.append(intent)
+
+    publisher = SettingsChangePublisher()
+    register_default_subscribers(
+        publisher,
+        provider_profile_on_refresh=captured_hook,
+    )
+
+    profile_subs = publisher.subscribers_for("provider_profile_manager")
+    assert profile_subs, "expected provider_profile_manager subscriber registered"
+    profile_sub = profile_subs[0]
+    assert isinstance(profile_sub, ProviderProfileManagerSubscriber)
+    assert profile_sub.on_refresh is captured_hook
+
+
+@pytest.mark.asyncio
+async def test_register_default_subscribers_wires_worker_reload_hook():
+    received: list[WorkerReloadIntent] = []
+
+    async def captured_hook(intent: WorkerReloadIntent) -> None:
+        received.append(intent)
+
+    publisher = SettingsChangePublisher()
+    register_default_subscribers(
+        publisher,
+        worker_on_reload=captured_hook,
+    )
+
+    worker_subs = publisher.subscribers_for("worker_reloaders")
+    assert worker_subs, "expected worker_reloaders subscriber registered"
+    worker_sub = worker_subs[0]
+    assert isinstance(worker_sub, WorkerReloadSubscriber)
+    assert worker_sub.on_reload is captured_hook
+
+
+@pytest.mark.asyncio
+async def test_register_default_subscribers_invokes_provider_hook_on_event(caplog):
+    """End-to-end through the publisher: when a provider-profile-affecting event
+    is published, the wired on_refresh hook must run."""
+
+    received: list[ProviderProfileRefreshIntent] = []
+
+    async def captured_hook(intent: ProviderProfileRefreshIntent) -> None:
+        received.append(intent)
+
+    publisher = SettingsChangePublisher()
+    register_default_subscribers(
+        publisher,
+        provider_profile_on_refresh=captured_hook,
+    )
+
+    from api_service.services.settings_catalog import SettingsChangeEvent
+
+    event = SettingsChangeEvent(
+        key="workflow.default_provider_profile_ref",
+        scope="workspace",
+        source="workspace_override",
+        apply_mode="next_launch",
+        actor_user_id=uuid4(),
+        changed_at=datetime.now(timezone.utc),
+        affected_systems=["task_creation", "workflow_runtime", "provider_profiles"],
+        refresh_targets=[
+            "provider_profile_manager",
+            "settings_catalog",
+            "task_creation_defaults",
+        ],
+    )
+
+    await publisher.publish([event])
+
+    assert len(received) == 1
+    assert received[0].key == "workflow.default_provider_profile_ref"
+    assert received[0].apply_mode == "next_launch"

--- a/tests/unit/services/test_settings_change_publisher.py
+++ b/tests/unit/services/test_settings_change_publisher.py
@@ -1,0 +1,283 @@
+"""Unit tests for the SettingsChangePublisher (MM-710)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from api_service.services.settings_catalog import SettingsChangeEvent
+from api_service.services.settings_change_publisher import (
+    SettingsChangePublisher,
+    SettingsChangeSubscriber,
+    get_settings_change_publisher,
+    reset_default_settings_change_publisher,
+)
+
+
+def _make_event(
+    *,
+    key: str = "workflow.default_task_runtime",
+    scope: str = "workspace",
+    source: str | None = None,
+    apply_mode: str = "next_task",
+    affected_systems: Iterable[str] = ("task_creation", "workflow_runtime"),
+    refresh_targets: Iterable[str] = (
+        "settings_catalog",
+        "task_creation_defaults",
+    ),
+) -> SettingsChangeEvent:
+    return SettingsChangeEvent(
+        key=key,
+        scope=scope,
+        source=source or f"{scope}_override",
+        apply_mode=apply_mode,
+        actor_user_id=uuid4(),
+        changed_at=datetime.now(timezone.utc),
+        affected_systems=list(affected_systems),
+        refresh_targets=list(refresh_targets),
+    )
+
+
+class _RecordingSubscriber:
+    def __init__(
+        self,
+        *,
+        name: str,
+        refresh_targets: Iterable[str],
+        side_effect: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self.refresh_targets = frozenset(refresh_targets)
+        self.received: list[SettingsChangeEvent] = []
+        self._side_effect = side_effect
+
+    async def __call__(self, event: SettingsChangeEvent) -> None:
+        self.received.append(event)
+        if self._side_effect is not None:
+            raise self._side_effect
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_publisher_around_test():
+    reset_default_settings_change_publisher()
+    yield
+    reset_default_settings_change_publisher()
+
+
+def test_subscribers_for_unknown_target_returns_empty_list():
+    publisher = SettingsChangePublisher()
+
+    assert publisher.subscribers_for("unknown_target") == []
+
+
+def test_register_rejects_duplicate_name():
+    publisher = SettingsChangePublisher()
+    subscriber_a = _RecordingSubscriber(name="task_creation_defaults", refresh_targets={"task_creation_defaults"})
+    subscriber_b = _RecordingSubscriber(name="task_creation_defaults", refresh_targets={"task_creation_defaults"})
+
+    publisher.register(subscriber_a)
+
+    with pytest.raises(ValueError):
+        publisher.register(subscriber_b)
+
+
+def test_register_requires_non_empty_refresh_targets():
+    publisher = SettingsChangePublisher()
+    subscriber = _RecordingSubscriber(name="empty", refresh_targets=())
+
+    with pytest.raises(ValueError):
+        publisher.register(subscriber)
+
+
+def test_unregister_is_idempotent():
+    publisher = SettingsChangePublisher()
+    subscriber = _RecordingSubscriber(name="solo", refresh_targets={"settings_catalog"})
+    publisher.register(subscriber)
+
+    publisher.unregister("solo")
+    publisher.unregister("solo")
+
+    assert publisher.subscribers_for("settings_catalog") == []
+
+
+@pytest.mark.asyncio
+async def test_publish_fans_out_to_each_matching_subscriber():
+    publisher = SettingsChangePublisher()
+    task_sub = _RecordingSubscriber(
+        name="task_creation_defaults",
+        refresh_targets={"task_creation_defaults"},
+    )
+    catalog_sub = _RecordingSubscriber(
+        name="settings_catalog_listener",
+        refresh_targets={"settings_catalog"},
+    )
+    other_sub = _RecordingSubscriber(
+        name="provider_profile_manager",
+        refresh_targets={"provider_profile_manager"},
+    )
+    publisher.register(task_sub)
+    publisher.register(catalog_sub)
+    publisher.register(other_sub)
+
+    event = _make_event(
+        refresh_targets=("settings_catalog", "task_creation_defaults"),
+    )
+
+    await publisher.publish([event])
+
+    assert task_sub.received == [event]
+    assert catalog_sub.received == [event]
+    assert other_sub.received == []
+
+
+@pytest.mark.asyncio
+async def test_publish_dedupes_subscriber_when_event_lists_multiple_matching_targets():
+    publisher = SettingsChangePublisher()
+    multi_sub = _RecordingSubscriber(
+        name="multi_target",
+        refresh_targets={
+            "task_creation_defaults",
+            "provider_profile_manager",
+            "settings_catalog",
+        },
+    )
+    publisher.register(multi_sub)
+
+    event = _make_event(
+        refresh_targets=(
+            "settings_catalog",
+            "task_creation_defaults",
+            "provider_profile_manager",
+        ),
+    )
+
+    await publisher.publish([event])
+
+    assert multi_sub.received == [event]
+
+
+@pytest.mark.asyncio
+async def test_publish_no_subscribers_for_target_is_a_no_op():
+    publisher = SettingsChangePublisher()
+
+    event = _make_event(
+        refresh_targets=("task_creation_defaults",),
+    )
+
+    await publisher.publish([event])
+
+
+@pytest.mark.asyncio
+async def test_publish_with_empty_refresh_targets_is_a_no_op():
+    publisher = SettingsChangePublisher()
+    sub = _RecordingSubscriber(
+        name="task_creation_defaults",
+        refresh_targets={"task_creation_defaults"},
+    )
+    publisher.register(sub)
+
+    event = _make_event(refresh_targets=())
+
+    await publisher.publish([event])
+
+    assert sub.received == []
+
+
+@pytest.mark.asyncio
+async def test_publish_isolates_subscriber_failures(caplog: pytest.LogCaptureFixture):
+    publisher = SettingsChangePublisher()
+    failing_sub = _RecordingSubscriber(
+        name="failing",
+        refresh_targets={"task_creation_defaults"},
+        side_effect=RuntimeError("boom"),
+    )
+    real_sub = _RecordingSubscriber(
+        name="real",
+        refresh_targets={"task_creation_defaults"},
+    )
+    publisher.register(failing_sub)
+    publisher.register(real_sub)
+
+    event = _make_event(refresh_targets=("task_creation_defaults",))
+
+    with caplog.at_level(logging.ERROR, logger="api_service.services.settings_change_publisher"):
+        await publisher.publish([event])
+
+    assert failing_sub.received == [event]
+    assert real_sub.received == [event]
+    failure_records = [
+        record
+        for record in caplog.records
+        if "subscriber" in record.getMessage().lower() and "boom" not in record.getMessage()
+        or "failing" in record.getMessage()
+    ]
+    assert failure_records, "expected at least one structured failure log entry"
+    failure_record = next(
+        record for record in caplog.records if "failing" in record.getMessage()
+    )
+    payload: dict[str, Any] = getattr(failure_record, "settings_change_publish", {})
+    assert payload.get("subscriber_name") == "failing"
+    assert payload.get("exception_class") == "RuntimeError"
+    assert payload.get("key") == event.key
+    assert payload.get("scope") == event.scope
+    assert payload.get("apply_mode") == event.apply_mode
+
+
+def test_get_settings_change_publisher_returns_stable_singleton():
+    a = get_settings_change_publisher()
+    b = get_settings_change_publisher()
+
+    assert a is b
+
+
+def test_reset_default_settings_change_publisher_replaces_singleton():
+    first = get_settings_change_publisher()
+    reset_default_settings_change_publisher()
+    second = get_settings_change_publisher()
+
+    assert first is not second
+
+
+def test_subscriber_protocol_runtime_checkable():
+    sub = _RecordingSubscriber(
+        name="task_creation_defaults",
+        refresh_targets={"task_creation_defaults"},
+    )
+
+    assert isinstance(sub, SettingsChangeSubscriber)
+
+
+@pytest.mark.asyncio
+async def test_secret_ref_event_carries_only_documented_fields():
+    """FR-010: the published event must not contain raw secret values."""
+
+    event = _make_event(
+        key="integrations.github.token_ref",
+        scope="user",
+        apply_mode="next_launch",
+        affected_systems=("github", "integrations"),
+        refresh_targets=("settings_catalog",),
+    )
+
+    dumped = event.model_dump()
+
+    assert set(dumped.keys()) == {
+        "event_type",
+        "key",
+        "scope",
+        "source",
+        "apply_mode",
+        "actor_user_id",
+        "changed_at",
+        "affected_systems",
+        "refresh_targets",
+    }
+    for value in dumped.values():
+        text = repr(value)
+        assert "ghp_" not in text
+        assert "github_pat_" not in text

--- a/tests/unit/services/test_settings_change_subscribers.py
+++ b/tests/unit/services/test_settings_change_subscribers.py
@@ -1,0 +1,234 @@
+"""Unit tests for the per-family setting change subscribers (MM-710)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+from uuid import uuid4
+
+import pytest
+
+from api_service.services.settings_catalog import SettingsChangeEvent
+from api_service.services.settings_change_publisher import (
+    SettingsChangePublisher,
+    reset_default_settings_change_publisher,
+)
+from api_service.services.settings_change_subscribers import (
+    OperationalControlsSubscriber,
+    OperationalRefreshIntent,
+    ProviderProfileManagerSubscriber,
+    ProviderProfileRefreshIntent,
+    TaskCreationDefaultsSubscriber,
+    WorkerReloadIntent,
+    WorkerReloadSubscriber,
+    register_default_subscribers,
+)
+
+
+def _event(
+    *,
+    key: str,
+    apply_mode: str,
+    affected_systems: Iterable[str],
+    refresh_targets: Iterable[str],
+    scope: str = "workspace",
+) -> SettingsChangeEvent:
+    return SettingsChangeEvent(
+        key=key,
+        scope=scope,
+        source=f"{scope}_override",
+        apply_mode=apply_mode,
+        actor_user_id=uuid4(),
+        changed_at=datetime.now(timezone.utc),
+        affected_systems=list(affected_systems),
+        refresh_targets=list(refresh_targets),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_publisher_around_test():
+    reset_default_settings_change_publisher()
+    yield
+    reset_default_settings_change_publisher()
+
+
+@pytest.mark.asyncio
+async def test_task_creation_defaults_subscriber_increments_and_records():
+    subscriber = TaskCreationDefaultsSubscriber()
+    start_version = subscriber.version
+
+    event = _event(
+        key="workflow.default_task_runtime",
+        apply_mode="next_task",
+        affected_systems=("task_creation", "workflow_runtime"),
+        refresh_targets=("settings_catalog", "task_creation_defaults"),
+    )
+
+    await subscriber(event)
+    await subscriber(event)
+
+    assert subscriber.version == start_version + 2
+    assert list(subscriber.recent_events)[-2:] == [event, event]
+    assert subscriber.name == "task_creation_defaults"
+    assert subscriber.refresh_targets == frozenset({"task_creation_defaults"})
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_subscriber_infers_soft_reload_for_worker_reload_mode():
+    subscriber = WorkerReloadSubscriber()
+
+    event = _event(
+        key="skills.policy_mode",
+        apply_mode="worker_reload",
+        affected_systems=("workflow_runtime", "skills"),
+        refresh_targets=("settings_catalog", "worker_reloaders"),
+    )
+
+    await subscriber(event)
+
+    assert len(subscriber.pending_intents) == 1
+    intent = subscriber.pending_intents[-1]
+    assert isinstance(intent, WorkerReloadIntent)
+    assert intent.intent == "soft_reload"
+    assert intent.key == "skills.policy_mode"
+    assert intent.scope == "workspace"
+    assert intent.apply_mode == "worker_reload"
+    assert intent.refresh_target == "worker_reloaders"
+    assert intent.affected_systems == ("workflow_runtime", "skills")
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_subscriber_records_process_restart_for_restart_mode():
+    subscriber = WorkerReloadSubscriber()
+
+    event = _event(
+        key="hypothetical.process_restart_setting",
+        apply_mode="process_restart",
+        affected_systems=("workflow_runtime",),
+        refresh_targets=("worker_reloaders",),
+    )
+
+    await subscriber(event)
+
+    intent = subscriber.pending_intents[-1]
+    assert intent.intent == "process_restart"
+
+
+@pytest.mark.asyncio
+async def test_worker_reload_subscriber_invokes_on_reload_hook_when_set():
+    seen: list[WorkerReloadIntent] = []
+
+    async def hook(intent: WorkerReloadIntent) -> None:
+        seen.append(intent)
+
+    subscriber = WorkerReloadSubscriber(on_reload=hook)
+
+    event = _event(
+        key="skills.policy_mode",
+        apply_mode="worker_reload",
+        affected_systems=("workflow_runtime", "skills"),
+        refresh_targets=("worker_reloaders",),
+    )
+
+    await subscriber(event)
+
+    assert len(seen) == 1
+    assert seen[0].intent == "soft_reload"
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_manager_subscriber_records_intent_and_version():
+    subscriber = ProviderProfileManagerSubscriber()
+    start_version = subscriber.version
+
+    event = _event(
+        key="workflow.default_provider_profile_ref",
+        apply_mode="next_launch",
+        affected_systems=("task_creation", "workflow_runtime", "provider_profiles"),
+        refresh_targets=(
+            "provider_profile_manager",
+            "settings_catalog",
+            "task_creation_defaults",
+        ),
+    )
+
+    await subscriber(event)
+
+    assert subscriber.version == start_version + 1
+    intent = subscriber.pending_intents[-1]
+    assert isinstance(intent, ProviderProfileRefreshIntent)
+    assert intent.key == "workflow.default_provider_profile_ref"
+    assert intent.apply_mode == "next_launch"
+    assert intent.refresh_target == "provider_profile_manager"
+
+
+@pytest.mark.asyncio
+async def test_operational_controls_subscriber_increments_and_records():
+    subscriber = OperationalControlsSubscriber()
+    start_version = subscriber.version
+
+    event = _event(
+        key="workflow.operation_mode",
+        apply_mode="manual_operation",
+        affected_systems=("operations",),
+        refresh_targets=("operational_controls", "settings_catalog"),
+    )
+
+    await subscriber(event)
+
+    assert subscriber.version == start_version + 1
+    intent = subscriber.pending_intents[-1]
+    assert isinstance(intent, OperationalRefreshIntent)
+    assert intent.key == "workflow.operation_mode"
+    assert intent.apply_mode == "manual_operation"
+    assert intent.refresh_target == "operational_controls"
+
+
+def test_register_default_subscribers_attaches_four_subscribers_to_publisher():
+    publisher = SettingsChangePublisher()
+
+    register_default_subscribers(publisher)
+
+    assert {sub.name for sub in publisher.subscribers_for("task_creation_defaults")} == {
+        "task_creation_defaults"
+    }
+    assert {sub.name for sub in publisher.subscribers_for("worker_reloaders")} == {
+        "worker_reloaders"
+    }
+    assert {sub.name for sub in publisher.subscribers_for("provider_profile_manager")} == {
+        "provider_profile_manager"
+    }
+    assert {sub.name for sub in publisher.subscribers_for("operational_controls")} == {
+        "operational_controls"
+    }
+
+
+def test_register_default_subscribers_is_idempotent():
+    publisher = SettingsChangePublisher()
+
+    register_default_subscribers(publisher)
+    register_default_subscribers(publisher)
+
+    assert len(publisher.subscribers_for("task_creation_defaults")) == 1
+    assert len(publisher.subscribers_for("worker_reloaders")) == 1
+    assert len(publisher.subscribers_for("provider_profile_manager")) == 1
+    assert len(publisher.subscribers_for("operational_controls")) == 1
+
+
+def test_subscriber_ledgers_are_bounded():
+    """Bounded deques must prevent unbounded memory growth in long-lived processes."""
+
+    task_sub = TaskCreationDefaultsSubscriber()
+    worker_sub = WorkerReloadSubscriber()
+    profile_sub = ProviderProfileManagerSubscriber()
+    ops_sub = OperationalControlsSubscriber()
+
+    for subscriber, ledger_attr in (
+        (task_sub, "recent_events"),
+        (worker_sub, "pending_intents"),
+        (profile_sub, "pending_intents"),
+        (ops_sub, "pending_intents"),
+    ):
+        ledger = getattr(subscriber, ledger_attr)
+        assert ledger.maxlen is not None
+        assert ledger.maxlen >= 32


### PR DESCRIPTION
## Summary

Wires the four non-UI subscriber families — workers, task creation, profile manager, and operations — to the `SettingsChangePublisher` so committed `setting_changed` events drive observable per-family behavior beyond UI query invalidation. Builds on MM-663's apply-mode descriptors and `SettingsChangeEvent` envelope.

- Adds `SettingsChangePublisher` with a documented subscriber-registration contract and per-key dispatch in `api_service/services/settings_change_publisher.py`.
- Adds default per-family subscribers (workers, task creation, profile manager, operations) in `api_service/services/settings_change_subscribers.py` that act on the event's `apply_mode` and `affected_systems` fields.
- Adds production hook factories in `api_service/services/settings_change_hooks.py`:
  - `make_provider_profile_refresh_hook` signals `sync_profiles` to every running `ProviderProfileManager` Temporal workflow.
  - `make_worker_reload_broadcast_hook` emits a structured INFO-level broadcast for `worker_reload`-class apply modes.
  - `make_operational_mode_hook` exposes a handler-fed structured payload for operational mode events.
- Routes the dispatch through `SettingsCatalogService.apply_overrides` so every committed change is fanned out via the publisher contract; wires the production hooks once per process in `api_service/main.py` startup.
- Snapshot test coverage at the unit and hermetic integration boundaries asserts each subscriber family acts on `apply_mode` + `affected_systems`.

## Jira

- **Issue**: [MM-710](https://moonladder.atlassian.net/browse/MM-710)
- **Original Jira status**: In Progress

## MoonSpec

- **Active feature path**: `specs/360-setting-change-subscribers/`
- **Source design**: `docs/Security/SettingsSystem.md` §3.12, §19, §26
- **Coverage IDs verified**: DESIGN-REQ-038 (publisher contract), DESIGN-REQ-039 (per-family subscribers for workers / task creation / profile manager / operations)

## Verification

- **Verdict**: FULLY_IMPLEMENTED (latest post-remediation moonspec-verify, 2026-05-17)
- The verification gate confirms publisher contract, per-family subscriber behavior, and observable hooks for `worker_reload` and provider-profile refresh.

## Tests run

- `python -m pytest tests/unit/services/test_settings_change_publisher.py tests/unit/services/test_settings_change_subscribers.py tests/unit/services/test_settings_catalog.py` — PASS (111)
- `python -m pytest tests/unit/services/test_settings_change_hooks.py` — PASS (12)
- `python -m pytest tests/unit/services/ -k "settings"` — PASS (125)
- `python -m pytest tests/integration/api/test_settings_change_subscribers_contract.py` — PASS (9, hermetic ASGI/SQLite, `integration_ci` marked)
- `./tools/test_unit.sh --python-only` (full suite) on the prior verify pass: 5120 passed; 22 pre-existing failures confirmed unrelated to MM-710 (reproduced with the MM-710 changes stashed).

## Remaining risks

- The worker-reload broadcaster in `api_service/main.py` currently uses a structured INFO-level log as the cross-process surface. The hook factory accepts an injected broadcaster so this can be swapped for a real out-of-process control plane (Redis pub/sub, Temporal control workflow) in a follow-up without changing the subscriber contract.
- `./tools/test_integration.sh` (compose-backed full hermetic CI) was not exercised in the verification sandbox because the compose image build hit a registry 403; the same hermetic ASGI/SQLite topology used by the contract suite was exercised and passed. The full required CI integration_ci suite must run as part of merge gating.
- No persistent storage was added. Operational-mode events surface through the handler-fed payload only; durable operator-action surfaces (if needed beyond UI hints) remain follow-on work.

## Test plan

- [ ] Required CI: unit suite passes
- [ ] Required CI: hermetic `integration_ci` suite passes (`tests/integration/api/test_settings_change_subscribers_contract.py` included)
- [ ] Manual smoke: PATCH a `worker_reload` setting and confirm `settings.worker_reload_broadcast` structured log fires
- [ ] Manual smoke: PATCH a provider-profile-affecting setting and confirm `sync_profiles` signal is sent to running `ProviderProfileManager` workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MM-710]: https://moonladder.atlassian.net/browse/MM-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ