### PR TITLE
MM-698 Preserve backend portability for Kubernetes modes

### DIFF
--- a/docs/ManagedAgents/DockerSidecarRuntime.md
+++ b/docs/ManagedAgents/DockerSidecarRuntime.md
@@ -193,6 +193,10 @@ spec:
     agent:         { cpu: "2", memory: 4Gi }
     dockerSidecar: { cpu: "4", memory: 8Gi, ephemeralStorage: 40Gi }
 
+  labels:
+    moonmind.kind: managed-session
+    moonmind.workload_mode: docker-sidecar
+
   readiness:
     docker:
       required: true
@@ -206,6 +210,7 @@ spec:
     moonmindDeploymentSecretsInSession: forbidden
     appContainerControlFromSession: forbidden
     apiContainerWorkloadDockerSocketAccess: false
+    kubernetesJobRuntimeSupported: false
 ```
 
 ---
@@ -228,6 +233,10 @@ Recommended defaults:
 - Locked-down Kubernetes clusters: `kubernetes-job` (see §13).
 
 The mode is a deployment / profile decision. Task instructions cannot raise it.
+The durable profile contract includes the future `kubernetes-job` mode so the
+workspace, labels, capability, and resource semantics remain portable, but that
+mode fails closed unless the deployment profile explicitly sets
+`policy.kubernetesJobRuntimeSupported: true`.
 
 Docker deployments may set `MOONMIND_MANAGED_SESSION_DOCKER_MODE` to
 `docker-sidecar` or `no-docker` at the worker launcher boundary. When the
@@ -779,6 +788,14 @@ workspace: current-session
 ```
 
 That mode preserves the principle (no host Docker, no shared daemon) but trades the "agents see normal Docker" property for native cluster scheduling. It is a future option, not the default execution path today.
+
+The profile-level `labels` map is part of the durable runtime profile rather
+than a Docker-rendering detail. Docker launchers render those labels as Docker
+labels today; Kubernetes renderers map the same values to Pod or Job metadata.
+Kubernetes Job profiles omit `dockerSidecar`, `resources.dockerSidecar`, and
+`resources.nestedContainers`; backend-specific rendering owns the Job resource
+shape after `policy.kubernetesJobRuntimeSupported` has explicitly opted the
+deployment into that mode.
 
 ---
 

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -580,6 +580,7 @@ ManagedRuntimeWorkloadMode = Literal[
     "docker-sidecar",
     "docker-sidecar-rootless",
     "no-docker",
+    "kubernetes-job",
 ]
 MoonMindOpsRuntimeOperation = Literal[
     "status",
@@ -882,6 +883,7 @@ class RuntimeProfileDockerSidecarLaunchPlan(BaseModel):
         alias="applyLimitsOutsideNestedDaemon",
     )
     workload_mode: ManagedRuntimeWorkloadMode = Field(..., alias="workloadMode")
+    labels: dict[str, str] = Field(default_factory=dict)
     socket_volume_name: str = Field(..., alias="socketVolumeName", min_length=1)
     socket_path: str = Field(..., alias="socketPath", min_length=1)
     graph_volume_name: str = Field(..., alias="graphVolumeName", min_length=1)
@@ -913,6 +915,9 @@ class RuntimeProfilePolicy(BaseModel):
     )
     api_container_workload_docker_socket_access: bool = Field(
         False, alias="apiContainerWorkloadDockerSocketAccess"
+    )
+    kubernetes_job_runtime_supported: bool = Field(
+        False, alias="kubernetesJobRuntimeSupported"
     )
 
 
@@ -1014,6 +1019,15 @@ def _mounts_arbitrary_host_path(mounts: list[RuntimeProfileMount]) -> bool:
     return False
 
 
