### PR TITLE
[codex] Complete Jira when no-diff work is already implemented

### DIFF
--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -276,6 +276,22 @@ If required completion returns `blocked` or `failed`, merge automation does not
 return terminal success. The failure is surfaced as a Jira-sourced blocker with
 operator-visible reason text.
 
+### 10.2.1 Already-implemented no-change completion
+
+For Jira-oriented PR-publishing runs where PR output is optional, the run may
+finish with no repository changes because the Jira issue is already implemented.
+When the agent or structured publish output explicitly confirms that already
+implemented outcome, `MoonMind.Run` invokes the same trusted Jira completion
+activity directly and requires the selected issue to reach a done-category
+status before the run can finish successfully.
+
+This path is intentionally not driven by fuzzy text search over arbitrary issue
+keys. The run uses the canonical Jira issue key from task metadata or a single
+validated Jira key from the Jira-backed task text. If the no-change result is
+ambiguous, for example it only says there was no diff but does not confirm the
+issue was already implemented, MoonMind does not mutate Jira and the run summary
+must state that no confirmation was available.
+
 ### 10.3 Output
 
 Merge automation summaries include compact `postMergeJira` evidence:

--- a/docs/Tasks/TaskPublishing.md
+++ b/docs/Tasks/TaskPublishing.md
@@ -41,6 +41,13 @@ For Jira-backed PR-publishing tasks, the authored or preset-provided Jira issue 
 
 The publish path must not infer post-merge completion targets through fuzzy summary search or by transitioning every issue key found in PR metadata. PR metadata is only a strict fallback when stronger configured or captured Jira context is unavailable.
 
+If a Jira-oriented PR-publishing task completes with no repository changes
+because the issue is already implemented, `MoonMind.Run` completes that
+authoritative Jira issue through the same trusted Jira transition boundary used
+for post-merge completion. Ambiguous no-change results that do not explicitly
+confirm the issue is already implemented remain non-mutating and must say so in
+the run summary.
+
 ## Branch Naming
 
 ### Auto-generated Branches

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -158,6 +158,14 @@ _ALREADY_IMPLEMENTED_NO_WORK_PATTERN = re.compile(
     r"\balready\s+(?:implemented|done|complete(?:d)?|satisfied|in\s+place)\b",
     re.IGNORECASE,
 )
+_ALREADY_IMPLEMENTED_UNCERTAINTY_PATTERN = re.compile(
+    r"\b(?:whether|if|unless|until|unconfirmed|unclear|unknown|"
+    r"not\s+(?:confirm(?:ed)?|verified|clear|sure)|"
+    r"(?:could\s+not|couldn't|cannot|can't|unable\s+to|did\s+not|didn't|"
+    r"does\s+not|doesn't)\s+confirm|"
+    r"(?:without|no)\s+confirmation)\b",
+    re.IGNORECASE,
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -5813,6 +5821,7 @@ class MoonMindRunWorkflow:
         outputs = self._get_from_result(execution_result, "outputs")
         if not isinstance(outputs, Mapping):
             return
+        self._record_no_change_publish_evidence(outputs)
 
         not_required_reason = self._publish_not_required_reason(outputs)
         if not_required_reason is not None:
@@ -6105,6 +6114,26 @@ class MoonMindRunWorkflow:
             self._report_created = True
             self._report_ref = report_ref
             self._publish_context["reportRef"] = report_ref
+
+    def _record_no_change_publish_evidence(self, outputs: Mapping[str, Any]) -> None:
+        push_status = self._coerce_text(outputs.get("push_status"), max_chars=80)
+        if push_status == "no_commits":
+            self._publish_context["noChangePublish"] = {"status": "no_commits"}
+            return
+
+        for key in ("noChanges", "no_changes", "repositoryUnchanged"):
+            if outputs.get(key) is True:
+                self._publish_context["noChangePublish"] = {"status": key}
+                return
+
+        publish_outcome = outputs.get("publishOutcome") or outputs.get(
+            "publish_outcome"
+        )
+        if isinstance(publish_outcome, Mapping):
+            for key in ("noChanges", "no_changes", "repositoryUnchanged"):
+                if publish_outcome.get(key) is True:
+                    self._publish_context["noChangePublish"] = {"status": key}
+                    return
 
     @staticmethod
     def _node_selected_skill(node: Mapping[str, Any]) -> str:
@@ -7017,6 +7046,8 @@ class MoonMindRunWorkflow:
             include_applied_templates=True,
         ):
             return
