### PR TITLE
[codex] Handle PR-not-required publish outcomes

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5626,9 +5626,11 @@ class MoonMindRunWorkflow:
     def _publish_not_required_reason(self, outputs: Mapping[str, Any]) -> str | None:
         for source in self._publish_outcome_sources(outputs):
             status = self._coerce_text(
-                source.get("status")
-                or source.get("publishStatus")
+                source.get("publishStatus")
                 or source.get("publish_status")
+                or source.get("publishOutcome")
+                or source.get("publish_outcome")
+                or source.get("status")
                 or source.get("outcome"),
                 max_chars=80,
             )
@@ -5645,7 +5647,9 @@ class MoonMindRunWorkflow:
                 continue
 
             reason = self._coerce_text(
-                source.get("reason")
+                source.get("publishReason")
+                or source.get("publish_reason")
+                or source.get("reason")
                 or source.get("summary")
                 or source.get("message")
                 or outputs.get("operator_summary")
@@ -5662,32 +5666,7 @@ class MoonMindRunWorkflow:
             candidate = outputs.get(key)
             if isinstance(candidate, Mapping):
                 yield candidate
-
-        flattened: dict[str, Any] = {}
-        for key in (
-            "publishStatus",
-            "publish_status",
-            "publishOutcome",
-            "publish_outcome",
-            "prRequired",
-            "pr_required",
-            "publishReason",
-            "publish_reason",
-        ):
-            if key in outputs:
-                flattened[key] = outputs[key]
-        if flattened:
-            if "reason" not in flattened:
-                flattened["reason"] = flattened.get("publishReason") or flattened.get(
-                    "publish_reason"
-                )
-            if "status" not in flattened:
-                flattened["status"] = flattened.get("publishStatus") or flattened.get(
-                    "publish_status"
-                ) or flattened.get("publishOutcome") or flattened.get(
-                    "publish_outcome"
-                )
-            yield flattened
+        yield outputs
 
     @staticmethod
     def _is_successful_jira_story_output(*, mode: str, status: str) -> bool:
@@ -5864,9 +5843,10 @@ class MoonMindRunWorkflow:
 
     def _pr_publish_optional_for_task(self, parameters: Mapping[str, Any]) -> bool:
         task_payload = self._mapping_value(parameters, "task")
-        return bool(
-            self._task_skill_names(parameters, task_payload) & _PR_OPTIONAL_TASK_SKILLS
-        )
+        skill_names = self._task_skill_names(parameters, task_payload)
+        if not skill_names:
+            return False
+        return skill_names.issubset(_PR_OPTIONAL_TASK_SKILLS)
 
     def _task_skill_names(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -131,8 +131,22 @@ _TERMINAL_LAST_ERROR_UNSET = object()
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 _PR_OPTIONAL_AGENT_SKILLS = JIRA_AGENT_SKILLS
+_PR_OPTIONAL_TASK_SKILLS = frozenset(
+    {"jira-implement", *_PR_OPTIONAL_AGENT_SKILLS}
+)
+_PUBLISH_NOT_REQUIRED_STATUSES = frozenset(
+    {
+        "not_required",
+        "not-required",
+        "notrequired",
+        "not_applicable",
+        "not-applicable",
+    }
+)
 _JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
-_JIRA_BACKED_AGENT_SKILLS = JIRA_BACKED_AGENT_SKILLS
+_JIRA_BACKED_AGENT_SKILLS = frozenset(
+    {"jira-implement", *JIRA_BACKED_AGENT_SKILLS}
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -3621,7 +3635,9 @@ class MoonMindRunWorkflow:
         )
         failure_mode = plan_definition.policy.failure_mode
         publish_mode = self._publish_mode(parameters)
-        pr_publish_optional = self._pr_publish_optional_for_plan(ordered_nodes)
+        pr_publish_optional = self._pr_publish_optional_for_plan(
+            ordered_nodes
+        ) or self._pr_publish_optional_for_task(parameters)
         require_pull_request_url = (
             publish_mode == "pr"
             and self._integration is None
@@ -4319,6 +4335,9 @@ class MoonMindRunWorkflow:
                 parameters=parameters,
                 execution_result=execution_result,
             )
+            if self._publish_status == "not_required":
+                require_pull_request_url = False
+                pull_request_url = None
             if (
                 self._publish_status == "failed"
                 and publish_status_before != "failed"
@@ -4512,7 +4531,11 @@ class MoonMindRunWorkflow:
                     )
 
                 push_status = agent_outputs.get("push_status", "")
-                if push_status == "no_commits":
+                if self._publish_status == "not_required":
+                    self._get_logger().info(
+                        "Skipping native PR creation: publish output not required."
+                    )
+                elif push_status == "no_commits":
                     self._get_logger().info(
                         "Skipping native PR creation: agent made no commits "
                         "on branch '%s'.",
@@ -4592,6 +4615,8 @@ class MoonMindRunWorkflow:
             self._publish_reason = (
                 "Jira issue agent completed; no PR output required"
             )
+            if self._merge_automation_requested(parameters):
+                self._publish_context["mergeAutomationStatus"] = "not_applicable"
         # Persist the PR URL so the workflow output can determine if a PR was created.
         self._pull_request_url = pull_request_url
         publish_mode = self._publish_mode(parameters)
@@ -5528,6 +5553,14 @@ class MoonMindRunWorkflow:
         if not isinstance(outputs, Mapping):
             return
 
+        not_required_reason = self._publish_not_required_reason(outputs)
+        if not_required_reason is not None:
+            self._publish_status = "not_required"
+            self._publish_reason = not_required_reason
+            if self._merge_automation_requested(parameters):
+                self._publish_context["mergeAutomationStatus"] = "not_applicable"
+            return
+
         push_status = self._coerce_text(outputs.get("push_status"))
         if push_status is None:
             return
@@ -5589,6 +5622,72 @@ class MoonMindRunWorkflow:
         if push_status == "pushed" and publish_mode == "branch":
             self._publish_status = "published"
             self._publish_reason = "published branch"
+
+    def _publish_not_required_reason(self, outputs: Mapping[str, Any]) -> str | None:
+        for source in self._publish_outcome_sources(outputs):
+            status = self._coerce_text(
+                source.get("status")
+                or source.get("publishStatus")
+                or source.get("publish_status")
+                or source.get("outcome"),
+                max_chars=80,
+            )
+            pr_required = source.get("prRequired")
+            if pr_required is None:
+                pr_required = source.get("pr_required")
+            required = source.get("required")
+
+            status_not_required = bool(
+                status and status.lower() in _PUBLISH_NOT_REQUIRED_STATUSES
+            )
+            pr_explicitly_not_required = pr_required is False or required is False
+            if not status_not_required and not pr_explicitly_not_required:
+                continue
+
+            reason = self._coerce_text(
+                source.get("reason")
+                or source.get("summary")
+                or source.get("message")
+                or outputs.get("operator_summary")
+                or outputs.get("operatorSummary"),
+                max_chars=700,
+            )
+            return reason or "publish output not required"
+        return None
+
+    def _publish_outcome_sources(
+        self, outputs: Mapping[str, Any]
+    ) -> Iterable[Mapping[str, Any]]:
+        for key in ("publishOutcome", "publish_outcome", "publish"):
+            candidate = outputs.get(key)
+            if isinstance(candidate, Mapping):
+                yield candidate
+
+        flattened: dict[str, Any] = {}
+        for key in (
+            "publishStatus",
+            "publish_status",
+            "publishOutcome",
+            "publish_outcome",
+            "prRequired",
+            "pr_required",
+            "publishReason",
+            "publish_reason",
+        ):
+            if key in outputs:
+                flattened[key] = outputs[key]
+        if flattened:
+            if "reason" not in flattened:
+                flattened["reason"] = flattened.get("publishReason") or flattened.get(
+                    "publish_reason"
+                )
+            if "status" not in flattened:
+                flattened["status"] = flattened.get("publishStatus") or flattened.get(
+                    "publish_status"
+                ) or flattened.get("publishOutcome") or flattened.get(
+                    "publish_outcome"
+                )
+            yield flattened
 
     @staticmethod
     def _is_successful_jira_story_output(*, mode: str, status: str) -> bool:
@@ -5763,6 +5862,44 @@ class MoonMindRunWorkflow:
                 return False
         return True
 
+    def _pr_publish_optional_for_task(self, parameters: Mapping[str, Any]) -> bool:
+        task_payload = self._mapping_value(parameters, "task")
+        return bool(
+            self._task_skill_names(parameters, task_payload) & _PR_OPTIONAL_TASK_SKILLS
+        )
+
+    def _task_skill_names(
+        self,
+        parameters: Mapping[str, Any],
+        task_payload: Mapping[str, Any],
+    ) -> set[str]:
+        skill_names: set[str] = set()
+        for payload in (parameters, task_payload):
+            for key in ("tool", "skill"):
+                nested = payload.get(key)
+                if isinstance(nested, Mapping):
+                    name = self._coerce_text(
+                        nested.get("name") or nested.get("id"),
+                        max_chars=120,
+                    )
+                    if name:
+                        skill_names.add(name.lower())
+        skills_payload = task_payload.get("skills")
+        if isinstance(skills_payload, Mapping):
+            include = skills_payload.get("include")
+            if isinstance(include, Sequence) and not isinstance(include, (str, bytes)):
+                for item in include:
+                    if isinstance(item, Mapping):
+                        name = self._coerce_text(
+                            item.get("name") or item.get("id"),
+                            max_chars=120,
+                        )
+                    else:
+                        name = self._coerce_text(item, max_chars=120)
+                    if name:
+                        skill_names.add(name.lower())
+        return skill_names
+
     def _execution_result_has_publishable_changes(self, execution_result: Any) -> bool:
         if self._extract_pull_request_url(execution_result):
             return True
@@ -5901,6 +6038,22 @@ class MoonMindRunWorkflow:
                 True,
             )
 
+        if self._publish_status == "not_required":
+            if self._report_requested(parameters) and not self._report_created:
+                return (
+                    "failed",
+                    "reportOutput requested but no final report was created",
+                    True,
+                )
+            return (
+                "success",
+                self._compose_success_completion_message(
+                    publish_detail=self._publish_reason,
+                    publish_mode=publish_mode,
+                ),
+                False,
+            )
+
         missing_outcome = self._missing_required_outcome_reason(
             parameters=parameters,
             publish_mode=publish_mode,
@@ -5914,16 +6067,6 @@ class MoonMindRunWorkflow:
             return (
                 "success",
                 self._compose_success_completion_message(publish_mode=publish_mode),
-                False,
-            )
-
-        if self._publish_status == "not_required":
-            return (
-                "success",
-                self._compose_success_completion_message(
-                    publish_detail=self._publish_reason,
-                    publish_mode=publish_mode,
-                ),
                 False,
             )
 
@@ -5978,6 +6121,8 @@ class MoonMindRunWorkflow:
         parameters: Mapping[str, Any],
         publish_mode: str,
     ) -> str | None:
+        if self._publish_status == "not_required":
+            return None
         if publish_mode == "pr" and not self._pull_request_created():
             return "publishMode 'pr' requested but no PR was created"
         if publish_mode == "branch" and self._publish_status is None:
@@ -6188,33 +6333,7 @@ class MoonMindRunWorkflow:
         parameters: Mapping[str, Any],
         task_payload: Mapping[str, Any],
     ) -> bool:
-        skill_names: set[str] = set()
-        for payload in (parameters, task_payload):
-            for key in ("tool", "skill"):
-                nested = payload.get(key)
-                if isinstance(nested, Mapping):
-                    name = self._coerce_text(
-                        nested.get("name") or nested.get("id"),
-                        max_chars=120,
-                    )
-                    if name:
-                        skill_names.add(name.lower())
-        skills_payload = task_payload.get("skills")
-        if isinstance(skills_payload, Mapping):
-            include = skills_payload.get("include")
-            if isinstance(include, Sequence) and not isinstance(include, (str, bytes)):
-                for item in include:
-                    if isinstance(item, Mapping):
-                        name = self._coerce_text(
-                            item.get("name") or item.get("id"),
-                            max_chars=120,
-                        )
-                        if name:
-                            skill_names.add(name.lower())
-                    else:
-                        name = self._coerce_text(item, max_chars=120)
-                        if name:
-                            skill_names.add(name.lower())
+        skill_names = self._task_skill_names(parameters, task_payload)
         return bool(skill_names & _JIRA_BACKED_AGENT_SKILLS)
 
     def _jira_issue_key_text_sources(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2621,6 +2621,132 @@ def test_jira_story_output_status_satisfies_pr_publish(story_status: str) -> Non
         status=story_status,
     )
 
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+        if activity_type == "agent_skill.resolve":
+            return {"manifestRef": "art_skill_snapshot_1"}
+
+        if activity_type == "artifact.read":
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Jira Implement",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "tpl:jira-implement:1.0.0:08:abc12345",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "claude",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "claude"},
+                                "selectedSkill": "auto",
+                                "annotations": {
+                                    "jiraImplementRole": "final-transition",
+                                },
+                                "instructions": "Finalize Jira status.",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Completed with status completed",
+            "metadata": {
+                "operator_summary": "MM-697 was transitioned to Done.",
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _immediate_wait_condition,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+            run_workflow_module.NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+        },
+    )
+
+    await workflow._run_execution_stage(
+        parameters={
+            "repo": "MoonLadderStudios/MoonMind",
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-697"},
+            "task": {
+                "skills": {
+                    "include": [
+                        {"name": "jira-implement"},
+                    ],
+                },
+            },
+        },
+        plan_ref="art_plan_1",
+    )
+
+    assert not create_pr_called
+    assert workflow._publish_status == "not_required"
+    assert workflow._publish_context["mergeAutomationStatus"] == "not_applicable"
+
 @pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2622,6 +2622,65 @@ def test_jira_story_output_status_satisfies_pr_publish(story_status: str) -> Non
     )
 
 