+def _normalize_profile_labels(labels: Mapping[str, str]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in labels.items():
+        key = require_non_blank(str(raw_key), field_name="labels key")
+        value = require_non_blank(str(raw_value), field_name=f"labels[{key}]")
+        normalized[key] = value
+    return normalized
+
+
 class ManagedAgentRuntimeProfile(BaseModel):
     """Validated managed-session runtime profile for Docker sidecar capability."""
 
@@ -1032,10 +1046,12 @@ class ManagedAgentRuntimeProfile(BaseModel):
         default_factory=RuntimeProfileCleanupPolicy
     )
     readiness: dict[str, Any] = Field(default_factory=dict)
+    labels: dict[str, str] = Field(default_factory=dict)
     policy: RuntimeProfilePolicy = Field(default_factory=RuntimeProfilePolicy)
 
     @model_validator(mode="after")
     def _validate_runtime_profile(self) -> "ManagedAgentRuntimeProfile":
+        self.labels = _normalize_profile_labels(self.labels)
         if _contains_sensitive_key(self.agent.env):
             raise ValueError(
                 "agent.env must not receive deployment credentials or unrelated "
@@ -1069,6 +1085,10 @@ class ManagedAgentRuntimeProfile(BaseModel):
                 "API container must not have normal workload Docker socket access; "
                 "workload Docker control belongs to the isolated session sidecar"
             )
+
+        if self.workload_mode == "kubernetes-job":
+            self._validate_kubernetes_job_profile(sidecar)
+            return self
 
         if self.workload_mode == "no-docker":
             if self.agent.docker_client.enabled:
@@ -1144,6 +1164,40 @@ class ManagedAgentRuntimeProfile(BaseModel):
         self._validate_sidecar_resources()
         self._validate_sidecar_cleanup()
         return self
