### PR TITLE
Use this preselected single-story request or active feature context as the canonical Moon Spec orchestration input:

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,8 @@ Key diagnostics:
 - Existing execution/artifact stores only; no new persistence (001-workflow-console-routes)
 - Python 3.12; TypeScript/React for Mission Control visible copy + Pydantic v2, FastAPI, Temporal Python SDK, pytest, React, Vitest (001-step-execution-contracts)
 - Existing Temporal artifact store and workflow history; no new persistent storage (001-step-execution-contracts)
+- Python 3.12 target per repo instructions; TypeScript/React for Mission Control UI + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest (001-fix-schedule-creation)
+- Existing recurring task definition/run tables and Temporal schedule state; no new persistent storage (001-fix-schedule-creation)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5974,7 +5974,7 @@ def _compute_schedule_delay(
     delay = scheduled_for - now
     if delay.total_seconds() < 1:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "code": "schedule_in_past",
                 "message": "scheduledFor must be a future datetime.",
@@ -6032,23 +6032,35 @@ async def _handle_recurring_schedule(
     session: Any,
 ) -> ScheduleCreatedResponse:
     """Delegate recurring schedule creation to RecurringTasksService."""
-    from api_service.services.recurring_tasks_service import RecurringTasksService
+    from api_service.services.recurring_tasks_service import (
+        RecurringTaskValidationError,
+        RecurringTasksService,
+    )
 
     svc = RecurringTasksService(session)
     target = _build_recurring_target(request_payload)
-    definition = await svc.create_definition(
-        name=schedule.name or "Inline schedule",
-        description=None,
-        enabled=True,
-        schedule_type="cron",
-        cron=schedule.cron,
-        timezone=schedule.timezone or "UTC",
-        scope_type="personal",
-        scope_ref=None,
-        owner_user_id=user.id,
-        target=target,
-        policy=None,
-    )
+    try:
+        definition = await svc.create_definition(
+            name=schedule.name or "Inline schedule",
+            description=schedule.description,
+            enabled=schedule.enabled,
+            schedule_type="cron",
+            cron=schedule.cron or "",
+            timezone=schedule.timezone or "UTC",
+            scope_type=schedule.scope_type or "personal",
+            scope_ref=None,
+            owner_user_id=user.id,
+            target=target,
+            policy=schedule.policy or {},
+        )
+    except RecurringTaskValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "invalid_recurring_task",
+                "message": str(exc),
+            },
+        ) from exc
     return ScheduleCreatedResponse(
         definitionId=str(definition.id),
         name=definition.name,
@@ -6094,7 +6106,7 @@ async def _resolve_schedule_routing(
     if schedule.mode == "recurring":
         if session is None:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={
                     "code": "invalid_execution_request",
                     "message": "Recurring schedules require a database session.",
@@ -6111,7 +6123,7 @@ async def _resolve_schedule_routing(
     if schedule.mode == "once":
         if schedule.scheduled_for is None:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={
                     "code": "invalid_execution_request",
                     "message": "scheduledFor is required when schedule.mode is 'once'.",

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6039,6 +6039,15 @@ async def _handle_recurring_schedule(
 
     svc = RecurringTasksService(session)
     target = _build_recurring_target(request_payload)
+    scope_type = schedule.scope_type or "personal"
+    if scope_type == "global" and not _is_execution_admin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "operator_role_required",
+                "message": "Operator privileges are required for global schedules.",
+            },
+        )
     try:
         definition = await svc.create_definition(
             name=schedule.name or "Inline schedule",
@@ -6047,11 +6056,11 @@ async def _handle_recurring_schedule(
             schedule_type="cron",
             cron=schedule.cron or "",
             timezone=schedule.timezone or "UTC",
-            scope_type=schedule.scope_type or "personal",
+            scope_type=scope_type,
             scope_ref=None,
             owner_user_id=user.id,
             target=target,
-            policy=schedule.policy or {},
+            policy=schedule.policy,
         )
     except RecurringTaskValidationError as exc:
         raise HTTPException(

--- a/api_service/api/routers/recurring_tasks.py
+++ b/api_service/api/routers/recurring_tasks.py
@@ -233,7 +233,7 @@ def _map_error(exc: Exception) -> HTTPException:
         )
     if isinstance(exc, RecurringTaskValidationError):
         return HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "code": "invalid_recurring_task",
                 "message": str(exc),

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+
+import type { BootPayload } from "../boot/parseBootPayload";
+import { renderWithClient } from "../utils/test-utils";
+import { SchedulesPage } from "./schedules";
+
+const mockPayload: BootPayload = {
+  page: "schedules",
+  apiBase: "/api",
+  initialData: {},
+};
+
+describe("SchedulesPage", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: "schedule-1",
+            name: "Daily missing fields",
+            enabled: true,
+            cron: "0 9 * * *",
+            timezone: "UTC",
+            lastDispatchStatus: null,
+            nextRunAt: null,
+          },
+          {
+            id: "schedule-2",
+            name: "Sparse schedule",
+          },
+        ],
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("renders nullable schedule list fields with placeholders", async () => {
+    renderWithClient(<SchedulesPage payload={mockPayload} />);
+
+    expect(await screen.findByText("Daily missing fields")).not.toBeNull();
+    expect(await screen.findByText("Sparse schedule")).not.toBeNull();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("routes creation to the workflow create page without local mutations", async () => {
+    renderWithClient(<SchedulesPage payload={mockPayload} />);
+
+    const createLink = await screen.findByRole("link", {
+      name: "Create from workflow page",
+    });
+    expect(createLink.getAttribute("href")).toBe(
+      "/workflows/new?scheduleMode=recurring",
+    );
+    expect(screen.queryByRole("button", { name: "Create Schedule" })).toBeNull();
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Schedule (Cron)")).toBeNull();
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const mutationCalls = fetchSpy.mock.calls.filter(([, init]) => {
+      const method = String(init?.method || "GET").toUpperCase();
+      return method === "POST" || method === "PUT";
+    });
+    expect(mutationCalls).toEqual([]);
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/recurring-tasks"),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { DataTable } from '../components/tables/DataTable';
 
 import { z } from 'zod';
@@ -8,26 +7,19 @@ import { BootPayload } from '../boot/parseBootPayload';
 const ScheduleSchema = z.object({
   id: z.string(),
   name: z.string(),
-  lastDispatchStatus: z.string(),
-  nextRunAt: z.string(),
-  schedule: z.string().optional(),
+  enabled: z.boolean().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional(),
+  lastDispatchStatus: z.string().nullable().optional(),
+  nextRunAt: z.string().nullable().optional(),
 });
 type Schedule = z.infer<typeof ScheduleSchema>;
-
-interface SaveSchedulePayload {
-  name: string;
-  schedule: string;
-}
 
 const SchedulesResponseSchema = z.object({
   items: z.array(ScheduleSchema),
 });
 
 export function SchedulesPage({ payload }: { payload: BootPayload }) {
-  const queryClient = useQueryClient();
-  const [showModal, setShowModal] = useState(false);
-  const [editingSchedule, setEditingSchedule] = useState<Schedule | null>(null);
-
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['schedules'],
     queryFn: async () => {
@@ -39,37 +31,6 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
     },
   });
 
-  const saveMutation = useMutation({
-    mutationFn: async (mutationPayload: SaveSchedulePayload) => {
-      const method = editingSchedule ? 'PUT' : 'POST';
-      const endpoint = editingSchedule ? `${payload.apiBase}/recurring-tasks/${editingSchedule.id}` : `${payload.apiBase}/recurring-tasks`;
-      const response = await fetch(endpoint, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(mutationPayload),
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to save: ${response.statusText}`);
-      }
-      return response.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedules'] });
-      setShowModal(false);
-      setEditingSchedule(null);
-    }
-  });
-
-  const handleEdit = (schedule: Schedule) => {
-    setEditingSchedule(schedule);
-    setShowModal(true);
-  };
-
-  const handleCreate = () => {
-    setEditingSchedule(null);
-    setShowModal(true);
-  };
-
   return (
     <div className="max-w-6xl mx-auto p-6 space-y-6">
       <header className="border-b border-gray-200 pb-4 mb-6 flex justify-between items-center">
@@ -77,9 +38,9 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
           <h2 className="text-2xl font-bold text-gray-900 tracking-tight">Recurring Schedules</h2>
           <p className="text-sm text-gray-500 mt-1">Managed recurring schedules for queue and manifest targets.</p>
         </div>
-        <button onClick={handleCreate} className="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700">
-          Create Schedule
-        </button>
+        <a href="/workflows/new?scheduleMode=recurring" className="text-blue-600 hover:underline">
+          Create from workflow page
+        </a>
       </header>
       <div className="bg-white rounded-lg shadow-sm p-6 border border-gray-100">
         {isLoading ? (
@@ -92,49 +53,22 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
             columns={[
               { key: 'id', header: 'ID' },
               { key: 'name', header: 'Name' },
-              { key: 'lastDispatchStatus', header: 'Last Dispatch Status' },
-              { key: 'nextRunAt', header: 'Next Run At' },
-              { key: 'actions', header: 'Actions', render: (item) => <button onClick={() => handleEdit(item)} className="text-blue-600 hover:underline">Edit</button> },
+              {
+                key: 'lastDispatchStatus',
+                header: 'Last Dispatch Status',
+                render: (item) => item.lastDispatchStatus ?? '—',
+              },
+              {
+                key: 'nextRunAt',
+                header: 'Next Run At',
+                render: (item) => item.nextRunAt ? new Date(item.nextRunAt).toLocaleString() : '—',
+              },
             ]}
             emptyMessage="No recurring schedules found."
             getRowKey={(item) => item.id}
           />
         )}
       </div>
-
-      {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center p-4">
-          <div className="bg-white p-6 rounded shadow-lg max-w-md w-full">
-            <h3 className="text-lg font-bold mb-4">{editingSchedule ? 'Edit Schedule' : 'Create Schedule'}</h3>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                const formData = new FormData(e.currentTarget);
-                saveMutation.mutate({
-                  name: String(formData.get('name') || ''),
-                  schedule: String(formData.get('schedule') || ''),
-                });
-              }}
-              className="space-y-4"
-            >
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Name</label>
-                <input required type="text" name="name" defaultValue={editingSchedule?.name || ''} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Schedule (Cron)</label>
-                <input required type="text" name="schedule" defaultValue={editingSchedule?.schedule || ''} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="* * * * *" />
-              </div>
-              <div className="flex justify-end space-x-2 pt-4">
-                <button type="button" onClick={() => setShowModal(false)} className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">Cancel</button>
-                <button type="submit" disabled={saveMutation.isPending} className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-                  {saveMutation.isPending ? 'Saving...' : 'Save'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -13,7 +13,6 @@ const ScheduleSchema = z.object({
   lastDispatchStatus: z.string().nullable().optional(),
   nextRunAt: z.string().nullable().optional(),
 });
-type Schedule = z.infer<typeof ScheduleSchema>;
 
 const SchedulesResponseSchema = z.object({
   items: z.array(ScheduleSchema),

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -518,6 +518,22 @@ describe("WorkflowStart schedule mode entry", () => {
     expect(await screen.findByLabelText("Cron Expression")).not.toBeNull();
   });
 
+  it("preselects once schedule mode from the query parameter", async () => {
+    window.history.pushState(
+      {},
+      "Task Create",
+      "/workflows/new?scheduleMode=once",
+    );
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const scheduleMode = (await screen.findByLabelText(
+      "Schedule Mode",
+    )) as HTMLSelectElement;
+    expect(scheduleMode.value).toBe("once");
+    expect(await screen.findByLabelText("Scheduled For")).not.toBeNull();
+  });
+
   it("keeps immediate schedule mode as the default without the query parameter", async () => {
     window.history.pushState({}, "Task Create", "/workflows/new");
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -462,6 +462,74 @@ function collectObjectKeys(value: unknown, keys = new Set<string>()): Set<string
   return keys;
 }
 
+describe("WorkflowStart schedule mode entry", () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/workflows/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: { worker: ["speckit-orchestrate", "pr-resolver"] },
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: [] }),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [],
+          } as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({}),
+        } as Response);
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    window.history.pushState({}, "Task Create", "/workflows/new");
+  });
+
+  it("preselects recurring schedule mode from the query parameter", async () => {
+    window.history.pushState(
+      {},
+      "Task Create",
+      "/workflows/new?scheduleMode=recurring",
+    );
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const scheduleMode = (await screen.findByLabelText(
+      "Schedule Mode",
+    )) as HTMLSelectElement;
+    expect(scheduleMode.value).toBe("recurring");
+    expect(await screen.findByLabelText("Cron Expression")).not.toBeNull();
+  });
+
+  it("keeps immediate schedule mode as the default without the query parameter", async () => {
+    window.history.pushState({}, "Task Create", "/workflows/new");
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const scheduleMode = (await screen.findByLabelText(
+      "Schedule Mode",
+    )) as HTMLSelectElement;
+    expect(scheduleMode.value).toBe("immediate");
+  });
+});
+
 describe.skip("Task Create Entrypoint", () => {
   let fetchSpy: MockInstance;
   let consoleInfoSpy: MockInstance;

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3826,7 +3826,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       return "immediate";
     }
     const params = new URLSearchParams(window.location.search);
-    return params.get("scheduleMode") === "recurring" ? "recurring" : "immediate";
+    const mode = params.get("scheduleMode");
+    if (mode === "recurring" || mode === "once") {
+      return mode;
+    }
+    return "immediate";
   });
   const [scheduledFor, setScheduledFor] = useState("");
   const [scheduleDeferredMinutes, setScheduleDeferredMinutes] = useState("");

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3821,7 +3821,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     readProposeTasksPreference(defaultProposeTasks),
   );
   const isInitialMount = useRef(true);
-  const [scheduleMode, setScheduleMode] = useState<ScheduleMode>("immediate");
+  const [scheduleMode, setScheduleMode] = useState<ScheduleMode>(() => {
+    if (typeof window === "undefined") {
+      return "immediate";
+    }
+    const params = new URLSearchParams(window.location.search);
+    return params.get("scheduleMode") === "recurring" ? "recurring" : "immediate";
+  });
   const [scheduledFor, setScheduledFor] = useState("");
   const [scheduleDeferredMinutes, setScheduleDeferredMinutes] = useState("");
   const [scheduleCron, setScheduleCron] = useState("");

--- a/tests/integration/api/test_recurring_schedule_creation.py
+++ b/tests/integration/api/test_recurring_schedule_creation.py
@@ -1,0 +1,124 @@
+"""Hermetic API contract tests for recurring schedule creation via executions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_service.api.routers.executions import (
+    _get_service,
+    get_temporal_client,
+    router,
+)
+from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
+from api_service.services.recurring_tasks_service import RecurringTaskValidationError
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _override_user_dependencies(app: FastAPI) -> SimpleNamespace:
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="recurring@example.com",
+        is_active=True,
+        is_superuser=False,
+    )
+    user_dependencies = {
+        dep.call
+        for route_entry in router.routes
+        if route_entry.dependant is not None
+        for dep in route_entry.dependant.dependencies
+        if dep.call.__name__ == "_current_user_fallback"
+    }
+    if not user_dependencies:
+        user_dependencies = {get_current_user()}
+
+    for dependency in user_dependencies:
+        app.dependency_overrides[dependency] = lambda user=user: user
+    return user
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[_get_service] = lambda: AsyncMock()
+    app.dependency_overrides[get_temporal_client] = lambda: AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace()
+    _override_user_dependencies(app)
+    return TestClient(app)
+
+
+def test_executions_recurring_schedule_success_contract() -> None:
+    definition_id = uuid4()
+    next_run_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with _client() as client, patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            return_value=SimpleNamespace(
+                id=definition_id,
+                name="Inline schedule",
+                cron="0 * * * *",
+                timezone="UTC",
+                next_run_at=next_run_at,
+            )
+        )
+
+        response = client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "task": {"instructions": "Run this on a schedule"},
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.json()
+    body = response.json()
+    assert body["scheduled"] is True
+    assert body["definitionId"] == str(definition_id)
+    assert body["redirectPath"] == f"/schedules/{definition_id}"
+
+
+def test_executions_recurring_schedule_validation_contract() -> None:
+    with _client() as client, patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            side_effect=RecurringTaskValidationError("target.kind is required")
+        )
+
+        response = client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "task": {"instructions": "Run this on a schedule"},
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "invalid_recurring_task",
+        "message": "target.kind is required",
+    }

--- a/tests/integration/api/test_recurring_schedule_creation.py
+++ b/tests/integration/api/test_recurring_schedule_creation.py
@@ -45,12 +45,20 @@ def _override_user_dependencies(app: FastAPI) -> SimpleNamespace:
     return user
 
 
+def _mock_service_override() -> AsyncMock:
+    return AsyncMock()
+
+
+def _empty_session_override() -> SimpleNamespace:
+    return SimpleNamespace()
+
+
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(router)
-    app.dependency_overrides[_get_service] = lambda: AsyncMock()
-    app.dependency_overrides[get_temporal_client] = lambda: AsyncMock()
-    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace()
+    app.dependency_overrides[_get_service] = _mock_service_override
+    app.dependency_overrides[get_temporal_client] = _mock_service_override
+    app.dependency_overrides[get_async_session] = _empty_session_override
     _override_user_dependencies(app)
     return TestClient(app)
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -49,6 +49,7 @@ from api_service.db.models import (
     TemporalExecutionRecord,
     TemporalWorkflowType,
 )
+from api_service.services.recurring_tasks_service import RecurringTaskValidationError
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.service import ExecutionDependencySummary
 from moonmind.workflows.temporal import (
@@ -4542,6 +4543,103 @@ def test_create_task_shaped_recurring_schedule_uses_root_proposal_fallbacks(
     assert "proposalPolicy" not in stored_payload
     assert stored_payload["task"]["proposeTasks"] is True
     assert stored_payload["task"]["proposalPolicy"] == {"targets": ["moonmind"]}
+
+
+def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    definition_id = uuid4()
+    next_run_at = datetime.now(UTC) + timedelta(hours=1)
+    policy = {"overlap": {"mode": "skip"}}
+
+    with patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            return_value=SimpleNamespace(
+                id=definition_id,
+                name="Nightly workflow",
+                cron="0 2 * * *",
+                timezone="America/New_York",
+                next_run_at=next_run_at,
+            )
+        )
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "name": "Nightly workflow",
+                        "description": "Run overnight",
+                        "enabled": False,
+                        "cron": "0 2 * * *",
+                        "timezone": "America/New_York",
+                        "scopeType": "personal",
+                        "policy": policy,
+                    },
+                    "task": {
+                        "instructions": "Run this on a schedule",
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.json()
+    body = response.json()
+    assert body["scheduled"] is True
+    assert body["definitionId"] == str(definition_id)
+    assert body["name"] == "Nightly workflow"
+    assert body["cron"] == "0 2 * * *"
+    assert body["timezone"] == "America/New_York"
+    assert body["redirectPath"] == f"/schedules/{definition_id}"
+    called_kwargs = service.create_definition.await_args.kwargs
+    assert called_kwargs["description"] == "Run overnight"
+    assert called_kwargs["enabled"] is False
+    assert called_kwargs["scope_type"] == "personal"
+    assert called_kwargs["policy"] == policy
+
+
+def test_create_task_shaped_recurring_schedule_validation_maps_to_422(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+
+    with patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            side_effect=RecurringTaskValidationError("target.kind is required")
+        )
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "task": {
+                        "instructions": "Run this on a schedule",
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "invalid_recurring_task",
+        "message": "target.kind is required",
+    }
 
 def test_create_execution_surfaces_domain_validation_errors(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4605,6 +4605,84 @@ def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(
     assert called_kwargs["policy"] == policy
 
 
+def test_create_task_shaped_recurring_schedule_preserves_missing_policy(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    next_run_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            return_value=SimpleNamespace(
+                id=uuid4(),
+                name="Inline schedule",
+                cron="0 * * * *",
+                timezone="UTC",
+                next_run_at=next_run_at,
+            )
+        )
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "task": {
+                        "instructions": "Run this on a schedule",
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.json()
+    assert service.create_definition.await_args.kwargs["policy"] is None
+
+
+def test_create_task_shaped_recurring_schedule_rejects_global_scope_for_non_operator(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+
+    with patch(
+        "api_service.services.recurring_tasks_service.RecurringTasksService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock()
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                        "scopeType": "global",
+                    },
+                    "task": {
+                        "instructions": "Run this on a schedule",
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == {
+        "code": "operator_role_required",
+        "message": "Operator privileges are required for global schedules.",
+    }
+    service.create_definition.assert_not_awaited()
+
+
 def test_create_task_shaped_recurring_schedule_validation_maps_to_422(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_recurring_tasks.py
+++ b/tests/unit/api/routers/test_recurring_tasks.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 
 from api_service.api.routers import recurring_tasks as recurring_router
 from api_service.db.models import (
@@ -17,6 +17,7 @@ from api_service.db.models import (
     RecurringTaskScheduleType,
     RecurringTaskScopeType,
 )
+from api_service.services.recurring_tasks_service import RecurringTaskValidationError
 
 def _definition(**overrides):
     now = datetime.now(UTC)
@@ -64,6 +65,18 @@ def _run(**overrides):
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def test_recurring_task_validation_error_maps_to_422() -> None:
+    exc = recurring_router._map_error(
+        RecurringTaskValidationError("target.kind is required")
+    )
+
+    assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert exc.detail == {
+        "code": "invalid_recurring_task",
+        "message": "target.kind is required",
+    }
 
 @pytest.mark.asyncio
 async def test_list_recurring_tasks_global_requires_operator() -> None:


### PR DESCRIPTION
Automated changes by MoonMind.