### PR TITLE
[codex] Fix task detail step ledger fallback

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3218,6 +3218,23 @@ def _fallback_current_step_order(record: Any) -> int | None:
     memo = getattr(record, "memo", None)
     if not isinstance(memo, Mapping):
         return None
+    structured = memo.get("mm_current_step_order")
+    if isinstance(structured, bool):
+        structured = None
+    if isinstance(structured, int):
+        return structured if structured > 0 else None
+    if isinstance(structured, str):
+        candidate = structured.strip()
+        if candidate:
+            try:
+                order = int(candidate)
+            except ValueError:
+                order = None
+            if order is not None:
+                return order if order > 0 else None
+    # Compatibility fallback for in-flight workflows that predate
+    # ``mm_current_step_order``; the human-readable ``summary`` carries the
+    # current step as ``step <n>/<total>``.
     summary = str(memo.get("summary") or "").strip()
     match = re.search(r"\bstep\s+(\d+)\s*/\s*\d+\b", summary, re.IGNORECASE)
     if match is None:
@@ -3246,7 +3263,6 @@ def _fallback_step_ledger_from_record(record: Any) -> StepLedgerSnapshotModel | 
 
     ordered_nodes: list[dict[str, Any]] = []
     dependency_map: dict[str, list[str]] = {}
-    explicit_dependencies = False
 
     for index, step in enumerate(normalized_steps, start=1):
         step_id = str(
@@ -3271,24 +3287,14 @@ def _fallback_step_ledger_from_record(record: Any) -> StepLedgerSnapshotModel | 
                 "inputs": {"title": title},
             }
         )
