### PR TITLE
MM-708 harden Jira completion target resolution

### DIFF
--- a/moonmind/workflows/temporal/post_merge_jira_completion.py
+++ b/moonmind/workflows/temporal/post_merge_jira_completion.py
@@ -152,12 +152,37 @@ def _append_candidate(
     if issue_key:
         candidates.append(JiraIssueCandidate(issue_key=issue_key, source=source))
 
+_CANDIDATE_SOURCE_PRIORITIES = {
+    "explicit_post_merge": 0,
+    "merge_automation": 1,
+    "task_origin": 1,
+    "task_metadata": 1,
+    "publish_context": 1,
+    "pr_metadata": 2,
+}
+
+def _candidate_priority(candidate: JiraIssueCandidate) -> int:
+    return _CANDIDATE_SOURCE_PRIORITIES.get(candidate.source, 1)
+
+def _highest_priority_candidates(
+    candidates: list[JiraIssueCandidate],
+) -> list[JiraIssueCandidate]:
+    if not candidates:
+        return []
+    selected_priority = min(_candidate_priority(candidate) for candidate in candidates)
+    return [
+        candidate
+        for candidate in candidates
+        if _candidate_priority(candidate) == selected_priority
+    ]
+
 async def resolve_issue_key(
     candidates: list[JiraIssueCandidate],
     *,
     get_issue: Callable[[str], Awaitable[dict[str, Any]]],
 ) -> dict[str, Any]:
-    if not candidates:
+    selected_candidates = _highest_priority_candidates(candidates)
+    if not selected_candidates:
         return {
             "status": "missing",
             "issueKey": None,
@@ -169,7 +194,7 @@ async def resolve_issue_key(
     evidence: list[dict[str, Any]] = []
     candidates_by_key: dict[str, list[JiraIssueCandidate]] = {}
     ordered_keys: list[str] = []
-    for candidate in candidates:
+    for candidate in selected_candidates:
         issue_key = _normalize_issue_key(candidate.issue_key)
         if not issue_key:
             evidence.append(

--- a/moonmind/workflows/temporal/post_merge_jira_completion.py
+++ b/moonmind/workflows/temporal/post_merge_jira_completion.py
@@ -162,7 +162,7 @@ _CANDIDATE_SOURCE_PRIORITIES = {
 }
 
 def _candidate_priority(candidate: JiraIssueCandidate) -> int:
-    return _CANDIDATE_SOURCE_PRIORITIES.get(candidate.source, 1)
+    return _CANDIDATE_SOURCE_PRIORITIES.get(candidate.source, 2)
 
 def _highest_priority_candidates(
     candidates: list[JiraIssueCandidate],

--- a/tests/unit/workflows/temporal/test_post_merge_jira_completion.py
+++ b/tests/unit/workflows/temporal/test_post_merge_jira_completion.py
@@ -99,6 +99,27 @@ async def test_resolve_issue_key_deduplicates_and_detects_ambiguity() -> None:
     assert ambiguous["issueKey"] is None
     assert calls == ["MM-403", "MM-403", "MM-403", "MM-404"]
 
+@pytest.mark.asyncio
+async def test_resolve_issue_key_treats_unknown_sources_as_fallback() -> None:
+    calls: list[str] = []
+
+    async def get_issue(issue_key: str) -> dict[str, object]:
+        calls.append(issue_key)
+        return _issue(issue_key)
+
+    resolved = await resolve_issue_key(
+        [
+            JiraIssueCandidate(issue_key="MM-403", source="merge_automation"),
+            JiraIssueCandidate(issue_key="MM-404", source="future_source"),
+        ],
+        get_issue=get_issue,
+    )
+
+    assert resolved["status"] == "resolved"
+    assert resolved["issueKey"] == "MM-403"
+    assert resolved["source"] == "merge_automation"
+    assert calls == ["MM-403"]
+
 def test_select_done_transition_requires_exactly_one_safe_done_transition() -> None:
     config = PostMergeJiraCompletionConfig()
 

--- a/tests/unit/workflows/temporal/test_post_merge_jira_completion.py
+++ b/tests/unit/workflows/temporal/test_post_merge_jira_completion.py
@@ -76,16 +76,28 @@ async def test_resolve_issue_key_deduplicates_and_detects_ambiguity() -> None:
     ]
     assert calls == ["MM-403"]
 
-    ambiguous = await resolve_issue_key(
+    lower_priority_metadata = await resolve_issue_key(
         [
             JiraIssueCandidate(issue_key="MM-403", source="merge_automation"),
             JiraIssueCandidate(issue_key="MM-404", source="pr_metadata"),
         ],
         get_issue=get_issue,
     )
+    assert lower_priority_metadata["status"] == "resolved"
+    assert lower_priority_metadata["issueKey"] == "MM-403"
+    assert lower_priority_metadata["source"] == "merge_automation"
+    assert calls == ["MM-403", "MM-403"]
+
+    ambiguous = await resolve_issue_key(
+        [
+            JiraIssueCandidate(issue_key="MM-403", source="merge_automation"),
+            JiraIssueCandidate(issue_key="MM-404", source="task_metadata"),
+        ],
+        get_issue=get_issue,
+    )
     assert ambiguous["status"] == "ambiguous"
     assert ambiguous["issueKey"] is None
-    assert calls == ["MM-403", "MM-403", "MM-404"]
+    assert calls == ["MM-403", "MM-403", "MM-403", "MM-404"]
 
 def test_select_done_transition_requires_exactly_one_safe_done_transition() -> None:
     config = PostMergeJiraCompletionConfig()
@@ -183,6 +195,157 @@ async def test_complete_post_merge_jira_transitions_one_valid_issue() -> None:
     assert decision.status == "succeeded"
     assert decision.transitioned is True
     assert calls[-1] == ("transition_issue", ("MM-403", "41", {}))
+
+@pytest.mark.asyncio
+async def test_complete_post_merge_jira_uses_canonical_key_before_pr_metadata() -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def get_issue(issue_key: str) -> dict[str, object]:
+        calls.append(("get_issue", issue_key))
+        return _issue(issue_key)
+
+    async def get_transitions(issue_key: str) -> list[dict[str, object]]:
+        calls.append(("get_transitions", issue_key))
+        return [_transition("41", "Done")]
+
+    async def transition_issue(
+        issue_key: str,
+        transition_id: str,
+        fields: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(("transition_issue", (issue_key, transition_id, fields)))
+        return {"transitioned": True}
+
+    decision = await complete_post_merge_jira(
+        {
+            "jiraIssueKey": "MM-403",
+            "postMergeJira": {"enabled": True, "required": True},
+            "candidateContext": {"prMetadataKeys": ["MM-404"]},
+            "pullRequest": {
+                "title": "MM-405 unrelated metadata",
+                "body": "Reviewed alongside MM-406",
+            },
+        },
+        get_issue=get_issue,
+        get_transitions=get_transitions,
+        transition_issue=transition_issue,
+    )
+
+    assert decision.status == "succeeded"
+    assert decision.issueResolution["issueKey"] == "MM-403"
+    assert decision.issueResolution["source"] == "merge_automation"
+    assert calls == [
+        ("get_issue", "MM-403"),
+        ("get_issue", "MM-403"),
+        ("get_transitions", "MM-403"),
+        ("transition_issue", ("MM-403", "41", {})),
+    ]
+
+@pytest.mark.asyncio
+async def test_complete_post_merge_jira_allows_single_pr_metadata_fallback() -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def get_issue(issue_key: str) -> dict[str, object]:
+        calls.append(("get_issue", issue_key))
+        return _issue(issue_key)
+
+    async def get_transitions(issue_key: str) -> list[dict[str, object]]:
+        calls.append(("get_transitions", issue_key))
+        return [_transition("41", "Done")]
+
+    async def transition_issue(
+        issue_key: str,
+        transition_id: str,
+        fields: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(("transition_issue", (issue_key, transition_id, fields)))
+        return {"transitioned": True}
+
+    decision = await complete_post_merge_jira(
+        {
+            "postMergeJira": {"enabled": True, "required": True},
+            "pullRequest": {
+                "title": "MM-404 completed work",
+                "body": "Same issue repeated for traceability: MM-404",
+            },
+        },
+        get_issue=get_issue,
+        get_transitions=get_transitions,
+        transition_issue=transition_issue,
+    )
+
+    assert decision.status == "succeeded"
+    assert decision.issueResolution["issueKey"] == "MM-404"
+    assert decision.issueResolution["source"] == "pr_metadata"
+    assert calls[-1] == ("transition_issue", ("MM-404", "41", {}))
+    assert [call for call in calls if call[0] == "transition_issue"] == [
+        ("transition_issue", ("MM-404", "41", {}))
+    ]
+
+@pytest.mark.asyncio
+async def test_complete_post_merge_jira_blocks_multiple_pr_metadata_fallback_keys() -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def get_issue(issue_key: str) -> dict[str, object]:
+        calls.append(("get_issue", issue_key))
+        return _issue(issue_key)
+
+    async def get_transitions(issue_key: str) -> list[dict[str, object]]:
+        calls.append(("get_transitions", issue_key))
+        return [_transition("41", "Done")]
+
+    async def transition_issue(
+        issue_key: str,
+        transition_id: str,
+        fields: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(("transition_issue", (issue_key, transition_id, fields)))
+        return {"transitioned": True}
+
+    decision = await complete_post_merge_jira(
+        {
+            "postMergeJira": {"enabled": True, "required": True},
+            "candidateContext": {"prMetadataKeys": ["MM-404", "MM-405"]},
+        },
+        get_issue=get_issue,
+        get_transitions=get_transitions,
+        transition_issue=transition_issue,
+    )
+
+    assert decision.status == "blocked"
+    assert decision.issueResolution["status"] == "ambiguous"
+    assert [call for call in calls if call[0] == "transition_issue"] == []
+
+@pytest.mark.asyncio
+async def test_complete_post_merge_jira_blocks_missing_key_without_transition() -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def get_issue(issue_key: str) -> dict[str, object]:
+        calls.append(("get_issue", issue_key))
+        return _issue(issue_key)
+
+    async def get_transitions(issue_key: str) -> list[dict[str, object]]:
+        calls.append(("get_transitions", issue_key))
+        return [_transition("41", "Done")]
+
+    async def transition_issue(
+        issue_key: str,
+        transition_id: str,
+        fields: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(("transition_issue", (issue_key, transition_id, fields)))
+        return {"transitioned": True}
+
+    decision = await complete_post_merge_jira(
+        {"postMergeJira": {"enabled": True, "required": True}},
+        get_issue=get_issue,
+        get_transitions=get_transitions,
+        transition_issue=transition_issue,
+    )
+
+    assert decision.status == "blocked"
+    assert decision.issueResolution["status"] == "missing"
+    assert calls == []
 
 @pytest.mark.asyncio
 async def test_complete_post_merge_jira_returns_failed_decision_for_read_failures() -> None:


### PR DESCRIPTION
## Summary
- Jira issue key: MM-708
- Active MoonSpec feature path: `specs/001-harden-jira-completion`
- Verification verdict: FULLY_IMPLEMENTED

## Changes
- Enforces deterministic post-merge Jira completion target priority: explicit `postMergeJira.issueKey`, canonical/captured Jira context, then strict PR metadata fallback.
- Adds strict fallback tests for canonical-over-metadata, single PR metadata fallback, multiple metadata ambiguity, and missing target blocking.

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Python: `5222 passed, 6 skipped, 1 xpassed, 16 subtests passed`
- Frontend/Vitest: `22 passed`; `375 passed | 232 skipped`

## Remaining Risks
- Full hermetic Docker integration suite was not rerun in this handoff step; the relevant workflow-boundary regression tests are covered by the unit runner.
- The local checkout has Git metadata permission issues for fetch/reflog updates, but the remote branch push and PR creation use authenticated GitHub tooling.