+
+    def _validate_kubernetes_job_profile(
+        self, sidecar: RuntimeProfileDockerSidecar | None
+    ) -> None:
+        if not self.policy.kubernetes_job_runtime_supported:
+            raise ValueError(
+                "workloadMode kubernetes-job requires explicit deployment support "
+                "via policy.kubernetesJobRuntimeSupported"
+            )
+        if self.agent.docker_client.enabled:
+            raise ValueError(
+                "agent.dockerClient.enabled must be false for kubernetes-job profiles; "
+                "Kubernetes Job workloads do not expose a Docker daemon to the agent"
+            )
+        if "DOCKER_HOST" in self.agent.env:
+            raise ValueError(
+                "agent.env.DOCKER_HOST must not be set for kubernetes-job profiles; "
+                "Kubernetes Job workloads are requested through MoonMind capability"
+            )
+        if sidecar is not None and sidecar.enabled:
+            raise ValueError(
+                "dockerSidecar.enabled must be false for kubernetes-job profiles; "
+                "Kubernetes Job workloads are not Docker sidecar materializations"
+            )
+        if self.resources.docker_sidecar is not None:
+            raise ValueError(
+                "resources.dockerSidecar must be omitted for kubernetes-job profiles; "
+                "backend-specific rendering owns Kubernetes Job resource mapping"
+            )
+        if self.resources.nested_containers is not None:
+            raise ValueError(
+                "resources.nestedContainers must be omitted for kubernetes-job "
+                "profiles; Kubernetes Job mode does not use nested Docker containers"
+            )
 
     def _validate_sidecar_resources(self) -> None:
         required_resources = (
@@ -1240,13 +1294,14 @@ def build_docker_sidecar_launch_plan(
 ) -> RuntimeProfileDockerSidecarLaunchPlan | None:
     """Return the compact MM-695 launch contract for Docker sidecar profiles."""
 
-    if profile.workload_mode == "no-docker":
+    if profile.workload_mode in {"no-docker", "kubernetes-job"}:
         return None
     sidecar = profile.docker_sidecar
     if sidecar is None or sidecar.socket is None or sidecar.storage is None:
         raise ValueError("validated Docker sidecar profile is missing sidecar shape")
     return RuntimeProfileDockerSidecarLaunchPlan(
         workloadMode=profile.workload_mode,
+        labels=profile.labels,
         socketVolumeName=sidecar.socket.volume_name,
         socketPath=sidecar.socket.path,
         graphVolumeName=sidecar.storage.volume_name,

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1052,6 +1052,12 @@ class ManagedAgentRuntimeProfile(BaseModel):
     @model_validator(mode="after")
     def _validate_runtime_profile(self) -> "ManagedAgentRuntimeProfile":
         self.labels = _normalize_profile_labels(self.labels)
+        if _contains_sensitive_key(self.labels):
+            raise ValueError(
+                "labels must not receive deployment credentials or unrelated "
+                "session tokens; credential exposure would leak MoonMind or "
+                "cross-session authority into the workload"
+            )
         if _contains_sensitive_key(self.agent.env):
             raise ValueError(
                 "agent.env must not receive deployment credentials or unrelated "
@@ -1294,7 +1300,12 @@ def build_docker_sidecar_launch_plan(
 ) -> RuntimeProfileDockerSidecarLaunchPlan | None:
     """Return the compact MM-695 launch contract for Docker sidecar profiles."""
 
-    if profile.workload_mode in {"no-docker", "kubernetes-job"}:
+    if profile.workload_mode == "kubernetes-job":
+        raise ValueError(
+            "workloadMode kubernetes-job is validated but cannot be launched until "
+            "the Kubernetes Job runtime renderer is wired into managed sessions"
+        )
+    if profile.workload_mode == "no-docker":
         return None
     sidecar = profile.docker_sidecar
     if sidecar is None or sidecar.socket is None or sidecar.storage is None:

--- a/tests/integration/schemas/test_managed_runtime_profile_contract.py
+++ b/tests/integration/schemas/test_managed_runtime_profile_contract.py
@@ -219,16 +219,15 @@ def test_launch_context_rejects_mm698_ungated_kubernetes_job_mode() -> None:
         )
 
 
-def test_launch_context_accepts_mm698_supported_kubernetes_job_without_plan() -> None:
-    context = build_managed_profile_launch_context(
-        profile={
-            "profile_id": "codex_default",
-            "credential_source": "oauth_volume",
-            "runtime_profile": _valid_kubernetes_job_profile(),
-        },
-        runtime_for_profile="codex_cli",
-        workflow_id="wf-agent-run-1",
-        default_credential_source="oauth_volume",
-    )
-
-    assert context.docker_sidecar_launch_plan is None
+def test_launch_context_rejects_mm698_supported_kubernetes_job_without_renderer() -> None:
+    with pytest.raises(ValueError, match="cannot be launched until"):
+        build_managed_profile_launch_context(
+            profile={
+                "profile_id": "codex_default",
+                "credential_source": "oauth_volume",
+                "runtime_profile": _valid_kubernetes_job_profile(),
+            },
+            runtime_for_profile="codex_cli",
+            workflow_id="wf-agent-run-1",
+            default_credential_source="oauth_volume",
+        )

--- a/tests/integration/schemas/test_managed_runtime_profile_contract.py
+++ b/tests/integration/schemas/test_managed_runtime_profile_contract.py
@@ -103,6 +103,10 @@ def _valid_docker_sidecar_profile() -> dict:
                 "preserveWorkspace": "retention_policy",
             },
         },
+        "labels": {
+            "moonmind.kind": "managed-session",
+            "moonmind.workload_mode": "docker-sidecar",
+        },
         "policy": {
             "hostDockerSocket": "forbidden",
             "sharedDaemonAcrossUsers": "forbidden",
@@ -146,6 +150,10 @@ def test_launch_context_exposes_mm695_sidecar_launch_plan() -> None:
     assert plan is not None
     assert plan["issueKey"] == "MM-695"
     assert plan["applyLimitsOutsideNestedDaemon"] is True
+    assert plan["labels"] == {
+        "moonmind.kind": "managed-session",
+        "moonmind.workload_mode": "docker-sidecar",
+    }
     assert plan["resources"]["dockerSidecar"]["ephemeralStorage"] == "40Gi"
     assert plan["resources"]["nestedContainers"]["maxContainers"] == 16
     assert plan["cleanup"]["onSessionEnd"]["stopNestedContainers"] is True
@@ -153,3 +161,74 @@ def test_launch_context_exposes_mm695_sidecar_launch_plan() -> None:
         "markDockerCapabilityUnavailable": True,
         "preserveAgentSession": True,
     }
