### PR TITLE
[codex] Preserve remediation runtime fields

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2548,6 +2548,10 @@ describe('Workflow Detail Entrypoint', () => {
       rawState: 'failed',
       temporalStatus: 'failed',
       repository: 'MoonLadderStudios/MoonMind',
+      targetRuntime: 'claude_code',
+      model: 'claude-opus-4-1-20250805',
+      effort: 'high',
+      profileId: 'claude_anthropic',
       createdAt: '2026-04-22T00:00:00Z',
       updatedAt: '2026-04-22T00:00:01Z',
       actions: { canSetTitle: true },
@@ -2669,6 +2673,14 @@ describe('Workflow Detail Entrypoint', () => {
       expect(remediationCreateCall).toBeTruthy();
       expect(JSON.parse(String(remediationCreateCall?.[1]?.body))).toMatchObject({
         repository: 'MoonLadderStudios/MoonMind',
+        targetRuntime: 'claude_code',
+        profileId: 'claude_anthropic',
+        runtime: {
+          mode: 'claude_code',
+          model: 'claude-opus-4-1-20250805',
+          effort: 'high',
+          profileId: 'claude_anthropic',
+        },
         remediation: {
           mode: 'snapshot_then_follow',
           authorityMode: 'approval_gated',

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2671,10 +2671,11 @@ describe('Workflow Detail Entrypoint', () => {
         ([url, init]) => String(url) === '/api/executions/test-123/remediation' && init?.method === 'POST',
       );
       expect(remediationCreateCall).toBeTruthy();
-      expect(JSON.parse(String(remediationCreateCall?.[1]?.body))).toMatchObject({
+      const remediationBody = JSON.parse(String(remediationCreateCall?.[1]?.body));
+      expect(remediationBody).not.toHaveProperty('targetRuntime');
+      expect(remediationBody).not.toHaveProperty('profileId');
+      expect(remediationBody).toMatchObject({
         repository: 'MoonLadderStudios/MoonMind',
-        targetRuntime: 'claude_code',
-        profileId: 'claude_anthropic',
         runtime: {
           mode: 'claude_code',
           model: 'claude-opus-4-1-20250805',

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -609,8 +609,6 @@ function buildRemediationRuntimeRequestFields(
   if (profileId) runtime.profileId = profileId;
 
   return {
-    ...(mode ? { targetRuntime: mode } : {}),
-    ...(profileId ? { profileId } : {}),
     ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
   };
 }

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -589,6 +589,32 @@ const ExecutionDetailSchema = z
   })
   .passthrough();
 
+type ExecutionDetail = z.infer<typeof ExecutionDetailSchema>;
+
+function buildRemediationRuntimeRequestFields(
+  execution: ExecutionDetail | null | undefined,
+): Record<string, unknown> {
+  const mode = detailStringValue(execution?.targetRuntime);
+  const profileId = detailStringValue(execution?.profileId);
+  const model = detailStringValue(
+    execution?.model,
+    execution?.resolvedModel,
+    execution?.requestedModel,
+  );
+  const effort = detailStringValue(execution?.effort);
+  const runtime: Record<string, string> = {};
+  if (mode) runtime.mode = mode;
+  if (model) runtime.model = model;
+  if (effort) runtime.effort = effort;
+  if (profileId) runtime.profileId = profileId;
+
+  return {
+    ...(mode ? { targetRuntime: mode } : {}),
+    ...(profileId ? { profileId } : {}),
+    ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
+  };
+}
+
 const RemediationApprovalStateSchema = z
   .object({
     requestId: z.string().nullable().optional(),
@@ -4332,6 +4358,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
         body: JSON.stringify({
           repository: execution?.repository ?? null,
+          ...buildRemediationRuntimeRequestFields(execution),
           instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
           remediation: {
             mode: remediationMode,


### PR DESCRIPTION
## Summary
- carry the target execution runtime/profile/model/effort into remediation task creation from Mission Control
- add regression coverage for remediation requests from a Claude-profile target run

## Root Cause
Workflow mm:4e2eff07-1cea-426d-b1b1-fd348ff992c7 was created without the target run's runtime/profile fields, so the backend defaulted to codex_cli and attempted to use the unauthenticated codex_default profile, producing HTTP 401.

## Validation
- ./tools/test_unit.sh
- npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx -t "renders remediation create action"