### PR TITLE
[codex] fix Jira Implement task routing

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -125,6 +125,7 @@ from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 from moonmind.workflows.temporal.story_output_tools import (
+    JIRA_STORY_TOOL_NAMES,
     register_story_output_tool_handlers,
 )
 from moonmind.workflows.temporal.service import TemporalExecutionService
@@ -849,9 +850,7 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
     return normalized
 
 _JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
-_JIRA_STORY_OUTPUT_TOOLS = frozenset(
-    {"story.create_jira_issues", "story.create_jira_orchestrate_tasks"}
-)
+_JIRA_STORY_OUTPUT_TOOLS = JIRA_STORY_TOOL_NAMES
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
 def _requires_branch_publish_for_story_output(value: Any) -> bool:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5925,36 +5925,9 @@ class MoonMindRunWorkflow:
                         skill_names.add(name.lower())
 
         if include_applied_templates:
-            for payload in (parameters, task_payload):
-                applied_templates = payload.get("appliedStepTemplates")
-                if not isinstance(applied_templates, Sequence) or isinstance(
-                    applied_templates,
-                    (str, bytes, bytearray),
-                ):
-                    continue
-                for template in applied_templates:
-                    if not isinstance(template, Mapping):
-                        continue
-                    slug_sources: list[Any] = [template]
-                    composition = template.get("composition")
-                    for include_source in (composition, template):
-                        if not isinstance(include_source, Mapping):
-                            continue
-                        includes = include_source.get("includes")
-                        if isinstance(includes, Sequence) and not isinstance(
-                            includes,
-                            (str, bytes, bytearray),
-                        ):
-                            slug_sources.extend(includes)
-                    for slug_source in slug_sources:
-                        if not isinstance(slug_source, Mapping):
-                            continue
-                        slug = self._coerce_text(
-                            slug_source.get("slug") or slug_source.get("presetSlug"),
-                            max_chars=120,
-                        )
-                        if slug:
-                            skill_names.add(slug.lower())
+            skill_names.update(
+                self._task_applied_template_slugs(parameters, task_payload)
+            )
 
         skills_payload = task_payload.get("skills")
         if isinstance(skills_payload, Mapping):
@@ -5990,16 +5963,31 @@ class MoonMindRunWorkflow:
             for item in applied_templates:
                 if not isinstance(item, Mapping):
                     continue
-                slug = self._coerce_text(
-                    item.get("slug")
-                    or item.get("templateSlug")
-                    or item.get("template_slug")
-                    or item.get("id")
-                    or item.get("name"),
-                    max_chars=120,
-                )
-                if slug:
-                    slugs.add(slug.lower())
+                slug_sources: list[Any] = [item]
+                composition = item.get("composition")
+                for include_source in (composition, item):
+                    if not isinstance(include_source, Mapping):
+                        continue
+                    includes = include_source.get("includes")
+                    if isinstance(includes, Sequence) and not isinstance(
+                        includes,
+                        (str, bytes, bytearray),
+                    ):
+                        slug_sources.extend(includes)
+                for slug_source in slug_sources:
+                    if not isinstance(slug_source, Mapping):
+                        continue
+                    slug = self._coerce_text(
+                        slug_source.get("slug")
+                        or slug_source.get("presetSlug")
+                        or slug_source.get("templateSlug")
+                        or slug_source.get("template_slug")
+                        or slug_source.get("id")
+                        or slug_source.get("name"),
+                        max_chars=120,
+                    )
+                    if slug:
+                        slugs.add(slug.lower())
         return slugs
 
     def _execution_result_has_publishable_changes(self, execution_result: Any) -> bool:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3640,7 +3640,10 @@ class MoonMindRunWorkflow:
         publish_mode = self._publish_mode(parameters)
         pr_publish_optional = self._pr_publish_optional_for_plan(
             ordered_nodes
-        ) or self._pr_publish_optional_for_task(parameters)
+        ) or self._pr_publish_optional_for_task(
+            parameters,
+            include_applied_templates=True,
+        )
         require_pull_request_url = (
             publish_mode == "pr"
             and self._integration is None
@@ -5889,7 +5892,11 @@ class MoonMindRunWorkflow:
         include_applied_templates: bool = False,
     ) -> bool:
         task_payload = self._mapping_value(parameters, "task")