+
+
+def _valid_kubernetes_job_profile(*, supported: bool = True) -> dict:
+    return {
+        "workloadMode": "kubernetes-job",
+        "workspace": {
+            "volume": "agent_workspaces",
+            "mountPath": "/work/agent_jobs",
+            "repoEnv": "MOONMIND_REPO_DIR",
+            "lifecycle": "session",
+        },
+        "agent": {
+            "image": "moonmind/managed-agent:2026-05-16",
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "dockerClient": {
+                "enabled": False,
+                "composePlugin": False,
+                "daemonInAgent": False,
+            },
+            "env": {},
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+            ],
+        },
+        "dockerSidecar": {"enabled": False},
+        "resources": {
+            "session": {"maxRuntimeSeconds": 14400},
+            "agent": {"cpu": "2", "memory": "4Gi"},
+        },
+        "labels": {
+            "moonmind.kind": "managed-session",
+            "moonmind.workload_mode": "kubernetes-job",
+        },
+        "policy": {
+            "hostDockerSocket": "forbidden",
+            "sharedDaemonAcrossUsers": "forbidden",
+            "moonmindDeploymentSecretsInSession": "forbidden",
+            "appContainerControlFromSession": "forbidden",
+            "apiContainerWorkloadDockerSocketAccess": False,
+            "kubernetesJobRuntimeSupported": supported,
+        },
+    }
+
+
+def test_launch_context_rejects_mm698_ungated_kubernetes_job_mode() -> None:
+    with pytest.raises(ValueError, match="kubernetes-job requires explicit"):
+        build_managed_profile_launch_context(
+            profile={
+                "profile_id": "codex_default",
+                "credential_source": "oauth_volume",
+                "runtime_profile": _valid_kubernetes_job_profile(supported=False),
+            },
+            runtime_for_profile="codex_cli",
+            workflow_id="wf-agent-run-1",
+            default_credential_source="oauth_volume",
+        )
+
+
+def test_launch_context_accepts_mm698_supported_kubernetes_job_without_plan() -> None:
+    context = build_managed_profile_launch_context(
+        profile={
+            "profile_id": "codex_default",
+            "credential_source": "oauth_volume",
+            "runtime_profile": _valid_kubernetes_job_profile(),
+        },
+        runtime_for_profile="codex_cli",
+        workflow_id="wf-agent-run-1",
+        default_credential_source="oauth_volume",
+    )
+
+    assert context.docker_sidecar_launch_plan is None

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -722,6 +722,14 @@ def test_managed_agent_runtime_profile_accepts_valid_docker_sidecar_contract() -
     assert profile.policy.moonmind_deployment_secrets_in_session == "forbidden"
 
 
+def test_managed_agent_runtime_profile_rejects_sensitive_label_keys() -> None:
+    payload = _valid_docker_sidecar_profile()
+    payload["labels"]["moonmind.session_token"] = "should-not-leak"
+
+    with pytest.raises(ValidationError, match="labels must not receive deployment"):
+        ManagedAgentRuntimeProfile.model_validate(payload)
+
+
 def test_managed_agent_runtime_profile_builds_mm695_sidecar_launch_plan() -> None:
     profile = ManagedAgentRuntimeProfile.model_validate(_valid_docker_sidecar_profile())
 
@@ -1111,7 +1119,15 @@ def test_mm698_kubernetes_job_profile_is_backend_portable_when_supported() -> No
     assert profile.resources.docker_sidecar is None
     assert profile.resources.nested_containers is None
     assert profile.labels["moonmind.workload_mode"] == "kubernetes-job"
