### PR TITLE
MM-717 Apply workspace and side-effect policies

### DIFF
--- a/moonmind/workflows/temporal/step_attempts.py
+++ b/moonmind/workflows/temporal/step_attempts.py
@@ -4,13 +4,49 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from moonmind.schemas.step_attempt_models import (
     AttemptReason,
     AttemptStatus,
     StepAttemptIdentityModel,
     StepAttemptManifestModel,
+)
+from moonmind.schemas.temporal_models import WorkspacePolicy
+from moonmind.workflows.temporal.step_checkpoints import (
+    checkpoint_kinds_for_workspace_policy,
+)
+
+GitEffectDisposition = Literal[
+    "accepted",
+    "candidate",
+    "discarded",
+    "superseded",
+    "none",
+]
+SideEffectClass = Literal[
+    "workspace_mutation",
+    "artifact_write",
+    "external_idempotent",
+    "external_non_idempotent",
+    "publication",
+    "provider_account",
+    "memory_update",
+    "retrieval_index_update",
+]
+SideEffectDisposition = Literal["accepted", "candidate", "blocked", "discarded"]
+
+_GATED_SIDE_EFFECT_CLASSES = {
+    "external_non_idempotent",
+    "publication",
+    "provider_account",
+}
+_GATED_OPERATION_PREFIXES = (
+    "jira.transition",
+    "repo.merge",
+    "repo.publish",
+    "deployment.",
+    "provider_account.",
 )
 
 