-        skill_names = self._task_skill_names(parameters, task_payload)
+        skill_names = self._task_skill_names(
+            parameters,
+            task_payload,
+            include_applied_templates=False,
+        )
         if include_applied_templates:
             skill_names = skill_names | self._task_applied_template_slugs(
                 parameters, task_payload
@@ -5902,6 +5909,8 @@ class MoonMindRunWorkflow:
         self,
         parameters: Mapping[str, Any],
         task_payload: Mapping[str, Any],
+        *,
+        include_applied_templates: bool = True,
     ) -> set[str]:
         skill_names: set[str] = set()
         for payload in (parameters, task_payload):
@@ -5915,36 +5924,37 @@ class MoonMindRunWorkflow:
                     if name:
                         skill_names.add(name.lower())
 
-        for payload in (parameters, task_payload):
-            applied_templates = payload.get("appliedStepTemplates")
-            if not isinstance(applied_templates, Sequence) or isinstance(
-                applied_templates,
-                (str, bytes, bytearray),
-            ):
-                continue
-            for template in applied_templates:
-                if not isinstance(template, Mapping):
+        if include_applied_templates:
+            for payload in (parameters, task_payload):
+                applied_templates = payload.get("appliedStepTemplates")
+                if not isinstance(applied_templates, Sequence) or isinstance(
+                    applied_templates,
+                    (str, bytes, bytearray),
+                ):
                     continue
-                slug_sources: list[Any] = [template]
-                composition = template.get("composition")
-                for include_source in (composition, template):
-                    if not isinstance(include_source, Mapping):
+                for template in applied_templates:
+                    if not isinstance(template, Mapping):
                         continue
-                    includes = include_source.get("includes")
-                    if isinstance(includes, Sequence) and not isinstance(
-                        includes,
-                        (str, bytes, bytearray),
-                    ):
-                        slug_sources.extend(includes)
-                for slug_source in slug_sources:
-                    if not isinstance(slug_source, Mapping):
-                        continue
-                    slug = self._coerce_text(
-                        slug_source.get("slug") or slug_source.get("presetSlug"),
-                        max_chars=120,
-                    )
-                    if slug:
-                        skill_names.add(slug.lower())
+                    slug_sources: list[Any] = [template]
+                    composition = template.get("composition")
+                    for include_source in (composition, template):
+                        if not isinstance(include_source, Mapping):
+                            continue
+                        includes = include_source.get("includes")
+                        if isinstance(includes, Sequence) and not isinstance(
+                            includes,
+                            (str, bytes, bytearray),
+                        ):
+                            slug_sources.extend(includes)
+                    for slug_source in slug_sources:
+                        if not isinstance(slug_source, Mapping):
+                            continue
+                        slug = self._coerce_text(
+                            slug_source.get("slug") or slug_source.get("presetSlug"),
+                            max_chars=120,
+                        )
+                        if slug:
+                            skill_names.add(slug.lower())
 
         skills_payload = task_payload.get("skills")
         if isinstance(skills_payload, Mapping):

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1277,6 +1277,90 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     }
 
 
+def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Jira Breakdown and Implement",
+                "instructions": "Break down docs/Design.md into Jira stories.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "breakdown",
+                        "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                        "instructions": "Extract MoonSpec stories.",
+                    },
+                    {
+                        "id": "reconcile",
+                        "tool": {
+                            "type": "skill",
+                            "name": "story-reconcile-implementation",
+                        },
+                        "instructions": "Reconcile stories with current implementation.",
+                    },
+                    {
+                        "id": "jira",
+                        "tool": {"type": "skill", "name": "story.create_jira_issues"},
+                        "instructions": "Create Jira issues from the generated breakdown.",
+                        "storyOutput": {
+                            "mode": "jira",
+                            "jira": {
+                                "projectKey": "MM",
+                                "issueTypeName": "Story",
+                                "dependencyMode": "linear_blocker_chain",
+                            },
+                        },
+                    },
+                    {
+                        "id": "implement",
+                        "tool": {
+                            "type": "skill",
+                            "name": "story.create_jira_implement_tasks",
+                        },
+                        "instructions": "Create dependent Jira Implement tasks.",
+                        "jiraOrchestration": {
+                            "task": {
+                                "repository": "MoonLadderStudios/MoonMind",
+                                "runtime": {"mode": "codex_cli"},
+                                "publish": {
+                                    "mode": "pr",
+                                    "mergeAutomation": {"enabled": True},
+                                },
+                            },
+                            "traceability": {"sourceIssueKey": "MM-404"},
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    implement = plan["nodes"][3]
+
+    assert implement["tool"] == {
+        "type": "skill",
+        "name": "story.create_jira_implement_tasks",
+        "version": "1.0",
+    }
+    assert implement["inputs"]["selectedSkill"] == "story.create_jira_implement_tasks"
+    assert implement["inputs"]["jiraOrchestration"]["task"]["publish"] == {
+        "mode": "pr",
+        "mergeAutomation": {"enabled": True},
+    }
+    assert implement["inputs"]["jiraOrchestration"]["traceability"] == {
+        "sourceIssueKey": "MM-404"
+    }
+
+
 def test_runtime_planner_dedupes_repeated_identical_preset_steps():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1242,7 +1242,8 @@ def test_jira_implement_applied_template_makes_pr_publish_optional(
                     }
                 ],
             },
