### PR TITLE
Triage GitHub issue #552 to Jira: After tasks fail or are considered successful, there should be a review step

### DIFF
--- a/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-comment.md
+++ b/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-comment.md
@@ -1,0 +1,15 @@
+Triaged this into Jira because the requested post-run review behavior is not fully implemented yet, and the remaining work is clear enough for backlog tracking.
+
+Created Jira story: MM-733
+https://moonladder.atlassian.net/browse/MM-733
+
+Evidence from the current codebase:
+
+| Requirement | Status | Evidence |
+| --- | --- | --- |
+| Review after failed or successful tasks | Not implemented | `moonmind/workflows/temporal/workflows/run.py` only runs `_run_proposals_stage()` when proposal generation is explicitly requested. |
+| Diagnose failed tasks and propose a repair task | Partially implemented | Proposal delivery exists, but `moonmind/workflows/temporal/activity_runtime.py` `proposal_generate()` depends on an explicit proposal idea and does not inspect terminal failure evidence by itself. |
+| Check successful tasks for real completeness | Not implemented | `moonmind/workflows/temporal/activities/step_review.py` currently returns `FULLY_IMPLEMENTED` unconditionally and has a TODO for the actual LLM review call. |
+| Add follow-up work when success is incomplete | Partially implemented | Task proposal infrastructure exists, but `tests/integration/workflows/temporal/workflows/test_run.py` confirms proposal generation only runs with `task.proposeTasks` enabled. |
+
+I did not close this GitHub issue because the behavior still needs product implementation. No product code was changed during this triage.

--- a/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-jira-story.md
+++ b/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-jira-story.md
@@ -1,0 +1,47 @@
+# Story: Add automatic post-run review and follow-up proposal generation
+
+## User story
+As a MoonMind operator, I want every completed or failed task to go through an automated review step so that failures produce actionable repair proposals and successful runs are checked for completeness before being treated as done.
+
+## Background / source GitHub issue
+- Repository: MoonLadderStudios/MoonMind
+- GitHub issue: https://github.com/MoonLadderStudios/MoonMind/issues/552
+- Issue title: After tasks fail or are considered successful, there should be a review step
+- Requested behavior: after tasks fail or are considered successful, review the result; failed tasks should diagnose why they failed and propose a task to fix the root cause; successful tasks should be checked for actual completeness and, when incomplete, additional work should be proposed or queued.
+
+## Current codebase findings
+- `moonmind/workflows/temporal/workflows/run.py` has a best-effort proposal phase, but `_run_proposals_stage()` only runs when proposal generation is requested by the run payload.
+- `moonmind/workflows/temporal/workflows/run.py` gates proposal generation through `_proposal_generation_requested()`, which requires `task.proposeTasks` or legacy root `proposeTasks`.
+- `moonmind/workflows/temporal/activity_runtime.py` `proposal_generate()` builds a follow-up proposal only when an explicit proposal idea can be resolved; it does not review terminal success or failure evidence by itself.
+- `moonmind/workflows/temporal/activities/step_review.py` is currently a placeholder: it returns `FULLY_IMPLEMENTED` with confidence `1.0` and contains a TODO to wire the LLM call.
+- `tests/unit/workflows/temporal/test_step_review_activity.py` asserts the placeholder behavior.
+- `tests/integration/workflows/temporal/workflows/test_run.py` covers proposal invocation only when `task.proposeTasks` is true and confirms no proposal activity runs when proposal opt-in is absent.
+
+## Acceptance criteria
+1. Every `MoonMind.Run` terminal path for success and failure records a post-run review decision or an explicit skipped reason before the final execution summary is published.
+2. Failed runs pass structured failure diagnostics, failed step identity, relevant artifact/log refs, task instructions, and publish/proposal context into the post-run review.
+3. Successful runs pass task instructions, step ledger/result evidence, publish status, generated artifacts, and completion summary into the post-run review.
+4. The review can classify at least: complete, incomplete_follow_up_needed, failure_fix_needed, review_blocked, and review_not_applicable.
+5. For failure_fix_needed, MoonMind creates or delivers a repair task proposal that includes the diagnosed cause, evidence refs, affected step, and concrete repair instructions.
+6. For incomplete_follow_up_needed, MoonMind creates or delivers a continuation task proposal or appends additional planned work according to the existing task/proposal contract chosen by implementation design.
+7. Post-run review must not silently mark incomplete work as successful when the reviewer cannot inspect required evidence; it should record review_blocked with actionable diagnostics.
+8. Proposal creation remains idempotent for workflow retries and does not create duplicate repair or continuation proposals for the same workflow/run/review verdict.
+9. Mission Control execution details expose the post-run review status and proposal/delivery outcome without requiring operators to inspect raw workflow history.
+10. Tests cover success-complete, success-incomplete, failed-with-repair-proposal, review-blocked, proposal idempotency, and the existing proposal-disabled behavior.
+
+## Implementation notes
+- Reuse the existing proposal infrastructure where possible: `proposal.generate`, `proposal.submit`, `TaskProposalService`, and existing proposal delivery status surfaces.
+- Replace or extend the placeholder `step.review` behavior with a real post-run review boundary rather than relying on the current unconditional `FULLY_IMPLEMENTED` verdict.
+- Preserve Temporal compatibility for in-flight workflow payloads; if workflow/activity signatures change, add boundary or replay-style coverage as required by repo policy.
+- The review should be best-effort only if that is an explicit product decision; otherwise terminal completion should visibly reflect review failure or blocked review state.
+
+## Verification
+- Add unit tests for review verdict parsing and proposal payload creation.
+- Add Temporal workflow boundary tests proving review runs after terminal success and failure paths.
+- Add integration or API serialization coverage showing review status and proposal outcomes in execution detail payloads.
+- Run `./tools/test_unit.sh` and targeted integration tests for proposal/review workflow boundaries.
+
+## Out of scope
+- Reworking unrelated proposal queue UI flows.
+- Creating provider-specific reviewer logic outside the existing runtime/tool adapter boundaries.
+- Changing external provider billing/model semantics beyond passing configured runtime values through existing validation.

