### PR TITLE
Triage GitHub issue #424 to Jira: Talking to MoonMind

### DIFF
--- a/var/artifacts/github-issue-to-jira/20260524-github-issue-424/MoonLadderStudios-MoonMind-issue-424-comment.md
+++ b/var/artifacts/github-issue-to-jira/20260524-github-issue-424/MoonLadderStudios-MoonMind-issue-424-comment.md
@@ -1,0 +1,23 @@
+Result: this needs clarification before it can become actionable backlog work.
+
+I reviewed the issue against the current codebase. MoonMind already has several state/control surfaces today:
+
+| Area | Evidence |
+| --- | --- |
+| Execution lifecycle and state | `GET /api/executions`, `GET /api/executions/{workflowId}`, update, signal, cancel, rerun, facets, and step-ledger routes in `api_service/api/routers/executions.py`; documented in `docs/Tasks/TaskRunsApi.md`. |
+| Active job observability | `/api/task-runs/{taskRunId}/observability-summary`, structured observability events, logs, diagnostics, and live-follow support in `api_service/api/routers/task_runs.py`; documented in `docs/Tasks/TaskRunsApi.md`. |
+| Operator UI | README describes Mission Control as the current surface for real-time progress, step progress, logs, diagnostics, artifacts, interventions, and execution history. |
+| MCP/tool direction | `/mcp/tools` and `/mcp/tools/call` exist, but the legacy queue registry is currently a stub and the issue does not specify which MoonMind-owned conversational/tool surface should be expanded. |
+
+The remaining request is still too broad to create a good Jira story. It says there should be “better methods of talking to MoonMind,” “a method of talking to the orchestrator,” and “possibly” better tools for active jobs, but it does not define the desired user, transport, operations, or acceptance criteria.
+
+Could you clarify the intended surface and scope?
+
+1. Should this be a human-facing chat/CLI, an MCP tool set for agents, REST endpoints, Mission Control UI, or something else?
+2. What deployment-level questions must it answer, for example service health, Temporal worker health, queue/backlog state, configured providers, active sessions, or recent failures?
+3. What active-job operations are expected, for example inspect, follow logs, pause, resume, cancel, approve, retry, attach context, or send feedback?
+4. Should this target the current Temporal execution model rather than the removed legacy `mm-orchestrator` runtime?
+
+Once those are answered, this can be split into a concrete story with acceptance criteria instead of guessing at the wrong interface.
+
+Tests not run: no product code was changed; this was a triage review only.

