### PR TITLE
[codex] Clarify Jira no-diff completion summaries

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5824,6 +5824,7 @@ class MoonMindRunWorkflow:
                 self._publish_status = "not_required"
                 self._publish_reason = self._compose_no_change_publish_reason(
                     publish_mode=publish_mode,
+                    pr_publish_optional=True,
                 )
                 if self._merge_automation_requested(parameters):
                     self._publish_context["mergeAutomationStatus"] = "not_applicable"
@@ -6330,6 +6331,7 @@ class MoonMindRunWorkflow:
         self,
         *,
         publish_mode: str,
+        pr_publish_optional: bool = False,
     ) -> str:
         branch = self._coerce_text(self._publish_context.get("branch"), max_chars=120)
         base_ref = self._coerce_text(self._publish_context.get("baseRef"), max_chars=120)
@@ -6347,7 +6349,12 @@ class MoonMindRunWorkflow:
             commit_count = int(commit_count_value.strip())
 
         parts: list[str] = []
-        if publish_mode == "pr":
+        if publish_mode == "pr" and pr_publish_optional:
+            parts.append(
+                "No pull request was required because this Jira-oriented task "
+                "completed without repository changes"
+            )
+        elif publish_mode == "pr":
             parts.append(
                 "publishMode 'pr' requested, but no publishable diff was produced"
             )
@@ -6365,6 +6372,11 @@ class MoonMindRunWorkflow:
 
         if operator_summary:
             parts.append(f"final agent report: {operator_summary}")
+        elif publish_mode == "pr" and pr_publish_optional:
+            parts.append(
+                "no structured agent report confirmed whether the Jira issue was "
+                "already implemented"
+            )
 
         reason = ". ".join(part.rstrip(".") for part in parts if part)
         return f"{reason}." if reason else "publish skipped: no local changes"
@@ -6376,7 +6388,7 @@ class MoonMindRunWorkflow:
         publish_mode: str = "",
     ) -> str:
         parts = ["Workflow completed successfully"]
-        detail = self._coerce_text(publish_detail, max_chars=180)
+        detail = self._coerce_text(publish_detail, max_chars=900)
         if detail and detail.lower() not in {
             "completed",
             "workflow completed successfully",

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1088,8 +1088,55 @@ def test_jira_implement_no_commit_pr_handoff_is_not_required(
 
     assert mock_run_workflow._publish_status == "not_required"
     assert status == "success"
-    assert "no publishable diff was produced" in message
+    assert "No pull request was required" in message
+    assert "Jira-oriented task completed without repository changes" in message
+    assert "MM-675 was already implemented" in message
+    assert "no publishable diff was produced" not in message
     assert publish_failure is False
+
+
+def test_jira_implement_no_commit_pr_handoff_without_agent_report_is_explicit(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    execution_result = {
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "feature/no-op",
+            "push_base_ref": "origin/main",
+            "push_commit_count": 0,
+        }
+    }
+    parameters = {
+        "publishMode": "pr",
+        "task": {
+            "appliedStepTemplates": [
+                {"slug": "jira-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-7",
+        execution_result=execution_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result=execution_result,
+    )
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    assert status == "success"
+    assert "No pull request was required" in message
+    assert "Jira-oriented task completed without repository changes" in message
+    assert (
+        "no structured agent report confirmed whether the Jira issue was "
+        "already implemented"
+    ) in message
+    assert publish_failure is False
+
 
 def test_structured_publish_not_required_satisfies_pr_publish_mode(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
## Summary

- Clarify the PR-optional Jira no-commit completion message so it says no pull request was required because the task completed without repository changes.
- Preserve the hard failure wording for ordinary `publishMode=pr` no-diff runs.
- Add coverage for both the confirmed already-implemented case and the ambiguous no-agent-report case.

## Verification

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k "no_commit_pr_handoff or structured_publish_not_required or no_commit_pr_publish"`

## Notes

This PR is ready for review, not a draft.