### PR TITLE
The show filters button turns completely purple with a green border when selected and can no longer be read. It should be readable when highlighted. A

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1083,6 +1083,11 @@ h1 {
   grid-template-columns: minmax(0, 1fr);
 }
 
+.workflow-list-mobile-filter-controls .queue-inline-filter {
+  border-radius: 0.6rem;
+  padding: 0.28rem 0.6rem;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -982,11 +982,12 @@ h1 {
   gap: 0.35rem;
   max-width: 100%;
   border: 1px solid var(--mm-control-border);
-  border-radius: 999px;
+  border-radius: 0.6rem;
   background: var(--mm-control-shell);
   color: rgb(var(--mm-ink));
-  padding: 0.16rem 0.52rem;
+  padding: 0.28rem 0.6rem;
   font-size: 0.78rem;
+  line-height: 1.3;
   box-shadow: inset 0 1px 0 var(--mm-glass-edge);
 }
 
@@ -1064,10 +1065,16 @@ h1 {
 }
 
 .workflow-list-mobile-filter-toggle:hover,
-.workflow-list-mobile-filter-toggle:focus-visible {
+.workflow-list-mobile-filter-toggle:focus-visible,
+.workflow-list-mobile-filter-toggle:active,
+.workflow-list-mobile-filter-toggle[aria-expanded="true"] {
+  background: var(--mm-control-shell-hover);
+  background-image: none;
   border-color: rgb(var(--mm-accent) / 0.7);
-  color: rgb(var(--mm-accent));
+  color: rgb(var(--mm-ink));
   box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
 }
 
 .workflow-list-mobile-filter-controls {


### PR DESCRIPTION
The show filters button turns completely purple with a green border when selected and can no longer be read. It should be readable when highlighted. Additionally, on mobile the filters are ovals where the text seems to spill over the border. The ovals should be updated to avoid this, possibly by switching to rectangles with rounded corners instead of full oval edges.