### PR TITLE
I want to be able to type in the skill input box of the start workflow page on mobile and also be able to click the dropdown and see available options

### DIFF
--- a/frontend/src/components/SkillCombobox.test.tsx
+++ b/frontend/src/components/SkillCombobox.test.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { fireEvent, render, screen, within } from "../utils/test-utils";
+import { SkillCombobox } from "./SkillCombobox";
+
+const OPTIONS = ["auto", "moonspec-orchestrate", "pr-resolver", "jira-implement"];
+
+function Harness({ initialValue = "" }: { initialValue?: string }): ReactElement {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <SkillCombobox
+      value={value}
+      options={OPTIONS}
+      onChange={setValue}
+      placeholder="auto (default), moonspec-orchestrate, ..."
+      dataStepIndex="0"
+      ariaLabel="Step 1 skill"
+    />
+  );
+}
+
+describe("SkillCombobox", () => {
+  it("renders the input with skill-step metadata for the workflow form", () => {
+    render(<Harness />);
+
+    const input = screen.getByRole("combobox", { name: "Step 1 skill" });
+    expect(input.getAttribute("data-step-field")).toBe("skillId");
+    expect(input.getAttribute("data-step-index")).toBe("0");
+  });
+
+  it("opens the dropdown when the toggle button is tapped and exposes all options", () => {
+    render(<Harness />);
+
+    const toggle = screen.getByRole("button", { name: "Show skill options" });
+    fireEvent.click(toggle);
+
+    const listbox = screen.getByRole("listbox");
+    const optionTexts = within(listbox)
+      .getAllByRole("option")
+      .map((node) => node.textContent);
+    expect(optionTexts).toEqual(OPTIONS);
+  });
+
+  it("filters options as the user types and selects on pointer down", () => {
+    render(<Harness />);
+
+    const input = screen.getByRole("combobox", { name: "Step 1 skill" });
+    fireEvent.change(input, { target: { value: "moon" } });
+
+    const filtered = within(screen.getByRole("listbox"))
+      .getAllByRole("option")
+      .map((node) => node.textContent);
+    expect(filtered).toEqual(["moonspec-orchestrate"]);
+
+    fireEvent.pointerDown(screen.getByRole("option", { name: "moonspec-orchestrate" }));
+
+    expect((input as HTMLInputElement).value).toBe("moonspec-orchestrate");
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("opens the dropdown when the input is focused on a touch tap", () => {
+    render(<Harness />);
+
+    const input = screen.getByRole("combobox", { name: "Step 1 skill" });
+    fireEvent.pointerDown(input);
+    fireEvent.focus(input);
+
+    expect(screen.getByRole("listbox")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/SkillCombobox.test.tsx
+++ b/frontend/src/components/SkillCombobox.test.tsx
@@ -34,7 +34,7 @@ describe("SkillCombobox", () => {
     render(<Harness />);
 
     const toggle = screen.getByRole("button", { name: "Show skill options" });
-    fireEvent.click(toggle);
+    fireEvent.pointerDown(toggle);
 
     const listbox = screen.getByRole("listbox");
     const optionTexts = within(listbox)

--- a/frontend/src/components/SkillCombobox.tsx
+++ b/frontend/src/components/SkillCombobox.tsx
@@ -1,0 +1,279 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type {
+  ChangeEvent,
+  CSSProperties,
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactElement,
+} from "react";
+
+export interface SkillComboboxProps {
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  inputId?: string;
+  dataStepIndex?: string;
+  ariaLabel?: string;
+  inputClassName?: string;
+}
+
+const MAX_VISIBLE_OPTIONS = 50;
+
+function filterOptions(options: readonly string[], query: string): string[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return options.slice(0, MAX_VISIBLE_OPTIONS);
+  }
+  const startsWith: string[] = [];
+  const includes: string[] = [];
+  for (const option of options) {
+    const lower = option.toLowerCase();
+    if (lower.startsWith(trimmed)) {
+      startsWith.push(option);
+    } else if (lower.includes(trimmed)) {
+      includes.push(option);
+    }
+  }
+  return [...startsWith, ...includes].slice(0, MAX_VISIBLE_OPTIONS);
+}
+
+export function SkillCombobox({
+  value,
+  options,
+  onChange,
+  placeholder,
+  inputId,
+  dataStepIndex,
+  ariaLabel,
+  inputClassName,
+}: SkillComboboxProps): ReactElement {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const generatedListId = useId();
+  const listboxId = `${generatedListId}-listbox`;
+
+  const filteredOptions = useMemo(
+    () => filterOptions(options, value),
+    [options, value],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDown = (event: PointerEvent | MouseEvent): void => {
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+      const target = event.target as Node | null;
+      if (target && !container.contains(target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHighlightedIndex(-1);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (highlightedIndex >= filteredOptions.length) {
+      setHighlightedIndex(filteredOptions.length - 1);
+    }
+  }, [filteredOptions.length, highlightedIndex]);
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange(event.target.value);
+      setIsOpen(true);
+    },
+    [onChange],
+  );
+
+  const handleInputPointerDown = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleToggle = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      setIsOpen((prev) => {
+        const next = !prev;
+        if (next) {
+          inputRef.current?.focus();
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleOptionPick = useCallback(
+    (option: string) => {
+      onChange(option);
+      setIsOpen(false);
+      inputRef.current?.focus();
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+        setHighlightedIndex((prev) => {
+          if (filteredOptions.length === 0) {
+            return -1;
+          }
+          const next = prev + 1;
+          return next >= filteredOptions.length ? 0 : next;
+        });
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+        }
+        setHighlightedIndex((prev) => {
+          if (filteredOptions.length === 0) {
+            return -1;
+          }
+          const next = prev <= 0 ? filteredOptions.length - 1 : prev - 1;
+          return next;
+        });
+      } else if (event.key === "Enter") {
+        if (
+          isOpen &&
+          highlightedIndex >= 0 &&
+          highlightedIndex < filteredOptions.length
+        ) {
+          const chosen = filteredOptions[highlightedIndex];
+          if (chosen !== undefined) {
+            event.preventDefault();
+            handleOptionPick(chosen);
+          }
+        }
+      } else if (event.key === "Escape") {
+        if (isOpen) {
+          event.preventDefault();
+          setIsOpen(false);
+        }
+      }
+    },
+    [filteredOptions, handleOptionPick, highlightedIndex, isOpen],
+  );
+
+  const listStyle: CSSProperties = {
+    position: "absolute",
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
+    top: "calc(100% + 0.25rem)",
+    zIndex: 30,
+    maxHeight: "16rem",
+    overflowY: "auto",
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="skill-combobox"
+      style={{ position: "relative" }}
+    >
+      <div className="skill-combobox-input-row">
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="text"
+          autoComplete="off"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-label={ariaLabel}
+          value={value}
+          placeholder={placeholder}
+          data-step-field="skillId"
+          {...(dataStepIndex !== undefined ? { "data-step-index": dataStepIndex } : {})}
+          className={inputClassName}
+          onChange={handleInputChange}
+          onPointerDown={handleInputPointerDown}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          className="skill-combobox-toggle"
+          aria-label={isOpen ? "Hide skill options" : "Show skill options"}
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          tabIndex={-1}
+          onClick={handleToggle}
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 12 8"
+            width="12"
+            height="8"
+          >
+            <path
+              d="M1 1.5 L6 6.5 L11 1.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      {isOpen && filteredOptions.length > 0 ? (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="skill-combobox-listbox"
+          style={listStyle}
+        >
+          {filteredOptions.map((option, index) => {
+            const isHighlighted = index === highlightedIndex;
+            const isSelected = option === value;
+            return (
+              <li
+                key={option}
+                role="option"
+                aria-selected={isSelected}
+                data-highlighted={isHighlighted ? "true" : undefined}
+                className="skill-combobox-option"
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                  handleOptionPick(option);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+              >
+                {option}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/SkillCombobox.tsx
+++ b/frontend/src/components/SkillCombobox.tsx
@@ -9,8 +9,9 @@ import {
 import type {
   ChangeEvent,
   CSSProperties,
+  FocusEvent,
   KeyboardEvent,
-  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
   ReactElement,
 } from "react";
 
@@ -20,6 +21,7 @@ export interface SkillComboboxProps {
   onChange: (value: string) => void;
   placeholder?: string;
   inputId?: string;
+  dataStepField?: string;
   dataStepIndex?: string;
   ariaLabel?: string;
   inputClassName?: string;
@@ -49,6 +51,7 @@ export function SkillCombobox({
   onChange,
   placeholder,
   inputId,
+  dataStepField,
   dataStepIndex,
   ariaLabel,
   inputClassName,
@@ -109,8 +112,17 @@ export function SkillCombobox({
     setIsOpen(true);
   }, []);
 
+  const handleBlur = useCallback((event: FocusEvent<HTMLInputElement>) => {
+    const container = containerRef.current;
+    const next = event.relatedTarget as Node | null;
+    if (container && next && container.contains(next)) {
+      return;
+    }
+    setIsOpen(false);
+  }, []);
+
   const handleToggle = useCallback(
-    (event: ReactMouseEvent<HTMLButtonElement>) => {
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
       setIsOpen((prev) => {
         const next = !prev;
@@ -190,6 +202,11 @@ export function SkillCombobox({
     overflowY: "auto",
   };
 
+  const activeDescendantId =
+    isOpen && highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
+
   return (
     <div
       ref={containerRef}
@@ -205,25 +222,27 @@ export function SkillCombobox({
           role="combobox"
           aria-autocomplete="list"
           aria-expanded={isOpen}
-          aria-controls={listboxId}
+          aria-controls={isOpen ? listboxId : undefined}
+          aria-activedescendant={activeDescendantId}
           aria-label={ariaLabel}
           value={value}
           placeholder={placeholder}
-          data-step-field="skillId"
+          data-step-field={dataStepField ?? "skillId"}
           {...(dataStepIndex !== undefined ? { "data-step-index": dataStepIndex } : {})}
           className={inputClassName}
           onChange={handleInputChange}
           onPointerDown={handleInputPointerDown}
           onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
         />
         <button
           type="button"
           className="skill-combobox-toggle"
           aria-label={isOpen ? "Hide skill options" : "Show skill options"}
           aria-expanded={isOpen}
-          aria-controls={listboxId}
+          aria-controls={isOpen ? listboxId : undefined}
           tabIndex={-1}
-          onClick={handleToggle}
+          onPointerDown={handleToggle}
         >
           <svg
             aria-hidden="true"
@@ -255,6 +274,7 @@ export function SkillCombobox({
             const isSelected = option === value;
             return (
               <li
+                id={`${listboxId}-option-${index}`}
                 key={option}
                 role="option"
                 aria-selected={isSelected}

--- a/frontend/src/components/SkillCombobox.tsx
+++ b/frontend/src/components/SkillCombobox.tsx
@@ -25,12 +25,10 @@ export interface SkillComboboxProps {
   inputClassName?: string;
 }
 
-const MAX_VISIBLE_OPTIONS = 50;
-
 function filterOptions(options: readonly string[], query: string): string[] {
   const trimmed = query.trim().toLowerCase();
   if (!trimmed) {
-    return options.slice(0, MAX_VISIBLE_OPTIONS);
+    return [...options];
   }
   const startsWith: string[] = [];
   const includes: string[] = [];
@@ -42,7 +40,7 @@ function filterOptions(options: readonly string[], query: string): string[] {
       includes.push(option);
     }
   }
-  return [...startsWith, ...includes].slice(0, MAX_VISIBLE_OPTIONS);
+  return [...startsWith, ...includes];
 }
 
 export function SkillCombobox({

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8714,9 +8714,12 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
 
                   {step.stepType === "skill" ? (
                     <div className="stack queue-step-type-panel">
-                      <label>
-                        Skill (optional)
+                      <div className="field">
+                        <label htmlFor={`queue-step-${step.localId}-skill-id`}>
+                          Skill (optional)
+                        </label>
                         <SkillCombobox
+                          inputId={`queue-step-${step.localId}-skill-id`}
                           value={step.skillId}
                           options={skillComboboxOptions}
                           dataStepIndex={String(index)}
@@ -8737,7 +8740,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                             Leave skill blank to inherit primary step defaults.
                           </span>
                         )}
-                      </label>
+                      </div>
 
                       {showSkillArgsField ? (
                         <label

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import type { BootPayload } from "../boot/parseBootPayload";
+import { SkillCombobox } from "../components/SkillCombobox";
 import { useLiquidGL } from "../lib/liquidGL/useLiquidGL";
 import { navigateTo } from "../lib/navigation";
 import {
@@ -20,7 +21,6 @@ import {
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
 export const ARTIFACT_COMPLETE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 2000];
 const ARTIFACT_COMPLETE_RETRY_MESSAGE = "artifact upload is not complete";
-const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
 const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
 const REPOSITORY_OPTIONS_DATALIST_ID = "queue-repository-options";
@@ -5433,6 +5433,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     ],
   );
 
+  const skillComboboxOptions = useMemo(() => {
+    const ids = skillsQuery.data?.ids || [];
+    return Array.from(new Set(["auto", ...ids]));
+  }, [skillsQuery.data?.ids]);
+
   const effortOptions = useMemo(
     () =>
       Array.from(
@@ -8391,12 +8396,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           aria-label="Steps"
         >
           <div id="queue-steps-list" className="stack queue-steps-list">
-            <datalist id={SKILL_OPTIONS_DATALIST_ID}>
-              <option value="auto" />
-              {(skillsQuery.data?.ids || []).map((skillId) => (
-                <option key={skillId} value={skillId} />
-              ))}
-            </datalist>
             <datalist id={MODEL_OPTIONS_DATALIST_ID}>
               {modelOptions.map((item) => (
                 <option key={item} value={item} />
@@ -8717,19 +8716,19 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                     <div className="stack queue-step-type-panel">
                       <label>
                         Skill (optional)
-                        <input
-                          data-step-field="skillId"
-                          data-step-index={String(index)}
-                          list={SKILL_OPTIONS_DATALIST_ID}
+                        <SkillCombobox
                           value={step.skillId}
+                          options={skillComboboxOptions}
+                          dataStepIndex={String(index)}
+                          ariaLabel={`Step ${index + 1} skill`}
                           placeholder={
                             isPrimaryStep
                               ? "auto (default), moonspec-orchestrate, ..."
                               : "inherit primary step skill"
                           }
-                          onChange={(event) =>
+                          onChange={(nextValue) =>
                             updateStep(step.localId, {
-                              skillId: event.target.value,
+                              skillId: nextValue,
                             })
                           }
                         />

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3390,6 +3390,90 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   padding: 0.25rem 0 0;
 }
 
+.skill-combobox {
+  position: relative;
+  width: 100%;
+}
+
+.skill-combobox-input-row {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.skill-combobox-input-row > input {
+  flex: 1 1 auto;
+  width: 100%;
+  padding-inline-end: 2.25rem;
+}
+
+.skill-combobox-toggle {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: 0;
+  color: rgb(var(--mm-muted));
+  cursor: pointer;
+  border-radius: 0.56rem;
+  touch-action: manipulation;
+}
+
+.skill-combobox-toggle:hover,
+.skill-combobox-toggle:focus-visible {
+  color: rgb(var(--mm-ink));
+}
+
+.skill-combobox-toggle[aria-expanded="true"] svg {
+  transform: rotate(180deg);
+}
+
+.skill-combobox-toggle svg {
+  transition: transform 0.15s ease;
+}
+
+.skill-combobox-listbox {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  background: rgb(var(--mm-panel));
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.56rem;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.18);
+}
+
+.skill-combobox-option {
+  padding: 0.6rem 0.7rem;
+  border-radius: 0.4rem;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  color: rgb(var(--mm-ink));
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.skill-combobox-option[data-highlighted="true"],
+.skill-combobox-option:hover {
+  background: rgb(var(--mm-accent) / 0.18);
+}
+
+.skill-combobox-option[aria-selected="true"] {
+  font-weight: 600;
+}
+
 .queue-step-preset-options {
   padding-top: 0.25rem;
 }


### PR DESCRIPTION
I want to be able to type in the skill input box of the start workflow page on mobile and also be able to click the dropdown and see available options. If I’ve started typing something, the available options will be related to what I’ve typed and not just all options. Currently I can type but I can’t actually click the dropdown to see options on mobile. Fix this.