+def test_pr_publish_optional_for_task_requires_all_skills_pr_optional() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    pure_task = {
+        "task": {"skills": {"include": [{"name": "jira-implement"}]}}
+    }
+    mixed_task = {
+        "task": {
+            "skills": {
+                "include": [
+                    {"name": "jira-implement"},
+                    {"name": "general-coder"},
+                ]
+            }
+        }
+    }
+    empty_task = {"task": {"skills": {"include": []}}}
+
+    assert workflow._pr_publish_optional_for_task(pure_task) is True
+    assert workflow._pr_publish_optional_for_task(mixed_task) is False
+    assert workflow._pr_publish_optional_for_task(empty_task) is False
+
+
+def test_publish_not_required_reason_reads_flattened_outputs() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    reason = workflow._publish_not_required_reason(
+        {
+            "publish_status": "not_required",
+            "publish_reason": "Jira issue agent completed; no PR output required",
+        }
+    )
+
+    assert reason == "Jira issue agent completed; no PR output required"
+
+
+def test_publish_not_required_reason_reads_required_false_in_outputs() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    reason = workflow._publish_not_required_reason(
+        {
+            "required": False,
+            "summary": "Plan blocked upstream; nothing to publish.",
+        }
+    )
+
+    assert reason == "Plan blocked upstream; nothing to publish."
+
+
+def test_publish_not_required_reason_ignores_unrelated_status_in_outputs() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    reason = workflow._publish_not_required_reason(
+        {"status": "COMPLETED", "summary": "Agent finished."}
+    )
+
+    assert reason is None
+
+
 @pytest.mark.asyncio
 async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1053,6 +1053,62 @@ def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     assert "Files edited in this run: none." in message
     assert publish_failure is True
 
