### PR TITLE
[codex] Guard deployment desired state persistence

### DIFF
--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -600,13 +600,7 @@ The tool captures and stores:
 
 The before state is written to an immutable artifact.
 
-## 10.4 Persist desired image
-
-The tool writes the desired image reference into the allowlisted deployment env file or equivalent deployment-state store before Compose commands resolve image variables.
-
-The tool must not edit arbitrary files selected by the caller. If a later pull, runner safety check, or service recreation fails, the run records the failed state and command diagnostics.
-
-## 10.5 Pull images
+## 10.4 Pull images and check runner safety
 
 The tool runs the equivalent of:
 
@@ -615,6 +609,21 @@ docker compose pull --policy always --ignore-buildable
 ```
 
 The exact flags are implementation-specific and policy-controlled. Pull output is captured in the command log artifact.
+
+After the target image can be inspected, the privileged worker checks whether
+applying the update would recreate the worker container that is executing the
+operation. If the update is unsafe for the current runner, the run fails before
+mutating persisted desired deployment state.
+
+## 10.5 Persist desired image
+
+The tool writes the desired image reference into the allowlisted deployment env
+file or equivalent deployment-state store after runner safety checks pass and
+before Compose commands resolve image variables for service recreation.
+
+The tool must not edit arbitrary files selected by the caller. If service
+recreation or verification fails after desired state persistence, the run records
+the failed state and command diagnostics.
 
 ## 10.6 Recreate services
 

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -731,7 +731,7 @@ class HostDockerComposeRunner:
         self._ensure_host_project_read_alias()
         resolved = self._compose_command(command)
         env = os.environ.copy()
-        if requested_image and not self.env_file:
+        if requested_image:
             env["MOONMIND_IMAGE"] = requested_image
         process = await asyncio.create_subprocess_exec(
             *resolved,
@@ -953,6 +953,11 @@ class DeploymentUpdateExecutor:
                 _ensure_command_succeeded("pull", pull_result)
                 target_image = await self.runner.inspect_image(requested_image)
                 command_log["targetImage"] = _target_image_audit(target_image)
+                if not resolved_digest:
+                    resolved_digest = _resolved_digest_from_target_image(
+                        repository=str(parsed["image"]["repository"]),
+                        target_image=target_image,
+                    )
                 _ensure_runner_survives_update(
                     command_plan=command_plan,
                     before_state=before_state,
@@ -1226,6 +1231,31 @@ def _target_image_audit(target_image: Mapping[str, Any]) -> dict[str, Any]:
             "repoDigests": target_image.get("RepoDigests"),
         }
     )
+
+
+def _resolved_digest_from_target_image(
+    *, repository: str, target_image: Mapping[str, Any] | None
+) -> str | None:
+    if not target_image:
+        return None
+    repo_digests = target_image.get("RepoDigests")
+    if not isinstance(repo_digests, Sequence) or isinstance(
+        repo_digests, (str, bytes, bytearray)
+    ):
+        return None
+    repository_prefix = f"{repository}@"
+    fallback: str | None = None
+    for raw_digest in repo_digests:
+        digest = str(raw_digest or "").strip()
+        if "@sha256:" not in digest:
+            continue
+        _repo, _separator, digest_value = digest.partition("@")
+        if not digest_value:
+            continue
+        if digest.startswith(repository_prefix):
+            return digest_value
+        fallback = fallback or digest_value
+    return fallback
 
 
 def _runner_already_uses_target_image(

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -942,23 +942,6 @@ class DeploymentUpdateExecutor:
                 before_ref = await write_evidence("before-state", before_state)
 
                 _add_progress(
-                    progress_events,
-                    "PERSISTING_DESIRED_STATE",
-                    "Persisting requested deployment state.",
-                )
-                desired_payload = {
-                    "stack": parsed["stack"],
-                    "imageRepository": parsed["image"]["repository"],
-                    "requestedReference": parsed["image"]["reference"],
-                    "resolvedDigest": resolved_digest,
-                    "reason": parsed["reason"],
-                    "operator": operator or None,
-                    "createdAt": _utc_now(),
-                    "sourceRunId": source_run_id,
-                }
-                await self.desired_state_store.persist(desired_payload)
-
-                _add_progress(
                     progress_events, "PULLING_IMAGES", "Pulling requested images."
                 )
                 pull_result = await self.runner.pull(
@@ -975,6 +958,23 @@ class DeploymentUpdateExecutor:
                     before_state=before_state,
                     target_image=target_image,
                 )
+
+                _add_progress(
+                    progress_events,
+                    "PERSISTING_DESIRED_STATE",
+                    "Persisting requested deployment state.",
+                )
+                desired_payload = {
+                    "stack": parsed["stack"],
+                    "imageRepository": parsed["image"]["repository"],
+                    "requestedReference": parsed["image"]["reference"],
+                    "resolvedDigest": resolved_digest,
+                    "reason": parsed["reason"],
+                    "operator": operator or None,
+                    "createdAt": _utc_now(),
+                    "sourceRunId": source_run_id,
+                }
+                await self.desired_state_store.persist(desired_payload)
 
                 _add_progress(
                     progress_events,

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -58,12 +58,14 @@ class RecordingRunner:
         *,
         verification_succeeded: bool = True,
         verification_status: str | None = None,
+        target_repo_digests: tuple[str, ...] = (),
         block_on_before: bool = False,
     ) -> None:
         self.events = events
         self.commands: list[tuple[str, tuple[str, ...]]] = []
         self.verification_succeeded = verification_succeeded
         self.verification_status = verification_status
+        self.target_repo_digests = target_repo_digests
         self._before_event = None
         self._release_event = None
         if block_on_before:
@@ -108,7 +110,7 @@ class RecordingRunner:
         return {
             "Id": "sha256:" + "b" * 64,
             "RepoTags": [requested_image],
-            "RepoDigests": [],
+            "RepoDigests": list(self.target_repo_digests),
         }
 
     async def verify(
@@ -424,6 +426,34 @@ async def test_lifecycle_persists_desired_state_after_runner_safety_check() -> N
     assert store.records[0]["resolvedDigest"] == "sha256:" + "a" * 64
     assert store.records[0]["reason"] == "Update to the latest tested build"
     assert store.records[0]["sourceRunId"] == "run-123"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_persists_pulled_digest_for_mutable_tag() -> None:
+    events: list[str] = []
+    runner = RecordingRunner(
+        events,
+        target_repo_digests=(
+            "ghcr.io/moonladderstudios/moonmind@sha256:" + "d" * 64,
+        ),
+    )
+    executor, store, _evidence, _runner, _events = _executor(
+        runner=runner, events=events
+    )
+
+    result = await executor.execute(
+        _inputs(
+            image={
+                "repository": "ghcr.io/moonladderstudios/moonmind",
+                "reference": "latest",
+            }
+        )
+    )
+
+    assert result.status == "COMPLETED"
+    assert store.records[0]["requestedReference"] == "latest"
+    assert store.records[0]["resolvedDigest"] == "sha256:" + "d" * 64
+    assert result.outputs["resolvedDigest"] == "sha256:" + "d" * 64
 
 
 @pytest.mark.asyncio
@@ -1336,7 +1366,7 @@ async def test_host_compose_runner_aliases_host_project_path_for_file_reads(
 
 
 @pytest.mark.asyncio
-async def test_host_compose_runner_prefers_compose_env_file_over_process_override(
+async def test_host_compose_runner_sets_requested_image_with_env_file(
     tmp_path, monkeypatch
 ):
     compose = tmp_path / "docker-compose.yaml"
@@ -1376,7 +1406,7 @@ async def test_host_compose_runner_prefers_compose_env_file_over_process_overrid
     )
 
     assert "--env-file" in captured["args"]
-    assert captured["env"].get("MOONMIND_IMAGE") != "example/app:stable"
+    assert captured["env"].get("MOONMIND_IMAGE") == "example/app:stable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -409,14 +409,14 @@ async def test_file_stack_lock_recovers_stale_lock_before_acquire(tmp_path) -> N
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_order_persists_desired_state_before_compose_up() -> None:
+async def test_lifecycle_persists_desired_state_after_runner_safety_check() -> None:
     executor, store, _evidence, _runner, events = _executor()
 
     result = await executor.execute(_inputs(), {"source_run_id": "run-123"})
 
     assert result.status == "COMPLETED"
-    assert events.index("runner:capture:before") < events.index("desired:persist")
-    assert events.index("desired:persist") < events.index("runner:pull")
+    assert events.index("runner:capture:before") < events.index("runner:pull")
+    assert events.index("runner:inspect-image") < events.index("desired:persist")
     assert events.index("desired:persist") < events.index("runner:up")
     assert store.records[0]["stack"] == "moonmind"
     assert store.records[0]["imageRepository"] == "ghcr.io/moonladderstudios/moonmind"
@@ -623,8 +623,11 @@ async def test_command_failures_include_normalized_failure_class(
     assert exc_info.value.details["phase"] == expected_phase
     assert exc_info.value.details["failureClass"] == expected_class
     if expected_phase == "pull":
+        assert store.records == []
+        assert "desired:persist" not in events
+    else:
         assert len(store.records) == 1
-        assert events.index("desired:persist") < events.index("runner:pull")
+        assert events.index("desired:persist") < events.index("runner:up")
 
 
 @pytest.mark.asyncio
@@ -720,8 +723,8 @@ async def test_privileged_worker_fails_before_recreating_its_own_container(
     assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
     assert exc_info.value.details["failureClass"] == "runner_self_recreation_unsafe"
     assert exc_info.value.details["service"] == "temporal-worker-agent-runtime"
-    assert len(store.records) == 1
-    assert events.index("desired:persist") < events.index("runner:pull")
+    assert store.records == []
+    assert "desired:persist" not in events
     assert "runner:pull" in events
     assert "runner:inspect-image" in events
     assert "runner:up" not in events
@@ -752,8 +755,8 @@ async def test_privileged_worker_allows_changed_services_when_worker_image_is_cu
 
     assert result.status == "COMPLETED"
     assert len(store.records) == 1
-    assert events.index("desired:persist") < events.index("runner:pull")
-    assert events.index("runner:inspect-image") < events.index("runner:up")
+    assert events.index("runner:inspect-image") < events.index("desired:persist")
+    assert events.index("desired:persist") < events.index("runner:up")
     assert "runner:up" in events
 
 
@@ -1106,8 +1109,8 @@ async def test_progress_contains_lifecycle_states_without_command_output() -> No
         "VALIDATING",
         "LOCK_WAITING",
         "CAPTURING_BEFORE_STATE",
-        "PERSISTING_DESIRED_STATE",
         "PULLING_IMAGES",
+        "PERSISTING_DESIRED_STATE",
         "RECREATING_SERVICES",
         "VERIFYING",
         "CAPTURING_AFTER_STATE",


### PR DESCRIPTION
## Summary
- Move deployment desired-state persistence until after the target image is pulled, inspected, and the privileged-runner self-recreation guard passes.
- Keep unsafe self-update attempts from mutating the persisted deployment env/json state before failing.
- Update deployment lifecycle docs and unit assertions for the new ordering.

## Root Cause
Workflow `mm:3183518e-d276-4da9-8e87-cb60de95914e` failed with `DEPLOYMENT_RUNNER_UNSAFE` because the deployment update was running inside the worker container that a full-stack update would recreate. The previous lifecycle persisted the requested desired image before that safety failure, leaving durable desired state ahead of an update that could not safely run from that worker.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/skills/test_deployment_update_execution.py`
- `./tools/test_unit.sh`