-        dependencies = normalize_dependency_ids(
+        dependency_map[step_id] = normalize_dependency_ids(
             step.get("dependsOn")
             or step.get("depends_on")
             or step.get("dependencies")
         )
-        if dependencies:
-            explicit_dependencies = True
-        dependency_map[step_id] = dependencies
 
     if not ordered_nodes:
         return None
-
-    if not explicit_dependencies and len(ordered_nodes) > 1:
-        previous_step_id = None
-        for node in ordered_nodes:
-            step_id = str(node.get("id") or "").strip()
-            dependency_map[step_id] = [previous_step_id] if previous_step_id else []
-            previous_step_id = step_id
 
     updated_at = _compatibility_refreshed_at(record)
     rows = build_initial_step_rows(
@@ -3358,6 +3364,7 @@ async def _load_execution_progress(
             "Failed to query execution progress for %s: %s",
             workflow_id,
             exc,
+            exc_info=True,
         )
         return None, None
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -95,6 +95,7 @@ from moonmind.workflows.temporal import (
     TemporalExecutionValidationError,
     build_manifest_status_snapshot,
 )
+from moonmind.workflows.temporal.step_ledger import build_initial_step_rows
 from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactAuthorizationError,
     build_artifact_ref,
@@ -2802,7 +2803,7 @@ async def _resolver_child_observability(
     task_run_id: str | None = None
     child_status: str | None = None
     try:
-        payload = await query_workflow(
+        payload = await _query_workflow_for_detail(
             temporal_client,
             workflow_id,
             "get_step_ledger",
@@ -2839,6 +2840,21 @@ async def _resolver_child_observability(
         detailHref=f"/tasks/{quote(workflow_id, safe='')}?source=temporal",
     )
 
+
+async def _query_workflow_for_detail(
+    temporal_client: Client,
+    workflow_id: str,
+    query_name: str,
+) -> Any:
+    timeout_seconds = float(
+        settings.temporal_dashboard.live_query_timeout_seconds
+    )
+    return await asyncio.wait_for(
+        query_workflow(temporal_client, workflow_id, query_name),
+        timeout=timeout_seconds,
+    )
+
+
 async def _enrich_execution_merge_automation(
     execution: ExecutionModel,
     *,
@@ -2851,7 +2867,7 @@ async def _enrich_execution_merge_automation(
     payload = merge_automation.model_dump(by_alias=True, exclude_none=True)
     if workflow_id:
         try:
-            live_payload = await query_workflow(
+            live_payload = await _query_workflow_for_detail(
                 temporal_client,
                 workflow_id,
                 "summary",
@@ -3153,19 +3169,195 @@ async def _enrich_step_ledger_task_run_refs(payload: Any) -> Any:
     enriched_payload["steps"] = enriched_steps
     return enriched_payload
 
+
+def _fallback_step_tool_payload(step: Mapping[str, Any]) -> dict[str, str]:
+    step_type = str(step.get("type") or "").strip()
+    tool = step.get("tool") if isinstance(step.get("tool"), Mapping) else None
+    skill = step.get("skill") if isinstance(step.get("skill"), Mapping) else None
+    source = tool or skill or {}
+    source_type = str(
+        source.get("type")
+        or source.get("kind")
+        or ("tool" if tool is not None else "skill")
+    ).strip()
+    if step_type in {"tool", "skill", "agent_runtime"}:
+        source_type = step_type
+    name = str(
+        source.get("name")
+        or source.get("id")
+        or step.get("targetRuntime")
+        or step.get("runtime")
+        or ""
+    ).strip()
+    version = str(source.get("version") or "").strip()
+    return {
+        "type": source_type or "skill",
+        "name": name,
+        "version": version,
+    }
+
+
+def _fallback_step_title(
+    step: Mapping[str, Any],
+    *,
+    step_id: str,
+    tool_payload: Mapping[str, str],
+) -> str:
+    return (
+        str(
+            step.get("title")
+            or step.get("name")
+            or tool_payload.get("name")
+            or step_id
+        ).strip()
+        or step_id
+    )
+
+
+def _fallback_current_step_order(record: Any) -> int | None:
+    memo = getattr(record, "memo", None)
+    if not isinstance(memo, Mapping):
+        return None
+    summary = str(memo.get("summary") or "").strip()
+    match = re.search(r"\bstep\s+(\d+)\s*/\s*\d+\b", summary, re.IGNORECASE)
+    if match is None:
+        return None
+    try:
+        order = int(match.group(1))
+    except ValueError:
+        return None
+    return order if order > 0 else None
+
+
+def _fallback_step_ledger_from_record(record: Any) -> StepLedgerSnapshotModel | None:
+    parameters = getattr(record, "parameters", None)
+    if not isinstance(parameters, Mapping):
+        return None
+    task = parameters.get("task")
+    if not isinstance(task, Mapping):
+        return None
+    raw_steps = task.get("steps")
+    if not isinstance(raw_steps, list):
+        return None
+
+    normalized_steps = [step for step in raw_steps if isinstance(step, Mapping)]
+    if not normalized_steps:
+        return None
+
+    ordered_nodes: list[dict[str, Any]] = []
+    dependency_map: dict[str, list[str]] = {}
+    explicit_dependencies = False
+
+    for index, step in enumerate(normalized_steps, start=1):
+        step_id = str(
+            step.get("id")
+            or step.get("logicalStepId")
+            or step.get("logical_step_id")
+            or f"step-{index:04d}"
+        ).strip()
+        if not step_id:
+            continue
+        tool_payload = _fallback_step_tool_payload(step)
+        title = _fallback_step_title(
+            step,
+            step_id=step_id,
+            tool_payload=tool_payload,
+        )
+        ordered_nodes.append(
+            {
+                "id": step_id,
+                "title": title,
+                "tool": tool_payload,
+                "inputs": {"title": title},
+            }
+        )
+        dependencies = normalize_dependency_ids(
+            step.get("dependsOn")
+            or step.get("depends_on")
+            or step.get("dependencies")
+        )
+        if dependencies:
+            explicit_dependencies = True
+        dependency_map[step_id] = dependencies
+
+    if not ordered_nodes:
+        return None
+
+    if not explicit_dependencies and len(ordered_nodes) > 1:
+        previous_step_id = None
+        for node in ordered_nodes:
+            step_id = str(node.get("id") or "").strip()
+            dependency_map[step_id] = [previous_step_id] if previous_step_id else []
+            previous_step_id = step_id
+
+    updated_at = _compatibility_refreshed_at(record)
+    rows = build_initial_step_rows(
+        ordered_nodes=ordered_nodes,
+        dependency_map=dependency_map,
+        updated_at=updated_at,
+    )
+
+    current_order = _fallback_current_step_order(record)
+    if current_order is not None:
+        waiting_reason = str(
+            getattr(record, "waiting_reason", None)
+            or (getattr(record, "memo", {}) or {}).get("waiting_reason")
+            or ""
+        ).strip()
+        summary = str((getattr(record, "memo", {}) or {}).get("summary") or "").strip()
+        for row in rows:
+            if row.get("order") != current_order:
+                continue
+            row["status"] = "awaiting_external" if waiting_reason else "running"
+            row["attempt"] = max(int(row.get("attempt") or 0), 1)
+            row["startedAt"] = row.get("startedAt") or updated_at.isoformat()
+            row["updatedAt"] = updated_at.isoformat()
+            row["waitingReason"] = waiting_reason or None
+            row["attentionRequired"] = bool(
+                waiting_reason or getattr(record, "attention_required", False)
+            )
+            row["summary"] = summary or row.get("summary")
+            break
+
+    snapshot = {
+        "workflowId": str(getattr(record, "workflow_id", "") or "").strip(),
+        "runId": str(getattr(record, "run_id", "") or "").strip(),
+        "runScope": "latest",
+        "steps": rows,
+    }
+    try:
+        return StepLedgerSnapshotModel.model_validate(snapshot)
+    except ValidationError:
+        logger.warning(
+            "Failed to build fallback step ledger for %s",
+            getattr(record, "workflow_id", "<unknown>"),
+            exc_info=True,
+        )
+        return None
+
 async def _load_execution_progress(
     *,
     temporal_client: Client,
     workflow_id: str,
 ) -> tuple[ExecutionProgressModel | None, str | None]:
     try:
-        payload = await query_workflow(temporal_client, workflow_id, "get_progress")
+        payload = await _query_workflow_for_detail(
+            temporal_client,
+            workflow_id,
+            "get_progress",
+        )
+    except TimeoutError:
+        logger.warning(
+            "Timed out querying execution progress for %s after %.3fs",
+            workflow_id,
+            settings.temporal_dashboard.live_query_timeout_seconds,
+        )
+        return None, None
     except Exception as exc:
         logger.warning(
             "Failed to query execution progress for %s: %s",
             workflow_id,
             exc,
-            exc_info=True,
         )
         return None, None
 
@@ -3203,20 +3395,32 @@ async def _load_execution_step_ledger(
     *,
     temporal_client: Client,
     workflow_id: str,
+    fallback_record: Any | None = None,
 ) -> StepLedgerSnapshotModel:
     try:
-        payload = await query_workflow(
+        payload = await _query_workflow_for_detail(
             temporal_client,
             workflow_id,
             "get_step_ledger",
         )
-    except RPCError as exc:
+    except (RPCError, TimeoutError) as exc:
         logger.warning(
             "Failed to query execution step ledger for %s: %s",
             workflow_id,
             exc,
-            exc_info=True,
+            exc_info=not isinstance(exc, TimeoutError),
         )
+        fallback = (
+            _fallback_step_ledger_from_record(fallback_record)
+            if fallback_record is not None
+            else None
+        )
+        if fallback is not None:
+            logger.info(
+                "Serving fallback step ledger for %s from stored task parameters",
+                workflow_id,
+            )
+            return fallback
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={
@@ -6533,6 +6737,7 @@ async def describe_execution_steps(
     return await _load_execution_step_ledger(
         temporal_client=temporal_client,
         workflow_id=canonical_workflow_id,
+        fallback_record=record,
     )
 
 @router.get("/{workflow_id}", response_model=ExecutionModel)

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -219,6 +219,11 @@ class TemporalDashboardSettings(BaseSettings):
         False,
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_DEBUG_FIELDS_ENABLED"),
     )
+    live_query_timeout_seconds: float = Field(
+        1.0,
+        validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIVE_QUERY_TIMEOUT_SECONDS"),
+        gt=0,
+    )
     list_endpoint: str = Field(
         "/api/executions",
         validation_alias=AliasChoices("TEMPORAL_DASHBOARD_LIST_ENDPOINT"),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -7523,6 +7523,8 @@ class MoonMindRunWorkflow:
             "title": self._title or "Run",
             "summary": self._summary,
         }
+        if isinstance(self._step_count, int) and self._step_count > 0:
+            memo_dict["mm_current_step_order"] = self._step_count
         if workflow.patched("run-memo-runtime-skill-visibility"):
             if self._target_runtime:
                 memo_dict["targetRuntime"] = self._target_runtime

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, Iterator
@@ -209,13 +210,17 @@ class _QueryHandle:
         ledger=None,
         summary=None,
         error: Exception | None = None,
+        delay_seconds: float = 0,
     ) -> None:
         self._progress = progress
         self._ledger = ledger
         self._summary = summary
         self._error = error
+        self._delay_seconds = delay_seconds
 
     async def query(self, name: str):
+        if self._delay_seconds > 0:
+            await asyncio.sleep(self._delay_seconds)
         if self._error is not None:
             raise self._error
         if name == "get_progress":
@@ -233,6 +238,7 @@ def _override_query_client(
     ledger=None,
     summary=None,
     error: Exception | None = None,
+    delay_seconds: float = 0,
 ) -> SimpleNamespace:
     handles: dict[str, _QueryHandle] = {}
 
@@ -243,6 +249,7 @@ def _override_query_client(
                 ledger=ledger,
                 summary=summary,
                 error=error,
+                delay_seconds=delay_seconds,
             )
         return handles[workflow_id]
 
@@ -5911,6 +5918,51 @@ def test_describe_execution_leaves_progress_null_when_query_fails() -> None:
     assert payload["stepsHref"] == "/api/executions/mm:wf-1/steps"
     assert payload["progress"] is None
 
+def test_describe_execution_bounds_slow_live_progress_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        progress={"total": 99},
+        delay_seconds=0.2,
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+    monkeypatch.setattr(
+        settings.temporal,
+        "temporal_authoritative_read_enabled",
+        False,
+    )
+
+    with (
+        patch(
+            "api_service.api.routers.executions._hydrate_execution_report_projection",
+            new_callable=AsyncMock,
+            side_effect=lambda execution, **_kwargs: execution,
+        ),
+        patch(
+            "api_service.api.routers.executions._resolve_task_run_ids_from_managed_store",
+            return_value={},
+        ),
+        TestClient(app) as test_client,
+    ):
+        started = time.perf_counter()
+        response = test_client.get("/api/executions/mm:wf-1")
+        elapsed = time.perf_counter() - started
+
+    assert response.status_code == 200
+    assert elapsed < 0.15
+    assert response.json()["progress"] is None
+
 def test_describe_execution_skips_live_progress_query_for_terminal_runs() -> None:
     from api_service.db.models import TemporalExecutionCloseStatus
 
@@ -6198,6 +6250,100 @@ def test_get_execution_steps_returns_503_for_temporal_rpc_errors() -> None:
 
     assert response.status_code == 503
     assert response.json()["detail"]["code"] == "temporal_unavailable"
+
+def test_get_execution_steps_returns_503_for_slow_temporal_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={"workflowId": "mm:wf-1", "runId": "run-99", "steps": []},
+        delay_seconds=0.2,
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+
+    with TestClient(app) as test_client:
+        started = time.perf_counter()
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+        elapsed = time.perf_counter() - started
+
+    assert response.status_code == 503
+    assert elapsed < 0.15
+    assert response.json()["detail"]["code"] == "temporal_unavailable"
+
+def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    record.memo = {
+        **record.memo,
+        "summary": "Executing plan step 2/2: moonspec-implement",
+    }
+    record.parameters = {
+        "task": {
+            "steps": [
+                {
+                    "id": "fetch-issue",
+                    "title": "Fetch issue",
+                    "type": "tool",
+                    "tool": {"id": "jira.get_issue", "version": "1.0.0"},
+                },
+                {
+                    "id": "implement",
+                    "title": "Implement issue",
+                    "type": "skill",
+                    "skill": {"id": "moonspec-implement"},
+                    "dependsOn": ["fetch-issue"],
+                },
+            ],
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={"workflowId": "mm:wf-1", "runId": "run-99", "steps": []},
+        delay_seconds=0.2,
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["workflowId"] == "mm:wf-1"
+    assert payload["runId"] == "run-2"
+    assert [step["logicalStepId"] for step in payload["steps"]] == [
+        "fetch-issue",
+        "implement",
+    ]
+    assert payload["steps"][0]["tool"] == {
+        "type": "tool",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
+    }
+    assert payload["steps"][1]["tool"]["name"] == "moonspec-implement"
+    assert payload["steps"][1]["dependsOn"] == ["fetch-issue"]
+    assert payload["steps"][1]["status"] == "running"
+    assert payload["steps"][1]["attempt"] == 1
 
 def test_get_execution_steps_returns_500_for_invalid_ledger_payload() -> None:
     app = FastAPI()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6345,6 +6345,123 @@ def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query
     assert payload["steps"][1]["status"] == "running"
     assert payload["steps"][1]["attempt"] == 1
 
+def test_get_execution_steps_fallback_prefers_structured_step_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    record.memo = {
+        **record.memo,
+        "summary": "Executing plan step 1/2: fetch-issue",
+        "mm_current_step_order": 2,
+    }
+    record.parameters = {
+        "task": {
+            "steps": [
+                {
+                    "id": "fetch-issue",
+                    "title": "Fetch issue",
+                    "type": "tool",
+                    "tool": {"id": "jira.get_issue", "version": "1.0.0"},
+                },
+                {
+                    "id": "implement",
+                    "title": "Implement issue",
+                    "type": "skill",
+                    "skill": {"id": "moonspec-implement"},
+                    "dependsOn": ["fetch-issue"],
+                },
+            ],
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={"workflowId": "mm:wf-1", "runId": "run-99", "steps": []},
+        delay_seconds=0.2,
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    payload = response.json()
+    # The structured memo field wins over the stale summary string.
+    assert payload["steps"][1]["status"] == "running"
+    assert payload["steps"][0]["status"] == "ready"
+
+def test_get_execution_steps_fallback_preserves_independent_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    record.memo = {
+        **record.memo,
+        "summary": "Executing plan step 1/3: alpha",
+    }
+    record.parameters = {
+        "task": {
+            "steps": [
+                {
+                    "id": "alpha",
+                    "title": "Alpha",
+                    "type": "tool",
+                    "tool": {"id": "tool.alpha"},
+                },
+                {
+                    "id": "beta",
+                    "title": "Beta",
+                    "type": "tool",
+                    "tool": {"id": "tool.beta"},
+                },
+                {
+                    "id": "gamma",
+                    "title": "Gamma",
+                    "type": "tool",
+                    "tool": {"id": "tool.gamma"},
+                },
+            ],
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={"workflowId": "mm:wf-1", "runId": "run-99", "steps": []},
+        delay_seconds=0.2,
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard,
+        "live_query_timeout_seconds",
+        0.01,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    payload = response.json()
+    # No step declared ``dependsOn`` so the fallback must not fabricate a chain
+    # — independent steps should remain runnable in parallel.
+    assert payload["steps"][0]["dependsOn"] == []
+    assert payload["steps"][1]["dependsOn"] == []
+    assert payload["steps"][2]["dependsOn"] == []
+    assert payload["steps"][0]["status"] == "running"
+    assert payload["steps"][1]["status"] == "ready"
+    assert payload["steps"][2]["status"] == "ready"
+
 def test_get_execution_steps_returns_500_for_invalid_ledger_payload() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -438,6 +438,22 @@ def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "progress" not in latest_memo
     assert "checks" not in latest_memo
 
+def test_run_memo_includes_current_step_order_when_step_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memo_updates = _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    workflow = MoonMindRunWorkflow()
+
+    workflow._title = "Ledger run"
+    workflow._summary = "Executing plan step 2/3"
+    workflow._update_memo()
+    assert "mm_current_step_order" not in memo_updates[-1]
+
+    workflow._step_count = 2
+    workflow._update_memo()
+    assert memo_updates[-1]["mm_current_step_order"] == 2
+
 def test_run_memo_surfaces_runtime_and_skill_visibility(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- bound task-detail live Temporal queries with a configurable timeout
- serve a conservative stored-parameter step ledger when the live step query is unavailable
- cover slow-query behavior and fallback step rendering in execution router tests

## Root Cause
The task details steps endpoint depended exclusively on live Temporal workflow queries. When workflow workers were slow or unavailable, the endpoint returned 503 even though persisted task step definitions were available.

## Validation
- .venv/bin/pytest tests/unit/api/routers/test_executions.py -q -k 'get_execution_steps or live_progress_query'
- curl http://localhost:8000/api/executions/mm%3Ac2d29083-1aa1-4c70-8c3b-186cf78cab19/steps returned 200 OK with 15 steps after restart
- ./tools/test_unit.sh tests/unit/api/routers/test_executions.py -q -k 'execution_steps or live_progress_query' passed the targeted Python cases, then hit an unrelated existing Vitest timeout in entrypoints/tasks-list.test.tsx
