### PR TITLE
If i create a task with one runtime and provider profile and its awaiting slot, then i edit it to another provider profile thats not in use, it still…

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1384,7 +1384,8 @@ class MoonMindAgentRun:
             self._apply_runtime_selection_update(request, payload)
         runtime_id = self._managed_runtime_id(request.agent_id)
         manager_id = self._manager_workflow_id(runtime_id)
-        if manager_id != previous_manager_id:
+        assigned_profile_id = self._assigned_profile_id
+        if manager_id != previous_manager_id or assigned_profile_id:
             previous_manager_handle = workflow.get_external_workflow_handle(
                 previous_manager_id
             )
@@ -1392,7 +1393,7 @@ class MoonMindAgentRun:
                 await previous_manager_handle.signal(
                     "release_slot",
                     self._release_slot_payload(
-                        profile_id=self._assigned_profile_id,
+                        profile_id=assigned_profile_id,
                         request=request,
                     ),
                 )
@@ -1750,10 +1751,7 @@ class MoonMindAgentRun:
                                     or self.runtime_selection_updated_event.is_set(),
                                     timeout=timedelta(seconds=slot_wait_timeout_seconds),
                                 )
-                                if (
-                                    self.runtime_selection_updated_event.is_set()
-                                    and not self.slot_assigned_event.is_set()
-                                ):
+                                if self.runtime_selection_updated_event.is_set():
                                     (
                                         manager_handle,
                                         manager_id,
@@ -1844,10 +1842,7 @@ class MoonMindAgentRun:
                                 lambda: self.slot_assigned_event.is_set()
                                 or self.runtime_selection_updated_event.is_set(),
                             )
