### PR TITLE
MM-673 Managed PR creation transport with REST primary and gh fallback

### DIFF
--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -166,11 +166,12 @@ class PublishService:
         )
         token = ""
         push_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+        resolved_github_credential = None
         if repo:
             from moonmind.auth.github_credentials import resolve_github_credential
 
-            resolved = await resolve_github_credential(repo=repo)
-            token = resolved.token or ""
+            resolved_github_credential = await resolve_github_credential(repo=repo)
+            token = resolved_github_credential.token or ""
             if token:
                 push_env["GITHUB_TOKEN"] = token
                 push_env["GH_TOKEN"] = token
@@ -216,11 +217,22 @@ class PublishService:
                 return f"published PR {url}"
             return f"published PR from {branch_name}"
 
+        if resolved_github_credential is None:
+            from moonmind.auth.github_credentials import resolve_github_credential
+
+            resolved_github_credential = await resolve_github_credential()
+            token = resolved_github_credential.token or ""
+        if not token:
+            raise RuntimeError(
+                "GitHub CLI PR fallback requires an explicit resolved token; "
+                "ambient gh auth state is not a managed publishing contract. "
+                f"{resolved_github_credential.safe_summary}"
+            )
+
         verify_cli_is_executable(self._gh_binary)
         gh_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