+        if not self._has_no_change_publish_evidence():
+            return
         evidence = self._already_implemented_no_work_evidence()
         if not evidence:
             return
@@ -7084,6 +7115,13 @@ class MoonMindRunWorkflow:
                 f"{completion_summary}"
             ).strip()
 
+    def _has_no_change_publish_evidence(self) -> bool:
+        evidence = self._publish_context.get("noChangePublish")
+        if not isinstance(evidence, Mapping):
+            return False
+        status = self._coerce_text(evidence.get("status"), max_chars=80)
+        return bool(status)
+
     def _already_implemented_no_work_evidence(self) -> str | None:
         for candidate in (
             self._publish_reason,
@@ -7096,8 +7134,10 @@ class MoonMindRunWorkflow:
             match = _ALREADY_IMPLEMENTED_NO_WORK_PATTERN.search(text)
             if not match:
                 continue
-            uncertainty_prefix = text[max(0, match.start() - 80) : match.start()]
-            if "whether" in uncertainty_prefix.lower():
+            uncertainty_context = text[
+                max(0, match.start() - 140) : min(len(text), match.end() + 60)
+            ]
+            if _ALREADY_IMPLEMENTED_UNCERTAINTY_PATTERN.search(uncertainty_context):
                 continue
             return text
         return None

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -154,6 +154,10 @@ _JIRA_BACKED_AGENT_SKILLS = frozenset(
 _PLAIN_TEXT_BLOCKED_OUTCOME_PATTERN = re.compile(
     r"(?im)^\s*(?:#{1,6}\s*)?(?:result|verdict|outcome)\s*:\s*blocked\b[^\n]*"
 )
+_ALREADY_IMPLEMENTED_NO_WORK_PATTERN = re.compile(
+    r"\balready\s+(?:implemented|done|complete(?:d)?|satisfied|in\s+place)\b",
+    re.IGNORECASE,
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -259,6 +263,9 @@ RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
 RUN_STEP_ATTEMPT_MANIFEST_PATCH = "run-step-attempt-manifest-v1"
+RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
+    "run-already-implemented-jira-completion-v1"
+)
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
@@ -4870,6 +4877,9 @@ class MoonMindRunWorkflow:
             self._publish_status = "published"
             self._publish_reason = "published pull request"
             self._publish_context["pullRequestUrl"] = pull_request_url
+        await self._complete_already_implemented_jira_if_needed(
+            parameters=parameters,
+        )
         if self._plan_blocked_message:
             self._summary = self._plan_blocked_message
         else:
@@ -6990,6 +7000,143 @@ class MoonMindRunWorkflow:
         if isinstance(post_merge_jira, Mapping):
             summary["postMergeJira"] = dict(post_merge_jira)
         return summary
+
+    async def _complete_already_implemented_jira_if_needed(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+    ) -> None:
+        if not workflow.patched(RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH):
+            return
+        if self._publish_status != "not_required":
+            return
+        if self._publish_mode(parameters) != "pr":
+            return
+        if not self._pr_publish_optional_for_task(
+            parameters,
+            include_applied_templates=True,
+        ):
+            return
+        evidence = self._already_implemented_no_work_evidence()
+        if not evidence:
+            return
+
+        issue_key = self._canonical_jira_issue_key_from_parameters(parameters)
+        if not issue_key:
+            raise ValueError(
+                "Jira completion required for already-implemented no-change result, "
+                "but no authoritative Jira issue key was found."
+            )
+
+        post_merge_jira = self._already_implemented_jira_completion_config(
+            parameters=parameters,
+            issue_key=issue_key,
+        )
+        decision = await workflow.execute_activity(
+            "merge_automation.complete_post_merge_jira",
+            {
+                "parentWorkflowId": workflow.info().workflow_id,
+                "parentRunId": workflow.info().run_id,
+                "resolverDisposition": "already_implemented_no_changes",
+                "jiraIssueKey": issue_key,
+                "postMergeJira": post_merge_jira,
+                "candidateContext": {
+                    "taskOriginIssueKey": issue_key,
+                    "taskMetadataIssueKey": issue_key,
+                    "publishContextIssueKey": issue_key,
+                    "alreadyImplementedEvidence": evidence[:700],
+                },
+            },
+            start_to_close_timeout=timedelta(minutes=2),
+            task_queue=INTEGRATIONS_TASK_QUEUE,
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        decision_map = dict(decision) if isinstance(decision, Mapping) else {}
+        compact_result = {
+            key: value
+            for key, value in decision_map.items()
+            if key not in {"issueResolution", "transition", "artifactRefs"}
+        }
+        compact_result.setdefault("issueKey", issue_key)
+        self._publish_context["alreadyImplementedJiraCompletion"] = compact_result
+
+        status = self._coerce_text(decision_map.get("status"), max_chars=80)
+        if status not in {"succeeded", "noop_already_done"}:
+            reason = self._coerce_text(
+                decision_map.get("reason"),
+                max_chars=500,
+            )
+            raise ValueError(
+                reason
+                or "Jira completion failed for already-implemented no-change result."
+            )
+
+        completion_summary = self._already_implemented_jira_completion_summary(
+            decision_map=decision_map,
+            issue_key=issue_key,
+        )
+        if completion_summary and completion_summary not in str(
+            self._publish_reason or ""
+        ):
+            self._publish_reason = (
+                f"{str(self._publish_reason or '').rstrip('. ')}. "
+                f"{completion_summary}"
+            ).strip()
+
+    def _already_implemented_no_work_evidence(self) -> str | None:
+        for candidate in (
+            self._publish_reason,
+            self._operator_summary,
+            self._last_step_summary,
+        ):
+            text = self._coerce_text(candidate, max_chars=900)
+            if not text:
+                continue
+            match = _ALREADY_IMPLEMENTED_NO_WORK_PATTERN.search(text)
+            if not match:
+                continue
+            uncertainty_prefix = text[max(0, match.start() - 80) : match.start()]
+            if "whether" in uncertainty_prefix.lower():
+                continue
+            return text
+        return None
+
+    def _already_implemented_jira_completion_config(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+        issue_key: str,
+    ) -> dict[str, Any]:
+        request = self._merge_automation_request(parameters) or {}
+        post_merge_jira = request.get("postMergeJira")
+        if not isinstance(post_merge_jira, Mapping):
+            post_merge_jira = {}
+        config = dict(post_merge_jira)
+        config["enabled"] = True
+        config["required"] = True
+        config["issueKey"] = issue_key
+        config.setdefault("strategy", "done_category")
+        return config
+
+    def _already_implemented_jira_completion_summary(
+        self,
+        *,
+        decision_map: Mapping[str, Any],
+        issue_key: str,
+    ) -> str:
+        status = self._coerce_text(decision_map.get("status"), max_chars=80)
+        if status == "succeeded":
+            transition_name = self._coerce_text(
+                decision_map.get("transitionName"),
+                max_chars=80,
+            )
+            if transition_name:
+                return f"Jira issue {issue_key} was moved to {transition_name}."
+            return f"Jira issue {issue_key} was moved to Done."
+        if status == "noop_already_done":
+            return f"Jira issue {issue_key} was already in a done-category status."
+        return ""
 
     def _merge_automation_child_succeeded(self, result: Any) -> bool:
         status = self._coerce_text(self._get_from_result(result, "status"), max_chars=40)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.workflows.run import (
     NATIVE_PR_PUSH_STATUS_GATE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
+    RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
@@ -1137,6 +1138,194 @@ def test_jira_implement_no_commit_pr_handoff_without_agent_report_is_explicit(
     ) in message
     assert publish_failure is False
 
+
+@pytest.mark.asyncio
+async def test_already_implemented_no_commit_pr_handoff_completes_jira_done(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity_calls: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append({"activityType": activity_type, "payload": payload})
+        return {
+            "status": "succeeded",
+            "required": True,
+            "issueKey": "MM-675",
+            "issueKeySource": "explicit_post_merge",
+            "alreadyDone": False,
+            "transitioned": True,
+            "transitionId": "41",
+            "transitionName": "Done",
+            "toStatusName": "Done",
+            "toStatusCategory": "done",
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = (
+        "No pull request was required because this Jira-oriented task completed "
+        "without repository changes. final agent report: MM-675 was already implemented."
+    )
+    expected_evidence = mock_run_workflow._publish_reason[:700]
+
+    await mock_run_workflow._complete_already_implemented_jira_if_needed(
+        parameters={
+            "publishMode": "pr",
+            "task": {
+                "instructions": "Complete Jira issue MM-675.",
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+    )
+
+    assert activity_calls == [
+        {
+            "activityType": "merge_automation.complete_post_merge_jira",
+            "payload": {
+                "parentWorkflowId": "wf-1",
+                "parentRunId": "run-1",
+                "resolverDisposition": "already_implemented_no_changes",
+                "jiraIssueKey": "MM-675",
+                "postMergeJira": {
+                    "enabled": True,
+                    "required": True,
+                    "issueKey": "MM-675",
+                    "strategy": "done_category",
+                },
+                "candidateContext": {
+                    "taskOriginIssueKey": "MM-675",
+                    "taskMetadataIssueKey": "MM-675",
+                    "publishContextIssueKey": "MM-675",
+                    "alreadyImplementedEvidence": expected_evidence,
+                },
+            },
+        }
+    ]
+    assert mock_run_workflow._publish_context[
+        "alreadyImplementedJiraCompletion"
+    ] == {
+        "status": "succeeded",
+        "required": True,
+        "issueKey": "MM-675",
+        "issueKeySource": "explicit_post_merge",
+        "alreadyDone": False,
+        "transitioned": True,
+        "transitionId": "41",
+        "transitionName": "Done",
+        "toStatusName": "Done",
+        "toStatusCategory": "done",
+    }
+    assert "Jira issue MM-675 was moved to Done." in str(
+        mock_run_workflow._publish_reason
+    )
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_no_commit_pr_handoff_does_not_complete_jira_done(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity_calls: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append({"activityType": activity_type, "payload": payload})
+        return {"status": "succeeded"}
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = (
+        "No pull request was required because this Jira-oriented task completed "
+        "without repository changes. no structured agent report confirmed whether "
+        "the Jira issue was already implemented."
+    )
+
+    await mock_run_workflow._complete_already_implemented_jira_if_needed(
+        parameters={
+            "publishMode": "pr",
+            "task": {
+                "instructions": "Complete Jira issue MM-675.",
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+    )
+
+    assert activity_calls == []
+    assert "alreadyImplementedJiraCompletion" not in mock_run_workflow._publish_context
+
+
+@pytest.mark.asyncio
+async def test_already_implemented_jira_completion_failure_blocks_success(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_execute_activity(
+        _activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        return {
+            "status": "blocked",
+            "required": True,
+            "issueKey": "MM-675",
+            "reason": "Expected exactly one done-category Jira transition.",
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = "MM-675 was already implemented."
+
+    with pytest.raises(ValueError, match="Expected exactly one done-category"):
+        await mock_run_workflow._complete_already_implemented_jira_if_needed(
+            parameters={
+                "publishMode": "pr",
+                "task": {
+                    "instructions": "Complete Jira issue MM-675.",
+                    "appliedStepTemplates": [
+                        {"slug": "jira-implement", "version": "1.0.0"},
+                    ],
+                },
+            }
+        )
 
 def test_structured_publish_not_required_satisfies_pr_publish_mode(
     mock_run_workflow: MoonMindRunWorkflow,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1180,6 +1180,7 @@ async def test_already_implemented_no_commit_pr_handoff_completes_jira_done(
         "No pull request was required because this Jira-oriented task completed "
         "without repository changes. final agent report: MM-675 was already implemented."
     )
+    mock_run_workflow._publish_context["noChangePublish"] = {"status": "no_commits"}
     expected_evidence = mock_run_workflow._publish_reason[:700]
 
     await mock_run_workflow._complete_already_implemented_jira_if_needed(
@@ -1237,6 +1238,49 @@ async def test_already_implemented_no_commit_pr_handoff_completes_jira_done(
 
 
 @pytest.mark.asyncio
+async def test_already_implemented_jira_completion_requires_no_change_signal(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity_calls: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append({"activityType": activity_type, "payload": payload})
+        return {"status": "succeeded"}
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = "MM-675 was already implemented."
+
+    await mock_run_workflow._complete_already_implemented_jira_if_needed(
+        parameters={
+            "publishMode": "pr",
+            "task": {
+                "instructions": "Complete Jira issue MM-675.",
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+    )
+
+    assert activity_calls == []
+
+
+@pytest.mark.asyncio
 async def test_ambiguous_no_commit_pr_handoff_does_not_complete_jira_done(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
@@ -1267,6 +1311,56 @@ async def test_ambiguous_no_commit_pr_handoff_does_not_complete_jira_done(
         "without repository changes. no structured agent report confirmed whether "
         "the Jira issue was already implemented."
     )
+    mock_run_workflow._publish_context["noChangePublish"] = {"status": "no_commits"}
+
+    await mock_run_workflow._complete_already_implemented_jira_if_needed(
+        parameters={
+            "publishMode": "pr",
+            "task": {
+                "instructions": "Complete Jira issue MM-675.",
+                "appliedStepTemplates": [
+                    {"slug": "jira-implement", "version": "1.0.0"},
+                ],
+            },
+        }
+    )
+
+    assert activity_calls == []
+    assert "alreadyImplementedJiraCompletion" not in mock_run_workflow._publish_context
+
+
+@pytest.mark.asyncio
+async def test_uncertain_already_implemented_wording_does_not_complete_jira_done(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity_calls: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append({"activityType": activity_type, "payload": payload})
+        return {"status": "succeeded"}
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    mock_run_workflow._publish_status = "not_required"
+    mock_run_workflow._publish_reason = (
+        "No pull request was required because this Jira-oriented task completed "
+        "without repository changes. The agent could not confirm if MM-675 was "
+        "already implemented."
+    )
+    mock_run_workflow._publish_context["noChangePublish"] = {"status": "no_commits"}
 
     await mock_run_workflow._complete_already_implemented_jira_if_needed(
         parameters={
@@ -1313,6 +1407,7 @@ async def test_already_implemented_jira_completion_failure_blocks_success(
     )
     mock_run_workflow._publish_status = "not_required"
     mock_run_workflow._publish_reason = "MM-675 was already implemented."
+    mock_run_workflow._publish_context["noChangePublish"] = {"status": "no_commits"}
 
     with pytest.raises(ValueError, match="Expected exactly one done-category"):
         await mock_run_workflow._complete_already_implemented_jira_if_needed(


### PR DESCRIPTION
## Summary

- Add a replay-patched `MoonMind.Run` hook for PR-optional Jira tasks that complete with no repository changes because the issue is already implemented.
- Reuse the trusted `merge_automation.complete_post_merge_jira` activity so the issue is moved to a done-category status, or treated as a no-op if already Done.
- Keep ambiguous no-change runs non-mutating when the agent did not actually confirm the issue was already implemented.
- Document the already-implemented no-change completion behavior.

## Verification

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k "already_implemented or no_commit_pr_handoff or structured_publish_not_required or no_commit_pr_publish"`

This PR is ready for review, not a draft.