### PR TITLE
[codex] Propagate task identity to Codex sessions

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1251,12 +1251,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         }
         session_environment.setdefault("MOONMIND_WORKDIR", str(self._workspace_root))
         session_environment.setdefault("MOONMIND_JOB_ID", binding.task_run_id)
+        # Task identity is authorization-critical: caller-inheritance checks rely on these
+        # values matching the active workflow/binding. Overwrite any incoming overrides so
+        # a managed profile cannot spoof or stale-pin the identity of the current run.
         if self._task_workflow_id:
-            session_environment.setdefault(
-                "MOONMIND_TASK_WORKFLOW_ID",
-                self._task_workflow_id,
-            )
-        session_environment.setdefault("MOONMIND_TASK_RUN_ID", binding.task_run_id)
+            session_environment["MOONMIND_TASK_WORKFLOW_ID"] = self._task_workflow_id
+        else:
+            session_environment.pop("MOONMIND_TASK_WORKFLOW_ID", None)
+        session_environment["MOONMIND_TASK_RUN_ID"] = binding.task_run_id
         session_environment.setdefault(
             "MOONMIND_CONTAINER_WORKSPACE_VOLUME",
             os.environ.get("MOONMIND_AGENT_WORKSPACES_VOLUME_NAME", "agent_workspaces"),

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -305,6 +305,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         apply_session_control_action: SessionControlSignaler,
         workspace_root: str,
         session_image_ref: str,
+        task_workflow_id: str | None = None,
         defer_turn_instructions_until_session_launch: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -323,6 +324,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._apply_session_control_action = apply_session_control_action
         self._workspace_root = Path(workspace_root).resolve()
         self._session_image_ref = str(session_image_ref).strip()
+        self._task_workflow_id = str(task_workflow_id or "").strip() or None
         self._defer_turn_instructions_until_session_launch = bool(
             defer_turn_instructions_until_session_launch
         )
@@ -1249,6 +1251,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         }
         session_environment.setdefault("MOONMIND_WORKDIR", str(self._workspace_root))
         session_environment.setdefault("MOONMIND_JOB_ID", binding.task_run_id)
