### PR TITLE
[codex] Handle Jira Implement no-op publish

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5864,6 +5864,48 @@ class MoonMindRunWorkflow:
                     )
                     if name:
                         skill_names.add(name.lower())
+
+        for payload in (parameters, task_payload):
+            applied_templates = payload.get("appliedStepTemplates")
+            if not isinstance(applied_templates, Sequence) or isinstance(
+                applied_templates,
+                (str, bytes, bytearray),
+            ):
+                continue
+            for template in applied_templates:
+                if not isinstance(template, Mapping):
+                    continue
+                slug = self._coerce_text(
+                    template.get("slug") or template.get("presetSlug"),
+                    max_chars=120,
+                )
+                if slug:
+                    skill_names.add(slug.lower())
+                composition = template.get("composition")
+                include_sources: list[Any] = []
+                if isinstance(composition, Mapping):
+                    composition_includes = composition.get("includes")
+                    if isinstance(composition_includes, Sequence) and not isinstance(
+                        composition_includes,
+                        (str, bytes, bytearray),
+                    ):
+                        include_sources.extend(composition_includes)
+                template_includes = template.get("includes")
+                if isinstance(template_includes, Sequence) and not isinstance(
+                    template_includes,
+                    (str, bytes, bytearray),
+                ):
+                    include_sources.extend(template_includes)
+                for include in include_sources:
+                    if not isinstance(include, Mapping):
+                        continue
+                    include_slug = self._coerce_text(
+                        include.get("slug") or include.get("presetSlug"),
+                        max_chars=120,
+                    )
+                    if include_slug:
+                        skill_names.add(include_slug.lower())
+
         skills_payload = task_payload.get("skills")
         if isinstance(skills_payload, Mapping):
             include = skills_payload.get("include")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5875,36 +5875,26 @@ class MoonMindRunWorkflow:
             for template in applied_templates:
                 if not isinstance(template, Mapping):
                     continue
-                slug = self._coerce_text(
-                    template.get("slug") or template.get("presetSlug"),
-                    max_chars=120,
-                )
-                if slug:
-                    skill_names.add(slug.lower())
+                slug_sources: list[Any] = [template]
                 composition = template.get("composition")
-                include_sources: list[Any] = []
-                if isinstance(composition, Mapping):
-                    composition_includes = composition.get("includes")
-                    if isinstance(composition_includes, Sequence) and not isinstance(
-                        composition_includes,
+                for include_source in (composition, template):
+                    if not isinstance(include_source, Mapping):
+                        continue
+                    includes = include_source.get("includes")
+                    if isinstance(includes, Sequence) and not isinstance(
+                        includes,
                         (str, bytes, bytearray),
                     ):
-                        include_sources.extend(composition_includes)
-                template_includes = template.get("includes")
-                if isinstance(template_includes, Sequence) and not isinstance(
-                    template_includes,
-                    (str, bytes, bytearray),
-                ):
-                    include_sources.extend(template_includes)
-                for include in include_sources:
-                    if not isinstance(include, Mapping):
+                        slug_sources.extend(includes)
+                for slug_source in slug_sources:
+                    if not isinstance(slug_source, Mapping):
                         continue
-                    include_slug = self._coerce_text(
-                        include.get("slug") or include.get("presetSlug"),
+                    slug = self._coerce_text(
+                        slug_source.get("slug") or slug_source.get("presetSlug"),
                         max_chars=120,
                     )
-                    if include_slug:
-                        skill_names.add(include_slug.lower())
+                    if slug:
+                        skill_names.add(slug.lower())
 
         skills_payload = task_payload.get("skills")
         if isinstance(skills_payload, Mapping):

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2792,11 +2792,13 @@ async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
             "publishMode": "pr",
             "mergeAutomation": {"enabled": True, "jiraIssueKey": "MM-697"},
             "task": {
-                "skills": {
-                    "include": [
-                        {"name": "jira-implement"},
-                    ],
-                },
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.0.0",
+                        "composition": {"includes": []},
+                    }
+                ],
             },
         },
         plan_ref="art_plan_1",
@@ -2805,6 +2807,7 @@ async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
     assert not create_pr_called
     assert workflow._publish_status == "not_required"
     assert workflow._publish_context["mergeAutomationStatus"] == "not_applicable"
+
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1109,6 +1109,26 @@ def test_jira_implement_task_makes_pr_publish_optional(
         }
     )
 
+
+def test_jira_implement_applied_template_makes_pr_publish_optional(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.0.0",
+                        "composition": {"includes": []},
+                    }
+                ],
+            },
+        }
+    )
+
+
 def test_native_pr_branch_resolution_keeps_legacy_branch_only_replay_shape(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Recognize Jira Implement applied-template provenance when deciding whether PR publication is optional.
- Keep FULLY_IMPLEMENTED/no-code-change Jira Implement runs from failing parent publish enforcement just because no PR was produced.
- Add regression coverage for the expanded template payload shape and execution-stage native PR skip.

## Root cause
The existing publish-optional classifier recognized `jira-implement` when it appeared in `task.skills.include`, but rerun/template-expanded tasks carry it under `task.appliedStepTemplates`. Those runs reached the intended no-op path but the parent workflow still enforced `publishMode: pr` as if a PR were mandatory.

## Validation
- `./tools/test_unit.sh`
