### PR TITLE
MM-724 complete session retrieval scope filters

### DIFF
--- a/api_service/api/routers/retrieval_gateway.py
+++ b/api_service/api/routers/retrieval_gateway.py
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/retrieval", tags=["Retrieval"])
 
+REPOSITORY_SCOPE_FILTER_KEYS = ("repo", "repository")
+SESSION_SCOPE_FILTER_KEYS = frozenset(
+    {
+        "repo",
+        "repository",
+        "workspace",
+        "workspace_id",
+        "run",
+        "run_id",
+        "job",
+        "job_id",
+        "tenant",
+        "tenant_id",
+        "task_run_id",
+        "taskRunId",
+    }
+)
+SESSION_SCOPE_FILTER_KEYS_MESSAGE = ", ".join(sorted(SESSION_SCOPE_FILTER_KEYS))
+
 @dataclass(frozen=True, slots=True)
 class RetrievalAuthContext:
     auth_source: str
@@ -44,21 +63,23 @@ class RetrievalQuery(BaseModel):
                 f"Unsupported retrieval budget keys: {joined}. Allowed keys: latency_ms, tokens."
             )
 
-        allowed_filters = {"repo", "repository"}
-        unsupported_filters = sorted(set(self.filters) - allowed_filters)
+        unsupported_filters = sorted(set(self.filters) - SESSION_SCOPE_FILTER_KEYS)
         if unsupported_filters:
             joined = ", ".join(unsupported_filters)
             raise ValueError(
-                f"Unsupported retrieval filter keys: {joined}. Allowed keys: repo, repository."
+                "Unsupported retrieval filter keys: "
+                f"{joined}. Allowed keys: {SESSION_SCOPE_FILTER_KEYS_MESSAGE}."
             )
 
         has_scope_filter = any(
-            str(self.filters.get(key, "")).strip() for key in allowed_filters
+            str(self.filters.get(key, "")).strip()
+            for key in SESSION_SCOPE_FILTER_KEYS
         )
         if not has_scope_filter:
             raise ValueError(
-                "Session-issued retrieval requires a repo or repository "
-                "filter to bound corpus scope."
+                "Session-issued retrieval requires at least one supported "
+                "scope filter to bound corpus scope. Allowed keys: "
+                f"{SESSION_SCOPE_FILTER_KEYS_MESSAGE}."
             )
         return self
 
@@ -169,7 +190,7 @@ async def authorize_retrieval_request(
     )
 
 def _requested_repo(payload: RetrievalQuery) -> str:
-    for key in ("repo", "repository"):
+    for key in REPOSITORY_SCOPE_FILTER_KEYS:
         value = str(payload.filters.get(key, "")).strip()
         if value:
             return value
@@ -181,6 +202,14 @@ def _enforce_repo_scope(payload: RetrievalQuery, auth: RetrievalAuthContext) -> 
         return
     repo = _requested_repo(payload)
     allowed = set(auth.allowed_repositories)
+    if not repo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Repository scope is required for retrieval tokens with a "
+                "configured repository allowlist."
+            ),
+        )
     if repo and repo not in allowed:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/api_service/api/routers/retrieval_gateway.py