+def test_structured_publish_not_required_satisfies_pr_publish_mode(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    execution_result = {
+        "outputs": {
+            "publishOutcome": {
+                "status": "not_required",
+                "reason": "Jira issue already implemented; no pull request required.",
+                "prRequired": False,
+            },
+            "operator_summary": "MM-697 was transitioned to Done.",
+        }
+    }
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-8",
+        execution_result=execution_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-697"},
+        },
+        execution_result=execution_result,
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-697"},
+        }
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    assert mock_run_workflow._publish_context["mergeAutomationStatus"] == "not_applicable"
+    assert status == "success"
+    assert "Jira issue already implemented" in message
+    assert publish_failure is False
+
+
+def test_jira_implement_task_makes_pr_publish_optional(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "skills": {
+                    "include": [
+                        {"name": "jira-implement"},
+                    ]
+                }
+            },
+        }
+    )
+
 def test_native_pr_branch_resolution_keeps_legacy_branch_only_replay_shape(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Treat structured publishOutcome not_required as a successful publish decision for PR-mode runs.
- Make Jira Implement tasks eligible for PR-optional completion when no PR is required.
- Skip native PR creation and mark merge automation not applicable for validated no-PR outcomes.

## Validation
- pytest tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_run_artifacts.py -q --tb=short

## Notes
- Full ./tools/test_unit.sh was attempted earlier but the local .venv uses Python 3.11.13 and collection stops on an existing Python 3.12-only f-string in tests/unit/services/temporal/runtime/test_managed_session_controller.py:2191.