### PR TITLE
MM-669 Authored branch and PR work branch resolution chains

### DIFF
--- a/artifacts.readonly-context/context/rag-context-5aae68bf1af5.json
+++ b/artifacts.readonly-context/context/rag-context-5aae68bf1af5.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 4: from threading import Lock, Thread\n2. frontend/vite.config.ts (score: 1.000, trust: canonical)\n    line 1: import { defineConfig } from 'vite';\n3. api_service/docker/README.md (score: 1.000, trust: canonical)\n    line 21: The final runtime image copies the produced launchers, the Node runtime, supporting `node_modules`, and license files from the builder. It intentionally relies on the platform-specific optional dependency already installed under `@openai/codex` rather than copying an extra Codex vendor tree into the image.\n4. moonmind/rag/guardrails.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations\n5. moonmind/rag/retriever.py (score: 1.000, trust: canonical)\n    line 2: from typing import List\n6. tests/e2e/test_confluence_e2e.py (score: 1.000, trust: canonical)\n    line 4: from dotenv import load_dotenv\n7. moonmind/rag/context_injection.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations\n8. moonmind/rag/service.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 4: from threading import Lock, Thread",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 4,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/vite.config.ts",
+      "text": "line 1: import { defineConfig } from 'vite';",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/docker/README.md",
+      "text": "line 21: The final runtime image copies the produced launchers, the Node runtime, supporting `node_modules`, and license files from the builder. It intentionally relies on the platform-specific optional dependency already installed under `@openai/codex` rather than copying an extra Codex vendor tree into the image.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 21,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/rag/guardrails.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/rag/retriever.py",
+      "text": "line 2: from typing import List",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 2,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "tests/e2e/test_confluence_e2e.py",
+      "text": "line 4: from dotenv import load_dotenv",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 4,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/rag/context_injection.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/rag/service.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-17T07:23:13Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.readonly-context/context/rag-context-85304bbbd239.json
+++ b/artifacts.readonly-context/context/rag-context-85304bbbd239.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth.py (score: 1.000, trust: canonical)\n    line 87: # Hardcoded default user details for disabled auth mode\n2. moonmind/cli.py (score: 1.000, trust: canonical)\n    line 16: rag_app = typer.Typer(help=\"Retrieval helpers for Codex workers.\")\n3. moonmind/indexers/jira_indexer.py (score: 1.000, trust: canonical)\n    line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)\n4. docs/MoonMindRoadmap.md (score: 1.000, trust: canonical)\n    line 28: **README claim:** *\"MoonMind can run Claude Code, Gemini CLI, and Codex CLI as managed workers on your own infrastructure.\"*\n5. docs/ExternalAgents/OpenClawAgentAdapter.md (score: 1.000, trust: canonical)\n    line 22: > OpenClaw is a **streaming-gateway** provider, not a poll-by-external-id provider like Jules or Codex Cloud.\n6. docs/ManagedAgents/ManagedAgentsAuthentication.md (score: 1.000, trust: canonical)\n    line 25: | OAuth volume provisioning scripts | `tools/auth-gemini-volume.sh`, `tools/auth-codex-volume.sh`, `tools/auth-claude-volume.sh` |\n7. docs/ManagedAgents/AgentSessionDeploymentSafetyCutover.md (score: 1.000, trust: canonical)\n    line 7: - **replay-safe rollout** gates are in place before production promotion.\n8. docs/ManagedAgents/ClaudeAnthropicOAuth.md (score: 1.000, trust: canonical)\n    line 7: This document defines the OAuth-backed Claude Code authentication path for",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth.py",
+      "text": "line 87: # Hardcoded default user details for disabled auth mode",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 87,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/cli.py",
+      "text": "line 16: rag_app = typer.Typer(help=\"Retrieval helpers for Codex workers.\")",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 16,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/indexers/jira_indexer.py",
+      "text": "line 8: # LlamaIndex Jira reader (ensure this import path is correct if it's part of an integration package)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 8,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/MoonMindRoadmap.md",
+      "text": "line 28: **README claim:** *\"MoonMind can run Claude Code, Gemini CLI, and Codex CLI as managed workers on your own infrastructure.\"*",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 28,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ExternalAgents/OpenClawAgentAdapter.md",
+      "text": "line 22: > OpenClaw is a **streaming-gateway** provider, not a poll-by-external-id provider like Jules or Codex Cloud.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 22,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ManagedAgentsAuthentication.md",
+      "text": "line 25: | OAuth volume provisioning scripts | `tools/auth-gemini-volume.sh`, `tools/auth-codex-volume.sh`, `tools/auth-claude-volume.sh` |",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 25,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/AgentSessionDeploymentSafetyCutover.md",
+      "text": "line 7: - **replay-safe rollout** gates are in place before production promotion.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 7,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ClaudeAnthropicOAuth.md",
+      "text": "line 7: This document defines the OAuth-backed Claude Code authentication path for",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 7,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-17T07:11:29Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.readonly-context/context/rag-context-c80e966f7ee1.json
+++ b/artifacts.readonly-context/context/rag-context-c80e966f7ee1.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth.py (score: 1.000, trust: canonical)\n    line 3: from typing import AsyncGenerator, Optional\n2. tests/helpers/step_type_payloads.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations\n3. docs/MoonMindArchitecture.md (score: 1.000, trust: canonical)\n    line 19: This document describes the current architecture and target direction. It intentionally separates **managed runtime runs** from **managed sessions** so the project can accurately describe the current Claude Code path without overstating Claude session parity.\n4. moonmind/planning/__init__.py (score: 1.000, trust: canonical)\n    line 3: from .jira_story_planner import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft\n5. moonmind/jules/__init__.py (score: 1.000, trust: canonical)\n    line 3: from .runtime import (\n6. moonmind/planning/jira_story_planner.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Skeleton for planning Jira stories from high level text.\"\"\"\n7. moonmind/claude/runtime.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations\n8. moonmind/config/jules_settings.py (score: 1.000, trust: canonical)\n    line 3: from __future__ import annotations",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth.py",
+      "text": "line 3: from typing import AsyncGenerator, Optional",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "tests/helpers/step_type_payloads.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/MoonMindArchitecture.md",
+      "text": "line 19: This document describes the current architecture and target direction. It intentionally separates **managed runtime runs** from **managed sessions** so the project can accurately describe the current Claude Code path without overstating Claude session parity.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 19,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/planning/__init__.py",
+      "text": "line 3: from .jira_story_planner import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/jules/__init__.py",
+      "text": "line 3: from .runtime import (",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/planning/jira_story_planner.py",
+      "text": "line 1: \"\"\"Skeleton for planning Jira stories from high level text.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/claude/runtime.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/config/jules_settings.py",
+      "text": "line 3: from __future__ import annotations",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 3,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-17T07:45:43Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/artifacts.readonly-context/context/rag-context-d8acc96cf752.json
+++ b/artifacts.readonly-context/context/rag-context-d8acc96cf752.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/main.py (score: 1.000, trust: canonical)\n    line 21: from fastapi.responses import JSONResponse, RedirectResponse\n2. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 4: from threading import Lock, Thread\n3. frontend/src/components/skills/SkillProvenanceBadge.tsx (score: 1.000, trust: canonical)\n    line 20: readOnly?: boolean | null | undefined;\n4. docs/Artifacts/ReportArtifacts.md (score: 1.000, trust: canonical)\n    line 7: The core contract in this document — `report.*` link types, the compact `report_bundle_v = 1` workflow result, the `reportProjection` execution-detail summary, retention defaults, the Mission Control report-first surface, and the report/observability separation — is implemented across the specs called out in section 22. Sections that are still future work (a dedicated `/report` endpoint, stronger evidence grouping semantics, multi-step task-level projections) are marked **Deferred** inline.\n5. frontend/src/components/settings/GeneratedSettingsSection.tsx (score: 1.000, trust: canonical)\n    line 49: read_only: boolean;\n6. frontend/src/components/settings/GeneratedSettingsSection.test.tsx (score: 1.000, trust: canonical)\n    line 39: read_only: false,\n7. docs/Artifacts/ArtifactPresentationContract.md (score: 1.000, trust: canonical)\n    line 15: - stable conventions for `link_type`, default reads, downloads, previews, and rendering hints\n8. frontend/src/components/settings/ProviderProfilesManager.tsx (score: 1.000, trust: canonical)\n    line 28: readiness?: ProviderProfileReadiness | null;",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/main.py",
+      "text": "line 21: from fastapi.responses import JSONResponse, RedirectResponse",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 21,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 4: from threading import Lock, Thread",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 4,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/components/skills/SkillProvenanceBadge.tsx",
+      "text": "line 20: readOnly?: boolean | null | undefined;",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 20,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Artifacts/ReportArtifacts.md",
+      "text": "line 7: The core contract in this document — `report.*` link types, the compact `report_bundle_v = 1` workflow result, the `reportProjection` execution-detail summary, retention defaults, the Mission Control report-first surface, and the report/observability separation — is implemented across the specs called out in section 22. Sections that are still future work (a dedicated `/report` endpoint, stronger evidence grouping semantics, multi-step task-level projections) are marked **Deferred** inline.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 7,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/components/settings/GeneratedSettingsSection.tsx",
+      "text": "line 49: read_only: boolean;",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 49,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/components/settings/GeneratedSettingsSection.test.tsx",
+      "text": "line 39: read_only: false,",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 39,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Artifacts/ArtifactPresentationContract.md",
+      "text": "line 15: - stable conventions for `link_type`, default reads, downloads, previews, and rendering hints",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 15,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "frontend/src/components/settings/ProviderProfilesManager.tsx",
+      "text": "line 28: readiness?: ProviderProfileReadiness | null;",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 28,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-17T07:22:08Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -696,6 +696,86 @@ def _coerce_mapping(value: Any) -> dict[str, Any]:
 def _coerce_non_empty_text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
+
+def _first_non_empty_text(*values: Any) -> str:
+    for value in values:
+        text = _coerce_non_empty_text(value)
+        if text:
+            return text
+    return ""
+
+
+def _repository_default_branch_candidate(*payloads: Mapping[str, Any]) -> str:
+    for payload in payloads:
+        value = _first_non_empty_text(
+            payload.get("defaultBranch"),
+            payload.get("default_branch"),
+            payload.get("repositoryDefaultBranch"),
+            payload.get("repository_default_branch"),
+        )
+        if value:
+            return value
+    return ""
+
+
+def _resolve_authored_branch(
+    *,
+    git_payload: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+    selected_skill_inputs: Mapping[str, Any],
+    parameter_payload: Mapping[str, Any],
+    input_payload: Mapping[str, Any],
+) -> str:
+    repository_default_branch = _repository_default_branch_candidate(
+        git_payload,
+        task_payload,
+        selected_skill_inputs,
+        parameter_payload,
+        input_payload,
+    )
+    return _first_non_empty_text(
+        git_payload.get("branch"),
+        task_payload.get("branch"),
+        selected_skill_inputs.get("branch"),
+        parameter_payload.get("branch"),
+        input_payload.get("branch"),
+        repository_default_branch,
+    )
+
+
+def _resolve_workspace_work_branch(
+    *,
+    task_payload: Mapping[str, Any],
+    parameter_payload: Mapping[str, Any],
+    input_payload: Mapping[str, Any],
+) -> str:
+    task_workspace_spec = _coerce_mapping(
+        task_payload.get("workspaceSpec") or task_payload.get("workspace_spec")
+    )
+    parameter_workspace_spec = _coerce_mapping(
+        parameter_payload.get("workspaceSpec") or parameter_payload.get("workspace_spec")
+    )
+    input_workspace_spec = _coerce_mapping(
+        input_payload.get("workspaceSpec") or input_payload.get("workspace_spec")
+    )
+    workspace_payload = _coerce_mapping(
+        task_payload.get("workspace")
+        or parameter_payload.get("workspace")
+        or input_payload.get("workspace")
+    )
+    return _first_non_empty_text(
+        task_workspace_spec.get("targetBranch"),
+        parameter_workspace_spec.get("targetBranch"),
+        input_workspace_spec.get("targetBranch"),
+        workspace_payload.get("targetBranch"),
+    )
+
+
+def _generate_runtime_pr_branch(prefix: str) -> str:
+    branch_prefix = f"{prefix}-" if prefix else ""
+    return f"{branch_prefix}{str(uuid.uuid4())[:8]}"
+
+
 def _slugify_branch_prefix(value: Any, *, max_length: int = 40) -> str:
     candidate = _coerce_non_empty_text(value)
     if not candidate:
@@ -762,40 +842,6 @@ def _derive_pr_resolver_title(
         or ""
     ).strip()
 
-def _first_non_empty_text(*values: Any) -> str:
-    for value in values:
-        if isinstance(value, str):
-            text = value.strip()
-            if text:
-                return text
-    return ""
-
-def _resolve_authored_branch(
-    *,
-    task_payload: Mapping[str, Any],
-    git_payload: Mapping[str, Any],
-    selected_skill_inputs: Mapping[str, Any],
-    parameter_payload: Mapping[str, Any],
-    input_payload: Mapping[str, Any],
-) -> str:
-    return _first_non_empty_text(
-        git_payload.get("branch"),
-        task_payload.get("branch"),
-        selected_skill_inputs.get("branch"),
-        parameter_payload.get("branch"),
-        input_payload.get("branch"),
-        git_payload.get("defaultBranch"),
-        git_payload.get("default_branch"),
-        task_payload.get("defaultBranch"),
-        task_payload.get("default_branch"),
-        selected_skill_inputs.get("defaultBranch"),
-        selected_skill_inputs.get("default_branch"),
-        parameter_payload.get("defaultBranch"),
-        parameter_payload.get("default_branch"),
-        input_payload.get("defaultBranch"),
-        input_payload.get("default_branch"),
-    )
-
 def _normalize_runtime_mode(raw_mode: Any) -> str:
     normalized = str(raw_mode or "").strip().lower()
     if not normalized:
@@ -804,11 +850,7 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
 
 _JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _JIRA_STORY_OUTPUT_TOOLS = frozenset(
-    {
-        "story.create_jira_issues",
-        "story.create_jira_orchestrate_tasks",
-        "story.create_jira_implement_tasks",
-    }
+    {"story.create_jira_issues", "story.create_jira_orchestrate_tasks"}
 )
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
@@ -1208,7 +1250,28 @@ def _build_runtime_planner():
         node_publish_mode = str(node_inputs.get("publishMode") or "").lower()
         if not publish_uses_git and node_publish_mode in {"pr", "branch"}:
             node_inputs["publishMode"] = "none"
+        publish_mode_is_pr = (
+            publish_uses_git
+            and isinstance(publish_mode, str)
+            and publish_mode.strip().lower() == "pr"
+        )
+        authored_branch = _resolve_authored_branch(
+            git_payload=git_payload,
+            task_payload=task_payload,
+            selected_skill_inputs=selected_skill_inputs,
+            parameter_payload=parameter_payload,
+            input_payload=input_payload,
+        )
         for git_key in ("startingBranch", "targetBranch"):
+            if publish_mode_is_pr and git_key == "targetBranch":
+                git_val = _resolve_workspace_work_branch(
+                    task_payload=task_payload,
+                    parameter_payload=parameter_payload,
+                    input_payload=input_payload,
+                )
+                if git_val:
+                    node_inputs[git_key] = git_val
+                continue
             git_val = (
                 git_payload.get(git_key)
                 or task_payload.get(git_key)
@@ -1218,21 +1281,10 @@ def _build_runtime_planner():
             )
             if isinstance(git_val, str) and git_val.strip():
                 node_inputs[git_key] = git_val.strip()
-        authored_branch = _resolve_authored_branch(
-            task_payload=task_payload,
-            git_payload=git_payload,
-            selected_skill_inputs=selected_skill_inputs,
-            parameter_payload=parameter_payload,
-            input_payload=input_payload,
-        )
         if authored_branch:
             node_inputs["branch"] = authored_branch
 
-        if (
-            publish_uses_git
-            and isinstance(publish_mode, str)
-            and publish_mode.strip().lower() == "pr"
-        ):
+        if publish_mode_is_pr:
             # In the single authored branch model, ``branch`` is the PR base,
             # not the work/head branch. Always resolve a distinct head branch
             # for PR publishing when one was not explicitly provided.
@@ -1251,9 +1303,11 @@ def _build_runtime_planner():
                         selected_skill_name=selected_skill_name,
                     )
 