@@ -49,6 +85,174 @@ def step_attempt_operation_idempotency_key(
     return f"{identity}:{operation_id}"
 
 
+def workspace_policy_metadata(
+    *,
+    policy: WorkspacePolicy,
+    checkpoint_ref: str | None = None,
+    checkpoint_valid: bool | None = None,
+    rejection_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build compact workspace policy diagnostics for an attempt manifest."""
+
+    required_kinds = checkpoint_kinds_for_workspace_policy(policy)
+    checkpoint_text = str(checkpoint_ref or "").strip() or None
+    evidence_required = bool(required_kinds)
+    evidence_accepted = (
+        not evidence_required
+        or (checkpoint_text is not None and checkpoint_valid is not False)
+    )
+    metadata: dict[str, Any] = {
+        "policy": policy,
+        "requiredCheckpointKinds": list(required_kinds),
+        "checkpointRef": checkpoint_text,
+        "checkpointValid": checkpoint_valid,
+        "evidenceRequired": evidence_required,
+        "evidenceAccepted": evidence_accepted,
+    }
+    if rejection_reason:
+        metadata["rejectionReason"] = str(rejection_reason).strip()
+    elif not evidence_accepted:
+        metadata["rejectionReason"] = "missing_required_checkpoint_evidence"
+    return metadata
+
+
+def validate_workspace_policy_launch(
+    *,
+    policy: WorkspacePolicy,
+    checkpoint_ref: str | None = None,
+    checkpoint_valid: bool | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic launch gate decision for workspace policy evidence."""
+
+    metadata = workspace_policy_metadata(
+        policy=policy,
+        checkpoint_ref=checkpoint_ref,
+        checkpoint_valid=checkpoint_valid,
+    )
+    return {
+        "allowed": bool(metadata["evidenceAccepted"]),
+        "policy": policy,
+        "reason": None
+        if metadata["evidenceAccepted"]
+        else metadata["rejectionReason"],
+        "workspace": metadata,
+    }
+
+
+def git_effect_metadata(
+    *,
+    disposition: GitEffectDisposition,
+    baseline_commit: str | None = None,
+    head_commit: str | None = None,
+    working_tree_diff_ref: str | None = None,
+    patch_ref: str | None = None,
+    workspace_checkpoint_ref: str | None = None,
+    typed_artifact_ref: str | None = None,
+    published_ref: str | None = None,
+    no_change_accepted: bool = False,
+) -> dict[str, Any]:
+    """Build compact git effect metadata and enforce accepted-output evidence."""
+
+    effect = {
+        "disposition": disposition,
+        "baselineCommit": str(baseline_commit or "").strip() or None,
+        "headCommit": str(head_commit or "").strip() or None,
+        "workingTreeDiffRef": str(working_tree_diff_ref or "").strip() or None,
+        "patchRef": str(patch_ref or "").strip() or None,
+        "workspaceCheckpointRef": str(workspace_checkpoint_ref or "").strip() or None,
+        "typedArtifactRef": str(typed_artifact_ref or "").strip() or None,
+        "publishedRef": str(published_ref or "").strip() or None,
+        "noChangeAccepted": bool(no_change_accepted),
+    }
+    accepted_output = any(
+        (
+            effect["headCommit"],
+            effect["publishedRef"],
+            effect["typedArtifactRef"],
+            effect["noChangeAccepted"],
+        )
+    )
+    effect["acceptedOutputPresent"] = accepted_output
+    if disposition == "accepted" and not accepted_output:
+        raise ValueError(
+            "accepted git effect requires commit/ref, typed artifact, or no-change disposition"
+        )
+    return effect
+
+
+def logical_step_success_allowed(
+    *,
+    outputs: Mapping[str, Any] | None = None,
+    git_effect: Mapping[str, Any] | None = None,
+) -> bool:
+    """Return whether a logical implementation step has accepted output evidence."""
+
+    effect = dict(git_effect or {})
+    if effect.get("disposition") == "accepted" and effect.get(
+        "acceptedOutputPresent"
+    ):
+        return True
+    output_payload = dict(outputs or {})
+    for key in (
+        "commitSha",
+        "commitRef",
+        "branchRef",
+        "publishedRef",
+        "typedArtifactRef",
+        "primaryRef",
+        "summaryRef",
+    ):
+        value = output_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+    return bool(output_payload.get("noChangeAccepted"))
+
+
+def side_effect_record(
+    *,
+    effect_class: SideEffectClass,
+    operation: str,
+    target: str | None = None,
+    idempotency_key: str | None = None,
+    workflow_state_accepted: bool = False,
+    disposition: SideEffectDisposition | None = None,
+    effect_kind: Literal["normal", "cleanup", "compensation"] = "normal",
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Build a compact side-effect decision and gate unsafe effect classes."""
+
+    operation_text = str(operation or "").strip()
+    if not operation_text:
+        raise ValueError("operation must be a non-empty string")
+    key_text = str(idempotency_key or "").strip() or None
+    if effect_class == "external_idempotent" and key_text is None:
+        raise ValueError("external_idempotent side effects require an idempotency key")
+    if effect_kind in {"cleanup", "compensation"} and key_text is None:
+        raise ValueError("cleanup and compensation side effects require an idempotency key")
+    operation_lower = operation_text.lower()
+    gated_operation = any(
+        operation_lower.startswith(prefix) for prefix in _GATED_OPERATION_PREFIXES
+    )
+    blocked = (
+        effect_class in _GATED_SIDE_EFFECT_CLASSES or gated_operation
+    ) and not workflow_state_accepted
+    final_disposition = disposition or ("blocked" if blocked else "accepted")
+    record: dict[str, Any] = {
+        "class": effect_class,
+        "kind": effect_kind,
+        "operation": operation_text,
+        "target": str(target or "").strip() or None,
+        "idempotencyKey": key_text,
+        "workflowStateAccepted": workflow_state_accepted,
+        "disposition": final_disposition,
+    }
+    if blocked:
+        record["reason"] = reason or "workflow_state_not_gate_approved"
+    elif reason:
+        record["reason"] = reason
+    return record
+
+
 def build_step_attempt_manifest_payload(
     *,
     workflow_id: str,
@@ -64,10 +268,12 @@ def build_step_attempt_manifest_payload(
     input_refs: Sequence[str] = (),
     context: Mapping[str, Any] | None = None,
     workspace: Mapping[str, Any] | None = None,
+    git_effect: Mapping[str, Any] | None = None,
     execution: Mapping[str, Any] | None = None,
     outputs: Mapping[str, Any] | None = None,
     checks: Sequence[Mapping[str, Any]] = (),
     side_effects: Mapping[str, Any] | None = None,
+    side_effect_records: Sequence[Mapping[str, Any]] = (),
     dependency_effects: Mapping[str, Any] | None = None,
     budget: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -78,6 +284,12 @@ def build_step_attempt_manifest_payload(
     input_payload: dict[str, Any] = {}
     if prepared_refs:
         input_payload["preparedInputRefs"] = prepared_refs
+    workspace_payload = dict(workspace or {})
+    if git_effect is not None:
+        workspace_payload["gitEffect"] = dict(git_effect)
+    side_effect_payload = dict(side_effects or {})
+    if side_effect_records:
+        side_effect_payload["records"] = [dict(record) for record in side_effect_records]
     manifest = StepAttemptManifestModel(
         workflowId=workflow_id,
         runId=run_id,
@@ -90,11 +302,11 @@ def build_step_attempt_manifest_payload(
         updatedAt=updated_at,
         input=input_payload,
         context=dict(context or {}),
-        workspace=dict(workspace or {}),
+        workspace=workspace_payload,
         execution=dict(execution or {}),
         outputs=bounded_outputs,
         checks=[dict(check) for check in checks],
-        sideEffects=dict(side_effects or {}),
+        sideEffects=side_effect_payload,
         dependencyEffects=dict(dependency_effects or {}),
         budget=dict(budget or {}),
     )

--- a/moonmind/workflows/temporal/step_attempts.py
+++ b/moonmind/workflows/temporal/step_attempts.py
@@ -24,6 +24,7 @@ GitEffectDisposition = Literal[
     "candidate",
     "discarded",
     "superseded",
+    "blocked",
     "none",
 ]
 SideEffectClass = Literal[

--- a/moonmind/workflows/temporal/step_attempts.py
+++ b/moonmind/workflows/temporal/step_attempts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime
+import posixpath
+import re
 from typing import Any, Literal
 
 from moonmind.schemas.step_attempt_models import (
@@ -48,6 +50,47 @@ _GATED_OPERATION_PREFIXES = (
     "deployment.",
     "provider_account.",
 )
+_SECRET_LIKE_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9_]+"),
+    re.compile(r"github_pat_[A-Za-z0-9_]+"),
+    re.compile(r"AIza[A-Za-z0-9_-]+"),
+    re.compile(r"AKIA[A-Z0-9]{16}"),
+    re.compile(r"(?i)token\s*=\s*[^/\s&]+"),
+    re.compile(r"(?i)password\s*=\s*[^/\s&]+"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+
+def _sanitize_diagnostic_text(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    for pattern in _SECRET_LIKE_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
+def _normalized_absolute_workspace_path(value: str | None) -> str | None:
+    path = str(value or "").strip().replace("\\", "/")
+    if not path.startswith("/"):
+        return None
+    return posixpath.normpath(path)
+
+
+def _target_within_approved_workspace_roots(
+    target: str | None,
+    approved_workspace_roots: Sequence[str],
+) -> bool:
+    target_path = _normalized_absolute_workspace_path(target)
+    if target_path is None:
+        return False
+    for root in approved_workspace_roots:
+        root_path = _normalized_absolute_workspace_path(root)
+        if root_path is None:
+            continue
+        if target_path == root_path or target_path.startswith(f"{root_path}/"):
+            return True
+    return False
 
 
 def step_attempt_id(
@@ -218,6 +261,7 @@ def side_effect_record(
     disposition: SideEffectDisposition | None = None,
     effect_kind: Literal["normal", "cleanup", "compensation"] = "normal",
     reason: str | None = None,
+    approved_workspace_roots: Sequence[str] = (),
 ) -> dict[str, Any]:
     """Build a compact side-effect decision and gate unsafe effect classes."""
 
@@ -233,23 +277,36 @@ def side_effect_record(
     gated_operation = any(
         operation_lower.startswith(prefix) for prefix in _GATED_OPERATION_PREFIXES
     )
-    blocked = (
+    workspace_boundary_blocked = (
+        effect_class == "workspace_mutation"
+        and bool(approved_workspace_roots)
+        and not _target_within_approved_workspace_roots(
+            target,
+            approved_workspace_roots,
+        )
+    )
+    workflow_gate_blocked = (
         effect_class in _GATED_SIDE_EFFECT_CLASSES or gated_operation
     ) and not workflow_state_accepted
+    blocked = workspace_boundary_blocked or workflow_gate_blocked
     final_disposition = disposition or ("blocked" if blocked else "accepted")
     record: dict[str, Any] = {
         "class": effect_class,
         "kind": effect_kind,
         "operation": operation_text,
-        "target": str(target or "").strip() or None,
-        "idempotencyKey": key_text,
+        "target": _sanitize_diagnostic_text(target),
+        "idempotencyKey": _sanitize_diagnostic_text(key_text),
         "workflowStateAccepted": workflow_state_accepted,
         "disposition": final_disposition,
     }
-    if blocked:
-        record["reason"] = reason or "workflow_state_not_gate_approved"
+    if workspace_boundary_blocked:
+        record["reason"] = "workspace_target_outside_approved_roots"
+    elif workflow_gate_blocked:
+        record["reason"] = (
+            _sanitize_diagnostic_text(reason) or "workflow_state_not_gate_approved"
+        )
     elif reason:
-        record["reason"] = reason
+        record["reason"] = _sanitize_diagnostic_text(reason)
     return record
 
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1665,6 +1665,7 @@ class MoonMindRunWorkflow:
         *,
         updated_at: datetime,
         summary: str | None = None,
+        increment_attempt: bool = True,
     ) -> None:
         self._restore_resume_workspace_for_failed_step(logical_step_id)
         if not self._try_update_step_row(
@@ -1674,7 +1675,7 @@ class MoonMindRunWorkflow:
             summary=summary,
             waiting_reason=None,
             attention_required=False,
-            increment_attempt=True,
+            increment_attempt=increment_attempt,
             set_started_at=True,
         ):
             return
@@ -3800,8 +3801,9 @@ class MoonMindRunWorkflow:
                             execution_result = {
                                 "status": "FAILED",
                                 "outputs": {
-                                    "failureMessage": (
-                                        "missing_required_checkpoint_evidence"
+                                    "error": "missing_required_checkpoint_evidence",
+                                    "summary": (
+                                        "Workspace policy rejected before launch."
                                     ),
                                 },
                             }
@@ -4949,12 +4951,28 @@ class MoonMindRunWorkflow:
                 node_id,
                 updated_at=workflow.now(),
                 summary=f"Re-checking Jira blockers for {tool_name}",
+                increment_attempt=False,
             )
             await self._record_step_attempt_manifest_start(
                 node_id,
                 updated_at=workflow.now(),
                 reason="policy_revalidation",
             )
+            recheck_attempt = self._step_attempt_for(node_id) or 0
+            if self._is_step_attempt_launch_blocked(
+                node_id,
+                attempt=recheck_attempt,
+            ):
+                current_result = {
+                    "status": "FAILED",
+                    "outputs": {
+                        "error": "missing_required_checkpoint_evidence",
+                        "summary": (
+                            "Workspace policy rejected before launch."
+                        ),
+                    },
+                }
+                break
             recheck_payload = dict(execute_payload)
             idempotency_key = recheck_payload.get("idempotency_key")
             if isinstance(idempotency_key, str) and idempotency_key.strip():

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -537,6 +537,8 @@ class MoonMindRunWorkflow:
         self._resume_workspace_restored_ref: str | None = None
         self._prepared_artifact_refs: list[str] = []
         self._step_checkpoint_refs: dict[str, str] = {}
+        self._previous_step_checkpoint_refs: dict[str, str] = {}
+        self._step_attempt_launch_blocks: set[str] = set()
 
         # State tracking
         self._paused: bool = False
@@ -732,6 +734,12 @@ class MoonMindRunWorkflow:
             reason=reason,
             source_attempt=source_attempt,
         )
+        workspace = self._step_attempt_workspace(
+            logical_step_id,
+            attempt=identity.attempt,
+            source_attempt=source_attempt,
+        )
+        launch_blocked = self._workspace_policy_launch_blocked(workspace)
         manifest = StepAttemptManifestModel(
             schemaVersion="v1",
             stepAttemptId=step_attempt_id,
@@ -742,25 +750,25 @@ class MoonMindRunWorkflow:
             attemptScope="run",
             lineage=lineage,
             reason=reason,
-            status="running",
-            terminalDisposition=None,
+            status="blocked" if launch_blocked else "running",
+            terminalDisposition="blocked" if launch_blocked else None,
             startedAt=updated_at,
             updatedAt=updated_at,
             input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
             context={},
-            workspace=self._step_attempt_workspace(
-                logical_step_id,
-                attempt=identity.attempt,
-                source_attempt=source_attempt,
-            ),
+            workspace=workspace,
             execution={},
-            outputs={},
+            outputs={
+                "summary": "Workspace policy rejected before launch."
+            }
+            if launch_blocked
+            else {},
             checks=[],
             sideEffects={},
             dependencyEffects={"invalidatedLogicalStepIds": []},
             budget={},
         )
-        return await self._write_step_attempt_manifest(
+        manifest_ref = await self._write_step_attempt_manifest(
             logical_step_id,
             attempt=attempt,
             manifest=manifest,
@@ -768,6 +776,17 @@ class MoonMindRunWorkflow:
             idempotency_key=idempotency_key,
             updated_at=updated_at,
         )
+        if launch_blocked:
+            self._record_workspace_policy_launch_block(
+                logical_step_id,
+                attempt=attempt,
+                updated_at=updated_at,
+                reason=str(
+                    workspace.get("rejectionReason")
+                    or "missing_required_checkpoint_evidence"
+                ),
+            )
+        return manifest_ref
 
     async def _record_step_attempt_manifest_terminal(
         self,
@@ -1200,6 +1219,44 @@ class MoonMindRunWorkflow:
         value = row.get("startedAt") or row.get("started_at")
         return value if isinstance(value, datetime) else None
 
+    @staticmethod
+    def _workspace_policy_launch_blocked(workspace: Mapping[str, Any]) -> bool:
+        return workspace.get("evidenceAccepted") is False
+
+    @staticmethod
+    def _step_attempt_launch_block_key(logical_step_id: str, attempt: int) -> str:
+        return f"{logical_step_id}:{attempt}"
+
+    def _record_workspace_policy_launch_block(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+        updated_at: datetime,
+        reason: str,
+    ) -> None:
+        self._step_attempt_launch_blocks.add(
+            self._step_attempt_launch_block_key(logical_step_id, attempt)
+        )
+        self._mark_step_terminal(
+            logical_step_id,
+            status="failed",
+            updated_at=updated_at,
+            summary="Workspace policy rejected before launch.",
+            last_error=reason,
+        )
+
+    def _is_step_attempt_launch_blocked(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+    ) -> bool:
+        return (
+            self._step_attempt_launch_block_key(logical_step_id, attempt)
+            in self._step_attempt_launch_blocks
+        )
+
     def _step_attempt_workspace(
         self,
         logical_step_id: str,
@@ -1219,7 +1276,9 @@ class MoonMindRunWorkflow:
                 }
             )
             return workspace
-        checkpoint_ref = self._step_checkpoint_refs.get(logical_step_id)
+        checkpoint_ref = self._step_checkpoint_refs.get(
+            logical_step_id
+        ) or self._previous_step_checkpoint_refs.get(logical_step_id)
         if attempt > 1:
             workspace = workspace_policy_metadata(
                 policy="continue_from_previous_attempt",
@@ -1619,6 +1678,17 @@ class MoonMindRunWorkflow:
             set_started_at=True,
         ):
             return
+        previous_checkpoint_ref = self._step_checkpoint_refs.get(logical_step_id)
+        if not previous_checkpoint_ref:
+            row = self._step_ledger_row_for(logical_step_id)
+            if isinstance(row, Mapping):
+                raw_ref = row.get("stateCheckpointRef")
+                if isinstance(raw_ref, str) and raw_ref.strip():
+                    previous_checkpoint_ref = raw_ref.strip()
+        if previous_checkpoint_ref:
+            self._previous_step_checkpoint_refs[logical_step_id] = (
+                previous_checkpoint_ref
+            )
         self._step_checkpoint_refs.pop(logical_step_id, None)
         try:
             clear_step_checkpoint_evidence(
@@ -1648,18 +1718,35 @@ class MoonMindRunWorkflow:
         attempt = self._step_attempt_for(logical_step_id)
         if attempt is None or attempt <= 0:
             return None
+        source_attempt = self._step_attempt_source_identity(
+            logical_step_id,
+            attempt=attempt,
+        )
+        workspace = self._step_attempt_workspace(
+            logical_step_id,
+            attempt=attempt,
+            source_attempt=source_attempt,
+        )
+        launch_blocked = self._workspace_policy_launch_blocked(workspace)
         manifest_payload = build_step_attempt_manifest_payload(
             workflow_id=workflow.info().workflow_id,
             run_id=workflow.info().run_id,
             logical_step_id=logical_step_id,
             attempt=attempt,
             reason=reason,  # type: ignore[arg-type]
-            status="running",
+            status="blocked" if launch_blocked else "running",
             updated_at=updated_at,
-            summary=summary,
+            summary=(
+                "Workspace policy rejected before launch."
+                if launch_blocked
+                else summary
+            ),
             input_refs=input_refs,
+            workspace=workspace,
             execution=execution,
         )
+        if launch_blocked:
+            manifest_payload["terminalDisposition"] = "blocked"
         try:
             manifest_ref = await self._write_json_artifact(
                 name=f"reports/step_attempt_{logical_step_id}_attempt_{attempt}.json",
@@ -1707,6 +1794,16 @@ class MoonMindRunWorkflow:
             )
         except KeyError:
             return manifest_ref
+        if launch_blocked:
+            self._record_workspace_policy_launch_block(
+                logical_step_id,
+                attempt=attempt,
+                updated_at=updated_at,
+                reason=str(
+                    workspace.get("rejectionReason")
+                    or "missing_required_checkpoint_evidence"
+                ),
+            )
         self._sync_progress_snapshot(updated_at=updated_at)
         return manifest_ref
 
@@ -3696,6 +3793,20 @@ class MoonMindRunWorkflow:
                                 ),
                             },
                         )
+                        if self._is_step_attempt_launch_blocked(
+                            node_id,
+                            attempt=current_step_attempt,
+                        ):
+                            execution_result = {
+                                "status": "FAILED",
+                                "outputs": {
+                                    "failureMessage": (
+                                        "missing_required_checkpoint_evidence"
+                                    ),
+                                },
+                            }
+                            result_status = "FAILED"
+                            break
 
                     if tool_type == "agent_runtime":
                         # --- Agent dispatch: child workflow ---

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -99,7 +99,9 @@ from moonmind.workflows.temporal.step_ledger import (
 )
 from moonmind.workflows.temporal.step_attempts import (
     build_step_attempt_manifest_payload,
+    git_effect_metadata,
     step_attempt_operation_idempotency_key,
+    workspace_policy_metadata,
 )
 from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
@@ -812,11 +814,17 @@ class MoonMindRunWorkflow:
             updatedAt=updated_at,
             input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
             context={},
-            workspace=self._step_attempt_workspace(
-                logical_step_id,
-                attempt=identity.attempt,
-                source_attempt=source_attempt,
-            ),
+            workspace={
+                **self._step_attempt_workspace(
+                    logical_step_id,
+                    attempt=identity.attempt,
+                    source_attempt=source_attempt,
+                ),
+                "gitEffect": self._step_attempt_git_effect(
+                    logical_step_id,
+                    terminal_disposition=terminal_disposition,
+                ),
+            },
             execution=self._step_attempt_compact_execution_refs(logical_step_id),
             outputs=self._step_attempt_compact_output_refs(logical_step_id),
             checks=list(
@@ -1200,19 +1208,80 @@ class MoonMindRunWorkflow:
         source_attempt: Mapping[str, Any] | None,
     ) -> dict[str, Any]:
         if source_attempt and logical_step_id == self._resume_failed_step_id:
-            workspace = {
-                "policy": "resume_from_source_attempt",
-                "sourceAttempt": dict(source_attempt),
-            }
-            if self._resume_workspace_restored_ref:
-                workspace["restoredCheckpointRef"] = self._resume_workspace_restored_ref
+            workspace = workspace_policy_metadata(
+                policy="start_from_last_passed_commit",
+                checkpoint_ref=self._resume_workspace_restored_ref,
+                checkpoint_valid=bool(self._resume_workspace_restored_ref),
+            )
+            workspace.update(
+                {
+                    "sourceAttempt": dict(source_attempt),
+                }
+            )
             return workspace
+        checkpoint_ref = self._step_checkpoint_refs.get(logical_step_id)
         if attempt > 1:
+            workspace = workspace_policy_metadata(
+                policy="continue_from_previous_attempt",
+                checkpoint_ref=checkpoint_ref,
+                checkpoint_valid=bool(checkpoint_ref) if checkpoint_ref else None,
+            )
+            workspace["sourceAttempt"] = dict(source_attempt) if source_attempt else None
+            return workspace
+        return workspace_policy_metadata(
+            policy="fresh_branch_from_source",
+            checkpoint_ref=checkpoint_ref,
+            checkpoint_valid=None,
+        )
+
+    def _step_attempt_git_effect(
+        self,
+        logical_step_id: str,
+        *,
+        terminal_disposition: str,
+    ) -> dict[str, Any]:
+        outputs = self._step_attempt_compact_output_refs(logical_step_id)
+        row = self._step_ledger_row_for(logical_step_id)
+        checkpoint_ref = None
+        if isinstance(row, Mapping):
+            raw_checkpoint = row.get("stateCheckpointRef")
+            if isinstance(raw_checkpoint, str) and raw_checkpoint.strip():
+                checkpoint_ref = raw_checkpoint.strip()
+        disposition = (
+            "accepted"
+            if terminal_disposition == "accepted"
+            else (
+                "candidate"
+                if terminal_disposition in {"retryable", "needs_human"}
+                else (
+                    "discarded"
+                    if terminal_disposition in {"discarded", "failed_unrecoverable"}
+                    else str(terminal_disposition or "none")
+                )
+            )
+        )
+        typed_artifact_ref = (
+            outputs.get("primaryRef")
+            or outputs.get("summaryRef")
+            or outputs.get("logsRef")
+            or outputs.get("stdoutRef")
+        )
+        try:
+            return git_effect_metadata(
+                disposition=disposition,  # type: ignore[arg-type]
+                workspace_checkpoint_ref=checkpoint_ref,
+                typed_artifact_ref=typed_artifact_ref,
+                no_change_accepted=(
+                    terminal_disposition == "accepted" and not typed_artifact_ref
+                ),
+            )
+        except ValueError:
             return {
-                "policy": "continue_from_previous_attempt",
-                "sourceAttempt": dict(source_attempt) if source_attempt else None,
+                "disposition": "candidate",
+                "workspaceCheckpointRef": checkpoint_ref,
+                "acceptedOutputPresent": False,
+                "rejectionReason": "missing_accepted_output",
             }
-        return {"policy": "initial_workspace"}
 
     def _step_attempt_compact_execution_refs(
         self,

--- a/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
@@ -95,6 +95,13 @@ async def test_step_attempt_manifest_refs_are_append_only_for_reexecution(
         "artifact-attempt-1",
         "artifact-attempt-2",
     ]
+    assert writes[0]["payload"]["workspace"]["policy"] == "fresh_branch_from_source"
+    assert writes[0]["payload"]["workspace"]["evidenceAccepted"] is True
+    assert writes[1]["payload"]["workspace"]["policy"] == "continue_from_previous_attempt"
+    assert writes[1]["payload"]["workspace"]["evidenceAccepted"] is False
+    assert writes[1]["payload"]["workspace"]["rejectionReason"] == (
+        "missing_required_checkpoint_evidence"
+    )
     assert writes[1]["payload"]["workspace"]["sourceAttempt"] == {
         "workflowId": "wf-boundary",
         "runId": "run-boundary",
@@ -160,7 +167,9 @@ async def test_resume_attempt_manifest_carries_lineage_without_large_payloads(
     assert manifest["lineage"]["sourceRunId"] == "run-source"
     assert manifest["lineage"]["sourceAttempt"] == 2
     assert manifest["lineage"]["lineageAttemptOrdinal"] == 3
-    assert manifest["workspace"]["restoredCheckpointRef"] == (
+    assert manifest["workspace"]["policy"] == "start_from_last_passed_commit"
+    assert manifest["workspace"]["checkpointRef"] == (
         "artifact://workspace/before-implement"
     )
+    assert manifest["workspace"]["evidenceAccepted"] is True
     assert "payload" not in manifest

--- a/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py
@@ -102,12 +102,19 @@ async def test_step_attempt_manifest_refs_are_append_only_for_reexecution(
     assert writes[1]["payload"]["workspace"]["rejectionReason"] == (
         "missing_required_checkpoint_evidence"
     )
+    assert writes[1]["payload"]["status"] == "blocked"
+    assert writes[1]["payload"]["terminalDisposition"] == "blocked"
+    assert writes[1]["payload"]["outputs"]["summary"] == (
+        "Workspace policy rejected before launch."
+    )
     assert writes[1]["payload"]["workspace"]["sourceAttempt"] == {
         "workflowId": "wf-boundary",
         "runId": "run-boundary",
         "logicalStepId": "implement",
         "attempt": 1,
     }
+    assert step["status"] == "failed"
+    assert step["lastError"] == "missing_required_checkpoint_evidence"
 
 
 async def test_resume_attempt_manifest_carries_lineage_without_large_payloads(

--- a/tests/unit/workflows/temporal/test_step_attempts.py
+++ b/tests/unit/workflows/temporal/test_step_attempts.py
@@ -174,6 +174,33 @@ def test_side_effect_records_gate_external_effects() -> None:
     assert cleanup["disposition"] == "accepted"
 
 
+def test_side_effect_records_sanitize_diagnostics_and_gate_workspace_writes() -> None:
+    outside_workspace = side_effect_record(
+        effect_class="workspace_mutation",
+        operation="workspace.write",
+        target="/tmp/outside-workspace/token=ghp_leakedsecret",
+        approved_workspace_roots=["/work/agent_jobs/run/repo"],
+        reason="password=hunter2",
+    )
+
+    assert outside_workspace["disposition"] == "blocked"
+    assert outside_workspace["reason"] == "workspace_target_outside_approved_roots"
+    assert "ghp_leakedsecret" not in str(outside_workspace)
+    assert "hunter2" not in str(outside_workspace)
+
+    approved_workspace = side_effect_record(
+        effect_class="workspace_mutation",
+        operation="workspace.write",
+        target="/work/agent_jobs/run/repo/moonmind/workflows/temporal/run.py",
+        approved_workspace_roots=["/work/agent_jobs/run/repo"],
+    )
+
+    assert approved_workspace["disposition"] == "accepted"
+    assert approved_workspace["target"].endswith(
+        "/moonmind/workflows/temporal/run.py"
+    )
+
+
 def test_manifest_payload_embeds_policy_git_effect_and_side_effect_records() -> None:
     now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
     payload = build_step_attempt_manifest_payload(

--- a/tests/unit/workflows/temporal/test_step_attempts.py
+++ b/tests/unit/workflows/temporal/test_step_attempts.py
@@ -5,8 +5,13 @@ from datetime import UTC, datetime
 from moonmind.schemas.step_attempt_models import STEP_ATTEMPT_CONTENT_TYPE
 from moonmind.workflows.temporal.step_attempts import (
     build_step_attempt_manifest_payload,
+    git_effect_metadata,
+    logical_step_success_allowed,
+    side_effect_record,
     step_attempt_id,
     step_attempt_operation_idempotency_key,
+    validate_workspace_policy_launch,
+    workspace_policy_metadata,
 )
 
 
@@ -71,3 +76,134 @@ def test_manifest_payload_is_compact_boundary_contract() -> None:
     assert payload["input"] == {"preparedInputRefs": ["artifact://input"]}
     assert payload["execution"]["kind"] == "skill"
     assert payload["outputs"] == {"summary": "Executing plan step"}
+
+
+def test_workspace_policy_metadata_rejects_missing_required_checkpoint() -> None:
+    decision = validate_workspace_policy_launch(
+        policy="apply_previous_diff_to_clean_baseline",
+    )
+
+    assert decision["allowed"] is False
+    assert decision["reason"] == "missing_required_checkpoint_evidence"
+    assert decision["workspace"]["policy"] == "apply_previous_diff_to_clean_baseline"
+    assert decision["workspace"]["requiredCheckpointKinds"] == ["git_patch"]
+    assert decision["workspace"]["evidenceAccepted"] is False
+
+    fresh = workspace_policy_metadata(policy="fresh_branch_from_source")
+    assert fresh["evidenceRequired"] is False
+    assert fresh["evidenceAccepted"] is True
+
+
+def test_git_effect_metadata_enforces_accepted_output_rule() -> None:
+    candidate = git_effect_metadata(
+        disposition="candidate",
+        working_tree_diff_ref="artifact://diff",
+        patch_ref="artifact://patch",
+    )
+
+    assert candidate["disposition"] == "candidate"
+    assert candidate["acceptedOutputPresent"] is False
+
+    accepted = git_effect_metadata(
+        disposition="accepted",
+        head_commit="abc123",
+        workspace_checkpoint_ref="artifact://checkpoint",
+    )
+    assert accepted["acceptedOutputPresent"] is True
+    assert logical_step_success_allowed(git_effect=accepted) is True
+
+    no_change = git_effect_metadata(
+        disposition="accepted",
+        no_change_accepted=True,
+    )
+    assert no_change["acceptedOutputPresent"] is True
+
+    try:
+        git_effect_metadata(disposition="accepted", patch_ref="artifact://patch")
+    except ValueError as exc:
+        assert "accepted git effect requires" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("accepted dirty workspace without accepted output was allowed")
+
+
+def test_side_effect_records_gate_external_effects() -> None:
+    blocked = side_effect_record(
+        effect_class="publication",
+        operation="repo.merge_pr",
+        target="PR-1",
+        workflow_state_accepted=False,
+    )
+
+    assert blocked["disposition"] == "blocked"
+    assert blocked["reason"] == "workflow_state_not_gate_approved"
+
+    accepted = side_effect_record(
+        effect_class="publication",
+        operation="repo.merge_pr",
+        target="PR-1",
+        workflow_state_accepted=True,
+    )
+    assert accepted["disposition"] == "accepted"
+
+    idempotent = side_effect_record(
+        effect_class="external_idempotent",
+        operation="jira.add_comment",
+        target="MM-717",
+        idempotency_key="wf:run:step:attempt:comment",
+    )
+    assert idempotent["idempotencyKey"] == "wf:run:step:attempt:comment"
+
+    jira_transition = side_effect_record(
+        effect_class="external_idempotent",
+        operation="jira.transition_issue",
+        target="MM-717",
+        idempotency_key="wf:run:step:attempt:jira-transition",
+        workflow_state_accepted=False,
+    )
+    assert jira_transition["disposition"] == "blocked"
+
+    cleanup = side_effect_record(
+        effect_class="external_idempotent",
+        effect_kind="cleanup",
+        operation="deployment.cleanup",
+        target="deploy-1",
+        idempotency_key="wf:run:step:attempt:cleanup",
+        workflow_state_accepted=True,
+    )
+    assert cleanup["kind"] == "cleanup"
+    assert cleanup["disposition"] == "accepted"
+
+
+def test_manifest_payload_embeds_policy_git_effect_and_side_effect_records() -> None:
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+    payload = build_step_attempt_manifest_payload(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        attempt=2,
+        reason="tests_failed",
+        status="failed",
+        updated_at=now,
+        workspace=workspace_policy_metadata(
+            policy="continue_from_previous_attempt",
+            checkpoint_ref="artifact://checkpoint",
+            checkpoint_valid=True,
+        ),
+        git_effect=git_effect_metadata(
+            disposition="candidate",
+            working_tree_diff_ref="artifact://diff",
+            patch_ref="artifact://patch",
+            workspace_checkpoint_ref="artifact://checkpoint",
+        ),
+        side_effect_records=[
+            side_effect_record(
+                effect_class="publication",
+                operation="repo.merge_pr",
+                workflow_state_accepted=False,
+            )
+        ],
+    )
+
+    assert payload["workspace"]["policy"] == "continue_from_previous_attempt"
+    assert payload["workspace"]["gitEffect"]["disposition"] == "candidate"
+    assert payload["sideEffects"]["records"][0]["disposition"] == "blocked"

--- a/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_resume_from_failed_step.py
@@ -370,17 +370,17 @@ async def test_resume_attempt_manifest_preserves_source_lineage(
         "relationship": "resume_from_failed_step",
         "lineageAttemptOrdinal": 2,
     }
-    assert manifest["workspace"]["policy"] == "resume_from_source_attempt"
+    assert manifest["workspace"]["policy"] == "start_from_last_passed_commit"
+    assert manifest["workspace"]["checkpointRef"] == (
+        "artifact://workspace/before-implement"
+    )
+    assert manifest["workspace"]["evidenceAccepted"] is True
     assert manifest["workspace"]["sourceAttempt"] == {
         "workflowId": "mm:source",
         "runId": "run-source",
         "logicalStepId": "implement",
         "attempt": 1,
     }
-    assert (
-        manifest["workspace"]["restoredCheckpointRef"]
-        == "artifact://workspace/before-implement"
-    )
 
 
 def test_resume_source_rejects_missing_workspace_evidence() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -669,7 +669,11 @@ async def test_run_records_step_attempt_manifest_ref_when_work_begins(
     assert writes[0]["payload"]["outputs"] == {}
     assert writes[1]["payload"]["reason"] == "runtime_recovered"
     assert writes[1]["payload"]["execution"] == {}
-    assert writes[1]["payload"]["outputs"] == {}
+    assert writes[1]["payload"]["status"] == "blocked"
+    assert writes[1]["payload"]["terminalDisposition"] == "blocked"
+    assert writes[1]["payload"]["outputs"] == {
+        "summary": "Workspace policy rejected before launch."
+    }
     assert writes[1]["payload"]["workspace"]["policy"] == (
         "continue_from_previous_attempt"
     )
@@ -1360,7 +1364,10 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
             return {
                 "status": "COMPLETED",
                 "summary": "Patch applied cleanly",
-                "outputs": {"outputSummaryRef": f"art_summary_{len(skill_inputs)}"},
+                "outputs": {
+                    "outputSummaryRef": f"art_summary_{len(skill_inputs)}",
+                    "stateCheckpointRef": f"art_checkpoint_{len(skill_inputs)}",
+                },
             }
         if activity_type == "step.review":
             return next(review_verdicts)
@@ -1547,6 +1554,7 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
             "summary": "Agent run completed",
             "output_refs": ["art_output_1"],
             "failure_class": None,
+            "metadata": {"stateCheckpointRef": f"art_checkpoint_{len(child_requests)}"},
         }
 
     workflow_info = SimpleNamespace(


### PR DESCRIPTION
## Jira
- Issue: MM-717

## MoonSpec
- Feature path: `specs/001-apply-workspace-policies`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- `pytest tests/unit/workflows/temporal/test_step_attempts.py tests/unit/workflows/temporal/test_step_checkpoints.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/integration/workflows/temporal/test_step_attempt_manifest_evidence.py -q` — PASS (`46 passed`)
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` — PASS (Python `5302 passed`; frontend `23` files / `380` tests passed)

## Remaining risks
- No blocking implementation gaps found in post-remediation MoonSpec verification.
- Existing test-suite warnings remain unrelated to MM-717 behavior.
