### PR TITLE
MM-706 Align branch resolution and push safety

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7039,50 +7039,6 @@ class TemporalAgentRuntimeActivities:
             protected = {"main", "master", "HEAD"}
             if target_branch_name and not target_branch_push_allowed:
                 protected.add(target_branch_name)
-            if (
-                current_branch == "HEAD"
-                and head_branch_name
-                and head_branch_name not in protected
-            ):
-                repair_proc = await asyncio.create_subprocess_exec(
-                    *self._workspace_git_command(
-                        workspace, "checkout", "-B", head_branch_name,
-                    ),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=command_env,
-                )
-                try:
-                    repair_stdout, repair_stderr = await asyncio.wait_for(
-                        repair_proc.communicate(), timeout=30,
-                    )
-                except asyncio.TimeoutError:
-                    repair_proc.kill()
-                    await repair_proc.wait()
-                    return {
-                        "push_status": "failed",
-                        "push_error": "detached HEAD recovery timed out after 30s",
-                        "push_branch": "HEAD",
-                    }
-                if repair_proc.returncode != 0:
-                    repair_detail = (
-                        repair_stderr.decode("utf-8", errors="replace").strip()
-                        or repair_stdout.decode("utf-8", errors="replace").strip()
-                    )
-                    return {
-                        "push_status": "failed",
-                        "push_error": (
-                            "could not recover detached HEAD onto "
-                            f"'{head_branch_name}': {repair_detail}"
-                        ),
-                        "push_branch": "HEAD",
-                    }
-                logger.info(
-                    "Recovered detached HEAD for run %s onto branch '%s' before push",
-                    run_id,
-                    head_branch_name,
-                )
-                current_branch = head_branch_name
             if not current_branch or current_branch in protected:
                 logger.warning(
                     "Post-agent git push skipped for run %s: "

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -764,9 +764,10 @@ def _derive_pr_resolver_title(
 
 def _first_non_empty_text(*values: Any) -> str:
     for value in values:
-        text = str(value or "").strip()
-        if text:
-            return text
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return text
     return ""
 
 def _resolve_authored_branch(
@@ -793,7 +794,6 @@ def _resolve_authored_branch(
         parameter_payload.get("default_branch"),
         input_payload.get("defaultBranch"),
         input_payload.get("default_branch"),
-        "main",
     )
 
 def _normalize_runtime_mode(raw_mode: Any) -> str:

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -762,6 +762,40 @@ def _derive_pr_resolver_title(
         or ""
     ).strip()
 
+def _first_non_empty_text(*values: Any) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+def _resolve_authored_branch(
+    *,
+    task_payload: Mapping[str, Any],
+    git_payload: Mapping[str, Any],
+    selected_skill_inputs: Mapping[str, Any],
+    parameter_payload: Mapping[str, Any],
+    input_payload: Mapping[str, Any],
+) -> str:
+    return _first_non_empty_text(
+        git_payload.get("branch"),
+        task_payload.get("branch"),
+        selected_skill_inputs.get("branch"),
+        parameter_payload.get("branch"),
+        input_payload.get("branch"),
+        git_payload.get("defaultBranch"),
+        git_payload.get("default_branch"),
+        task_payload.get("defaultBranch"),
+        task_payload.get("default_branch"),
+        selected_skill_inputs.get("defaultBranch"),
+        selected_skill_inputs.get("default_branch"),
+        parameter_payload.get("defaultBranch"),
+        parameter_payload.get("default_branch"),
+        input_payload.get("defaultBranch"),
+        input_payload.get("default_branch"),
+        "main",
+    )
+
 def _normalize_runtime_mode(raw_mode: Any) -> str:
     normalized = str(raw_mode or "").strip().lower()
     if not normalized:
@@ -1170,7 +1204,7 @@ def _build_runtime_planner():
         node_publish_mode = str(node_inputs.get("publishMode") or "").lower()
         if not publish_uses_git and node_publish_mode in {"pr", "branch"}:
             node_inputs["publishMode"] = "none"
-        for git_key in ("startingBranch", "targetBranch", "branch"):
+        for git_key in ("startingBranch", "targetBranch"):
             git_val = (
                 git_payload.get(git_key)
                 or task_payload.get(git_key)
@@ -1180,6 +1214,15 @@ def _build_runtime_planner():
             )
             if isinstance(git_val, str) and git_val.strip():
                 node_inputs[git_key] = git_val.strip()
+        authored_branch = _resolve_authored_branch(
+            task_payload=task_payload,
+            git_payload=git_payload,
+            selected_skill_inputs=selected_skill_inputs,
+            parameter_payload=parameter_payload,
+            input_payload=input_payload,
+        )
+        if authored_branch:
+            node_inputs["branch"] = authored_branch
 
         if (
             publish_uses_git

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4477,7 +4477,6 @@ class MoonMindRunWorkflow:
                 agent_outputs.get("branch"),
                 agent_outputs.get("targetBranch"),
                 workspace_spec.get("targetBranch"),
-                parameters.get("targetBranch"),
                 last_node_inputs.get("targetBranch"),
             )
             base_candidates = (

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -425,84 +425,26 @@ class TestPushWorkspaceBranch:
         assert result["push_status"] == "protected_branch"
 
     @pytest.mark.asyncio
-    async def test_push_recovers_detached_head_to_explicit_head_branch(self):
+    async def test_push_refuses_detached_head_even_with_explicit_head_branch(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        call_count = 0
-        captured_checkout_args = None
 
         async def _mock_exec(*args, **kwargs):
-            nonlocal call_count, captured_checkout_args
-            call_count += 1
             proc = AsyncMock()
-            if call_count == 1:  # rev-parse
-                proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
-                proc.returncode = 0
-            elif call_count == 2:  # checkout -B feature branch
-                captured_checkout_args = args
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count == 3:  # status --porcelain
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count == 4:  # push
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            else:  # rev-list --count
-                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
-                proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
+            proc.returncode = 0
             return proc
 
-        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec) as mock_exec:
             result = await activities._push_workspace_branch(
                 "run-1",
                 target_branch="main",
                 head_branch="feature/recover-detached-head",
             )
 
-        assert result["push_status"] == "pushed"
-        assert result["push_branch"] == "feature/recover-detached-head"
-        assert captured_checkout_args is not None
-        assert captured_checkout_args[-3:] == (
-            "checkout",
-            "-B",
-            "feature/recover-detached-head",
-        )
-
-    @pytest.mark.asyncio
-    async def test_push_detached_head_recovery_timeout_kills_checkout(self):
-        store = _make_mock_store()
-        activities = TemporalAgentRuntimeActivities(run_store=store)
-        call_count = 0
-        repair_proc = MagicMock()
-        repair_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
-        repair_proc.wait = AsyncMock(return_value=0)
-        repair_proc.kill = MagicMock()
-
-        async def _mock_exec(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:  # rev-parse
-                proc = MagicMock()
-                proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
-                proc.returncode = 0
-                return proc
-            if call_count == 2:  # checkout -B feature branch
-                return repair_proc
-            raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
-
-        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
-            result = await activities._push_workspace_branch(
-                "run-1",
-                target_branch="main",
-                head_branch="feature/recover-detached-head",
-            )
-
-        assert result["push_status"] == "failed"
+        assert result["push_status"] == "protected_branch"
         assert result["push_branch"] == "HEAD"
-        assert result["push_error"] == "detached HEAD recovery timed out after 30s"
-        repair_proc.kill.assert_called_once_with()
-        repair_proc.wait.assert_awaited_once()
+        assert mock_exec.call_count == 1
 
     @pytest.mark.asyncio
     async def test_push_protected_target_branch(self):

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2473,6 +2473,43 @@ def test_runtime_planner_authored_branch_fallback_order():
 
         assert plan["nodes"][-1]["inputs"]["branch"] == expected_branch
 
+def test_runtime_planner_leaves_branch_unset_without_authored_branch():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "branch"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert "branch" not in plan["nodes"][-1]["inputs"]
+
+def test_runtime_planner_ignores_non_string_branch_values():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "branch"},
+                "git": {"defaultBranch": {"name": "main"}},
+            }
+        },
+        parameters={"defaultBranch": {"name": "trunk"}},
+        snapshot=snapshot,
+    )
+
+    assert "branch" not in plan["nodes"][-1]["inputs"]
+
 def test_runtime_planner_publish_pr_uses_step_title_for_target_branch_prefix():
     planner = _build_runtime_planner()
     snapshot = _make_snapshot()

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2426,6 +2426,53 @@ def test_runtime_planner_publish_pr_treats_authored_branch_as_base():
     assert node_inputs["targetBranch"].startswith("fix-create-branch-publish-")
     assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", node_inputs["targetBranch"])
 
+def test_runtime_planner_authored_branch_fallback_order():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    cases = [
+        ({"task": {"git": {"branch": "feature/git"}}}, "feature/git"),
+        ({"task": {"branch": "feature/task"}}, "feature/task"),
+        (
+            {
+                "task": {
+                    "tool": {
+                        "name": "auto",
+                        "inputs": {"branch": "feature/skill"},
+                    }
+                }
+            },
+            "feature/skill",
+        ),
+        ({}, "feature/parameter"),
+        ({"branch": "feature/input"}, "feature/input"),
+        ({"defaultBranch": "trunk"}, "trunk"),
+    ]
+
+    for input_overrides, expected_branch in cases:
+        task = {
+            "instructions": "Do work",
+            "runtime": {"mode": "codex_cli"},
+            "publish": {"mode": "branch"},
+        }
+        task.update(input_overrides.get("task", {}))
+        inputs = {"task": task}
+        for key, value in input_overrides.items():
+            if key != "task":
+                inputs[key] = value
+        parameters = {
+            "branch": "feature/parameter",
+            "defaultBranch": "main",
+        }
+        if expected_branch in {"feature/input", "trunk"}:
+            parameters.pop("branch")
+        if expected_branch == "trunk":
+            parameters.pop("defaultBranch")
+
+        plan = planner(inputs=inputs, parameters=parameters, snapshot=snapshot)
+
+        assert plan["nodes"][-1]["inputs"]["branch"] == expected_branch
+
 def test_runtime_planner_publish_pr_uses_step_title_for_target_branch_prefix():
     planner = _build_runtime_planner()
     snapshot = _make_snapshot()

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1090,6 +1090,66 @@ def test_native_pr_branch_resolution_uses_patched_publish_defaults(
     assert head_branch == ""
     assert base_branch == "release"
 
+def test_native_pr_branch_resolution_prefers_runtime_owned_head_sources(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={"targetBranch": "legacy/parameter-target"},
+        agent_outputs={},
+        workspace_spec={"targetBranch": "runtime/generated-head"},
+        last_node_inputs={"targetBranch": "plan/generated-head"},
+        publish_payload={"prBaseBranch": "develop"},
+    )
+
+    assert head_branch == "runtime/generated-head"
+    assert base_branch == "develop"
+
+def test_native_pr_branch_resolution_prefers_provider_output_over_workspace_head(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={"push_branch": "provider/head"},
+        workspace_spec={"targetBranch": "workspace/head"},
+        last_node_inputs={"targetBranch": "generated/head"},
+        publish_payload={"prBaseBranch": "main"},
+    )
+
+    assert head_branch == "provider/head"
+    assert base_branch == "main"
+
+def test_native_pr_branch_resolution_ignores_legacy_parameter_target_branch(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={"targetBranch": "legacy/parameter-target"},
+        agent_outputs={},
+        workspace_spec={},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "develop"},
+    )
+
+    assert head_branch == ""
+    assert base_branch == "develop"
+
 def test_native_pr_push_status_gate_preserves_legacy_protected_branch_fallback(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Align branch resolution and push safety with the TaskPublishing contract for Jira issue MM-706.

## Jira

- Jira issue key: MM-706

## MoonSpec

- Active feature path: `specs/706-align-branch-resolution-push-safety`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run

- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_authored_branch_fallback_order tests/unit/workflows/temporal/workflows/test_run_integration.py::test_native_pr_branch_resolution_prefers_runtime_owned_head_sources tests/unit/workflows/temporal/workflows/test_run_integration.py::test_native_pr_branch_resolution_prefers_provider_output_over_workspace_head tests/unit/workflows/temporal/workflows/test_run_integration.py::test_native_pr_branch_resolution_ignores_legacy_parameter_target_branch tests/unit/services/temporal/test_fetch_result_push.py::TestPushWorkspaceBranch::test_push_refuses_detached_head_even_with_explicit_head_branch tests/unit/services/temporal/test_fetch_result_push.py::TestFetchResultPushIntegration::test_fetch_result_allows_same_target_branch_for_branch_publish -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining risks

- `./tools/test_integration.sh` was not rerun because the MoonSpec plan classifies compose-backed integration as conditional and no worker topology, routing, persistence, or compose-backed boundary change was introduced.