-                branch_prefix = f"{prefix}-" if prefix else ""
-                node_inputs["targetBranch"] = (
-                    f"{branch_prefix}{str(uuid.uuid4())[:8]}"
+                node_inputs["targetBranch"] = _generate_runtime_pr_branch(prefix)
+            if not _coerce_non_empty_text(node_inputs.get("targetBranch")):
+                raise RuntimeError(
+                    "publishMode 'pr' requested but no PR head branch could be "
+                    "resolved from workspace metadata or runtime planner generation"
                 )
 
         # --- Assemble plan ---
@@ -1433,7 +1487,7 @@ def _build_runtime_planner():
                     publish_payload=publish_payload,
                     selected_skill_name=selected_skill_name,
                 ) or "story-breakdown"
-                node_inputs["targetBranch"] = f"{prefix}-{str(uuid.uuid4())[:8]}"
+                node_inputs["targetBranch"] = _generate_runtime_pr_branch(prefix)
             story_output_payload = dict(story_output_payload)
             story_output_payload.setdefault("mode", story_output_mode or "docs_tmp")
             if story_output_mode == "jira" and creates_story_breakdown_artifact:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3615,9 +3615,13 @@ class MoonMindRunWorkflow:
                         "failed with status '%s'.",
                         push_status,
                     )
