### PR TITLE
[codex] Fix Codex empty turn recovery

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -435,17 +435,35 @@ def _docker_workflow_mode_forbidden_failure(*, workflow_docker_mode: str, tool_n
 
 CODEX_TRANSIENT_TURN_ERROR_TYPE = "CodexTransientTurnError"
 CODEX_PERMANENT_TURN_ERROR_TYPE = "CodexPermanentTurnError"
+CODEX_EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
+
+
+def _is_empty_assistant_recovery_failure(
+    metadata: Mapping[str, Any] | None,
+) -> bool:
+    if not metadata:
+        return False
+    failure_cause = str(metadata.get("failureCause") or "").strip()
+    if failure_cause == CODEX_EMPTY_ASSISTANT_FAILURE_CAUSE:
+        return True
+    retry_action = str(metadata.get("retryRecommendedAction") or "").strip()
+    reason = str(metadata.get("reason") or "").strip()
+    return (
+        retry_action == "clear_session"
+        and "produced no assistant output" in reason
+    )
 
 def _codex_transient_turn_failure(
     reason: str,
     *,
     metadata: Mapping[str, Any] | None = None,
 ) -> temporal_exceptions.ApplicationError:
+    metadata_payload = dict(metadata or {})
     return temporal_exceptions.ApplicationError(
         reason or "codex turn produced no assistant output",
-        dict(metadata or {}),
+        metadata_payload,
         type=CODEX_TRANSIENT_TURN_ERROR_TYPE,
-        non_retryable=False,
+        non_retryable=_is_empty_assistant_recovery_failure(metadata_payload),
     )
 
 def _codex_permanent_turn_failure(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1256,6 +1256,47 @@ async def test_send_turn_transient_failure_preserves_diagnostic_metadata() -> No
         )
 
     assert exc_info.value.type == "CodexTransientTurnError"
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.details == (failure_metadata,)
+
+
+async def test_send_turn_other_transient_failure_remains_retryable() -> None:
+    failure_metadata = {
+        "reason": "codex app-server temporarily unavailable",
+        "failureClass": "transient",
+    }
+    controller = AsyncMock()
+    controller.send_turn = AsyncMock(
+        return_value=CodexManagedSessionTurnResponse(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+            },
+            turnId="turn-1",
+            status="failed",
+            metadata=failure_metadata,
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    with pytest.raises(
+        activity_runtime_module.temporal_exceptions.ApplicationError
+    ) as exc_info:
+        await activities.agent_runtime_send_turn(
+            {
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+                "instructions": "Inspect the workspace",
+            }
+        )
+
+    assert exc_info.value.type == "CodexTransientTurnError"
+    assert exc_info.value.non_retryable is False
     assert exc_info.value.details == (failure_metadata,)
 
 async def test_send_turn_heartbeats_while_waiting_for_remote_session_controller(


### PR DESCRIPTION
## Summary

- Mark Codex empty-assistant turn failures as non-retryable at the activity layer so workflow-level recovery can clear the managed session and retry on a fresh thread.
- Preserve normal Temporal activity retries for other transient Codex turn failures.
- Add unit coverage for both the empty-assistant recovery case and ordinary transient failures.

## Root Cause

A Codex turn could complete with no assistant output and leave a zero-byte rollout JSONL. Activity-level retries then attempted to resume that same empty thread before the adapter could run its existing clear-session recovery path.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_send_turn_transient_failure_preserves_diagnostic_metadata tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_send_turn_other_transient_failure_remains_retryable tests/unit/workflows/adapters/test_codex_session_adapter.py::test_start_resets_session_once_after_empty_assistant_activity_failure`

Note: full `./tools/test_unit.sh` was attempted earlier and stopped during collection because the local repo `.venv` uses Python 3.11 while an existing test file contains Python 3.12-only f-string syntax.
