### PR TITLE
MM-679 Jules external publishing adapter uses native PR creation

### DIFF
--- a/artifacts.readonly/context/rag-context-bf5a80b45592.json
+++ b/artifacts.readonly/context/rag-context-bf5a80b45592.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/auth.py (score: 1.000, trust: canonical)\n    line 87: # Hardcoded default user details for disabled auth mode\n2. moonmind/integrations/jira/client.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"\n3. moonmind/integrations/jira/auth.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"\n4. moonmind/integrations/jira/models.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"\n5. moonmind/integrations/jira/tool.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"High-level Jira tool orchestration and policy enforcement.\"\"\"\n6. moonmind/integrations/jira/adf.py (score: 1.000, trust: canonical)\n    line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"\n7. moonmind/integrations/pentest/models.py (score: 1.000, trust: canonical)\n    line 150: @field_validator(\"provider_id\", mode=\"before\")\n8. moonmind/integrations/jira/__init__.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/auth.py",
+      "text": "line 87: # Hardcoded default user details for disabled auth mode",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 87,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/client.py",
+      "text": "line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/auth.py",
+      "text": "line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/models.py",
+      "text": "line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/tool.py",
+      "text": "line 1: \"\"\"High-level Jira tool orchestration and policy enforcement.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/adf.py",
+      "text": "line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 27,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/pentest/models.py",
+      "text": "line 150: @field_validator(\"provider_id\", mode=\"before\")",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 150,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/__init__.py",
+      "text": "line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-19T22:43:40Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/moonmind/schemas/jules_models.py
+++ b/moonmind/schemas/jules_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 JulesNormalizedStatus = Literal[
     "queued",
@@ -176,11 +176,19 @@ class JulesTaskResponse(BaseModel):
     status: Optional[str] = Field(None, alias="state")
     url: Optional[str] = Field(None, alias="url")
     name: Optional[str] = Field(None, alias="name")
+    response_pull_request_url: Optional[str] = Field(
+        None,
+        alias="pull_request_url",
+        validation_alias=AliasChoices("pull_request_url", "pullRequestUrl"),
+    )
     outputs: list[SessionOutput] = Field(default_factory=list, alias="outputs")
 
     @property
     def pull_request_url(self) -> Optional[str]:
-        """Return the URL of the first pull request output, if any."""
+        """Return the provider PR URL, preferring the task response field."""
+        response_url = str(self.response_pull_request_url or "").strip()
+        if response_url:
+            return response_url
         return next((
             output.pull_request.url
             for output in self.outputs

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -436,6 +436,7 @@ def _docker_workflow_mode_forbidden_failure(*, workflow_docker_mode: str, tool_n
 CODEX_TRANSIENT_TURN_ERROR_TYPE = "CodexTransientTurnError"
 CODEX_PERMANENT_TURN_ERROR_TYPE = "CodexPermanentTurnError"
 CODEX_EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
+_PROVIDER_NATIVE_PR_AGENT_IDS = frozenset({"jules", "jules_api"})
 
 
 def _is_empty_assistant_recovery_failure(
@@ -5795,7 +5796,7 @@ class TemporalAgentRuntimeActivities:
                 runId=request.run_id,
                 agentId=request.agent_id,
             )
-        run_id, _agent_id = self._agent_runtime_request_identifiers(request)
+        run_id, agent_id = self._agent_runtime_request_identifiers(request)
 
         publish_mode = (
             request.publish_mode
@@ -5922,7 +5923,11 @@ class TemporalAgentRuntimeActivities:
 
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
-            if result.failure_class is None and publish_mode != "none":
+            if (
+                result.failure_class is None
+                and publish_mode != "none"
+                and agent_id.strip().lower() not in _PROVIDER_NATIVE_PR_AGENT_IDS
+            ):
                 raw_commit_message = (
                     request.commit_message
                     if isinstance(request, AgentRuntimeFetchResultInput)

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -439,6 +439,12 @@ CODEX_EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
 _PROVIDER_NATIVE_PR_AGENT_IDS = frozenset({"jules", "jules_api"})
 
 
+def _normalize_provider_native_pr_agent_id(agent_id: str | None) -> str:
+    if not isinstance(agent_id, str):
+        return ""
+    return agent_id.strip().lower().replace("-", "_")
+
+
 def _is_empty_assistant_recovery_failure(
     metadata: Mapping[str, Any] | None,
 ) -> bool:
@@ -5923,10 +5929,14 @@ class TemporalAgentRuntimeActivities:
 
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
+            publish_agent_id = agent_id
+            if record is not None:
+                publish_agent_id = record.runtime_id or record.agent_id or agent_id
             if (
                 result.failure_class is None
                 and publish_mode != "none"
-                and agent_id.strip().lower() not in _PROVIDER_NATIVE_PR_AGENT_IDS
+                and _normalize_provider_native_pr_agent_id(publish_agent_id)
+                not in _PROVIDER_NATIVE_PR_AGENT_IDS
             ):
                 raw_commit_message = (
                     request.commit_message

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4655,9 +4655,11 @@ class MoonMindRunWorkflow:
                 pull_request_url = self._extract_pull_request_url(execution_result)
 
                 # If still not found, check the diagnostics artifact if present
-                if pull_request_url is None and tool_type == "skill":
+                if pull_request_url is None:
                     outputs = self._get_from_result(execution_result, "outputs") or {}
-                    diag_ref = outputs.get("diagnostics_ref")
+                    diag_ref = outputs.get("diagnostics_ref") or outputs.get(
+                        "diagnosticsRef"
+                    )
                     if diag_ref:
                         try:
                             diag_payload = await execute_typed_activity(

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -18,11 +18,13 @@ class _FakeJulesAdapterClient:
         create_status: str = "pending",
         get_status: str = "completed",
         get_pull_request_url: str | None = None,
+        get_response_pull_request_url: str | None = None,
         resolve_raises: bool = False,
     ) -> None:
         self.create_status = create_status
         self.get_status = get_status
         self.get_pull_request_url = get_pull_request_url
+        self.get_response_pull_request_url = get_response_pull_request_url
         self.resolve_raises = resolve_raises
         self.created: list[object] = []
         self.lookups: list[object] = []
@@ -47,6 +49,7 @@ class _FakeJulesAdapterClient:
             task_id=request.task_id,
             status=self.get_status,
             url=f"https://jules.example.test/tasks/{request.task_id}",
+            response_pull_request_url=self.get_response_pull_request_url,
             outputs=outputs,
         )
 
@@ -128,6 +131,40 @@ async def test_status_and_fetch_result_prefer_pull_request_url():
     assert result.metadata["normalizedStatus"] == "completed"
     assert result.metadata["externalUrl"] == "https://github.com/org/repo/pull/123"
     assert result.metadata["pullRequestUrl"] == "https://github.com/org/repo/pull/123"
+
+
+async def test_status_and_fetch_result_prefer_response_pull_request_url_field():
+    client = _FakeJulesAdapterClient(
+        get_status="in_progress",
+        get_response_pull_request_url="https://github.com/org/repo/pull/456",
+        get_pull_request_url="https://github.com/org/repo/pull/123",
+    )
+    adapter = JulesAgentAdapter(client_factory=lambda: client)
+
+    status = await adapter.status("task-pr")
+    result = await adapter.fetch_result("task-pr")
+
+    assert status.status == "completed"
+    assert status.metadata["externalUrl"] == "https://github.com/org/repo/pull/456"
+    assert status.metadata["pullRequestUrl"] == "https://github.com/org/repo/pull/456"
+    assert result.metadata["externalUrl"] == "https://github.com/org/repo/pull/456"
+    assert result.metadata["pullRequestUrl"] == "https://github.com/org/repo/pull/456"
+
+
+async def test_task_response_accepts_top_level_pull_request_url_alias():
+    response = JulesTaskResponse.model_validate(
+        {
+            "id": "task-123",
+            "state": "IN_PROGRESS",
+            "pull_request_url": "https://github.com/org/repo/pull/789",
+            "outputs": [
+                {"pullRequest": {"url": "https://github.com/org/repo/pull/123"}}
+            ],
+        }
+    )
+
+    assert response.pull_request_url == "https://github.com/org/repo/pull/789"
+
 
 async def test_cancel_returns_intervention_requested_when_provider_rejects_cancel():
     client = _FakeJulesAdapterClient(resolve_raises=True)

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1706,6 +1706,36 @@ async def test_fetch_result_forwards_pr_resolver_expected_flag(tmp_path: Path) -
         )
         assert result.failure_class == "user_error"
 
+
+async def test_fetch_result_skips_infrastructure_push_for_jules_runtime(
+    tmp_path: Path,
+) -> None:
+    from unittest.mock import patch
+
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="fr-jules", status="completed", runtime_id="jules")
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    push_branch = AsyncMock(return_value={"push_status": "pushed"})
+    activities._push_workspace_branch = push_branch
+
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+        autospec=True,
+    ) as mock_adapter_cls:
+        adapter = mock_adapter_cls.return_value
+        adapter.fetch_result = AsyncMock(
+            return_value=AgentRunResult(summary="Jules completed")
+        )
+
+        result = await activities.agent_runtime_fetch_result(
+            {"run_id": "fr-jules", "agent_id": "jules", "publishMode": "pr"}
+        )
+
+    assert result.failure_class is None
+    push_branch.assert_not_awaited()
+
+
 async def test_fetch_result_reverifies_and_clears_pr_not_found_when_merged(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1713,7 +1713,7 @@ async def test_fetch_result_skips_infrastructure_push_for_jules_runtime(
     from unittest.mock import patch
 
     store = _make_store(tmp_path)
-    _save_record(store, run_id="fr-jules", status="completed", runtime_id="jules")
+    _save_record(store, run_id="fr-jules", status="completed", runtime_id="jules-api")
 
     activities = TemporalAgentRuntimeActivities(run_store=store)
     push_branch = AsyncMock(return_value={"push_status": "pushed"})
@@ -1729,7 +1729,7 @@ async def test_fetch_result_skips_infrastructure_push_for_jules_runtime(
         )
 
         result = await activities.agent_runtime_fetch_result(
-            {"run_id": "fr-jules", "agent_id": "jules", "publishMode": "pr"}
+            {"run_id": "fr-jules", "publishMode": "pr"}
         )
 
     assert result.failure_class is None

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2926,6 +2926,144 @@ async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
 
     assert not create_pr_called, "repo.create_pr should not have been called"
 
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_jules_pr_extracts_url_from_diagnostics_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            )
+            if artifact_ref == "diag-1":
+                return (
+                    "Jules completed and created "
+                    "https://github.com/MoonLadderStudios/MoonMind/pull/679"
+                )
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "jules",
+                                "version": "1.0.0",
+                                "description": "Jules",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Publish Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "step-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "jules",
+                                "version": "1.0.0",
+                            },
+                            "inputs": {
+                                "repo_ref": "git:org/repo#branch",
+                                "runtime": {"mode": "jules"},
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Agent finished",
+            "diagnostics_ref": "diag-1",
+            "metadata": {"jules_session_id": "session-123"},
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert not create_pr_called, "repo.create_pr should not have been called"
+    assert workflow._pull_request_url == (
+        "https://github.com/MoonLadderStudios/MoonMind/pull/679"
+    )
+    assert workflow._publish_status == "published"
+
+
 @pytest.mark.asyncio
 async def test_run_execution_stage_non_jules_agent_with_session_id_creates_native_pr(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Jira issue: MM-679

Summary:
- Prefer the Jules task response `pull_request_url` / `pullRequestUrl` field before output-derived pull request URLs.
- Extract GitHub pull request URLs from diagnostics artifacts for Jules agent-runtime publish results when no direct URL is present.
- Skip infrastructure-level git push for provider-native PR runtimes `jules` and `jules_api`.
- Add focused regression coverage for Jules PR URL extraction, diagnostics fallback, runtime push exclusion, and planner prompt suffix behavior.

Tests run:
- `pytest tests/unit/workflows/adapters/test_jules_agent_adapter.py tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_jules_pr_extracts_url_from_diagnostics_ref tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_fetch_result_skips_infrastructure_push_for_jules_runtime tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_publish_pr_skips_gh_suffix_for_jules -q --tb=short`
- `pytest tests/integration/temporal/test_integrations_monitoring.py -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Remaining risks:
- A broader Temporal workflow integration path was not used as final evidence because the targeted workflow test produced no output for about two minutes in this managed environment during implementation; focused unit coverage and a smaller Jules integration module passed.