-        }
+        },
+        include_applied_templates=True,
     )
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1247,6 +1247,63 @@ def test_jira_implement_applied_template_makes_pr_publish_optional(
     )
 
 
+def test_jira_implement_applied_template_legacy_shapes_make_pr_publish_optional(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    parameters = {
+        "publishMode": "pr",
+        "task": {
+            "appliedStepTemplates": [
+                {"presetSlug": "jira-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    assert mock_run_workflow._task_applied_template_slugs(
+        parameters,
+        parameters["task"],
+    ) == {"jira-implement"}
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        parameters,
+        include_applied_templates=True,
+    )
+
+
+def test_jira_implement_applied_template_composition_includes_make_pr_publish_optional(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    parameters = {
+        "publishMode": "pr",
+        "task": {
+            "appliedStepTemplates": [
+                {
+                    "slug": "parent-flow",
+                    "composition": {
+                        "includes": [
+                            {"presetSlug": "jira-implement"},
+                        ],
+                    },
+                }
+            ],
+        },
+    }
+
+    assert mock_run_workflow._task_applied_template_slugs(
+        parameters,
+        parameters["task"],
+    ) == {"parent-flow", "jira-implement"}
+    assert not mock_run_workflow._pr_publish_optional_for_task(
+        parameters,
+        include_applied_templates=True,
+    )
+
+    parameters["task"]["appliedStepTemplates"][0].pop("slug")
+    assert mock_run_workflow._pr_publish_optional_for_task(
+        parameters,
+        include_applied_templates=True,
+    )
+
+
 def test_native_pr_branch_resolution_keeps_legacy_branch_only_replay_shape(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- route `story.create_jira_implement_tasks` using the shared Jira story-output tool registry so it stays a tool step instead of entering agent-skill resolution
- make Jira Implement applied-template PR optional handling explicit at execution call sites
- add regression coverage for Jira Breakdown and Implement planner output

## Root Cause
The runtime planner had a partial hardcoded Jira story-output tool allowlist. `story.create_jira_implement_tasks` was registered by the dispatcher, but not included in that planner list, so the planner classified it as an `agent_runtime` step and attempted to resolve it as an agent skill.

## Validation
- `./tools/test_unit.sh`
- Python: `5371 passed, 6 skipped, 1 xpassed`
- Frontend: `23 passed`, `381 passed | 232 skipped`
