### PR TITLE
Implement the document and code improvements suggested below:

### DIFF
--- a/docs/Tasks/TaskFinishSummarySystem.md
+++ b/docs/Tasks/TaskFinishSummarySystem.md
@@ -2,8 +2,9 @@
 
 Status: Active  
 Owners: MoonMind Engineering  
-Last Updated: 2026-03-27  
-Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskProposalQueue.md`
+Last Updated: 2026-05-17  
+Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskProposalQueue.md`,
+`docs/Temporal/ErrorTaxonomy.md`, `docs/Temporal/StepLedgerAndProgressModel.md`
 
 ---
 
@@ -72,11 +73,96 @@ The finish summary data is small and stored as JSON. A `reports/run_summary.json
 }
 ```
 
-### 2.3 Secret Handling
+### 2.3 Failure Diagnostics Contract
+
+Failed and canceled runs MUST include a bounded, redacted, operator-meaningful
+failure reason. Generic Temporal wrappers (for example `Activity task failed`,
+`Child Workflow execution failed`) are not acceptable as the operator-visible
+reason — the workflow MUST walk the exception chain and surface the deepest
+non-generic root cause.
+
+`finishOutcome.reason` is the canonical operator-facing failure string. When a
+run fails, it MUST be sourced from a structured failure diagnostic captured at
+the failure boundary, not reconstructed from the terminal `summary` field
+alone.
+
+Failed runs SHOULD additionally include a structured `failure` object alongside
+`finishOutcome`. The object is small, free of secrets, and shaped as:
+
+```json
+{
+  "failure": {
+    "stage": "executing",
+    "category": "integration_error",
+    "source": "child_workflow",
+    "stepId": "apply-patch",
+    "stepTitle": "Apply patch",
+    "childWorkflowId": "task-123:agent:apply-patch",
+    "message": "Provider authentication failed with HTTP 401 for profile codex-prod.",
+    "rootCauseType": "ApplicationError",
+    "diagnosticsRef": "artifact://..."
+  }
+}
+```
+
+Field semantics:
+
+* `stage`: the workflow stage that was active when the failure was captured
+  (`prepare`, `planning`, `executing`, `publish`, `proposals`, `finalizing`).
+* `category`: aligns with `ExecutionTerminalStateInput.error_category` and the
+  policy categories in `docs/Temporal/ErrorTaxonomy.md`. Permitted values are
+  `user_error`, `integration_error`, `execution_error`, and `system_error`.
+  `ApplicationError.type` values such as `INVALID_INPUT`,
+  `UnsupportedStatus`, `ProfileResolutionError`, `SlotAcquisitionTimeout`, and
+  `RATE_LIMITED` are mapped onto these four categories.
+* `source`: where the failure originated — `child_workflow`, `activity`, or
+  `workflow`.
+* `stepId` / `stepTitle`: the failing plan node when applicable.
+* `childWorkflowId`: the child workflow id when the failure originated from a
+  child workflow.
+* `message`: the redacted, bounded operator-facing root cause. Truncated to
+  ~1000 characters.
+* `rootCauseType`: the deepest non-generic exception class name observed in
+  the failure chain.
+* `diagnosticsRef`: an optional artifact ref pointing at larger structured
+  diagnostics. Large diagnostic payloads MUST NOT be embedded inline — they
+  belong in artifacts. See `docs/Temporal/StepLedgerAndProgressModel.md` for
+  the same rule applied to per-step `lastError`.
+
+When a structured `failure` is present, the `lastStep` block SHOULD reflect
+the failure so operators see the failing tool, not a stale prior step:
+
+* `lastStep.id` is set to the failing step's `stepId`.
+* `lastStep.summary` matches the diagnostic `message`.
+* `lastStep.lastError` carries the diagnostic `category` (mirroring the
+  step-ledger `lastError` semantics defined in
+  `docs/Temporal/StepLedgerAndProgressModel.md`).
+* `lastStep.diagnosticsRef` is set when the diagnostic carries one.
+
+The terminal-state activity (`execution.record_terminal_state`) uses the same
+diagnostic when recording the `summary` and `errorCategory` so the visibility
+projection and the finish-summary artifact never disagree about why a run
+failed.
+
+#### First-failure-wins capture
+
+Failure diagnostics are captured at the first failure boundary that surfaces a
+non-generic root cause (for example the `except Exception` block around a
+`MoonMind.AgentRun` child workflow execution or a plan-step activity). Later
+generic re-raises in higher-level handlers MUST NOT overwrite an earlier,
+deeper diagnostic.
+
+### 2.5 Secret Handling
 
 Finish summaries MUST NOT contain tokens, API keys, credential strings, or full command lines with secret arguments. All strings are passed through redaction mechanisms before sync.
 