+++ b/api_service/api/routers/retrieval_gateway.py
@@ -24,8 +24,7 @@ router = APIRouter(prefix="/retrieval", tags=["Retrieval"])
 REPOSITORY_SCOPE_FILTER_KEYS = ("repo", "repository")
 SESSION_SCOPE_FILTER_KEYS = frozenset(
     {
-        "repo",
-        "repository",
+        *REPOSITORY_SCOPE_FILTER_KEYS,
         "workspace",
         "workspace_id",
         "run",
@@ -39,6 +38,7 @@ SESSION_SCOPE_FILTER_KEYS = frozenset(
     }
 )
 SESSION_SCOPE_FILTER_KEYS_MESSAGE = ", ".join(sorted(SESSION_SCOPE_FILTER_KEYS))
+
 
 @dataclass(frozen=True, slots=True)
 class RetrievalAuthContext:

--- a/docs/Rag/WorkflowRag.md
+++ b/docs/Rag/WorkflowRag.md
@@ -394,6 +394,16 @@ Workflow RAG should expose simple, high-value levers for retrieval amount and sc
 - **filters**
   - repo/workspace/run/job/tenant metadata used to constrain the search space.
 
+  Session-issued RetrievalGateway requests accept the following exact scope filter
+  keys and forward them unchanged into retrieval execution:
+  `repo`, `repository`, `workspace`, `workspace_id`, `run`, `run_id`, `job`,
+  `job_id`, `tenant`, `tenant_id`, `task_run_id`, and `taskRunId`.
+  At least one supported scope filter is required. Unsupported filter keys fail
+  validation before retrieval runs. Automatic retrieval currently supplies
+  available `job_id`, `run_id`, `repo`, and `repository` metadata; workspace and
+  tenant-equivalent filters are applied when supplied by the session or by
+  deployment-specific indexed metadata.
+
 ### 11.2 Budget knobs
 
 - **token budget**

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -145,6 +145,47 @@ def test_context_accepts_scoped_retrieval_token_and_preserves_request_knobs(
     ]
 
 
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"workspace": "workspace-a"},
+        {"workspace_id": "workspace-1"},
+        {"run": "run-a"},
+        {"run_id": "run-1"},
+        {"job": "job-a"},
+        {"job_id": "job-1"},
+        {"tenant": "tenant-a"},
+        {"tenant_id": "tenant-1"},
+        {"task_run_id": "task-run-1"},
+        {"taskRunId": "task-run-2"},
+        {
+            "repo": "moonmind",
+            "workspace_id": "workspace-1",
+            "run_id": "run-1",
+            "job_id": "job-1",
+            "tenant_id": "tenant-1",
+        },
+    ],
+)
+def test_context_accepts_supported_session_scope_filters(
+    filters: dict[str, str],
+) -> None:
+    app = _build_app()
+    app.dependency_overrides[authorize_retrieval_request] = _oidc_auth
+    service = StubService()
+    app.dependency_overrides[get_retrieval_service] = lambda: service
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/retrieval/context",
+            json={"query": "q", "filters": filters},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["filters"] == filters
+    assert service.calls[0]["filters"] == filters
+
+
 def test_context_fails_fast_when_retrieval_unavailable_for_session() -> None:
     app = _build_app()
     app.dependency_overrides[authorize_retrieval_request] = _oidc_auth
@@ -187,6 +228,23 @@ def test_context_retrieval_token_enforces_allowed_repository_scope(
     assert response.status_code == 403
 
 
+def test_context_retrieval_token_allowlist_requires_repository_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_RETRIEVAL_TOKEN", "scoped-token")
+    monkeypatch.setenv("MOONMIND_RETRIEVAL_ALLOWED_REPOSITORIES", "moonmind")
+    app = _build_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/retrieval/context",
+            json={"query": "q", "filters": {"job_id": "job-1"}},
+            headers={"X-MoonMind-Retrieval-Token": "scoped-token"},
+        )
+
+    assert response.status_code == 403
+    assert "Repository scope is required" in response.json()["detail"]
+
 
 def test_context_rejects_missing_repository_scope_for_authorized_request() -> None:
     app = _build_app()
@@ -203,7 +261,7 @@ def test_context_rejects_missing_repository_scope_for_authorized_request() -> No
 
     assert response.status_code == 422
     detail = response.json()["detail"]
-    assert "repo" in str(detail)
+    assert "scope filter" in str(detail)
 
 
 def test_context_rejects_unsupported_filter_keys_for_authorized_request() -> None:
@@ -222,6 +280,7 @@ def test_context_rejects_unsupported_filter_keys_for_authorized_request() -> Non
     assert response.status_code == 422
     detail = response.json()["detail"]
     assert "branch" in str(detail)
+    assert "workspace_id" in str(detail)
 
 def test_context_rejects_unsupported_budget_keys_for_authorized_request() -> None:
     app = _build_app()


### PR DESCRIPTION
Jira issue key: MM-724

Summary:
- Expands RetrievalGateway session scope validation beyond repo/repository to workspace, run, job, tenant, and task-run equivalent metadata keys.
- Preserves filter forwarding unchanged into retrieval execution and keeps repository allowlist enforcement strict when token-scoped repository allowlists are configured.
- Documents the supported session filter contract in docs/Rag/WorkflowRag.md and adds unit coverage for accepted/rejected combinations.

Tests run:
- ./tools/test_unit.sh tests/unit/api/routers/test_retrieval_gateway.py

Remaining risks:
- Full integration suite was not run in this PR-publication step.
- Workspace and tenant filters depend on matching indexed metadata being available in deployment-specific retrieval data.