### PR TITLE
[codex] Fix workflow failure publishing

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -135,6 +135,7 @@ from moonmind.workflows.skills.skill_registry import (
     create_registry_snapshot,
     parse_skill_registry,
 )
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
 from moonmind.workflows.temporal.activity_catalog import TemporalActivityCatalog
 from moonmind.workflows.temporal.artifacts import (
     ArtifactRef,
@@ -1743,12 +1744,15 @@ class TemporalSkillActivities:
                 principal or "system:deployment",
             )
 
-        return await execute_skill_activity(
-            invocation_payload=invocation_payload,
-            registry_snapshot=resolved_snapshot,
-            dispatcher=self._dispatcher,
-            context=execution_context,
-        )
+        try:
+            return await execute_skill_activity(
+                invocation_payload=invocation_payload,
+                registry_snapshot=resolved_snapshot,
+                dispatcher=self._dispatcher,
+                context=execution_context,
+            )
+        except ToolFailure as exc:
+            raise _tool_failure_application_error(exc) from exc
 
     async def mm_tool_execute(
         self,
@@ -1772,6 +1776,27 @@ class TemporalSkillActivities:
             context=context,
             idempotency_key=idempotency_key,
         )
+
+
+def _tool_failure_application_error(
+    exc: ToolFailure,
+) -> temporal_exceptions.ApplicationError:
+    payload = _redacted_tool_failure_payload(exc)
+    return temporal_exceptions.ApplicationError(
+        f"{exc.error_code}: {exc.message}",
+        payload,
+        type=exc.error_code,
+        non_retryable=not exc.retryable,
+    )
+
+
+def _redacted_tool_failure_payload(exc: ToolFailure) -> dict[str, Any]:
+    redactor = SecretRedactor.from_environ(placeholder="[REDACTED]")
+    encoded = json.dumps(exc.to_payload(), default=str, sort_keys=True)
+    scrubbed = redactor.scrub(encoded)
+    decoded = json.loads(scrubbed)
+    return decoded if isinstance(decoded, dict) else {"message": str(decoded)}
+
 
 class TemporalManifestActivities:
     """Implementation helpers for manifest-ingest activity steps."""
@@ -7112,6 +7137,41 @@ class TemporalAgentRuntimeActivities:
             protected = {"main", "master", "HEAD"}
             if target_branch_name and not target_branch_push_allowed:
                 protected.add(target_branch_name)
+            if (
+                current_branch in {"main", "master"}
+                and head_branch_name
+                and head_branch_name not in protected
+            ):
+                checkout_proc = await asyncio.create_subprocess_exec(
+                    *self._workspace_git_command(
+                        workspace,
+                        "checkout",
+                        "-B",
+                        head_branch_name,
+                    ),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=command_env,
+                )
+                checkout_stdout, checkout_stderr = await asyncio.wait_for(
+                    checkout_proc.communicate(), timeout=30,
+                )
+                if checkout_proc.returncode != 0:
+                    detail = (
+                        checkout_stderr.decode("utf-8", errors="replace").strip()
+                        or checkout_stdout.decode("utf-8", errors="replace").strip()
+                        or "(no stderr)"
+                    )
+                    return {
+                        "push_status": "failed",
+                        "push_branch": current_branch,
+                        "push_error": (
+                            "could not switch protected workspace branch "
+                            f"'{current_branch}' to publish branch "
+                            f"'{head_branch_name}': {detail}"
+                        ),
+                    }
+                current_branch = head_branch_name
             if not current_branch or current_branch in protected:
                 logger.warning(
                     "Post-agent git push skipped for run %s: "

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -63,7 +63,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedProfileLaunchContext,
     build_managed_profile_launch_context,
 )
-from moonmind.utils.logging import SecretRedactor
+from moonmind.utils.logging import SecretRedactor, redact_sensitive_text
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
 from moonmind.workflows.adapters.codex_cloud_agent_adapter import CodexCloudAgentAdapter
 from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as CodexCloudHttpClient
@@ -1781,21 +1781,45 @@ class TemporalSkillActivities:
 def _tool_failure_application_error(
     exc: ToolFailure,
 ) -> temporal_exceptions.ApplicationError:
-    payload = _redacted_tool_failure_payload(exc)
+    redactor = SecretRedactor.from_environ(placeholder="[REDACTED]")
+    payload = _redacted_tool_failure_payload(exc, redactor=redactor)
     return temporal_exceptions.ApplicationError(
-        f"{exc.error_code}: {exc.message}",
+        _scrub_temporal_failure_text(
+            f"{exc.error_code}: {exc.message}",
+            redactor=redactor,
+        ),
         payload,
         type=exc.error_code,
         non_retryable=not exc.retryable,
     )
 
 
-def _redacted_tool_failure_payload(exc: ToolFailure) -> dict[str, Any]:
-    redactor = SecretRedactor.from_environ(placeholder="[REDACTED]")
-    encoded = json.dumps(exc.to_payload(), default=str, sort_keys=True)
-    scrubbed = redactor.scrub(encoded)
-    decoded = json.loads(scrubbed)
-    return decoded if isinstance(decoded, dict) else {"message": str(decoded)}
+def _redacted_tool_failure_payload(
+    exc: ToolFailure,
+    *,
+    redactor: SecretRedactor,
+) -> dict[str, Any]:
+    try:
+        encoded = json.dumps(exc.to_payload(), default=str, sort_keys=True)
+        scrubbed = _scrub_temporal_failure_text(encoded, redactor=redactor)
+        decoded = json.loads(scrubbed)
+        return decoded if isinstance(decoded, dict) else {"message": str(decoded)}
+    except Exception:
+        return {
+            "error_code": exc.error_code,
+            "message": _scrub_temporal_failure_text(
+                exc.message,
+                redactor=redactor,
+            ),
+        }
+
+
+def _scrub_temporal_failure_text(
+    text: str,
+    *,
+    redactor: SecretRedactor,
+) -> str:
+    return redact_sensitive_text(redactor.scrub(text))
 
 
 class TemporalManifestActivities:
@@ -7153,9 +7177,14 @@ class TemporalAgentRuntimeActivities:
                     stderr=asyncio.subprocess.PIPE,
                     env=command_env,
                 )