-### 2.4 Preset Summary Ownership
+This rule applies to the structured `failure` diagnostic defined in §2.3 as
+well. The diagnostic `message` is passed through the same redaction policy
+used for `operatorSummary` and step summaries (for example
+`scrub_github_tokens`) before being written to `reports/run_summary.json` or
+sent to the terminal-state activity.
+
+### 2.6 Preset Summary Ownership
 
 Task presets do not own generic end-of-run narration. Presets may emit structured
 facts that are useful after execution, such as a Jira issue key, pull request

--- a/docs/Temporal/ErrorTaxonomy.md
+++ b/docs/Temporal/ErrorTaxonomy.md
@@ -1,10 +1,12 @@
 # Temporal Error Taxonomy
 
 Status: **Core policy document** (partially enforced in current activity definitions; broader adoption ongoing)
-Last updated: 2026-03-30
+Last updated: 2026-05-17
 Related:
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](./ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
+- [`docs/Temporal/StepLedgerAndProgressModel.md`](./StepLedgerAndProgressModel.md)
+- [`docs/Tasks/TaskFinishSummarySystem.md`](../Tasks/TaskFinishSummarySystem.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 
 ---
@@ -467,6 +469,32 @@ Workflows decide what to do with activity failures:
 ## 10.3 Workflows should not repair malformed contracts
 
 Workflow code should not become a compatibility layer for malformed provider/runtime payloads. That logic belongs in adapters and activities.
+
+## 10.4 Workflows own the operator-facing failure diagnostic
+
+Even though activities own failure translation, workflows are responsible for
+turning the resulting exception chain into the bounded, redacted failure
+reason that operators see in `reports/run_summary.json` and in the terminal
+execution state.
+
+`MoonMind.Run` captures a structured **failure diagnostic** at the first
+failure boundary that surfaces a non-generic root cause — typically the
+`except Exception` blocks around a `MoonMind.AgentRun` child workflow
+execution, a plan-step activity execution, the merge-automation child
+workflow, and the top-level planning/execution exception handlers. That
+diagnostic carries the deepest root-cause message, a `category` that maps onto
+this taxonomy, the failing `stepId`/`childWorkflowId`, and an optional
+`diagnosticsRef` artifact pointer for larger detail.
+
+The canonical contract for the diagnostic — including its JSON shape, the
+secret-handling rules, and how it feeds `finishOutcome.reason`, `lastStep`,
+and the terminal-state `errorCategory` — lives in
+[`docs/Tasks/TaskFinishSummarySystem.md`](../Tasks/TaskFinishSummarySystem.md).
+The `category` values used there (`user_error`, `integration_error`,
+`execution_error`, `system_error`) are how this taxonomy's
+`ApplicationError.type` values such as `INVALID_INPUT`, `UnsupportedStatus`,
+`ProfileResolutionError`, `SlotAcquisitionTimeout`, and `RATE_LIMITED` are
+projected onto the four operator-visible categories.
 
 ---
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -376,7 +376,7 @@ class MoonMindRunWorkflow:
             "SlotAcquisitionTimeout",
             "RATE_LIMITED",
         }
-        for app_type in application_types:
+        for app_type in reversed(application_types):
             if app_type in user_error_types:
                 return "user_error"
             if app_type in integration_error_types:
@@ -3124,6 +3124,7 @@ class MoonMindRunWorkflow:
 
                     if tool_type == "agent_runtime":
                         # --- Agent dispatch: child workflow ---
+                        child_workflow_id: str | None = None
                         try:
                             resolved_skillset_ref = (
                                 await self._resolve_agent_node_skillset_ref(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -315,6 +315,152 @@ class MoonMindRunWorkflow:
             return chain[-1][1][:1000]
         return exc.__class__.__name__
 
+    @staticmethod
+    def _failure_root_cause(exc: BaseException) -> BaseException:
+        """Walk the exception chain to the deepest non-generic cause."""
+
+        generic_types = (
+            exceptions.ActivityError,
+            exceptions.ChildWorkflowError,
+        )
+        chain: list[BaseException] = []
+        current: BaseException | None = exc
+        for _ in range(20):
+            if current is None:
+                break
+            chain.append(current)
+            next_exc = getattr(current, "cause", None)
+            if not isinstance(next_exc, BaseException):
+                next_exc = current.__cause__
+            current = next_exc
+        for candidate in reversed(chain):
+            if not isinstance(candidate, generic_types):
+                return candidate
+        return chain[-1] if chain else exc
+
+    @classmethod
+    def _classify_failure_category(cls, exc: BaseException) -> str:
+        """Map an exception chain to one of the canonical errorCategory values.
+
+        Categories align with `ExecutionTerminalStateInput.error_category`:
+        ``user_error`` | ``integration_error`` | ``execution_error`` | ``system_error``.
+        """
+
+        # CancelledError is not a normal failure; callers must handle it before
+        # invoking this helper, but classify defensively.
+        if isinstance(exc, (CancelledError, asyncio.CancelledError)):
+            return "execution_error"
+
+        root = cls._failure_root_cause(exc)
+
+        # Inspect ApplicationError.type when present (set by activities raising
+        # typed errors per docs/Temporal/ErrorTaxonomy.md).
+        application_types: list[str] = []
+        current: BaseException | None = exc
+        for _ in range(20):
+            if current is None:
+                break
+            if isinstance(current, exceptions.ApplicationError):
+                raw_type = getattr(current, "type", None)
+                if isinstance(raw_type, str) and raw_type.strip():
+                    application_types.append(raw_type.strip())
+            next_exc = getattr(current, "cause", None)
+            if not isinstance(next_exc, BaseException):
+                next_exc = current.__cause__
+            current = next_exc
+
+        user_error_types = {"INVALID_INPUT"}
+        integration_error_types = {
+            "UnsupportedStatus",
+            "ProfileResolutionError",
+            "SlotAcquisitionTimeout",
+            "RATE_LIMITED",
+        }
+        for app_type in application_types:
+            if app_type in user_error_types:
+                return "user_error"
+            if app_type in integration_error_types:
+                return "integration_error"
+
+        # Heuristic fallback based on the deepest root-cause type.
+        root_type_name = root.__class__.__name__
+        if root_type_name in {"ValueError", "TypeError", "KeyError"}:
+            # These typically indicate malformed/invalid input.
+            return "user_error"
+        if "Timeout" in root_type_name or "Connection" in root_type_name:
+            return "integration_error"
+        return "execution_error"
+
+    def _failure_diagnostic_from_exception(
+        self,
+        exc: BaseException,
+        *,
+        stage: str | None = None,
+        step_id: str | None = None,
+        step_title: str | None = None,
+        source: str | None = None,
+        child_workflow_id: str | None = None,
+        diagnostics_ref: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a bounded, redacted failure diagnostic from a failure chain.
+
+        The returned dict is intentionally small and free of secrets so it
+        can flow through the workflow's finish-summary contract and the
+        terminal-state activity without leaking credential-bearing payloads.
+        """
+
+        raw_message = self._operator_failure_summary(exc)
+        sanitized = self._sanitize_operator_summary(raw_message) or raw_message
+        bounded_message = self._coerce_text(sanitized, max_chars=1000) or (
+            exc.__class__.__name__
+        )
+        category = self._classify_failure_category(exc)
+        root = self._failure_root_cause(exc)
+
+        diagnostic: dict[str, Any] = {
+            "stage": self._coerce_text(stage or self._state, max_chars=80),
+            "category": category,
+            "source": self._coerce_text(source, max_chars=40) or "workflow",
+            "stepId": self._coerce_text(step_id, max_chars=120),
+            "stepTitle": self._coerce_text(step_title, max_chars=200),
+            "childWorkflowId": self._coerce_text(child_workflow_id, max_chars=400),
+            "message": bounded_message,
+            "rootCauseType": self._coerce_text(
+                root.__class__.__name__, max_chars=80
+            ),
+            "diagnosticsRef": self._coerce_text(diagnostics_ref, max_chars=400),
+        }
+        # Drop empty optional keys to keep the structure compact.
+        return {key: value for key, value in diagnostic.items() if value is not None}
+
+    def _record_failure_diagnostic(
+        self,
+        exc: BaseException,
+        *,
+        stage: str | None = None,
+        step_id: str | None = None,
+        step_title: str | None = None,
+        source: str | None = None,
+        child_workflow_id: str | None = None,
+        diagnostics_ref: str | None = None,
+    ) -> dict[str, Any]:
+        """Capture a failure diagnostic on the workflow if none is set yet."""
+
+        diagnostic = self._failure_diagnostic_from_exception(
+            exc,
+            stage=stage,
+            step_id=step_id,
+            step_title=step_title,
+            source=source,
+            child_workflow_id=child_workflow_id,
+            diagnostics_ref=diagnostics_ref,
+        )
+        # First failure wins: keep the deepest available root cause and avoid
+        # later generic wrapping handlers from overwriting it.
+        if self._failure_diagnostic is None:
+            self._failure_diagnostic = diagnostic
+        return diagnostic
+
     def __init__(self) -> None:
         self._state = STATE_INITIALIZING
         self._owner_type: Optional[str] = None
@@ -339,6 +485,11 @@ class MoonMindRunWorkflow:
         self._last_step_summary: Optional[str] = None
         self._plan_blocked_message: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
+        # Bounded, redacted structured failure diagnostic captured at the
+        # failure boundary. Surfaced in reports/run_summary.json and reused by
+        # terminal-state recording so operators see the deepest root cause
+        # instead of generic Temporal wrappers.
+        self._failure_diagnostic: Optional[dict[str, Any]] = None
         self._merge_automation_disposition: Optional[str] = None
         self._merge_automation_head_sha: Optional[str] = None
         self._report_created: bool = False
@@ -2406,19 +2557,24 @@ class MoonMindRunWorkflow:
                     )
                     return {"status": "canceled"}
         except ValueError as exc:
+            diagnostic = self._record_failure_diagnostic(
+                exc,
+                stage=self._state,
+                source="workflow",
+            )
             await self._run_finalizing_stage(
-                parameters=parameters, status="failed", error=str(exc)
+                parameters=parameters, status="failed", error=diagnostic["message"]
             )
             self._close_status = CLOSE_STATUS_FAILED
-            self._set_state(STATE_FAILED, summary=str(exc))
+            self._set_state(STATE_FAILED, summary=diagnostic["message"])
             await self._record_terminal_state(
                 state=STATE_FAILED,
                 close_status=CLOSE_STATUS_FAILED,
-                summary=str(exc),
-                error_category="execution_error",
+                summary=diagnostic["message"],
+                error_category=diagnostic["category"],
             )
             raise exceptions.ApplicationError(
-                str(exc),
+                diagnostic["message"],
                 non_retryable=True,
             ) from exc
         self._set_state(STATE_PLANNING, summary="Planning execution strategy.")
@@ -2448,23 +2604,33 @@ class MoonMindRunWorkflow:
                 plan_ref=resolved_plan_ref,
             )
         except ValueError as exc:
+            diagnostic = self._record_failure_diagnostic(
+                exc,
+                stage=self._state,
+                source="workflow",
+            )
             await self._run_finalizing_stage(
-                parameters=parameters, status="failed", error=str(exc)
+                parameters=parameters, status="failed", error=diagnostic["message"]
             )
             self._close_status = CLOSE_STATUS_FAILED
-            self._set_state(STATE_FAILED, summary=str(exc))
+            self._set_state(STATE_FAILED, summary=diagnostic["message"])
             await self._record_terminal_state(
                 state=STATE_FAILED,
                 close_status=CLOSE_STATUS_FAILED,
-                summary=str(exc),
-                error_category="execution_error",
+                summary=diagnostic["message"],
+                error_category=diagnostic["category"],
             )
             raise exceptions.ApplicationError(
-                str(exc),
+                diagnostic["message"],
                 non_retryable=True,
             ) from exc
         except Exception as exc:
-            failure_summary = self._operator_failure_summary(exc)
+            diagnostic = self._record_failure_diagnostic(
+                exc,
+                stage=self._state,
+                source="workflow",
+            )
+            failure_summary = diagnostic["message"]
             await self._run_finalizing_stage(
                 parameters=parameters, status="failed", error=failure_summary
             )
@@ -2474,7 +2640,7 @@ class MoonMindRunWorkflow:
                 state=STATE_FAILED,
                 close_status=CLOSE_STATUS_FAILED,
                 summary=failure_summary,
-                error_category="execution_error",
+                error_category=diagnostic["category"],
             )
             raise
 
@@ -3030,13 +3196,21 @@ class MoonMindRunWorkflow:
                                 self._active_agent_child_workflow_id = None
                                 self._active_agent_id = None
                             execution_result = self._map_agent_run_result(child_result)
-                        except Exception:
+                        except Exception as exc:
+                            diagnostic = self._record_failure_diagnostic(
+                                exc,
+                                stage=self._state,
+                                step_id=node_id,
+                                step_title=tool_name,
+                                source="child_workflow",
+                                child_workflow_id=child_workflow_id,
+                            )
                             self._mark_step_terminal(
                                 node_id,
                                 status="failed",
                                 updated_at=workflow.now(),
-                                summary=f"{tool_name} failed",
-                                last_error="execution_error",
+                                summary=diagnostic["message"],
+                                last_error=diagnostic["category"],
                             )
                             if failure_mode == "FAIL_FAST":
                                 raise
@@ -3107,13 +3281,20 @@ class MoonMindRunWorkflow:
                                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
                                 **self._execute_kwargs_for_route(route),
                             )
-                        except Exception:
+                        except Exception as exc:
+                            diagnostic = self._record_failure_diagnostic(
+                                exc,
+                                stage=self._state,
+                                step_id=node_id,
+                                step_title=tool_name,
+                                source="activity",
+                            )
                             self._mark_step_terminal(
                                 node_id,
                                 status="failed",
                                 updated_at=workflow.now(),
-                                summary=f"{tool_name} failed",
-                                last_error="execution_error",
+                                summary=diagnostic["message"],
+                                last_error=diagnostic["category"],
                             )
                             if failure_mode == "FAIL_FAST":
                                 raise
@@ -4056,13 +4237,20 @@ class MoonMindRunWorkflow:
                     cancellation_type=ActivityCancellationType.TRY_CANCEL,
                     **self._execute_kwargs_for_route(route),
                 )
-            except Exception:
+            except Exception as exc:
+                diagnostic = self._record_failure_diagnostic(
+                    exc,
+                    stage=self._state,
+                    step_id=node_id,
+                    step_title=f"Re-check of Jira blockers for {tool_name}",
+                    source="activity",
+                )
                 self._mark_step_terminal(
                     node_id,
                     status="failed",
                     updated_at=workflow.now(),
-                    summary=f"Re-check of Jira blockers for {tool_name} failed",
-                    last_error="execution_error",
+                    summary=diagnostic["message"],
+                    last_error=diagnostic["category"],
                 )
                 if failure_mode == "FAIL_FAST":
                     raise
@@ -5612,10 +5800,17 @@ class MoonMindRunWorkflow:
             self._update_memo()
             self._update_search_attributes()
             raise
-        except Exception:
+        except Exception as exc:
             self._awaiting_external = False
             self._waiting_reason = None
             self._publish_context["mergeAutomationStatus"] = "failed"
+            self._record_failure_diagnostic(
+                exc,
+                stage=self._state,
+                source="child_workflow",
+                child_workflow_id=workflow_id,
+                step_title="merge automation",
+            )
             self._update_memo()
             self._update_search_attributes()
             raise
@@ -6887,6 +7082,12 @@ class MoonMindRunWorkflow:
                     elif publish_mode == "none":
                         code = "PUBLISH_DISABLED"
 
+            diagnostic_reason: str | None = None
+            if status == "failed" and isinstance(self._failure_diagnostic, dict):
+                diagnostic_reason = self._failure_diagnostic.get("message") or None
+
+            finish_outcome_reason = diagnostic_reason or error or "completed"
+
             finish_summary = {
                 "schemaVersion": "v1",
                 "jobId": workflow.info().workflow_id,
@@ -6902,7 +7103,7 @@ class MoonMindRunWorkflow:
                 "finishOutcome": {
                     "code": code,
                     "stage": self._state,
-                    "reason": error or "completed",
+                    "reason": finish_outcome_reason,
                 },
                 "publish": {
                     "mode": publish_mode,
@@ -6937,12 +7138,42 @@ class MoonMindRunWorkflow:
                 merge_automation_summary = self._merge_automation_summary_from_context()
                 if merge_automation_summary:
                     finish_summary["mergeAutomation"] = merge_automation_summary
-            if self._last_step_id or self._last_step_summary or self._last_diagnostics_ref:
-                finish_summary["lastStep"] = {
-                    "id": self._last_step_id,
-                    "summary": self._last_step_summary,
-                    "diagnosticsRef": self._last_diagnostics_ref,
+            last_step_summary = self._last_step_summary
+            last_step_id = self._last_step_id
+            last_diagnostics_ref = self._last_diagnostics_ref
+            last_step_error: str | None = None
+            if status == "failed" and isinstance(self._failure_diagnostic, dict):
+                diag = self._failure_diagnostic
+                # Prefer the diagnostic when it covers a specific failed step so
+                # the operator sees the failing tool, not the last successful
+                # step recorded earlier in the run.
+                diag_step_id = diag.get("stepId")
+                if diag_step_id:
+                    last_step_id = diag_step_id
+                    last_step_summary = diag.get("message") or last_step_summary
+                    if diag.get("diagnosticsRef"):
+                        last_diagnostics_ref = diag.get("diagnosticsRef")
+                elif diag.get("message"):
+                    last_step_summary = last_step_summary or diag.get("message")
+                last_step_error = diag.get("category")
+
+            if (
+                last_step_id
+                or last_step_summary
+                or last_diagnostics_ref
+                or last_step_error
+            ):
+                last_step_block: dict[str, Any] = {
+                    "id": last_step_id,
+                    "summary": last_step_summary,
+                    "diagnosticsRef": last_diagnostics_ref,
                 }
+                if last_step_error:
+                    last_step_block["lastError"] = last_step_error
+                finish_summary["lastStep"] = last_step_block
+
+            if status == "failed" and isinstance(self._failure_diagnostic, dict):
+                finish_summary["failure"] = dict(self._failure_diagnostic)
 
             artifact_create_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
                 "artifact.create"

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -111,6 +111,116 @@ def test_operator_failure_summary_skips_temporal_activity_wrapper() -> None:
     )
 
 
+def _make_workflow_for_diagnostic() -> MoonMindRunWorkflow:
+    wf = MoonMindRunWorkflow()
+    wf._state = "executing"
+    return wf
+
+
+def test_failure_diagnostic_from_exception_captures_deep_root_cause() -> None:
+    wf = _make_workflow_for_diagnostic()
+    failure = _NestedFailure(
+        "Child Workflow execution failed",
+        _NestedFailure(
+            "Activity task failed",
+            RuntimeError(
+                "Provider authentication failed with HTTP 401 for profile codex-prod."
+            ),
+        ),
+    )
+
+    diag = wf._failure_diagnostic_from_exception(
+        failure,
+        stage="executing",
+        step_id="apply-patch",
+        step_title="Apply patch",
+        source="child_workflow",
+        child_workflow_id="task-123:agent:apply-patch",
+    )
+
+    assert diag["stage"] == "executing"
+    assert diag["stepId"] == "apply-patch"
+    assert diag["stepTitle"] == "Apply patch"
+    assert diag["source"] == "child_workflow"
+    assert diag["childWorkflowId"] == "task-123:agent:apply-patch"
+    assert (
+        diag["message"]
+        == "Provider authentication failed with HTTP 401 for profile codex-prod."
+    )
+    assert diag["rootCauseType"] == "RuntimeError"
+    assert diag["category"] == "execution_error"
+
+
+def test_failure_diagnostic_redacts_github_tokens() -> None:
+    wf = _make_workflow_for_diagnostic()
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+    failure = RuntimeError(
+        f"Push failed because token {secret} was rejected by the server"
+    )
+
+    diag = wf._failure_diagnostic_from_exception(failure, stage="executing")
+
+    assert secret not in diag["message"]
+    # Sanity check: redacted message still mentions the failure context.
+    assert "Push failed" in diag["message"]
+
+
+def test_failure_diagnostic_classifies_invalid_input_as_user_error() -> None:
+    from temporalio.exceptions import ApplicationError
+
+    wf = _make_workflow_for_diagnostic()
+    failure = ApplicationError(
+        "Plan tool 'apply-patch' was not found in registry snapshot",
+        type="INVALID_INPUT",
+        non_retryable=True,
+    )
+
+    diag = wf._failure_diagnostic_from_exception(failure, stage="planning")
+
+    assert diag["category"] == "user_error"
+    assert "Plan tool" in diag["message"]
+
+
+def test_failure_diagnostic_classifies_profile_resolution_as_integration() -> None:
+    from temporalio.exceptions import ApplicationError
+
+    wf = _make_workflow_for_diagnostic()
+    failure = ApplicationError(
+        "No enabled provider profiles for runtime codex_cli",
+        type="ProfileResolutionError",
+        non_retryable=True,
+    )
+
+    diag = wf._failure_diagnostic_from_exception(failure, stage="executing")
+
+    assert diag["category"] == "integration_error"
+
+
+def test_record_failure_diagnostic_keeps_first_root_cause() -> None:
+    wf = _make_workflow_for_diagnostic()
+    first = RuntimeError(
+        "Provider authentication failed with HTTP 401 for profile codex-prod."
+    )
+    wf._record_failure_diagnostic(
+        first,
+        stage="executing",
+        step_id="apply-patch",
+        step_title="Apply patch",
+        source="child_workflow",
+        child_workflow_id="wf:1",
+    )
+
+    second = RuntimeError("generic wrapper from higher-level handler")
+    wf._record_failure_diagnostic(second, stage="finalizing", source="workflow")
+
+    assert wf._failure_diagnostic is not None
+    assert wf._failure_diagnostic["stepId"] == "apply-patch"
+    assert (
+        wf._failure_diagnostic["message"]
+        == "Provider authentication failed with HTTP 401 for profile codex-prod."
+    )
+
+
 @pytest.fixture
 def mock_run_environment(monkeypatch):
     monkeypatch.setattr(


### PR DESCRIPTION
Implement the document and code improvements suggested below:

This can be achieved by making **failure diagnostics a first-class part of the finish-summary contract**, not by relying on Temporal’s default exception text.

MoonMind already has the right insertion point: `MoonMind.Run` finalization builds `reports/run_summary.json`, including `finishOutcome.reason`, `publish`, `proposals`, dependencies, and optional `lastStep` data. It also records terminal execution state with a `summary` and `errorCategory`.  The current gap is that child workflow/activity failures can be collapsed earlier into generic step state like `summary=f"{tool_name} failed"` and `last_error="execution_error"`, so by the time the final summary is written the most useful root-cause text may already be gone. 

The design should add a bounded, redacted **failure diagnostic** object that is captured at the failure boundary and then reused everywhere the operator sees the run outcome:

```json
{
  "finishOutcome": {
    "code": "FAILED",
    "stage": "executing",
    "reason": "Agent step 'apply-patch' failed: Provider authentication failed with HTTP 401 for profile codex-prod (retryRecommendation: reauthenticate)."
  },
  "failure": {
    "stage": "executing",
    "category": "integration_error",
    "source": "child_workflow",
    "stepId": "apply-patch",
    "stepTitle": "Apply patch",
    "childWorkflowId": "task-123:agent:apply-patch",
    "message": "Provider authentication failed with HTTP 401 for profile codex-prod.",
    "rootCauseType": "ApplicationError",
    "diagnosticsRef": "artifact://..."
  },
  "lastStep": {
    "id": "apply-patch",
    "summary": "Provider authentication failed with HTTP 401 for profile codex-prod.",
    "lastError": "integration_error",
    "diagnosticsRef": "artifact://..."
  }
}
```

Implementation-wise, add a helper such as `_failure_diagnostic_from_exception(exc, context=...)` in `MoonMindRunWorkflow`. It should walk the exception chain, prefer the deepest non-generic root-cause message, classify it with the existing error taxonomy, redact secrets with the same redaction policy already required for summaries, and truncate all inline strings. The code already has `scrub_github_tokens` available and the finish-summary doc already requires summaries to avoid tokens, API keys, credential strings, or secret-bearing command lines.  

Then use that helper in the exception handlers around:

1. `workflow.execute_child_workflow("MoonMind.AgentRun", ...)`
2. `workflow.execute_activity(...)` plan-step execution
3. merge automation child workflow failures
4. integration polling/fetch/publish failures
5. top-level planning/execution `except Exception as exc`

Instead of only doing:

```python
summary=f"{tool_name} failed"
last_error="execution_error"
```

the workflow should do something closer to:

```python
diagnostic = self._failure_diagnostic_from_exception(
    exc,
    stage=self._state,
    step_id=node_id,
    step_title=tool_name,
    source="child_workflow",
    child_workflow_id=child_workflow_id,
)

self._failure_diagnostic = diagnostic

self._mark_step_terminal(
    node_id,
    status="failed",
    updated_at=workflow.now(),
    summary=diagnostic["message"],
    last_error=diagnostic["category"],
)
```

Then `_run_finalizing_stage(...)` should prefer that diagnostic when setting `finishOutcome.reason`, `lastStep.summary`, `lastStep.lastError`, and the terminal-state `summary`. The existing terminal-state input already supports `summary` and `errorCategory`, so this does not require a new persistence concept; it mainly requires passing a better message through the existing path. 

The category should align with `docs/Temporal/ErrorTaxonomy.md`, which is already the policy source of truth for retryable, non-retryable, and retryable-with-policy failures.  The step-level representation should also align with `docs/Temporal/StepLedgerAndProgressModel.md`, which already says `lastError` is a bounded latest error summary and that large diagnostics belong in artifacts rather than inline workflow state.  

The existing document to update is **`docs/Tasks/TaskFinishSummarySystem.md`**. It already owns the canonical end-of-run summary, `reports/run_summary.json`, `finishOutcome.reason`, syncable result payload, and secret-handling rules.  Add a new section there, for example **“Failure Diagnostics Contract”**, specifying that failed and canceled runs must include a bounded, redacted, operator-meaningful failure reason, plus optional structured failure metadata. A smaller cross-reference can be added to `docs/Temporal/ErrorTaxonomy.md`, but the primary design-spec update belongs in `TaskFinishSummarySystem.md`.