### PR TITLE
I want there to be less space from the top of the page to the border at the botttom of the masthead. One option that seems possible is to remove the r

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -755,6 +755,8 @@ describe('Mission Control shared entry', () => {
   });
 
   it('lets masthead content and chrome span the page while panels stay constrained', async () => {
+    const dashboardRootBlock = cssRuleBlock(missionControlCss, '.dashboard-root');
+    expect(dashboardRootBlock).toContain('--dashboard-pt: 0rem;');
     expect(missionControlCss).toMatch(
       /\.dashboard-shell-full\s*\{[^}]*width:\s*100%/s,
     );

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -756,7 +756,7 @@ describe('Mission Control shared entry', () => {
 
   it('lets masthead content and chrome span the page while panels stay constrained', async () => {
     const dashboardRootBlock = cssRuleBlock(missionControlCss, '.dashboard-root');
-    expect(dashboardRootBlock).toContain('--dashboard-pt: 0rem;');
+    expect(dashboardRootBlock).toContain('--dashboard-pt: 0;');
     expect(missionControlCss).toMatch(
       /\.dashboard-shell-full\s*\{[^}]*width:\s*100%/s,
     );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -165,7 +165,7 @@ samp {
 }
 
 .dashboard-root {
-  --dashboard-pt: 0rem;
+  --dashboard-pt: 0;
 
   margin: 0 auto;
   max-width: none;
@@ -208,7 +208,7 @@ samp {
   content: "";
   position: absolute;
   z-index: -1;
-  top: calc(-1 * var(--dashboard-pt, 0.9rem));
+  top: calc(-1 * var(--dashboard-pt, 0));
   left: calc(50% - 50cqw - 1rem);
   right: calc(50% - 50cqw - 1rem);
   bottom: 0;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -165,7 +165,7 @@ samp {
 }
 
 .dashboard-root {
-  --dashboard-pt: 0.9rem;
+  --dashboard-pt: 0rem;
 
   margin: 0 auto;
   max-width: none;


### PR DESCRIPTION
I want there to be less space from the top of the page to the border at the botttom of the masthead. One option that seems possible is to remove the root padding from the top, but I am open to alternative as well if that's not best practice.