### PR TITLE
[codex] Handle empty Codex rollout resume

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1949,6 +1949,13 @@ class CodexManagedSessionRuntime:
             return None
         return normalized if Path(normalized).is_file() else None
 
+    @staticmethod
+    def _resume_failure_allows_fallback(message: str) -> bool:
+        normalized = message.lower()
+        if "no rollout found" in normalized or "thread not found" in normalized:
+            return True
+        return "rollout at " in normalized and " is empty" in normalized
+
     def _resume_thread(
         self,
         *,
@@ -1962,17 +1969,19 @@ class CodexManagedSessionRuntime:
         params: dict[str, Any] = {"threadId": state.vendor_thread_id}
         if thread_path:
             params["path"] = thread_path
+        fallback_started = False
         try:
             resumed = client.request("thread/resume", params)
             thread_payload = resumed.get("thread")
         except RuntimeError as exc:
             message = str(exc)
-            if "no rollout found" not in message and "thread not found" not in message:
+            if not self._resume_failure_allows_fallback(message):
                 raise
             if not allow_fallback_start:
                 raise
             started = client.request("thread/start", {"cwd": str(self._workspace_path)})
             thread_payload = started.get("thread")
+            fallback_started = True
         if not isinstance(thread_payload, Mapping):
             raise RuntimeError(
                 "codex app-server thread/resume did not return a thread"
@@ -1982,9 +1991,9 @@ class CodexManagedSessionRuntime:
             raise RuntimeError(
                 "codex app-server thread/resume returned a blank thread id"
             )
-        recovered_thread_path = (
-            thread_path if vendor_thread_id == state.vendor_thread_id else None
-        )
+        recovered_thread_path = None
+        if not fallback_started and vendor_thread_id == state.vendor_thread_id:
+            recovered_thread_path = thread_path
         state.vendor_thread_id = vendor_thread_id
         state.vendor_thread_path = self._normalized_thread_path(
             thread_payload.get("path") or recovered_thread_path

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from moonmind.schemas.managed_session_models import LaunchCodexManagedSessionRequest
 
+
 def write_fake_app_server(
     tmp_path: Path,
     *,
@@ -25,6 +26,7 @@ def write_fake_app_server(
     steer_record_path: Path | None = None,
     interrupt_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
+    thread_resume_error_message: str | None = None,
 ) -> Path:
     script = tmp_path / "fake_app_server.py"
     completion_block = """
@@ -48,6 +50,7 @@ INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
 STEER_RECORD_PATH = __STEER_RECORD_PATH__
 CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
 FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
+THREAD_RESUME_ERROR_MESSAGE = __THREAD_RESUME_ERROR_MESSAGE__
 RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
 START_THREAD_ID = __START_THREAD_ID__
 START_THREAD_PATH = __START_THREAD_PATH__
@@ -153,7 +156,10 @@ for line in sys.stdin:
         if FAIL_THREAD_RESUME:
             sys.stdout.write(json.dumps({
                 "id": msg_id,
-                "error": {"code": -32600, "message": "no rollout found for thread id vendor-thread-1"},
+                "error": {
+                    "code": -32603 if THREAD_RESUME_ERROR_MESSAGE else -32600,
+                    "message": THREAD_RESUME_ERROR_MESSAGE or "no rollout found for thread id vendor-thread-1",
+                },
             }) + "\\n")
             sys.stdout.flush()
             continue
@@ -316,6 +322,7 @@ __COMPLETION_BLOCK__
             repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
         )
         .replace("__FAIL_THREAD_RESUME__", "True" if fail_thread_resume else "False")
+        .replace("__THREAD_RESUME_ERROR_MESSAGE__", repr(thread_resume_error_message))
         .replace(
             "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
             "True" if resume_requires_existing_rollout_path else "False",

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2544,6 +2544,64 @@ def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_n
     assert updated_state["vendorThreadId"] == "vendor-thread-2"
     assert "vendorThreadPath" not in updated_state
 
+
+def test_runtime_send_turn_starts_new_thread_when_rollout_resume_file_is_empty(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    empty_rollout = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "05"
+        / "18"
+        / "rollout-2026-05-18T23-33-21-vendor-thread-1.jsonl"
+    )
+    empty_rollout.parent.mkdir(parents=True)
+    empty_rollout.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        thread_resume_error_message=(
+            "failed to read thread: thread-store internal error: failed to read "
+            f"thread {empty_rollout}: rollout at {empty_rollout} is empty"
+        ),
+        start_thread_id="vendor-thread-2",
+        start_thread_path=None,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    state_path = Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+    state_payload["vendorThreadPath"] = str(empty_rollout)
+    state_path.write_text(json.dumps(state_payload) + "\n", encoding="utf-8")
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated_state["vendorThreadId"] == "vendor-thread-2"
+    assert "vendorThreadPath" not in updated_state
+
+
 def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

This complements #2211. That PR routes empty-assistant turn failures into the existing Codex managed-session recovery path. This PR handles the lower-level resume-cache case where Codex cannot resume an existing thread because its rollout JSONL already exists but is empty.

## Root Cause

Codex App Server can report an empty rollout file as a thread-store internal error during `thread/resume`:

`failed to read thread ... rollout at ... is empty`

MoonMind already treated missing rollout/thread state as disposable cache loss and started a fresh thread, but this empty-rollout error shape was not classified as recoverable. That caused managed-session retries to fail before a new turn could start.

## Changes

- Treat empty rollout resume failures as recoverable cache misses in the Codex managed-session runtime.
- Start a fresh Codex thread for that case, matching the existing fallback behavior for missing rollout/thread state.
- Avoid preserving the stale rollout path after fallback starts a fresh thread.
- Add a regression test that simulates the exact empty-rollout resume error shape.

## Relationship to #2211

No file overlap with #2211. This PR is intentionally separate and complementary:

- #2211: activity/adapter boundary recovery for empty assistant output.
- This PR: runtime boundary recovery for already-empty rollout cache during thread resume.

## Verification

- `pytest tests/unit/services/temporal/runtime/test_codex_session_runtime.py -k 'fallback_starts_new_thread or rollout_resume_file_is_empty or nonexistent_vendor_thread_path' -q` passed through the canonical runner.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed.
  - Python: 5343 passed, 6 skipped, 1 xpassed, 16 subtests passed.
  - Frontend: 23 files passed; 381 passed, 232 skipped.
