### PR TITLE
[codex] Guard deployment update env-file path handling

### DIFF
--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -1191,7 +1191,14 @@ async def test_host_compose_runner_aliases_host_project_path_for_file_reads(
     local_dir = tmp_path / "workspace" / "host_project"
     local_dir.mkdir(parents=True)
     compose = local_dir / "docker-compose.yaml"
-    compose.write_text("services: {}\n", encoding="utf-8")
+    compose.write_text(
+        "services:\n"
+        "  api:\n"
+        "    image: example/app:latest\n"
+        "    env_file:\n"
+        "      - .env\n",
+        encoding="utf-8",
+    )
     dotenv = local_dir / ".env"
     dotenv.write_text("POSTGRES_PASSWORD=secret\n", encoding="utf-8")
     host_dir = tmp_path / "host" / "MoonMind"
@@ -1225,8 +1232,9 @@ async def test_host_compose_runner_aliases_host_project_path_for_file_reads(
         local_project_dir=str(local_dir),
     )
 
-    await runner._run_compose_command(("docker", "compose", "up", "-d"))
+    result = await runner._run_compose_command(("docker", "compose", "up", "-d"))
 
+    assert result["exitCode"] == 0
     assert host_dir.is_symlink()
     assert host_dir.resolve() == local_dir
     assert captured["cwd"] == str(local_dir)


### PR DESCRIPTION
## Summary

Adds regression coverage for the deployment update runner path split that caused Docker Compose to look for service env files such as `.env` under the host project directory while the worker reads the checkout from its mounted local path.

The current runner aliases the host project path to the active local checkout before invoking Compose; this test now makes that coverage explicit with a Compose service that declares `env_file: .env`.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/skills/test_deployment_update_execution.py`
- `.venv/bin/pytest tests/integration/temporal/test_deployment_update_execution_contract.py -q`

## Notes

This PR is ready for review, not a draft.