-    assert build_docker_sidecar_launch_plan(profile) is None
+
+
+def test_mm698_kubernetes_job_profile_fails_fast_without_runtime_renderer() -> None:
+    profile = ManagedAgentRuntimeProfile.model_validate(
+        _valid_kubernetes_job_profile()
+    )
+
+    with pytest.raises(ValueError, match="cannot be launched until"):
+        build_docker_sidecar_launch_plan(profile)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -685,6 +685,10 @@ def _valid_docker_sidecar_profile() -> dict:
                 "intervalSeconds": 2,
             },
         },
+        "labels": {
+            "moonmind.kind": "managed-session",
+            "moonmind.workload_mode": "docker-sidecar",
+        },
         "policy": {
             "hostDockerSocket": "forbidden",
             "sharedDaemonAcrossUsers": "forbidden",
@@ -708,6 +712,10 @@ def test_managed_agent_runtime_profile_accepts_valid_docker_sidecar_contract() -
     assert profile.docker_sidecar.image == "docker:27-dind"
     assert profile.resources.docker_sidecar is not None
     assert profile.resources.docker_sidecar.ephemeral_storage == "40Gi"
+    assert profile.labels == {
+        "moonmind.kind": "managed-session",
+        "moonmind.workload_mode": "docker-sidecar",
+    }
     assert profile.cleanup.on_session_end.remove_docker_graph is True
     assert profile.policy.host_docker_socket == "forbidden"
     assert profile.policy.shared_daemon_across_users == "forbidden"
@@ -724,6 +732,10 @@ def test_managed_agent_runtime_profile_builds_mm695_sidecar_launch_plan() -> Non
     assert dumped["issueKey"] == "MM-695"
     assert dumped["applyLimitsOutsideNestedDaemon"] is True
     assert dumped["resources"]["session"]["maxRuntimeSeconds"] == 14400
+    assert dumped["labels"] == {
+        "moonmind.kind": "managed-session",
+        "moonmind.workload_mode": "docker-sidecar",
+    }
     assert dumped["resources"]["dockerSidecar"]["ephemeralStorage"] == "40Gi"
     assert dumped["resources"]["nestedContainers"]["maxContainers"] == 16
     assert dumped["cleanup"]["onSessionEnd"] == {
@@ -1033,3 +1045,123 @@ def test_no_docker_profile_cannot_be_raised_by_task_requested_mode() -> None:
             profile,
             task_requested_workload_mode="docker-sidecar",
         )
+
+
+def _valid_kubernetes_job_profile(*, supported: bool = True) -> dict:
+    return {
+        "workloadMode": "kubernetes-job",
+        "workspace": {
+            "volume": "agent_workspaces",
+            "mountPath": "/work/agent_jobs",
+            "repoEnv": "MOONMIND_REPO_DIR",
+            "lifecycle": "session",
+        },
+        "agent": {
+            "image": "moonmind/managed-agent:2026-05-16",
+            "workspace": {"mountPath": "/work/agent_jobs"},
+            "dockerClient": {
+                "enabled": False,
+                "composePlugin": False,
+                "daemonInAgent": False,
+            },
+            "env": {},
+            "mounts": [
+                {"name": "workspace", "mountPath": "/work/agent_jobs"},
+            ],
+        },
+        "dockerSidecar": {"enabled": False},
+        "resources": {
+            "session": {"maxRuntimeSeconds": 14400},
+            "agent": {"cpu": "2", "memory": "4Gi"},
+        },
+        "labels": {
+            "moonmind.kind": "managed-session",
+            "moonmind.workload_mode": "kubernetes-job",
+        },
+        "policy": {
+            "hostDockerSocket": "forbidden",
+            "sharedDaemonAcrossUsers": "forbidden",
+            "moonmindDeploymentSecretsInSession": "forbidden",
+            "appContainerControlFromSession": "forbidden",
+            "apiContainerWorkloadDockerSocketAccess": False,
+            "kubernetesJobRuntimeSupported": supported,
+        },
+    }
+
+
+def test_mm698_kubernetes_job_profile_requires_explicit_deployment_support() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="kubernetes-job requires explicit deployment support",
+    ):
+        ManagedAgentRuntimeProfile.model_validate(
+            _valid_kubernetes_job_profile(supported=False)
+        )
+
+
+def test_mm698_kubernetes_job_profile_is_backend_portable_when_supported() -> None:
+    profile = ManagedAgentRuntimeProfile.model_validate(
+        _valid_kubernetes_job_profile()
+    )
+
+    assert profile.workload_mode == "kubernetes-job"
+    assert profile.agent.docker_client.enabled is False
+    assert profile.docker_sidecar is not None
+    assert profile.docker_sidecar.enabled is False
+    assert profile.resources.docker_sidecar is None
+    assert profile.resources.nested_containers is None
+    assert profile.labels["moonmind.workload_mode"] == "kubernetes-job"
+    assert build_docker_sidecar_launch_plan(profile) is None
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda p: p["agent"]["dockerClient"].update({"enabled": True}),
+            "agent.dockerClient.enabled must be false for kubernetes-job",
+        ),
+        (
+            lambda p: p["agent"]["env"].update(
+                {"DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock"}
+            ),
+            "DOCKER_HOST must not be set for kubernetes-job",
+        ),
+        (
+            lambda p: p["dockerSidecar"].update({"enabled": True}),
+            "dockerSidecar.enabled must be false for kubernetes-job",
+        ),
+        (
+            lambda p: p["resources"].update(
+                {
+                    "dockerSidecar": {
+                        "cpu": "4",
+                        "memory": "8Gi",
+                        "ephemeralStorage": "40Gi",
+                    }
+                }
+            ),
+            "resources.dockerSidecar must be omitted for kubernetes-job",
+        ),
+        (
+            lambda p: p["resources"].update(
+                {
+                    "nestedContainers": {
+                        "defaultCpu": "2",
+                        "defaultMemory": "4Gi",
+                        "maxContainers": 16,
+                    }
+                }
+            ),
+            "resources.nestedContainers must be omitted for kubernetes-job",
+        ),
+    ],
+)
+def test_mm698_kubernetes_job_profile_rejects_docker_sidecar_assumptions(
+    mutate, message
+) -> None:
+    payload = _valid_kubernetes_job_profile()
+    mutate(payload)
+
+    with pytest.raises(ValidationError, match=message):
+        ManagedAgentRuntimeProfile.model_validate(payload)


