### PR TITLE
MM-715 add immutable attempt context bundles

### DIFF
--- a/moonmind/workflows/tasks/__init__.py
+++ b/moonmind/workflows/tasks/__init__.py
@@ -2,11 +2,16 @@
 
 from .payload import compile_task_payload_templates
 from .prepared_context import (
+    AttemptContextBundle,
     PreparedContextFailure,
     PreparedInputEntry,
     PreparedInputManifest,
+    RetrievalManifest,
     StepPreparedContext,
+    build_attempt_context_bundle,
+    build_memory_manifest,
     build_prepared_input_manifest,
+    build_retrieval_manifest,
     build_resume_prepared_artifact_refs,
     merge_prepared_input_refs,
     merge_prepared_raw_input_refs,
@@ -15,11 +20,16 @@ from .prepared_context import (
 )
 
 __all__ = [
+    "AttemptContextBundle",
     "PreparedContextFailure",
     "PreparedInputEntry",
     "PreparedInputManifest",
+    "RetrievalManifest",
     "StepPreparedContext",
+    "build_attempt_context_bundle",
+    "build_memory_manifest",
     "build_prepared_input_manifest",
+    "build_retrieval_manifest",
     "build_resume_prepared_artifact_refs",
     "compile_task_payload_templates",
     "merge_prepared_input_refs",

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 TargetKind = Literal["objective", "step"]
+MemoryProposalState = Literal[
+    "proposed",
+    "accepted_for_run_context",
+    "applied_to_repo",
+    "rejected",
+    "superseded",
+]
+ATTEMPT_CONTEXT_BUILDER_VERSION = "attempt-context-builder-v1"
 
 _INLINE_ATTACHMENT_KEYS = {
     "base64",
@@ -107,6 +117,132 @@ class StepPreparedContext(BaseModel):
         }
 
 
+class RetrievalManifest(BaseModel):
+    """Compact retrieval input manifest recorded for one attempt."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    query: str | None = None
+    selector: dict[str, Any] | None = None
+    index_version: str | None = Field(default=None, alias="indexVersion")
+    returned_refs: list[str] = Field(default_factory=list, alias="returnedRefs")
+    filters: dict[str, Any] = Field(default_factory=dict)
+    compact_summaries: list[str] = Field(
+        default_factory=list,
+        alias="compactSummaries",
+    )
+    retrieval_manifest_ref: str = Field(alias="retrievalManifestRef")
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> "RetrievalManifest":
+        if not self.query and not self.selector and not self.returned_refs:
+            raise ValueError(
+                "retrieval manifest requires query, selector, or returnedRefs"
+            )
+        _reject_secretish_values(self.model_dump(by_alias=True), path="retrieval")
+        return self
+
+
+class MemoryProposal(BaseModel):
+    """Compact memory proposal with explicit promotion state."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    proposal_ref: str = Field(alias="proposalRef")
+    state: MemoryProposalState
+    summary: str | None = None
+    policy_ref: str | None = Field(default=None, alias="policyRef")
+
+    @field_validator("proposal_ref")
+    @classmethod
+    def _proposal_ref_required(cls, value: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            raise ValueError("proposalRef is required")
+        return candidate
+
+    @model_validator(mode="after")
+    def _validate_policy_state(self) -> "MemoryProposal":
+        if (
+            self.state == "applied_to_repo"
+            and not str(self.policy_ref or "").strip()
+        ):
+            raise ValueError(
+                "applied_to_repo memory proposals require an explicit policyRef"
+            )
+        _reject_secretish_values(self.model_dump(by_alias=True), path="memory")
+        return self
+
+
+class MemoryManifest(BaseModel):
+    """Compact memory manifest recorded for one attempt."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    proposals: list[MemoryProposal] = Field(default_factory=list)
+    memory_manifest_ref: str = Field(alias="memoryManifestRef")
+
+
+class AttemptContextBundle(BaseModel):
+    """Digest-addressed context envelope for one runtime attempt."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["v1"] = Field("v1", alias="schemaVersion")
+    workflow_id: str = Field(alias="workflowId")
+    run_id: str = Field(alias="runId")
+    logical_step_id: str = Field(alias="logicalStepId")
+    attempt: int
+    reason: str = "initial_execution"
+    prepared_input_refs: list[str] = Field(
+        default_factory=list,
+        alias="preparedInputRefs",
+    )
+    retrieval_manifest_ref: str | None = Field(
+        default=None,
+        alias="retrievalManifestRef",
+    )
+    memory_manifest_ref: str | None = Field(default=None, alias="memoryManifestRef")
+    runtime_selection: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="runtimeSelection",
+    )
+    context_bundle_ref: str = Field(alias="contextBundleRef")
+    context_bundle_digest: str = Field(alias="contextBundleDigest")
+    builder_version: str = Field(alias="builderVersion")
+
+    @field_validator("workflow_id", "run_id", "logical_step_id", "reason")
+    @classmethod
+    def _required_text(cls, value: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            raise ValueError("field must be a non-empty string")
+        return candidate
+
+    @field_validator("attempt")
+    @classmethod
+    def _positive_attempt(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("attempt must be positive")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_safe_content(self) -> "AttemptContextBundle":
+        _reject_secretish_values(self.model_dump(by_alias=True), path="attemptContext")
+        return self
+
+    def to_manifest_projection(self) -> dict[str, Any]:
+        return {
+            "context": {
+                "contextBundleRef": self.context_bundle_ref,
+                "contextBundleDigest": self.context_bundle_digest,
+                "builderVersion": self.builder_version,
+                "retrievalManifestRef": self.retrieval_manifest_ref,
+                "memoryManifestRef": self.memory_manifest_ref,
+            }
+        }
+
+
 class PreparedContextFailure(BaseModel):
     """Bounded failure diagnostic for prepared context generation."""
 
@@ -197,6 +333,96 @@ def select_step_prepared_context(
     )
 
 
+def build_attempt_context_bundle(
+    *,
+    workflow_id: str,
+    run_id: str,
+    logical_step_id: str,
+    attempt: int | None = None,
+    reason: str = "initial_execution",
+    prepared_context: StepPreparedContext | None = None,
+    runtime_selection: Mapping[str, Any] | None = None,
+    retrieval: Mapping[str, Any] | None = None,
+    memory_proposals: Sequence[Mapping[str, Any]] | None = None,
+    builder_version: str = ATTEMPT_CONTEXT_BUILDER_VERSION,
+) -> AttemptContextBundle:
+    """Build a compact, digest-addressed attempt context bundle."""
+
+    prepared_input_refs = (
+        prepared_context.input_refs if prepared_context is not None else []
+    )
+    retrieval_manifest_ref = None
+    if isinstance(retrieval, Mapping) and retrieval:
+        retrieval_manifest_ref = (
+            build_retrieval_manifest(retrieval).retrieval_manifest_ref
+        )
+    memory_manifest_ref = None
+    if memory_proposals:
+        memory_manifest_ref = (
+            build_memory_manifest(memory_proposals).memory_manifest_ref
+        )
+
+    base_payload = {
+        "schemaVersion": "v1",
+        "workflowId": workflow_id,
+        "runId": run_id,
+        "logicalStepId": logical_step_id,
+        "attempt": attempt or 1,
+        "reason": reason,
+        "preparedInputRefs": list(prepared_input_refs),
+        "retrievalManifestRef": retrieval_manifest_ref,
+        "memoryManifestRef": memory_manifest_ref,
+        "runtimeSelection": dict(runtime_selection or {}),
+        "builderVersion": builder_version,
+    }
+    digest = _digest_payload(base_payload)
+    payload = {
+        **base_payload,
+        "contextBundleRef": f"attempt-context-bundle://{digest}",
+        "contextBundleDigest": digest,
+    }
+    return AttemptContextBundle.model_validate(payload)
+
+
+def build_retrieval_manifest(retrieval: Mapping[str, Any]) -> RetrievalManifest:
+    payload = {
+        "query": _optional_text(retrieval.get("query")),
+        "selector": _optional_mapping(retrieval.get("selector")),
+        "indexVersion": _optional_text(
+            retrieval.get("indexVersion") or retrieval.get("index_version")
+        ),
+        "returnedRefs": _clean_existing_refs(
+            retrieval.get("returnedRefs") or retrieval.get("returned_refs")
+        ),
+        "filters": _optional_mapping(retrieval.get("filters")) or {},
+        "compactSummaries": _bounded_summaries(
+            retrieval.get("compactSummaries") or retrieval.get("compact_summaries")
+        ),
+    }
+    digest = _digest_payload(payload)
+    payload["retrievalManifestRef"] = f"attempt-retrieval-manifest://{digest}"
+    return RetrievalManifest.model_validate(payload)
+
+
+def build_memory_manifest(
+    proposals: Sequence[Mapping[str, Any]],
+) -> MemoryManifest:
+    proposal_models = [
+        MemoryProposal.model_validate(proposal)
+        for proposal in proposals
+        if isinstance(proposal, Mapping)
+    ]
+    payload = {
+        "proposals": [
+            proposal.model_dump(by_alias=True, exclude_none=True)
+            for proposal in proposal_models
+        ]
+    }
+    digest = _digest_payload(payload)
+    payload["memoryManifestRef"] = f"attempt-memory-manifest://{digest}"
+    return MemoryManifest.model_validate(payload)
+
+
 def merge_prepared_input_refs(
     existing_refs: Sequence[Any] | None,
     prepared_context: StepPreparedContext,
@@ -271,6 +497,10 @@ def _entry_from_attachment(
 ) -> PreparedInputEntry:
     try:
         _reject_inline_attachment_content(attachment)
+        _reject_secretish_values(
+            attachment,
+            path=_attachment_target_label(target_kind, step_ref),
+        )
         artifact_id = _artifact_id(attachment)
     except ValueError as exc:
         raise ValueError(
@@ -395,6 +625,50 @@ def _reject_inline_attachment_content(attachment: Mapping[str, Any]) -> None:
             raise ValueError(
                 "inline attachment content is not allowed in prepared inputs"
             )
+
+
+def _reject_secretish_values(value: Any, *, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _reject_secretish_values(item, path=f"{path}.{key}")
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, item in enumerate(value):
+            _reject_secretish_values(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, str) and _SECRETISH_RE.search(value):
+        raise ValueError(f"{path} contains raw secret material")
+
+
+def _digest_payload(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _optional_mapping(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return dict(value)
+
+
+def _bounded_summaries(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values: Sequence[Any] = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = value
+    else:
+        values = []
+    summaries: list[str] = []
+    for item in values:
+        candidate = _optional_text(item)
+        if candidate:
+            summaries.append(candidate[:500])
+    return summaries
 
 
 def _optional_text(value: Any) -> str | None:

--- a/moonmind/workflows/tasks/prepared_context.py
+++ b/moonmind/workflows/tasks/prepared_context.py
@@ -32,7 +32,7 @@ _INLINE_ATTACHMENT_KEYS = {
 }
 _DATA_URL_RE = re.compile(r"data:[^\s'\")]+", re.IGNORECASE)
 _SECRETISH_RE = re.compile(
-    r"(ghp_|github_pat_|AIza|ATATT|AKIA|token=|password=|"
+    r"(ghp_|github_pat_|AIza|ATATT|AKIA|"
     r"-----BEGIN [A-Z ]*PRIVATE KEY-----)",
     re.IGNORECASE,
 )
@@ -392,7 +392,10 @@ def build_retrieval_manifest(retrieval: Mapping[str, Any]) -> RetrievalManifest:
             retrieval.get("indexVersion") or retrieval.get("index_version")
         ),
         "returnedRefs": _clean_existing_refs(
-            retrieval.get("returnedRefs") or retrieval.get("returned_refs")
+            retrieval.get("returnedRefs")
+            or retrieval.get("returned_refs")
+            or retrieval.get("retrievedRefs")
+            or retrieval.get("retrieved_refs")
         ),
         "filters": _optional_mapping(retrieval.get("filters")) or {},
         "compactSummaries": _bounded_summaries(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -39,6 +39,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.tasks.routing import _coerce_bool
     from moonmind.workflows.tasks.prepared_context import (
+        build_attempt_context_bundle,
         build_prepared_input_manifest,
         build_resume_prepared_artifact_refs,
         merge_prepared_input_refs,
@@ -5996,9 +5997,12 @@ class MoonMindRunWorkflow:
             parameters["metadata"] = metadata_payload
 
         input_refs = node_inputs.get("inputRefs") or []
+        task_payload_for_context: Mapping[str, Any] | None = None
+        prepared_context = None
         if isinstance(workflow_parameters, Mapping):
             task_payload = workflow_parameters.get("task")
             if isinstance(task_payload, Mapping):
+                task_payload_for_context = task_payload
                 prepared_manifest = build_prepared_input_manifest(task_payload)
                 if prepared_manifest.has_entries:
                     prepared_context = select_step_prepared_context(
@@ -6026,6 +6030,66 @@ class MoonMindRunWorkflow:
                         )
                         metadata_payload["moonmind"] = moonmind_payload
                         parameters["metadata"] = metadata_payload
+
+        runtime_selection = {
+            "runtimeId": agent_id,
+            "agentKind": agent_kind,
+        }
+        if selected_skill:
+            runtime_selection["skillId"] = selected_skill
+        retrieval_context = None
+        memory_proposals = None
+        if isinstance(task_payload_for_context, Mapping):
+            raw_retrieval_context = (
+                task_payload_for_context.get("attemptRetrieval")
+                or task_payload_for_context.get("retrievalManifest")
+                or task_payload_for_context.get("retrieval")
+            )
+            if isinstance(raw_retrieval_context, Mapping):
+                retrieval_context = raw_retrieval_context
+            raw_memory_proposals = (
+                task_payload_for_context.get("memoryProposals")
+                or task_payload_for_context.get("memoryEffects")
+                or task_payload_for_context.get("memory")
+            )
+            if isinstance(raw_memory_proposals, Sequence) and not isinstance(
+                raw_memory_proposals,
+                (str, bytes, bytearray),
+            ):
+                memory_proposals = [
+                    proposal
+                    for proposal in raw_memory_proposals
+                    if isinstance(proposal, Mapping)
+                ]
+        attempt_context = build_attempt_context_bundle(
+            workflow_id=wf_info.workflow_id,
+            run_id=wf_info.run_id,
+            logical_step_id=node_id,
+            attempt=step_attempt or 1,
+            prepared_context=prepared_context,
+            runtime_selection=runtime_selection,
+            retrieval=retrieval_context,
+            memory_proposals=memory_proposals,
+        )
+        metadata_payload = (
+            parameters.get("metadata")
+            if isinstance(parameters.get("metadata"), dict)
+            else {}
+        )
+        moonmind_payload = (
+            metadata_payload.get("moonmind")
+            if isinstance(metadata_payload.get("moonmind"), dict)
+            else {}
+        )
+        moonmind_payload["attemptContext"] = attempt_context.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
+        moonmind_payload["attemptManifestProjection"] = (
+            attempt_context.to_manifest_projection()
+        )
+        metadata_payload["moonmind"] = moonmind_payload
+        parameters["metadata"] = metadata_payload
 
         return AgentExecutionRequest(
             agent_kind=agent_kind,

--- a/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -58,6 +58,23 @@ def test_run_boundary_prepares_objective_and_current_step_context_only() -> None
     assert dumped["parameters"]["metadata"]["moonmind"]["preparedContext"][
         "targetCounts"
     ] == {"objective": 1, "step": 1}
+    attempt_context = dumped["parameters"]["metadata"]["moonmind"]["attemptContext"]
+    projection = dumped["parameters"]["metadata"]["moonmind"][
+        "attemptManifestProjection"
+    ]
+    assert attempt_context["workflowId"] == "run-target-aware-integration"
+    assert attempt_context["logicalStepId"] == "first-step"
+    assert attempt_context["preparedInputRefs"] == [
+        "prepared-context://objective/objective-artifact",
+        "prepared-context://steps/first-step/first-step-artifact",
+        "artifact://objective-artifact",
+        "artifact://first-step-artifact",
+    ]
+    assert attempt_context["contextBundleDigest"].startswith("sha256:")
+    assert projection["context"]["contextBundleRef"] == (
+        attempt_context["contextBundleRef"]
+    )
+    assert "preparedInputRefs" not in projection["context"]
 
 
 def test_agent_run_child_input_scope_is_parent_selected() -> None:

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -432,13 +432,37 @@ def test_attempt_context_records_retrieval_and_memory_manifest_refs() -> None:
     assert bundle.memory_manifest_ref == memory.memory_manifest_ref
 
 
+def test_retrieval_manifest_accepts_documented_retrieved_refs_key() -> None:
+    retrieval = build_retrieval_manifest(
+        {
+            "retrievedRefs": ["artifact://doc-1", "artifact://doc-2"],
+        }
+    )
+
+    assert retrieval.returned_refs == ["artifact://doc-1", "artifact://doc-2"]
+    assert retrieval.retrieval_manifest_ref.startswith(
+        "attempt-retrieval-manifest://sha256:"
+    )
+
+
+def test_retrieval_manifest_allows_literal_assignment_search_terms() -> None:
+    retrieval = build_retrieval_manifest(
+        {
+            "query": "find `password=` assignments and token= examples",
+            "indexVersion": "rag-index-1",
+        }
+    )
+
+    assert retrieval.query == "find `password=` assignments and token= examples"
+
+
 def test_attempt_context_rejects_secretish_values_and_unknown_memory_states() -> None:
     with pytest.raises(ValueError, match="raw secret material"):
         build_prepared_input_manifest(
             {
                 "inputAttachments": [
                     {
-                        "artifactId": "token=password=unsafe",
+                        "artifactId": "ghp_unsafe",
                     }
                 ]
             }
@@ -450,7 +474,7 @@ def test_attempt_context_rejects_secretish_values_and_unknown_memory_states() ->
             run_id="run-1",
             logical_step_id="collect-evidence",
             retrieval={
-                "query": "token=unsafe",
+                "query": "ghp_unsafe",
                 "indexVersion": "rag-index-1",
             },
         )

--- a/tests/unit/workflows/tasks/test_prepared_context.py
+++ b/tests/unit/workflows/tasks/test_prepared_context.py
@@ -7,8 +7,11 @@ from moonmind.workflows.tasks.prepared_context import (
     PreparedContextFailure,
     PreparedInputEntry,
     PreparedInputManifest,
+    build_attempt_context_bundle,
+    build_memory_manifest,
     build_resume_prepared_artifact_refs,
     build_prepared_input_manifest,
+    build_retrieval_manifest,
     select_step_prepared_context,
 )
 
@@ -323,6 +326,154 @@ def test_step_context_metadata_is_bounded_and_target_aware() -> None:
         "artifact://artifact-step-1",
     ]
     assert "data:image" not in str(metadata)
+
+
+def test_attempt_context_bundle_digest_is_stable_and_attempt_scoped() -> None:
+    manifest = build_prepared_input_manifest(_task_payload())
+    context = select_step_prepared_context(manifest, logical_step_id="collect-evidence")
+
+    first = build_attempt_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="collect-evidence",
+        attempt=1,
+        prepared_context=context,
+        runtime_selection={"runtimeId": "codex_cli"},
+    )
+    duplicate = build_attempt_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="collect-evidence",
+        attempt=1,
+        prepared_context=context,
+        runtime_selection={"runtimeId": "codex_cli"},
+    )
+    changed_attempt = build_attempt_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="collect-evidence",
+        attempt=2,
+        prepared_context=context,
+        runtime_selection={"runtimeId": "codex_cli"},
+    )
+
+    assert first.context_bundle_digest == duplicate.context_bundle_digest
+    assert first.context_bundle_ref == (
+        f"attempt-context-bundle://{first.context_bundle_digest}"
+    )
+    assert first.context_bundle_digest != changed_attempt.context_bundle_digest
+    assert first.builder_version == "attempt-context-builder-v1"
+    projection = first.to_manifest_projection()
+    assert projection["context"]["contextBundleDigest"] == first.context_bundle_digest
+    assert "preparedInputRefs" not in projection["context"]
+
+
+def test_attempt_context_records_retrieval_and_memory_manifest_refs() -> None:
+    retrieval = build_retrieval_manifest(
+        {
+            "query": "attempt context bundle",
+            "indexVersion": "rag-index-1",
+            "returnedRefs": ["artifact://doc-1"],
+            "filters": {"source": "docs"},
+            "compactSummaries": ["Relevant source design section."],
+        }
+    )
+    memory = build_memory_manifest(
+        [
+            {
+                "proposalRef": "memory://proposal-1",
+                "state": "proposed",
+                "summary": "Remember failed attempt evidence.",
+            },
+            {
+                "proposalRef": "memory://proposal-2",
+                "state": "rejected",
+                "summary": "Rejected noisy suggestion.",
+            },
+        ]
+    )
+    bundle = build_attempt_context_bundle(
+        workflow_id="workflow-1",
+        run_id="run-1",
+        logical_step_id="collect-evidence",
+        attempt=1,
+        retrieval={
+            "query": "attempt context bundle",
+            "indexVersion": "rag-index-1",
+            "returnedRefs": ["artifact://doc-1"],
+            "filters": {"source": "docs"},
+            "compactSummaries": ["Relevant source design section."],
+        },
+        memory_proposals=[
+            {
+                "proposalRef": "memory://proposal-1",
+                "state": "proposed",
+                "summary": "Remember failed attempt evidence.",
+            },
+            {
+                "proposalRef": "memory://proposal-2",
+                "state": "rejected",
+                "summary": "Rejected noisy suggestion.",
+            },
+        ],
+    )
+
+    assert retrieval.query == "attempt context bundle"
+    assert retrieval.index_version == "rag-index-1"
+    assert retrieval.returned_refs == ["artifact://doc-1"]
+    assert retrieval.compact_summaries == ["Relevant source design section."]
+    assert retrieval.retrieval_manifest_ref.startswith(
+        "attempt-retrieval-manifest://sha256:"
+    )
+    assert memory.proposals[0].state == "proposed"
+    assert memory.proposals[1].state == "rejected"
+    assert memory.memory_manifest_ref.startswith("attempt-memory-manifest://sha256:")
+    assert bundle.retrieval_manifest_ref == retrieval.retrieval_manifest_ref
+    assert bundle.memory_manifest_ref == memory.memory_manifest_ref
+
+
+def test_attempt_context_rejects_secretish_values_and_unknown_memory_states() -> None:
+    with pytest.raises(ValueError, match="raw secret material"):
+        build_prepared_input_manifest(
+            {
+                "inputAttachments": [
+                    {
+                        "artifactId": "token=password=unsafe",
+                    }
+                ]
+            }
+        )
+
+    with pytest.raises(ValueError, match="raw secret material"):
+        build_attempt_context_bundle(
+            workflow_id="workflow-1",
+            run_id="run-1",
+            logical_step_id="collect-evidence",
+            retrieval={
+                "query": "token=unsafe",
+                "indexVersion": "rag-index-1",
+            },
+        )
+
+    with pytest.raises(ValidationError, match="Input should be"):
+        build_memory_manifest(
+            [
+                {
+                    "proposalRef": "memory://proposal-1",
+                    "state": "auto_promoted",
+                }
+            ]
+        )
+
+    with pytest.raises(ValueError, match="policyRef"):
+        build_memory_manifest(
+            [
+                {
+                    "proposalRef": "memory://proposal-1",
+                    "state": "applied_to_repo",
+                }
+            ]
+        )
 
 
 def test_resume_prepared_artifact_refs_are_compact_and_deduped() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -57,11 +57,78 @@ def _build_request_for_step(step_id: str, *, runtime_mode: str = "jules"):
 def test_run_request_records_prepared_manifest_before_step_dispatch() -> None:
     request = _build_request_for_step("collect-evidence")
 
-    prepared_context = request.parameters["metadata"]["moonmind"]["preparedContext"]
+    moonmind_metadata = request.parameters["metadata"]["moonmind"]
+    prepared_context = moonmind_metadata["preparedContext"]
+    attempt_context = moonmind_metadata["attemptContext"]
+    projection = moonmind_metadata["attemptManifestProjection"]
 
     assert prepared_context["manifestRef"].startswith("prepared-context-manifest://")
     assert prepared_context["logicalStepId"] == "collect-evidence"
     assert prepared_context["targetCounts"] == {"objective": 1, "step": 1}
+    assert attempt_context["workflowId"] == "run-target-aware"
+    assert attempt_context["runId"] == "run-id-1"
+    assert attempt_context["logicalStepId"] == "collect-evidence"
+    assert attempt_context["attempt"] == 1
+    assert attempt_context["preparedInputRefs"] == prepared_context["inputRefs"]
+    assert attempt_context["contextBundleDigest"].startswith("sha256:")
+    assert attempt_context["contextBundleRef"] == (
+        f"attempt-context-bundle://{attempt_context['contextBundleDigest']}"
+    )
+    assert attempt_context["builderVersion"] == "attempt-context-builder-v1"
+    assert projection["context"]["contextBundleDigest"] == (
+        attempt_context["contextBundleDigest"]
+    )
+    assert "preparedInputRefs" not in projection["context"]
+
+
+def test_run_request_records_retrieval_and_memory_refs_in_attempt_projection() -> None:
+    wf = MoonMindRunWorkflow()
+    task_payload = {
+        **_task_payload(),
+        "retrieval": {
+            "query": "attempt context",
+            "indexVersion": "rag-index-1",
+            "returnedRefs": ["artifact://retrieved-doc"],
+            "filters": {"kind": "docs"},
+            "compactSummaries": ["Relevant design summary."],
+        },
+        "memoryProposals": [
+            {
+                "proposalRef": "memory://proposal-1",
+                "state": "proposed",
+                "summary": "Candidate memory.",
+            }
+        ],
+    }
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_workflow_info(),
+    ):
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="collect-evidence",
+            tool_name="codex_cli",
+            workflow_parameters={"task": task_payload},
+        )
+
+    attempt_context = request.parameters["metadata"]["moonmind"]["attemptContext"]
+    projection = request.parameters["metadata"]["moonmind"][
+        "attemptManifestProjection"
+    ]
+
+    assert attempt_context["retrievalManifestRef"].startswith(
+        "attempt-retrieval-manifest://sha256:"
+    )
+    assert attempt_context["memoryManifestRef"].startswith(
+        "attempt-memory-manifest://sha256:"
+    )
+    assert projection["context"]["retrievalManifestRef"] == (
+        attempt_context["retrievalManifestRef"]
+    )
+    assert projection["context"]["memoryManifestRef"] == (
+        attempt_context["memoryManifestRef"]
+    )
+    assert "Relevant design summary." not in str(projection)
 
 
 def test_run_request_filters_prepared_context_to_current_step() -> None:


### PR DESCRIPTION
## Summary
- Jira issue key: MM-715
- Active MoonSpec feature path: specs/001-attempt-context-bundles
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- pytest tests/unit/workflows/tasks/test_prepared_context.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py -q
- pytest tests/integration/workflows/temporal/workflows/test_run_target_aware_inputs.py -q
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh

## Remaining risks
- Branch was created before the latest main updates; GitHub checks should validate merge readiness.
- No persistent storage migration is included; this story adds compact runtime metadata contracts and workflow-boundary coverage.