### PR TITLE
[codex] Fix Jira Implement no-change publish

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -147,6 +147,9 @@ _JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
 _JIRA_BACKED_AGENT_SKILLS = frozenset(
     {"jira-implement", *JIRA_BACKED_AGENT_SKILLS}
 )
+_PLAIN_TEXT_BLOCKED_OUTCOME_PATTERN = re.compile(
+    r"(?im)^\s*(?:#{1,6}\s*)?(?:result|verdict|outcome)\s*:\s*blocked\b[^\n]*"
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -4841,6 +4844,11 @@ class MoonMindRunWorkflow:
                 message = self._blocked_outcome_message_from_mapping(candidate)
                 if message:
                     return message
+            match = _PLAIN_TEXT_BLOCKED_OUTCOME_PATTERN.search(value)
+            if match:
+                summary = self._coerce_text(value, max_chars=700)
+                if summary:
+                    return f"Workflow blocked by plan step: {summary}"
 
         return None
 
@@ -5566,6 +5574,14 @@ class MoonMindRunWorkflow:
             return
 
         if push_status == "no_commits":
+            if publish_mode == "pr" and self._pr_publish_optional_for_task(parameters):
+                self._publish_status = "not_required"
+                self._publish_reason = self._compose_no_change_publish_reason(
+                    publish_mode=publish_mode,
+                )
+                if self._merge_automation_requested(parameters):
+                    self._publish_context["mergeAutomationStatus"] = "not_applicable"
+                return
             self._publish_status = "skipped"
             self._publish_reason = self._compose_no_change_publish_reason(
                 publish_mode=publish_mode,
@@ -5878,6 +5894,28 @@ class MoonMindRunWorkflow:
                         name = self._coerce_text(item, max_chars=120)
                     if name:
                         skill_names.add(name.lower())
+        for payload in (parameters, task_payload):
+            applied_templates = payload.get("appliedStepTemplates")
+            if applied_templates is None:
+                applied_templates = payload.get("applied_step_templates")
+            if not isinstance(applied_templates, Sequence) or isinstance(
+                applied_templates,
+                (str, bytes),
+            ):
+                continue
+            for item in applied_templates:
+                if not isinstance(item, Mapping):
+                    continue
+                slug = self._coerce_text(
+                    item.get("slug")
+                    or item.get("templateSlug")
+                    or item.get("template_slug")
+                    or item.get("id")
+                    or item.get("name"),
+                    max_chars=120,
+                )
+                if slug:
+                    skill_names.add(slug.lower())
         return skill_names
 
     def _execution_result_has_publishable_changes(self, execution_result: Any) -> bool:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4846,7 +4846,7 @@ class MoonMindRunWorkflow:
                     return message
             match = _PLAIN_TEXT_BLOCKED_OUTCOME_PATTERN.search(value)
             if match:
-                summary = self._coerce_text(value, max_chars=700)
+                summary = self._coerce_text(value[match.start():], max_chars=700)
                 if summary:
                     return f"Workflow blocked by plan step: {summary}"
 
@@ -5574,7 +5574,9 @@ class MoonMindRunWorkflow:
             return
 
         if push_status == "no_commits":
-            if publish_mode == "pr" and self._pr_publish_optional_for_task(parameters):
+            if publish_mode == "pr" and self._pr_publish_optional_for_task(
+                parameters, include_applied_templates=True
+            ):
                 self._publish_status = "not_required"
                 self._publish_reason = self._compose_no_change_publish_reason(
                     publish_mode=publish_mode,
@@ -5857,9 +5859,18 @@ class MoonMindRunWorkflow:
                 return False
         return True
 
-    def _pr_publish_optional_for_task(self, parameters: Mapping[str, Any]) -> bool:
+    def _pr_publish_optional_for_task(
+        self,
+        parameters: Mapping[str, Any],
+        *,
+        include_applied_templates: bool = False,
+    ) -> bool:
         task_payload = self._mapping_value(parameters, "task")
         skill_names = self._task_skill_names(parameters, task_payload)
+        if include_applied_templates:
+            skill_names = skill_names | self._task_applied_template_slugs(
+                parameters, task_payload
+            )
         if not skill_names:
             return False
         return skill_names.issubset(_PR_OPTIONAL_TASK_SKILLS)
@@ -5894,6 +5905,14 @@ class MoonMindRunWorkflow:
                         name = self._coerce_text(item, max_chars=120)
                     if name:
                         skill_names.add(name.lower())
+        return skill_names
+
+    def _task_applied_template_slugs(
+        self,
+        parameters: Mapping[str, Any],
+        task_payload: Mapping[str, Any],
+    ) -> set[str]:
+        slugs: set[str] = set()
         for payload in (parameters, task_payload):
             applied_templates = payload.get("appliedStepTemplates")
             if applied_templates is None:
@@ -5915,8 +5934,8 @@ class MoonMindRunWorkflow:
                     max_chars=120,
                 )
                 if slug:
-                    skill_names.add(slug.lower())
-        return skill_names
+                    slugs.add(slug.lower())
+        return slugs
 
     def _execution_result_has_publishable_changes(self, execution_result: Any) -> bool:
         if self._extract_pull_request_url(execution_result):

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1053,6 +1053,44 @@ def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     assert "Files edited in this run: none." in message
     assert publish_failure is True
 
+def test_jira_implement_no_commit_pr_handoff_is_not_required(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    execution_result = {
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "feature/no-op",
+            "push_base_ref": "origin/main",
+            "push_commit_count": 0,
+            "operator_summary": "MM-675 was already implemented.",
+        }
+    }
+    parameters = {
+        "publishMode": "pr",
+        "task": {
+            "appliedStepTemplates": [
+                {"slug": "jira-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-7",
+        execution_result=execution_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result=execution_result,
+    )
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    assert status == "success"
+    assert "no publishable diff was produced" in message
+    assert publish_failure is False
+
 def test_structured_publish_not_required_satisfies_pr_publish_mode(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
@@ -1108,6 +1146,35 @@ def test_jira_implement_task_makes_pr_publish_optional(
             },
         }
     )
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+    )
+
+
+def test_plain_text_blocked_result_short_circuits_publish(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    message = mock_run_workflow._blocked_outcome_message(
+        {
+            "outputs": {
+                "operator_summary": (
+                    "## Result: BLOCKED - cannot transition Jira issue MM-675\n\n"
+                    "The assessment verdict artifact is unavailable."
+                )
+            }
+        }
+    )
+
+    assert message is not None
+    assert message.startswith("Workflow blocked by plan step:")
+    assert "cannot transition Jira issue MM-675" in message
 
 def test_native_pr_branch_resolution_keeps_legacy_branch_only_replay_shape(
     mock_run_workflow: MoonMindRunWorkflow,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1146,7 +1146,8 @@ def test_jira_implement_task_makes_pr_publish_optional(
             },
         }
     )
-    assert mock_run_workflow._pr_publish_optional_for_task(
+    # appliedStepTemplates alone must not relax PR creation for the whole run.
+    assert not mock_run_workflow._pr_publish_optional_for_task(
         {
             "publishMode": "pr",
             "task": {
@@ -1155,6 +1156,18 @@ def test_jira_implement_task_makes_pr_publish_optional(
                 ],
             },
         }
+    )
+    # It only relaxes the no-commit publish fallback when opted in explicitly.
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        },
+        include_applied_templates=True,
     )
 
 


### PR DESCRIPTION
## Summary
- recognize Jira Implement runs from applied step templates when deciding whether PR publishing is optional
- treat no-commit PR handoff as publish not required for PR-optional Jira Implement flows
- surface plain-text blocked outcomes instead of hiding them behind a publish-stage failure

## Root Cause
A Jira Implement run that produced no repository diff could still leave top-level publishMode=pr active. The parent workflow then failed finalization with a no-publishable-diff error even when the preset path had no PR to create, and plain-text BLOCKED summaries from managed runtimes were not being classified as blocked outcomes.

## Validation
- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k "jira_implement_task_makes_pr_publish_optional or jira_implement_no_commit_pr_handoff_is_not_required or plain_text_blocked_result_short_circuits_publish or determine_publish_completion_fails_for_no_commit_pr_publish"
- python3.12 -m pytest -q tests/unit/workflows/temporal/workflows/test_run_integration.py

Full ./tools/test_unit.sh was attempted, but the repo-local .venv is Python 3.11 and collection stops on an unrelated Python 3.12-only f-string in tests/unit/services/temporal/runtime/test_managed_session_controller.py:2550.