### PR TITLE
MM-716 Generalize checkpoint contracts beyond failed-step Resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,8 @@ Key diagnostics:
 - Existing `settings_overrides` and `settings_audit_events` SQLAlchemy/Alembic tables (`api_service/db/models.py`). No new persistent storage. (358-settings-migration-and-backup-docs)
 - Python 3.12 (backend, tests); TypeScript/React for the §26 component-split reference test (Vitest). + pytest, pytest-asyncio, `SettingsCatalogService`/`SettingsRegistry`/`SettingsCatalogBuilder`/`SettingsMigrationOrchestrator`/`SettingsChangePublisher`/`settings_backup`/`settings_migrations`, FastAPI ASGI test client, SQLAlchemy async fixtures, Docker Compose (`docker-compose.test.yaml`), Vitest, Testing Library. (359-mm713-settings-guardrail-suite)
 - Existing `settings_overrides`, `settings_audit_events`, `managed_secrets`, `managed_agent_provider_profiles` schemas. No new persistent storage. (359-mm713-settings-guardrail-suite)
+- Python 3.12 + Pydantic v2, Temporal Python SDK models/helpers, existing artifact-ref conventions (716-generalize-checkpoint-contracts)
+- Existing artifact refs only; no new persistent storage (716-generalize-checkpoint-contracts)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -335,7 +335,7 @@ class StepAttemptBoundaryResultModel(BaseModel):
 class WorkspaceCheckpointEvidenceModel(BaseModel):
     """Compact workspace evidence for restoring or validating a checkpoint."""
 
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     kind: WorkspaceCheckpointKind = Field(..., alias="kind")
     base_commit: str | None = Field(None, alias="baseCommit")

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -57,6 +57,9 @@ TASK_RUN_ID_PARAM_KEYS = ("taskRunId", "task_run_id")
 STEP_ATTEMPT_MANIFEST_CONTENT_TYPE = (
     "application/vnd.moonmind.step-attempt+json;version=1"
 )
+STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE = (
+    "application/vnd.moonmind.step-attempt-checkpoint+json;version=1"
+)
 
 StepAttemptReason = Literal[
     "initial_execution",
@@ -90,6 +93,42 @@ StepAttemptTerminalDisposition = Literal[
     "failed_unrecoverable",
 ]
 StepAttemptSemanticOperation = Literal["retry", "reattempt", "resume"]
+StepAttemptCheckpointBoundary = Literal[
+    "after_prepare",
+    "before_attempt",
+    "after_attempt",
+    "after_gate",
+    "before_publication",
+    "before_resume_restoration",
+]
+WorkspaceCheckpointKind = Literal[
+    "git_commit",
+    "git_patch",
+    "worktree_archive",
+    "ephemeral_workspace_ref",
+    "external_state_ref",
+]
+WorkspacePolicy = Literal[
+    "restore_pre_attempt",
+    "continue_from_previous_attempt",
+    "apply_previous_diff_to_clean_baseline",
+    "start_from_last_passed_commit",
+    "fresh_branch_from_source",
+]
+StepCheckpointValidationFailureCode = Literal[
+    "source_mismatch",
+    "task_input_mismatch",
+    "plan_mismatch",
+    "step_mismatch",
+    "attempt_mismatch",
+    "artifact_missing",
+    "artifact_unauthorized",
+    "artifact_corrupted",
+    "workspace_mismatch",
+    "checkpoint_kind_incompatible",
+    "policy_incompatible",
+    "invalid_checkpoint",
+]
 _STEP_ATTEMPT_INLINE_EVIDENCE_KEYS = {
     "content",
     "diff",
@@ -103,6 +142,39 @@ _STEP_ATTEMPT_INLINE_EVIDENCE_KEYS = {
     "stderr",
     "stdout",
 }
+
+
+def _reject_inline_checkpoint_evidence(value: Any, path: str) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_text = str(key)
+            normalized = (
+                key_text.replace("_", "").replace("-", "").replace(" ", "").lower()
+            )
+            is_ref_key = normalized.endswith("ref") or normalized.endswith("refs")
+            is_summary_key = "summary" in normalized or "message" in normalized
+            if (
+                (
+                    normalized in _STEP_ATTEMPT_INLINE_EVIDENCE_KEYS
+                    or normalized == "inlinecheckpointpayload"
+                )
+                and not is_ref_key
+                and not is_summary_key
+            ):
+                raise ValueError(
+                    "Step Attempt checkpoints must store large evidence as "
+                    f"compact refs, not inline values at {path}.{key_text}."
+                )
+            if isinstance(nested, str) and len(nested) > 1000:
+                if not is_ref_key and not is_summary_key:
+                    raise ValueError(
+                        "Step Attempt checkpoints must store large evidence as "
+                        f"compact refs, not inline values at {path}.{key_text}."
+                    )
+            _reject_inline_checkpoint_evidence(nested, f"{path}.{key_text}")
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            _reject_inline_checkpoint_evidence(nested, f"{path}[{index}]")
 
 def normalize_dependency_ids(raw_value: Any) -> list[str]:
     """Normalize a list of dependency IDs, stripping whitespace and removing duplicates/non-strings."""
@@ -258,6 +330,228 @@ class StepAttemptBoundaryResultModel(BaseModel):
     manifest_artifact_ref: str = Field(..., alias="manifestArtifactRef", min_length=1)
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     summary: str | None = Field(None, alias="summary", max_length=1000)
+
+
+class WorkspaceCheckpointEvidenceModel(BaseModel):
+    """Compact workspace evidence for restoring or validating a checkpoint."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    kind: WorkspaceCheckpointKind = Field(..., alias="kind")
+    base_commit: str | None = Field(None, alias="baseCommit")
+    head_commit: str | None = Field(None, alias="headCommit")
+    patch_ref: str | None = Field(None, alias="patchRef")
+    archive_ref: str | None = Field(None, alias="archiveRef")
+    workspace_ref: str | None = Field(None, alias="workspaceRef")
+    external_state_ref: str | None = Field(None, alias="externalStateRef")
+    manifest_ref: str | None = Field(None, alias="manifestRef")
+    branch: str | None = Field(None, alias="branch")
+    includes_untracked: bool = Field(False, alias="includesUntracked")
+    includes_ignored_files: bool = Field(False, alias="includesIgnoredFiles")
+    created_at: datetime | None = Field(None, alias="createdAt")
+    expires_at: datetime | None = Field(None, alias="expiresAt")
+
+    @field_validator(
+        "base_commit",
+        "head_commit",
+        "patch_ref",
+        "archive_ref",
+        "workspace_ref",
+        "external_state_ref",
+        "manifest_ref",
+        "branch",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @model_validator(mode="after")
+    def _validate_kind_evidence(self) -> "WorkspaceCheckpointEvidenceModel":
+        if self.kind == "git_commit" and not (
+            self.base_commit or self.head_commit
+        ):
+            raise ValueError(
+                "git_commit checkpoint requires baseCommit or headCommit"
+            )
+        if self.kind == "git_patch" and not (
+            self.base_commit and self.patch_ref
+        ):
+            raise ValueError("git_patch checkpoint requires baseCommit and patchRef")
+        if self.kind == "worktree_archive" and not (
+            self.archive_ref and self.manifest_ref
+        ):
+            raise ValueError(
+                "worktree_archive checkpoint requires archiveRef and manifestRef"
+            )
+        if self.kind == "ephemeral_workspace_ref" and not self.workspace_ref:
+            raise ValueError(
+                "ephemeral_workspace_ref checkpoint requires workspaceRef"
+            )
+        if self.kind == "external_state_ref" and not self.external_state_ref:
+            raise ValueError("external_state_ref checkpoint requires externalStateRef")
+        _reject_inline_checkpoint_evidence(
+            self.model_dump(by_alias=True, mode="json"),
+            "workspace",
+        )
+        return self
+
+
+class StepCheckpointValidationResultModel(BaseModel):
+    """Compact workflow-visible checkpoint validation decision."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    valid: bool = Field(..., alias="valid")
+    failure_code: StepCheckpointValidationFailureCode | None = Field(
+        None, alias="failureCode"
+    )
+    message: str = Field(..., alias="message", min_length=1, max_length=1000)
+    checkpoint_id: str = Field(..., alias="checkpointId", min_length=1)
+    checkpoint_ref: str | None = Field(None, alias="checkpointRef")
+
+    @model_validator(mode="after")
+    def _validate_result_shape(self) -> "StepCheckpointValidationResultModel":
+        if self.valid and self.failure_code is not None:
+            raise ValueError("valid checkpoint result cannot include failureCode")
+        if not self.valid and self.failure_code is None:
+            raise ValueError("invalid checkpoint result requires failureCode")
+        return self
+
+
+class StepAttemptCheckpointModel(BaseModel):
+    """Artifact-backed Step Attempt checkpoint payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: Literal["v1"] = Field("v1", alias="schemaVersion")
+    content_type: Literal[STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE] = Field(
+        STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE,
+        alias="contentType",
+    )
+    checkpoint_id: str = Field(..., alias="checkpointId", min_length=1)
+    checkpoint_kind: Literal["step_boundary"] = Field(
+        "step_boundary", alias="checkpointKind"
+    )
+    boundary: StepAttemptCheckpointBoundary = Field(..., alias="boundary")
+    source: StepAttemptIdentityModel = Field(..., alias="source")
+    task_input_snapshot_ref: str = Field(
+        ..., alias="taskInputSnapshotRef", min_length=1
+    )
+    plan_ref: str | None = Field(None, alias="planRef")
+    plan_digest: str | None = Field(None, alias="planDigest")
+    prepared_input_refs: list[str] = Field(
+        default_factory=list, alias="preparedInputRefs"
+    )
+    workspace: WorkspaceCheckpointEvidenceModel = Field(..., alias="workspace")
+    step_outputs: dict[str, Any] = Field(default_factory=dict, alias="stepOutputs")
+    validation: StepCheckpointValidationResultModel | None = Field(
+        None, alias="validation"
+    )
+    created_at: datetime = Field(..., alias="createdAt")
+
+    @field_validator("plan_ref", "plan_digest", mode="before")
+    @classmethod
+    def _normalize_optional_ref(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator("prepared_input_refs")
+    @classmethod
+    def _normalize_prepared_input_refs(cls, value: list[str]) -> list[str]:
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    @field_validator("step_outputs", mode="before")
+    @classmethod
+    def _validate_compact_step_outputs(cls, value: Any) -> dict[str, Any]:
+        output = validate_compact_temporal_mapping(
+            value, field_name="stepOutputs"
+        )
+        _reject_inline_checkpoint_evidence(output, "stepOutputs")
+        return output
+
+    @model_validator(mode="after")
+    def _validate_checkpoint_identity(self) -> "StepAttemptCheckpointModel":
+        expected = (
+            f"{self.source.workflow_id}:{self.source.run_id}:"
+            f"{self.source.logical_step_id}:attempt:{self.source.attempt}:"
+            f"checkpoint:{self.boundary}"
+        )
+        if self.checkpoint_id != expected:
+            raise ValueError("checkpointId must match Step Attempt boundary identity")
+        if self.plan_ref is None and self.plan_digest is None:
+            raise ValueError("checkpoint requires planRef or planDigest")
+        return self
+
+
+class StepCheckpointValidationRequestModel(BaseModel):
+    """Input for validating checkpoint evidence before attempt or Resume execution."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    checkpoint: StepAttemptCheckpointModel = Field(..., alias="checkpoint")
+    expected_source: StepAttemptIdentityModel = Field(..., alias="expectedSource")
+    expected_task_input_snapshot_ref: str = Field(
+        ..., alias="expectedTaskInputSnapshotRef", min_length=1
+    )
+    expected_plan_ref: str | None = Field(None, alias="expectedPlanRef")
+    expected_plan_digest: str | None = Field(None, alias="expectedPlanDigest")
+    workspace_policy: WorkspacePolicy | None = Field(None, alias="workspacePolicy")
+    required_artifact_refs: list[str] = Field(
+        default_factory=list, alias="requiredArtifactRefs"
+    )
+    unauthorized_artifact_refs: list[str] = Field(
+        default_factory=list, alias="unauthorizedArtifactRefs"
+    )
+    corrupted_artifact_refs: list[str] = Field(
+        default_factory=list, alias="corruptedArtifactRefs"
+    )
+    expected_workspace: dict[str, Any] = Field(
+        default_factory=dict, alias="expectedWorkspace"
+    )
+    checkpoint_ref: str | None = Field(None, alias="checkpointRef")
+
+    @field_validator(
+        "expected_plan_ref",
+        "expected_plan_digest",
+        "checkpoint_ref",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator(
+        "required_artifact_refs",
+        "unauthorized_artifact_refs",
+        "corrupted_artifact_refs",
+    )
+    @classmethod
+    def _normalize_artifact_refs(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            candidate = str(item).strip()
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            normalized.append(candidate)
+        return normalized
+
+    @field_validator("expected_workspace", mode="before")
+    @classmethod
+    def _validate_expected_workspace(cls, value: Any) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value, field_name="expectedWorkspace"
+        )
 
 
 class StepAttemptSemanticOperationModel(BaseModel):

--- a/moonmind/workflows/temporal/step_checkpoints.py
+++ b/moonmind/workflows/temporal/step_checkpoints.py
@@ -1,0 +1,227 @@
+"""Pure helpers for Step Attempt checkpoint identity and validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from moonmind.schemas.temporal_models import (
+    STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE,
+    StepAttemptCheckpointBoundary,
+    StepAttemptCheckpointModel,
+    StepAttemptIdentityModel,
+    StepCheckpointValidationRequestModel,
+    StepCheckpointValidationResultModel,
+    WorkspaceCheckpointKind,
+    WorkspacePolicy,
+)
+
+_POLICY_CHECKPOINT_KINDS: dict[WorkspacePolicy, tuple[WorkspaceCheckpointKind, ...]] = {
+    "restore_pre_attempt": (
+        "git_commit",
+        "worktree_archive",
+        "ephemeral_workspace_ref",
+    ),
+    "continue_from_previous_attempt": (
+        "ephemeral_workspace_ref",
+        "git_patch",
+        "worktree_archive",
+        "git_commit",
+        "external_state_ref",
+    ),
+    "apply_previous_diff_to_clean_baseline": ("git_patch",),
+    "start_from_last_passed_commit": ("git_commit",),
+    "fresh_branch_from_source": (),
+}
+
+
+def build_step_checkpoint_id(
+    identity: StepAttemptIdentityModel,
+    boundary: StepAttemptCheckpointBoundary,
+) -> str:
+    """Build the deterministic identifier for one Step Attempt checkpoint."""
+
+    return (
+        f"{identity.workflow_id}:{identity.run_id}:"
+        f"{identity.logical_step_id}:attempt:{identity.attempt}:"
+        f"checkpoint:{boundary}"
+    )
+
+
+def build_step_checkpoint_idempotency_key(
+    identity: StepAttemptIdentityModel,
+    boundary: StepAttemptCheckpointBoundary,
+    operation: str = "write",
+) -> str:
+    """Build a deterministic idempotency key for checkpoint activity writes."""
+
+    operation_id = str(operation or "").strip()
+    if not operation_id:
+        raise ValueError("operation must be a non-empty string")
+    return f"{build_step_checkpoint_id(identity, boundary)}:{operation_id}"
+
+
+def build_step_checkpoint_payload(
+    *,
+    identity: StepAttemptIdentityModel,
+    boundary: StepAttemptCheckpointBoundary,
+    task_input_snapshot_ref: str,
+    workspace: Mapping[str, Any],
+    created_at: datetime,
+    plan_ref: str | None = None,
+    plan_digest: str | None = None,
+    prepared_input_refs: list[str] | tuple[str, ...] = (),
+    step_outputs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-serializable checkpoint artifact payload."""
+
+    checkpoint = StepAttemptCheckpointModel(
+        schemaVersion="v1",
+        contentType=STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE,
+        checkpointId=build_step_checkpoint_id(identity, boundary),
+        checkpointKind="step_boundary",
+        boundary=boundary,
+        source=identity,
+        taskInputSnapshotRef=task_input_snapshot_ref,
+        planRef=plan_ref,
+        planDigest=plan_digest,
+        preparedInputRefs=list(prepared_input_refs),
+        workspace=dict(workspace),
+        stepOutputs=dict(step_outputs or {}),
+        createdAt=created_at,
+    )
+    return checkpoint.model_dump(by_alias=True, mode="json")
+
+
+def checkpoint_kinds_for_workspace_policy(
+    policy: WorkspacePolicy,
+) -> tuple[WorkspaceCheckpointKind, ...]:
+    """Return accepted checkpoint kinds for a workspace policy."""
+
+    return _POLICY_CHECKPOINT_KINDS[policy]
+
+
+def validate_step_checkpoint(
+    request: StepCheckpointValidationRequestModel,
+) -> StepCheckpointValidationResultModel:
+    """Validate checkpoint evidence before launching attempt or Resume work."""
+
+    checkpoint = request.checkpoint
+    source = checkpoint.source
+    expected = request.expected_source
+    if source.workflow_id != expected.workflow_id or source.run_id != expected.run_id:
+        return _invalid(request, "source_mismatch", "checkpoint source workflow/run mismatch")
+    if source.logical_step_id != expected.logical_step_id:
+        return _invalid(request, "step_mismatch", "checkpoint logical step mismatch")
+    if source.attempt != expected.attempt:
+        return _invalid(request, "attempt_mismatch", "checkpoint attempt mismatch")
+    if checkpoint.task_input_snapshot_ref != request.expected_task_input_snapshot_ref:
+        return _invalid(
+            request,
+            "task_input_mismatch",
+            "checkpoint task input snapshot mismatch",
+        )
+    if request.expected_plan_ref is not None and (
+        checkpoint.plan_ref != request.expected_plan_ref
+    ):
+        return _invalid(request, "plan_mismatch", "checkpoint plan ref mismatch")
+    if request.expected_plan_digest is not None and (
+        checkpoint.plan_digest != request.expected_plan_digest
+    ):
+        return _invalid(request, "plan_mismatch", "checkpoint plan digest mismatch")
+    if request.workspace_policy is not None:
+        accepted_kinds = checkpoint_kinds_for_workspace_policy(request.workspace_policy)
+        if accepted_kinds and checkpoint.workspace.kind not in accepted_kinds:
+            return _invalid(
+                request,
+                "policy_incompatible",
+                (
+                    f"checkpoint kind {checkpoint.workspace.kind} does not satisfy "
+                    f"workspace policy {request.workspace_policy}"
+                ),
+            )
+    workspace_payload = checkpoint.workspace.model_dump(by_alias=True, mode="json")
+    for key, expected_value in request.expected_workspace.items():
+        if workspace_payload.get(key) != expected_value:
+            return _invalid(
+                request,
+                "workspace_mismatch",
+                f"checkpoint workspace {key} mismatch",
+            )
+    available_artifact_refs = _checkpoint_artifact_refs(checkpoint, request)
+    for artifact_ref in request.unauthorized_artifact_refs:
+        if artifact_ref in available_artifact_refs:
+            return _invalid(
+                request,
+                "artifact_unauthorized",
+                f"checkpoint artifact ref {artifact_ref} is unauthorized",
+            )
+    for artifact_ref in request.corrupted_artifact_refs:
+        if artifact_ref in available_artifact_refs:
+            return _invalid(
+                request,
+                "artifact_corrupted",
+                f"checkpoint artifact ref {artifact_ref} is corrupted",
+            )
+    for artifact_ref in request.required_artifact_refs:
+        if artifact_ref not in available_artifact_refs:
+            return _invalid(
+                request,
+                "artifact_missing",
+                f"checkpoint missing required artifact ref {artifact_ref}",
+            )
+    return StepCheckpointValidationResultModel(
+        valid=True,
+        failureCode=None,
+        message="checkpoint validation passed",
+        checkpointId=checkpoint.checkpoint_id,
+        checkpointRef=request.checkpoint_ref,
+    )
+
+
+def _invalid(
+    request: StepCheckpointValidationRequestModel,
+    failure_code: str,
+    message: str,
+) -> StepCheckpointValidationResultModel:
+    return StepCheckpointValidationResultModel(
+        valid=False,
+        failureCode=failure_code,
+        message=message,
+        checkpointId=request.checkpoint.checkpoint_id,
+        checkpointRef=request.checkpoint_ref,
+    )
+
+
+def _checkpoint_artifact_refs(
+    checkpoint: StepAttemptCheckpointModel,
+    request: StepCheckpointValidationRequestModel,
+) -> set[str]:
+    refs: set[str] = {
+        checkpoint.task_input_snapshot_ref,
+        *checkpoint.prepared_input_refs,
+    }
+    if checkpoint.plan_ref:
+        refs.add(checkpoint.plan_ref)
+    if request.checkpoint_ref:
+        refs.add(request.checkpoint_ref)
+    _collect_ref_values(checkpoint.workspace.model_dump(by_alias=True, mode="json"), refs)
+    _collect_ref_values(checkpoint.step_outputs, refs)
+    return refs
+
+
+def _collect_ref_values(value: Any, refs: set[str]) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            normalized = str(key).replace("_", "").replace("-", "").lower()
+            if normalized.endswith("ref") and isinstance(nested, str) and nested.strip():
+                refs.add(nested.strip())
+            elif normalized.endswith("refs") and isinstance(nested, list):
+                for item in nested:
+                    if isinstance(item, str) and item.strip():
+                        refs.add(item.strip())
+            _collect_ref_values(nested, refs)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_ref_values(item, refs)

--- a/moonmind/workflows/temporal/step_checkpoints.py
+++ b/moonmind/workflows/temporal/step_checkpoints.py
@@ -132,7 +132,7 @@ def validate_step_checkpoint(
         return _invalid(request, "plan_mismatch", "checkpoint plan digest mismatch")
     if request.workspace_policy is not None:
         accepted_kinds = checkpoint_kinds_for_workspace_policy(request.workspace_policy)
-        if accepted_kinds and checkpoint.workspace.kind not in accepted_kinds:
+        if checkpoint.workspace.kind not in accepted_kinds:
             return _invalid(
                 request,
                 "policy_incompatible",
@@ -214,7 +214,9 @@ def _checkpoint_artifact_refs(
 def _collect_ref_values(value: Any, refs: set[str]) -> None:
     if isinstance(value, dict):
         for key, nested in value.items():
-            normalized = str(key).replace("_", "").replace("-", "").lower()
+            normalized = (
+                str(key).replace("_", "").replace("-", "").replace(" ", "").lower()
+            )
             if normalized.endswith("ref") and isinstance(nested, str) and nested.strip():
                 refs.add(nested.strip())
             elif normalized.endswith("refs") and isinstance(nested, list):

--- a/tests/integration/workflows/temporal/test_step_checkpoint_validation.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_validation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from moonmind.schemas.temporal_models import (
+    StepCheckpointValidationRequestModel,
+    StepAttemptCheckpointModel,
+    StepAttemptIdentityModel,
+)
+from moonmind.workflows.temporal.step_checkpoints import (
+    build_step_checkpoint_payload,
+    validate_step_checkpoint,
+)
+
+
+def _identity() -> StepAttemptIdentityModel:
+    return StepAttemptIdentityModel(
+        workflowId="workflow-1",
+        runId="run-1",
+        logicalStepId="implement-story",
+        attempt=2,
+    )
+
+
+def _valid_checkpoint() -> StepAttemptCheckpointModel:
+    return StepAttemptCheckpointModel.model_validate(
+        build_step_checkpoint_payload(
+            identity=_identity(),
+            boundary="before_attempt",
+            task_input_snapshot_ref="artifact-input",
+            plan_ref="artifact-plan",
+            plan_digest="sha256:plan",
+            workspace={
+                "kind": "git_patch",
+                "baseCommit": "abc123",
+                "patchRef": "artifact-patch",
+                "manifestRef": "artifact-manifest",
+            },
+            step_outputs={"summaryRef": "artifact-summary"},
+            created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        )
+    )
+
+
+def test_checkpoint_validation_boundary_allows_compact_valid_evidence() -> None:
+    result = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=_valid_checkpoint(),
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanRef="artifact-plan",
+            expectedPlanDigest="sha256:plan",
+            workspacePolicy="apply_previous_diff_to_clean_baseline",
+            requiredArtifactRefs=[
+                "artifact-input",
+                "artifact-plan",
+                "artifact-patch",
+                "artifact-manifest",
+            ],
+            checkpointRef="artifact-checkpoint",
+        )
+    )
+
+    serialized = result.model_dump(by_alias=True)
+    assert serialized == {
+        "valid": True,
+        "failureCode": None,
+        "message": "checkpoint validation passed",
+        "checkpointId": (
+            "workflow-1:run-1:implement-story:attempt:2:checkpoint:before_attempt"
+        ),
+        "checkpointRef": "artifact-checkpoint",
+    }
+
+
+def test_checkpoint_validation_boundary_blocks_runtime_launch_on_mismatch() -> None:
+    plan_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=_valid_checkpoint(),
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:other",
+            workspacePolicy="apply_previous_diff_to_clean_baseline",
+        )
+    )
+    assert plan_mismatch.valid is False
+    assert plan_mismatch.failure_code == "plan_mismatch"
+
+    policy_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=_valid_checkpoint(),
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            workspacePolicy="start_from_last_passed_commit",
+        )
+    )
+    assert policy_mismatch.valid is False
+    assert policy_mismatch.failure_code == "policy_incompatible"

