### PR TITLE
MM-671 resolve managed push credentials

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6726,20 +6726,29 @@ class TemporalAgentRuntimeActivities:
             )
 
     @staticmethod
-    def _workspace_command_env(workspace: str) -> dict[str, str]:
+    def _workspace_command_env(
+        workspace: str,
+        *,
+        github_token: str | None = None,
+    ) -> dict[str, str]:
         """Build a subprocess env that exposes workspace-local command shims."""
         env = dict(os.environ)
         support_root = Path(workspace).resolve().parent / ".moonmind"
         support_bin = support_root / "bin"
         support_gitconfig = support_root / "gitconfig"
-        github_token = str(env.get("GITHUB_TOKEN", "")).strip()
+        normalized_github_token = str(
+            github_token or env.get("GITHUB_TOKEN", "")
+        ).strip()
+        if normalized_github_token:
+            env["GITHUB_TOKEN"] = normalized_github_token
+            env["GH_TOKEN"] = normalized_github_token
         git_helper_path = support_bin / "git-credential-moonmind"
         helper_command: str | None = None
 
         try:
             support_root.mkdir(parents=True, exist_ok=True)
             support_bin.mkdir(parents=True, exist_ok=True)
-            if github_token:
+            if normalized_github_token:
                 helper_script = (
                     "#!/usr/bin/env python3\n"
                     "import os\n"
@@ -6819,6 +6828,14 @@ class TemporalAgentRuntimeActivities:
             env["GIT_COMMITTER_EMAIL"] = git_email
         env["GIT_TERMINAL_PROMPT"] = "0"
         return env
+
+    @staticmethod
+    async def _resolve_workspace_push_github_token(workspace: str) -> str:
+        repo = TemporalAgentRuntimeActivities._detect_repo_from_workspace(workspace)
+        from moonmind.auth.github_credentials import resolve_github_credential
+
+        resolved = await resolve_github_credential(repo=repo or None)
+        return str(resolved.token or "").strip()
 
     async def _commit_workspace_changes_if_needed(
         self,
@@ -7025,7 +7042,11 @@ class TemporalAgentRuntimeActivities:
         try:
             self._normalize_workspace_git_alternates(workspace)
             self._recover_orphan_workspace_object_stores(workspace)
-            command_env = self._workspace_command_env(workspace)
+            github_token = await self._resolve_workspace_push_github_token(workspace)
+            command_env = self._workspace_command_env(
+                workspace,
+                github_token=github_token,
+            )
             branch_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
                     workspace, "rev-parse", "--abbrev-ref", "HEAD",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5834,6 +5834,7 @@ class TemporalAgentRuntimeActivities:
             workflow_id=f"agent_runtime_activity:{run_id}",
             run_store=self._run_store,
         )
+        workspace_github_token: str | None = None
         try:
             result = await adapter.fetch_result(
                 run_id, pr_resolver_expected=pr_resolver_expected
@@ -5844,6 +5845,11 @@ class TemporalAgentRuntimeActivities:
                     self._normalize_workspace_git_alternates(record.workspace_path)
                     self._recover_orphan_workspace_object_stores(
                         record.workspace_path
+                    )
+                    workspace_github_token = (
+                        await self._resolve_workspace_push_github_token(
+                            record.workspace_path
+                        )
                     )
                 result = self._maybe_enrich_gemini_failure_result(
                     result=result,
@@ -5869,6 +5875,7 @@ class TemporalAgentRuntimeActivities:
                     run_id=run_id,
                     head_branch=head_branch,
                     base_branch=target_branch,
+                    github_token=workspace_github_token,
                 )
                 if merged_pr is not None:
                     result = self._apply_pr_reverify_override(
@@ -5935,6 +5942,7 @@ class TemporalAgentRuntimeActivities:
                     push_kwargs["commit_message"] = raw_commit_message.strip()
                 push_info = await self._push_workspace_branch(
                     run_id,
+                    github_token=workspace_github_token,
                     **push_kwargs,
                 )
                 meta.update(push_info)
@@ -5942,7 +5950,10 @@ class TemporalAgentRuntimeActivities:
             # Enrich result with pull_request_url detected from workspace git
             # state (CLI stdout may not always surface PR URLs reliably).
             if result.failure_class is None:
-                pr_url = self._detect_pr_url_from_workspace(run_id)
+                pr_url = self._detect_pr_url_from_workspace(
+                    run_id,
+                    github_token=workspace_github_token,
+                )
                 if pr_url:
                     meta["pull_request_url"] = pr_url
 
@@ -7021,6 +7032,7 @@ class TemporalAgentRuntimeActivities:
         head_branch: str | None = None,
         commit_message: str | None = None,
         allow_target_branch_push: bool = False,
+        github_token: str | None = None,
     ) -> dict[str, Any]:
         """Push the workspace branch to origin.
 
@@ -7042,10 +7054,15 @@ class TemporalAgentRuntimeActivities:
         try:
             self._normalize_workspace_git_alternates(workspace)
             self._recover_orphan_workspace_object_stores(workspace)
-            github_token = await self._resolve_workspace_push_github_token(workspace)
-            command_env = self._workspace_command_env(
+            resolved_github_token = str(github_token or "").strip()
+            if not resolved_github_token:
+                resolved_github_token = await self._resolve_workspace_push_github_token(
+                    workspace
+                )
+            command_env = self._workspace_command_env(workspace)
+            auth_command_env = self._workspace_command_env(
                 workspace,
-                github_token=github_token,
+                github_token=resolved_github_token,
             )
             branch_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
@@ -7196,7 +7213,7 @@ class TemporalAgentRuntimeActivities:
                 workspace=workspace,
                 branch=current_branch,
                 run_id=run_id,
-                env=command_env,
+                env=auth_command_env,
             )
 
             push_proc = await asyncio.create_subprocess_exec(
@@ -7209,7 +7226,7 @@ class TemporalAgentRuntimeActivities:
                 ),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env=command_env,
+                env=auth_command_env,
             )
             try:
                 push_stdout, push_stderr = await asyncio.wait_for(
@@ -7252,7 +7269,7 @@ class TemporalAgentRuntimeActivities:
                         ),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
-                        env=command_env,
+                        env=auth_command_env,
                     )
                     try:
                         fetch_stdout, fetch_stderr = await asyncio.wait_for(
@@ -7293,7 +7310,7 @@ class TemporalAgentRuntimeActivities:
                                     workspace=workspace,
                                     branch=current_branch,
                                     run_id=run_id,
-                                    env=command_env,
+                                    env=auth_command_env,
                                 )
                             )
                         if (
@@ -7368,7 +7385,7 @@ class TemporalAgentRuntimeActivities:
                             ),
                             stdout=asyncio.subprocess.PIPE,
                             stderr=asyncio.subprocess.PIPE,
-                            env=command_env,
+                            env=auth_command_env,
                         )
                         try:
                             _, retry_push_stderr = await asyncio.wait_for(
@@ -7649,7 +7666,12 @@ class TemporalAgentRuntimeActivities:
             # branch publication handle any remote-side rejection.
             return -1
 
-    def _detect_pr_url_from_workspace(self, run_id: str) -> str | None:
+    def _detect_pr_url_from_workspace(
+        self,
+        run_id: str,
+        *,
+        github_token: str | None = None,
+    ) -> str | None:
         """Best-effort detection of a PR URL from the workspace git state."""
         import subprocess
 
@@ -7669,6 +7691,7 @@ class TemporalAgentRuntimeActivities:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=self._workspace_command_env(workspace),
             )
             if branch_result.returncode != 0:
                 return None
@@ -7689,7 +7712,10 @@ class TemporalAgentRuntimeActivities:
                 text=True,
                 timeout=30,
                 cwd=workspace,
-                env=self._workspace_command_env(workspace),
+                env=self._workspace_command_env(
+                    workspace,
+                    github_token=github_token,
+                ),
             )
             if pr_result.returncode != 0:
                 return None
@@ -7745,6 +7771,7 @@ class TemporalAgentRuntimeActivities:
         run_id: str,
         head_branch: str | None,
         base_branch: str | None = None,
+        github_token: str | None = None,
     ) -> dict[str, Any] | None:
         """Return PR metadata when *head_branch*'s PR is merged on GitHub.
 
@@ -7792,7 +7819,10 @@ class TemporalAgentRuntimeActivities:
                 text=True,
                 timeout=30,
                 cwd=workspace,
-                env=self._workspace_command_env(workspace),
+                env=self._workspace_command_env(
+                    workspace,
+                    github_token=github_token,
+                ),
             )
             if pr_result.returncode != 0:
                 return None

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -1279,6 +1279,9 @@ class TestPushWorkspaceBranch:
         assert helper_path.is_file()
         assert env["PATH"].startswith(str(support_bin))
         assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+        assert env["GITHUB_TOKEN"] == "ghp_test_token_value"
+        assert env["GH_TOKEN"] == "ghp_test_token_value"
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
 
         helper_text = helper_path.read_text(encoding="utf-8")
         gitconfig_text = gitconfig.read_text(encoding="utf-8")
@@ -1288,6 +1291,31 @@ class TestPushWorkspaceBranch:
         assert "password={token}" in helper_text
         assert "git-credential-moonmind" in gitconfig_text
         assert str(workspace.resolve()) in gitconfig_text
+
+    def test_workspace_command_env_uses_resolved_github_token(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "run-1" / "repo"
+        support_root = workspace.parent / ".moonmind"
+        support_bin = support_root / "bin"
+        gitconfig = support_root / "gitconfig"
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        env = TemporalAgentRuntimeActivities._workspace_command_env(
+            str(workspace),
+            github_token="resolved-token",
+        )
+
+        helper_path = support_bin / "git-credential-moonmind"
+        assert env["GITHUB_TOKEN"] == "resolved-token"
+        assert env["GH_TOKEN"] == "resolved-token"
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+        assert helper_path.is_file()
+        assert "resolved-token" not in helper_path.read_text(encoding="utf-8")
+        assert "resolved-token" not in gitconfig.read_text(encoding="utf-8")
 
     def test_workspace_command_env_logs_bootstrap_failures(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
@@ -1347,6 +1375,66 @@ class TestPushWorkspaceBranch:
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "auto-abc123"
         assert "push_commit_count" not in result
+
+    @pytest.mark.asyncio
+    async def test_push_resolves_github_token_and_injects_push_env(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        captured_push_env: dict[str, str] | None = None
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count, captured_push_env
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # remote branch sha before push
+                proc.communicate = AsyncMock(return_value=(b"auto-remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # push
+                captured_push_env = kwargs["env"]
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"auto-head-sha\n", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        resolved = MagicMock()
+        resolved.token = "resolved-push-token"
+        with (
+            patch.object(
+                TemporalAgentRuntimeActivities,
+                "_detect_repo_from_workspace",
+                return_value="owner/repo",
+            ) as detect_repo,
+            patch(
+                "moonmind.auth.github_credentials.resolve_github_credential",
+                new_callable=AsyncMock,
+                return_value=resolved,
+            ) as resolve_github,
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+        ):
+            result = await activities._push_workspace_branch("run-1")
+
+        detect_repo.assert_called_once_with("/work/agent_jobs/run-1/repo")
+        resolve_github.assert_awaited_once_with(repo="owner/repo")
+        assert result["push_status"] == "pushed"
+        assert captured_push_env is not None
+        assert captured_push_env["GITHUB_TOKEN"] == "resolved-push-token"
+        assert captured_push_env["GH_TOKEN"] == "resolved-push-token"
+        assert captured_push_env["GIT_TERMINAL_PROMPT"] == "0"
 
     @pytest.mark.asyncio
     async def test_push_revlist_nonzero_returncode_falls_through(self):

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -57,7 +57,7 @@ def _make_subprocess_result(
         args=[], returncode=returncode, stdout=stdout, stderr=stderr,
     )
 
-def test_detect_pr_url_uses_workspace_command_shims(tmp_path):
+def test_detect_pr_url_uses_workspace_command_shims_and_resolved_token(tmp_path):
     store = _make_mock_store(workspace_path=str(tmp_path / "run-1" / "repo"))
     activities = TemporalAgentRuntimeActivities(run_store=store)
     workspace = Path(str(store.load.return_value.workspace_path))
@@ -74,7 +74,10 @@ def test_detect_pr_url_uses_workspace_command_shims(tmp_path):
         return _make_subprocess_result(stdout='[{"url":"https://github.com/o/r/pull/1"}]\n')
 
     with patch("subprocess.run", side_effect=_mock_run):
-        pr_url = activities._detect_pr_url_from_workspace("run-1")
+        pr_url = activities._detect_pr_url_from_workspace(
+            "run-1",
+            github_token="resolved-token",
+        )
 
     assert pr_url == "https://github.com/o/r/pull/1"
     assert len(calls) == 3
@@ -82,6 +85,8 @@ def test_detect_pr_url_uses_workspace_command_shims(tmp_path):
     gh_env = gh_call["kwargs"]["env"]
     assert isinstance(gh_env, dict)
     assert gh_env["PATH"].startswith(str(workspace.parent / ".moonmind" / "bin"))
+    assert gh_env["GITHUB_TOKEN"] == "resolved-token"
+    assert gh_env["GH_TOKEN"] == "resolved-token"
 
 def test_parse_git_status_paths_handles_nul_delimited_non_ascii_and_renames() -> None:
     status_output = (
@@ -1437,6 +1442,87 @@ class TestPushWorkspaceBranch:
         assert captured_push_env["GIT_TERMINAL_PROMPT"] == "0"
 
     @pytest.mark.asyncio
+    async def test_push_does_not_expose_resolved_token_to_commit_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        captured_commit_env: dict[str, str] | None = None
+        captured_push_env: dict[str, str] | None = None
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal captured_commit_env, captured_push_env
+            command = [str(arg) for arg in args]
+            proc = AsyncMock()
+            if "rev-parse" in command and "--abbrev-ref" in command:
+                proc.communicate = AsyncMock(
+                    return_value=(b"feature/token-scope\n", b"")
+                )
+                proc.returncode = 0
+            elif "status" in command:
+                proc.communicate = AsyncMock(return_value=(b"M  changed.txt\0", b""))
+                proc.returncode = 0
+            elif "add" in command:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif "diff" in command and "--cached" in command:
+                proc.communicate = AsyncMock(return_value=(b"changed.txt\n", b""))
+                proc.returncode = 0
+            elif "commit" in command:
+                captured_commit_env = kwargs["env"]
+                proc.communicate = AsyncMock(return_value=(b"[feature abc] msg\n", b""))
+                proc.returncode = 0
+            elif "symbolic-ref" in command:
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif "rev-parse" in command and "--verify" in command:
+                proc.communicate = AsyncMock(return_value=(b"", b"missing ref"))
+                proc.returncode = 1
+            elif "ls-remote" in command:
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"remote-sha\trefs/heads/feature/token-scope\n",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif "push" in command:
+                captured_push_env = kwargs["env"]
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif "rev-parse" in command and "HEAD" in command:
+                proc.communicate = AsyncMock(return_value=(b"head-sha\n", b""))
+                proc.returncode = 0
+            elif "rev-list" in command:
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"unexpected command: {command!r}")
+            return proc
+
+        with (
+            patch.object(
+                TemporalAgentRuntimeActivities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-push-token",
+            ),
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+        ):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        assert captured_commit_env is not None
+        assert "GITHUB_TOKEN" not in captured_commit_env
+        assert "GH_TOKEN" not in captured_commit_env
+        assert captured_push_env is not None
+        assert captured_push_env["GITHUB_TOKEN"] == "resolved-push-token"
+        assert captured_push_env["GH_TOKEN"] == "resolved-push-token"
+
+    @pytest.mark.asyncio
     async def test_push_revlist_nonzero_returncode_falls_through(self):
         """Non-zero rev-list returncode falls through to 'pushed' instead of false no_commits."""
         store = _make_mock_store()
@@ -1545,6 +1631,12 @@ class TestFetchResultPushIntegration:
                 activities, "_detect_pr_url_from_workspace",
                 return_value=None,
             ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
             ) as MockAdapter,
@@ -1559,7 +1651,11 @@ class TestFetchResultPushIntegration:
                 {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
             )
 
-        mock_push.assert_called_once_with("run-1", target_branch=None)
+        mock_push.assert_called_once_with(
+            "run-1",
+            github_token="resolved-token",
+            target_branch=None,
+        )
         assert result.metadata["push_status"] == "pushed"
         assert result.metadata["push_branch"] == "my-branch"
 
@@ -1583,6 +1679,12 @@ class TestFetchResultPushIntegration:
                 "_detect_pr_url_from_workspace",
                 return_value=None,
             ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
             ) as MockAdapter,
@@ -1605,6 +1707,7 @@ class TestFetchResultPushIntegration:
 
         mock_push.assert_called_once_with(
             "run-1",
+            github_token="resolved-token",
             target_branch="feature/existing",
             allow_target_branch_push=True,
             head_branch="feature/existing",
@@ -1653,6 +1756,12 @@ class TestFetchResultPushIntegration:
                 activities, "_detect_pr_url_from_workspace",
                 return_value=None,
             ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
             ) as MockAdapter,
@@ -1695,6 +1804,12 @@ class TestFetchResultPushIntegration:
             patch.object(
                 activities, "_detect_pr_url_from_workspace",
                 return_value=None,
+            ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
             ),
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
@@ -1795,6 +1910,12 @@ class TestFetchResultPushIntegration:
                 activities, "_detect_pr_url_from_workspace",
                 return_value=None,
             ),
+            patch.object(
+                activities,
+                "_resolve_workspace_push_github_token",
+                new_callable=AsyncMock,
+                return_value="resolved-token",
+            ),
             patch(
                 "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
             ) as MockAdapter,
@@ -1816,6 +1937,7 @@ class TestFetchResultPushIntegration:
 
         mock_push.assert_called_once_with(
             "run-1",
+            github_token="resolved-token",
             target_branch=None,
             commit_message="Use explicit publish commit",
         )

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -240,6 +240,8 @@ def test_parent_run_scope_uses_managed_session_spool(
 ) -> None:
     module = _load_module()
     parent_run_scope = module["_parent_run_scope"]
+    for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
+        monkeypatch.delenv(env_key, raising=False)
 
     monkeypatch.setenv(
         "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
@@ -255,6 +257,8 @@ def test_parent_run_scope_hashes_nonstandard_session_spool_path(
     module = _load_module()
     parent_run_scope = module["_parent_run_scope"]
     stable_scope_from_path = module["_stable_scope_from_path"]
+    for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
+        monkeypatch.delenv(env_key, raising=False)
 
     spool = tmp_path / "custom-spool" / "output"
     monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1760,6 +1760,7 @@ async def test_fetch_result_reverifies_and_clears_pr_not_found_when_merged(
         run_id="fr-reverify",
         head_branch="mm-398-e3573b0c",
         base_branch="main",
+        github_token=None,
     )
     assert result.failure_class is None, (
         "PR re-verified as merged: failure_class must be cleared"
@@ -1870,6 +1871,7 @@ async def test_fetch_result_reverifies_blocked_resolver_by_pr_number_when_merged
         run_id=run_id,
         head_branch=None,
         base_branch=None,
+        github_token=None,
     )
     assert result.failure_class is None
     assert "#1727" in (result.summary or "")


### PR DESCRIPTION
Jira issue key: MM-671

Summary:
- Resolve the GitHub token at the managed runtime push boundary using the canonical GitHub credential resolver.
- Inject the resolved token into the push subprocess environment as both GITHUB_TOKEN and GH_TOKEN, while preserving GIT_TERMINAL_PROMPT=0.
- Keep token material out of generated workspace git helper/config files and add unit coverage for push env injection.

Tests run:
- ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py

Remaining risks:
- Full unit suite was not run in this publication step; verification focused on the changed managed push behavior and the test runner's frontend unit phase.
- Live GitHub credential resolution in production still depends on the configured managed GitHub credential source being available at runtime.
