### PR TITLE
[codex] Fix Jira no-commit publish fallback

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5891,9 +5891,12 @@ class MoonMindRunWorkflow:
         task_payload = self._mapping_value(parameters, "task")
         skill_names = self._task_skill_names(parameters, task_payload)
         if include_applied_templates:
-            skill_names = skill_names | self._task_applied_template_slugs(
+            applied_template_slugs = self._task_applied_template_slugs(
                 parameters, task_payload
             )
+            if applied_template_slugs:
+                skill_names = {name for name in skill_names if name != "auto"}
+            skill_names = skill_names | applied_template_slugs
         if not skill_names:
             return False
         return skill_names.issubset(_PR_OPTIONAL_TASK_SKILLS)
@@ -5914,37 +5917,6 @@ class MoonMindRunWorkflow:
                     )
                     if name:
                         skill_names.add(name.lower())
-
-        for payload in (parameters, task_payload):
-            applied_templates = payload.get("appliedStepTemplates")
-            if not isinstance(applied_templates, Sequence) or isinstance(
-                applied_templates,
-                (str, bytes, bytearray),
-            ):
-                continue
-            for template in applied_templates:
-                if not isinstance(template, Mapping):
-                    continue
-                slug_sources: list[Any] = [template]
-                composition = template.get("composition")
-                for include_source in (composition, template):
-                    if not isinstance(include_source, Mapping):
-                        continue
-                    includes = include_source.get("includes")
-                    if isinstance(includes, Sequence) and not isinstance(
-                        includes,
-                        (str, bytes, bytearray),
-                    ):
-                        slug_sources.extend(includes)
-                for slug_source in slug_sources:
-                    if not isinstance(slug_source, Mapping):
-                        continue
-                    slug = self._coerce_text(
-                        slug_source.get("slug") or slug_source.get("presetSlug"),
-                        max_chars=120,
-                    )
-                    if slug:
-                        skill_names.add(slug.lower())
 
         skills_payload = task_payload.get("skills")
         if isinstance(skills_payload, Mapping):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5895,7 +5895,7 @@ class MoonMindRunWorkflow:
                 parameters, task_payload
             )
             if applied_template_slugs:
-                skill_names = {name for name in skill_names if name != "auto"}
+                skill_names.discard("auto")
             skill_names = skill_names | applied_template_slugs
         if not skill_names:
             return False
@@ -5954,6 +5954,8 @@ class MoonMindRunWorkflow:
                     continue
                 slug = self._coerce_text(
                     item.get("slug")
+                    or item.get("presetSlug")
+                    or item.get("preset_slug")
                     or item.get("templateSlug")
                     or item.get("template_slug")
                     or item.get("id")

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2748,6 +2748,10 @@ async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
             "summary": "Completed with status completed",
             "metadata": {
                 "operator_summary": "MM-697 was transitioned to Done.",
+                "push_status": "no_commits",
+                "push_branch": "jira-implement-mm-697",
+                "push_base_ref": "origin/main",
+                "push_commit_count": 0,
             },
             "output_refs": [],
         }

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1219,6 +1219,20 @@ def test_jira_implement_task_makes_pr_publish_optional(
         },
         include_applied_templates=True,
     )
+    # Templates carrying only presetSlug must also relax the no-commit fallback.
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "tool": {"type": "skill", "name": "auto"},
+                "skill": {"name": "auto"},
+                "appliedStepTemplates": [
+                    {"presetSlug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        },
+        include_applied_templates=True,
+    )
 
 
 def test_plain_text_blocked_result_short_circuits_publish(
@@ -1255,7 +1269,8 @@ def test_jira_implement_applied_template_makes_pr_publish_optional(
                     }
                 ],
             },
-        }
+        },
+        include_applied_templates=True,
     )
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1206,6 +1206,19 @@ def test_jira_implement_task_makes_pr_publish_optional(
         },
         include_applied_templates=True,
     )
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        {
+            "publishMode": "pr",
+            "task": {
+                "tool": {"type": "skill", "name": "auto"},
+                "skill": {"name": "auto"},
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        },
+        include_applied_templates=True,
+    )
 
 
 def test_plain_text_blocked_result_short_circuits_publish(


### PR DESCRIPTION
## Summary
- Fix Jira implement no-commit publish fallback so applied Jira presets are only considered when explicitly requested.
- Avoid treating generic `auto` as a blocking skill in the applied-template no-commit path.
- Add regression coverage for the failed task payload shape and publish metadata path.

## Root Cause
A Jira implement run with `publishMode: pr` and top-level `auto` selected skill produced `push_status=no_commits`. The no-commit fallback intended to classify applied `jira-implement` as PR-optional, but `auto` remained in the skill set and caused the subset check to fail.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py::test_jira_implement_task_makes_pr_publish_optional tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_jira_implement_not_required_skips_native_pr`
- `python3.12 -m pytest -q tests/unit/workflows/temporal/workflows/test_run_integration.py::test_jira_implement_task_makes_pr_publish_optional tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_jira_implement_not_required_skips_native_pr`

Note: full `./tools/test_unit.sh` is blocked in this checkout because `.venv` uses Python 3.11 and cannot collect a Python 3.12-only f-string in `tests/unit/services/temporal/runtime/test_managed_session_controller.py:2550`.