### PR TITLE
[codex] Improve container shutdown reaping

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
 
   api:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     ports:
       - "8000:8000"
     environment:
@@ -258,6 +259,7 @@ services:
 
   temporal-worker-workflow:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -312,6 +314,7 @@ services:
 
   temporal-worker-artifacts:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -366,6 +369,7 @@ services:
 
   temporal-worker-llm:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -422,6 +426,7 @@ services:
 
   temporal-worker-sandbox:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -506,6 +511,7 @@ services:
 
   temporal-worker-agent-runtime:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -607,6 +613,7 @@ services:
 
   temporal-worker-integrations:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
+    init: true
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -2003,6 +2003,7 @@ class DockerCodexManagedSessionController:
             self._docker_binary,
             "run",
             "-d",
+            "--init",
             "--name",
             container_name,
             "--user",

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -306,7 +306,7 @@ async def start_terminal_bridge_container(
     )
     try:
         proc = await asyncio.create_subprocess_exec(
-            "docker", "run", "-d", "-i", "-t", "--rm",
+            "docker", "run", "-d", "--init", "-i", "-t", "--rm",
             "--name", container_name,
             "--label", "moonmind.oauth_session=true",
             "--label", f"moonmind.oauth_session_id={session_id}",

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -81,7 +81,10 @@ def test_api_service_runs_with_container_init():
     assert isinstance(
         api_service, dict
     ), "api service is missing from docker-compose.yaml"
-    assert api_service.get("init") is True
+    assert api_service.get("init") is True, (
+        "api service must run with an init process so child subprocesses "
+        "are reaped and shutdown signals are forwarded"
+    )
 
 
 def test_api_service_mounts_agent_runtime_workspace_volume():

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -53,6 +53,11 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
             "profiles" not in service_config
         ), f"Worker fleet '{fleet}' should not have profiles so it starts by default"
 
+        assert service_config.get("init") is True, (
+            f"Worker fleet '{fleet}' must run with an init process so child "
+            "agent/tool processes are reaped and shutdown signals are forwarded"
+        )
+
         # Verify the command is polling, not sleep
         env_vars = service_config.get("environment", [])
         command_var = next(
@@ -61,6 +66,22 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
         assert (
             "sleep" not in command_var
         ), f"Worker '{fleet}' must not be configured to sleep. Found: {command_var}"
+
+
+def test_api_service_runs_with_container_init():
+    """API service supervises subprocess-capable routes and should reap children."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    api_service = services.get("api")
+    assert isinstance(
+        api_service, dict
+    ), "api service is missing from docker-compose.yaml"
+    assert api_service.get("init") is True
 
 
 def test_api_service_mounts_agent_runtime_workspace_volume():

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -171,6 +171,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     run_command = next(
         command for command in commands if command[:2] == ("docker", "run")
     )
+    assert "--init" in run_command
     assert "--name" in run_command
     assert "--user" in run_command
     assert "1000:1000" in run_command

--- a/tests/unit/services/temporal/runtime/test_terminal_bridge.py
+++ b/tests/unit/services/temporal/runtime/test_terminal_bridge.py
@@ -206,6 +206,7 @@ async def test_start_terminal_bridge_container_uses_provider_bootstrap_command(
     )
 
     assert result["container_name"] == "moonmind_auth_oas_terminal_runner"
+    assert "--init" in observed
     assert "-v" in observed
     assert "codex_auth_volume:/home/app/.codex" in observed
     assert "--user" in observed


### PR DESCRIPTION
## Summary
- Run API and Temporal worker containers with Docker init enabled so PID 1 forwards signals and reaps child processes.
- Launch managed Codex session containers and OAuth terminal runner containers with `--init`.
- Add regression coverage for compose init settings and managed Docker run arguments.

## Why
Docker shutdown was waiting minutes after SIGKILL while old managed Codex session containers accumulated zombie git/bash children. Enabling an init process at the long-running service and managed-session boundaries addresses child reaping and cleaner signal handling for new containers.

## Local operations performed
- Removed stopped managed Codex session containers: 62 before cleanup, 0 after cleanup.
- Restarted Docker and recreated the compose stack so `init=true` is applied to API and worker containers.
- Confirmed API and all Temporal worker healthchecks are healthy.
- Docker image count is down to 32, but `docker system df` still times out after 20s, so host Docker metadata cleanup may need further daemon/storage investigation outside this PR.

## Validation
- `docker compose config`
- `./tools/test_unit.sh` (Python: 5335 passed, 6 skipped, 1 xpassed; frontend: 381 passed, 232 skipped)
- `docker compose ps` shows API and all worker containers running healthy