-                checkout_stdout, checkout_stderr = await asyncio.wait_for(
-                    checkout_proc.communicate(), timeout=30,
-                )
+                try:
+                    checkout_stdout, checkout_stderr = await asyncio.wait_for(
+                        checkout_proc.communicate(), timeout=30,
+                    )
+                except asyncio.TimeoutError:
+                    checkout_proc.kill()
+                    await checkout_proc.wait()
+                    raise
                 if checkout_proc.returncode != 0:
                     detail = (
                         checkout_stderr.decode("utf-8", errors="replace").strip()
@@ -7165,10 +7194,13 @@ class TemporalAgentRuntimeActivities:
                     return {
                         "push_status": "failed",
                         "push_branch": current_branch,
-                        "push_error": (
+                        "push_error": _scrub_temporal_failure_text(
                             "could not switch protected workspace branch "
                             f"'{current_branch}' to publish branch "
-                            f"'{head_branch_name}': {detail}"
+                            f"'{head_branch_name}': {detail}",
+                            redactor=SecretRedactor.from_environ(
+                                placeholder="[REDACTED]"
+                            ),
                         ),
                     }
                 current_branch = head_branch_name

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1344,6 +1344,17 @@ class DockerCodexManagedSessionController:
                     request=request,
                     git_env=git_env,
                 )
+            elif (
+                request.workspace_spec.get("targetBranch")
+                and await self._workspace_is_git_repository(
+                    workspace_path=workspace_path
+                )
+            ):
+                await self._ensure_target_branch(
+                    workspace_path=workspace_path,
+                    request=request,
+                    git_env=await self._git_host_environment(request),
+                )
             return
 
         if not repository:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -194,6 +195,91 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert stored.container_id == "ctr-1"
     assert stored.runtime_id == "codex_cli"
     session_supervisor.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_controller_checks_out_target_branch_for_existing_git_workspace_without_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 1000,
+    )
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "task-1" / "repo"
+    workspace_path.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    (workspace_path / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "README.md"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "seed"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "feature/publish"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "main"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+    )
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={"targetBranch": "feature/publish"},
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+    )
+
+    await controller._ensure_workspace_paths(request)
+
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=workspace_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert branch == "feature/publish"
+
 
 @pytest.mark.asyncio
 async def test_controller_launches_private_docker_sidecar_for_docker_enabled_session(

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -405,6 +405,58 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "main"
 
     @pytest.mark.asyncio
+    async def test_push_recovers_main_workspace_to_requested_pr_head_branch(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        calls: list[tuple[object, ...]] = []
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            del kwargs
+            call_count += 1
+            calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse --abbrev-ref HEAD
+                proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # checkout -B requested head branch
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # remote branch sha before push
+                proc.communicate = AsyncMock(return_value=(b"remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"head-sha\n", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="main",
+                head_branch="feature/recovered-publish",
+            )
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/recovered-publish"
+        assert result["push_base_branch"] == "main"
+        assert result["push_head_sha"] == "head-sha"
+        assert any(
+            call[-3:] == ("checkout", "-B", "feature/recovered-publish")
+            for call in calls
+        )
+
+    @pytest.mark.asyncio
     async def test_push_protected_branch_master(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -457,6 +457,76 @@ class TestPushWorkspaceBranch:
         )
 
     @pytest.mark.asyncio
+    async def test_push_redacts_checkout_failure_for_requested_pr_head_branch(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        async def _mock_exec(*args, **kwargs):
+            del args, kwargs
+            proc = AsyncMock()
+            if _mock_exec.call_count == 0:
+                proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+                proc.returncode = 0
+            else:
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"",
+                        b"fatal: token=ghp_checkoutfailure1234567890abc leaked",
+                    )
+                )
+                proc.returncode = 1
+            _mock_exec.call_count += 1
+            return proc
+
+        _mock_exec.call_count = 0
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="main",
+                head_branch="feature/recovered-publish",
+            )
+
+        assert result["push_status"] == "failed"
+        assert "ghp_checkoutfailure1234567890abc" not in result["push_error"]
+        assert "[REDACTED]" in result["push_error"]
+
+    @pytest.mark.asyncio
+    async def test_push_kills_checkout_process_on_timeout_for_requested_pr_head_branch(
+        self,
+    ):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        checkout_proc = AsyncMock()
+        checkout_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        checkout_proc.kill = MagicMock()
+        checkout_proc.wait = AsyncMock(return_value=0)
+
+        async def _mock_exec(*args, **kwargs):
+            del args, kwargs
+            if _mock_exec.call_count == 0:
+                proc = AsyncMock()
+                proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+                proc.returncode = 0
+            else:
+                proc = checkout_proc
+            _mock_exec.call_count += 1
+            return proc
+
+        _mock_exec.call_count = 0
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="main",
+                head_branch="feature/recovered-publish",
+            )
+
+        assert result["push_status"] == "failed"
+        checkout_proc.kill.assert_called_once()
+        checkout_proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_push_protected_branch_master(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -28,6 +28,7 @@ from moonmind.workflows.skills.skill_registry import (
     create_registry_snapshot,
     parse_skill_registry,
 )
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     DEPLOYMENT_UPDATE_TOOL_VERSION,
@@ -1868,6 +1869,63 @@ async def test_build_activity_bindings_mm_tool_execute_handler_supports_keyword_
             assert result.outputs["ok"] is True
             assert captured_context["workflow_id"] == "wf-1"
             assert captured_context["idempotency_key"] == "wf-1_n1_execute"
+
+
+async def test_mm_tool_execute_preserves_tool_failure_envelope() -> None:
+    dispatcher = SkillActivityDispatcher()
+
+    def _failing_handler(
+        _inputs: dict[str, object],
+        _context: dict[str, object] | None,
+    ) -> SkillResult:
+        raise ToolFailure(
+            error_code="DEPLOYMENT_RUNNER_UNSAFE",
+            message="Deployment update would recreate the worker container.",
+            retryable=False,
+            details={
+                "failureClass": "runner_self_recreation_unsafe",
+                "service": "temporal-worker-agent-runtime",
+            },
+        )
+
+    dispatcher.register_skill(
+        skill_name="repo.run_tests",
+        version="1.0.0",
+        handler=_failing_handler,
+    )
+    snapshot = create_registry_snapshot(
+        skills=parse_skill_registry(_registry_payload()),
+        artifact_store=InMemoryArtifactStore(),
+    )
+    activities = TemporalSkillActivities(dispatcher=dispatcher)
+
+    with pytest.raises(temporal_exceptions.ApplicationError) as exc_info:
+        await activities.mm_tool_execute(
+            invocation_payload={
+                "id": "deploy",
+                "tool": {
+                    "type": "skill",
+                    "name": "repo.run_tests",
+                    "version": "1.0.0",
+                },
+                "inputs": {"repo_ref": "git:org/repo#main"},
+            },
+            registry_snapshot=snapshot,
+        )
+
+    assert exc_info.value.type == "DEPLOYMENT_RUNNER_UNSAFE"
+    assert exc_info.value.non_retryable is True
+    assert "Deployment update would recreate" in str(exc_info.value)
+    assert exc_info.value.details[0] == {
+        "error_code": "DEPLOYMENT_RUNNER_UNSAFE",
+        "message": "Deployment update would recreate the worker container.",
+        "retryable": False,
+        "details": {
+            "failureClass": "runner_self_recreation_unsafe",
+            "service": "temporal-worker-agent-runtime",
+        },
+    }
+
 
 async def test_build_activity_bindings_does_not_mutate_sandbox_method_signatures(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1878,13 +1878,18 @@ async def test_mm_tool_execute_preserves_tool_failure_envelope() -> None:
         _inputs: dict[str, object],
         _context: dict[str, object] | None,
     ) -> SkillResult:
+        leaked_token = "ghp_toolfailuretoken1234567890abcd"
         raise ToolFailure(
             error_code="DEPLOYMENT_RUNNER_UNSAFE",
-            message="Deployment update would recreate the worker container.",
+            message=(
+                "Deployment update would recreate the worker container "
+                f"with token {leaked_token}."
+            ),
             retryable=False,
             details={
                 "failureClass": "runner_self_recreation_unsafe",
                 "service": "temporal-worker-agent-runtime",
+                "token": leaked_token,
             },
         )
 
@@ -1916,13 +1921,19 @@ async def test_mm_tool_execute_preserves_tool_failure_envelope() -> None:
     assert exc_info.value.type == "DEPLOYMENT_RUNNER_UNSAFE"
     assert exc_info.value.non_retryable is True
     assert "Deployment update would recreate" in str(exc_info.value)
+    assert "ghp_toolfailuretoken1234567890abcd" not in str(exc_info.value)
+    assert "[REDACTED]" in str(exc_info.value)
     assert exc_info.value.details[0] == {
         "error_code": "DEPLOYMENT_RUNNER_UNSAFE",
-        "message": "Deployment update would recreate the worker container.",
+        "message": (
+            "Deployment update would recreate the worker container "
+            "with token [REDACTED]."
+        ),
         "retryable": False,
         "details": {
             "failureClass": "runner_self_recreation_unsafe",
             "service": "temporal-worker-agent-runtime",
+            "token": "[REDACTED]",
         },
     }
 


### PR DESCRIPTION
## Summary

Fixes two issues observed while troubleshooting workflow `mm:2906fc0f-0ae1-4efe-a2ea-bc46d3ec0212` and the follow-up troubleshooting workflow `mm:07dd1d31-2b3b-42a4-b667-44431acd7147`.

- Preserve `ToolFailure` details from `mm.tool.execute` by converting them into typed Temporal `ApplicationError` failures with the redacted tool payload attached.
- Ensure Codex managed sessions check out `workspaceSpec.targetBranch` even when the workspace is an existing git checkout without a repository spec.
- Recover PR publish handoff when a managed workspace is still on `main`/`master` but a generated PR head branch was provided, by switching to that head branch before committing and pushing.
- Harden the failure paths from review feedback: redact ToolFailure messages, tolerate JSON redaction edge cases, redact checkout stderr in push errors, and kill timed-out checkout subprocesses.

## Root Cause

The deployment update workflow hit a real `DEPLOYMENT_RUNNER_UNSAFE` guard, but `ToolFailure` was escaping as a generic application failure, so the workflow summary only showed `ToolFailure: Application error`. The follow-up remediation workflow committed a fix but could not publish because its managed session workspace stayed on `main`, producing `push_status=protected_branch`.

## Validation

- `git diff --check`
- `./tools/test_unit.sh` Python phase: `5466 passed, 6 skipped, 1 xpassed, 101 warnings, 16 subtests passed`
- Full `./tools/test_unit.sh` frontend phase initially hit one local workflow-detail live-log test miss; reran the filtered case through `./tools/test_unit.sh --ui-args entrypoints/workflow-detail.test.tsx -t "keeps panels expanded when operators use their controls"` and it passed.
- GitHub PR checks are green: `test-backend`, `test-frontend`, `test-integration-ci`, `check-generated-contracts`, and CodeQL.
