### PR TITLE
[codex] Fix step attachment IDs in task submissions

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3974,6 +3974,21 @@ def _coerce_step_count(value: Any) -> int:
         raise _invalid_task_request("payload.task.steps must be a JSON array.")
     return len(value)
 
+def _default_task_step_id(index: int) -> str:
+    return f"step-{index + 1}"
+
+def _task_step_id_from_payload(step: Mapping[str, Any], index: int) -> str:
+    return (
+        str(
+            step.get("id")
+            or step.get("stepId")
+            or step.get("stepRef")
+            or step.get("ref")
+            or ""
+        ).strip()
+        or _default_task_step_id(index)
+    )
+
 _ATTACHMENT_REF_KEYS = frozenset(
     {"artifactId", "filename", "contentType", "sizeBytes"}
 )
@@ -4076,7 +4091,7 @@ async def _validate_and_collect_task_input_attachments(
         step = raw_steps[index] if isinstance(raw_steps, list) else {}
         step_ref = ""
         if isinstance(step, Mapping):
-            step_ref = str(step.get("id") or "").strip()
+            step_ref = _task_step_id_from_payload(step, index)
         for ref in refs:
             attachment_index.append(
                 {
@@ -4261,6 +4276,7 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
             value = step_payload.get(key)
             if isinstance(value, str) and value.strip():
                 normalized_step[key] = value.strip()
+        normalized_step["id"] = _task_step_id_from_payload(step_payload, index)
 
         normalized_skills = _normalize_task_skill_selectors(
             step_payload.get("skills"),

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3978,16 +3978,11 @@ def _default_task_step_id(index: int) -> str:
     return f"step-{index + 1}"
 
 def _task_step_id_from_payload(step: Mapping[str, Any], index: int) -> str:
-    return (
-        str(
-            step.get("id")
-            or step.get("stepId")
-            or step.get("stepRef")
-            or step.get("ref")
-            or ""
-        ).strip()
-        or _default_task_step_id(index)
-    )
+    for key in ("id", "stepId", "stepRef", "ref"):
+        candidate = str(step.get(key) or "").strip()
+        if candidate:
+            return candidate
+    return _default_task_step_id(index)
 
 _ATTACHMENT_REF_KEYS = frozenset(
     {"artifactId", "filename", "contentType", "sizeBytes"}

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -135,6 +135,64 @@ def test_mm641_task_shaped_submission_boundary_exposes_canonical_task_parameters
     ]
     assert task["steps"][0]["jiraOrchestration"] == {"issueKey": "MM-641"}
 
+
+def test_task_shaped_submission_boundary_assigns_step_id_for_step_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client, service = _client()
+    test_client.app.dependency_overrides[get_async_session] = lambda: _artifact_session(
+        [
+            SimpleNamespace(
+                artifact_id="art_01MM641STEPANON00000000",
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=20,
+            )
+        ]
+    )
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "claude_code",
+                    "task": {
+                        "instructions": "Inspect the uploaded screenshot.",
+                        "steps": [
+                            {
+                                "instructions": "Inspect the step screenshot.",
+                                "inputAttachments": [
+                                    {
+                                        "artifactId": "art_01MM641STEPANON00000000",
+                                        "filename": "step.png",
+                                        "contentType": "image/png",
+                                        "sizeBytes": 20,
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["task"]
+    assert task["steps"][0]["id"] == "step-1"
+    assert task["steps"][0]["inputAttachments"] == [
+        {
+            "artifactId": "art_01MM641STEPANON00000000",
+            "filename": "step.png",
+            "contentType": "image/png",
+            "sizeBytes": 20,
+        }
+    ]
+
+
 def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3892,6 +3892,64 @@ def test_create_task_shaped_execution_normalizes_snake_case_input_attachments(
     ]
     assert "input_attachments" not in step_payload
 
+def test_create_task_shaped_execution_uses_nonblank_step_id_fallback(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    execute = AsyncMock(
+        return_value=_ExecuteResult(
+            [
+                SimpleNamespace(
+                    artifact_id="art_01STEPINPUT000000000000",
+                    status=TemporalArtifactStatus.COMPLETE,
+                    content_type="image/png",
+                    size_bytes=20,
+                ),
+            ]
+        )
+    )
+    test_client.app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        execute=execute
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Inspect submitted screenshot.",
+                    "steps": [
+                        {
+                            "id": "   ",
+                            "stepRef": "review-step",
+                            "instructions": "Inspect the step screenshot.",
+                            "inputAttachments": [
+                                {
+                                    "artifactId": "art_01STEPINPUT000000000000",
+                                    "filename": "step.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 20,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["task"]["steps"][0]["id"] == "review-step"
+
 def test_create_task_shaped_execution_preserves_canonical_mm627_task_shape(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3800,6 +3800,7 @@ def test_create_task_shaped_execution_forwards_input_attachments(
             "sizeBytes": 20,
         }
     ]
+    assert initial_parameters["task"]["steps"][0]["id"] == "step-1"
 
 def test_create_task_shaped_execution_normalizes_snake_case_input_attachments(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
@@ -3880,6 +3881,7 @@ def test_create_task_shaped_execution_normalizes_snake_case_input_attachments(
         }
     ]
     step_payload = initial_parameters["task"]["steps"][0]
+    assert step_payload["id"] == "step-1"
     assert step_payload["inputAttachments"] == [
         {
             "artifactId": "art_01STEPINPUT000000000000",


### PR DESCRIPTION
## Summary

- Assign deterministic step ids during task-shaped submission normalization when callers submit step-scoped input attachments without an explicit step id.
- Reuse the resolved step id in input attachment metadata so prepared-input manifests and task snapshots stay traceable.
- Add API and compose-backed integration coverage for anonymous step attachment submissions.

## Root Cause

The failed workflow received task.steps[0].inputAttachments without id, stepRef, or ref. MoonMind.Run correctly rejected that payload before execution because prepared input materialization needs a stable step reference for deterministic workspace paths.

## Validation

- ./tools/test_unit.sh --python-only
- ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py -k "input_attachments or canonical_mm627_task_shape"
- docker compose -f docker-compose.test.yaml run --rm pytest bash -lc "pytest tests/integration/temporal/test_task_shaped_submission_normalization.py -q --tb=short"

## Notes

- Full ./tools/test_unit.sh was attempted; Python passed, but the wrapper also ran Vitest and hit an unrelated existing workflow-detail.test.tsx failure looking for live log data.
