### PR TITLE
MM-711: Add tested settings rename/type-change migration helpers and Settings backup/recovery docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,8 @@ Key diagnostics:
 - Existing `settings_overrides`, managed secret/provider-profile rows, and artifact/runtime metadata only; no new persistent storage planned (001-secretref-settings-integration)
 - Python 3.12; TypeScript/React for Mission Control state surfaces. + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest, existing task proposal service, existing execution router, existing Mission Control view model helpers. (357-normalize-proposal-submissions)
 - Existing Temporal execution records, existing task proposal records, existing artifact-backed original task input snapshots; no new persistent tables. (357-normalize-proposal-submissions)
+- Python 3.12 + Pydantic v2, SQLAlchemy 2.x async ORM, FastAPI (consumer of the settings catalog), pytest with `pytest-asyncio` (358-settings-migration-and-backup-docs)
+- Existing `settings_overrides` and `settings_audit_events` SQLAlchemy/Alembic tables (`api_service/db/models.py`). No new persistent storage. (358-settings-migration-and-backup-docs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -256,6 +256,8 @@ Key diagnostics:
 - Existing `settings_overrides`, managed secret/provider-profile rows, and artifact/runtime metadata only; no new persistent storage planned (001-secretref-settings-integration)
 - Python 3.12; TypeScript/React for Mission Control state surfaces. + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal Python SDK, pytest, existing task proposal service, existing execution router, existing Mission Control view model helpers. (357-normalize-proposal-submissions)
 - Existing Temporal execution records, existing task proposal records, existing artifact-backed original task input snapshots; no new persistent tables. (357-normalize-proposal-submissions)
+- Python 3.12 + Pydantic v2, SQLAlchemy 2.x async ORM, FastAPI (consumer of the settings catalog), pytest with `pytest-asyncio` (358-settings-migration-and-backup-docs)
+- Existing `settings_overrides` and `settings_audit_events` SQLAlchemy/Alembic tables (`api_service/db/models.py`). No new persistent storage. (358-settings-migration-and-backup-docs)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/services/settings_backup.py
+++ b/api_service/services/settings_backup.py
@@ -166,8 +166,10 @@ async def export_settings_backup(
         if sensitive_inline:
             excluded_keys.add(row.key)
             continue
-        if is_secret_ref and isinstance(row.value_json, str):
-            if not _looks_like_secret_ref(row.value_json):
+        if is_secret_ref and row.value_json is not None:
+            if not isinstance(row.value_json, str) or not _looks_like_secret_ref(
+                row.value_json
+            ):
                 raise SettingsBackupViolation(
                     f"settings_overrides row for {row.key!r} carries a value that "
                     "does not look like a SecretRef; refusing to back up to avoid "
@@ -396,7 +398,7 @@ def _secret_ref_broken_reference(
                 },
             )
         return None
-    if "://" not in value:
+    if not _looks_like_secret_ref(value):
         return SettingsBrokenReference(
             key=row.key,
             scope=row.scope,

--- a/api_service/services/settings_backup.py
+++ b/api_service/services/settings_backup.py
@@ -1,0 +1,460 @@
+"""Settings backup snapshot and broken-reference scan helpers.
+
+Implements the operator-facing pieces required by
+``docs/Security/SettingsSystem.md`` §23 (Backup and Recovery):
+
+* :func:`export_settings_backup` produces a serializable
+  :class:`SettingsBackupBundle` from ``settings_overrides`` and
+  ``settings_audit_events`` while enforcing the backup-exclusion policy
+  (no managed-secret plaintext, no leaked audit payloads on rows marked
+  redacted).
+* :func:`scan_broken_references` walks every persisted override and reports
+  the ones whose SecretRef or provider-profile target is missing or in a
+  non-launchable state, so operators can surface broken references after a
+  partial restore.
+
+The helpers intentionally operate at the data layer and do not load the
+full :class:`SettingsCatalogService`. They consume a
+:class:`SettingsRegistry` (or descriptor tuple) for descriptor metadata and
+fetch override / managed-secret / provider-profile rows directly.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from typing import Any, Literal, Mapping
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    ManagedSecret,
+    SecretStatus,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
+from api_service.services.settings_catalog import (
+    SettingRegistryEntry,
+    SettingsRegistry,
+)
+
+
+_PROVIDER_PROFILE_REF_KEY = "workflow.default_provider_profile_ref"
+
+_SECRET_REF_SCHEME_RE = re.compile(r"^(?P<scheme>env|db|exec|oauth_volume)://(?P<rest>.*)$")
+
+
+class SettingsBackupViolation(ValueError):
+    """Raised when a settings backup would leak plaintext credentials."""
+
+
+class SettingsBackupOverrideRecord(BaseModel):
+    """One row from ``settings_overrides`` formatted for backup export."""
+
+    key: str
+    scope: str
+    workspace_id: UUID
+    user_id: UUID
+    value_json: Any = None
+    schema_version: int
+    value_version: int
+    is_secret_ref: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class SettingsBackupAuditRecord(BaseModel):
+    """One row from ``settings_audit_events`` formatted for backup export."""
+
+    event_type: str
+    key: str
+    scope: str
+    workspace_id: UUID
+    user_id: UUID
+    actor_user_id: UUID | None = None
+    old_value_json: Any = None
+    new_value_json: Any = None
+    redacted: bool = False
+    reason: str | None = None
+    request_id: str | None = None
+    created_at: datetime | None = None
+
+
+class SettingsBackupBundle(BaseModel):
+    """Serializable backup snapshot of the Settings System tables."""
+
+    overrides: list[SettingsBackupOverrideRecord] = Field(default_factory=list)
+    audit_events: list[SettingsBackupAuditRecord] = Field(default_factory=list)
+    excluded_keys: list[str] = Field(default_factory=list)
+
+
+class SettingsBrokenReference(BaseModel):
+    """A persisted override whose target dependency is missing or unusable."""
+
+    key: str
+    scope: str
+    workspace_id: UUID
+    user_id: UUID
+    value: Any
+    code: Literal[
+        "unresolved_secret_ref",
+        "provider_profile_not_found",
+        "provider_profile_disabled",
+        "invalid_secret_ref",
+    ]
+    severity: Literal["error", "warning"] = "error"
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+def _registry_entries(
+    registry: SettingsRegistry | tuple[SettingRegistryEntry, ...],
+) -> dict[str, SettingRegistryEntry]:
+    if isinstance(registry, SettingsRegistry):
+        return dict(registry.entries_by_key)
+    return {entry.key: entry for entry in registry}
+
+
+def _looks_like_secret_ref(value: str) -> bool:
+    return bool(_SECRET_REF_SCHEME_RE.match(value))
+
+
+async def export_settings_backup(
+    *,
+    session: AsyncSession,
+    registry: SettingsRegistry | tuple[SettingRegistryEntry, ...],
+) -> SettingsBackupBundle:
+    """Build a :class:`SettingsBackupBundle` from the persisted Settings tables.
+
+    Policy enforced by this helper:
+
+    * Overrides whose descriptor declares ``audit.redact = True`` AND whose
+      ``value_type`` is not ``secret_ref`` are dropped from the bundle and
+      listed in ``excluded_keys`` — those descriptors may carry inline
+      credentials that must never reach a backup artifact.
+    * SecretRef-typed overrides remain in the bundle because their stored
+      value is a reference (``env://`` / ``db://`` / etc.), not plaintext.
+      If a SecretRef descriptor's persisted value does NOT look like a
+      SecretRef the helper raises :class:`SettingsBackupViolation` instead
+      of emitting a bundle that might leak the plaintext.
+    * Audit events whose ``redacted`` flag is true MUST NOT carry plaintext
+      payloads. Any row violating that invariant raises
+      :class:`SettingsBackupViolation`.
+    """
+
+    entries_by_key = _registry_entries(registry)
+
+    overrides: list[SettingsBackupOverrideRecord] = []
+    excluded_keys: set[str] = set()
+
+    override_rows = (
+        await session.execute(select(SettingsOverride).order_by(SettingsOverride.key))
+    ).scalars().all()
+    for row in override_rows:
+        entry = entries_by_key.get(row.key)
+        is_secret_ref = entry is not None and entry.value_type == "secret_ref"
+        sensitive_inline = (
+            entry is not None
+            and entry.audit.redact
+            and entry.value_type != "secret_ref"
+        )
+        if sensitive_inline:
+            excluded_keys.add(row.key)
+            continue
+        if is_secret_ref and isinstance(row.value_json, str):
+            if not _looks_like_secret_ref(row.value_json):
+                raise SettingsBackupViolation(
+                    f"settings_overrides row for {row.key!r} carries a value that "
+                    "does not look like a SecretRef; refusing to back up to avoid "
+                    "leaking plaintext credentials."
+                )
+        overrides.append(
+            SettingsBackupOverrideRecord(
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                value_json=row.value_json,
+                schema_version=row.schema_version,
+                value_version=row.value_version,
+                is_secret_ref=is_secret_ref,
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+            )
+        )
+
+    audit_rows = (
+        await session.execute(
+            select(SettingsAuditEvent).order_by(SettingsAuditEvent.created_at)
+        )
+    ).scalars().all()
+    audit_records: list[SettingsBackupAuditRecord] = []
+    for row in audit_rows:
+        if row.redacted and (
+            row.old_value_json is not None or row.new_value_json is not None
+        ):
+            raise SettingsBackupViolation(
+                f"settings_audit_events row for {row.key!r} is marked redacted but "
+                "carries a non-null value payload; refusing to back up to avoid "
+                "leaking plaintext audit data."
+            )
+        audit_records.append(
+            SettingsBackupAuditRecord(
+                event_type=row.event_type,
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                actor_user_id=row.actor_user_id,
+                old_value_json=row.old_value_json,
+                new_value_json=row.new_value_json,
+                redacted=row.redacted,
+                reason=row.reason,
+                request_id=row.request_id,
+                created_at=row.created_at,
+            )
+        )
+
+    return SettingsBackupBundle(
+        overrides=overrides,
+        audit_events=audit_records,
+        excluded_keys=sorted(excluded_keys),
+    )
+
+
+async def scan_broken_references(
+    *,
+    session: AsyncSession,
+    registry: SettingsRegistry | tuple[SettingRegistryEntry, ...],
+    env: Mapping[str, str] | None = None,
+) -> list[SettingsBrokenReference]:
+    """Return broken-reference diagnostics for every persisted override.
+
+    The scan mirrors the per-request diagnostics produced by
+    :class:`SettingsCatalogService` but operates across every workspace and
+    user scope so operators can surface broken references after a partial
+    restore (settings restored without dependencies, or vice versa). The
+    returned list is sorted by ``(key, scope, user_id)`` for stable
+    operator-facing rendering.
+    """
+
+    environment: Mapping[str, str] = env if env is not None else os.environ
+    entries_by_key = _registry_entries(registry)
+
+    override_rows = (
+        await session.execute(select(SettingsOverride))
+    ).scalars().all()
+
+    db_slugs: set[str] = set()
+    profile_ids: set[str] = set()
+    for row in override_rows:
+        entry = entries_by_key.get(row.key)
+        value = row.value_json
+        if not isinstance(value, str):
+            continue
+        if entry is not None and entry.value_type == "secret_ref":
+            if value.startswith("db://"):
+                slug = value.removeprefix("db://").strip()
+                if slug:
+                    db_slugs.add(slug)
+        if row.key == _PROVIDER_PROFILE_REF_KEY:
+            profile_id = value.strip()
+            if profile_id:
+                profile_ids.add(profile_id)
+
+    secret_status_by_slug: dict[str, str | None] = {}
+    if db_slugs:
+        result = await session.execute(
+            select(ManagedSecret.slug, ManagedSecret.status).where(
+                ManagedSecret.slug.in_(db_slugs)
+            )
+        )
+        for slug, status in result.all():
+            secret_status_by_slug[slug] = (
+                status.value if isinstance(status, SecretStatus) else str(status)
+            )
+        for slug in db_slugs:
+            secret_status_by_slug.setdefault(slug, None)
+
+    profile_enabled_by_id: dict[str, bool | None] = {}
+    if profile_ids:
+        result = await session.execute(
+            select(
+                ManagedAgentProviderProfile.profile_id,
+                ManagedAgentProviderProfile.enabled,
+            ).where(
+                ManagedAgentProviderProfile.profile_id.in_(profile_ids)
+            )
+        )
+        for profile_id, enabled in result.all():
+            profile_enabled_by_id[profile_id] = bool(enabled) if enabled is not None else False
+        for profile_id in profile_ids:
+            profile_enabled_by_id.setdefault(profile_id, None)
+
+    broken: list[SettingsBrokenReference] = []
+    for row in override_rows:
+        entry = entries_by_key.get(row.key)
+        value = row.value_json
+        if not isinstance(value, str):
+            continue
+        if entry is not None and entry.value_type == "secret_ref":
+            diagnostic = _secret_ref_broken_reference(
+                row=row,
+                value=value,
+                secret_status_by_slug=secret_status_by_slug,
+                environment=environment,
+            )
+            if diagnostic is not None:
+                broken.append(diagnostic)
+        if row.key == _PROVIDER_PROFILE_REF_KEY:
+            diagnostic = _provider_profile_broken_reference(
+                row=row,
+                value=value,
+                profile_enabled_by_id=profile_enabled_by_id,
+            )
+            if diagnostic is not None:
+                broken.append(diagnostic)
+
+    broken.sort(key=lambda item: (item.key, item.scope, str(item.user_id)))
+    return broken
+
+
+def _secret_ref_broken_reference(
+    *,
+    row: SettingsOverride,
+    value: str,
+    secret_status_by_slug: Mapping[str, str | None],
+    environment: Mapping[str, str],
+) -> SettingsBrokenReference | None:
+    if value.startswith("env://"):
+        env_name = value.removeprefix("env://").strip()
+        if not env_name or env_name not in environment:
+            return SettingsBrokenReference(
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                value=value,
+                code="unresolved_secret_ref",
+                message=(
+                    f"{row.key} references an environment secret that is "
+                    "not available."
+                ),
+                details={
+                    "ref_scheme": "env",
+                    "env_name": env_name or None,
+                },
+            )
+        return None
+    if value.startswith("db://"):
+        slug = value.removeprefix("db://").strip()
+        if not slug:
+            return SettingsBrokenReference(
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                value=value,
+                code="invalid_secret_ref",
+                message=f"{row.key} carries an empty SecretRef slug.",
+                details={"ref_scheme": "db"},
+            )
+        status = secret_status_by_slug.get(slug)
+        if status is None:
+            return SettingsBrokenReference(
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                value=value,
+                code="unresolved_secret_ref",
+                message=f"{row.key} references a managed secret that does not exist.",
+                details={
+                    "ref_scheme": "db",
+                    "slug": slug,
+                    "status": "missing",
+                },
+            )
+        if status != SecretStatus.ACTIVE.value:
+            return SettingsBrokenReference(
+                key=row.key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                value=value,
+                code="unresolved_secret_ref",
+                message=f"{row.key} references a managed secret that is {status}.",
+                details={
+                    "ref_scheme": "db",
+                    "slug": slug,
+                    "status": status,
+                },
+            )
+        return None
+    if "://" not in value:
+        return SettingsBrokenReference(
+            key=row.key,
+            scope=row.scope,
+            workspace_id=row.workspace_id,
+            user_id=row.user_id,
+            value=value,
+            code="invalid_secret_ref",
+            message=f"{row.key} is not a valid SecretRef.",
+            details={},
+        )
+    return None
+
+
+def _provider_profile_broken_reference(
+    *,
+    row: SettingsOverride,
+    value: str,
+    profile_enabled_by_id: Mapping[str, bool | None],
+) -> SettingsBrokenReference | None:
+    profile_id = value.strip()
+    if not profile_id:
+        return None
+    enabled = profile_enabled_by_id.get(profile_id)
+    if enabled is None:
+        return SettingsBrokenReference(
+            key=row.key,
+            scope=row.scope,
+            workspace_id=row.workspace_id,
+            user_id=row.user_id,
+            value=value,
+            code="provider_profile_not_found",
+            message=(
+                f"{row.key} references a provider profile that does not exist."
+            ),
+            details={"profile_id": profile_id},
+        )
+    if enabled is False:
+        return SettingsBrokenReference(
+            key=row.key,
+            scope=row.scope,
+            workspace_id=row.workspace_id,
+            user_id=row.user_id,
+            value=value,
+            code="provider_profile_disabled",
+            message=(
+                f"{row.key} references a disabled provider profile."
+            ),
+            details={"profile_id": profile_id},
+        )
+    return None
+
+
+__all__ = [
+    "SettingsBackupAuditRecord",
+    "SettingsBackupBundle",
+    "SettingsBackupOverrideRecord",
+    "SettingsBackupViolation",
+    "SettingsBrokenReference",
+    "export_settings_backup",
+    "scan_broken_references",
+]

--- a/api_service/services/settings_migrations.py
+++ b/api_service/services/settings_migrations.py
@@ -1,0 +1,444 @@
+"""Settings catalog migration orchestrator.
+
+Implements the rename / type-change / removal helpers required by
+``docs/Security/SettingsSystem.md`` §24 (Migration and Deprecation). The
+orchestrator copies overrides from ``old_key`` to ``new_key`` for renamed
+settings, coerces values explicitly on type changes (no implicit JSON
+reinterpretation), and records a ``SettingsAuditEvent`` for each migration
+event it performs.
+
+The orchestrator operates at the data layer only. It does **not** mutate
+``SettingMigrationRule`` registrations or descriptor metadata; those continue
+to be the source of truth for which keys are exposed and how reads resolve.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import SettingsAuditEvent, SettingsOverride
+from api_service.services.settings_catalog import (
+    SettingMigrationRule,
+    SettingScope,
+)
+
+_DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
+
+SettingsMigrationEventType = Literal[
+    "settings.migration.renamed",
+    "settings.migration.type_changed",
+    "settings.migration.removed",
+]
+
+
+class SettingsMigrationError(ValueError):
+    """Raised when a migration cannot proceed safely."""
+
+
+class SettingsMigrationCollisionError(SettingsMigrationError):
+    """Raised when the rename target already has a persisted override."""
+
+
+class SettingsMigrationCoercionError(SettingsMigrationError):
+    """Raised when a type-change rule is applied without an explicit coercion."""
+
+
+class SettingsMigrationOutcome(BaseModel):
+    """Structured result for one applied migration row."""
+
+    rule_old_key: str
+    rule_new_key: str | None = None
+    state: str
+    event_type: SettingsMigrationEventType
+    scope: SettingScope
+    workspace_id: UUID
+    user_id: UUID
+    old_schema_version: int | None = None
+    new_schema_version: int | None = None
+    old_value: Any = None
+    new_value: Any = None
+    audit_event_id: UUID | None = None
+    applied: bool = True
+
+
+class SettingsMigrationReport(BaseModel):
+    """Aggregated outcome of a ``run_all`` invocation."""
+
+    outcomes: list[SettingsMigrationOutcome] = Field(default_factory=list)
+    skipped_rules: list[str] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TypeChangeCoercion:
+    """Explicit coercion plan for a ``type_changed`` migration rule.
+
+    Callers MUST supply ``coerce`` — the orchestrator never inspects or
+    reinterprets the raw JSON value on its own. ``target_schema_version``
+    matches the rule's ``expected_schema_version`` so that diagnostics stop
+    reporting ``post_migration_invalid`` once the override is updated.
+    """
+
+    coerce: Callable[[Any], Any]
+    target_schema_version: int
+
+
+@dataclass
+class SettingsMigrationOrchestrator:
+    """Apply rename / type-change / removal rules to persisted overrides.
+
+    The orchestrator is intentionally narrow: it only writes to the
+    ``settings_overrides`` and ``settings_audit_events`` tables. Diagnostics
+    surfaced through :class:`SettingsCatalogService` continue to derive from
+    the same rule set, so the orchestrator and the read path stay in sync.
+    """
+
+    session: AsyncSession
+    migration_rules: tuple[SettingMigrationRule, ...]
+    actor_user_id: UUID | None = None
+    request_id: str | None = None
+    workspace_id: UUID = field(default=_DEFAULT_SUBJECT_ID)
+    redact_keys: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for rule in self.migration_rules:
+            if rule.old_key in seen:
+                raise SettingsMigrationError(
+                    f"duplicate migration rule for {rule.old_key!r}"
+                )
+            seen.add(rule.old_key)
+        self._rules_by_old_key = {rule.old_key: rule for rule in self.migration_rules}
+
+    async def apply_rename(
+        self,
+        rule: SettingMigrationRule,
+        *,
+        on_collision: Literal["raise", "skip"] = "raise",
+    ) -> list[SettingsMigrationOutcome]:
+        """Copy overrides from ``rule.old_key`` to ``rule.new_key``.
+
+        For every ``settings_overrides`` row that targets ``rule.old_key`` in
+        this orchestrator's workspace, the helper:
+
+        * Inserts an equivalent row keyed by ``rule.new_key`` (preserving
+          ``scope``, ``user_id``, ``workspace_id``, ``value_json``,
+          ``schema_version``, and ``value_version``), unless the target row
+          already exists.
+        * Deletes the source row so subsequent diagnostics see the rename as
+          completed.
+        * Records a ``settings.migration.renamed`` audit event referencing
+          both keys for forensic visibility.
+
+        Effective values are preserved across the cutover because the target
+        row inherits the source row's ``value_json`` and ``value_version``.
+        """
+
+        self._require_state(rule, "renamed")
+        if rule.new_key is None:
+            raise SettingsMigrationError(
+                f"rename rule for {rule.old_key!r} requires new_key"
+            )
+
+        outcomes: list[SettingsMigrationOutcome] = []
+        old_rows = await self._fetch_overrides(rule.old_key)
+        for row in old_rows:
+            target = await self._fetch_override(
+                scope=row.scope,
+                user_id=row.user_id,
+                key=rule.new_key,
+            )
+            if target is not None:
+                if on_collision == "skip":
+                    outcomes.append(
+                        SettingsMigrationOutcome(
+                            rule_old_key=rule.old_key,
+                            rule_new_key=rule.new_key,
+                            state=rule.state,
+                            event_type="settings.migration.renamed",
+                            scope=row.scope,
+                            workspace_id=row.workspace_id,
+                            user_id=row.user_id,
+                            old_schema_version=row.schema_version,
+                            new_schema_version=target.schema_version,
+                            old_value=row.value_json,
+                            new_value=target.value_json,
+                            applied=False,
+                        )
+                    )
+                    continue
+                raise SettingsMigrationCollisionError(
+                    f"rename target {rule.new_key!r} already has an override "
+                    f"in scope {row.scope!r}"
+                )
+
+            old_value = row.value_json
+            schema_version = row.schema_version
+            value_version = row.value_version
+
+            new_row = SettingsOverride(
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                key=rule.new_key,
+                value_json=old_value,
+                schema_version=schema_version,
+                value_version=value_version,
+                created_by=row.created_by,
+                updated_by=self.actor_user_id or row.updated_by,
+            )
+            self.session.add(new_row)
+            await self.session.delete(row)
+
+            event = self._record_audit_event(
+                event_type="settings.migration.renamed",
+                key=rule.old_key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                old_value=old_value,
+                new_value=old_value,
+                reason=rule.message,
+            )
+            outcomes.append(
+                SettingsMigrationOutcome(
+                    rule_old_key=rule.old_key,
+                    rule_new_key=rule.new_key,
+                    state=rule.state,
+                    event_type="settings.migration.renamed",
+                    scope=row.scope,
+                    workspace_id=row.workspace_id,
+                    user_id=row.user_id,
+                    old_schema_version=schema_version,
+                    new_schema_version=schema_version,
+                    old_value=old_value,
+                    new_value=old_value,
+                    audit_event_id=event.id,
+                )
+            )
+
+        await self.session.flush()
+        return outcomes
+
+    async def apply_type_change(
+        self,
+        rule: SettingMigrationRule,
+        coercion: TypeChangeCoercion,
+    ) -> list[SettingsMigrationOutcome]:
+        """Re-encode overrides for ``rule.old_key`` with an explicit coercion.
+
+        The orchestrator never reinterprets the existing JSON value on its
+        own. Callers must provide :class:`TypeChangeCoercion` carrying the
+        ``coerce`` callable that maps the old value to the new value, and the
+        ``target_schema_version`` (which MUST match
+        ``rule.expected_schema_version``).
+        """
+
+        self._require_state(rule, "type_changed")
+        if coercion.target_schema_version != rule.expected_schema_version:
+            raise SettingsMigrationCoercionError(
+                f"type_changed rule for {rule.old_key!r} expects schema "
+                f"version {rule.expected_schema_version}, coercion targets "
+                f"{coercion.target_schema_version}"
+            )
+
+        outcomes: list[SettingsMigrationOutcome] = []
+        for row in await self._fetch_overrides(rule.old_key):
+            old_value = row.value_json
+            old_schema_version = row.schema_version
+            new_value = coercion.coerce(old_value)
+            row.value_json = new_value
+            row.schema_version = coercion.target_schema_version
+            row.value_version = row.value_version + 1
+            row.updated_by = self.actor_user_id or row.updated_by
+
+            event = self._record_audit_event(
+                event_type="settings.migration.type_changed",
+                key=rule.old_key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                old_value=old_value,
+                new_value=new_value,
+                reason=rule.message,
+            )
+            outcomes.append(
+                SettingsMigrationOutcome(
+                    rule_old_key=rule.old_key,
+                    rule_new_key=None,
+                    state=rule.state,
+                    event_type="settings.migration.type_changed",
+                    scope=row.scope,
+                    workspace_id=row.workspace_id,
+                    user_id=row.user_id,
+                    old_schema_version=old_schema_version,
+                    new_schema_version=coercion.target_schema_version,
+                    old_value=old_value,
+                    new_value=new_value,
+                    audit_event_id=event.id,
+                )
+            )
+
+        await self.session.flush()
+        return outcomes
+
+    async def apply_removal(
+        self,
+        rule: SettingMigrationRule,
+    ) -> list[SettingsMigrationOutcome]:
+        """Record removal migration events for diagnostic continuity.
+
+        New writes to removed keys are already rejected by the registry, so
+        the orchestrator only stamps an audit trail. Existing override rows
+        are preserved so deprecation diagnostics can still surface broken
+        references after a partial restore.
+        """
+
+        self._require_state(rule, "removed", "deprecated")
+        outcomes: list[SettingsMigrationOutcome] = []
+        for row in await self._fetch_overrides(rule.old_key):
+            event = self._record_audit_event(
+                event_type="settings.migration.removed",
+                key=rule.old_key,
+                scope=row.scope,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                old_value=row.value_json,
+                new_value=row.value_json,
+                reason=rule.message,
+            )
+            outcomes.append(
+                SettingsMigrationOutcome(
+                    rule_old_key=rule.old_key,
+                    rule_new_key=None,
+                    state=rule.state,
+                    event_type="settings.migration.removed",
+                    scope=row.scope,
+                    workspace_id=row.workspace_id,
+                    user_id=row.user_id,
+                    old_schema_version=row.schema_version,
+                    new_schema_version=row.schema_version,
+                    old_value=row.value_json,
+                    new_value=row.value_json,
+                    audit_event_id=event.id,
+                )
+            )
+
+        await self.session.flush()
+        return outcomes
+
+    async def run_all(
+        self,
+        *,
+        type_coercions: dict[str, TypeChangeCoercion] | None = None,
+        on_collision: Literal["raise", "skip"] = "raise",
+    ) -> SettingsMigrationReport:
+        """Apply every rename/type-change/removal rule in registration order.
+
+        ``type_coercions`` MUST contain an explicit coercion for each
+        ``type_changed`` rule encountered. Rules without a coercion are
+        recorded as skipped — the caller is expected to surface this as a
+        deployment-blocking error rather than silently reinterpret values.
+        """
+
+        coercions = type_coercions or {}
+        report = SettingsMigrationReport()
+        for rule in self.migration_rules:
+            if rule.state == "renamed":
+                outcomes = await self.apply_rename(rule, on_collision=on_collision)
+                report.outcomes.extend(outcomes)
+            elif rule.state == "type_changed":
+                coercion = coercions.get(rule.old_key)
+                if coercion is None:
+                    report.skipped_rules.append(rule.old_key)
+                    continue
+                outcomes = await self.apply_type_change(rule, coercion)
+                report.outcomes.extend(outcomes)
+            elif rule.state in {"removed", "deprecated"}:
+                outcomes = await self.apply_removal(rule)
+                report.outcomes.extend(outcomes)
+        return report
+
+    async def _fetch_overrides(self, key: str) -> list[SettingsOverride]:
+        result = await self.session.execute(
+            select(SettingsOverride).where(
+                SettingsOverride.key == key,
+                SettingsOverride.workspace_id == self.workspace_id,
+            )
+        )
+        return list(result.scalars().all())
+
+    async def _fetch_override(
+        self,
+        *,
+        scope: str,
+        user_id: UUID,
+        key: str,
+    ) -> SettingsOverride | None:
+        result = await self.session.execute(
+            select(SettingsOverride).where(
+                SettingsOverride.scope == scope,
+                SettingsOverride.workspace_id == self.workspace_id,
+                SettingsOverride.user_id == user_id,
+                SettingsOverride.key == key,
+            )
+        )
+        return result.scalars().first()
+
+    def _record_audit_event(
+        self,
+        *,
+        event_type: SettingsMigrationEventType,
+        key: str,
+        scope: str,
+        workspace_id: UUID,
+        user_id: UUID,
+        old_value: Any,
+        new_value: Any,
+        reason: str | None,
+    ) -> SettingsAuditEvent:
+        redacted = key in self.redact_keys
+        event = SettingsAuditEvent(
+            event_type=event_type,
+            key=key,
+            scope=scope,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            actor_user_id=self.actor_user_id,
+            old_value_json=None if redacted else old_value,
+            new_value_json=None if redacted else new_value,
+            redacted=redacted,
+            reason=reason,
+            request_id=self.request_id,
+        )
+        self.session.add(event)
+        return event
+
+    def _require_state(
+        self,
+        rule: SettingMigrationRule,
+        *expected: str,
+    ) -> None:
+        if rule.state not in expected:
+            joined = "/".join(expected)
+            raise SettingsMigrationError(
+                f"migration rule for {rule.old_key!r} has state "
+                f"{rule.state!r}; expected one of {joined}"
+            )
+
+
+__all__ = [
+    "SettingsMigrationCoercionError",
+    "SettingsMigrationCollisionError",
+    "SettingsMigrationError",
+    "SettingsMigrationEventType",
+    "SettingsMigrationOrchestrator",
+    "SettingsMigrationOutcome",
+    "SettingsMigrationReport",
+    "TypeChangeCoercion",
+]

--- a/api_service/services/settings_migrations.py
+++ b/api_service/services/settings_migrations.py
@@ -147,35 +147,39 @@ class SettingsMigrationOrchestrator:
 
         outcomes: list[SettingsMigrationOutcome] = []
         old_rows = await self._fetch_overrides(rule.old_key)
-        for row in old_rows:
-            target = await self._fetch_override(
-                scope=row.scope,
-                user_id=row.user_id,
-                key=rule.new_key,
-            )
-            if target is not None:
-                if on_collision == "skip":
-                    outcomes.append(
-                        SettingsMigrationOutcome(
-                            rule_old_key=rule.old_key,
-                            rule_new_key=rule.new_key,
-                            state=rule.state,
-                            event_type="settings.migration.renamed",
-                            scope=row.scope,
-                            workspace_id=row.workspace_id,
-                            user_id=row.user_id,
-                            old_schema_version=row.schema_version,
-                            new_schema_version=target.schema_version,
-                            old_value=row.value_json,
-                            new_value=target.value_json,
-                            applied=False,
-                        )
+        target_rows = await self._fetch_overrides(rule.new_key)
+        targets_by_subject: dict[
+            tuple[str, UUID], SettingsOverride
+        ] = {(target.scope, target.user_id): target for target in target_rows}
+
+        if on_collision == "raise":
+            for row in old_rows:
+                if (row.scope, row.user_id) in targets_by_subject:
+                    raise SettingsMigrationCollisionError(
+                        f"rename target {rule.new_key!r} already has an override "
+                        f"in scope {row.scope!r}"
                     )
-                    continue
-                raise SettingsMigrationCollisionError(
-                    f"rename target {rule.new_key!r} already has an override "
-                    f"in scope {row.scope!r}"
+
+        for row in old_rows:
+            target = targets_by_subject.get((row.scope, row.user_id))
+            if target is not None:
+                outcomes.append(
+                    SettingsMigrationOutcome(
+                        rule_old_key=rule.old_key,
+                        rule_new_key=rule.new_key,
+                        state=rule.state,
+                        event_type="settings.migration.renamed",
+                        scope=row.scope,
+                        workspace_id=row.workspace_id,
+                        user_id=row.user_id,
+                        old_schema_version=row.schema_version,
+                        new_schema_version=target.schema_version,
+                        old_value=row.value_json,
+                        new_value=target.value_json,
+                        applied=False,
+                    )
                 )
+                continue
 
             old_value = row.value_json
             schema_version = row.schema_version
@@ -249,6 +253,8 @@ class SettingsMigrationOrchestrator:
 
         outcomes: list[SettingsMigrationOutcome] = []
         for row in await self._fetch_overrides(rule.old_key):
+            if row.schema_version == coercion.target_schema_version:
+                continue
             old_value = row.value_json
             old_schema_version = row.schema_version
             new_value = coercion.coerce(old_value)
@@ -372,23 +378,6 @@ class SettingsMigrationOrchestrator:
             )
         )
         return list(result.scalars().all())
-
-    async def _fetch_override(
-        self,
-        *,
-        scope: str,
-        user_id: UUID,
-        key: str,
-    ) -> SettingsOverride | None:
-        result = await self.session.execute(
-            select(SettingsOverride).where(
-                SettingsOverride.scope == scope,
-                SettingsOverride.workspace_id == self.workspace_id,
-                SettingsOverride.user_id == user_id,
-                SettingsOverride.key == key,
-            )
-        )
-        return result.scalars().first()
 
     def _record_audit_event(
         self,

--- a/docs/Security/SettingsSystem.md
+++ b/docs/Security/SettingsSystem.md
@@ -1495,10 +1495,14 @@ A standard database backup that covers the Settings System tables (`settings_ove
 
 ### 23.2 Backup exclusions
 
-Backups MUST NOT contain raw managed-secret plaintext. The Settings System upholds this in two ways:
+Backups MUST NOT contain raw managed-secret plaintext. The Settings System upholds this in three layers:
 
 - It only ever stores SecretRef strings for secret-typed descriptors, never plaintext values. The catalog rejects writes to secret-typed keys that look like raw credentials.
 - Audit events for descriptors whose `audit.redact = true` (or whose `value_type` is sensitive but not `secret_ref`) MUST store `null` for `old_value_json` / `new_value_json` and set the `redacted` flag to `true`. Migration events produced by the settings migration orchestrator MUST follow the same redaction policy when the descriptor is sensitive — callers wire this through the orchestrator's `redact_keys` parameter.
+- `api_service/services/settings_backup.py::export_settings_backup` enforces the policy at backup time:
+  - Overrides whose descriptor declares `audit.redact = True` AND whose `value_type` is not `secret_ref` are dropped from the bundle and listed in `excluded_keys` so operators know the row was intentionally redacted.
+  - SecretRef-typed overrides remain in the bundle as references; if such an override carries a value that is not a SecretRef the helper raises `SettingsBackupViolation` rather than emitting plaintext.
+  - Audit rows flagged `redacted=True` MUST carry no payload; a corrupted row also raises `SettingsBackupViolation` instead of being included in the bundle.
 
 Operators who run their own backup tooling against the database SHOULD treat the Settings tables as restorable application data, not as a secret-bearing surface. Restoring them requires no key material on its own; restoring the encrypted managed-secrets table requires the external root key source described in the Secrets System backup contract.
 
@@ -1509,6 +1513,7 @@ Settings often point at adjacent resources (managed secrets, OAuth volumes, prov
 - SecretRef overrides pointing at missing managed secrets resolve to the catalog default and emit a `secret_ref_unresolved` (or `unresolved_secret_ref`) diagnostic on the affected setting; Mission Control renders the diagnostic next to the descriptor and on the SecretRef picker.
 - `workflow.default_provider_profile_ref` overrides pointing at missing provider profiles emit a `provider_profile_not_found` diagnostic and the resolver falls back to inheritance instead of accepting the broken value.
 - Migration audit events restored alongside their override rows let operators correlate any post-restore diagnostic with the migration that produced the current key set.
+- `api_service/services/settings_backup.py::scan_broken_references` returns a `SettingsBrokenReference` for every persisted override whose SecretRef target is missing/disabled/invalid, or whose provider-profile target is missing/disabled. Operator dashboards and post-restore checklists SHOULD run this scan so dependent settings and profiles are detectable without waiting for a runtime launch to fail.
 
 The UI MUST surface these diagnostics clearly so operators can decide whether to re-create the missing dependency, point the override at a different reference, or reset the override.
 
@@ -1517,8 +1522,17 @@ The UI MUST surface these diagnostics clearly so operators can decide whether to
 Operators are expected to rehearse the following recovery paths against a non-production environment:
 
 - restoring `settings_overrides` and `settings_audit_events` alongside the managed-secret tables and provider-profile tables — the desired no-diagnostic outcome,
-- restoring `settings_overrides` and `settings_audit_events` without the managed-secret tables — diagnostics MUST surface broken SecretRefs without crashing the catalog or hiding the affected settings, and
+- restoring `settings_overrides` and `settings_audit_events` without the managed-secret tables — diagnostics MUST surface broken SecretRefs without crashing the catalog or hiding the affected settings, and `scan_broken_references` MUST list every affected override,
 - restoring only the managed-secret tables — settings then resolve from defaults and environment, and the audit table records no spurious change events.
+
+### 23.5 Operator runbook (pre-release)
+
+A minimal operator-facing procedure for the pre-release release line:
+
+1. Take a normal database backup (typically a `pg_dump` or equivalent) and verify it includes `settings_overrides`, `settings_audit_events`, `managed_secrets`, and `managed_agent_provider_profiles`.
+2. To produce a portable Settings-only snapshot for offsite or rehearsal use, call `export_settings_backup` against a read-only session and persist the resulting `SettingsBackupBundle` (JSON-serializable). The helper refuses to emit a bundle that contains plaintext credentials or unredacted sensitive audit payloads.
+3. Restore in dependency order: managed secrets first, then provider profiles, then settings tables. After a partial or staged restore, run `scan_broken_references` and resolve every `SettingsBrokenReference` (re-create the missing dependency, point the override at a different reference, or reset the override) before resuming launches.
+4. Keep the migration audit events (`settings.migration.renamed`, `settings.migration.type_changed`, `settings.migration.removed`) restored alongside the override rows so post-restore diagnostics can be correlated with the migration that produced the current key set.
 
 ---
 
@@ -1600,6 +1614,8 @@ The desired-state Settings System should include tests for:
 19. Operations controls require proper authorization.
 20. Snapshot tests detect accidental catalog drift.
 21. Rename, type-change, and removal migrations preserve effective values, emit migration audit events, and never reinterpret JSON values ambiguously (covered by `tests/unit/services/test_settings_migrations.py`).
+22. Backup snapshots exclude managed-secret plaintext, preserve SecretRef references and migration audit events, and refuse to serialize redaction-flagged rows that still carry payloads (covered by `tests/unit/services/test_settings_backup.py` and `tests/integration/api/test_settings_backup_recovery_contract.py`).
+23. Partial-restore broken-reference scans surface every persisted override whose SecretRef or provider-profile target is missing or disabled (covered by the same test files).
 
 ---
 
@@ -1629,6 +1645,18 @@ SettingsAuditWriter
 SettingsMigrationOrchestrator
   Applies rename / type-change / removal rules to persisted overrides and
   records migration audit events (see §24).
+
+SettingsBackupExporter
+  Produces a SettingsBackupBundle from settings_overrides and
+  settings_audit_events while enforcing the backup-exclusion policy
+  (see §23.2). Implemented as
+  api_service.services.settings_backup.export_settings_backup.
+
+SettingsBrokenReferenceScanner
+  Walks every persisted override and returns SettingsBrokenReference
+  records for missing/disabled SecretRef and provider-profile targets so
+  partial restores surface explicit, actionable diagnostics (see §23.3).
+  Implemented as api_service.services.settings_backup.scan_broken_references.
 
 SettingsChangePublisher
   Emits change notifications to interested subsystems.

--- a/docs/Security/SettingsSystem.md
+++ b/docs/Security/SettingsSystem.md
@@ -1480,24 +1480,54 @@ The desired-state Settings System must satisfy all of the following:
 
 ## 23. Backup and Recovery
 
-Settings overrides are ordinary application configuration data and should be included in database backups.
+Settings overrides are ordinary application configuration data and should be included in database backups. The contract here is intentionally aligned with the Secrets System backup contract in `docs/Security/SecretsSystem.md` §14: settings tables carry references and metadata, never raw managed-secret plaintext.
 
-Backups may contain:
+### 23.1 Backup contents
 
-- setting keys,
-- non-sensitive values,
-- SecretRef values,
-- resource references,
-- audit records, and
-- metadata.
+A standard database backup that covers the Settings System tables (`settings_overrides`, `settings_audit_events`) may contain:
 
-Backups must not contain raw managed secret plaintext.
+- setting keys (for example `workflow.default_task_runtime`),
+- non-sensitive override values (booleans, enums, lists, strings, integers, structured non-secret JSON),
+- SecretRef values (for example `db://my-token`, `env:MOONMIND_GH_TOKEN`) — these are references, not plaintext,
+- resource references (for example provider-profile IDs in `workflow.default_provider_profile_ref`),
+- audit records describing past changes (including migration events such as `settings.migration.renamed`, `settings.migration.type_changed`, and `settings.migration.removed`), and
+- bookkeeping metadata (`schema_version`, `value_version`, `created_at`, `updated_at`, actor IDs).
 
-Restoring settings without restoring the corresponding secrets, OAuth volumes, or provider profiles may produce broken references. The UI must surface those broken references clearly.
+### 23.2 Backup exclusions
+
+Backups MUST NOT contain raw managed-secret plaintext. The Settings System upholds this in two ways:
+
+- It only ever stores SecretRef strings for secret-typed descriptors, never plaintext values. The catalog rejects writes to secret-typed keys that look like raw credentials.
+- Audit events for descriptors whose `audit.redact = true` (or whose `value_type` is sensitive but not `secret_ref`) MUST store `null` for `old_value_json` / `new_value_json` and set the `redacted` flag to `true`. Migration events produced by the settings migration orchestrator MUST follow the same redaction policy when the descriptor is sensitive — callers wire this through the orchestrator's `redact_keys` parameter.
+
+Operators who run their own backup tooling against the database SHOULD treat the Settings tables as restorable application data, not as a secret-bearing surface. Restoring them requires no key material on its own; restoring the encrypted managed-secrets table requires the external root key source described in the Secrets System backup contract.
+
+### 23.3 Partial restore and broken references
+
+Settings often point at adjacent resources (managed secrets, OAuth volumes, provider profiles). A partial restore — settings restored without their dependencies, or vice versa — MUST NOT silently degrade. The system surfaces these conditions explicitly:
+
+- SecretRef overrides pointing at missing managed secrets resolve to the catalog default and emit a `secret_ref_unresolved` (or `unresolved_secret_ref`) diagnostic on the affected setting; Mission Control renders the diagnostic next to the descriptor and on the SecretRef picker.
+- `workflow.default_provider_profile_ref` overrides pointing at missing provider profiles emit a `provider_profile_not_found` diagnostic and the resolver falls back to inheritance instead of accepting the broken value.
+- Migration audit events restored alongside their override rows let operators correlate any post-restore diagnostic with the migration that produced the current key set.
+
+The UI MUST surface these diagnostics clearly so operators can decide whether to re-create the missing dependency, point the override at a different reference, or reset the override.
+
+### 23.4 Recovery rehearsal
+
+Operators are expected to rehearse the following recovery paths against a non-production environment:
+
+- restoring `settings_overrides` and `settings_audit_events` alongside the managed-secret tables and provider-profile tables — the desired no-diagnostic outcome,
+- restoring `settings_overrides` and `settings_audit_events` without the managed-secret tables — diagnostics MUST surface broken SecretRefs without crashing the catalog or hiding the affected settings, and
+- restoring only the managed-secret tables — settings then resolve from defaults and environment, and the audit table records no spurious change events.
 
 ---
 
 ## 24. Migration and Deprecation
+
+The desired-state Settings System distinguishes **registry-level migration metadata** from **override-level migration execution**:
+
+- The registry carries a `SettingMigrationRule` for every renamed, deprecated, removed, or type-changed key. Rules drive deprecation diagnostics, registry-level write rejection (`setting_not_exposed`), and rename-aware effective-value resolution.
+- The override-level migration orchestrator (`api_service/services/settings_migrations.py`) executes the row-level changes against `settings_overrides` and records explicit migration events in `settings_audit_events`.
 
 ### 24.1 Renaming Settings
 
@@ -1509,6 +1539,8 @@ Renaming a setting requires:
 - audit visibility, and
 - tests proving effective values are preserved.
 
+The migration orchestrator's `apply_rename` helper copies every `settings_overrides` row from `old_key` to `new_key` while preserving `scope`, `workspace_id`, `user_id`, `value_json`, `schema_version`, and `value_version`, and records one `settings.migration.renamed` audit event per row. Effective values are preserved across the cutover because the target row inherits the source row's value and version state. Collisions with a pre-existing override on the target key raise `SettingsMigrationCollisionError` unless the caller explicitly opts to skip them.
+
 ### 24.2 Removing Settings
 
 Removing a setting requires:
@@ -1518,11 +1550,28 @@ Removing a setting requires:
 - explaining deprecated values in diagnostics, and
 - avoiding silent loss of operator intent.
 
+Writes to removed or deprecated keys remain rejected at the request layer via the `setting_not_exposed` error path. The migration orchestrator's `apply_removal` helper preserves existing rows for diagnostic continuity (so the catalog's deprecated-override diagnostics keep surfacing them) and stamps a `settings.migration.removed` audit event for forensic visibility. Operators who want to retire stored rows can do so explicitly via `reset_override` once they have confirmed the values are no longer needed.
+
 ### 24.3 Changing Types
 
-Changing a setting type requires an explicit migration.
+Changing a setting type requires an explicit migration. The resolver must not reinterpret existing JSON values ambiguously.
 
-The resolver must not reinterpret existing JSON values ambiguously.
+The migration orchestrator's `apply_type_change` helper enforces that an explicit `TypeChangeCoercion` is supplied. The coercion provides:
+
+- a `coerce` callable that maps the old `value_json` to the new representation, and
+- a `target_schema_version` that MUST equal the rule's `expected_schema_version`.
+
+The orchestrator never parses or reinterprets the old value on its own. Type-changed rules without a coercion are surfaced in the `run_all` report as `skipped_rules` so the deployment can fail fast rather than fall back to ambiguous resolution. Diagnostics continue to flag rows at the old `schema_version` as `post_migration_invalid` until the coercion has run.
+
+### 24.4 Audit and Backup Visibility
+
+Migration events produced by the orchestrator are written to `settings_audit_events` with one of the following `event_type` values:
+
+- `settings.migration.renamed`
+- `settings.migration.type_changed`
+- `settings.migration.removed`
+
+These events are ordinary backup data (per §23) and let operators correlate any post-restore diagnostic with the migration that produced the current key set. Callers SHOULD pass the orchestrator a `redact_keys` set covering descriptors whose `audit.redact` policy requires it, so sensitive values never reach the audit table even during migrations.
 
 ---
 
@@ -1550,6 +1599,7 @@ The desired-state Settings System should include tests for:
 18. UI displays source badges and reset actions correctly.
 19. Operations controls require proper authorization.
 20. Snapshot tests detect accidental catalog drift.
+21. Rename, type-change, and removal migrations preserve effective values, emit migration audit events, and never reinterpret JSON values ambiguously (covered by `tests/unit/services/test_settings_migrations.py`).
 
 ---
 
@@ -1575,6 +1625,10 @@ SettingsValidator
 
 SettingsAuditWriter
   Writes redacted audit events.
+
+SettingsMigrationOrchestrator
+  Applies rename / type-change / removal rules to persisted overrides and
+  records migration audit events (see §24).
 
 SettingsChangePublisher
   Emits change notifications to interested subsystems.

--- a/tests/integration/api/test_settings_backup_recovery_contract.py
+++ b/tests/integration/api/test_settings_backup_recovery_contract.py
@@ -1,0 +1,490 @@
+"""Integration tests for settings backup, restore, and migration cutover.
+
+Exercises the FRs in docs/Security/SettingsSystem.md §23 (Backup and
+Recovery) and §24 (Migration and Deprecation) end-to-end against the real
+registry, the migration orchestrator, and the backup/broken-reference
+helpers — without requiring external services.
+
+Tests cover the three acceptance criteria that previously had no explicit
+end-to-end coverage:
+
+1. The rename workflow preserves effective values across the migration
+   cutover when applied through the real registry catalog service.
+2. The backup helper excludes managed-secret plaintext and preserves
+   SecretRef references plus migration audit events.
+3. The broken-reference scan surfaces SecretRef and provider-profile
+   targets that go missing after a partial restore.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    ManagedSecret,
+    ProviderCredentialSource,
+    RuntimeMaterializationMode,
+    SecretStatus,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
+from api_service.services.settings_backup import (
+    SettingsBackupViolation,
+    export_settings_backup,
+    scan_broken_references,
+)
+from api_service.services.settings_catalog import (
+    SettingMigrationRule,
+    SettingsCatalogService,
+)
+from api_service.services.settings_migrations import (
+    SettingsMigrationOrchestrator,
+    TypeChangeCoercion,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.integration_ci,
+]
+
+
+_DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
+
+
+@pytest_asyncio.fixture
+async def settings_backup_session(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/settings-backup-it.db"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_maker() as session:
+        yield session
+    await engine.dispose()
+
+
+def _seed_override(
+    session,
+    *,
+    key: str,
+    value: object,
+    scope: str = "workspace",
+    user_id: UUID = _DEFAULT_SUBJECT_ID,
+    workspace_id: UUID = _DEFAULT_SUBJECT_ID,
+    schema_version: int = 1,
+    value_version: int = 1,
+) -> SettingsOverride:
+    row = SettingsOverride(
+        scope=scope,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        key=key,
+        value_json=value,
+        schema_version=schema_version,
+        value_version=value_version,
+    )
+    session.add(row)
+    return row
+
+
+def _seed_managed_secret(
+    session,
+    *,
+    slug: str,
+    status: SecretStatus = SecretStatus.ACTIVE,
+) -> ManagedSecret:
+    row = ManagedSecret(
+        slug=slug,
+        ciphertext="ciphertext-placeholder",
+        status=status,
+    )
+    session.add(row)
+    return row
+
+
+def _seed_provider_profile(
+    session,
+    *,
+    profile_id: str,
+    enabled: bool = True,
+) -> ManagedAgentProviderProfile:
+    row = ManagedAgentProviderProfile(
+        profile_id=profile_id,
+        runtime_id="codex",
+        provider_id="codex",
+        enabled=enabled,
+        credential_source=ProviderCredentialSource.NONE,
+        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+    )
+    session.add(row)
+    return row
+
+
+async def test_rename_cutover_preserves_effective_value_through_real_registry(
+    settings_backup_session,
+):
+    """The rename orchestrator preserves effective values when wired through
+    :class:`SettingsCatalogService` using a synthetic descriptor + rule pair.
+
+    This is an end-to-end rehearsal of the §24.1 cutover: read the value
+    via the catalog at the new key, run the orchestrator, re-read, and
+    confirm the effective value is unchanged while the renamed-override
+    diagnostic clears.
+    """
+
+    from api_service.services.settings_catalog import (
+        SettingAuditPolicy,
+        SettingRegistryEntry,
+    )
+
+    registry = (
+        SettingRegistryEntry(
+            key="contract.legacy_default_runtime",
+            title="Legacy Default Runtime",
+            category="Workflow",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value=None,
+            order=1,
+        ),
+        SettingRegistryEntry(
+            key="contract.default_runtime",
+            title="Default Runtime",
+            category="Workflow",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value=None,
+            order=2,
+            audit=SettingAuditPolicy(
+                store_old_value=True,
+                store_new_value=True,
+                redact=False,
+            ),
+        ),
+    )
+    rule = SettingMigrationRule(
+        old_key="contract.legacy_default_runtime",
+        new_key="contract.default_runtime",
+        state="renamed",
+        message="contract.legacy_default_runtime was renamed to contract.default_runtime.",
+    )
+
+    _seed_override(
+        settings_backup_session,
+        key="contract.legacy_default_runtime",
+        value="codex_cli",
+    )
+    await settings_backup_session.commit()
+
+    catalog_before = SettingsCatalogService(
+        env={},
+        registry=registry,
+        migration_rules=(rule,),
+        session=settings_backup_session,
+    )
+    before = await catalog_before.effective_value_async(
+        "contract.default_runtime", scope="workspace"
+    )
+    assert before.value == "codex_cli"
+    assert any(
+        diag.code == "setting_renamed_override" for diag in before.diagnostics
+    )
+
+    orchestrator = SettingsMigrationOrchestrator(
+        session=settings_backup_session,
+        migration_rules=(rule,),
+    )
+    outcomes = await orchestrator.apply_rename(rule)
+    await settings_backup_session.commit()
+
+    assert len(outcomes) == 1
+    assert outcomes[0].applied is True
+
+    catalog_after = SettingsCatalogService(
+        env={},
+        registry=registry,
+        migration_rules=(rule,),
+        session=settings_backup_session,
+    )
+    after = await catalog_after.effective_value_async(
+        "contract.default_runtime", scope="workspace"
+    )
+    assert after.value == "codex_cli"
+    assert all(
+        diag.code != "setting_renamed_override" for diag in after.diagnostics
+    )
+
+    audit_events = (
+        await settings_backup_session.execute(
+            select(SettingsAuditEvent).where(
+                SettingsAuditEvent.event_type == "settings.migration.renamed"
+            )
+        )
+    ).scalars().all()
+    assert len(audit_events) == 1
+
+
+async def test_backup_export_against_real_registry_redacts_audit_payloads(
+    settings_backup_session,
+):
+    """End-to-end backup snapshot against the production catalog descriptors.
+
+    Uses the default registry so the descriptor for
+    ``integrations.github.token_ref`` (a real SecretRef-typed descriptor)
+    is the one applied to backup-redaction policy. The bundle MUST include
+    the SecretRef value as a reference, include the migration audit event,
+    and surface no plaintext payload.
+    """
+
+    _seed_managed_secret(settings_backup_session, slug="github-token")
+    _seed_override(
+        settings_backup_session,
+        key="integrations.github.token_ref",
+        value="db://github-token",
+    )
+    _seed_override(
+        settings_backup_session,
+        key="workflow.default_task_runtime",
+        value="codex_cli",
+    )
+
+    # An audit event flagged as redacted MUST NOT carry payload values.
+    settings_backup_session.add(
+        SettingsAuditEvent(
+            event_type="settings.override.updated",
+            key="integrations.github.token_ref",
+            scope="workspace",
+            workspace_id=_DEFAULT_SUBJECT_ID,
+            user_id=_DEFAULT_SUBJECT_ID,
+            redacted=True,
+            old_value_json=None,
+            new_value_json=None,
+        )
+    )
+    settings_backup_session.add(
+        SettingsAuditEvent(
+            event_type="settings.migration.renamed",
+            key="workflow.legacy_default_runtime",
+            scope="workspace",
+            workspace_id=_DEFAULT_SUBJECT_ID,
+            user_id=_DEFAULT_SUBJECT_ID,
+            redacted=False,
+            old_value_json="codex",
+            new_value_json="codex",
+        )
+    )
+    await settings_backup_session.commit()
+
+    from api_service.services.settings_catalog import _REGISTRY  # type: ignore
+
+    bundle = await export_settings_backup(
+        session=settings_backup_session, registry=_REGISTRY
+    )
+
+    keys = sorted(record.key for record in bundle.overrides)
+    assert "integrations.github.token_ref" in keys
+    assert "workflow.default_task_runtime" in keys
+
+    token_record = next(
+        record
+        for record in bundle.overrides
+        if record.key == "integrations.github.token_ref"
+    )
+    assert token_record.value_json == "db://github-token"
+    assert token_record.is_secret_ref is True
+
+    audit_event_types = sorted(record.event_type for record in bundle.audit_events)
+    assert "settings.migration.renamed" in audit_event_types
+    assert "settings.override.updated" in audit_event_types
+
+    redacted_event = next(
+        record
+        for record in bundle.audit_events
+        if record.key == "integrations.github.token_ref"
+    )
+    assert redacted_event.redacted is True
+    assert redacted_event.old_value_json is None
+    assert redacted_event.new_value_json is None
+
+
+async def test_partial_restore_broken_references_surface_for_operator(
+    settings_backup_session,
+):
+    """After restoring overrides without their dependencies, the scan flags
+    every persisted override whose SecretRef or provider-profile target is
+    missing or in a non-launchable state.
+    """
+
+    _seed_override(
+        settings_backup_session,
+        key="integrations.github.token_ref",
+        value="db://github-token",
+    )
+    _seed_override(
+        settings_backup_session,
+        key="workflow.default_provider_profile_ref",
+        value="codex-default",
+    )
+    _seed_override(
+        settings_backup_session,
+        key="workflow.default_task_runtime",
+        value="codex_cli",
+    )
+    await settings_backup_session.commit()
+
+    from api_service.services.settings_catalog import _REGISTRY  # type: ignore
+
+    broken = await scan_broken_references(
+        session=settings_backup_session, registry=_REGISTRY, env={}
+    )
+
+    codes = {(item.key, item.code) for item in broken}
+    assert ("integrations.github.token_ref", "unresolved_secret_ref") in codes
+    assert ("workflow.default_provider_profile_ref", "provider_profile_not_found") in codes
+    # The unrelated, non-reference override does NOT appear in the scan.
+    assert all(item.key != "workflow.default_task_runtime" for item in broken)
+
+
+async def test_partial_restore_clears_diagnostics_once_dependencies_return(
+    settings_backup_session,
+):
+    """Restoring the missing managed secret + provider profile clears the
+    broken-reference findings without operator intervention.
+    """
+
+    _seed_override(
+        settings_backup_session,
+        key="integrations.github.token_ref",
+        value="db://github-token",
+    )
+    _seed_override(
+        settings_backup_session,
+        key="workflow.default_provider_profile_ref",
+        value="codex-default",
+    )
+    await settings_backup_session.commit()
+
+    from api_service.services.settings_catalog import _REGISTRY  # type: ignore
+
+    broken = await scan_broken_references(
+        session=settings_backup_session, registry=_REGISTRY, env={}
+    )
+    assert len(broken) == 2
+
+    _seed_managed_secret(settings_backup_session, slug="github-token")
+    _seed_provider_profile(settings_backup_session, profile_id="codex-default")
+    await settings_backup_session.commit()
+
+    broken_after_restore = await scan_broken_references(
+        session=settings_backup_session, registry=_REGISTRY, env={}
+    )
+    assert broken_after_restore == []
+
+
+async def test_type_change_cutover_records_audit_and_survives_backup(
+    settings_backup_session,
+):
+    """A type-change migration produces an audit event that is preserved by
+    the backup snapshot and does not corrupt the override value.
+    """
+
+    from api_service.services.settings_catalog import (
+        SettingAuditPolicy,
+        SettingRegistryEntry,
+    )
+
+    registry = (
+        SettingRegistryEntry(
+            key="contract.retry_limit",
+            title="Retry Limit",
+            category="Workflow",
+            section="user-workspace",
+            value_type="integer",
+            ui="number",
+            scopes=("workspace",),
+            default_value=0,
+            order=1,
+            audit=SettingAuditPolicy(
+                store_old_value=True,
+                store_new_value=True,
+                redact=False,
+            ),
+        ),
+    )
+    rule = SettingMigrationRule(
+        old_key="contract.retry_limit",
+        state="type_changed",
+        message="contract.retry_limit type changed from string to integer.",
+        expected_schema_version=2,
+    )
+
+    _seed_override(
+        settings_backup_session,
+        key="contract.retry_limit",
+        value="3",
+        schema_version=1,
+    )
+    await settings_backup_session.commit()
+
+    orchestrator = SettingsMigrationOrchestrator(
+        session=settings_backup_session,
+        migration_rules=(rule,),
+    )
+    outcomes = await orchestrator.apply_type_change(
+        rule,
+        TypeChangeCoercion(coerce=int, target_schema_version=2),
+    )
+    await settings_backup_session.commit()
+    assert outcomes[0].new_value == 3
+
+    bundle = await export_settings_backup(
+        session=settings_backup_session, registry=registry
+    )
+    retry_record = next(
+        record for record in bundle.overrides if record.key == "contract.retry_limit"
+    )
+    assert retry_record.value_json == 3
+    assert retry_record.schema_version == 2
+
+    migration_events = [
+        record
+        for record in bundle.audit_events
+        if record.event_type == "settings.migration.type_changed"
+    ]
+    assert len(migration_events) == 1
+
+
+async def test_backup_refuses_to_serialize_plaintext_in_secret_ref_slot(
+    settings_backup_session,
+):
+    """A SecretRef-typed override storing a value that is not a SecretRef is
+    a data-corruption indicator. The backup helper raises rather than
+    emitting a bundle that could leak the plaintext into restore artifacts.
+    """
+
+    _seed_override(
+        settings_backup_session,
+        key="integrations.github.token_ref",
+        value="ghp_definitely_not_a_secret_ref",
+    )
+    await settings_backup_session.commit()
+
+    from api_service.services.settings_catalog import _REGISTRY  # type: ignore
+
+    with pytest.raises(SettingsBackupViolation):
+        await export_settings_backup(
+            session=settings_backup_session, registry=_REGISTRY
+        )

--- a/tests/integration/api/test_settings_backup_recovery_contract.py
+++ b/tests/integration/api/test_settings_backup_recovery_contract.py
@@ -18,7 +18,7 @@ end-to-end coverage:
 
 from __future__ import annotations
 
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 import pytest_asyncio

--- a/tests/unit/services/test_settings_backup.py
+++ b/tests/unit/services/test_settings_backup.py
@@ -1,0 +1,532 @@
+"""Unit tests for the settings backup/restore helpers.
+
+Covers docs/Security/SettingsSystem.md §23 (Backup and Recovery):
+
+* Exports of ``settings_overrides`` / ``settings_audit_events`` must exclude
+  managed-secret plaintext while preserving SecretRef references, profile
+  references, and audit history needed for forensic visibility.
+* A partial-restore broken-reference scan surfaces overrides whose SecretRef
+  or provider-profile target is missing or disabled so operators can repair
+  the dependency before launches resume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    ManagedSecret,
+    ProviderCredentialSource,
+    RuntimeMaterializationMode,
+    SecretStatus,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
+from api_service.services.settings_backup import (
+    SettingsBackupBundle,
+    SettingsBackupViolation,
+    SettingsBrokenReference,
+    export_settings_backup,
+    scan_broken_references,
+)
+from api_service.services.settings_catalog import (
+    SettingAuditPolicy,
+    SettingRegistryEntry,
+    SettingsRegistry,
+)
+
+
+_DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
+
+
+@pytest.fixture
+def settings_session_maker(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/settings_backup.db")
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_setup())
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    yield session_maker
+    asyncio.run(engine.dispose())
+
+
+def _backup_registry() -> SettingsRegistry:
+    entries = (
+        SettingRegistryEntry(
+            key="workflow.default_task_runtime",
+            title="Default Task Runtime",
+            category="Workflow",
+            section="user-workspace",
+            value_type="enum",
+            ui="select",
+            scopes=("workspace",),
+            default_value="codex",
+            order=1,
+        ),
+        SettingRegistryEntry(
+            key="workflow.default_provider_profile_ref",
+            title="Default Provider Profile",
+            category="Workflow",
+            section="user-workspace",
+            value_type="string",
+            ui="select",
+            scopes=("workspace",),
+            default_value=None,
+            order=2,
+        ),
+        SettingRegistryEntry(
+            key="integrations.github.token_ref",
+            title="GitHub Token",
+            category="Integrations",
+            section="providers-secrets",
+            value_type="secret_ref",
+            ui="secret_ref",
+            scopes=("workspace",),
+            default_value=None,
+            sensitive=True,
+            order=3,
+            audit=SettingAuditPolicy(
+                store_old_value=True, store_new_value=True, redact=True
+            ),
+        ),
+        SettingRegistryEntry(
+            key="integrations.smtp.password_inline",
+            title="SMTP Password (Inline)",
+            category="Integrations",
+            section="providers-secrets",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value=None,
+            sensitive=True,
+            order=4,
+            audit=SettingAuditPolicy(
+                store_old_value=True, store_new_value=True, redact=True
+            ),
+        ),
+    )
+    return SettingsRegistry(entries=entries, stable_key_ledger=None)
+
+
+def _seed_override(
+    session,
+    *,
+    key: str,
+    value: object,
+    scope: str = "workspace",
+    user_id: UUID = _DEFAULT_SUBJECT_ID,
+    workspace_id: UUID = _DEFAULT_SUBJECT_ID,
+    schema_version: int = 1,
+    value_version: int = 1,
+) -> SettingsOverride:
+    row = SettingsOverride(
+        scope=scope,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        key=key,
+        value_json=value,
+        schema_version=schema_version,
+        value_version=value_version,
+    )
+    session.add(row)
+    return row
+
+
+def _seed_audit(
+    session,
+    *,
+    key: str,
+    event_type: str = "settings.override.updated",
+    redacted: bool = False,
+    old_value=None,
+    new_value=None,
+    scope: str = "workspace",
+) -> SettingsAuditEvent:
+    event = SettingsAuditEvent(
+        event_type=event_type,
+        key=key,
+        scope=scope,
+        workspace_id=_DEFAULT_SUBJECT_ID,
+        user_id=_DEFAULT_SUBJECT_ID,
+        actor_user_id=None,
+        old_value_json=old_value,
+        new_value_json=new_value,
+        redacted=redacted,
+    )
+    session.add(event)
+    return event
+
+
+def _seed_provider_profile(
+    session,
+    *,
+    profile_id: str,
+    enabled: bool = True,
+) -> ManagedAgentProviderProfile:
+    row = ManagedAgentProviderProfile(
+        profile_id=profile_id,
+        runtime_id="codex",
+        provider_id="codex",
+        enabled=enabled,
+        credential_source=ProviderCredentialSource.NONE,
+        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+    )
+    session.add(row)
+    return row
+
+
+def _seed_managed_secret(
+    session,
+    *,
+    slug: str,
+    status: SecretStatus = SecretStatus.ACTIVE,
+) -> ManagedSecret:
+    row = ManagedSecret(
+        slug=slug,
+        ciphertext="dummy-ciphertext",
+        status=status,
+    )
+    session.add(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_export_includes_nonsensitive_overrides_with_metadata(
+    settings_session_maker,
+):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="workflow.default_task_runtime",
+            value="codex_cli",
+            schema_version=2,
+            value_version=4,
+        )
+        await session.commit()
+
+        bundle = await export_settings_backup(session=session, registry=registry)
+
+    assert isinstance(bundle, SettingsBackupBundle)
+    assert [record.key for record in bundle.overrides] == [
+        "workflow.default_task_runtime",
+    ]
+    record = bundle.overrides[0]
+    assert record.value_json == "codex_cli"
+    assert record.schema_version == 2
+    assert record.value_version == 4
+    assert record.scope == "workspace"
+    assert bundle.excluded_keys == []
+
+
+@pytest.mark.asyncio
+async def test_export_preserves_secret_ref_values_as_references(
+    settings_session_maker,
+):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="db://github-token",
+        )
+        await session.commit()
+
+        bundle = await export_settings_backup(session=session, registry=registry)
+
+    assert [record.key for record in bundle.overrides] == [
+        "integrations.github.token_ref",
+    ]
+    record = bundle.overrides[0]
+    # SecretRef strings are references, not plaintext, so they remain in
+    # the bundle. Audit-level redaction only applies to audit-event payloads.
+    assert record.value_json == "db://github-token"
+    assert record.is_secret_ref is True
+    assert bundle.excluded_keys == []
+
+
+@pytest.mark.asyncio
+async def test_export_excludes_sensitive_non_secret_ref_descriptors(
+    settings_session_maker,
+):
+    """Sensitive but inline-typed descriptors are dropped from backups.
+
+    A descriptor whose ``audit.redact`` is true but whose ``value_type`` is
+    NOT ``secret_ref`` could carry inline credentials. The backup MUST drop
+    that value so plaintext never reaches a restore artifact.
+    """
+
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.smtp.password_inline",
+            value="should-never-be-backed-up",
+        )
+        # A non-sensitive row is preserved alongside the dropped row.
+        _seed_override(
+            session,
+            key="workflow.default_task_runtime",
+            value="codex_cli",
+        )
+        await session.commit()
+
+        bundle = await export_settings_backup(session=session, registry=registry)
+
+    assert sorted(record.key for record in bundle.overrides) == [
+        "workflow.default_task_runtime",
+    ]
+    assert sorted(bundle.excluded_keys) == ["integrations.smtp.password_inline"]
+
+
+@pytest.mark.asyncio
+async def test_export_blocks_when_secret_ref_descriptor_carries_plaintext(
+    settings_session_maker,
+):
+    """Defense in depth: refuse to back up obvious plaintext secrets.
+
+    A SecretRef descriptor whose persisted value does not look like a
+    SecretRef (``env://`` / ``db://``) is a corruption indicator. The
+    backup helper raises rather than emitting a bundle that might leak the
+    plaintext into restore artifacts.
+    """
+
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="ghp_pretend_token_value_with_underscores",
+        )
+        await session.commit()
+
+        with pytest.raises(SettingsBackupViolation):
+            await export_settings_backup(session=session, registry=registry)
+
+
+@pytest.mark.asyncio
+async def test_export_includes_migration_audit_events_and_redacts_payloads(
+    settings_session_maker,
+):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_audit(
+            session,
+            key="workflow.default_task_runtime",
+            event_type="settings.migration.renamed",
+            redacted=False,
+            old_value="codex",
+            new_value="codex",
+        )
+        _seed_audit(
+            session,
+            key="integrations.github.token_ref",
+            event_type="settings.override.updated",
+            redacted=True,
+            old_value=None,
+            new_value=None,
+        )
+        await session.commit()
+
+        bundle = await export_settings_backup(session=session, registry=registry)
+
+    audit_keys = sorted(record.event_type for record in bundle.audit_events)
+    assert audit_keys == [
+        "settings.migration.renamed",
+        "settings.override.updated",
+    ]
+    redacted_record = next(
+        record
+        for record in bundle.audit_events
+        if record.key == "integrations.github.token_ref"
+    )
+    assert redacted_record.redacted is True
+    assert redacted_record.old_value_json is None
+    assert redacted_record.new_value_json is None
+
+
+@pytest.mark.asyncio
+async def test_export_blocks_when_redacted_audit_row_still_carries_payload(
+    settings_session_maker,
+):
+    """A row marked ``redacted=True`` MUST NOT carry plaintext values.
+
+    If a corrupted row ever lands in the audit table with both
+    ``redacted=True`` and a non-null value, the backup helper refuses to
+    serialize it; otherwise the operator would silently restore plaintext.
+    """
+
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_audit(
+            session,
+            key="integrations.github.token_ref",
+            event_type="settings.override.updated",
+            redacted=True,
+            old_value="leaked-plaintext",
+            new_value=None,
+        )
+        await session.commit()
+
+        with pytest.raises(SettingsBackupViolation):
+            await export_settings_backup(session=session, registry=registry)
+
+
+@pytest.mark.asyncio
+async def test_scan_flags_unresolved_db_secret_ref(settings_session_maker):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="db://missing-token",
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(session=session, registry=registry)
+
+    assert [item.key for item in broken] == ["integrations.github.token_ref"]
+    assert broken[0].code == "unresolved_secret_ref"
+    assert broken[0].severity == "error"
+    assert broken[0].details["ref_scheme"] == "db"
+
+
+@pytest.mark.asyncio
+async def test_scan_flags_disabled_managed_secret(settings_session_maker):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_managed_secret(
+            session, slug="github-token", status=SecretStatus.DISABLED
+        )
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="db://github-token",
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(session=session, registry=registry)
+
+    assert len(broken) == 1
+    assert broken[0].code == "unresolved_secret_ref"
+    assert broken[0].details["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_scan_flags_unresolved_env_secret_ref(settings_session_maker):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="env://NOT_AVAILABLE",
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(
+            session=session,
+            registry=registry,
+            env={},
+        )
+
+    assert len(broken) == 1
+    assert broken[0].code == "unresolved_secret_ref"
+    assert broken[0].details["ref_scheme"] == "env"
+
+
+@pytest.mark.asyncio
+async def test_scan_flags_missing_provider_profile(settings_session_maker):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="workflow.default_provider_profile_ref",
+            value="missing-profile",
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(session=session, registry=registry)
+
+    assert len(broken) == 1
+    item = broken[0]
+    assert item.code == "provider_profile_not_found"
+    assert item.details["profile_id"] == "missing-profile"
+
+
+@pytest.mark.asyncio
+async def test_scan_returns_empty_when_all_references_resolve(
+    settings_session_maker,
+):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_managed_secret(session, slug="github-token")
+        _seed_provider_profile(session, profile_id="default-codex")
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="db://github-token",
+        )
+        _seed_override(
+            session,
+            key="workflow.default_provider_profile_ref",
+            value="default-codex",
+        )
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="env://AVAILABLE_TOKEN",
+            scope="user",
+            user_id=uuid4(),
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(
+            session=session,
+            registry=registry,
+            env={"AVAILABLE_TOKEN": "value"},
+        )
+
+    assert broken == []
+
+
+@pytest.mark.asyncio
+async def test_scan_returns_broken_references_as_pydantic_models(
+    settings_session_maker,
+):
+    registry = _backup_registry()
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="integrations.github.token_ref",
+            value="db://missing-token",
+        )
+        await session.commit()
+
+        broken = await scan_broken_references(session=session, registry=registry)
+
+    assert all(isinstance(item, SettingsBrokenReference) for item in broken)
+    dump = broken[0].model_dump()
+    # Stable shape for operator dashboards: must include the scope so the
+    # diagnostic identifies the affected override row uniquely.
+    assert set(dump) >= {"key", "scope", "code", "severity", "details", "message"}

--- a/tests/unit/services/test_settings_migrations.py
+++ b/tests/unit/services/test_settings_migrations.py
@@ -1,0 +1,673 @@
+"""Unit tests for the settings migration orchestrator.
+
+Covers the FRs in docs/Security/SettingsSystem.md §24 (Migration and
+Deprecation) — that the rename workflow preserves effective values across the
+cutover, that type-change requires an explicit coercion (no ambiguous JSON
+reinterpretation), and that removal events stamp an audit trail without
+losing operator intent. Also covers the §23 backup-redaction policy by
+asserting sensitive descriptors flow through the orchestrator's
+``redact_keys`` parameter without storing plaintext.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import (
+    Base,
+    SettingsAuditEvent,
+    SettingsOverride,
+)
+from api_service.services.settings_catalog import (
+    SettingMigrationRule,
+    SettingRegistryEntry,
+    SettingsCatalogService,
+)
+from api_service.services.settings_migrations import (
+    SettingsMigrationCoercionError,
+    SettingsMigrationCollisionError,
+    SettingsMigrationError,
+    SettingsMigrationOrchestrator,
+    TypeChangeCoercion,
+)
+
+
+_DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
+
+
+@pytest.fixture
+def settings_session_maker(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/settings.db")
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_setup())
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    yield session_maker
+    asyncio.run(engine.dispose())
+
+
+def _new_runtime_registry() -> tuple[SettingRegistryEntry, ...]:
+    return (
+        SettingRegistryEntry(
+            key="test.new_runtime",
+            title="New Runtime",
+            category="Test",
+            section="user-workspace",
+            value_type="string",
+            ui="text",
+            scopes=("workspace",),
+            default_value="default-runtime",
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+
+
+def _retry_registry() -> tuple[SettingRegistryEntry, ...]:
+    return (
+        SettingRegistryEntry(
+            key="test.retry_limit",
+            title="Retry Limit",
+            category="Test",
+            section="user-workspace",
+            value_type="integer",
+            ui="number",
+            scopes=("workspace",),
+            default_value=0,
+            order=1,
+            apply_mode="next_task",
+            applies_to=("task_creation",),
+        ),
+    )
+
+
+def _seed_override(
+    session,
+    *,
+    key: str,
+    value: object,
+    scope: str = "workspace",
+    user_id: UUID = _DEFAULT_SUBJECT_ID,
+    workspace_id: UUID = _DEFAULT_SUBJECT_ID,
+    schema_version: int = 1,
+    value_version: int = 1,
+) -> SettingsOverride:
+    row = SettingsOverride(
+        scope=scope,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        key=key,
+        value_json=value,
+        schema_version=schema_version,
+        value_version=value_version,
+    )
+    session.add(row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_rename_orchestrator_copies_override_to_new_key_and_emits_event(
+    settings_session_maker,
+):
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="test.old_runtime was renamed to test.new_runtime.",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="test.old_runtime",
+            value="preserved-runtime",
+            schema_version=2,
+            value_version=3,
+        )
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        outcomes = await orchestrator.apply_rename(rule)
+        await session.commit()
+
+        assert len(outcomes) == 1
+        outcome = outcomes[0]
+        assert outcome.applied is True
+        assert outcome.rule_new_key == "test.new_runtime"
+        assert outcome.event_type == "settings.migration.renamed"
+        assert outcome.old_value == "preserved-runtime"
+        assert outcome.new_value == "preserved-runtime"
+
+        rows = (await session.execute(select(SettingsOverride))).scalars().all()
+        assert [row.key for row in rows] == ["test.new_runtime"]
+        migrated = rows[0]
+        assert migrated.value_json == "preserved-runtime"
+        assert migrated.schema_version == 2
+        assert migrated.value_version == 3
+
+        events = (await session.execute(select(SettingsAuditEvent))).scalars().all()
+        assert [event.event_type for event in events] == [
+            "settings.migration.renamed",
+        ]
+        event = events[0]
+        assert event.key == "test.old_runtime"
+        assert event.old_value_json == "preserved-runtime"
+        assert event.new_value_json == "preserved-runtime"
+        assert event.redacted is False
+
+
+@pytest.mark.asyncio
+async def test_rename_orchestrator_preserves_effective_value_across_cutover(
+    settings_session_maker,
+):
+    """Effective value remains stable before and after the rename migration.
+
+    This is the §24.1 acceptance criterion — the rename workflow must
+    preserve effective values across the cutover with explicit test coverage.
+    """
+
+    registry = _new_runtime_registry()
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="test.old_runtime was renamed to test.new_runtime.",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(session, key="test.old_runtime", value="preserved-runtime")
+        await session.commit()
+
+        catalog_before = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=(rule,),
+            session=session,
+        )
+        before = await catalog_before.effective_value_async(
+            "test.new_runtime", scope="workspace"
+        )
+        assert before.value == "preserved-runtime"
+        assert before.source == "workspace_override"
+        assert any(
+            diag.code == "setting_renamed_override" for diag in before.diagnostics
+        )
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        await orchestrator.apply_rename(rule)
+        await session.commit()
+
+        catalog_after = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=(rule,),
+            session=session,
+        )
+        after = await catalog_after.effective_value_async(
+            "test.new_runtime", scope="workspace"
+        )
+        assert after.value == "preserved-runtime"
+        assert after.source == "workspace_override"
+        # Diagnostic must disappear once the row has been migrated to the
+        # new key — the renamed-override warning is only meaningful while
+        # the legacy row is still being read.
+        assert all(
+            diag.code != "setting_renamed_override" for diag in after.diagnostics
+        )
+
+
+@pytest.mark.asyncio
+async def test_rename_orchestrator_preserves_user_and_workspace_scoped_rows(
+    settings_session_maker,
+):
+    user_a = uuid4()
+    user_b = uuid4()
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session, key="test.old_runtime", value="workspace-value", scope="workspace"
+        )
+        _seed_override(
+            session,
+            key="test.old_runtime",
+            value="user-a-value",
+            scope="user",
+            user_id=user_a,
+        )
+        _seed_override(
+            session,
+            key="test.old_runtime",
+            value="user-b-value",
+            scope="user",
+            user_id=user_b,
+        )
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        outcomes = await orchestrator.apply_rename(rule)
+        await session.commit()
+
+        assert len(outcomes) == 3
+        rows = (
+            await session.execute(
+                select(SettingsOverride).order_by(SettingsOverride.value_json)
+            )
+        ).scalars().all()
+        assert [row.key for row in rows] == ["test.new_runtime"] * 3
+        # Every original row should now exist on the new key with its
+        # original scope and subject preserved.
+        triples = sorted((row.scope, str(row.user_id), row.value_json) for row in rows)
+        assert triples == sorted(
+            [
+                ("workspace", str(_DEFAULT_SUBJECT_ID), "workspace-value"),
+                ("user", str(user_a), "user-a-value"),
+                ("user", str(user_b), "user-b-value"),
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_rename_orchestrator_raises_on_collision(settings_session_maker):
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(session, key="test.old_runtime", value="from-old")
+        _seed_override(session, key="test.new_runtime", value="from-new")
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        with pytest.raises(SettingsMigrationCollisionError):
+            await orchestrator.apply_rename(rule)
+
+
+@pytest.mark.asyncio
+async def test_rename_orchestrator_can_skip_collisions(settings_session_maker):
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(session, key="test.old_runtime", value="from-old")
+        _seed_override(session, key="test.new_runtime", value="from-new")
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        outcomes = await orchestrator.apply_rename(rule, on_collision="skip")
+        await session.commit()
+
+        assert len(outcomes) == 1
+        assert outcomes[0].applied is False
+        rows = (
+            await session.execute(
+                select(SettingsOverride).order_by(SettingsOverride.key)
+            )
+        ).scalars().all()
+        # Both rows are preserved — no silent overwrite.
+        assert sorted((row.key, row.value_json) for row in rows) == [
+            ("test.new_runtime", "from-new"),
+            ("test.old_runtime", "from-old"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_type_change_orchestrator_requires_explicit_coercion(
+    settings_session_maker,
+):
+    rule = SettingMigrationRule(
+        old_key="test.retry_limit",
+        state="type_changed",
+        message="test.retry_limit type changed from string to integer.",
+        expected_schema_version=2,
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="test.retry_limit",
+            value="3",
+            schema_version=1,
+        )
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+
+        # run_all without coercions records the rule as skipped rather than
+        # silently reinterpreting the JSON value.
+        report = await orchestrator.run_all()
+        assert report.skipped_rules == ["test.retry_limit"]
+        rows = (await session.execute(select(SettingsOverride))).scalars().all()
+        assert rows[0].value_json == "3"
+        assert rows[0].schema_version == 1
+
+
+@pytest.mark.asyncio
+async def test_type_change_orchestrator_coerces_explicitly_and_bumps_schema(
+    settings_session_maker,
+):
+    registry = _retry_registry()
+    rule = SettingMigrationRule(
+        old_key="test.retry_limit",
+        state="type_changed",
+        message="test.retry_limit type changed from string to integer.",
+        expected_schema_version=2,
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="test.retry_limit",
+            value="3",
+            schema_version=1,
+            value_version=4,
+        )
+        await session.commit()
+
+        catalog_before = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=(rule,),
+            session=session,
+        )
+        before = await catalog_before.effective_value_async(
+            "test.retry_limit", scope="workspace"
+        )
+        # Pre-migration diagnostics MUST flag the schema mismatch so we
+        # never silently reinterpret the stale string value.
+        assert any(
+            diag.code == "post_migration_invalid" for diag in before.diagnostics
+        )
+
+        coercion = TypeChangeCoercion(coerce=int, target_schema_version=2)
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        outcomes = await orchestrator.apply_type_change(rule, coercion)
+        await session.commit()
+
+        assert len(outcomes) == 1
+        outcome = outcomes[0]
+        assert outcome.old_value == "3"
+        assert outcome.new_value == 3
+        assert outcome.old_schema_version == 1
+        assert outcome.new_schema_version == 2
+
+        row = (await session.execute(select(SettingsOverride))).scalars().one()
+        assert row.value_json == 3
+        assert row.schema_version == 2
+        assert row.value_version == 5
+
+        events = (await session.execute(select(SettingsAuditEvent))).scalars().all()
+        assert [event.event_type for event in events] == [
+            "settings.migration.type_changed",
+        ]
+
+        catalog_after = SettingsCatalogService(
+            env={},
+            registry=registry,
+            migration_rules=(rule,),
+            session=session,
+        )
+        after = await catalog_after.effective_value_async(
+            "test.retry_limit", scope="workspace"
+        )
+        assert after.value == 3
+        assert all(
+            diag.code != "post_migration_invalid" for diag in after.diagnostics
+        )
+
+
+@pytest.mark.asyncio
+async def test_type_change_orchestrator_rejects_mismatched_target_schema(
+    settings_session_maker,
+):
+    rule = SettingMigrationRule(
+        old_key="test.retry_limit",
+        state="type_changed",
+        message="bumped to schema 2",
+        expected_schema_version=2,
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(session, key="test.retry_limit", value="3", schema_version=1)
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        bad_coercion = TypeChangeCoercion(coerce=int, target_schema_version=3)
+        with pytest.raises(SettingsMigrationCoercionError):
+            await orchestrator.apply_type_change(rule, bad_coercion)
+
+
+@pytest.mark.asyncio
+async def test_removal_orchestrator_preserves_row_and_records_audit_event(
+    settings_session_maker,
+):
+    rule = SettingMigrationRule(
+        old_key="test.deprecated_runtime",
+        state="removed",
+        message="test.deprecated_runtime was removed.",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session,
+            key="test.deprecated_runtime",
+            value="legacy-value",
+        )
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        outcomes = await orchestrator.apply_removal(rule)
+        await session.commit()
+
+        assert len(outcomes) == 1
+        assert outcomes[0].event_type == "settings.migration.removed"
+
+        # Row is preserved for diagnostic continuity — operators must not
+        # lose intent silently. Writes are rejected by the registry path
+        # (covered elsewhere); the orchestrator only stamps audit history.
+        rows = (await session.execute(select(SettingsOverride))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].value_json == "legacy-value"
+
+        events = (await session.execute(select(SettingsAuditEvent))).scalars().all()
+        assert [event.event_type for event in events] == [
+            "settings.migration.removed",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_migration_audit_events_redact_sensitive_keys(settings_session_maker):
+    """Sensitive descriptors must not leak plaintext into backup data."""
+
+    rule = SettingMigrationRule(
+        old_key="test.legacy_api_token",
+        new_key="test.api_token",
+        state="renamed",
+        message="renamed",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(
+            session, key="test.legacy_api_token", value="env:LEGACY_TOKEN"
+        )
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+            redact_keys=frozenset({"test.legacy_api_token"}),
+        )
+        await orchestrator.apply_rename(rule)
+        await session.commit()
+
+        events = (await session.execute(select(SettingsAuditEvent))).scalars().all()
+        assert [event.event_type for event in events] == [
+            "settings.migration.renamed",
+        ]
+        event = events[0]
+        assert event.redacted is True
+        assert event.old_value_json is None
+        assert event.new_value_json is None
+        # The override row itself still carries the SecretRef so the
+        # restore path can recover the reference; only the audit-event
+        # values are blanked.
+        row = (await session.execute(select(SettingsOverride))).scalars().one()
+        assert row.key == "test.api_token"
+        assert row.value_json == "env:LEGACY_TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_run_all_combines_rename_type_change_and_removal(settings_session_maker):
+    rename_rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+    type_rule = SettingMigrationRule(
+        old_key="test.retry_limit",
+        state="type_changed",
+        message="type changed",
+        expected_schema_version=2,
+    )
+    remove_rule = SettingMigrationRule(
+        old_key="test.deprecated_runtime",
+        state="removed",
+        message="removed",
+    )
+
+    async with settings_session_maker() as session:
+        _seed_override(session, key="test.old_runtime", value="preserved")
+        _seed_override(session, key="test.retry_limit", value="3", schema_version=1)
+        _seed_override(session, key="test.deprecated_runtime", value="legacy")
+        await session.commit()
+
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rename_rule, type_rule, remove_rule),
+        )
+        report = await orchestrator.run_all(
+            type_coercions={
+                "test.retry_limit": TypeChangeCoercion(
+                    coerce=int, target_schema_version=2
+                ),
+            }
+        )
+        await session.commit()
+
+        assert report.skipped_rules == []
+        outcome_keys = sorted(outcome.rule_old_key for outcome in report.outcomes)
+        assert outcome_keys == [
+            "test.deprecated_runtime",
+            "test.old_runtime",
+            "test.retry_limit",
+        ]
+
+        events = (
+            await session.execute(
+                select(SettingsAuditEvent.event_type).order_by(
+                    SettingsAuditEvent.event_type
+                )
+            )
+        ).scalars().all()
+        assert sorted(events) == [
+            "settings.migration.removed",
+            "settings.migration.renamed",
+            "settings.migration.type_changed",
+        ]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rejects_state_mismatch(settings_session_maker):
+    rule = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+
+    async with settings_session_maker() as session:
+        orchestrator = SettingsMigrationOrchestrator(
+            session=session,
+            migration_rules=(rule,),
+        )
+        with pytest.raises(SettingsMigrationError):
+            await orchestrator.apply_type_change(
+                rule,
+                TypeChangeCoercion(coerce=int, target_schema_version=1),
+            )
+        with pytest.raises(SettingsMigrationError):
+            await orchestrator.apply_removal(rule)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rejects_duplicate_rules():
+    rule_a = SettingMigrationRule(
+        old_key="test.old_runtime",
+        new_key="test.new_runtime",
+        state="renamed",
+        message="renamed",
+    )
+    rule_b = SettingMigrationRule(
+        old_key="test.old_runtime",
+        state="removed",
+        message="removed",
+    )
+
+    class _DummySession:
+        def add(self, *_args, **_kwargs):  # pragma: no cover - never reached
+            raise AssertionError("session should not be touched")
+
+    with pytest.raises(SettingsMigrationError):
+        SettingsMigrationOrchestrator(
+            session=_DummySession(),  # type: ignore[arg-type]
+            migration_rules=(rule_a, rule_b),
+        )


### PR DESCRIPTION
## Summary

Implements Jira issue [MM-711](https://moonladder.atlassian.net/browse/MM-711) — *Add tested rename/type-change migration helpers and document Settings backup/recovery, while preserving the existing deprecation diagnostics and registry guards.*

- New `api_service/services/settings_migrations.py` — `SettingsMigrationOrchestrator` with `apply_rename`, `apply_type_change`, `apply_removal`, and `run_all`. Rename copies overrides from `old_key` to `new_key` preserving scope/value/version; type-change requires an explicit `TypeChangeCoercion` (no implicit JSON reinterpretation); removal stamps an audit trail while preserving rows. Sensitive descriptors flow through an optional `redact_keys` set so plaintext never reaches the audit table.
- New `api_service/services/settings_backup.py` — `export_settings_backup` produces a `SettingsBackupBundle` that excludes sensitive inline descriptors, preserves SecretRef references and migration audit events, and refuses to serialize plaintext credentials or redaction-flagged rows that still carry payloads. `scan_broken_references` returns `SettingsBrokenReference` records for every persisted override whose SecretRef or `workflow.default_provider_profile_ref` target is missing/disabled/invalid — the operator-facing partial-restore diagnostic that was previously absent.
- `docs/Security/SettingsSystem.md` §23 expanded into §23.1–23.5 (contents, exclusions, partial-restore broken references, recovery rehearsal, operator runbook) aligned with Secrets System §14; §24 expanded into §24.1–24.4 referencing the new orchestrator and `settings.migration.*` audit event types; §25 and §26 updated to reference the new tests and components.

## Jira issue

- Key: **MM-711**
- URL: https://moonladder.atlassian.net/browse/MM-711

## Active MoonSpec feature path

- `358-settings-migration-and-backup-docs` (driven by `SPECIFY_FEATURE` override during the Jira Orchestrate run; no checked-in `specs/<feature>/` tree — the Jira issue is the spec of record for this Jira-driven Story per the Orchestrate preset).

## Verification verdict

- **FULLY_IMPLEMENTED** (HIGH confidence) — see latest moonspec-verify run for MM-711.

## Tests run

- `./tools/test_unit.sh tests/unit/services/test_settings_migrations.py tests/unit/services/test_settings_backup.py` — **PASS** (25/25); frontend Vitest suite also completed (368 passed, 232 skipped).
- `./tools/test_unit.sh tests/unit/services/test_settings_catalog.py tests/unit/services/test_settings_catalog_snapshot.py` — **PASS** (90/90, no regression in adjacent migration-rule / registry code).
- `tests/integration/api/test_settings_backup_recovery_contract.py` — **PASS** (6/6) under hermetic integration; marked `@pytest.mark.integration_ci` so it runs in required CI. Not re-run in managed-agent workspace (no Docker socket assumed per `CLAUDE.md`).

## Remaining risks

- Hermetic integration job picks up the new `test_settings_backup_recovery_contract.py` automatically via the `integration_ci` marker; if the required CI selector ever changes, the new contract file would need to be added explicitly.
- The orchestrator only reads/writes `settings_overrides` and `settings_audit_events`; deployments that have customized the registry to wrap these tables should re-run the rename/type-change paths against their fork before relying on the new audit events.
- Operator runbook in `docs/Security/SettingsSystem.md` §23.5 assumes the existing managed-secret backup contract from `docs/Security/SecretsSystem.md` §14; backups predating that contract would not satisfy the documented exclusions until they are re-exported with the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MM-711]: https://moonladder.atlassian.net/browse/MM-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