### PR TITLE
MM-714 Complete canonical Step Attempt manifest evidence

### DIFF
--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6603,6 +6603,10 @@ export interface components {
             childRunId?: string | null;
             /** Taskrunid */
             taskRunId?: string | null;
+            /** Latestattemptmanifestref */
+            latestAttemptManifestRef?: string | null;
+            /** Attemptmanifestrefs */
+            attemptManifestRefs?: string[];
         };
         /**
          * StepLedgerResumePreservationModel

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -206,6 +206,7 @@ class StepAttemptManifestModel(BaseModel):
             "workspace": self.workspace,
             "execution": self.execution,
             "outputs": self.outputs,
+            "checks": self.checks,
             "sideEffects": self.side_effects,
             "dependencyEffects": self.dependency_effects,
             "budget": self.budget,

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -54,6 +54,43 @@ TASK_RUN_ID_MEMO_KEYS = ("taskRunId", "task_run_id")
 TASK_RUN_ID_SEARCH_ATTR_KEYS = ("mm_task_run_id",)
 TASK_RUN_ID_PARAM_KEYS = ("taskRunId", "task_run_id")
 
+STEP_ATTEMPT_MANIFEST_CONTENT_TYPE = (
+    "application/vnd.moonmind.step-attempt+json;version=1"
+)
+
+StepAttemptReason = Literal[
+    "initial_execution",
+    "quality_gate_failed",
+    "tests_failed",
+    "runtime_recovered",
+    "resume_from_failed_step",
+    "remediation_context",
+    "operator_requested",
+    "dependency_invalidated",
+    "policy_revalidation",
+]
+StepAttemptStatus = Literal[
+    "pending",
+    "preparing",
+    "running",
+    "checking",
+    "succeeded",
+    "failed",
+    "blocked",
+    "canceled",
+    "superseded",
+]
+StepAttemptTerminalDisposition = Literal[
+    "accepted",
+    "retryable",
+    "blocked",
+    "needs_human",
+    "discarded",
+    "superseded",
+    "failed_unrecoverable",
+]
+StepAttemptSemanticOperation = Literal["retry", "reattempt", "resume"]
+
 def normalize_dependency_ids(raw_value: Any) -> list[str]:
     """Normalize a list of dependency IDs, stripping whitespace and removing duplicates/non-strings."""
     if not isinstance(raw_value, list):
@@ -69,6 +106,127 @@ def normalize_dependency_ids(raw_value: Any) -> list[str]:
         seen.add(candidate)
         normalized.append(candidate)
     return normalized
+
+
+class StepAttemptIdentityModel(BaseModel):
+    """Run-scoped identity for one semantic execution of a logical step."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    workflow_id: str = Field(..., alias="workflowId", min_length=1)
+    run_id: str = Field(..., alias="runId", min_length=1)
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    attempt: int = Field(..., alias="attempt", ge=1)
+
+
+class StepAttemptLineageModel(BaseModel):
+    """Optional cross-run provenance for resumed or related attempts."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    source_workflow_id: str = Field(..., alias="sourceWorkflowId", min_length=1)
+    source_run_id: str = Field(..., alias="sourceRunId", min_length=1)
+    source_logical_step_id: str = Field(
+        ..., alias="sourceLogicalStepId", min_length=1
+    )
+    source_attempt: int = Field(..., alias="sourceAttempt", ge=1)
+    relationship: str | None = Field(None, alias="relationship")
+    lineage_attempt_ordinal: int | None = Field(
+        None, alias="lineageAttemptOrdinal", ge=1
+    )
+
+
+class StepAttemptSummaryRefModel(BaseModel):
+    """Compact workflow-visible reference to artifact-backed attempt evidence."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    manifest_artifact_ref: str = Field(..., alias="manifestArtifactRef", min_length=1)
+    step_attempt_id: str = Field(..., alias="stepAttemptId", min_length=1)
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    attempt: int = Field(..., alias="attempt", ge=1)
+    reason: StepAttemptReason = Field(..., alias="reason")
+    status: StepAttemptStatus = Field(..., alias="status")
+    terminal_disposition: StepAttemptTerminalDisposition | None = Field(
+        None, alias="terminalDisposition"
+    )
+    summary: str | None = Field(None, alias="summary", max_length=1000)
+
+
+class StepAttemptManifestModel(BaseModel):
+    """Artifact-backed Step Attempt manifest payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["v1"] = Field("v1", alias="schemaVersion")
+    step_attempt_id: str = Field(..., alias="stepAttemptId", min_length=1)
+    workflow_id: str = Field(..., alias="workflowId", min_length=1)
+    run_id: str = Field(..., alias="runId", min_length=1)
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    attempt: int = Field(..., alias="attempt", ge=1)
+    attempt_scope: Literal["run"] = Field("run", alias="attemptScope")
+    lineage: StepAttemptLineageModel | None = Field(None, alias="lineage")
+    reason: StepAttemptReason = Field(..., alias="reason")
+    status: StepAttemptStatus = Field(..., alias="status")
+    terminal_disposition: StepAttemptTerminalDisposition | None = Field(
+        None, alias="terminalDisposition"
+    )
+    started_at: datetime | None = Field(None, alias="startedAt")
+    updated_at: datetime | None = Field(None, alias="updatedAt")
+    input: dict[str, Any] = Field(default_factory=dict, alias="input")
+    context: dict[str, Any] = Field(default_factory=dict, alias="context")
+    workspace: dict[str, Any] = Field(default_factory=dict, alias="workspace")
+    execution: dict[str, Any] = Field(default_factory=dict, alias="execution")
+    outputs: dict[str, Any] = Field(default_factory=dict, alias="outputs")
+    checks: list[dict[str, Any]] = Field(default_factory=list, alias="checks")
+    side_effects: dict[str, Any] = Field(default_factory=dict, alias="sideEffects")
+    dependency_effects: dict[str, Any] = Field(
+        default_factory=dict, alias="dependencyEffects"
+    )
+    budget: dict[str, Any] = Field(default_factory=dict, alias="budget")
+
+
+class StepAttemptBoundaryResultModel(BaseModel):
+    """Compact activity/workflow boundary result for attempt manifest operations."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    identity: StepAttemptIdentityModel = Field(..., alias="identity")
+    manifest_artifact_ref: str = Field(..., alias="manifestArtifactRef", min_length=1)
+    idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
+    summary: str | None = Field(None, alias="summary", max_length=1000)
+
+
+class StepAttemptSemanticOperationModel(BaseModel):
+    """Explicit semantic operation label that keeps retry, reattempt, and resume distinct."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    kind: StepAttemptSemanticOperation = Field(..., alias="kind")
+
+
+def build_step_attempt_id(identity: StepAttemptIdentityModel) -> str:
+    """Build the deterministic identifier for a Step Attempt."""
+
+    return (
+        f"{identity.workflow_id}:{identity.run_id}:"
+        f"{identity.logical_step_id}:attempt:{identity.attempt}"
+    )
+
+
+def build_step_attempt_idempotency_key(
+    identity: StepAttemptIdentityModel,
+    operation: str,
+) -> str:
+    """Build a deterministic idempotency key for an attempt-scoped side effect."""
+
+    normalized_operation = str(operation or "").strip()
+    if not normalized_operation:
+        raise ValueError("operation must be a non-empty string")
+    return (
+        f"{identity.workflow_id}:{identity.run_id}:"
+        f"{identity.logical_step_id}:{identity.attempt}:{normalized_operation}"
+    )
 
 class PullRequestRefModel(BaseModel):
     """Compact pull request identity carried through merge automation history."""
@@ -1099,6 +1257,12 @@ class StepLedgerRefsModel(BaseModel):
     child_workflow_id: str | None = Field(None, alias="childWorkflowId")
     child_run_id: str | None = Field(None, alias="childRunId")
     task_run_id: str | None = Field(None, alias="taskRunId")
+    latest_attempt_manifest_ref: str | None = Field(
+        None, alias="latestAttemptManifestRef"
+    )
+    attempt_manifest_refs: list[str] = Field(
+        default_factory=list, alias="attemptManifestRefs"
+    )
 
 class StepLedgerArtifactsModel(BaseModel):
     """Stable semantic artifact slots for step evidence."""

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -90,6 +90,19 @@ StepAttemptTerminalDisposition = Literal[
     "failed_unrecoverable",
 ]
 StepAttemptSemanticOperation = Literal["retry", "reattempt", "resume"]
+_STEP_ATTEMPT_INLINE_EVIDENCE_KEYS = {
+    "content",
+    "diff",
+    "diagnostics",
+    "log",
+    "logs",
+    "logtext",
+    "payload",
+    "provideroutput",
+    "raw",
+    "stderr",
+    "stdout",
+}
 
 def normalize_dependency_ids(raw_value: Any) -> list[str]:
     """Normalize a list of dependency IDs, stripping whitespace and removing duplicates/non-strings."""
@@ -184,6 +197,55 @@ class StepAttemptManifestModel(BaseModel):
         default_factory=dict, alias="dependencyEffects"
     )
     budget: dict[str, Any] = Field(default_factory=dict, alias="budget")
+
+    @model_validator(mode="after")
+    def _validate_compact_evidence(self) -> "StepAttemptManifestModel":
+        sections = {
+            "input": self.input,
+            "context": self.context,
+            "workspace": self.workspace,
+            "execution": self.execution,
+            "outputs": self.outputs,
+            "sideEffects": self.side_effects,
+            "dependencyEffects": self.dependency_effects,
+            "budget": self.budget,
+        }
+        for section_name, section_value in sections.items():
+            self._reject_inline_evidence(section_value, section_name)
+        return self
+
+    @classmethod
+    def _reject_inline_evidence(cls, value: Any, path: str) -> None:
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                key_text = str(key)
+                normalized = (
+                    key_text.replace("_", "")
+                    .replace("-", "")
+                    .replace(" ", "")
+                    .lower()
+                )
+                is_ref_key = normalized.endswith("ref") or normalized.endswith("refs")
+                is_summary_key = "summary" in normalized or "message" in normalized
+                if (
+                    normalized in _STEP_ATTEMPT_INLINE_EVIDENCE_KEYS
+                    and not is_ref_key
+                    and not is_summary_key
+                ):
+                    raise ValueError(
+                        "Step Attempt manifests must store large evidence as "
+                        f"compact refs, not inline values at {path}.{key_text}."
+                    )
+                if isinstance(nested, str) and len(nested) > 1000:
+                    if not is_ref_key and not is_summary_key:
+                        raise ValueError(
+                            "Step Attempt manifests must store large evidence as "
+                            f"compact refs, not inline values at {path}.{key_text}."
+                        )
+                cls._reject_inline_evidence(nested, f"{path}.{key_text}")
+        elif isinstance(value, list):
+            for index, nested in enumerate(value):
+                cls._reject_inline_evidence(nested, f"{path}[{index}]")
 
 
 class StepAttemptBoundaryResultModel(BaseModel):

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -17,6 +17,8 @@ def default_step_refs() -> dict[str, Any]:
         "childWorkflowId": None,
         "childRunId": None,
         "taskRunId": None,
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
 
 def default_step_artifacts() -> dict[str, Any]:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -65,7 +65,12 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.temporal_models import (
         DependencyResolvedSignalPayload,
         ExecutionProgressModel,
+        STEP_ATTEMPT_MANIFEST_CONTENT_TYPE,
+        StepAttemptIdentityModel,
+        StepAttemptManifestModel,
         StepLedgerSnapshotModel,
+        build_step_attempt_id,
+        build_step_attempt_idempotency_key,
         normalize_dependency_ids,
     )
 
@@ -647,6 +652,8 @@ class MoonMindRunWorkflow:
         *,
         name: str,
         payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
     ) -> str:
         artifact_create_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "artifact.create"
@@ -654,20 +661,29 @@ class MoonMindRunWorkflow:
         artifact_write_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "artifact.write_complete"
         )
-        artifact_ref, _upload_desc = await workflow.execute_activity(
+        create_payload: dict[str, Any] = {
+            "principal": self._principal(),
+            "name": name,
+            "content_type": content_type,
+        }
+        if metadata_json:
+            create_payload["metadata_json"] = dict(metadata_json)
+        artifact_create_result = await workflow.execute_activity(
             "artifact.create",
-            {
-                "principal": self._principal(),
-                "name": name,
-                "content_type": "application/json",
-            },
+            create_payload,
             **self._execute_kwargs_for_route(artifact_create_route),
         )
+        if isinstance(artifact_create_result, tuple) and artifact_create_result:
+            artifact_ref = artifact_create_result[0]
+        else:
+            artifact_ref = artifact_create_result
         artifact_id = (
             self._get_from_result(artifact_ref, "artifact_id")
             or self._get_from_result(artifact_ref, "artifactId")
             or ""
         )
+        if not artifact_id and content_type == STEP_ATTEMPT_MANIFEST_CONTENT_TYPE:
+            return f"virtual://{name}"
         if not artifact_id:
             raise ValueError(f"artifact.create returned no artifact_id for {name}")
         await execute_typed_activity(
@@ -676,11 +692,106 @@ class MoonMindRunWorkflow:
                 principal=self._principal(),
                 artifact_id=artifact_id,
                 payload=json.dumps(payload).encode("utf-8"),
-                content_type="application/json",
+                content_type=content_type,
             ),
             **self._execute_kwargs_for_route(artifact_write_route),
         )
         return str(artifact_id)
+
+    async def _record_step_attempt_manifest_start(
+        self,
+        logical_step_id: str,
+        *,
+        updated_at: datetime,
+        reason: str,
+    ) -> str | None:
+        attempt = self._step_attempt_for(logical_step_id)
+        if attempt is None or attempt < 1:
+            return None
+        identity = StepAttemptIdentityModel(
+            workflowId=workflow.info().workflow_id,
+            runId=workflow.info().run_id,
+            logicalStepId=logical_step_id,
+            attempt=attempt,
+        )
+        step_attempt_id = build_step_attempt_id(identity)
+        idempotency_key = build_step_attempt_idempotency_key(identity, "manifest")
+        manifest = StepAttemptManifestModel(
+            schemaVersion="v1",
+            stepAttemptId=step_attempt_id,
+            workflowId=identity.workflow_id,
+            runId=identity.run_id,
+            logicalStepId=identity.logical_step_id,
+            attempt=identity.attempt,
+            attemptScope="run",
+            reason=reason,
+            status="running",
+            terminalDisposition=None,
+            startedAt=updated_at,
+            updatedAt=updated_at,
+            input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
+            context={},
+            workspace={
+                "policy": (
+                    "initial_workspace"
+                    if identity.attempt == 1
+                    else "continue_from_previous_attempt"
+                )
+            },
+            execution={},
+            outputs={},
+            checks=[],
+            sideEffects={},
+            dependencyEffects={"invalidatedLogicalStepIds": []},
+            budget={},
+        )
+        try:
+            manifest_ref = await self._write_json_artifact(
+                name=(
+                    f"reports/step_attempts/{logical_step_id}_attempt_{attempt}.json"
+                ),
+                payload=manifest.model_dump(
+                    by_alias=True,
+                    exclude_none=True,
+                    mode="json",
+                ),
+                content_type=STEP_ATTEMPT_MANIFEST_CONTENT_TYPE,
+                metadata_json={
+                    "artifact_kind": "step_attempt_manifest",
+                    "stepAttemptId": step_attempt_id,
+                    "logicalStepId": logical_step_id,
+                    "attempt": attempt,
+                    "idempotencyKey": idempotency_key,
+                },
+            )
+        except AssertionError:
+            return None
+        except Exception as exc:
+            if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
+                return None
+            raise
+        for row in self._step_ledger_rows:
+            if row.get("logicalStepId") != logical_step_id:
+                continue
+            refs = dict(row.get("refs") or {})
+            history = [
+                ref
+                for ref in refs.get("attemptManifestRefs", [])
+                if isinstance(ref, str) and ref.strip()
+            ]
+            if manifest_ref not in history:
+                history.append(manifest_ref)
+            refs["latestAttemptManifestRef"] = manifest_ref
+            refs["attemptManifestRefs"] = history
+            update_step_row(
+                self._step_ledger_rows,
+                logical_step_id,
+                updated_at=updated_at,
+                refs=refs,
+            )
+            self._sync_progress_snapshot(updated_at=updated_at)
+            return manifest_ref
+        return manifest_ref
 
     async def _bundle_ordered_nodes_for_execution(
         self,
@@ -3115,6 +3226,11 @@ class MoonMindRunWorkflow:
                     updated_at=workflow.now(),
                     summary=self._summary,
                 )
+                await self._record_step_attempt_manifest_start(
+                    node_id,
+                    updated_at=workflow.now(),
+                    reason="initial_execution",
+                )
 
                 system_retries = 0
                 while system_retries <= 3:
@@ -3387,6 +3503,11 @@ class MoonMindRunWorkflow:
                                 node_id,
                                 updated_at=workflow.now(),
                                 summary=self._summary,
+                            )
+                            await self._record_step_attempt_manifest_start(
+                                node_id,
+                                updated_at=workflow.now(),
+                                reason="runtime_recovered",
                             )
                             continue
 
@@ -4224,6 +4345,11 @@ class MoonMindRunWorkflow:
                 node_id,
                 updated_at=workflow.now(),
                 summary=f"Re-checking Jira blockers for {tool_name}",
+            )
+            await self._record_step_attempt_manifest_start(
+                node_id,
+                updated_at=workflow.now(),
+                reason="policy_revalidation",
             )
             recheck_payload = dict(execute_payload)
             idempotency_key = recheck_payload.get("idempotency_key")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -716,6 +716,15 @@ class MoonMindRunWorkflow:
         )
         step_attempt_id = build_step_attempt_id(identity)
         idempotency_key = build_step_attempt_idempotency_key(identity, "manifest")
+        source_attempt = self._step_attempt_source_identity(
+            logical_step_id,
+            attempt=attempt,
+        )
+        lineage = self._step_attempt_lineage(
+            logical_step_id,
+            reason=reason,
+            source_attempt=source_attempt,
+        )
         manifest = StepAttemptManifestModel(
             schemaVersion="v1",
             stepAttemptId=step_attempt_id,
@@ -724,6 +733,7 @@ class MoonMindRunWorkflow:
             logicalStepId=identity.logical_step_id,
             attempt=identity.attempt,
             attemptScope="run",
+            lineage=lineage,
             reason=reason,
             status="running",
             terminalDisposition=None,
@@ -731,16 +741,17 @@ class MoonMindRunWorkflow:
             updatedAt=updated_at,
             input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
             context={},
-            workspace={
-                "policy": (
-                    "initial_workspace"
-                    if identity.attempt == 1
-                    else "continue_from_previous_attempt"
-                )
-            },
-            execution={},
-            outputs={},
-            checks=[],
+            workspace=self._step_attempt_workspace(
+                logical_step_id,
+                attempt=identity.attempt,
+                source_attempt=source_attempt,
+            ),
+            execution=self._step_attempt_compact_execution_refs(logical_step_id),
+            outputs=self._step_attempt_compact_output_refs(logical_step_id),
+            checks=list(
+                (self._step_ledger_row_for(logical_step_id) or {}).get("checks")
+                or []
+            ),
             sideEffects={},
             dependencyEffects={"invalidatedLogicalStepIds": []},
             budget={},
@@ -979,6 +990,168 @@ class MoonMindRunWorkflow:
             if isinstance(value, str) and value.strip():
                 return value.strip()
         return ""
+
+    def _resume_source_int(
+        self,
+        source: Mapping[str, Any],
+        *keys: str,
+    ) -> int | None:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int) and value >= 1:
+                return value
+            if isinstance(value, str) and value.strip():
+                try:
+                    parsed = int(value.strip())
+                except ValueError:
+                    continue
+                if parsed >= 1:
+                    return parsed
+        return None
+
+    def _step_attempt_source_identity(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+    ) -> dict[str, Any] | None:
+        if attempt > 1:
+            info = workflow.info()
+            return {
+                "workflowId": info.workflow_id,
+                "runId": info.run_id,
+                "logicalStepId": logical_step_id,
+                "attempt": attempt - 1,
+            }
+        resume_source = self._resume_source
+        if (
+            not isinstance(resume_source, Mapping)
+            or logical_step_id != self._resume_failed_step_id
+        ):
+            return None
+        source_workflow_id = self._resume_source_text(
+            resume_source,
+            "sourceWorkflowId",
+            "source_workflow_id",
+        )
+        source_run_id = self._resume_source_text(
+            resume_source,
+            "sourceRunId",
+            "source_run_id",
+        )
+        source_logical_step_id = self._resume_source_text(
+            resume_source,
+            "failedStepId",
+            "failed_step_id",
+        )
+        source_attempt = self._resume_source_int(
+            resume_source,
+            "failedStepAttempt",
+            "failed_step_attempt",
+        )
+        if (
+            not source_workflow_id
+            or not source_run_id
+            or not source_logical_step_id
+            or not source_attempt
+        ):
+            return None
+        return {
+            "workflowId": source_workflow_id,
+            "runId": source_run_id,
+            "logicalStepId": source_logical_step_id,
+            "attempt": source_attempt,
+        }
+
+    def _step_attempt_lineage(
+        self,
+        logical_step_id: str,
+        *,
+        reason: str,
+        source_attempt: Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if not source_attempt or logical_step_id != self._resume_failed_step_id:
+            return None
+        return {
+            "sourceWorkflowId": source_attempt["workflowId"],
+            "sourceRunId": source_attempt["runId"],
+            "sourceLogicalStepId": source_attempt["logicalStepId"],
+            "sourceAttempt": source_attempt["attempt"],
+            "relationship": reason,
+            "lineageAttemptOrdinal": 1,
+        }
+
+    def _step_attempt_workspace(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+        source_attempt: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        if source_attempt and logical_step_id == self._resume_failed_step_id:
+            workspace = {
+                "policy": "resume_from_source_attempt",
+                "sourceAttempt": dict(source_attempt),
+            }
+            if self._resume_workspace_restored_ref:
+                workspace["restoredCheckpointRef"] = self._resume_workspace_restored_ref
+            return workspace
+        if attempt > 1:
+            return {
+                "policy": "continue_from_previous_attempt",
+                "sourceAttempt": dict(source_attempt) if source_attempt else None,
+            }
+        return {"policy": "initial_workspace"}
+
+    def _step_attempt_compact_execution_refs(
+        self,
+        logical_step_id: str,
+    ) -> dict[str, Any]:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return {}
+        refs = row.get("refs")
+        artifacts = row.get("artifacts")
+        execution: dict[str, Any] = {}
+        if isinstance(refs, Mapping):
+            for source_key, target_key in (
+                ("childWorkflowId", "childWorkflowId"),
+                ("childRunId", "childRunId"),
+                ("taskRunId", "taskRunId"),
+            ):
+                value = refs.get(source_key)
+                if isinstance(value, str) and value.strip():
+                    execution[target_key] = value.strip()
+        if isinstance(artifacts, Mapping):
+            diagnostics_ref = artifacts.get("runtimeDiagnostics")
+            if isinstance(diagnostics_ref, str) and diagnostics_ref.strip():
+                execution["diagnosticsRef"] = diagnostics_ref.strip()
+        return execution
+
+    def _step_attempt_compact_output_refs(
+        self,
+        logical_step_id: str,
+    ) -> dict[str, Any]:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return {}
+        artifacts = row.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            return {}
+        outputs: dict[str, Any] = {}
+        for source_key, target_key in (
+            ("outputSummary", "summaryRef"),
+            ("outputPrimary", "primaryRef"),
+            ("runtimeStdout", "stdoutRef"),
+            ("runtimeStderr", "stderrRef"),
+            ("runtimeMergedLogs", "logsRef"),
+        ):
+            value = artifacts.get(source_key)
+            if isinstance(value, str) and value.strip():
+                outputs[target_key] = value.strip()
+        return outputs
 
     def _resume_workspace_checkpoint_ref(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -746,6 +746,72 @@ class MoonMindRunWorkflow:
                 attempt=identity.attempt,
                 source_attempt=source_attempt,
             ),
+            execution={},
+            outputs={},
+            checks=[],
+            sideEffects={},
+            dependencyEffects={"invalidatedLogicalStepIds": []},
+            budget={},
+        )
+        return await self._write_step_attempt_manifest(
+            logical_step_id,
+            attempt=attempt,
+            manifest=manifest,
+            step_attempt_id=step_attempt_id,
+            idempotency_key=idempotency_key,
+            updated_at=updated_at,
+        )
+
+    async def _record_step_attempt_manifest_terminal(
+        self,
+        logical_step_id: str,
+        *,
+        updated_at: datetime,
+        reason: str,
+        status: str,
+        terminal_disposition: str,
+    ) -> str | None:
+        attempt = self._step_attempt_for(logical_step_id)
+        if attempt is None or attempt < 1:
+            return None
+        identity = StepAttemptIdentityModel(
+            workflowId=workflow.info().workflow_id,
+            runId=workflow.info().run_id,
+            logicalStepId=logical_step_id,
+            attempt=attempt,
+        )
+        step_attempt_id = build_step_attempt_id(identity)
+        idempotency_key = build_step_attempt_idempotency_key(identity, "manifest")
+        source_attempt = self._step_attempt_source_identity(
+            logical_step_id,
+            attempt=attempt,
+        )
+        lineage = self._step_attempt_lineage(
+            logical_step_id,
+            reason=reason,
+            source_attempt=source_attempt,
+        )
+        manifest = StepAttemptManifestModel(
+            schemaVersion="v1",
+            stepAttemptId=step_attempt_id,
+            workflowId=identity.workflow_id,
+            runId=identity.run_id,
+            logicalStepId=identity.logical_step_id,
+            attempt=identity.attempt,
+            attemptScope="run",
+            lineage=lineage,
+            reason=reason,
+            status=status,
+            terminalDisposition=terminal_disposition,
+            startedAt=self._step_attempt_started_at(logical_step_id),
+            updatedAt=updated_at,
+            input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
+            context={},
+            workspace=self._step_attempt_workspace(
+                logical_step_id,
+                attempt=identity.attempt,
+                source_attempt=source_attempt,
+            ),
             execution=self._step_attempt_compact_execution_refs(logical_step_id),
             outputs=self._step_attempt_compact_output_refs(logical_step_id),
             checks=list(
@@ -756,6 +822,25 @@ class MoonMindRunWorkflow:
             dependencyEffects={"invalidatedLogicalStepIds": []},
             budget={},
         )
+        return await self._write_step_attempt_manifest(
+            logical_step_id,
+            attempt=attempt,
+            manifest=manifest,
+            step_attempt_id=step_attempt_id,
+            idempotency_key=idempotency_key,
+            updated_at=updated_at,
+        )
+
+    async def _write_step_attempt_manifest(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+        manifest: StepAttemptManifestModel,
+        step_attempt_id: str,
+        idempotency_key: str,
+        updated_at: datetime,
+    ) -> str | None:
         try:
             manifest_ref = await self._write_json_artifact(
                 name=(
@@ -775,8 +860,6 @@ class MoonMindRunWorkflow:
                     "idempotencyKey": idempotency_key,
                 },
             )
-        except AssertionError:
-            return None
         except Exception as exc:
             if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
                 return None
@@ -1080,8 +1163,16 @@ class MoonMindRunWorkflow:
             "sourceLogicalStepId": source_attempt["logicalStepId"],
             "sourceAttempt": source_attempt["attempt"],
             "relationship": reason,
-            "lineageAttemptOrdinal": 1,
+            "lineageAttemptOrdinal": int(source_attempt["attempt"])
+            + (self._step_attempt_for(logical_step_id) or 0),
         }
+
+    def _step_attempt_started_at(self, logical_step_id: str) -> datetime | None:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return None
+        value = row.get("startedAt") or row.get("started_at")
+        return value if isinstance(value, datetime) else None
 
     def _step_attempt_workspace(
         self,
@@ -3399,10 +3490,15 @@ class MoonMindRunWorkflow:
                     updated_at=workflow.now(),
                     summary=self._summary,
                 )
+                attempt_reason = (
+                    "resume_from_failed_step"
+                    if node_id == self._resume_failed_step_id
+                    else "initial_execution"
+                )
                 await self._record_step_attempt_manifest_start(
                     node_id,
                     updated_at=workflow.now(),
-                    reason="initial_execution",
+                    reason=attempt_reason,
                 )
 
                 system_retries = 0
@@ -3664,6 +3760,13 @@ class MoonMindRunWorkflow:
                                 summary=f"{tool_name} failed",
                                 last_error=failure_message,
                             )
+                            await self._record_step_attempt_manifest_terminal(
+                                node_id,
+                                updated_at=workflow.now(),
+                                reason=attempt_reason,
+                                status="failed",
+                                terminal_disposition="retryable",
+                            )
                             system_retries += 1
                             self._get_logger().info(
                                 f"Retrying plan node {node_id} after {failure_message} "
@@ -3682,6 +3785,7 @@ class MoonMindRunWorkflow:
                                 updated_at=workflow.now(),
                                 reason="runtime_recovered",
                             )
+                            attempt_reason = "runtime_recovered"
                             continue
 
                         self._mark_step_terminal(
@@ -3691,6 +3795,13 @@ class MoonMindRunWorkflow:
                             summary=operator_failure_summary
                             or f"{tool_name} failed",
                             last_error=failure_message,
+                        )
+                        await self._record_step_attempt_manifest_terminal(
+                            node_id,
+                            updated_at=workflow.now(),
+                            reason=attempt_reason,
+                            status="failed",
+                            terminal_disposition="failed_unrecoverable",
                         )
                         if failure_mode == "FAIL_FAST":
                             if provider_failure_summary:
@@ -3847,6 +3958,13 @@ class MoonMindRunWorkflow:
                 summary=self._get_from_result(execution_result, "summary")
                 or self._summary,
                 last_error=None,
+            )
+            await self._record_step_attempt_manifest_terminal(
+                node_id,
+                updated_at=workflow.now(),
+                reason=attempt_reason,
+                status="succeeded",
+                terminal_disposition="accepted",
             )
             self._record_step_checkpoint_evidence(
                 node_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -682,8 +682,6 @@ class MoonMindRunWorkflow:
             or self._get_from_result(artifact_ref, "artifactId")
             or ""
         )
-        if not artifact_id and content_type == STEP_ATTEMPT_MANIFEST_CONTENT_TYPE:
-            return f"virtual://{name}"
         if not artifact_id:
             raise ValueError(f"artifact.create returned no artifact_id for {name}")
         await execute_typed_activity(
@@ -862,6 +860,19 @@ class MoonMindRunWorkflow:
             )
         except Exception as exc:
             if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
+                return None
+            if (
+                isinstance(exc, ValueError)
+                and str(exc).startswith("artifact.create returned no artifact_id")
+            ):
+                self._get_logger().warning(
+                    "Skipping step-attempt manifest without artifact id.",
+                    extra={
+                        "event": "step_attempt_manifest_missing_artifact_id",
+                        "logical_step_id": logical_step_id,
+                        "attempt": attempt,
+                    },
+                )
                 return None
             raise
         for row in self._step_ledger_rows:

--- a/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
@@ -159,6 +159,7 @@ async def test_resume_attempt_manifest_carries_lineage_without_large_payloads(
     assert manifest["lineage"]["sourceWorkflowId"] == "wf-source"
     assert manifest["lineage"]["sourceRunId"] == "run-source"
     assert manifest["lineage"]["sourceAttempt"] == 2
+    assert manifest["lineage"]["lineageAttemptOrdinal"] == 3
     assert manifest["workspace"]["restoredCheckpointRef"] == (
         "artifact://workspace/before-implement"
     )

--- a/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-boundary",
+        run_id="run-boundary",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["user-1"]},
+    )
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        isEnabledFor=lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "logger", logger)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
+
+
+async def test_step_attempt_manifest_refs_are_append_only_for_reexecution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    writes: list[dict[str, Any]] = []
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "implement",
+                "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+                "inputs": {"title": "Implement"},
+            }
+        ],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("implement", updated_at=now, summary="Initial")
+    await workflow._record_step_attempt_manifest_start(
+        "implement",
+        updated_at=now,
+        reason="initial_execution",
+    )
+    workflow._mark_step_terminal(
+        "implement",
+        status="failed",
+        updated_at=now,
+        summary="Failed gate",
+    )
+    workflow._mark_step_running("implement", updated_at=now, summary="Retry")
+    await workflow._record_step_attempt_manifest_start(
+        "implement",
+        updated_at=now,
+        reason="quality_gate_failed",
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["refs"]["latestAttemptManifestRef"] == "artifact-attempt-2"
+    assert step["refs"]["attemptManifestRefs"] == [
+        "artifact-attempt-1",
+        "artifact-attempt-2",
+    ]
+    assert writes[1]["payload"]["workspace"]["sourceAttempt"] == {
+        "workflowId": "wf-boundary",
+        "runId": "run-boundary",
+        "logicalStepId": "implement",
+        "attempt": 1,
+    }
+
+
+async def test_resume_attempt_manifest_carries_lineage_without_large_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._resume_source = {
+        "sourceWorkflowId": "wf-source",
+        "sourceRunId": "run-source",
+        "sourceTaskInputSnapshotRef": "artifact://snapshot/source",
+        "sourcePlanDigest": "sha256:source-plan",
+        "failedStepId": "implement",
+        "failedStepAttempt": 2,
+        "resumeCheckpointRef": "artifact://resume/checkpoint",
+        "resumeWorkspace": {
+            "checkpointRef": "artifact://workspace/before-implement",
+        },
+        "preservedSteps": [],
+    }
+    writes: list[dict[str, Any]] = []
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "title": "Implement"}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("implement", updated_at=now, summary="Resume")
+    await workflow._record_step_attempt_manifest_start(
+        "implement",
+        updated_at=now,
+        reason="resume_from_failed_step",
+    )
+
+    manifest = writes[0]["payload"]
+    assert manifest["lineage"]["sourceWorkflowId"] == "wf-source"
+    assert manifest["lineage"]["sourceRunId"] == "run-source"
+    assert manifest["lineage"]["sourceAttempt"] == 2
+    assert manifest["workspace"]["restoredCheckpointRef"] == (
+        "artifact://workspace/before-implement"
+    )
+    assert "payload" not in manifest

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -243,8 +243,8 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
     assert captured[3][1]["artifact_ref"] == "art_plan_1"
     assert captured[4][0] == "artifact.read"
     assert captured[4][1]["artifact_ref"] == "artifact://registry/1"
-    assert captured[5][0] == "mm.skill.execute"
-    assert captured[5][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    skill_call = next(item for item in captured if item[0] == "mm.skill.execute")
+    assert skill_call[1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 @pytest.mark.asyncio
 async def test_run_finalizing_stage_writes_dependency_summary_metadata(
@@ -430,8 +430,8 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
 
     # provider_profile.list calls (3) happen first, then artifact.read for plan,
     # artifact.read for registry, then mm.tool.execute
-    assert captured[5][0] == "mm.tool.execute"
-    assert captured[5][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    tool_call = next(item for item in captured if item[0] == "mm.tool.execute")
+    assert tool_call[1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_plan(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
+from itertools import count
 from typing import Any, Callable
 
 import pytest
@@ -13,6 +14,18 @@ def _normalize_payload(payload: Any) -> dict[str, Any]:
         return payload
     dump_method = getattr(payload, 'model_dump', getattr(payload, 'dict', None))
     return dump_method() if dump_method else payload
+
+def _step_attempt_artifact_create_result(
+    payload: Any,
+    artifact_ids: count,
+) -> tuple[dict[str, str], dict[str, str]] | None:
+    normalized = _normalize_payload(payload)
+    if not str(normalized.get("name") or "").startswith("reports/step_attempts/"):
+        return None
+    return (
+        {"artifact_id": f"art_step_attempt_{next(artifact_ids)}"},
+        {"upload_url": "unused"},
+    )
 
 async def _immediate_wait_condition(
     predicate: Callable[[], bool],
@@ -551,6 +564,7 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
     workflow._repo = "MoonLadderStudios/MoonMind"
     workflow._integration = None
     child_calls: list[str] = []
+    step_attempt_artifact_ids = count(1)
 
     async def fake_execute_activity(
         activity_type: str,
@@ -558,6 +572,13 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
         **_kwargs: Any,
     ) -> Any:
         normalized = _normalize_payload(payload)
+        if activity_type == "artifact.create":
+            artifact_create_result = _step_attempt_artifact_create_result(
+                payload,
+                step_attempt_artifact_ids,
+            )
+            if artifact_create_result is not None:
+                return artifact_create_result
         if activity_type == "artifact.read":
             assert normalized["artifact_ref"] == "art_plan_1"
             return json.dumps(
@@ -624,6 +645,15 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
     ) -> object:
         return request
 
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> object:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_activity(activity_type, payload, **kwargs)
+
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_activity",
@@ -633,6 +663,11 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
         run_workflow_module.workflow,
         "execute_child_workflow",
         fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
     )
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
@@ -694,6 +729,7 @@ async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
     workflow._owner_id = "owner-1"
     workflow._repo = "MoonLadderStudios/MoonMind"
     skill_calls: list[tuple[str, str | None]] = []
+    step_attempt_artifact_ids = count(1)
 
     registry_payload = {
         "skills": [
@@ -744,6 +780,13 @@ async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
         **_kwargs: Any,
     ) -> Any:
         normalized = _normalize_payload(payload)
+        if activity_type == "artifact.create":
+            artifact_create_result = _step_attempt_artifact_create_result(
+                payload,
+                step_attempt_artifact_ids,
+            )
+            if artifact_create_result is not None:
+                return artifact_create_result
         if activity_type == "artifact.read":
             artifact_ref = normalized.get("artifact_ref")
             if artifact_ref == "artifact://registry/jira":
@@ -820,10 +863,24 @@ async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
             return {"status": "COMPLETED", "outputs": {"summary": "Implemented."}}
         raise AssertionError(f"unexpected activity {activity_type}")
 
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> object:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_activity(activity_type, payload, **kwargs)
+
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_activity",
         fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
     )
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
@@ -2181,12 +2238,20 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
 
     workflow = MoonMindRunWorkflow()
     workflow._owner_id = "owner-1"
+    step_attempt_artifact_ids = count(1)
 
     async def fake_execute_activity(
         activity_type: str,
         payload: dict[str, object],
         **_kwargs: object,
     ) -> object:
+        if activity_type == "artifact.create":
+            artifact_create_result = _step_attempt_artifact_create_result(
+                payload,
+                step_attempt_artifact_ids,
+            )
+            if artifact_create_result is not None:
+                return artifact_create_result
         assert activity_type == "artifact.read"
         return json.dumps(
             {
@@ -2223,6 +2288,15 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
             }
         ).encode("utf-8")
 
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> object:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_activity(activity_type, payload, **kwargs)
+
     async def fake_execute_child_workflow(*_args: object, **_kwargs: object) -> AgentRunResult:
         return AgentRunResult(
             summary="http 401",
@@ -2249,6 +2323,11 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
         return None
 
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_child_workflow",

--- a/tests/unit/workflows/temporal/test_step_attempt_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_attempt_manifest.py
@@ -184,6 +184,29 @@ def test_step_attempt_manifest_rejects_large_inline_evidence() -> None:
         StepAttemptManifestModel.model_validate(payload)
 
 
+def test_step_attempt_manifest_rejects_large_inline_check_evidence() -> None:
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "stepAttemptId": "workflow-1:run-1:implement-story:attempt:2",
+        "attemptScope": "run",
+        "reason": "runtime_recovered",
+        "status": "running",
+        "input": {"taskInputSnapshotRef": "artifact-input"},
+        "context": {"contextBundleRef": "artifact-context"},
+        "workspace": {"policy": "continue_from_previous_attempt"},
+        "execution": {"kind": "agent_run"},
+        "outputs": {"summaryRef": "artifact-summary"},
+        "checks": [{"kind": "unit", "logText": "x" * 2000}],
+        "sideEffects": {},
+        "dependencyEffects": {"invalidatedLogicalStepIds": []},
+        "budget": {"attemptLimit": 3},
+    }
+
+    with pytest.raises(ValidationError, match="compact refs"):
+        StepAttemptManifestModel.model_validate(payload)
+
+
 def test_step_attempt_idempotency_key_uses_attempt_identity_and_operation() -> None:
     identity = StepAttemptIdentityModel.model_validate(_identity())
 

--- a/tests/unit/workflows/temporal/test_step_attempt_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_attempt_manifest.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.temporal_models import (
+    STEP_ATTEMPT_MANIFEST_CONTENT_TYPE,
+    StepAttemptBoundaryResultModel,
+    StepAttemptIdentityModel,
+    StepAttemptManifestModel,
+    StepAttemptSemanticOperationModel,
+    build_step_attempt_id,
+    build_step_attempt_idempotency_key,
+)
+
+
+def _identity() -> dict[str, object]:
+    return {
+        "workflowId": "workflow-1",
+        "runId": "run-1",
+        "logicalStepId": "implement-story",
+        "attempt": 2,
+    }
+
+
+def test_step_attempt_identity_builds_deterministic_id() -> None:
+    identity = StepAttemptIdentityModel.model_validate(_identity())
+
+    assert identity.workflow_id == "workflow-1"
+    assert identity.attempt == 2
+    assert build_step_attempt_id(identity) == (
+        "workflow-1:run-1:implement-story:attempt:2"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reason", "unbounded_reason"),
+        ("status", "unknown_status"),
+        ("terminalDisposition", "maybe_ok"),
+    ],
+)
+def test_step_attempt_manifest_rejects_unsupported_canonical_values(
+    field: str,
+    value: str,
+) -> None:
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "stepAttemptId": "workflow-1:run-1:implement-story:attempt:2",
+        "attemptScope": "run",
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+        "input": {"taskInputSnapshotRef": "artifact-input"},
+        "context": {"contextBundleRef": "artifact-context"},
+        "workspace": {"policy": "continue_from_previous_attempt"},
+        "execution": {"kind": "agent_run"},
+        "outputs": {"summaryRef": "artifact-summary"},
+        "checks": [],
+        "sideEffects": {"external": []},
+        "dependencyEffects": {"invalidatedLogicalStepIds": []},
+        "budget": {"attemptLimit": 3},
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        StepAttemptManifestModel.model_validate(payload)
+
+
+def test_step_attempt_manifest_accepts_canonical_payload_and_content_type() -> None:
+    manifest = StepAttemptManifestModel.model_validate(
+        {
+            **_identity(),
+            "schemaVersion": "v1",
+            "stepAttemptId": "workflow-1:run-1:implement-story:attempt:2",
+            "attemptScope": "run",
+            "lineage": {
+                "sourceWorkflowId": "workflow-0",
+                "sourceRunId": "run-0",
+                "sourceLogicalStepId": "implement-story",
+                "sourceAttempt": 1,
+                "relationship": "resume_from_failed_step",
+                "lineageAttemptOrdinal": 3,
+            },
+            "reason": "resume_from_failed_step",
+            "status": "succeeded",
+            "terminalDisposition": "accepted",
+            "input": {"taskInputSnapshotRef": "artifact-input"},
+            "context": {"contextBundleRef": "artifact-context"},
+            "workspace": {"policy": "apply_previous_diff_to_clean_baseline"},
+            "execution": {"kind": "agent_run", "childWorkflowId": "child-1"},
+            "outputs": {"summaryRef": "artifact-summary"},
+            "checks": [{"kind": "unit", "status": "passed"}],
+            "sideEffects": {"git": {"disposition": "accepted"}},
+            "dependencyEffects": {"invalidatedLogicalStepIds": []},
+            "budget": {"attemptLimit": 3, "remainingAttempts": 1},
+        }
+    )
+
+    assert STEP_ATTEMPT_MANIFEST_CONTENT_TYPE == (
+        "application/vnd.moonmind.step-attempt+json;version=1"
+    )
+    assert manifest.lineage is not None
+    assert manifest.lineage.source_attempt == 1
+    assert manifest.model_dump(by_alias=True)["terminalDisposition"] == "accepted"
+
+
+def test_step_attempt_idempotency_key_uses_attempt_identity_and_operation() -> None:
+    identity = StepAttemptIdentityModel.model_validate(_identity())
+
+    key = build_step_attempt_idempotency_key(identity, "manifest")
+
+    assert key == "workflow-1:run-1:implement-story:2:manifest"
+    assert build_step_attempt_idempotency_key(identity, "gate:unit") != key
+    changed_attempt = identity.model_copy(update={"attempt": 3})
+    assert build_step_attempt_idempotency_key(changed_attempt, "manifest") != key
+
+
+def test_step_attempt_boundary_result_is_compact_and_typed() -> None:
+    result = StepAttemptBoundaryResultModel.model_validate(
+        {
+            "identity": _identity(),
+            "manifestArtifactRef": "artifact-step-attempt-2",
+            "idempotencyKey": "workflow-1:run-1:implement-story:2:manifest",
+            "summary": "Attempt manifest created.",
+        }
+    )
+
+    serialized = result.model_dump(by_alias=True)
+    assert serialized["manifestArtifactRef"] == "artifact-step-attempt-2"
+    assert "manifest" not in serialized
+    assert "payload" not in serialized
+
+
+def test_step_attempt_semantic_operation_keeps_retry_reattempt_resume_distinct() -> None:
+    retry = StepAttemptSemanticOperationModel.model_validate({"kind": "retry"})
+    reattempt = StepAttemptSemanticOperationModel.model_validate({"kind": "reattempt"})
+    resume = StepAttemptSemanticOperationModel.model_validate({"kind": "resume"})
+
+    assert {retry.kind, reattempt.kind, resume.kind} == {
+        "retry",
+        "reattempt",
+        "resume",
+    }

--- a/tests/unit/workflows/temporal/test_step_attempt_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_attempt_manifest.py
@@ -107,6 +107,83 @@ def test_step_attempt_manifest_accepts_canonical_payload_and_content_type() -> N
     assert manifest.model_dump(by_alias=True)["terminalDisposition"] == "accepted"
 
 
+def test_step_attempt_manifest_accepts_compact_evidence_refs() -> None:
+    manifest = StepAttemptManifestModel.model_validate(
+        {
+            **_identity(),
+            "schemaVersion": "v1",
+            "stepAttemptId": "workflow-1:run-1:implement-story:attempt:2",
+            "attemptScope": "run",
+            "reason": "runtime_recovered",
+            "status": "running",
+            "input": {"taskInputSnapshotRef": "artifact-input"},
+            "context": {"contextBundleRef": "artifact-context"},
+            "workspace": {
+                "policy": "continue_from_previous_attempt",
+                "sourceAttempt": {
+                    "workflowId": "workflow-1",
+                    "runId": "run-1",
+                    "logicalStepId": "implement-story",
+                    "attempt": 1,
+                },
+            },
+            "execution": {
+                "childWorkflowId": "child-1",
+                "childRunId": "child-run-1",
+                "diagnosticsRef": "artifact-diagnostics",
+            },
+            "outputs": {
+                "summaryRef": "artifact-summary",
+                "diffRef": "artifact-diff",
+            },
+            "checks": [{"kind": "unit", "status": "passed"}],
+            "sideEffects": {
+                "git": {
+                    "disposition": "accepted",
+                    "evidenceRef": "artifact-git-side-effect",
+                }
+            },
+            "dependencyEffects": {"invalidatedLogicalStepIds": []},
+            "budget": {"attemptLimit": 3, "remainingAttempts": 1},
+        }
+    )
+
+    serialized = manifest.model_dump(by_alias=True)
+    assert serialized["execution"]["diagnosticsRef"] == "artifact-diagnostics"
+    assert serialized["outputs"]["diffRef"] == "artifact-diff"
+    assert serialized["sideEffects"]["git"]["evidenceRef"] == (
+        "artifact-git-side-effect"
+    )
+
+
+def test_step_attempt_manifest_rejects_large_inline_evidence() -> None:
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "stepAttemptId": "workflow-1:run-1:implement-story:attempt:2",
+        "attemptScope": "run",
+        "reason": "runtime_recovered",
+        "status": "running",
+        "input": {"taskInputSnapshotRef": "artifact-input"},
+        "context": {"contextBundleRef": "artifact-context"},
+        "workspace": {"policy": "continue_from_previous_attempt"},
+        "execution": {"kind": "agent_run"},
+        "outputs": {"summaryRef": "artifact-summary"},
+        "checks": [],
+        "sideEffects": {
+            "git": {
+                "disposition": "accepted",
+                "logText": "x" * 2000,
+            }
+        },
+        "dependencyEffects": {"invalidatedLogicalStepIds": []},
+        "budget": {"attemptLimit": 3},
+    }
+
+    with pytest.raises(ValidationError, match="compact refs"):
+        StepAttemptManifestModel.model_validate(payload)
+
+
 def test_step_attempt_idempotency_key_uses_attempt_identity_and_operation() -> None:
     identity = StepAttemptIdentityModel.model_validate(_identity())
 

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -49,6 +49,29 @@ def test_build_initial_step_rows_uses_plan_metadata_and_dependencies() -> None:
     assert rows[1]["status"] == "pending"
     assert rows[1]["dependsOn"] == ["step-1"]
     assert rows[1]["tool"] == {"type": "skill", "name": "repo.test", "version": "1"}
+    assert rows[0]["refs"]["latestAttemptManifestRef"] is None
+    assert rows[0]["refs"]["attemptManifestRefs"] == []
+
+
+def test_step_ledger_refs_track_latest_and_historical_attempt_manifests() -> None:
+    refs = StepLedgerRefsModel.model_validate(
+        {
+            "childWorkflowId": "child-1",
+            "childRunId": "run-child",
+            "taskRunId": "task-run",
+            "latestAttemptManifestRef": "artifact-attempt-2",
+            "attemptManifestRefs": ["artifact-attempt-1", "artifact-attempt-2"],
+        }
+    )
+
+    assert refs.latest_attempt_manifest_ref == "artifact-attempt-2"
+    assert refs.attempt_manifest_refs == [
+        "artifact-attempt-1",
+        "artifact-attempt-2",
+    ]
+    assert refs.model_dump(by_alias=True)["latestAttemptManifestRef"] == (
+        "artifact-attempt-2"
+    )
 
 def test_build_initial_step_rows_skips_blank_node_ids() -> None:
     updated_at = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
@@ -88,6 +111,8 @@ def test_build_initial_step_rows_skips_blank_node_ids() -> None:
                 "childWorkflowId": None,
                 "childRunId": None,
                 "taskRunId": None,
+                "latestAttemptManifestRef": None,
+                "attemptManifestRefs": [],
             },
             "artifacts": {
                 "outputSummary": None,
@@ -318,6 +343,8 @@ def test_row_defaults_remain_bounded_and_structured() -> None:
         "childWorkflowId": None,
         "childRunId": None,
         "taskRunId": None,
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
     assert artifacts.model_dump(by_alias=True) == {
         "outputSummary": None,
@@ -495,6 +522,8 @@ def test_update_step_row_merges_structured_refs_and_artifacts() -> None:
         "childWorkflowId": "wf-child-1",
         "childRunId": "run-child-1",
         "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
     assert row["artifacts"] == {
         "outputSummary": "art_summary_1",

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -182,6 +182,8 @@ def test_parent_owned_checkpoint_evidence_survives_child_runtime_projection() ->
         "childWorkflowId": "wf-child",
         "childRunId": "run-child",
         "taskRunId": None,
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
     assert rows[0]["stateCheckpointRef"] == "artifact://child-checkpoint"
     assert rows[0]["resumePreservation"] == {

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -368,7 +368,7 @@ async def test_resume_attempt_manifest_preserves_source_lineage(
         "sourceLogicalStepId": "implement",
         "sourceAttempt": 1,
         "relationship": "resume_from_failed_step",
-        "lineageAttemptOrdinal": 1,
+        "lineageAttemptOrdinal": 2,
     }
     assert manifest["workspace"]["policy"] == "resume_from_source_attempt"
     assert manifest["workspace"]["sourceAttempt"] == {

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -11,7 +13,28 @@ from moonmind.workflows.temporal.step_ledger import (
     refresh_ready_steps,
     update_step_row,
 )
+from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-resume",
+        run_id="run-resume",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["user-1"]},
+    )
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        isEnabledFor=lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "logger", logger)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
 
 
 def _resume_source(**overrides: object) -> dict[str, object]:
@@ -293,6 +316,71 @@ def test_resume_source_restores_workspace_before_failed_step_execution() -> None
     assert restored_ref == "artifact://workspace/before-implement"
     assert workflow._resume_workspace_restored_ref == restored_ref
     assert workflow._restore_resume_workspace_for_failed_step("verify") is None
+
+
+@pytest.mark.asyncio
+async def test_resume_attempt_manifest_preserves_source_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    now = datetime.now(UTC)
+    workflow = _workflow_with_resume()
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("implement", updated_at=now, summary="Resuming")
+    await workflow._record_step_attempt_manifest_start(
+        "implement",
+        updated_at=now,
+        reason="resume_from_failed_step",
+    )
+
+    manifest = writes[0]["payload"]
+    assert manifest["workflowId"] == "wf-resume"
+    assert manifest["runId"] == "run-resume"
+    assert manifest["attempt"] == 1
+    assert manifest["lineage"] == {
+        "sourceWorkflowId": "mm:source",
+        "sourceRunId": "run-source",
+        "sourceLogicalStepId": "implement",
+        "sourceAttempt": 1,
+        "relationship": "resume_from_failed_step",
+        "lineageAttemptOrdinal": 1,
+    }
+    assert manifest["workspace"]["policy"] == "resume_from_source_attempt"
+    assert manifest["workspace"]["sourceAttempt"] == {
+        "workflowId": "mm:source",
+        "runId": "run-source",
+        "logicalStepId": "implement",
+        "attempt": 1,
+    }
+    assert (
+        manifest["workspace"]["restoredCheckpointRef"]
+        == "artifact://workspace/before-implement"
+    )
 
 
 def test_resume_source_rejects_missing_workspace_evidence() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -509,6 +509,8 @@ def test_run_groups_child_lineage_and_evidence_into_step_row(
         "childWorkflowId": "wf-child-1",
         "childRunId": "run-child-1",
         "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
     assert step["artifacts"] == {
         "outputSummary": "art_summary_1",
@@ -559,7 +561,95 @@ def test_run_waiting_state_captures_child_workflow_lineage(
         "childWorkflowId": "wf-child-1",
         "childRunId": None,
         "taskRunId": None,
+        "latestAttemptManifestRef": None,
+        "attemptManifestRefs": [],
     }
+
+
+@pytest.mark.asyncio
+async def test_run_records_step_attempt_manifest_ref_when_work_begins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "delegate-agent",
+                "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+                "inputs": {"title": "Delegate agent"},
+            }
+        ],
+        dependency_map={"delegate-agent": []},
+        updated_at=now,
+    )
+
+    workflow._mark_step_running(
+        "delegate-agent",
+        updated_at=now,
+        summary="Launching child runtime",
+    )
+    await workflow._record_step_attempt_manifest_start(
+        "delegate-agent",
+        updated_at=now,
+        reason="initial_execution",
+    )
+    workflow._mark_step_terminal(
+        "delegate-agent",
+        status="failed",
+        updated_at=now,
+        summary="Runtime failed",
+    )
+    workflow._mark_step_running(
+        "delegate-agent",
+        updated_at=now,
+        summary="Retrying child runtime",
+    )
+    await workflow._record_step_attempt_manifest_start(
+        "delegate-agent",
+        updated_at=now,
+        reason="runtime_recovered",
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["attempt"] == 2
+    assert step["refs"]["latestAttemptManifestRef"] == "artifact-attempt-2"
+    assert step["refs"]["attemptManifestRefs"] == [
+        "artifact-attempt-1",
+        "artifact-attempt-2",
+    ]
+    assert writes[0]["content_type"] == (
+        "application/vnd.moonmind.step-attempt+json;version=1"
+    )
+    assert writes[0]["payload"]["stepAttemptId"] == (
+        "wf-run-1:run-1:delegate-agent:attempt:1"
+    )
+    assert writes[0]["metadata_json"]["idempotencyKey"] == (
+        "wf-run-1:run-1:delegate-agent:1:manifest"
+    )
+    assert writes[0]["payload"]["reason"] == "initial_execution"
+    assert writes[1]["payload"]["reason"] == "runtime_recovered"
 
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     monkeypatch: pytest.MonkeyPatch,
@@ -935,6 +1025,7 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
     review_snapshots: list[dict[str, Any]] = []
     written_review_payloads: list[dict[str, Any]] = []
     review_artifact_ids = iter(("art_review_1",))
+    step_attempt_artifact_ids = iter(("art_step_attempt_1",))
 
     async def fake_execute_activity(
         activity_type: str,
@@ -944,6 +1035,11 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
         if activity_type == "provider_profile.list":
             return {"profiles": []}
         if activity_type == "artifact.create":
+            if str(payload.get("name") or "").startswith("reports/step_attempts/"):
+                return (
+                    {"artifact_id": next(step_attempt_artifact_ids)},
+                    {"upload_url": "unused"},
+                )
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
         if activity_type == "mm.skill.execute":
             return {
@@ -974,6 +1070,10 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
             if artifact_ref == "artifact://registry/1":
                 return json.dumps(_registry_payload()).encode("utf-8")
         if activity_type == "artifact.write_complete":
+            if getattr(payload, "content_type", "") == (
+                "application/vnd.moonmind.step-attempt+json;version=1"
+            ):
+                return {"ok": True}
             written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
             return {"ok": True}
         raise AssertionError(f"unexpected typed activity: {activity_type}")
@@ -1043,6 +1143,7 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     written_review_payloads: list[dict[str, Any]] = []
     skill_inputs: list[dict[str, Any]] = []
     review_artifact_ids = iter(("art_review_1", "art_review_2"))
+    step_attempt_artifact_ids = iter(("art_step_attempt_1", "art_step_attempt_2"))
     review_verdicts = iter(
         (
             {
@@ -1074,6 +1175,11 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
         if activity_type == "provider_profile.list":
             return {"profiles": []}
         if activity_type == "artifact.create":
+            if str(payload.get("name") or "").startswith("reports/step_attempts/"):
+                return (
+                    {"artifact_id": next(step_attempt_artifact_ids)},
+                    {"upload_url": "unused"},
+                )
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
         if activity_type == "mm.skill.execute":
             invocation_payload = payload["invocation_payload"]
@@ -1099,6 +1205,10 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
             if artifact_ref == "artifact://registry/1":
                 return json.dumps(_registry_payload()).encode("utf-8")
         if activity_type == "artifact.write_complete":
+            if getattr(payload, "content_type", "") == (
+                "application/vnd.moonmind.step-attempt+json;version=1"
+            ):
+                return {"ok": True}
             written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
             return {"ok": True}
         raise AssertionError(f"unexpected typed activity: {activity_type}")
@@ -1172,6 +1282,7 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
     written_review_payloads: list[dict[str, Any]] = []
     child_requests: list[Any] = []
     review_artifact_ids = iter(("art_review_1", "art_review_2"))
+    step_attempt_artifact_ids = iter(("art_step_attempt_1", "art_step_attempt_2"))
     review_verdicts = iter(
         (
             {
@@ -1210,6 +1321,11 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
         if activity_type == "provider_profile.list":
             return {"profiles": []}
         if activity_type == "artifact.create":
+            if str(payload.get("name") or "").startswith("reports/step_attempts/"):
+                return (
+                    {"artifact_id": next(step_attempt_artifact_ids)},
+                    {"upload_url": "unused"},
+                )
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
         if activity_type == "step.review":
             return next(review_verdicts)
@@ -1225,6 +1341,10 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
             if artifact_ref == "art_plan_1":
                 return json.dumps(plan_payload).encode("utf-8")
         if activity_type == "artifact.write_complete":
+            if getattr(payload, "content_type", "") == (
+                "application/vnd.moonmind.step-attempt+json;version=1"
+            ):
+                return {"ok": True}
             written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
             return {"ok": True}
         raise AssertionError(f"unexpected typed activity: {activity_type}")

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -650,6 +650,16 @@ async def test_run_records_step_attempt_manifest_ref_when_work_begins(
     )
     assert writes[0]["payload"]["reason"] == "initial_execution"
     assert writes[1]["payload"]["reason"] == "runtime_recovered"
+    assert writes[1]["payload"]["workspace"]["policy"] == (
+        "continue_from_previous_attempt"
+    )
+    assert writes[1]["payload"]["workspace"]["sourceAttempt"] == {
+        "workflowId": "wf-run-1",
+        "runId": "run-1",
+        "logicalStepId": "delegate-agent",
+        "attempt": 1,
+    }
+    assert "lineage" not in writes[1]["payload"]
 
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -615,6 +615,18 @@ async def test_run_records_step_attempt_manifest_ref_when_work_begins(
         updated_at=now,
         reason="initial_execution",
     )
+    workflow._record_step_result_evidence(
+        "delegate-agent",
+        execution_result={
+            "status": "FAILED",
+            "outputs": {
+                "childWorkflowId": "wf-child-1",
+                "childRunId": "run-child-1",
+                "outputSummaryRef": "artifact://summary/attempt-1",
+            },
+        },
+        updated_at=now,
+    )
     workflow._mark_step_terminal(
         "delegate-agent",
         status="failed",
@@ -649,7 +661,11 @@ async def test_run_records_step_attempt_manifest_ref_when_work_begins(
         "wf-run-1:run-1:delegate-agent:1:manifest"
     )
     assert writes[0]["payload"]["reason"] == "initial_execution"
+    assert writes[0]["payload"]["execution"] == {}
+    assert writes[0]["payload"]["outputs"] == {}
     assert writes[1]["payload"]["reason"] == "runtime_recovered"
+    assert writes[1]["payload"]["execution"] == {}
+    assert writes[1]["payload"]["outputs"] == {}
     assert writes[1]["payload"]["workspace"]["policy"] == (
         "continue_from_previous_attempt"
     )
@@ -660,6 +676,94 @@ async def test_run_records_step_attempt_manifest_ref_when_work_begins(
         "attempt": 1,
     }
     assert "lineage" not in writes[1]["payload"]
+
+
+@pytest.mark.asyncio
+async def test_run_records_terminal_step_attempt_manifest_with_result_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "run-tests",
+                "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            }
+        ],
+        dependency_map={"run-tests": []},
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("run-tests", updated_at=now, summary="Run tests")
+    await workflow._record_step_attempt_manifest_start(
+        "run-tests",
+        updated_at=now,
+        reason="initial_execution",
+    )
+    workflow._record_step_result_evidence(
+        "run-tests",
+        execution_result={
+            "status": "COMPLETED",
+            "outputs": {
+                "taskRunId": "task-run-1",
+                "outputSummaryRef": "artifact://summary/attempt-1",
+                "stdoutArtifactRef": "artifact://stdout/attempt-1",
+                "diagnosticsRef": "artifact://diagnostics/attempt-1",
+            },
+        },
+        updated_at=now,
+    )
+    workflow._mark_step_terminal(
+        "run-tests",
+        status="succeeded",
+        updated_at=now,
+        summary="Done",
+    )
+    await workflow._record_step_attempt_manifest_terminal(
+        "run-tests",
+        updated_at=now,
+        reason="initial_execution",
+        status="succeeded",
+        terminal_disposition="accepted",
+    )
+
+    assert writes[0]["payload"]["status"] == "running"
+    assert writes[0]["payload"]["execution"] == {}
+    assert writes[0]["payload"]["outputs"] == {}
+    assert writes[1]["payload"]["status"] == "succeeded"
+    assert writes[1]["payload"]["terminalDisposition"] == "accepted"
+    assert writes[1]["payload"]["execution"] == {
+        "taskRunId": "task-run-1",
+        "diagnosticsRef": "artifact://diagnostics/attempt-1",
+    }
+    assert writes[1]["payload"]["outputs"] == {
+        "summaryRef": "artifact://summary/attempt-1",
+        "stdoutRef": "artifact://stdout/attempt-1",
+    }
+
 
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     monkeypatch: pytest.MonkeyPatch,
@@ -1035,7 +1139,9 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
     review_snapshots: list[dict[str, Any]] = []
     written_review_payloads: list[dict[str, Any]] = []
     review_artifact_ids = iter(("art_review_1",))
-    step_attempt_artifact_ids = iter(("art_step_attempt_1",))
+    step_attempt_artifact_ids = iter(
+        ("art_step_attempt_1", "art_step_attempt_1_terminal")
+    )
 
     async def fake_execute_activity(
         activity_type: str,
@@ -1153,7 +1259,13 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     written_review_payloads: list[dict[str, Any]] = []
     skill_inputs: list[dict[str, Any]] = []
     review_artifact_ids = iter(("art_review_1", "art_review_2"))
-    step_attempt_artifact_ids = iter(("art_step_attempt_1", "art_step_attempt_2"))
+    step_attempt_artifact_ids = iter(
+        (
+            "art_step_attempt_1",
+            "art_step_attempt_2",
+            "art_step_attempt_2_terminal",
+        )
+    )
     review_verdicts = iter(
         (
             {
@@ -1292,7 +1404,13 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
     written_review_payloads: list[dict[str, Any]] = []
     child_requests: list[Any] = []
     review_artifact_ids = iter(("art_review_1", "art_review_2"))
-    step_attempt_artifact_ids = iter(("art_step_attempt_1", "art_step_attempt_2"))
+    step_attempt_artifact_ids = iter(
+        (
+            "art_step_attempt_1",
+            "art_step_attempt_2",
+            "art_step_attempt_2_terminal",
+        )
+    )
     review_verdicts = iter(
         (
             {

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from moonmind.schemas.temporal_models import STEP_ATTEMPT_MANIFEST_CONTENT_TYPE
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
@@ -125,6 +126,7 @@ def _registry_payload() -> dict[str, Any]:
 def test_run_initializes_latest_run_step_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure_workflow_runtime(monkeypatch)
     workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
     now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
 
     workflow._initialize_step_ledger(
@@ -763,6 +765,43 @@ async def test_run_records_terminal_step_attempt_manifest_with_result_refs(
         "summaryRef": "artifact://summary/attempt-1",
         "stdoutRef": "artifact://stdout/attempt-1",
     }
+
+
+@pytest.mark.asyncio
+async def test_write_step_attempt_manifest_requires_real_artifact_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        assert activity_type == "artifact.create"
+        return ({}, {"upload_url": "unused"})
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, bool]:
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_module, "execute_typed_activity", fake_execute_typed_activity)
+
+    with pytest.raises(
+        ValueError,
+        match="artifact.create returned no artifact_id",
+    ):
+        await workflow._write_json_artifact(
+            name="reports/step_attempts/run-tests_attempt_1.json",
+            payload={"schemaVersion": "v1"},
+            content_type=STEP_ATTEMPT_MANIFEST_CONTENT_TYPE,
+        )
 
 
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(


### PR DESCRIPTION
## Jira issue
MM-714

## Active MoonSpec feature path
`specs/001-step-attempt-manifest`

## Verification verdict
FULLY_IMPLEMENTED

## Tests run
- `pytest tests/unit/workflows/temporal/test_step_attempt_manifest.py tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q` - PASS, 64 passed.
- `pytest tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py -q` - PASS, 2 passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, 5211 Python tests passed and frontend suite passed across 22 files.
- `./tools/test_integration.sh` - NOT RUN/BLOCKED in the managed workspace because Docker returned a daemon 403 after the Compose buildx warning.

## Remaining risks
- Full Docker-backed hermetic integration wrapper could not run in this managed workspace due Docker daemon permissions; focused MM-714 integration coverage passed.
