### PR TITLE
[codex] Expose PentestGPT tool discovery

### DIFF
--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -12,6 +12,7 @@ from api_service.db.models import User
 from moonmind.config.settings import settings
 from moonmind.integrations.jira.errors import JiraToolError
 from moonmind.integrations.jira.tool import JiraToolService
+from moonmind.mcp.executable_tool_registry import ExecutableToolDiscoveryRegistry
 from moonmind.mcp.jira_tool_registry import (
     JiraToolExecutionContext,
     JiraToolRegistry,
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/mcp", tags=["mcp-tools"])
 
 _queue_registry = QueueToolRegistry()
+_execution_tool_registry = ExecutableToolDiscoveryRegistry()
 _jira_registry: JiraToolRegistry | None = None
 _jira_service: JiraToolService | None = None
 _jules_registry: JulesToolRegistry | None = None
@@ -109,7 +111,7 @@ async def list_tools(
     _user: User = Depends(get_current_user()),
 ) -> ToolListResponse:
     """Return all registered MCP tool definitions."""
-    tools = _queue_registry.list_tools()
+    tools = _queue_registry.list_tools() + _execution_tool_registry.list_tools()
     if _jira_registry is not None:
         tools = tools + _jira_registry.list_tools()
     if _jules_registry is not None:
@@ -124,6 +126,18 @@ async def call_tool(
     """Dispatch one MCP tool invocation."""
 
     try:
+        if _execution_tool_registry.has_tool(payload.tool):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "execution_tool_requires_task_submission",
+                    "message": (
+                        f"Tool '{payload.tool}' is a Temporal executable tool. "
+                        "Submit it as a task or plan step instead of calling "
+                        "/mcp/tools/call directly."
+                    ),
+                },
+            )
         if payload.tool.startswith("jira.") and _jira_registry is not None:
             if _jira_service is None:  # pragma: no cover
                 raise ToolNotFoundError(payload.tool)
@@ -152,6 +166,8 @@ async def call_tool(
                 arguments=payload.arguments,
                 context=queue_context,
             )
+    except HTTPException:
+        raise
     except JiraToolError as exc:
         raise _to_http_exception(exc) from None
     except Exception as exc:  # pragma: no cover - mapping layer

