### PR TITLE
Now that slash commands are a feature of MoonMind, I want to add clear commands into the Jira Orchestrate preset in appropriate locations based on und

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -170,6 +170,8 @@ steps:
       args: {}
   - title: Implement the task breakdown
     instructions: |-
+      /clear
+
       Run moonspec-implement when implementation work remains.
       Require TDD evidence: unit and integration tests are written and confirmed failing before production code.
       Mark completed tasks [X] in tasks.md and preserve the selected story scope.
@@ -180,6 +182,8 @@ steps:
         - git
   - title: Verify completion
     instructions: |-
+      /clear
+
       Run moonspec-verify as the final read-only gate unless an up-to-date verification report already covers the current code and artifacts.
       If the verdict is ADDITIONAL_WORK_NEEDED, preserve the report as the mandatory remediation input for the next step.
       If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context.
@@ -189,6 +193,8 @@ steps:
       args: {}
   - title: Remediate verification gaps
     instructions: |-
+      /clear
+
       Inspect the latest moonspec-verify result for {{ inputs.jira_issue_key }} before doing any work.
 
       If the latest verdict is FULLY_IMPLEMENTED, make no code changes and report that remediation is skipped because verification already passed.
@@ -205,6 +211,8 @@ steps:
         - git
   - title: Verify remediation
     instructions: |-
+      /clear
+
       Run moonspec-verify after remediation, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       This is the controlling verification gate for Jira Orchestrate publication. If the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop the orchestration, report the gaps or missing evidence, and do not continue to pull request creation.
@@ -217,6 +225,8 @@ steps:
     annotations:
       jiraOrchestrateRole: pull-request-handoff
     instructions: |-
+      /clear
+
       Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
 
       Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop without committing, pushing, creating a pull request, or changing Jira.


### PR DESCRIPTION
Now that slash commands are a feature of MoonMind, I want to add clear commands into the Jira Orchestrate preset in appropriate locations based on understanding how Moon Spec (a fork of Spec Kit) works and where a clear command would benefit the focus of the orchestration. For example, right before the implement step would probably make sense. Possibly other places as well.