### PR TITLE
MM-707 Validate semantic pull request metadata before managed PR publication

### DIFF
--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -5156,9 +5156,8 @@ class CodexWorker:
                     f"canonical Jira issue key {jira_issue_key}"
                 )
 
-            normalized_body = " ".join(body_text.casefold().split())
             for label, markers in _JIRA_PR_BODY_REQUIRED_FIELDS:
-                if not any(marker in normalized_body for marker in markers):
+                if not cls._pr_body_has_required_label(body_text, markers):
                     raise ValueError(
                         "task.publish.prBody for Jira-backed PRs must include "
                         f"{label}"
@@ -5169,6 +5168,19 @@ class CodexWorker:
             body=body_text,
             jira_issue_key=jira_issue_key,
             moon_spec_path=moon_spec_path,
+        )
+
+    @staticmethod
+    def _pr_body_has_required_label(body: str, markers: Sequence[str]) -> bool:
+        """Return true when a required PR metadata field appears as a label."""
+
+        return any(
+            re.search(
+                rf"(?im)^\s*(?:[-*]\s*)?{re.escape(marker)}\s*:",
+                body,
+            )
+            is not None
+            for marker in markers
         )
 
     @staticmethod
@@ -5219,6 +5231,33 @@ class CodexWorker:
             return cls._sanitize_pr_title(candidate, redact_uuids=False)
 
         return cls._sanitize_pr_title(f"MoonMind task result [mm:{str(job_id)[:8]}]")
+
+    @classmethod
+    def _derive_default_jira_pr_title(
+        cls,
+        *,
+        job_id: UUID,
+        canonical_payload: Mapping[str, Any],
+        resolved_steps: Sequence[ResolvedTaskStep],
+    ) -> str:
+        jira_issue_key = cls._resolve_canonical_jira_issue_key(canonical_payload)
+        if not jira_issue_key:
+            return cls._derive_default_pr_title(
+                job_id=job_id,
+                canonical_payload=canonical_payload,
+                resolved_steps=resolved_steps,
+            )
+
+        base_title = cls._derive_default_pr_title(
+            job_id=job_id,
+            canonical_payload=canonical_payload,
+            resolved_steps=resolved_steps,
+        )
+        issue_pattern = re.compile(rf"\b{re.escape(jira_issue_key)}\b", re.IGNORECASE)
+        if issue_pattern.search(base_title):
+            return base_title
+
+        return cls._sanitize_pr_title(f"{jira_issue_key} {base_title}")
 
     @staticmethod
     def _resolve_publish_runtime_mode(canonical_payload: Mapping[str, Any]) -> str:
@@ -5315,6 +5354,44 @@ class CodexWorker:
             "<!-- moonmind:end -->",
         ]
         return "\n".join(lines)
+
+    @classmethod
+    def _derive_default_jira_pr_body(
+        cls,
+        *,
+        job_id: UUID,
+        canonical_payload: Mapping[str, Any],
+        runtime_mode: str,
+        base_branch: str,
+        head_branch: str,
+    ) -> str:
+        jira_issue_key = cls._resolve_canonical_jira_issue_key(canonical_payload)
+        if not jira_issue_key:
+            return cls._derive_default_pr_body(
+                job_id=job_id,
+                runtime_mode=runtime_mode,
+                base_branch=base_branch,
+                head_branch=head_branch,
+            )
+
+        moon_spec_path = cls._resolve_canonical_moonspec_path(canonical_payload)
+        moon_spec_value = moon_spec_path or "Not provided"
+        body = cls._derive_default_pr_body(
+            job_id=job_id,
+            runtime_mode=runtime_mode,
+            base_branch=base_branch,
+            head_branch=head_branch,
+        )
+        review_metadata = [
+            f"Jira: {jira_issue_key}",
+            f"MoonSpec: {moon_spec_value}",
+            "Summary: Automated MoonMind managed PR publication.",
+            "Verification verdict: Pending reviewer validation.",
+            "Tests: See publish verification artifacts.",
+            "Remaining risks: Pending reviewer assessment.",
+            "",
+        ]
+        return "\n".join(review_metadata) + body
 
     @staticmethod
     def _parse_git_status_paths(status_output: str) -> tuple[str, ...]:
@@ -6049,6 +6126,8 @@ class CodexWorker:
             publish_note = f"published branch {prepared.working_branch}"
             pr_base: str | None = None
             validated_pr_metadata: ValidatedPullRequestMetadata | None = None
+            pr_title: str | None = None
+            pr_body: str | None = None
 
             if publish_mode == "pr":
                 try:
@@ -6103,6 +6182,33 @@ class CodexWorker:
                     )
                     raise
 
+                pr_title = self._resolve_publish_text_override(
+                    publish.get("prTitle")
+                ) or self._derive_default_jira_pr_title(
+                    job_id=job_id,
+                    canonical_payload=canonical_payload,
+                    resolved_steps=self._resolve_task_steps(canonical_payload),
+                )
+                pr_body = self._resolve_publish_text_override(
+                    publish.get("prBody")
+                ) or self._derive_default_jira_pr_body(
+                    job_id=job_id,
+                    canonical_payload=canonical_payload,
+                    runtime_mode=self._resolve_publish_runtime_mode(canonical_payload),
+                    base_branch=pr_base,
+                    head_branch=prepared.working_branch,
+                )
+                if preflight_result and preflight_result.verification_skip_reason:
+                    pr_body = self._append_skip_reason_to_pr_body(
+                        pr_body=pr_body,
+                        skip_reason=preflight_result.verification_skip_reason,
+                    )
+                validated_pr_metadata = self._validate_pull_request_metadata(
+                    title=pr_title,
+                    body=pr_body,
+                    canonical_payload=canonical_payload,
+                )
+
             commit_message = (
                 self._resolve_publish_text_override(publish.get("commitMessage"))
                 or f"MoonMind task result for job {job_id}"
@@ -6122,31 +6228,6 @@ class CodexWorker:
             )
 
             if publish_mode == "pr" and pr_base is not None:
-                pr_title = self._resolve_publish_text_override(
-                    publish.get("prTitle")
-                ) or self._derive_default_pr_title(
-                    job_id=job_id,
-                    canonical_payload=canonical_payload,
-                    resolved_steps=self._resolve_task_steps(canonical_payload),
-                )
-                pr_body = self._resolve_publish_text_override(
-                    publish.get("prBody")
-                ) or self._derive_default_pr_body(
-                    job_id=job_id,
-                    runtime_mode=self._resolve_publish_runtime_mode(canonical_payload),
-                    base_branch=pr_base,
-                    head_branch=prepared.working_branch,
-                )
-                if preflight_result and preflight_result.verification_skip_reason:
-                    pr_body = self._append_skip_reason_to_pr_body(
-                        pr_body=pr_body,
-                        skip_reason=preflight_result.verification_skip_reason,
-                    )
-                validated_pr_metadata = self._validate_pull_request_metadata(
-                    title=pr_title,
-                    body=pr_body,
-                    canonical_payload=canonical_payload,
-                )
                 publish_env = prepared.publish_command_env or {}
                 github_token = str(publish_env.get("GITHUB_TOKEN") or "").strip()
                 repository = str(canonical_payload.get("repository") or "").strip()

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -108,6 +108,28 @@ _SECRET_LIKE_METADATA_PATTERN = re.compile(
     """
 )
 _SENSITIVE_COMMAND_FLAGS = frozenset({"--title", "--body", "--message", "-m"})
+_JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
+_CONTROL_PLANE_PR_METADATA_PATTERNS = (
+    re.compile(
+        r"\b(?:change|move|transition)\s+jira\s+issue\s+"
+        r"[A-Z][A-Z0-9]+-\d+\s+to\s+"
+        r"(?:status\s+)?"
+        r"(?:in\s+progress|code\s+review|done|backlog|selected\s+for\s+development)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\btrusted\s+jira\s+issue\s+updater\s+workflow\b", re.IGNORECASE),
+    re.compile(r"\bjira\s+transition\s+tools?\b", re.IGNORECASE),
+    re.compile(r"\bbefore\s+implementation\s+starts?\b", re.IGNORECASE),
+    re.compile(r"\bdo\s+not\s+guess\s+transition\s+ids?\b", re.IGNORECASE),
+)
+_JIRA_PR_BODY_REQUIRED_FIELDS = (
+    ("Jira", ("jira",)),
+    ("MoonSpec", ("moonspec", "moon spec")),
+    ("Summary", ("summary",)),
+    ("Verification verdict", ("verification verdict", "verdict")),
+    ("Tests", ("tests", "test evidence")),
+    ("Remaining risks", ("remaining risks", "risks", "risk")),
+)
 _MOONMIND_SIGNAL_TAGS = frozenset(
     {
         "retry",
@@ -122,6 +144,24 @@ _MOONMIND_SIGNAL_TAGS = frozenset(
 _FIX_PROPOSAL_SKILL_ID = "fix-proposal"
 _CONTINUATION_PROPOSAL_SKILL_ID = "continuation-proposal"
 _PR_RESOLVER_SKILL_ID = "pr-resolver"
+
+
+@dataclass(frozen=True)
+class ValidatedPullRequestMetadata:
+    """Semantic PR metadata accepted for managed publication."""
+
+    title: str
+    body: str
+    jira_issue_key: str | None = None
+    moon_spec_path: str | None = None
+
+    def to_payload(self) -> dict[str, str]:
+        payload = {"title": self.title, "body": self.body}
+        if self.jira_issue_key:
+            payload["jiraIssueKey"] = self.jira_issue_key
+        if self.moon_spec_path:
+            payload["moonSpecPath"] = self.moon_spec_path
+        return payload
 
 # Worker runtime modes accepted by MOONMIND_WORKER_RUNTIME. Intentionally a subset
 # of SUPPORTED_RUNTIME_MODES: `codex_cloud` is excluded because it is not a local
@@ -5013,6 +5053,125 @@ class CodexWorker:
         return candidate
 
     @staticmethod
+    def _resolve_canonical_jira_issue_key(
+        canonical_payload: Mapping[str, Any],
+    ) -> str | None:
+        """Return the canonical Jira issue key attached to a task-shaped payload."""
+
+        task_node = canonical_payload.get("task")
+        task = task_node if isinstance(task_node, Mapping) else {}
+        candidates = (
+            task.get("jiraIssueKey"),
+            task.get("jira_issue_key"),
+            canonical_payload.get("jiraIssueKey"),
+            canonical_payload.get("jira_issue_key"),
+        )
+        for candidate in candidates:
+            value = str(candidate or "").strip().upper()
+            if value and _JIRA_ISSUE_KEY_PATTERN.fullmatch(value):
+                return value
+        jira_node = task.get("jira")
+        jira = jira_node if isinstance(jira_node, Mapping) else {}
+        for key in ("issueKey", "issue_key", "key"):
+            value = str(jira.get(key) or "").strip().upper()
+            if value and _JIRA_ISSUE_KEY_PATTERN.fullmatch(value):
+                return value
+        return None
+
+    @staticmethod
+    def _resolve_canonical_moonspec_path(
+        canonical_payload: Mapping[str, Any],
+    ) -> str | None:
+        """Return the active MoonSpec path when task payload metadata provides it."""
+
+        task_node = canonical_payload.get("task")
+        task = task_node if isinstance(task_node, Mapping) else {}
+        for candidate in (
+            task.get("moonSpecPath"),
+            task.get("moonspecPath"),
+            task.get("moon_spec_path"),
+            canonical_payload.get("moonSpecPath"),
+            canonical_payload.get("moonspecPath"),
+            canonical_payload.get("moon_spec_path"),
+        ):
+            value = str(candidate or "").strip()
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _contains_control_plane_pr_metadata(value: str) -> bool:
+        """Detect known workflow-control text that is invalid as PR review metadata."""
+
+        return any(
+            pattern.search(value) for pattern in _CONTROL_PLANE_PR_METADATA_PATTERNS
+        )
+
+    @classmethod
+    def _validate_pull_request_metadata(
+        cls,
+        *,
+        title: str,
+        body: str,
+        canonical_payload: Mapping[str, Any],
+    ) -> ValidatedPullRequestMetadata:
+        """Validate semantic PR metadata before creating or updating a PR."""
+
+        title_text = str(title or "")
+        body_text = str(body or "")
+        if not title_text.strip():
+            raise ValueError("task.publish.prTitle must be non-empty for PR publication")
+        if not body_text.strip():
+            raise ValueError("task.publish.prBody must be non-empty for PR publication")
+
+        combined = f"{title_text}\n{body_text}"
+        if cls._contains_control_plane_pr_metadata(combined):
+            raise ValueError(
+                "task.publish PR metadata appears to contain control-plane instructions; "
+                "provide reviewer-facing implementation metadata instead"
+            )
+
+        jira_issue_key = cls._resolve_canonical_jira_issue_key(canonical_payload)
+        moon_spec_path = cls._resolve_canonical_moonspec_path(canonical_payload)
+        if jira_issue_key:
+            issue_pattern = re.compile(
+                rf"\b{re.escape(jira_issue_key)}\b",
+                re.IGNORECASE,
+            )
+            if issue_pattern.search(title_text) is None:
+                raise ValueError(
+                    "task.publish.prTitle for Jira-backed PRs must include the "
+                    f"canonical Jira issue key {jira_issue_key}"
+                )
+            capability = issue_pattern.sub("", title_text)
+            capability = re.sub(r"[\s:;\-_\[\]()#]+", " ", capability).strip()
+            if not capability:
+                raise ValueError(
+                    "task.publish.prTitle for Jira-backed PRs must include an "
+                    "implemented capability"
+                )
+            if issue_pattern.search(body_text) is None:
+                raise ValueError(
+                    "task.publish.prBody for Jira-backed PRs must include the "
+                    f"canonical Jira issue key {jira_issue_key}"
+                )
+
+            normalized_body = " ".join(body_text.casefold().split())
+            for label, markers in _JIRA_PR_BODY_REQUIRED_FIELDS:
+                if not any(marker in normalized_body for marker in markers):
+                    raise ValueError(
+                        "task.publish.prBody for Jira-backed PRs must include "
+                        f"{label}"
+                    )
+
+        return ValidatedPullRequestMetadata(
+            title=title_text,
+            body=body_text,
+            jira_issue_key=jira_issue_key,
+            moon_spec_path=moon_spec_path,
+        )
+
+    @staticmethod
     def _sanitize_metadata_footer_value(
         value: str | None, *, fallback: str = "unknown"
     ) -> str:
@@ -5889,6 +6048,7 @@ class CodexWorker:
             publish_base_branch = prepared.starting_branch
             publish_note = f"published branch {prepared.working_branch}"
             pr_base: str | None = None
+            validated_pr_metadata: ValidatedPullRequestMetadata | None = None
 
             if publish_mode == "pr":
                 try:
@@ -5982,6 +6142,11 @@ class CodexWorker:
                         pr_body=pr_body,
                         skip_reason=preflight_result.verification_skip_reason,
                     )
+                validated_pr_metadata = self._validate_pull_request_metadata(
+                    title=pr_title,
+                    body=pr_body,
+                    canonical_payload=canonical_payload,
+                )
                 publish_env = prepared.publish_command_env or {}
                 github_token = str(publish_env.get("GITHUB_TOKEN") or "").strip()
                 repository = str(canonical_payload.get("repository") or "").strip()
@@ -6042,6 +6207,10 @@ class CodexWorker:
                 "skipped": False,
                 "verification": verification_payload,
             }
+            if publish_mode == "pr":
+                result_payload["readinessState"] = "pending"
+                if validated_pr_metadata is not None:
+                    result_payload["prMetadata"] = validated_pr_metadata.to_payload()
             prepared.publish_result_path.write_text(
                 json.dumps(result_payload, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -8057,6 +8057,20 @@ async def test_validate_pr_metadata_accepts_jira_backed_review_metadata() -> Non
     assert metadata.jira_issue_key == "MM-707"
     assert metadata.moon_spec_path == "specs/707-pr-metadata-validation"
 
+async def test_validate_pr_metadata_requires_jira_body_labels() -> None:
+    """Required Jira metadata fields should not pass through incidental words."""
+
+    with pytest.raises(ValueError, match="Jira"):
+        CodexWorker._validate_pull_request_metadata(
+            title="MM-707 Validate semantic pull request metadata",
+            body=(
+                "This summary mentions jira and moonspec naturally.\n"
+                "The verdict is that tests passed and the risk is low.\n"
+                "MM-707 is implemented."
+            ),
+            canonical_payload={"task": {"jiraIssueKey": "MM-707"}},
+        )
+
 
 @pytest.mark.parametrize(
     ("title", "body", "match"),
@@ -8103,6 +8117,49 @@ async def test_validate_pr_metadata_rejects_invalid_jira_metadata(
             body=body,
             canonical_payload={"task": {"jiraIssueKey": "MM-707"}},
         )
+
+async def test_derive_default_jira_pr_metadata_contains_required_review_fields() -> None:
+    """Default Jira-backed PR metadata should satisfy semantic publication rules."""
+
+    job_id = uuid4()
+    canonical_payload = {
+        "task": {
+            "jiraIssueKey": "MM-707",
+            "moonSpecPath": "specs/707-pr-metadata-validation",
+        }
+    }
+    title = CodexWorker._derive_default_jira_pr_title(
+        job_id=job_id,
+        canonical_payload=canonical_payload,
+        resolved_steps=[
+            ResolvedTaskStep(
+                step_index=1,
+                step_id="step-1",
+                title="Validate semantic pull request metadata",
+                instructions="unused",
+                effective_skill_id="auto",
+                effective_skill_args={},
+                has_step_instructions=True,
+            )
+        ],
+    )
+    body = CodexWorker._derive_default_jira_pr_body(
+        job_id=job_id,
+        canonical_payload=canonical_payload,
+        runtime_mode="codex",
+        base_branch="main",
+        head_branch="feature/branch",
+    )
+
+    metadata = CodexWorker._validate_pull_request_metadata(
+        title=title,
+        body=body,
+        canonical_payload=canonical_payload,
+    )
+
+    assert title.startswith("MM-707 ")
+    assert metadata.jira_issue_key == "MM-707"
+    assert "MoonSpec: specs/707-pr-metadata-validation" in body
 
 async def test_parse_git_status_paths_collects_renamed_source_paths() -> None:
     """Git status parser should include both sides of a rename or copy for safety."""
@@ -8540,6 +8597,8 @@ async def test_run_publish_stage_rejects_invalid_pr_metadata_before_pr_creation(
         )
 
     assert not any(call[:3] == ("gh", "pr", "create") for call in run_calls)
+    assert not any(call[:3] == ("git", "commit", "-m") for call in run_calls)
+    assert not any(call[:2] == ("git", "push") for call in run_calls)
 
 
 async def test_run_publish_stage_records_validated_pr_metadata(
@@ -8655,6 +8714,114 @@ async def test_run_publish_stage_records_validated_pr_metadata(
         "jiraIssueKey": "MM-707",
         "moonSpecPath": "specs/707-pr-metadata-validation",
     }
+
+async def test_run_publish_stage_defaults_jira_pr_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Jira-backed PR publish defaults should pass semantic validation."""
+
+    queue = FakeQueueClient(jobs=[])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(
+        config=CodexWorkerConfig(
+            moonmind_url="http://localhost:8000",
+            worker_id="worker-1",
+            worker_token=None,
+            poll_interval_ms=1500,
+            lease_seconds=120,
+            workdir=tmp_path,
+        ),
+        queue_client=queue,
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+
+    run_calls: list[tuple[str, ...]] = []
+
+    async def _capture_stage_command(
+        command,
+        *,
+        cwd,
+        log_path,
+        check=True,
+        env=None,
+        redaction_values=(),
+        cancel_event=None,
+    ):
+        _ = (cwd, log_path, check, env, redaction_values, cancel_event)
+        normalized = tuple(str(part) for part in command)
+        run_calls.append(normalized)
+        if normalized[:2] == ("git", "status"):
+            return CommandResult(normalized, 0, " M worker.py\n", "")
+        if normalized[:3] == ("gh", "pr", "create"):
+            return CommandResult(
+                normalized,
+                0,
+                "https://github.com/MoonLadderStudios/MoonMind/pull/707\n",
+                "",
+            )
+        return CommandResult(normalized, 0, "", "")
+
+    monkeypatch.setattr(worker, "_run_stage_command", _capture_stage_command)
+
+    job_id = uuid4()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / str(job_id),
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "context",
+        publish_result_path=tmp_path / "publish-result.json",
+        default_branch="main",
+        starting_branch="main",
+        new_branch="feature/branch",
+        working_branch="feature/branch",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True, exist_ok=True)
+    prepared.task_context_path.mkdir(parents=True, exist_ok=True)
+    prepared.execute_log_path.write_text(
+        "[command] $ ./tools/test_unit.sh "
+        "tests/unit/agents/codex_worker/test_worker.py\nok\n",
+        encoding="utf-8",
+    )
+
+    await worker._run_publish_stage(
+        job_id=job_id,
+        canonical_payload={
+            "task": {
+                "jiraIssueKey": "MM-707",
+                "moonSpecPath": "specs/707-pr-metadata-validation",
+                "steps": [
+                    {
+                        "id": "implementation",
+                        "title": "Validate semantic pull request metadata",
+                        "instructions": "Implement validation.",
+                    }
+                ],
+                "publish": {"mode": "pr"},
+            }
+        },
+        prepared=prepared,
+        skill_meta={},
+        job_type="task",
+        staged_artifacts=[],
+    )
+
+    pr_call = next(
+        call for call in run_calls if call[:3] == ("gh", "pr", "create")
+    )
+    pr_title = pr_call[pr_call.index("--title") + 1]
+    pr_body = pr_call[pr_call.index("--body") + 1]
+    assert pr_title == "MM-707 Validate semantic pull request metadata"
+    assert "Jira: MM-707" in pr_body
+    assert "Remaining risks:" in pr_body
 
 async def test_run_publish_stage_fails_without_verification_evidence_for_source_changes(
     tmp_path: Path,

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -8009,6 +8009,101 @@ async def test_resolve_publish_text_override_preserves_non_empty_verbatim() -> N
     assert CodexWorker._resolve_publish_text_override(" \n\t ") is None
     assert CodexWorker._resolve_publish_text_override(None) is None
 
+async def test_validate_pr_metadata_rejects_control_plane_text() -> None:
+    """PR metadata must describe implementation work, not workflow control actions."""
+
+    with pytest.raises(ValueError, match="control-plane"):
+        CodexWorker._validate_pull_request_metadata(
+            title=(
+                "Change Jira issue MM-707 to status In Progress before "
+                "implementation starts."
+            ),
+            body=(
+                "Use the trusted Jira issue updater workflow and Jira transition "
+                "tools before implementation starts."
+            ),
+            canonical_payload={"task": {"jiraIssueKey": "MM-707"}},
+        )
+
+    with pytest.raises(ValueError, match="prBody"):
+        CodexWorker._validate_pull_request_metadata(
+            title="MM-707 Validate semantic pull request metadata",
+            body="   ",
+            canonical_payload={"task": {"jiraIssueKey": "MM-707"}},
+        )
+
+async def test_validate_pr_metadata_accepts_jira_backed_review_metadata() -> None:
+    """Jira-backed PR metadata should carry the required review fields."""
+
+    metadata = CodexWorker._validate_pull_request_metadata(
+        title="MM-707 Validate semantic pull request metadata",
+        body=(
+            "Jira: https://moonladder.atlassian.net/browse/MM-707\n"
+            "MoonSpec: specs/707-pr-metadata-validation\n"
+            "Summary: Added semantic PR metadata validation.\n"
+            "Verification verdict: PASS.\n"
+            "Tests: ./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py\n"
+            "Remaining risks: None."
+        ),
+        canonical_payload={
+            "task": {
+                "jiraIssueKey": "MM-707",
+                "moonSpecPath": "specs/707-pr-metadata-validation",
+            }
+        },
+    )
+
+    assert metadata.title == "MM-707 Validate semantic pull request metadata"
+    assert metadata.jira_issue_key == "MM-707"
+    assert metadata.moon_spec_path == "specs/707-pr-metadata-validation"
+
+
+@pytest.mark.parametrize(
+    ("title", "body", "match"),
+    [
+        (
+            "Validate semantic pull request metadata",
+            "Jira: https://moonladder.atlassian.net/browse/MM-707\n"
+            "MoonSpec: specs/707-pr-metadata-validation\n"
+            "Summary: Added validation.\n"
+            "Verification verdict: PASS.\n"
+            "Tests: unit\n"
+            "Remaining risks: None.",
+            "canonical Jira issue key",
+        ),
+        (
+            "MM-707",
+            "Jira: https://moonladder.atlassian.net/browse/MM-707\n"
+            "MoonSpec: specs/707-pr-metadata-validation\n"
+            "Summary: Added validation.\n"
+            "Verification verdict: PASS.\n"
+            "Tests: unit\n"
+            "Remaining risks: None.",
+            "implemented capability",
+        ),
+        (
+            "MM-707 Validate semantic pull request metadata",
+            "Jira: https://moonladder.atlassian.net/browse/MM-707\n"
+            "MoonSpec: specs/707-pr-metadata-validation\n"
+            "Summary: Added validation.\n"
+            "Verification verdict: PASS.\n"
+            "Tests: unit\n",
+            "Remaining risks",
+        ),
+    ],
+)
+async def test_validate_pr_metadata_rejects_invalid_jira_metadata(
+    title: str, body: str, match: str
+) -> None:
+    """Jira-backed metadata has deterministic title/body invariants."""
+
+    with pytest.raises(ValueError, match=match):
+        CodexWorker._validate_pull_request_metadata(
+            title=title,
+            body=body,
+            canonical_payload={"task": {"jiraIssueKey": "MM-707"}},
+        )
+
 async def test_parse_git_status_paths_collects_renamed_source_paths() -> None:
     """Git status parser should include both sides of a rename or copy for safety."""
 
@@ -8352,6 +8447,214 @@ async def test_run_publish_stage_uses_verbatim_overrides_and_redacts_command_log
         artifact.name == "reports/publish_preflight.json"
         for artifact in staged_artifacts
     )
+
+async def test_run_publish_stage_rejects_invalid_pr_metadata_before_pr_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid semantic metadata should fail before GitHub/CLI PR side effects."""
+
+    queue = FakeQueueClient(jobs=[])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(
+        config=CodexWorkerConfig(
+            moonmind_url="http://localhost:8000",
+            worker_id="worker-1",
+            worker_token=None,
+            poll_interval_ms=1500,
+            lease_seconds=120,
+            workdir=tmp_path,
+        ),
+        queue_client=queue,
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+
+    run_calls: list[tuple[str, ...]] = []
+
+    async def _capture_stage_command(
+        command,
+        *,
+        cwd,
+        log_path,
+        check=True,
+        env=None,
+        redaction_values=(),
+        cancel_event=None,
+    ):
+        _ = (cwd, log_path, check, env, redaction_values, cancel_event)
+        normalized = tuple(str(part) for part in command)
+        run_calls.append(normalized)
+        if normalized[:2] == ("git", "status"):
+            return CommandResult(normalized, 0, " M worker.py\n", "")
+        return CommandResult(normalized, 0, "", "")
+
+    monkeypatch.setattr(worker, "_run_stage_command", _capture_stage_command)
+
+    job_id = uuid4()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / str(job_id),
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "context",
+        publish_result_path=tmp_path / "publish-result.json",
+        default_branch="main",
+        starting_branch="main",
+        new_branch="feature/branch",
+        working_branch="feature/branch",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True, exist_ok=True)
+    prepared.task_context_path.mkdir(parents=True, exist_ok=True)
+    prepared.execute_log_path.write_text(
+        "[command] $ ./tools/test_unit.sh\nok\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="control-plane"):
+        await worker._run_publish_stage(
+            job_id=job_id,
+            canonical_payload={
+                "task": {
+                    "jiraIssueKey": "MM-707",
+                    "publish": {
+                        "mode": "pr",
+                        "prTitle": "Change Jira issue MM-707 to status In Progress before implementation starts.",
+                        "prBody": (
+                            "Use the trusted Jira issue updater workflow and Jira "
+                            "transition tools."
+                        ),
+                    },
+                }
+            },
+            prepared=prepared,
+            skill_meta={},
+            job_type="task",
+            staged_artifacts=[],
+        )
+
+    assert not any(call[:3] == ("gh", "pr", "create") for call in run_calls)
+
+
+async def test_run_publish_stage_records_validated_pr_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful PR publish should record validated metadata for downstream workflows."""
+
+    queue = FakeQueueClient(jobs=[])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(
+        config=CodexWorkerConfig(
+            moonmind_url="http://localhost:8000",
+            worker_id="worker-1",
+            worker_token=None,
+            poll_interval_ms=1500,
+            lease_seconds=120,
+            workdir=tmp_path,
+        ),
+        queue_client=queue,
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+
+    async def _capture_stage_command(
+        command,
+        *,
+        cwd,
+        log_path,
+        check=True,
+        env=None,
+        redaction_values=(),
+        cancel_event=None,
+    ):
+        _ = (cwd, log_path, check, env, redaction_values, cancel_event)
+        normalized = tuple(str(part) for part in command)
+        if normalized[:2] == ("git", "status"):
+            return CommandResult(normalized, 0, " M worker.py\n", "")
+        if normalized[:3] == ("gh", "pr", "create"):
+            return CommandResult(
+                normalized,
+                0,
+                "https://github.com/MoonLadderStudios/MoonMind/pull/707\n",
+                "",
+            )
+        return CommandResult(normalized, 0, "", "")
+
+    monkeypatch.setattr(worker, "_run_stage_command", _capture_stage_command)
+
+    job_id = uuid4()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / str(job_id),
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "context",
+        publish_result_path=tmp_path / "publish-result.json",
+        default_branch="main",
+        starting_branch="main",
+        new_branch="feature/branch",
+        working_branch="feature/branch",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True, exist_ok=True)
+    prepared.task_context_path.mkdir(parents=True, exist_ok=True)
+    prepared.execute_log_path.write_text(
+        "[command] $ ./tools/test_unit.sh "
+        "tests/unit/agents/codex_worker/test_worker.py\nok\n",
+        encoding="utf-8",
+    )
+
+    pr_title = "MM-707 Validate semantic pull request metadata"
+    pr_body = (
+        "Jira: https://moonladder.atlassian.net/browse/MM-707\n"
+        "MoonSpec: specs/707-pr-metadata-validation\n"
+        "Summary: Added semantic PR metadata validation.\n"
+        "Verification verdict: PASS.\n"
+        "Tests: ./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py\n"
+        "Remaining risks: None."
+    )
+    publish_note = await worker._run_publish_stage(
+        job_id=job_id,
+        canonical_payload={
+            "task": {
+                "jiraIssueKey": "MM-707",
+                "moonSpecPath": "specs/707-pr-metadata-validation",
+                "publish": {
+                    "mode": "pr",
+                    "prTitle": pr_title,
+                    "prBody": pr_body,
+                },
+            }
+        },
+        prepared=prepared,
+        skill_meta={},
+        job_type="task",
+        staged_artifacts=[],
+    )
+
+    assert publish_note == "published PR https://github.com/MoonLadderStudios/MoonMind/pull/707"
+    publish_payload = json.loads(
+        prepared.publish_result_path.read_text(encoding="utf-8")
+    )
+    assert publish_payload["readinessState"] == "pending"
+    assert publish_payload["prMetadata"] == {
+        "title": pr_title,
+        "body": pr_body,
+        "jiraIssueKey": "MM-707",
+        "moonSpecPath": "specs/707-pr-metadata-validation",
+    }
 
 async def test_run_publish_stage_fails_without_verification_evidence_for_source_changes(
     tmp_path: Path,


### PR DESCRIPTION
Jira: MM-707
MoonSpec: specs/707-pr-metadata-validation
Summary: Validate semantic pull request metadata before managed PR publication. The runtime rejects control-plane PR titles/bodies before PR side effects, enforces Jira-backed title/body invariants, and records validated PR metadata plus readiness state for downstream workflows.
Verification verdict: FULLY_IMPLEMENTED
Tests run:
- ./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py tests/unit/publish/test_publish_service_github_auth.py -q (PASS)
- pytest tests/integration/temporal/test_github_publish_readiness_boundaries.py -q --tb=short (PASS)
- ./tools/test_integration.sh (NOT RUN: Docker daemon returned 403 Forbidden in this managed runtime; direct relevant boundary passed)
Remaining risks: Docker-backed integration wrapper could not run in this container due runtime Docker policy; the direct GitHub diagnostics boundary passed.