-        if token:
-            gh_env["GITHUB_TOKEN"] = token
-            gh_env["GH_TOKEN"] = token
+        gh_env["GITHUB_TOKEN"] = token
+        gh_env["GH_TOKEN"] = token
         if repo:
             gh_env["GH_REPO"] = repo
         await run_command(

--- a/tests/unit/agents/codex_worker/test_handlers.py
+++ b/tests/unit/agents/codex_worker/test_handlers.py
@@ -1515,8 +1515,10 @@ async def test_handler_resolves_relative_workdir_for_clone_destination() -> None
     clone_cmd = next(cmd for cmd in calls if cmd[:2] == ["git", "clone"])
     assert Path(clone_cmd[-1]).is_absolute()
 
-async def test_handler_publish_pr_invokes_gh(tmp_path: Path, monkeypatch) -> None:
-    """Publish mode `pr` should invoke gh PR creation command."""
+async def test_handler_publish_pr_rejects_gh_without_explicit_token(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Publish mode `pr` should not let gh use ambient auth without a token."""
 
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
@@ -1575,7 +1577,10 @@ async def test_handler_publish_pr_invokes_gh(tmp_path: Path, monkeypatch) -> Non
         },
     )
 
-    assert result.succeeded is True
+    assert result.succeeded is False
+    assert result.error_message is not None
+    assert "requires an explicit resolved token" in result.error_message
+    assert "ambient gh auth state is not a managed publishing contract" in result.error_message
     commit_call = next(
         call for call in calls if tuple(call["command"][:3]) == ("git", "commit", "-m")
     )
@@ -1585,22 +1590,9 @@ async def test_handler_publish_pr_invokes_gh(tmp_path: Path, monkeypatch) -> Non
     assert "123e4567-e89b-12d3-a456-426614174000" not in commit_cmd[3]
     assert commit_call["redaction_values"] == (commit_cmd[3],)
 
-    pr_call = next(
-        call for call in calls if tuple(call["command"][:3]) == ("gh", "pr", "create")
+    assert not any(
+        tuple(call["command"][:3]) == ("gh", "pr", "create") for call in calls
     )
-    pr_cmd = pr_call["command"]
-    pr_title = pr_cmd[pr_cmd.index("--title") + 1]
-    pr_body = pr_cmd[pr_cmd.index("--body") + 1]
-    assert pr_title == "implement publish test for job."
-    assert "MoonMind" not in pr_title
-    assert "123e4567-e89b-12d3-a456-426614174000" not in pr_title
-    assert "<!-- moonmind:begin -->" in pr_body
-    assert f"MoonMind Job: {job_id}" in pr_body
-    assert "Runtime: codex" in pr_body
-    assert "Base: main" in pr_body
-    assert "Head: moonmind-job-" in pr_body
-    assert "<!-- moonmind:end -->" in pr_body
-    assert pr_call["redaction_values"] == (pr_title, pr_body)
 
 async def test_derive_default_pr_body_sanitizes_metadata_values() -> None:
     """Generated handler footer should redact secret-like metadata values."""

--- a/tests/unit/publish/test_publish_service_github_auth.py
+++ b/tests/unit/publish/test_publish_service_github_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
@@ -73,3 +74,75 @@ async def test_publish_pr_uses_rest_service_without_ambient_gh(monkeypatch, tmp_
     assert created["github_token"] == "publish-token"
     assert created["repo"] == "owner/repo"
     assert not any(call["command"][:3] == ["gh", "pr", "create"] for call in calls)
+
+
+async def test_publish_pr_gh_fallback_injects_explicit_token_without_repo(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "publish-token")
+    monkeypatch.setenv("GH_TOKEN", "ambient-gh-token")
+    calls: list[dict[str, object]] = []
+
+    async def _run(command, **kwargs):
+        calls.append({"command": command, **kwargs})
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M file.py\n")
+        return SimpleNamespace(stdout="")
+
+    result = await PublishService(gh_binary=sys.executable).publish(
+        job_id=uuid4(),
+        instruction="MM-673 make change",
+        publish_mode="pr",
+        publish_base_branch="main",
+        runtime_mode="codex",
+        repo_dir=tmp_path,
+        run_command=_run,
+        repo=None,
+    )
+
+    gh_call = next(
+        call for call in calls if call["command"][:3] == [sys.executable, "pr", "create"]
+    )
+    gh_env = gh_call["env"]
+    assert result.startswith("published PR from moonmind-job-")
+    assert gh_env["GITHUB_TOKEN"] == "publish-token"
+    assert gh_env["GH_TOKEN"] == "publish-token"
+    assert gh_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert "GH_REPO" not in gh_env
+    assert "publish-token" in gh_call["redaction_values"]
+    assert "ambient-gh-token" not in gh_call["redaction_values"]
+
+
+async def test_publish_pr_gh_fallback_rejects_ambient_auth_without_token(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN_SECRET_REF", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_TOKEN_SECRET_REF", raising=False)
+    monkeypatch.delenv("MOONMIND_GITHUB_TOKEN_REF", raising=False)
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "ambient-gh-config"))
+    calls: list[dict[str, object]] = []
+
+    async def _run(command, **kwargs):
+        calls.append({"command": command, **kwargs})
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M file.py\n")
+        return SimpleNamespace(stdout="")
+
+    with pytest.raises(RuntimeError, match="requires an explicit resolved token"):
+        await PublishService(gh_binary=sys.executable).publish(
+            job_id=uuid4(),
+            instruction="MM-673 make change",
+            publish_mode="pr",
+            publish_base_branch="main",
+            runtime_mode="codex",
+            repo_dir=tmp_path,
+            run_command=_run,
+            repo=None,
+        )
+
+    assert not any(
+        call["command"][:3] == [sys.executable, "pr", "create"] for call in calls
+    )


### PR DESCRIPTION
Jira issue: MM-673

Summary:
- Uses the resolved repository credential as the managed PR publishing contract, keeping REST-first GitHub PR creation as the primary transport.
- Tightens the gh fallback so it only runs with explicit GH_TOKEN/GITHUB_TOKEN injection and does not rely on ambient gh auth state.
- Adds unit coverage for the managed GitHub auth fallback behavior.

Tests run:
- ./tools/test_unit.sh tests/unit/publish/test_publish_service_github_auth.py tests/unit/agents/codex_worker/test_handlers.py

Remaining risks:
- Full external GitHub permission behavior still depends on the runtime-provided repository token scopes in the target deployment.
