### PR TITLE
[codex] fix deployment update worker path handling

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -645,8 +645,31 @@ class HostDockerComposeRunner:
             # aliases inside the worker. They continue to rely on explicit
             # local compose-file remapping.
             return
+        if host_dir.is_symlink() and not host_dir.exists():
+            # Broken symlink at the alias path: clear it so the create path can
+            # reinstall a valid link below.
+            with contextlib.suppress(OSError):
+                host_dir.unlink()
         if host_dir.exists():
-            return
+            try:
+                already_aliased = host_dir.resolve() == local_dir.resolve()
+            except OSError:
+                already_aliased = False
+            if already_aliased:
+                return
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message=(
+                    "Deployment compose project path already exists at the worker's "
+                    "host path but does not resolve to the active checkout."
+                ),
+                retryable=False,
+                details={
+                    "project_dir": str(host_dir),
+                    "local_project_dir": str(local_dir),
+                    "failureClass": "policy_violation",
+                },
+            )
         parent = host_dir.parent
         if parent.exists() and not parent.is_dir():
             raise ToolFailure(
@@ -663,6 +686,7 @@ class HostDockerComposeRunner:
             parent.mkdir(parents=True, exist_ok=True)
             host_dir.symlink_to(local_dir, target_is_directory=True)
         except FileExistsError:
+            # Race: another worker installed the alias between our checks.
             return
         except OSError as exc:
             raise ToolFailure(
@@ -1123,8 +1147,6 @@ def _ensure_runner_survives_update(
 ) -> None:
     if command_plan.runner_mode != "privileged_worker":
         return
-    if _compose_up_targets_specific_services(command_plan.up_args):
-        return
     current_container_id = _current_container_id()
     if not current_container_id:
         return
@@ -1133,6 +1155,9 @@ def _ensure_runner_survives_update(
         current_container_id,
     )
     if not matching_service:
+        return
+    targeted_services = _compose_up_target_services(command_plan.up_args)
+    if targeted_services and matching_service not in targeted_services:
         return
     raise ToolFailure(
         error_code="DEPLOYMENT_RUNNER_UNSAFE",
@@ -1150,19 +1175,21 @@ def _ensure_runner_survives_update(
     )
 
 
-def _compose_up_targets_specific_services(args: Sequence[str]) -> bool:
+def _compose_up_target_services(args: Sequence[str]) -> tuple[str, ...]:
+    services: list[str] = []
     passthrough = False
     for raw in args[3:]:
         part = str(raw)
         if passthrough:
-            return True
+            services.append(part)
+            continue
         if part == "--":
             passthrough = True
             continue
         if part.startswith("-"):
             continue
-        return True
-    return False
+        services.append(part)
+    return tuple(services)
 
 
 def _current_container_id() -> str:

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -633,6 +633,52 @@ class HostDockerComposeRunner:
             )
         return [*self._compose_base_command(), *parts[2:]]
 
+    def _ensure_host_project_read_alias(self) -> None:
+        """Expose the local checkout at the host path for Compose-side file reads."""
+
+        host_dir = self._host_dir()
+        local_dir = self._local_dir()
+        if host_dir == local_dir:
+            return
+        if not host_dir.is_absolute():
+            # Windows host paths are not representable as Linux filesystem
+            # aliases inside the worker. They continue to rely on explicit
+            # local compose-file remapping.
+            return
+        if host_dir.exists():
+            return
+        parent = host_dir.parent
+        if parent.exists() and not parent.is_dir():
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message="Deployment compose project path parent is not a directory.",
+                retryable=False,
+                details={
+                    "project_dir": str(host_dir),
+                    "parent": str(parent),
+                    "failureClass": "policy_violation",
+                },
+            )
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+            host_dir.symlink_to(local_dir, target_is_directory=True)
+        except FileExistsError:
+            return
+        except OSError as exc:
+            raise ToolFailure(
+                error_code="POLICY_VIOLATION",
+                message=(
+                    "Deployment compose project directory is not readable at its "
+                    "host path inside the worker."
+                ),
+                retryable=False,
+                details={
+                    "project_dir": str(host_dir),
+                    "local_project_dir": str(local_dir),
+                    "failureClass": "policy_violation",
+                },
+            ) from exc
+
     async def _run_compose_command(
         self,
         command: Sequence[str],
@@ -641,6 +687,7 @@ class HostDockerComposeRunner:
         max_stdout_chars: int | None = 512,
         max_stderr_chars: int | None = 512,
     ) -> Mapping[str, Any]:
+        self._ensure_host_project_read_alias()
         resolved = self._compose_command(command)
         env = os.environ.copy()
         if requested_image and not self.env_file:
@@ -852,6 +899,10 @@ class DeploymentUpdateExecutor:
                     stack=parsed["stack"], phase="before"
                 )
                 before_ref = await write_evidence("before-state", before_state)