--- a/var/artifacts/github-issue-to-jira/20260524-github-issue-424/MoonLadderStudios-MoonMind-issue-424-ledger.json
+++ b/var/artifacts/github-issue-to-jira/20260524-github-issue-424/MoonLadderStudios-MoonMind-issue-424-ledger.json
@@ -1,0 +1,103 @@
+{
+  "issue": {
+    "repository": "MoonLadderStudios/MoonMind",
+    "number": 424,
+    "url": "https://github.com/MoonLadderStudios/MoonMind/issues/424",
+    "title": "Talking to MoonMind",
+    "state": "OPEN",
+    "author": "nsticco",
+    "createdAt": "2026-02-23T20:48:24Z",
+    "updatedAt": "2026-02-23T20:48:24Z"
+  },
+  "repositoryState": {
+    "branch": "triage-github-issue-424-to-jira-talking-e4d49fc0",
+    "head": "5276e23f261ee4aa260bc2537eb8f6f51ca7e06a"
+  },
+  "issueLedger": {
+    "requestedBehavior": "Better methods of talking to MoonMind, especially a way to talk to the orchestrator and understand deployment state; possibly better tools for active jobs.",
+    "userVisibleGoal": "Operators or agents can query MoonMind state and interact with active jobs through an unspecified interface.",
+    "explicitAcceptanceCriteria": [],
+    "constraints": [],
+    "examples": [],
+    "affectedAreas": [
+      "Execution lifecycle and status APIs",
+      "Managed run observability APIs",
+      "Mission Control UI",
+      "MCP/tool surface",
+      "Temporal-backed orchestration model"
+    ],
+    "ambiguityNotes": [
+      "The issue does not define the intended user or client: human operator, agent, UI, CLI, MCP client, or REST consumer.",
+      "The issue uses legacy orchestrator wording even though the repository has removed the old mm-orchestrator runtime and now centers Temporal-backed executions.",
+      "The issue does not list concrete deployment-state questions or active-job actions to support."
+    ]
+  },
+  "evidence": [
+    {
+      "requirement": "Expose current execution lifecycle and status",
+      "status": "implemented",
+      "evidence": [
+        "docs/Tasks/TaskRunsApi.md documents POST/GET /api/executions, detail, update, signal, cancel, rerun, manifest status, nodes, and steps.",
+        "api_service/api/routers/executions.py defines list/detail/update/signal/cancel/rerun execution routes."
+      ]
+    },
+    {
+      "requirement": "Expose active job observability",
+      "status": "implemented",
+      "evidence": [
+        "docs/Tasks/TaskRunsApi.md documents /api/task-runs observability summary, logs, live stream, and diagnostics.",
+        "api_service/api/routers/task_runs.py defines observability-summary, observability events, logs, diagnostics, and artifact-session control routes."
+      ]
+    },
+    {
+      "requirement": "Provide an operator UI for execution state",
+      "status": "implemented",
+      "evidence": [
+        "README.md describes Mission Control as showing real-time agent activity, step progress, logs, diagnostics, artifacts, interventions, and execution history."
+      ]
+    },
+    {
+      "requirement": "Provide better methods of talking to MoonMind/orchestrator/deployment state",
+      "status": "unclear",
+      "evidence": [],
+      "reason": "The requested interface, supported operations, actor, deployment-state scope, and Temporal-vs-legacy-orchestrator target are not specified."
+    },
+    {
+      "requirement": "Provide better tools for active jobs",
+      "status": "unclear",
+      "evidence": [],
+      "reason": "The issue says this possibly should exist but does not identify required active-job operations or acceptance criteria."
+    }
+  ],
+  "historyChecks": {
+    "gitLogSearch": "Found extensive old orchestrator removal/runtime history and current Temporal migration history, but no direct implementation for GitHub issue #424's ambiguous talking-to-MoonMind request.",
+    "mergedPrSearch": "Found unrelated Jira MM-424 visual-token PRs and orchestrator removal/migration PRs; no linked PR closing GitHub issue #424."
+  },
+  "tests": {
+    "run": [],
+    "skippedReason": "No product code changed; tests were not needed to distinguish implementation status from ambiguity."
+  },
+  "terminalAction": "needs_clarification",
+  "mutationAttempts": [
+    {
+      "surface": "github",
+      "action": "ensure_label",
+      "label": "needs clarification",
+      "result": "succeeded_or_already_exists"
+    },
+    {
+      "surface": "github",
+      "action": "apply_label",
+      "label": "needs clarification",
+      "result": "succeeded",
+      "issueUrl": "https://github.com/MoonLadderStudios/MoonMind/issues/424"
+    },
+    {
+      "surface": "github",
+      "action": "comment",
+      "result": "succeeded",
+      "commentUrl": "https://github.com/MoonLadderStudios/MoonMind/issues/424#issuecomment-4527916259"
+    }
+  ],
+  "githubCommentUrl": "https://github.com/MoonLadderStudios/MoonMind/issues/424#issuecomment-4527916259"
+}


### PR DESCRIPTION
Use the github-issue-to-jira skill for GitHub issue #424 in MoonLadderStudios/MoonMind.

Repository: MoonLadderStudios/MoonMind
Issue: https://github.com/MoonLadderStudios/MoonMind/issues/424
Jira target project: MM
Target issue type: Story

Review the open GitHub issue against the current codebase and take exactly one terminal action per the github-issue-to-jira skill: close as already implemented with evidence, label/comment needs clarification, or create a Jira story when remaining work is clear.
Do not implement product code as part of this triage task. Finish with the skill outcome and artifact paths.