--- a/tests/unit/workflows/temporal/test_step_checkpoints.py
+++ b/tests/unit/workflows/temporal/test_step_checkpoints.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.temporal_models import (
+    STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE,
+    StepCheckpointValidationRequestModel,
+    StepAttemptCheckpointModel,
+    StepAttemptIdentityModel,
+    WorkspaceCheckpointEvidenceModel,
+)
+from moonmind.workflows.temporal.step_checkpoints import (
+    build_step_checkpoint_id,
+    build_step_checkpoint_idempotency_key,
+    build_step_checkpoint_payload,
+    checkpoint_kinds_for_workspace_policy,
+    validate_step_checkpoint,
+)
+
+
+def _identity() -> StepAttemptIdentityModel:
+    return StepAttemptIdentityModel.model_validate(
+        {
+            "workflowId": "workflow-1",
+            "runId": "run-1",
+            "logicalStepId": "implement-story",
+            "attempt": 2,
+        }
+    )
+
+
+def _workspace_patch() -> dict[str, object]:
+    return {
+        "kind": "git_patch",
+        "baseCommit": "abc123",
+        "patchRef": "artifact-patch",
+        "manifestRef": "artifact-manifest",
+        "includesUntracked": True,
+    }
+
+
+def test_checkpoint_payload_uses_deterministic_boundary_identity() -> None:
+    identity = _identity()
+    created_at = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    payload = build_step_checkpoint_payload(
+        identity=identity,
+        boundary="before_attempt",
+        task_input_snapshot_ref="artifact-input",
+        plan_ref="artifact-plan",
+        plan_digest="sha256:plan",
+        workspace=_workspace_patch(),
+        step_outputs={"summaryRef": "artifact-summary"},
+        created_at=created_at,
+    )
+
+    expected_id = (
+        "workflow-1:run-1:implement-story:attempt:2:checkpoint:before_attempt"
+    )
+    assert payload["contentType"] == STEP_ATTEMPT_CHECKPOINT_CONTENT_TYPE
+    assert payload["checkpointId"] == expected_id
+    assert build_step_checkpoint_id(identity, "before_attempt") == expected_id
+    assert build_step_checkpoint_idempotency_key(identity, "before_attempt") == (
+        f"{expected_id}:write"
+    )
+
+    repeated = build_step_checkpoint_payload(
+        identity=identity,
+        boundary="before_attempt",
+        task_input_snapshot_ref="artifact-input",
+        plan_ref="artifact-plan",
+        plan_digest="sha256:plan",
+        workspace=_workspace_patch(),
+        step_outputs={"summaryRef": "artifact-summary"},
+        created_at=created_at,
+    )
+    assert repeated["checkpointId"] == payload["checkpointId"]
+
+
+def test_checkpoint_model_rejects_inline_large_or_raw_content() -> None:
+    identity = _identity()
+    payload = build_step_checkpoint_payload(
+        identity=identity,
+        boundary="after_attempt",
+        task_input_snapshot_ref="artifact-input",
+        plan_ref="artifact-plan",
+        workspace=_workspace_patch(),
+        created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+    )
+    payload["workspace"]["inlineCheckpointPayload"] = {"raw": "x" * 20}
+
+    with pytest.raises(ValidationError, match="compact refs"):
+        StepAttemptCheckpointModel.model_validate(payload)
+
+    payload = {
+        **build_step_checkpoint_payload(
+            identity=identity,
+            boundary="after_attempt",
+            task_input_snapshot_ref="artifact-input",
+            plan_ref="artifact-plan",
+            workspace=_workspace_patch(),
+            created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        ),
+        "stepOutputs": {"logText": "x" * 2000},
+    }
+    with pytest.raises(ValidationError, match="compact refs"):
+        StepAttemptCheckpointModel.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("workspace", "message"),
+    [
+        ({"kind": "git_commit"}, "git_commit checkpoint requires"),
+        ({"kind": "git_patch", "patchRef": "artifact-patch"}, "git_patch checkpoint requires"),
+        ({"kind": "worktree_archive", "archiveRef": "artifact-archive"}, "worktree_archive checkpoint requires"),
+        ({"kind": "ephemeral_workspace_ref"}, "ephemeral_workspace_ref checkpoint requires"),
+        ({"kind": "external_state_ref"}, "external_state_ref checkpoint requires"),
+    ],
+)
+def test_workspace_checkpoint_kinds_require_kind_specific_evidence(
+    workspace: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        WorkspaceCheckpointEvidenceModel.model_validate(workspace)
+
+
+def test_workspace_policy_matrix_and_validation_failure_codes() -> None:
+    assert checkpoint_kinds_for_workspace_policy("apply_previous_diff_to_clean_baseline") == (
+        "git_patch",
+    )
+    assert "worktree_archive" in checkpoint_kinds_for_workspace_policy(
+        "restore_pre_attempt"
+    )
+    assert checkpoint_kinds_for_workspace_policy("fresh_branch_from_source") == ()
+
+    checkpoint = StepAttemptCheckpointModel.model_validate(
+        build_step_checkpoint_payload(
+            identity=_identity(),
+            boundary="before_attempt",
+            task_input_snapshot_ref="artifact-input",
+            plan_digest="sha256:plan",
+            workspace={
+                "kind": "git_commit",
+                "headCommit": "def456",
+            },
+            created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        )
+    )
+    result = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            workspacePolicy="apply_previous_diff_to_clean_baseline",
+            requiredArtifactRefs=["artifact-input"],
+        )
+    )
+
+    assert result.valid is False
+    assert result.failure_code == "policy_incompatible"
+    assert "apply_previous_diff_to_clean_baseline" in result.message
+
+
+def test_validation_reports_source_plan_and_artifact_failures() -> None:
+    checkpoint = StepAttemptCheckpointModel.model_validate(
+        build_step_checkpoint_payload(
+            identity=_identity(),
+            boundary="before_resume_restoration",
+            task_input_snapshot_ref="artifact-input",
+            plan_digest="sha256:plan",
+            workspace=_workspace_patch(),
+            created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        )
+    )
+
+    source_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity().model_copy(update={"run_id": "run-2"}),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+        )
+    )
+    assert source_mismatch.failure_code == "source_mismatch"
+
+    plan_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:other",
+        )
+    )
+    assert plan_mismatch.failure_code == "plan_mismatch"
+
+    missing_artifact = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            requiredArtifactRefs=["artifact-missing"],
+        )
+    )
+    assert missing_artifact.failure_code == "artifact_missing"
+
+    unauthorized_artifact = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            unauthorizedArtifactRefs=["artifact-patch"],
+        )
+    )
+    assert unauthorized_artifact.failure_code == "artifact_unauthorized"
+
+    corrupted_artifact = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            corruptedArtifactRefs=["artifact-manifest"],
+        )
+    )
+    assert corrupted_artifact.failure_code == "artifact_corrupted"
+
+    workspace_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            expectedWorkspace={"baseCommit": "different"},
+        )
+    )
+    assert workspace_mismatch.failure_code == "workspace_mismatch"