-                elif not self._repo or not head_branch:
+                elif not head_branch:
                     raise ValueError(
-                        "publishMode 'pr' requested but no PR URL was returned, and missing repo/branch to create it natively"
+                        "publishMode 'pr' requested but no PR head branch could be resolved from provider outputs, workspace metadata, or runtime planner generation"
+                    )
+                elif not self._repo:
+                    raise ValueError(
+                        "publishMode 'pr' requested but no repository was available to create the pull request natively"
                     )
                 else:
                     self._get_logger().info(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1556,7 +1556,7 @@ async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
 
     with pytest.raises(
         ValueError,
-        match="publishMode 'pr' requested but no PR URL was returned, and missing repo/branch to create it natively",
+        match="publishMode 'pr' requested but no PR head branch could be resolved",
     ):
         await workflow._run_execution_stage(
             parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2426,89 +2426,152 @@ def test_runtime_planner_publish_pr_treats_authored_branch_as_base():
     assert node_inputs["targetBranch"].startswith("fix-create-branch-publish-")
     assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", node_inputs["targetBranch"])
 
-def test_runtime_planner_authored_branch_fallback_order():
+@pytest.mark.parametrize(
+    ("inputs", "parameters", "expected_branch"),
+    [
+        (
+            {"task": {"git": {"branch": "from-git"}}},
+            {"branch": "from-params"},
+            "from-git",
+        ),
+        (
+            {"task": {"branch": "from-task", "inputs": {"branch": "from-skill"}}},
+            {"branch": "from-params"},
+            "from-task",
+        ),
+        (
+            {"task": {"inputs": {"branch": "from-skill"}}},
+            {"branch": "from-params"},
+            "from-skill",
+        ),
+        ({}, {"branch": "from-params"}, "from-params"),
+        ({"branch": "from-input"}, {}, "from-input"),
+        (
+            {"task": {"git": {"defaultBranch": "from-default"}}},
+            {},
+            "from-default",
+        ),
+    ],
+)
+def test_runtime_planner_mm669_authored_branch_uses_documented_fallback_chain(
+    inputs,
+    parameters,
+    expected_branch,
+):
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+    task_overrides = dict(inputs.get("task", {}))
+    top_level_inputs = {key: value for key, value in inputs.items() if key != "task"}
+
+    task = {
+        "instructions": "Do work",
+        "title": "MM-669 branch resolution",
+        "runtime": {"mode": "codex_cli"},
+        "publish": {"mode": "pr"},
+        **task_overrides,
+    }
+    plan = planner(
+        inputs={**top_level_inputs, "task": task},
+        parameters={"publishMode": "pr", **parameters},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][-1]["inputs"]
+    assert node_inputs["branch"] == expected_branch
+    assert node_inputs["startingBranch"] == expected_branch
+
+def test_runtime_planner_mm669_pr_head_uses_workspace_metadata_before_generated_branch():
     planner = _build_runtime_planner()
     snapshot = _make_snapshot()
 
-    cases = [
-        ({"task": {"git": {"branch": "feature/git"}}}, "feature/git"),
-        ({"task": {"branch": "feature/task"}}, "feature/task"),
-        (
-            {
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "title": "MM-669 work branch",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={
+            "publishMode": "pr",
+            "targetBranch": "legacy-top-level-head",
+            "workspaceSpec": {"targetBranch": "workspace-head"},
+        },
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][-1]["inputs"]["targetBranch"] == "workspace-head"
+
+def test_runtime_planner_mm669_pr_head_ignores_legacy_top_level_target_branch():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "title": "MM-669 generated head",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={"publishMode": "pr", "targetBranch": "legacy-top-level-head"},
+        snapshot=snapshot,
+    )
+
+    target_branch = plan["nodes"][-1]["inputs"]["targetBranch"]
+    assert target_branch != "legacy-top-level-head"
+    assert target_branch.startswith("mm-669-generated-head-")
+
+def test_runtime_planner_mm669_pr_head_ignores_legacy_git_target_branch():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "title": "MM-669 generated head from git legacy",
+                "git": {"targetBranch": "legacy-git-head"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={"publishMode": "pr"},
+        snapshot=snapshot,
+    )
+
+    target_branch = plan["nodes"][-1]["inputs"]["targetBranch"]
+    assert target_branch != "legacy-git-head"
+    assert target_branch.startswith("mm-669-generated-head-from-git-legacy-")
+
+def test_runtime_planner_mm669_pr_mode_errors_when_head_branch_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.worker_runtime._generate_runtime_pr_branch",
+        lambda _prefix: "",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="publishMode 'pr' requested but no PR head branch could be resolved",
+    ):
+        planner(
+            inputs={
                 "task": {
-                    "tool": {
-                        "name": "auto",
-                        "inputs": {"branch": "feature/skill"},
-                    }
+                    "instructions": "Do work",
+                    "title": "MM-669 unresolved head",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
                 }
             },
-            "feature/skill",
-        ),
-        ({}, "feature/parameter"),
-        ({"branch": "feature/input"}, "feature/input"),
-        ({"defaultBranch": "trunk"}, "trunk"),
-    ]
-
-    for input_overrides, expected_branch in cases:
-        task = {
-            "instructions": "Do work",
-            "runtime": {"mode": "codex_cli"},
-            "publish": {"mode": "branch"},
-        }
-        task.update(input_overrides.get("task", {}))
-        inputs = {"task": task}
-        for key, value in input_overrides.items():
-            if key != "task":
-                inputs[key] = value
-        parameters = {
-            "branch": "feature/parameter",
-            "defaultBranch": "main",
-        }
-        if expected_branch in {"feature/input", "trunk"}:
-            parameters.pop("branch")
-        if expected_branch == "trunk":
-            parameters.pop("defaultBranch")
-
-        plan = planner(inputs=inputs, parameters=parameters, snapshot=snapshot)
-
-        assert plan["nodes"][-1]["inputs"]["branch"] == expected_branch
-
-def test_runtime_planner_leaves_branch_unset_without_authored_branch():
-    planner = _build_runtime_planner()
-    snapshot = _make_snapshot()
-
-    plan = planner(
-        inputs={
-            "task": {
-                "instructions": "Do work",
-                "runtime": {"mode": "codex_cli"},
-                "publish": {"mode": "branch"},
-            }
-        },
-        parameters={},
-        snapshot=snapshot,
-    )
-
-    assert "branch" not in plan["nodes"][-1]["inputs"]
-
-def test_runtime_planner_ignores_non_string_branch_values():
-    planner = _build_runtime_planner()
-    snapshot = _make_snapshot()
-
-    plan = planner(
-        inputs={
-            "task": {
-                "instructions": "Do work",
-                "runtime": {"mode": "codex_cli"},
-                "publish": {"mode": "branch"},
-                "git": {"defaultBranch": {"name": "main"}},
-            }
-        },
-        parameters={"defaultBranch": {"name": "trunk"}},
-        snapshot=snapshot,
-    )
-
-    assert "branch" not in plan["nodes"][-1]["inputs"]
+            parameters={"publishMode": "pr"},
+            snapshot=snapshot,
+        )
 
 def test_runtime_planner_publish_pr_uses_step_title_for_target_branch_prefix():
     planner = _build_runtime_planner()

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1090,7 +1090,7 @@ def test_native_pr_branch_resolution_uses_patched_publish_defaults(
     assert head_branch == ""
     assert base_branch == "release"
 
-def test_native_pr_branch_resolution_prefers_runtime_owned_head_sources(
+def test_native_pr_branch_resolution_mm669_uses_runtime_owned_head_sources(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1100,55 +1100,35 @@ def test_native_pr_branch_resolution_prefers_runtime_owned_head_sources(
     monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
 
     head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
-        parameters={"targetBranch": "legacy/parameter-target"},
+        parameters={"targetBranch": "legacy-top-level-head"},
         agent_outputs={},
-        workspace_spec={"targetBranch": "runtime/generated-head"},
-        last_node_inputs={"targetBranch": "plan/generated-head"},
-        publish_payload={"prBaseBranch": "develop"},
-    )
-
-    assert head_branch == "runtime/generated-head"
-    assert base_branch == "develop"
-
-def test_native_pr_branch_resolution_prefers_provider_output_over_workspace_head(
-    mock_run_workflow: MoonMindRunWorkflow,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fake_patched(patch_id: str) -> bool:
-        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
-
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
-
-    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
-        parameters={},
-        agent_outputs={"push_branch": "provider/head"},
-        workspace_spec={"targetBranch": "workspace/head"},
-        last_node_inputs={"targetBranch": "generated/head"},
+        workspace_spec={},
+        last_node_inputs={"targetBranch": "planner-generated-head"},
         publish_payload={"prBaseBranch": "main"},
     )
 
-    assert head_branch == "provider/head"
+    assert head_branch == "planner-generated-head"
     assert base_branch == "main"
 
-def test_native_pr_branch_resolution_ignores_legacy_parameter_target_branch(
-    mock_run_workflow: MoonMindRunWorkflow,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fake_patched(patch_id: str) -> bool:
-        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
-
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
-
-    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
-        parameters={"targetBranch": "legacy/parameter-target"},
+    head_branch, _ = mock_run_workflow._resolve_native_pr_branches(
+        parameters={"targetBranch": "legacy-top-level-head"},
         agent_outputs={},
-        workspace_spec={},
-        last_node_inputs={},
-        publish_payload={"prBaseBranch": "develop"},
+        workspace_spec={"targetBranch": "workspace-head"},
+        last_node_inputs={"targetBranch": "planner-generated-head"},
+        publish_payload={"prBaseBranch": "main"},
     )
 
-    assert head_branch == ""
-    assert base_branch == "develop"
+    assert head_branch == "workspace-head"
+
+    head_branch, _ = mock_run_workflow._resolve_native_pr_branches(
+        parameters={"targetBranch": "legacy-top-level-head"},
+        agent_outputs={"branch": "provider-head"},
+        workspace_spec={"targetBranch": "workspace-head"},
+        last_node_inputs={"targetBranch": "planner-generated-head"},
+        publish_payload={"prBaseBranch": "main"},
+    )
+
+    assert head_branch == "provider-head"
 
 def test_native_pr_push_status_gate_preserves_legacy_protected_branch_fallback(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
Jira issue: MM-669

Summary:
- Resolve authored branches in the runtime planner using the documented fallback chain: task.git.branch, task.branch, selected skill inputs, parameter payload, input payload, then repository default branch metadata.
- Keep PR base branch and PR work/head branch resolution separate for publishMode: pr.
- Resolve PR head branches from runtime-owned sources in order: provider/agent outputs, workspace work-branch metadata, then runtime planner generated branch names.
- Raise explicit errors when publishMode: pr cannot resolve a PR head branch.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_run_artifacts.py
- pytest tests/integration/api/test_task_contract_normalization.py -q --tb=short
- git diff --check

Remaining risks:
- Full unit suite was run during implementation and passed, but this clean PR branch was verified with the focused unit and integration checks above.