--- a/docs/ExternalAgents/ModelContextProtocol.md
+++ b/docs/ExternalAgents/ModelContextProtocol.md
@@ -108,6 +108,11 @@ Field names match the Pydantic models in [`moonmind/mcp/tool_registry.py`](../mo
 
 **What is registered today**
 
+- **Temporal executable tools** — The discovery response includes governed
+  task-submission tools such as **`security.pentest.run`** so Mission Control can
+  offer them in the Create page Tool picker. These tools execute through the
+  Temporal task/plan path, not as immediate `/mcp/tools/call` RPCs; direct calls
+  return `execution_tool_requires_task_submission`.
 - **Jules** — When `JULES_ENABLED` is true and both `JULES_API_URL` and `JULES_API_KEY` are set, the server registers **`jules.create_task`**, **`jules.resolve_task`**, and **`jules.get_task`** (see [`moonmind/mcp/jules_tool_registry.py`](../moonmind/mcp/jules_tool_registry.py)).
 - **Legacy queue tools** — The queue-backed MCP tools were removed as part of the **single-substrate (Temporal)** migration. [`QueueToolRegistry`](../moonmind/mcp/tool_registry.py) remains as a compatibility stub and does not register queue tools in production. Do not rely on `queue.*` tool names from older docs or specs.
 
@@ -132,7 +137,7 @@ Successful response:
 }
 ```
 
-The shape of `result` is tool-specific (for Jules tools, task payloads are JSON-serialized per the Jules client). Errors use HTTP status codes with a JSON `detail` object; common `code` values include `tool_not_found`, `invalid_tool_arguments`, and Jules-specific `jules_rate_limited` / `jules_request_failed` (see [`mcp_tools.py`](../api_service/api/routers/mcp_tools.py)).
+The shape of `result` is tool-specific (for Jules tools, task payloads are JSON-serialized per the Jules client). Errors use HTTP status codes with a JSON `detail` object; common `code` values include `tool_not_found`, `invalid_tool_arguments`, `execution_tool_requires_task_submission`, and Jules-specific `jules_rate_limited` / `jules_request_failed` (see [`mcp_tools.py`](../api_service/api/routers/mcp_tools.py)).
 
 ### Configuring Codex (and similar clients)
 

--- a/moonmind/mcp/executable_tool_registry.py
+++ b/moonmind/mcp/executable_tool_registry.py
@@ -71,7 +71,7 @@ _PENTEST_RUN_INPUT_SCHEMA: dict[str, Any] = {
             ),
         },
     },
-    "additionalProperties": True,
+    "additionalProperties": False,
 }
 
 
@@ -107,7 +107,7 @@ class ExecutableToolDiscoveryRegistry:
     def has_tool(self, name: str) -> bool:
         """Return whether this registry owns a discoverable executable tool."""
 
-        return str(name or "").strip() in self._tools
+        return name in self._tools
 
 
 __all__ = ["ExecutableToolDiscoveryRegistry"]

--- a/moonmind/mcp/executable_tool_registry.py
+++ b/moonmind/mcp/executable_tool_registry.py
@@ -1,0 +1,113 @@
+"""Discovery metadata for Temporal executable tools shown in Mission Control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from moonmind.integrations.pentest.models import PENTEST_TOOL_NAME, PENTEST_TOOL_VERSION
+from moonmind.mcp.tool_registry import ToolMetadata
+
+
+_PENTEST_RUN_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "target",
+        "scope_artifact_ref",
+        "operation_mode",
+        "runner_profile_id",
+    ],
+    "properties": {
+        "target": {
+            "type": "string",
+            "description": "Approved target URL, host, CIDR, FQDN, or application.",
+        },
+        "scope_artifact_ref": {
+            "type": "string",
+            "description": "ArtifactRef for the approved pentest scope document.",
+        },
+        "objective": {
+            "type": "string",
+            "description": "Bounded pentest objective for the approved target.",
+        },
+        "operation_mode": {
+            "type": "string",
+            "enum": ["recon_only", "validate_hypothesis", "full_authorized"],
+        },
+        "runner_profile_id": {
+            "type": "string",
+            "enum": ["pentestgpt-safe", "pentestgpt-vpn-lab"],
+            "default": "pentestgpt-safe",
+        },
+        "execution_profile_ref": {
+            "type": "string",
+            "description": "Exact PentestGPT Provider Profile to use.",
+        },
+        "provider_selector": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "provider_id": {"type": "string"},
+                "tags_any": {"type": "array", "items": {"type": "string"}},
+                "tags_all": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "time_budget_minutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 480,
+            "default": 60,
+        },
+        "repo_dir": {"type": "string"},
+        "evidence_level": {
+            "type": "string",
+            "enum": ["minimal", "standard", "full"],
+            "default": "standard",
+        },
+        "network_attachment_ref": {
+            "type": "string",
+            "description": (
+                "Optional approved network attachment ref required by VPN/lab "
+                "runner profiles."
+            ),
+        },
+    },
+    "additionalProperties": True,
+}
+
+
+class ExecutableToolDiscoveryRegistry:
+    """Read-only catalog for task-submission executable tools.
+
+    These tools are selected in Mission Control and executed by the Temporal task
+    submit path. They are intentionally not immediate `/mcp/tools/call` tools.
+    """
+
+    def __init__(self) -> None:
+        self._tools = {
+            PENTEST_TOOL_NAME: ToolMetadata(
+                name=PENTEST_TOOL_NAME,
+                description=(
+                    "Run an authorized PentestGPT workload against an approved "
+                    "target scope and publish normalized findings plus evidence "
+                    "artifacts."
+                ),
+                input_schema={
+                    **_PENTEST_RUN_INPUT_SCHEMA,
+                    "x-moonmind-tool-version": PENTEST_TOOL_VERSION,
+                    "x-moonmind-invocation": "temporal_task_submission",
+                },
+            )
+        }
+
+    def list_tools(self) -> list[ToolMetadata]:
+        """Return discoverable Temporal executable tools."""
+
+        return [self._tools[name] for name in sorted(self._tools)]
+
+    def has_tool(self, name: str) -> bool:
+        """Return whether this registry owns a discoverable executable tool."""
+
+        return str(name or "").strip() in self._tools
+
+
+__all__ = ["ExecutableToolDiscoveryRegistry"]

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -1,4 +1,4 @@
-"""Router tests for Jira MCP discovery and dispatch."""
+"""Router tests for MCP discovery and dispatch."""
 
 from __future__ import annotations
 
@@ -60,8 +60,50 @@ async def test_list_tools_includes_enabled_jira_tools(
         response = await client.get("/api/mcp/tools")
 
     assert response.status_code == 200
-    names = sorted(tool["name"] for tool in response.json()["tools"])
-    assert names == ["jira.get_issue", "jira.verify_connection"]
+    names = {tool["name"] for tool in response.json()["tools"]}
+    assert {"jira.get_issue", "jira.verify_connection"}.issubset(names)
+
+async def test_list_tools_includes_curated_pentest_execution_tool(
+    router_app: FastAPI,
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=router_app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/mcp/tools")
+
+    assert response.status_code == 200
+    tools = {tool["name"]: tool for tool in response.json()["tools"]}
+    pentest = tools["security.pentest.run"]
+    assert "PentestGPT" in pentest["description"]
+    assert pentest["inputSchema"]["required"] == [
+        "target",
+        "scope_artifact_ref",
+        "operation_mode",
+        "runner_profile_id",
+    ]
+    assert (
+        pentest["inputSchema"]["x-moonmind-invocation"]
+        == "temporal_task_submission"
+    )
+
+async def test_call_curated_execution_tool_requires_task_submission(
+    router_app: FastAPI,
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=router_app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/mcp/tools/call",
+            json={"tool": "security.pentest.run", "arguments": {}},
+        )
+
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"]["code"]
+        == "execution_tool_requires_task_submission"
+    )
 
 async def test_call_tool_dispatches_to_jira_service(
     router_app: FastAPI,


### PR DESCRIPTION
## Summary

Expose the curated `security.pentest.run` Temporal executable tool in `/mcp/tools` so Mission Control's Create page Tool picker can discover it.

## Why

The PentestGPT activity contract existed in the Temporal tool path, but the UI's trusted Tool picker is populated from `/mcp/tools`, which only surfaced Jira/Jules-style MCP tools. This made the PentestGPT option invisible even though the backend contract was present.

## Changes

- Add a read-only executable tool discovery registry for task-submission tools.
- Include `security.pentest.run` in `/mcp/tools` discovery metadata.
- Return `execution_tool_requires_task_submission` for direct `/mcp/tools/call` attempts because PentestGPT must execute through task/plan submission.
- Document the split between discoverable Temporal executable tools and immediate MCP tool calls.

## Validation

- `uv run pytest tests/unit/api/test_mcp_tools_router.py tests/unit/workflows/skills/test_pentest_tool_dispatcher.py tests/integration/temporal/test_pentest_tool_contract.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_mcp_tools_router.py tests/unit/workflows/skills/test_pentest_tool_dispatcher.py`