+        if self._task_workflow_id:
+            session_environment.setdefault(
+                "MOONMIND_TASK_WORKFLOW_ID",
+                self._task_workflow_id,
+            )
+        session_environment.setdefault("MOONMIND_TASK_RUN_ID", binding.task_run_id)
         session_environment.setdefault(
             "MOONMIND_CONTAINER_WORKSPACE_VOLUME",
             os.environ.get("MOONMIND_AGENT_WORKSPACES_VOLUME_NAME", "agent_workspaces"),

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1969,6 +1969,12 @@ class DockerCodexManagedSessionController:
         await self._ensure_workspace_paths(request)
         session_environment = dict(request.environment)
         session_environment.pop("GITHUB_TOKEN", None)
+        if request.workflow_id:
+            session_environment.setdefault(
+                "MOONMIND_TASK_WORKFLOW_ID",
+                request.workflow_id,
+            )
+        session_environment.setdefault("MOONMIND_TASK_RUN_ID", request.task_run_id)
         if self._moonmind_url:
             existing_moonmind_url = session_environment.get("MOONMIND_URL")
             if existing_moonmind_url is None or not str(existing_moonmind_url).strip():

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2016,6 +2016,7 @@ class MoonMindAgentRun:
                             apply_session_control_action=_apply_session_control_action,
                             workspace_root=_MANAGED_RUNTIME_STORE_ROOT,
                             session_image_ref=_DEFAULT_SESSION_IMAGE_REF,
+                            task_workflow_id=task_workflow_id,
                             launch_context_builder=_launch_context_builder,
                             defer_turn_instructions_until_session_launch=(
                                 defer_turn_instructions_until_session_launch

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -111,6 +111,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     session_supervisor.emit_session_event = Mock()
     request = LaunchCodexManagedSessionRequest(
         taskRunId="task-1",
+        workflowId="wf-task-1",
         sessionId="sess-1",
         threadId="logical-thread-1",
         workspacePath=str(workspace_root / "task-1" / "repo"),
@@ -182,6 +183,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert (
         "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS=1800" in run_command
     )
+    assert "MOONMIND_TASK_WORKFLOW_ID=wf-task-1" in run_command
+    assert "MOONMIND_TASK_RUN_ID=task-1" in run_command
     assert "python3" in run_command
     assert "moonmind.workflows.temporal.runtime.codex_session_runtime" in run_command
     stored = session_store.load("sess-1")

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -652,6 +652,88 @@ async def test_start_passes_managed_session_dood_context(
     )
     assert launch_environment["MOONMIND_WORKFLOW_DOCKER_MODE"] == "unrestricted"
 
+
+def _make_adapter_for_environment_test(
+    *,
+    tmp_path: Path,
+    task_workflow_id: str | None,
+) -> CodexSessionAdapter:
+    return CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        task_workflow_id=task_workflow_id,
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_async_noop,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+
+async def test_managed_session_launch_environment_overrides_incoming_task_identity(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    adapter = _make_adapter_for_environment_test(
+        tmp_path=tmp_path,
+        task_workflow_id="wf-parent-task-trusted",
+    )
+
+    spoofed_environment = {
+        "MOONMIND_TASK_WORKFLOW_ID": "wf-attacker-task",
+        "MOONMIND_TASK_RUN_ID": "wf-attacker-run",
+        "OTHER_VAR": "preserved",
+    }
+
+    launch_environment = adapter._managed_session_launch_environment(
+        binding=binding,
+        environment=spoofed_environment,
+    )
+
+    assert launch_environment["MOONMIND_TASK_WORKFLOW_ID"] == "wf-parent-task-trusted"
+    assert launch_environment["MOONMIND_TASK_RUN_ID"] == binding.task_run_id
+    assert launch_environment["OTHER_VAR"] == "preserved"
+
+
+async def test_managed_session_launch_environment_drops_task_workflow_when_unset(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    adapter = _make_adapter_for_environment_test(
+        tmp_path=tmp_path,
+        task_workflow_id=None,
+    )
+
+    spoofed_environment = {
+        "MOONMIND_TASK_WORKFLOW_ID": "wf-attacker-task",
+        "MOONMIND_TASK_RUN_ID": "wf-attacker-run",
+    }
+
+    launch_environment = adapter._managed_session_launch_environment(
+        binding=binding,
+        environment=spoofed_environment,
+    )
+
+    assert "MOONMIND_TASK_WORKFLOW_ID" not in launch_environment
+    assert launch_environment["MOONMIND_TASK_RUN_ID"] == binding.task_run_id
+
+
 async def test_start_omits_large_inline_instruction_from_result_metadata(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -620,6 +620,7 @@ async def test_start_passes_managed_session_dood_context(
         slot_releaser=_async_noop,
         cooldown_reporter=_async_noop,
         workflow_id="wf-agent-run-1",
+        task_workflow_id="wf-parent-task-1",
         runtime_id="codex_cli",
         run_store=ManagedRunStore(tmp_path / "managed_runs"),
         load_session_snapshot=_load_snapshot,
@@ -643,6 +644,8 @@ async def test_start_passes_managed_session_dood_context(
     launch_environment = launch_calls[0]["request"]["environment"]
     assert launch_environment["MOONMIND_WORKDIR"] == str(workspace_root)
     assert launch_environment["MOONMIND_JOB_ID"] == binding.task_run_id
+    assert launch_environment["MOONMIND_TASK_WORKFLOW_ID"] == "wf-parent-task-1"
+    assert launch_environment["MOONMIND_TASK_RUN_ID"] == binding.task_run_id
     assert (
         launch_environment["MOONMIND_CONTAINER_WORKSPACE_VOLUME"]
         == "agent_workspaces_test"

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
@@ -10,3 +10,4 @@ def test_managed_launch_binding_uses_temporal_patch_guard() -> None:
     assert "workflow.patched(MANAGED_TASK_WORKFLOW_BINDING_PATCH_ID)" in source
     assert "task_workflow_id = parent_info.workflow_id" in source
     assert "task_workflow_id = wf_id" in source
+    assert "task_workflow_id=task_workflow_id" in source


### PR DESCRIPTION
## Summary

- Propagate the parent task workflow id and task run id into Codex managed-session launch environments.
- Wire the root task workflow id from `MoonMind.AgentRun` into `CodexSessionAdapter`.
- Add focused coverage for adapter environment shaping, Docker session launch env, and the managed workflow binding guard.

## Root Cause

`batch-pr-resolver` already emits `runtimeInheritance="caller"` for child `pr-resolver` tasks, but Codex managed-session containers did not receive the parent task identity env needed for the executions API to authorize caller inheritance. Without that identity, child tasks could fall back to deployment runtime defaults instead of the batch resolver's provider profile, model, and effort.

## Validation

- `./tools/test_unit.sh`
  - Python: 5335 passed, 6 skipped, 1 xpassed
  - Frontend: 23 test files passed; 381 passed, 232 skipped