### PR DESCRIPTION
Jira issue key: MM-698

Summary:
- Adds `kubernetes-job` to the durable managed runtime workload mode contract behind explicit `policy.kubernetesJobRuntimeSupported` deployment support.
- Carries backend-neutral runtime profile labels into the sidecar launch contract.
- Rejects Docker sidecar assumptions for Kubernetes Job profiles while preserving docker-sidecar defaults and rootless as a hardening target.
- Updates Docker sidecar runtime docs and tests for backend portability.

Tests run:
- `pytest tests/unit/schemas/test_agent_runtime_models.py tests/integration/schemas/test_managed_runtime_profile_contract.py -q --tb=short`
- `pytest tests/integration/schemas/test_managed_runtime_profile_contract.py -m integration_ci -q --tb=short`
- `./tools/test_unit.sh tests/unit/schemas/test_agent_runtime_models.py`
- `python -m py_compile moonmind/schemas/agent_runtime_models.py tests/unit/schemas/test_agent_runtime_models.py tests/integration/schemas/test_managed_runtime_profile_contract.py`

Remaining risks:
- Kubernetes Job rendering remains future work; this change adds the durable contract and explicit deployment gate only.
- Full `./tools/test_unit.sh` previously exposed unrelated batch PR resolver parent-run-scope failures under this managed job environment.