-                            if (
-                                self.runtime_selection_updated_event.is_set()
-                                and not self.slot_assigned_event.is_set()
-                            ):
+                            if self.runtime_selection_updated_event.is_set():
                                 (
                                     manager_handle,
                                     manager_id,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1380,12 +1380,25 @@ class MoonMindAgentRun:
         self._pending_runtime_selection_update = None
         self.runtime_selection_updated_event.clear()
         previous_manager_id = manager_id
+        previous_profile_ref = request.execution_profile_ref
+        previous_selector_payload = request.profile_selector.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
+        assigned_profile_id = self._assigned_profile_id
         if payload:
             self._apply_runtime_selection_update(request, payload)
         runtime_id = self._managed_runtime_id(request.agent_id)
         manager_id = self._manager_workflow_id(runtime_id)
-        assigned_profile_id = self._assigned_profile_id
-        if manager_id != previous_manager_id or assigned_profile_id:
+        selector_payload = request.profile_selector.model_dump(
+            by_alias=True,
+            exclude_none=True,
+        )
+        slot_selection_changed = (
+            request.execution_profile_ref != previous_profile_ref
+            or selector_payload != previous_selector_payload
+        )
+        if manager_id != previous_manager_id or slot_selection_changed:
             previous_manager_handle = workflow.get_external_workflow_handle(
                 previous_manager_id
             )
@@ -1404,10 +1417,19 @@ class MoonMindAgentRun:
                     raise
             self.slot_assigned_event.clear()
             self._assigned_profile_id = None
-        selector_payload = request.profile_selector.model_dump(
-            by_alias=True,
-            exclude_none=True,
-        )
+        else:
+            manager_handle = workflow.get_external_workflow_handle(manager_id)
+            profile_count = await self._sync_manager_profiles(
+                manager_id=manager_id,
+                manager_handle=manager_handle,
+                runtime_id=runtime_id,
+            )
+            self._validate_synced_profile_selection(
+                profile_count=profile_count,
+                runtime_id=runtime_id,
+                request=request,
+            )
+            return manager_handle, manager_id, runtime_id
         manager_handle = await self._ensure_manager_started(manager_id, runtime_id)
         profile_count = await self._sync_manager_profiles(
             manager_id=manager_id,
@@ -1740,8 +1762,22 @@ class MoonMindAgentRun:
 
                     if workflow.patched("agent_run_slot_wait_retry_v1"):
                         slot_resets = 0
-                        while not self.slot_assigned_event.is_set():
+                        while (
+                            not self.slot_assigned_event.is_set()
+                            or self.runtime_selection_updated_event.is_set()
+                        ):
                             try:
+                                if self.runtime_selection_updated_event.is_set():
+                                    (
+                                        manager_handle,
+                                        manager_id,
+                                        runtime_id,
+                                    ) = await self._consume_runtime_selection_update_for_slot_wait(
+                                        request=request,
+                                        manager_id=manager_id,
+                                        runtime_id=runtime_id,
+                                    )
+                                    continue
                                 slot_wait_timeout_seconds = (
                                     self._slot_wait_timeout_override_seconds
                                     or _SLOT_WAIT_TIMEOUT_SECONDS
@@ -1839,19 +1875,8 @@ class MoonMindAgentRun:
                     else:
                         while not self.slot_assigned_event.is_set():
                             await workflow.wait_condition(
-                                lambda: self.slot_assigned_event.is_set()
-                                or self.runtime_selection_updated_event.is_set(),
+                                lambda: self.slot_assigned_event.is_set(),
                             )
-                            if self.runtime_selection_updated_event.is_set():
-                                (
-                                    manager_handle,
-                                    manager_id,
-                                    runtime_id,
-                                ) = await self._consume_runtime_selection_update_for_slot_wait(
-                                    request=request,
-                                    manager_id=manager_id,
-                                    runtime_id=runtime_id,
-                                )
 
                     # Reset the execution clock so the timeout budget starts
                     # from slot acquisition, not from workflow start.

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -342,10 +342,14 @@ class RuntimeUpdateProviderProfileManager:
     def __init__(self) -> None:
         self.pending_requests: list[dict] = []
         self.assignable_profile_id = "alternate-managed"
+        self.release_payloads: list[dict] = []
+        self.request_payloads: list[dict] = []
+        self.assign_then_update_model: str | None = None
 
     @workflow.signal
     def request_slot(self, payload: dict) -> None:
         requester = payload["requester_workflow_id"]
+        self.request_payloads.append(dict(payload))
         self.pending_requests = [
             req
             for req in self.pending_requests
@@ -355,6 +359,7 @@ class RuntimeUpdateProviderProfileManager:
 
     @workflow.signal
     def release_slot(self, payload: dict) -> None:
+        self.release_payloads.append(dict(payload))
         requester = payload.get("requester_workflow_id")
         self.pending_requests = [
             req
@@ -372,13 +377,31 @@ class RuntimeUpdateProviderProfileManager:
 
     @workflow.query
     def get_state(self) -> dict:
-        return {"pending_requests": list(self.pending_requests)}
+        return {
+            "pending_requests": list(self.pending_requests),
+            "release_payloads": list(self.release_payloads),
+            "request_payloads": list(self.request_payloads),
+        }
 
     @workflow.run
     async def run(self, input_payload: dict) -> dict:
+        self.assign_then_update_model = input_payload.get("assign_then_update_model")
         while True:
             await workflow.wait_condition(lambda: bool(self.pending_requests))
             req = self.pending_requests[0]
+            if self.assign_then_update_model:
+                self.pending_requests.pop(0)
+                profile_id = req.get("execution_profile_ref") or "default-managed"
+                handle = workflow.get_external_workflow_handle(
+                    req["requester_workflow_id"]
+                )
+                await handle.signal(
+                    "update_runtime_selection",
+                    {"model": self.assign_then_update_model},
+                )
+                await handle.signal("slot_assigned", {"profile_id": profile_id})
+                await workflow.sleep(3600)
+                continue
             if req.get("execution_profile_ref") != self.assignable_profile_id:
                 await workflow.sleep(1)
                 continue
@@ -665,6 +688,79 @@ async def test_managed_agent_runtime_selection_update_replaces_slot_wait_request
             )
             result = await child_handle.result()
             assert result.summary == "completed after runtime update"
+
+@pytest.mark.asyncio
+async def test_managed_agent_model_update_keeps_simultaneously_assigned_slot():
+    """Model-only edits racing with slot assignment must keep the acquired slot."""
+    _managed_launch_requests.clear()
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with (
+            Worker(
+                env.client,
+                task_queue="agent-run-task-queue-runtime-update-model",
+                workflows=[MoonMindAgentRun, RuntimeUpdateProviderProfileManager],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.artifacts",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+            Worker(
+                env.client,
+                task_queue="mm.activity.agent_runtime",
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            ),
+        ):
+            manager_id = "provider-profile-manager:gemini_cli"
+            await env.client.start_workflow(
+                RuntimeUpdateProviderProfileManager.run,
+                {
+                    "runtime_id": "gemini_cli",
+                    "assign_then_update_model": "new-model",
+                },
+                id=manager_id,
+                task_queue="agent-run-task-queue-runtime-update-model",
+            )
+            manager_handle = env.client.get_workflow_handle(manager_id)
+            child_handle = await env.client.start_workflow(
+                MoonMindAgentRun.run,
+                AgentExecutionRequest(
+                    agent_kind="managed",
+                    agent_id="gemini_cli",
+                    execution_profile_ref="default-managed",
+                    correlation_id="corr-runtime-update-model",
+                    idempotency_key="idem-runtime-update-model",
+                    parameters={
+                        "model": "old-model",
+                        "profileId": "default-managed",
+                    },
+                ),
+                id="test-agent-runtime-selection-model-update",
+                task_queue="agent-run-task-queue-runtime-update-model",
+            )
+
+            for _ in range(80):
+                if _managed_launch_requests:
+                    break
+                await asyncio.sleep(0.1)
+            manager_state = await manager_handle.query(
+                RuntimeUpdateProviderProfileManager.get_state
+            )
+            assert _managed_launch_requests, manager_state
+            launched_request = _managed_launch_requests[-1]["request"]
+            assert launched_request["executionProfileRef"] == "default-managed"
+            assert launched_request["parameters"]["model"] == "new-model"
+            assert manager_state["release_payloads"] == []
+            assert len(manager_state["request_payloads"]) == 1
+
+            await child_handle.signal(
+                MoonMindAgentRun.completion_signal,
+                {"summary": "completed after model update"},
+            )
+            result = await child_handle.result()
+            assert result.summary == "completed after model update"
 
 @pytest.mark.asyncio
 async def test_agent_run_binds_managed_launch_to_parent_workflow_for_new_histories():

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -423,7 +423,7 @@ class TestEnsureManagerAutoStart:
         )
 
         assert assigned_index < release_index < clear_index < request_index
-        assert "or assigned_profile_id" in source
+        assert "slot_selection_changed" in source
         assert "profile_id=assigned_profile_id" in source
 
     def test_slot_wait_runtime_update_preempts_simultaneous_slot_assignment(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -407,6 +407,32 @@ class TestEnsureManagerAutoStart:
 
         assert sync_index < validate_index < request_index
 
+    def test_slot_wait_runtime_update_releases_stale_assigned_slot_before_request(self):
+        """A profile edit must discard any old slot assigned before the edit wins."""
+        source = textwrap.dedent(
+            inspect.getsource(
+                MoonMindAgentRun._consume_runtime_selection_update_for_slot_wait
+            )
+        )
+
+        assigned_index = source.index("assigned_profile_id = self._assigned_profile_id")
+        release_index = source.index("await previous_manager_handle.signal(")
+        clear_index = source.index("self.slot_assigned_event.clear()")
+        request_index = source.index(
+            "manager_handle = await self._ensure_manager_and_signal"
+        )
+
+        assert assigned_index < release_index < clear_index < request_index
+        assert "or assigned_profile_id" in source
+        assert "profile_id=assigned_profile_id" in source
+
+    def test_slot_wait_runtime_update_preempts_simultaneous_slot_assignment(self):
+        """The wait loop must consume runtime edits even if slot_assigned is also set."""
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+
+        assert "and not self.slot_assigned_event.is_set()" not in source
+        assert source.count("if self.runtime_selection_updated_event.is_set():") == 2
+
     def test_manager_signal_payload_carries_execution_profile_ref(self):
         """The auto-start helper must include execution_profile_ref in request_slot payloads."""
         source = textwrap.dedent(


### PR DESCRIPTION
If i create a task with one runtime and provider profile and its awaiting slot, then i edit it to another provider profile thats not in use, it still says awaiting slot. When I edit a task to a new provider profile, I’d like for it to be reconsidered for initialization if the new provider profile is idle.