+                _ensure_runner_survives_update(
+                    command_plan=command_plan,
+                    before_state=before_state,
+                )
 
                 _add_progress(
                     progress_events,
@@ -1063,6 +1114,91 @@ def _verification_failure_reason(verification: ComposeVerification) -> str | Non
     if not verification.succeeded:
         return "Deployment verification did not prove desired state."
     return None
+
+
+def _ensure_runner_survives_update(
+    *,
+    command_plan: ComposeCommandPlan,
+    before_state: Mapping[str, Any],
+) -> None:
+    if command_plan.runner_mode != "privileged_worker":
+        return
+    if _compose_up_targets_specific_services(command_plan.up_args):
+        return
+    current_container_id = _current_container_id()
+    if not current_container_id:
+        return
+    matching_service = _service_for_container_id(
+        before_state.get("services"),
+        current_container_id,
+    )
+    if not matching_service:
+        return
+    raise ToolFailure(
+        error_code="DEPLOYMENT_RUNNER_UNSAFE",
+        message=(
+            "Deployment update would recreate the worker container that is "
+            "running the update command. Configure an external or ephemeral "
+            "deployment updater before running full-stack updates."
+        ),
+        retryable=False,
+        details={
+            "runnerMode": command_plan.runner_mode,
+            "service": matching_service,
+            "failureClass": "runner_self_recreation_unsafe",
+        },
+    )
+
+
+def _compose_up_targets_specific_services(args: Sequence[str]) -> bool:
+    passthrough = False
+    for raw in args[3:]:
+        part = str(raw)
+        if passthrough:
+            return True
+        if part == "--":
+            passthrough = True
+            continue
+        if part.startswith("-"):
+            continue
+        return True
+    return False
+
+
+def _current_container_id() -> str:
+    for name in ("MOONMIND_CONTAINER_ID", "HOSTNAME"):
+        value = str(os.environ.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _service_for_container_id(services: Any, container_id: str) -> str:
+    needle = container_id.strip().lower()
+    if not needle:
+        return ""
+    if not isinstance(services, Sequence) or isinstance(services, (str, bytes)):
+        return ""
+    for service in services:
+        if not isinstance(service, Mapping):
+            continue
+        candidate = str(
+            service.get("ID")
+            or service.get("Id")
+            or service.get("ContainerID")
+            or service.get("container_id")
+            or ""
+        ).strip().lower()
+        if not candidate:
+            continue
+        if candidate.startswith(needle) or needle.startswith(candidate):
+            return str(
+                service.get("Service")
+                or service.get("Name")
+                or service.get("Names")
+                or ""
+            ).strip()
+    return ""
 
 
 def _failure_reason(exc: Exception) -> str:

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -196,6 +196,22 @@ class FailingPullRunner(RecordingRunner):
         return {"stack": stack, "command": list(command), "exitCode": 23}
 
 
+class SelfHostedComposeRunner(RecordingRunner):
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        self.events.append(f"runner:capture:{phase}")
+        return {
+            "stack": stack,
+            "phase": phase,
+            "services": [
+                {
+                    "ID": "abc123def456",
+                    "Service": "temporal-worker-agent-runtime",
+                    "State": "running",
+                }
+            ],
+        }
+
+
 class SecretRecordingRunner(RecordingRunner):
     async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
         self.events.append(f"runner:capture:{phase}")
@@ -649,6 +665,33 @@ async def test_failed_command_result_stops_execution_and_persists_diagnostics() 
     assert command_payload["error"]["error_code"] == "DEPLOYMENT_COMMAND_FAILED"
 
 
+@pytest.mark.asyncio
+async def test_privileged_worker_fails_before_recreating_its_own_container(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOSTNAME", "abc123def456")
+    events: list[str] = []
+    runner = SelfHostedComposeRunner(events)
+    executor, store, evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs())
+
+    assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
+    assert exc_info.value.details["failureClass"] == "runner_self_recreation_unsafe"
+    assert exc_info.value.details["service"] == "temporal-worker-agent-runtime"
+    assert store.records == []
+    assert "runner:pull" not in events
+    assert "runner:up" not in events
+    assert [kind for kind, _payload in evidence.records] == [
+        "before-state",
+        "command-log",
+        "after-state",
+    ]
+
+
 def test_unsupported_runner_mode_fails_closed() -> None:
     with pytest.raises(ToolFailure) as exc_info:
         build_compose_command_plan(
@@ -1019,6 +1062,56 @@ async def test_host_compose_runner_returns_bounded_command_output_tails(
     assert result["stderr"] == "err tail"
     assert result["command"][-1] == "ps"
     assert captured["cwd"] == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_host_compose_runner_aliases_host_project_path_for_file_reads(
+    tmp_path, monkeypatch
+):
+    local_dir = tmp_path / "workspace" / "host_project"
+    local_dir.mkdir(parents=True)
+    compose = local_dir / "docker-compose.yaml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    dotenv = local_dir / ".env"
+    dotenv.write_text("POSTGRES_PASSWORD=secret\n", encoding="utf-8")
+    host_dir = tmp_path / "host" / "MoonMind"
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok", b""
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        cwd: str,
+        env: Mapping[str, str],
+        stdout: Any,
+        stderr: Any,
+    ):
+        captured["args"] = args
+        captured["cwd"] = cwd
+        assert (host_dir / ".env").read_text(encoding="utf-8") == (
+            "POSTGRES_PASSWORD=secret\n"
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    runner = HostDockerComposeRunner(
+        project_dir=str(host_dir),
+        local_project_dir=str(local_dir),
+    )
+
+    await runner._run_compose_command(("docker", "compose", "up", "-d"))
+
+    assert host_dir.is_symlink()
+    assert host_dir.resolve() == local_dir
+    assert captured["cwd"] == str(local_dir)
+    assert "--project-directory" in captured["args"]
+    assert str(host_dir) in captured["args"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping
 import pytest
 
 from moonmind.workflows.skills.deployment_execution import (
+    ComposeCommandPlan,
     ComposeVerification,
     DeploymentUpdateExecutor,
     DeploymentUpdateLockManager,
@@ -18,6 +19,7 @@ from moonmind.workflows.skills.deployment_execution import (
     InMemoryDesiredStateStore,
     TemporalDeploymentEvidenceWriter,
     _ensure_command_succeeded,
+    _ensure_runner_survives_update,
     _is_host_absolute_path,
     _remap_host_compose_path,
     _tail_text,
@@ -690,6 +692,124 @@ async def test_privileged_worker_fails_before_recreating_its_own_container(
         "command-log",
         "after-state",
     ]
+
+
+def test_runner_guard_skips_when_targeted_services_exclude_worker(monkeypatch) -> None:
+    monkeypatch.setenv("HOSTNAME", "abc123def456")
+    plan = ComposeCommandPlan(
+        runner_mode="privileged_worker",
+        pull_args=("docker", "compose", "pull"),
+        up_args=("docker", "compose", "up", "-d", "api"),
+    )
+    before_state = {
+        "services": [
+            {"ID": "abc123def456", "Service": "temporal-worker-agent-runtime"}
+        ]
+    }
+
+    # Worker is not in the targeted service list, so the guard must allow.
+    _ensure_runner_survives_update(command_plan=plan, before_state=before_state)
+
+
+def test_runner_guard_blocks_when_targeted_services_include_worker(monkeypatch) -> None:
+    monkeypatch.setenv("HOSTNAME", "abc123def456")
+    plan = ComposeCommandPlan(
+        runner_mode="privileged_worker",
+        pull_args=("docker", "compose", "pull"),
+        up_args=("docker", "compose", "up", "-d", "api", "temporal-worker-agent-runtime"),
+    )
+    before_state = {
+        "services": [
+            {"ID": "abc123def456", "Service": "temporal-worker-agent-runtime"}
+        ]
+    }
+
+    with pytest.raises(ToolFailure) as exc_info:
+        _ensure_runner_survives_update(command_plan=plan, before_state=before_state)
+
+    assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
+    assert exc_info.value.details["service"] == "temporal-worker-agent-runtime"
+
+
+def test_runner_guard_blocks_when_no_specific_services_targeted(monkeypatch) -> None:
+    monkeypatch.setenv("HOSTNAME", "abc123def456")
+    plan = ComposeCommandPlan(
+        runner_mode="privileged_worker",
+        pull_args=("docker", "compose", "pull"),
+        up_args=("docker", "compose", "up", "-d", "--wait"),
+    )
+    before_state = {
+        "services": [
+            {"ID": "abc123def456", "Service": "temporal-worker-agent-runtime"}
+        ]
+    }
+
+    with pytest.raises(ToolFailure) as exc_info:
+        _ensure_runner_survives_update(command_plan=plan, before_state=before_state)
+
+    assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
+
+
+def test_host_alias_replaces_broken_symlink(tmp_path) -> None:
+    local_dir = tmp_path / "workspace" / "host_project"
+    local_dir.mkdir(parents=True)
+    host_dir = tmp_path / "host" / "MoonMind"
+    host_dir.parent.mkdir(parents=True)
+    # Install a broken symlink pointing nowhere.
+    host_dir.symlink_to(tmp_path / "missing", target_is_directory=True)
+    assert host_dir.is_symlink()
+    assert not host_dir.exists()
+
+    runner = HostDockerComposeRunner(
+        project_dir=str(host_dir),
+        local_project_dir=str(local_dir),
+    )
+    runner._ensure_host_project_read_alias()
+
+    assert host_dir.is_symlink()
+    assert host_dir.resolve() == local_dir.resolve()
+
+
+def test_host_alias_fails_when_existing_path_targets_other_checkout(tmp_path) -> None:
+    local_dir = tmp_path / "workspace" / "host_project"
+    local_dir.mkdir(parents=True)
+    other_dir = tmp_path / "other_project"
+    other_dir.mkdir()
+    host_dir = tmp_path / "host" / "MoonMind"
+    host_dir.parent.mkdir(parents=True)
+    # Pre-existing directory at the alias path that does not match the checkout.
+    host_dir.mkdir()
+    (host_dir / "marker").write_text("foreign", encoding="utf-8")
+
+    runner = HostDockerComposeRunner(
+        project_dir=str(host_dir),
+        local_project_dir=str(local_dir),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        runner._ensure_host_project_read_alias()
+
+    assert exc_info.value.error_code == "POLICY_VIOLATION"
+    assert exc_info.value.details["failureClass"] == "policy_violation"
+    # The pre-existing foreign directory must be left untouched.
+    assert (host_dir / "marker").read_text(encoding="utf-8") == "foreign"
+
+
+def test_host_alias_is_idempotent_when_already_aliased(tmp_path) -> None:
+    local_dir = tmp_path / "workspace" / "host_project"
+    local_dir.mkdir(parents=True)
+    host_dir = tmp_path / "host" / "MoonMind"
+
+    runner = HostDockerComposeRunner(
+        project_dir=str(host_dir),
+        local_project_dir=str(local_dir),
+    )
+    runner._ensure_host_project_read_alias()
+    # Second call must not fail when the alias already resolves to the checkout.
+    runner._ensure_host_project_read_alias()
+
+    assert host_dir.is_symlink()
+    assert host_dir.resolve() == local_dir.resolve()
 
 
 def test_unsupported_runner_mode_fails_closed() -> None:


### PR DESCRIPTION
## Summary

- Fix deployment update compose execution when the control worker sees the repo at `/workspace/host_project` but Compose needs to read files at the host project path.
- Add a fail-closed guard so an in-stack privileged worker does not run a full-stack update that would recreate the container executing the update activity.
- Add regression tests for host-path aliasing and self-recreation detection.

## Root Cause

The failed deployment update could pull the target image, but `docker compose up` resolved `.env` against the host project directory path from inside the worker container. After that path issue was addressed, a retry showed that the current privileged-worker mode can recreate its own worker container during a full-stack update, stranding the activity.

## Validation

- `./tools/test_unit.sh`
- Host-side `docker compose up -d --remove-orphans --wait` recovered the local stack.
- Live guard check inside `moonmind-temporal-worker-agent-runtime-1` raised `DEPLOYMENT_RUNNER_UNSAFE` for the self-recreation case.