--- a/tests/unit/workflows/temporal/test_step_checkpoints.py
+++ b/tests/unit/workflows/temporal/test_step_checkpoints.py
@@ -82,19 +82,6 @@ def test_checkpoint_payload_uses_deterministic_boundary_identity() -> None:
 
 def test_checkpoint_model_rejects_inline_large_or_raw_content() -> None:
     identity = _identity()
-    payload = build_step_checkpoint_payload(
-        identity=identity,
-        boundary="after_attempt",
-        task_input_snapshot_ref="artifact-input",
-        plan_ref="artifact-plan",
-        workspace=_workspace_patch(),
-        created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
-    )
-    payload["workspace"]["inlineCheckpointPayload"] = {"raw": "x" * 20}
-
-    with pytest.raises(ValidationError, match="compact refs"):
-        StepAttemptCheckpointModel.model_validate(payload)
-
     payload = {
         **build_step_checkpoint_payload(
             identity=identity,
@@ -108,6 +95,16 @@ def test_checkpoint_model_rejects_inline_large_or_raw_content() -> None:
     }
     with pytest.raises(ValidationError, match="compact refs"):
         StepAttemptCheckpointModel.model_validate(payload)
+
+
+def test_workspace_checkpoint_model_rejects_unexpected_fields() -> None:
+    workspace = {
+        **_workspace_patch(),
+        "inlineCheckpointPayload": {"raw": "x" * 20},
+    }
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkspaceCheckpointEvidenceModel.model_validate(workspace)
 
 
 @pytest.mark.parametrize(
@@ -164,6 +161,19 @@ def test_workspace_policy_matrix_and_validation_failure_codes() -> None:
     assert result.valid is False
     assert result.failure_code == "policy_incompatible"
     assert "apply_previous_diff_to_clean_baseline" in result.message
+
+    fresh_branch_mismatch = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            workspacePolicy="fresh_branch_from_source",
+        )
+    )
+
+    assert fresh_branch_mismatch.valid is False
+    assert fresh_branch_mismatch.failure_code == "policy_incompatible"
 
 
 def test_validation_reports_source_plan_and_artifact_failures() -> None:
@@ -241,3 +251,29 @@ def test_validation_reports_source_plan_and_artifact_failures() -> None:
         )
     )
     assert workspace_mismatch.failure_code == "workspace_mismatch"
+
+
+def test_validation_collects_artifact_refs_from_space_separated_keys() -> None:
+    checkpoint = StepAttemptCheckpointModel.model_validate(
+        build_step_checkpoint_payload(
+            identity=_identity(),
+            boundary="before_resume_restoration",
+            task_input_snapshot_ref="artifact-input",
+            plan_digest="sha256:plan",
+            workspace=_workspace_patch(),
+            step_outputs={"patch Ref": "artifact-space-ref"},
+            created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        )
+    )
+
+    result = validate_step_checkpoint(
+        StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=_identity(),
+            expectedTaskInputSnapshotRef="artifact-input",
+            expectedPlanDigest="sha256:plan",
+            requiredArtifactRefs=["artifact-space-ref"],
+        )
+    )
+
+    assert result.valid is True


### PR DESCRIPTION
Jira issue key: MM-716

Active MoonSpec feature path: specs/716-generalize-checkpoint-contracts

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- pytest tests/unit/workflows/temporal/test_step_checkpoints.py -q — PASS (9 passed)
- pytest tests/integration/workflows/temporal/test_step_checkpoint_validation.py -q — PASS (2 passed)
- pytest tests/unit/workflows/temporal/test_step_attempt_manifest.py tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py -q — PASS (30 passed)
- ./tools/test_unit.sh — PASS (5290 passed, 6 skipped, 1 xpassed, 122 warnings, 16 subtests passed; frontend 23 files / 380 tests passed, 232 skipped)
- ./tools/test_integration.sh — NOT RUN: Docker build blocked by managed runtime admin policy (403 Forbidden); focused integration coverage passed.

Remaining risks:
- Full compose-backed hermetic integration wrapper could not run in this managed runtime because Docker build was blocked by administrative rules.
- AGENTS.md includes the generated active-technology entry for this feature.