--- a/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-ledger.json
+++ b/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-ledger.json
@@ -1,0 +1,88 @@
+{
+  "issue": {
+    "repository": "MoonLadderStudios/MoonMind",
+    "number": 552,
+    "url": "https://github.com/MoonLadderStudios/MoonMind/issues/552",
+    "title": "After tasks fail or are considered successful, there should be a review step",
+    "state_at_triage": "OPEN"
+  },
+  "repository_state": {
+    "branch": "triage-github-issue-552-to-jira-after-ta-5b50303c",
+    "head_sha": "5276e23f261ee4aa260bc2537eb8f6f51ca7e06a",
+    "working_tree_before_artifacts": "clean"
+  },
+  "issue_ledger": {
+    "requested_behavior": "After failed or successful tasks, run a review step; diagnose failures and propose repair tasks; verify successful tasks are actually complete and add follow-up work if incomplete.",
+    "user_visible_goal": "Operators get an automatic quality/recovery review at task completion instead of manually discovering incomplete or failed work.",
+    "acceptance_criteria_from_triage": [
+      "Terminal success and failure paths record post-run review status or explicit skipped reason.",
+      "Failed runs produce repair proposals with root-cause evidence when actionable.",
+      "Successful runs are checked against task instructions and evidence before being treated as complete.",
+      "Incomplete successful runs produce continuation proposals or planned follow-up work.",
+      "Proposal/review behavior is idempotent across workflow retries and visible in Mission Control."
+    ],
+    "constraints": [
+      "Do not implement product code during triage.",
+      "Use trusted Jira tool path for issue creation.",
+      "Respect Temporal workflow boundary and compatibility test policy for future implementation."
+    ],
+    "affected_areas": [
+      "moonmind/workflows/temporal/workflows/run.py",
+      "moonmind/workflows/temporal/activity_runtime.py",
+      "moonmind/workflows/temporal/activities/step_review.py",
+      "moonmind/workflows/task_proposals/",
+      "api_service/api/routers/executions.py",
+      "frontend/src/entrypoints/workflow-detail.tsx"
+    ],
+    "ambiguity_notes": []
+  },
+  "evidence": [
+    {
+      "requirement": "Review after failed or successful tasks",
+      "status": "not_implemented",
+      "evidence": "moonmind/workflows/temporal/workflows/run.py _run_proposals_stage() runs only when _proposal_generation_requested(parameters) is true."
+    },
+    {
+      "requirement": "Diagnose failed tasks and propose repair task",
+      "status": "partially_implemented",
+      "evidence": "moonmind/workflows/temporal/activity_runtime.py proposal_generate() creates proposal candidates only when an explicit proposal idea is resolved; it does not inspect terminal failure evidence itself."
+    },
+    {
+      "requirement": "Verify successful tasks really completed everything",
+      "status": "not_implemented",
+      "evidence": "moonmind/workflows/temporal/activities/step_review.py currently returns FULLY_IMPLEMENTED with confidence 1.0 and contains a TODO to wire the LLM review call."
+    },
+    {
+      "requirement": "Add additional follow-up work when incomplete",
+      "status": "partially_implemented",
+      "evidence": "tests/integration/workflows/temporal/workflows/test_run.py covers proposal activities when task.proposeTasks is true and confirms no proposal activity runs when proposal opt-in is absent."
+    }
+  ],
+  "history_checks": {
+    "git_log_search": "Found multiple proposal-system commits and PRs, but no evidence that GitHub issue #552's full automatic post-run review behavior is implemented.",
+    "merged_pr_search": "Found proposal delivery and step review gate related PRs including #754, #2167, #2168, but current code still shows placeholder review and opt-in proposal gating."
+  },
+  "jira": {
+    "project_key": "MM",
+    "issue_type": "Story",
+    "issue_type_id": "10005",
+    "created_key": "MM-733",
+    "url": "https://moonladder.atlassian.net/browse/MM-733",
+    "create_result_artifact": "var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/create_jira_result.json"
+  },
+  "github_mutation": {
+    "action": "commented",
+    "comment_url": "https://github.com/MoonLadderStudios/MoonMind/issues/552#issuecomment-4527896656",
+    "issue_closed": false
+  },
+  "terminal_action": "jira_created",
+  "tests": {
+    "run": [],
+    "skipped_reason": "No product code was changed; this was a triage and external issue-creation task."
+  },
+  "artifacts": {
+    "ledger": "var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-ledger.json",
+    "github_comment": "var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-comment.md",
+    "jira_story": "var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/MoonLadderStudios-MoonMind-issue-552-jira-story.md"
+  }
+}

--- a/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/create_jira_result.json
+++ b/var/artifacts/github-issue-to-jira/issue-552-20260524T085442Z/create_jira_result.json
@@ -1,0 +1,10 @@
+{
+  "ok": true,
+  "status": 200,
+  "result": {
+    "created": true,
+    "issueKey": "MM-733",
+    "issueId": "15699",
+    "self": "https://moonladder.atlassian.net/rest/api/3/issue/15699"
+  }
+}


### PR DESCRIPTION
Use the github-issue-to-jira skill for GitHub issue #552 in MoonLadderStudios/MoonMind.

Repository: MoonLadderStudios/MoonMind
Issue: https://github.com/MoonLadderStudios/MoonMind/issues/552
Jira target project: MM
Target issue type: Story

Review the open GitHub issue against the current codebase and take exactly one terminal action per the github-issue-to-jira skill: close as already implemented with evidence, label/comment needs clarification, or create a Jira story when remaining work is clear.
Do not implement product code as part of this triage task. Finish with the skill outcome and artifact paths.