### PR TITLE
Fix Jira Implement PR handoff planning

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1015,21 +1015,37 @@ def _template_step_id_matches(
     return len(parts) >= 4 and parts[3] == f"{step_index:02d}"
 
 
-def _is_jira_orchestrate_pr_handoff_node(
+def _is_jira_pr_handoff_node(
     node: Mapping[str, Any],
     *,
     task_payload: Mapping[str, Any],
 ) -> bool:
-    if not _task_has_applied_template(task_payload, "jira-orchestrate"):
+    has_jira_orchestrate = _task_has_applied_template(task_payload, "jira-orchestrate")
+    has_jira_implement = _task_has_applied_template(task_payload, "jira-implement")
+    if not has_jira_orchestrate and not has_jira_implement:
         return False
     inputs = node.get("inputs")
     if not isinstance(inputs, Mapping):
         return False
     annotations = inputs.get("annotations")
     if isinstance(annotations, Mapping):
-        role = str(annotations.get("jiraOrchestrateRole") or "").strip().lower()
+        role = (
+            str(
+                annotations.get("jiraOrchestrateRole")
+                or annotations.get("jiraImplementRole")
+                or ""
+            )
+            .strip()
+            .lower()
+        )
         if role == "pull-request-handoff":
             return True
+    if has_jira_implement and _template_step_id_matches(
+        node,
+        slug="jira-implement",
+        step_index=7,
+    ):
+        return True
     return any(
         _template_step_id_matches(
             node,
@@ -1711,7 +1727,7 @@ def _build_runtime_planner():
             if (
                 publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
                 and not _jira_agent_skill_selected(publish_selected_skill)
-                and not _is_jira_orchestrate_pr_handoff_node(
+                and not _is_jira_pr_handoff_node(
                     publish_node,
                     task_payload=task_payload,
                 )

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2392,6 +2392,57 @@ def test_runtime_planner_preserves_jira_orchestrate_pr_handoff_instructions():
     assert "commit your work" not in pr_node["inputs"]["instructions"]
 
 
+def test_runtime_planner_preserves_jira_implement_pr_handoff_instructions():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run Jira Implement for THOR-352.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "appliedStepTemplates": [{"slug": "jira-implement"}],
+                "steps": [
+                    {
+                        "id": "implement",
+                        "title": "Implement",
+                        "instructions": "Implement the Jira issue.",
+                    },
+                    {
+                        "id": "create-pr",
+                        "title": "Create pull request",
+                        "annotations": {
+                            "jiraImplementRole": "pull-request-handoff",
+                        },
+                        "instructions": (
+                            "Create a pull request and record pull_request_url."
+                        ),
+                    },
+                    {
+                        "id": "finalize-jira",
+                        "title": "Finalize Jira status",
+                        "tool": {"type": "skill", "name": "jira-issue-updater"},
+                        "instructions": "Move the Jira issue after PR creation.",
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    pr_node = plan["nodes"][1]
+    assert pr_node["inputs"]["title"] == "Create pull request"
+    assert pr_node["inputs"]["publishMode"] == "pr"
+    assert "Create a pull request" in pr_node["inputs"]["instructions"]
+    assert (
+        "Do NOT push or create a pull request"
+        not in pr_node["inputs"]["instructions"]
+    )
+    assert "commit your work" not in pr_node["inputs"]["instructions"]
+
+
 @pytest.mark.parametrize("step_index", [12, 13])
 def test_runtime_planner_preserves_jira_orchestrate_pr_handoff_step_id_fallback(
     step_index,
@@ -2425,6 +2476,53 @@ def test_runtime_planner_preserves_jira_orchestrate_pr_handoff_step_id_fallback(
                         "title": "Move Jira issue to Code Review",
                         "tool": {"type": "skill", "name": "jira-issue-updater"},
                         "instructions": "Move the Jira issue to Code Review.",
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    pr_node = plan["nodes"][1]
+    assert pr_node["inputs"]["title"] == "Create pull request"
+    assert "Create a pull request" in pr_node["inputs"]["instructions"]
+    assert (
+        "Do NOT push or create a pull request"
+        not in pr_node["inputs"]["instructions"]
+    )
+    assert "commit your work" not in pr_node["inputs"]["instructions"]
+
+
+def test_runtime_planner_preserves_jira_implement_pr_handoff_step_id_fallback():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Run Jira Implement for THOR-352.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "appliedStepTemplates": [{"slug": "jira-implement"}],
+                "steps": [
+                    {
+                        "id": "tpl:jira-implement:1.0.0:06:verify",
+                        "title": "Verify implementation",
+                        "instructions": "Verify the Jira issue.",
+                    },
+                    {
+                        "id": "tpl:jira-implement:1.0.0:07:create-pr",
+                        "title": "Create pull request",
+                        "instructions": (
+                            "Create a pull request and record pull_request_url."
+                        ),
+                    },
+                    {
+                        "id": "tpl:jira-implement:1.0.0:08:finalize",
+                        "title": "Finalize Jira status",
+                        "tool": {"type": "skill", "name": "jira-issue-updater"},
+                        "instructions": "Finalize Jira after PR creation.",
                     },
                 ],
             }


### PR DESCRIPTION
## Summary
- Treat Jira Implement PR handoff steps like Jira Orchestrate handoff steps in the runtime planner
- Prevent the generic commit-only suffix from contradicting explicit Jira Implement PR creation instructions
- Add annotation and template step-id fallback regression coverage

## Tests
- pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q
