### PR TITLE
Implement the described work remaining:

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you already have a subscription with a model provider:
 
 ### 🛰️ Bring Your Own Agent — or let MoonMind run one for you
 Other platforms make you rebuild agents in their SDK. MoonMind operates at a higher level of abstraction, orchestrating state-of-the-art agents out of the box.
-- **Managed Sessions and Managed Runs:** MoonMind can run owned CLI runtimes on your own infrastructure using your existing subscriptions or API keys. Codex CLI and Claude Code are first-class task-scoped managed-session runtimes; Gemini CLI remains a managed-runtime target that can adopt the same session pattern where its adapter supports it.
+- **Managed Sessions and Managed Runs:** MoonMind can run owned CLI runtimes on your own infrastructure using your existing subscriptions or API keys. Codex CLI is the live first-class task-scoped managed-session runtime. Claude Code is a first-class managed-runtime target and has Claude-specific session design models, but it does not yet enter the live task-scoped managed-session controller path. Gemini CLI remains a managed-runtime target that can adopt the same session pattern where its adapter supports it.
 - **External Delegated Agents:** Cloud-hosted agents like Jules and Codex Cloud are coordinated through external-agent adapters. MoonMind tracks status, injects context, and closes the feedback loop even when it does not own the provider's runtime envelope.
 - **Sandboxed Execution:** Managed runtime sessions and specialized workload containers run through controlled Docker boundaries with strict capability routing. File allowlists restrict modifications, and credentials are automatically sanitized from logs.
 - **Personal-use friendly defaults:** A fresh local install should boot successfully with `docker compose up -d`, then let you enter a small number of secrets in Mission Control instead of forcing enterprise-only secret infrastructure up front.
@@ -63,7 +63,7 @@ MoonMind runs as a set of decoupled containers from a single `docker-compose.yam
 | **API Service** | FastAPI control plane for Mission Control, `/api/executions`, artifacts, templates, proposals, and MCP/context surfaces. |
 | **Temporal Server** | Durable execution engine with PostgreSQL persistence. |
 | **Worker Fleet** | Specialized isolated workers for orchestration, sandbox execution, LLM calls, managed runtime supervision, and external integrations. |
-| **Managed Session Plane** | Task-scoped owned runtime sessions for Codex CLI and Claude Code. Ordinary managed-session Docker work uses a per-session sidecar daemon rather than the host socket. Additional runtime adapters can adopt the same shared `ManagedSession*` pattern. |
+| **Managed Session Plane** | Task-scoped owned runtime sessions for Codex CLI. Ordinary managed-session Docker work uses a per-session sidecar daemon rather than the host socket. Claude Code and additional runtime adapters can adopt the same shared `ManagedSession*` pattern once they provide a runtime-specific session controller. |
 | **External Agent Adapters** | Provider adapters for delegated external agents such as Jules and Codex Cloud. |
 | **Docker Workload Plane** | Control-plane-launched specialized workload containers for MoonMind admin/update, helper, and deliberately gated exceptional workloads, kept separate from managed agent session identity. |
 | **Mission Control** | Operational dashboard for managing tasks, reviewing per-step progress, and inspecting logs, diagnostics, and artifacts. |

--- a/docs/ManagedAgents/ClaudeCodeManagedSessions.md
+++ b/docs/ManagedAgents/ClaudeCodeManagedSessions.md
@@ -1,6 +1,6 @@
 # Claude Code Managed Sessions
 
-**Status:** Current implementation and desired-state contract
+**Status:** Desired-state contract and domain model notes; not yet a live task-scoped managed-session runtime
 **Audience:** Managed Agents platform, runtime integration, client surfaces, security, and enterprise administration
 **Related:** `docs/ManagedAgents/CodexCliManagedSessions.md`
 
@@ -26,20 +26,20 @@ The Claude Code variant diverges from Codex in a few important ways that must be
 5. **Checkpointing is first-class.** Claude automatically creates rewindable checkpoints around edits and user prompts. That belongs in the plane, not as an afterthought.
 6. **Child work comes in two shapes.** Claude subagents are child contexts inside one session; agent teams are multiple sessions with direct peer communication.
 
-The live MoonMind session-control plane now accepts `runtimeId = "claude_code"` and carries `runtimeFamily = "claude_code"` through `MoonMind.AgentSession`, `ManagedSessionBinding`, launch requests, and session projections. The Claude Code binding keeps the shared Managed Session Plane concepts intact, but changes the runtime adapter, policy compiler, context model, and child-session model to fit Claude Code.
+The live MoonMind session-control plane currently admits Codex CLI only. Claude Code is a live managed-run runtime, and this document describes the Claude Code binding that should eventually join the shared Managed Session Plane once it has a Claude-specific session adapter/controller. That future binding should keep the shared Managed Session Plane concepts intact, but change the runtime adapter, policy compiler, context model, and child-session model to fit Claude Code.
 
 Current live boundaries:
 
-- `MoonMind.Run` starts `MoonMind.AgentSession` for `codex_cli` and `claude_code` managed task steps.
-- `MoonMind.AgentSession` stores compact `ManagedSession*` binding, epoch, runtime handles, request tracking, and continuity refs.
-- `MoonMind.AgentRun` uses the session adapter when `request.managed_session` is present, regardless of whether the binding runtime is Codex CLI or Claude Code.
-- `agent_runtime.launch_session`, `send_turn`, `steer_turn`, `interrupt_turn`, `clear_session`, `terminate_session`, `fetch_session_summary`, and `publish_session_artifacts` use the shared session activity surface and carry the runtime family through the payload.
-- The Docker-backed session controller records Claude Code sessions as `runtimeId = "claude_code"` and preserves runtime-specific profile materialization through Provider Profiles.
+- `MoonMind.Run` starts `MoonMind.AgentSession` for `codex_cli` managed task steps.
+- `MoonMind.AgentSession` stores compact Codex session binding, epoch, runtime handles, request tracking, and continuity refs.
+- `MoonMind.AgentRun` uses the Codex session adapter when `request.managed_session` is present and the managed-session runtime canonicalizes to `codex_cli`.
+- `agent_runtime.launch_session`, `send_turn`, `steer_turn`, `interrupt_turn`, `clear_session`, `terminate_session`, `fetch_session_summary`, and `publish_session_artifacts` use the live Codex session activity surface.
+- The Docker-backed session controller records Codex CLI sessions as `runtimeId = "codex_cli"` and preserves Codex profile materialization through Provider Profiles.
 
 Known implementation gaps versus Codex:
 
-- Claude Code still uses the shared remote-session activity transport; Claude-native checkpoint, policy-dialog, Remote Control, and subagent/team semantics are represented by domain models and documentation but are not yet all exposed as separate live workflow updates.
-- Codex App Server-specific implementation class names remain in a few private adapter/controller modules as compatibility shims. Shared workflow/activity contracts should use `ManagedSession*` names.
+- Claude Code does not yet use the live remote-session activity transport. Claude-native checkpoint, policy-dialog, Remote Control, and subagent/team semantics are represented by domain models and documentation but are not yet exposed as live session workflow updates.
+- Codex App Server-specific implementation class names remain in private adapter/controller modules because the only live task-scoped managed-session transport is Codex-specific. Shared workflow/activity contracts should use `ManagedSession*` names when a second live runtime is added.
 
 ---
 

--- a/docs/ManagedAgents/ManagedAgentArchitecture.md
+++ b/docs/ManagedAgents/ManagedAgentArchitecture.md
@@ -40,7 +40,7 @@ At the system level:
 - **Authentication** is owned by Provider Profiles plus OAuth and secret-resolution subsystems.
 - **Secrets** are provided through references and launch-time materialization, never as raw durable payloads.
 
-Current maturity is **Codex and Claude Code first-class for managed sessions**. Codex CLI and Claude Code are both live task-scoped managed-session runtimes behind the shared `MoonMind.AgentSession` control plane. Gemini CLI remains a managed-runtime strategy and can adopt the session plane by implementing the same shared contracts rather than inventing a new top-level managed-agent abstraction.
+Current maturity is **Codex CLI first-class for managed sessions, with Claude Code first-class for managed runs**. Codex CLI is the live task-scoped managed-session runtime behind the shared `MoonMind.AgentSession` control plane. Claude Code has a live managed-run path and Claude-specific session design models, but it does not yet enter the live managed-session controller. Gemini CLI remains a managed-runtime strategy and can adopt the session plane by implementing the same shared contracts rather than inventing a new top-level managed-agent abstraction.
 
 ---
 
@@ -664,11 +664,11 @@ This distinction is especially important as MoonMind evolves richer build/test/c
 
 ## 11. Current maturity and runtime evolution
 
-### 11.1 Codex and Claude Code are current session runtimes
+### 11.1 Codex is the current live session runtime
 
-Codex CLI and Claude Code are current concrete managed-session implementations.
+Codex CLI is the current concrete managed-session implementation.
 
-The live task-scoped session plane is shared. Runtime-specific details such as Codex App Server protocol, Claude Code policy/context/checkpoint semantics, thread/turn mappings, and session reset mechanics remain documented in runtime-specific docs.
+The live task-scoped session plane is designed for shared workflow/activity contracts, but the current controller and transport are Codex-specific. Runtime-specific details such as Codex App Server protocol, thread/turn mappings, and session reset mechanics remain documented in runtime-specific docs. Claude Code policy/context/checkpoint semantics remain documented as design/domain model work until a Claude session controller is implemented.
 
 ### 11.2 Additional runtimes should extend the same model
 
@@ -684,7 +684,7 @@ The allowed variation is inside runtime-specific planes and capability flags.
 
 ### 11.3 Contract extraction rule
 
-The activity and session contracts are runtime-neutral `ManagedSession*` contracts at the workflow boundary. Codex-prefixed implementation classes may remain where they are private compatibility shims or runtime-specific bindings, but new shared workflow/activity contracts should use `ManagedSession*` names and carry the runtime family explicitly.
+The activity and session contracts should be runtime-neutral `ManagedSession*` contracts at the workflow boundary when additional runtimes are admitted. Today the live path is Codex-only, and Codex-prefixed implementation classes may remain where they are private compatibility shims or runtime-specific bindings. New shared workflow/activity contracts should use `ManagedSession*` names and carry the runtime family explicitly once a non-Codex controller exists.
 
 This document does not block that evolution. It provides the architectural direction that such extraction should serve.
 

--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -84,10 +84,10 @@ volume_mount_path: /home/app/.codex
 
 Claude Code uses the same Provider Profile and explicit mount-target pattern,
 with the runtime profile selecting the Claude auth volume and mount path. The
-session launch payload carries the same `MANAGED_AUTH_VOLUME_PATH` environment
-contract and `runtimeFamily = "claude_code"` so the managed-session controller
-can keep auth material separate from the task workspace while still recording a
-Claude Code session binding.
+managed-run launcher carries the same `MANAGED_AUTH_VOLUME_PATH` environment
+contract so auth material stays separate from the task workspace. A future
+Claude managed-session controller should preserve that separation before
+recording any Claude Code session binding.
 
 That shape describes the credential enrollment and verification home only. It
 does not set `CODEX_HOME` for managed sessions. The managed-session launcher

--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -31,7 +31,7 @@ The core model is:
 - higher layers store and exchange bindings, observations, events, and artifact refs,
 - runtime-native process, thread, container, transcript, and session identifiers remain opaque outside the owning plane.
 
-Codex CLI and Claude Code are the current concrete managed-session bindings. Gemini CLI and future managed runtimes should implement the same shared contract through their own runtime-specific planes.
+Codex CLI is the current concrete managed-session binding. Claude Code has managed-run support and Claude-specific session design models, but it should not be treated as a live managed-session binding until it implements its own runtime-specific session plane. Gemini CLI and future managed runtimes should implement the same shared contract through their own runtime-specific planes before being described as session-capable.
 
 ---
 
@@ -570,7 +570,7 @@ Runtime differences belong in:
 - bounded `runtimeDetails`,
 - runtime-specific docs.
 
-Codex-specific behavior belongs in Codex-managed-session docs. Claude Code, Gemini CLI, and future runtime docs should describe how their planes realize this contract rather than redefining it.
+Codex-specific behavior belongs in Codex-managed-session docs. Claude Code, Gemini CLI, and future runtime docs should describe how their future planes realize this contract rather than redefining it.
 
 ---
 

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -3,16 +3,16 @@
 **Status:** Current architecture and near-term direction
 **Updated:** 2026-05-06
 **Audience:** Contributors, operators, runtime authors, integration authors, and Mission Control developers
-**Purpose:** Top-level architecture for MoonMind's Temporal-native agent orchestration model, including managed runtime runs, Codex CLI and Claude Code managed sessions, external agents, artifacts, provider profiles, and workload containers.
+**Purpose:** Top-level architecture for MoonMind's Temporal-native agent orchestration model, including managed runtime runs, Codex CLI managed sessions, Claude Code managed runs, external agents, artifacts, provider profiles, and workload containers.
 
 MoonMind is an open-source platform for orchestrating leading AI coding agents and automation systems while adding resiliency, safety, context delivery, provider-profile routing, and artifact-first observability.
 
 MoonMind currently has two concrete managed-runtime centers of gravity:
 
 1. **Codex CLI** — a working managed runtime path and first-class task-scoped managed-session runtime.
-2. **Claude Code** — a working managed runtime path and first-class task-scoped managed-session runtime, backed by runtime strategies, provider-profile materialization, OAuth/API-key credential flows, context injection, GitHub auth handling, and managed-run/session supervision.
+2. **Claude Code** — a working managed runtime path backed by runtime strategies, provider-profile materialization, OAuth/API-key credential flows, context injection, GitHub auth handling, and managed-run supervision. Claude-specific session domain models exist, but Claude Code does not yet have a live task-scoped managed-session controller.
 
-`MoonMind.AgentRun` and the managed-runtime launcher support multiple managed CLI runtimes, including `codex_cli`, `claude_code`, and `gemini_cli`. The `claude` and `codex` aliases are normalized to canonical managed runtime IDs where needed. `MoonMind.AgentSession`, `managedSession` bindings, and the turn-level session-control catalog are runtime-neutral for session-capable runtimes; Codex CLI and Claude Code are the current session-capable set.
+`MoonMind.AgentRun` and the managed-runtime launcher support multiple managed CLI runtimes, including `codex_cli`, `claude_code`, and `gemini_cli`. The `claude` and `codex` aliases are normalized to canonical managed runtime IDs where needed. `MoonMind.AgentSession`, `managedSession` bindings, and the turn-level session-control catalog currently describe the live Codex CLI session path; future session-capable runtimes should add their own controller/adapter bindings before being admitted to that path.
 
 This document describes the current architecture and target direction. It separates **managed runtime runs** from **managed sessions** because `gemini_cli` and future runtimes may be managed-run capable before they are session-capable.
 
@@ -193,7 +193,7 @@ Diagram rules:
 | Runtime / integration | Current role | Current maturity | Architecture note |
 |---|---|---|---|
 | `codex_cli` | Managed CLI runtime and task-scoped managed-session runtime | Concrete working managed-run path and concrete `MoonMind.AgentSession` binding | Codex uses the shared session-plane contracts with Codex-specific transport details: session container, turn control, `session_epoch`, thread boundaries, clear/reset artifacts, and Codex App Server transport. |
-| `claude_code` | Managed CLI runtime and task-scoped managed-session runtime | Concrete working managed-run path and concrete `MoonMind.AgentSession` binding | Claude Code uses the shared session-plane contracts with runtime-family `claude_code`, provider-profile materialization, OAuth/API-key paths, MiniMax/Anthropic-compatible profile support, context injection, GitHub auth handling, and runtime-specific launch hardening. |
+| `claude_code` | Managed CLI runtime | Concrete working managed-run path; session design/domain models only | Claude Code uses provider-profile materialization, OAuth/API-key paths, MiniMax/Anthropic-compatible profile support, context injection, GitHub auth handling, and runtime-specific launch hardening. It is not yet admitted to the live `MoonMind.AgentSession` controller path. |
 | `gemini_cli` | Managed CLI runtime | Registered managed-runtime strategy and supported architecture target | Gemini participates in the same strategy/launcher/profile model, but this document's current focus is Codex CLI and Claude Code. |
 | Jules | External delegated agent | Concrete external-agent path | Delegated through integration adapters and canonical `AgentRun` contracts. |
 | Codex Cloud | External delegated agent | Concrete external-agent path | Coordinated through integration activities and canonical result/status contracts. |
@@ -221,7 +221,7 @@ The Temporal Service does not execute MoonMind application code. Workflow and Ac
 The Agent Orchestration Layer spans all true agent execution:
 
 - managed runtime runs launched and supervised by MoonMind
-- Codex CLI and Claude Code task-scoped managed sessions
+- Codex CLI task-scoped managed sessions
 - delegated external agents such as Jules and Codex Cloud
 
 The layer owns canonical contracts, provider-profile coordination, runtime dispatch, artifact publication, policy enforcement, failure classification, and operator-facing lifecycle semantics.
@@ -245,7 +245,7 @@ socket or a shared MoonMind daemon.
 
 **Session control surface** means the MoonMind-launched control surface inside or beside the managed-session container. It is not a Temporal component and is not directly contacted by workflow code. It is reached only by session-control activities such as `agent_runtime.send_turn`, `agent_runtime.steer_turn`, `agent_runtime.interrupt_turn`, `agent_runtime.clear_session`, and `agent_runtime.terminate_session`.
 
-Codex CLI and Claude Code are the current session-capable runtimes. Codex-specific and Claude-specific behavior is isolated behind runtime bindings while workflow/activity contracts use shared `ManagedSession*` envelopes.
+Codex CLI is the current live session-capable runtime. Claude Code has documented session semantics and domain models, but it must add a Claude-specific session adapter/controller before it is described as a live `ManagedSession*` runtime.
 
 ### Provider Profile and Auth Plane
 
@@ -320,7 +320,7 @@ Managed runtime processes, containers, external jobs, OAuth runners, and workloa
 
 A **managed run** is an asynchronously supervised CLI runtime execution. Claude Code and Codex CLI both work on this path today.
 
-A **managed session** is a longer-lived task-scoped runtime container with explicit session identity, turn control, continuity epochs, and clear/reset semantics. Codex CLI and Claude Code are the current concrete implementations of this path.
+A **managed session** is a longer-lived task-scoped runtime container with explicit session identity, turn control, continuity epochs, and clear/reset semantics. Codex CLI is the current concrete implementation of this path; Claude Code is a managed-run runtime with session-specific design models that are not yet wired into the live session controller.
 
 The top-level architecture must not collapse these together.
 
@@ -408,7 +408,7 @@ Long-lived entity workflows such as `MoonMind.AgentSession` and `MoonMind.Provid
 |---|---|
 | `MoonMind.Run` | Current live root workflow implementation for a user Workflow Execution. Owns the workflow envelope, planning, Step ordering, workflow cancellation, Step ledger, and final workflow summary. |
 | `MoonMind.AgentRun` | Child workflow for one true agent execution step. Handles managed, session-backed, and external agents through canonical contracts. |
-| `MoonMind.AgentSession` | Runtime-neutral task-scoped session entity workflow for Codex CLI and Claude Code. Owns compact session orchestration state, turn routing, session epochs, clear/reset metadata, reconciliation hooks, and teardown orchestration. It schedules activities for container and transport side effects. |
+| `MoonMind.AgentSession` | Task-scoped session entity workflow for the live Codex CLI session path. Owns compact session orchestration state, turn routing, session epochs, clear/reset metadata, reconciliation hooks, and teardown orchestration. It schedules activities for container and transport side effects. |
 | `MoonMind.ManagedSessionReconcile` | Bounded reconciliation workflow for managed-session records and container state. |
 | `MoonMind.ProviderProfileManager` | Per-runtime workflow that owns provider-profile slot acquisition, release, cooldown, assignment, lease safety nets, and queue draining. |
 | `MoonMind.OAuthSession` | Interactive auth-session workflow. Orchestrates volume provisioning, auth-runner lifecycle, finalize/cancel/fail signals, verification, profile registration, and cleanup. It does not hold PTY/WebSocket connections directly. |
@@ -432,11 +432,11 @@ For Claude Code, Codex CLI, Gemini CLI, and future managed CLI runtimes:
 11. Final outputs and diagnostics are returned as canonical `AgentRunResult` refs and compact metadata.
 12. Provider-profile slots, GitHub brokers, temporary files, process handles, Docker resources, auth runners, and workspace support files are released or reconciled through idempotent cleanup paths.
 
-This is the path where Codex CLI and Claude Code are concrete today.
+This is the path where Codex CLI is concrete today. Claude Code is concrete on the managed-run path, not the managed-session path.
 
 ### Managed-session shape
 
-For Codex CLI and Claude Code task-scoped sessions:
+For Codex CLI task-scoped sessions:
 
 1. `MoonMind.Run` determines that a step should use the managed-session path.
 2. `MoonMind.Run` ensures the task-scoped `MoonMind.AgentSession` exists.
@@ -474,7 +474,7 @@ Current session-control vocabulary:
 
 All operator or AgentRun-initiated control commands must carry a stable request/control ID. `MoonMind.AgentSession` deduplicates bounded request-tracking state and serializes mutating handlers. Fire-and-forget Signals may be retained for compatibility and notifications, but request/response control paths should use Updates with validation.
 
-These contracts are shared `ManagedSession*` workflow/activity contracts. Codex CLI and Claude Code runtime-specific semantics should remain behind adapter/controller boundaries.
+These contracts are shared `ManagedSession*` workflow/activity contracts for the live Codex CLI session path. Claude Code runtime-specific semantics should remain behind a future Claude adapter/controller boundary before Claude is admitted to this path.
 
 ### Worker affinity and session routing
 
@@ -1025,7 +1025,7 @@ Codex CLI:
 10. Continue-As-New state contract
 11. session-aware Mission Control projections
 
-Claude Code now satisfies this shared session-plane entry requirement through the `ManagedSession*` workflow/activity boundary. New runtimes should meet the same bar before being described as session-capable.
+Claude Code does not yet satisfy this shared session-plane entry requirement through a live controller/adapter boundary. New runtimes should meet the same bar before being described as session-capable.
 
 ### Adding an external agent should require
 
@@ -1045,7 +1045,7 @@ Claude Code now satisfies this shared session-plane entry requirement through th
 MoonMind's current focus is best described as:
 
 - **Codex CLI and Claude Code are both first-class working managed-runtime paths.**
-- **Codex CLI and Claude Code are both first-class managed-session paths.**
+- **Codex CLI is the first-class managed-session path; Claude Code is a first-class managed-run path until a Claude session controller is implemented.**
 - **Provider Profiles are the core runtime/provider/auth/policy abstraction for both.**
 - **`MoonMind.AgentRun` is the shared durable child workflow for true agent execution.**
 - **`MoonMind.AgentSession` remains a valid runtime-neutral Temporal entity workflow, not an Activity, because it owns durable session orchestration and uses Activities for side effects.**
@@ -1087,9 +1087,9 @@ In the current architecture:
 - `MoonMind.Run` remains the current live root workflow implementation for user Workflow Executions.
 - `MoonMind.AgentRun` owns one true agent execution step for managed, session-backed, and external agents.
 - `ManagedRuntimeStrategy`, `ManagedRuntimeLauncher`, `ManagedAgentAdapter`, `ManagedRunSupervisor`, and `ManagedRunStore` are the concrete managed-run path for CLI runtimes such as Claude Code and Codex CLI.
-- `MoonMind.AgentSession` owns the current Codex CLI and Claude Code task-scoped managed-session orchestration path while side effects remain in Agent Runtime activities.
+- `MoonMind.AgentSession` owns the current Codex CLI task-scoped managed-session orchestration path while side effects remain in Agent Runtime activities.
 - Provider Profiles are the durable routing, credential-source, materialization, slot, and cooldown policy boundary.
-- Claude Code is a current working path for many workflows and a peer task-scoped managed-session runtime.
+- Claude Code is a current working managed-run path for many workflows and a candidate for a future peer task-scoped managed-session runtime.
 - Artifacts and observability APIs remain authoritative for execution evidence.
 - External agents and Docker workload containers remain separate execution classes with clear contracts.
 

--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -484,7 +484,7 @@ Worker queue: `mm.activity.agent_runtime`
 
 The session-oriented activities are remote-session contracts. They must delegate through a session controller or adapter boundary and must not fall back to the worker-local managed runtime launcher/process loop.
 
-The session-oriented activity surface is runtime-neutral at the workflow boundary. Codex CLI and Claude Code both enter through `ManagedSession*` request and response envelopes; runtime-specific protocol details remain behind the session adapter/controller boundary. The current container transport uses the Codex App Server-compatible remote-session protocol for the Codex binding, while Claude Code carries `runtimeFamily = "claude_code"` through the same control surface and records `runtimeId = "claude_code"` in session state and projections.
+The session-oriented activity surface is intended to become runtime-neutral at the workflow boundary, but the live activity/controller path currently admits Codex CLI only. Runtime-specific protocol details remain behind the session adapter/controller boundary. The current container transport uses the Codex App Server-compatible remote-session protocol for the Codex binding. Claude Code must add a Claude-specific session adapter/controller before carrying `runtimeFamily = "claude_code"` or recording `runtimeId = "claude_code"` through this activity surface.
 
 `agent_runtime.prepare_turn_instructions` is replay-visible when scheduled by
 `MoonMind.AgentRun`. Moving it before or after session launch/status activities,

--- a/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
@@ -116,7 +116,7 @@ Rules:
 | `MoonMind.ManifestIngest` | Ingest a manifest artifact, validate, compile to a plan/graph, orchestrate execution, aggregate results | manifest artifact ref, policy params | aggregated outputs, per-node results | seconds → hours |
 | `MoonMind.ProviderProfileManager` | Coordinate provider-profile slot assignment, release, cooldowns, and reconciliation for managed runtimes | runtime/profile coordination inputs | slot assignment, lease state transitions | minutes → long-lived |
 | `MoonMind.AgentRun` | Own the durable lifecycle of one true managed or external agent execution | `AgentExecutionRequest`, refs, runtime metadata | canonical agent result, artifacts, lifecycle outcome | seconds → hours |
-| `MoonMind.AgentSession` | Own one task-scoped managed runtime session container, including launch, turn routing, clear/reset epoch changes, status, summary refs, and teardown | neutral `ManagedSessionWorkflowInput` for session-capable runtimes (`codex_cli`, `claude_code`) | session handle/state, continuity refs, control/reset refs | minutes → hours |
+| `MoonMind.AgentSession` | Own one task-scoped managed runtime session container, including launch, turn routing, clear/reset epoch changes, status, summary refs, and teardown | `ManagedSessionWorkflowInput` for the live session-capable runtime (`codex_cli`) | session handle/state, continuity refs, control/reset refs | minutes → hours |
 | `MoonMind.ManagedSessionReconcile` | Periodically reconcile managed-session supervision records and container state outside any one task step | reconciliation policy and runtime scope | reconciliation summary and cleanup actions | seconds → minutes per run |
 | `MoonMind.OAuthSession` | Manage browser-initiated OAuth or terminal-auth session lifecycle for managed runtimes | session config, runtime/provider context | auth/session status, profile registration side effects | minutes |
 | `MoonMind.MergeAutomation` | Wait for external pull request readiness after a published implementation run, then launch one resolver follow-up run when policy allows | parent run ref, compact pull request ref, optional Jira issue key, merge readiness policy | blocker summary, resolver run ref, terminal gate status | minutes → hours |
@@ -584,7 +584,7 @@ stateDiagram-v2
 
 Key notes:
 
-* this workflow owns one task-scoped managed runtime session for `codex_cli` or `claude_code`
+* this workflow owns one task-scoped managed runtime session for `codex_cli`
 * the workflow carries bounded session identity and refs, not large transcripts or logs
 * turn execution and session controls call `agent_runtime.*` activities on `mm.activity.agent_runtime`
 * clear/reset creates a new `session_epoch` and publishes explicit continuity artifacts

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -53,8 +53,8 @@ ManagedSessionControlAction = Literal[
 ]
 
 ManagedSessionControlMode = Literal["remote_container"]
-ManagedSessionRuntimeFamily = Literal["codex", "claude_code"]
-ManagedSessionRuntimeId = Literal["codex_cli", "claude_code"]
+ManagedSessionRuntimeFamily = Literal["codex"]
+ManagedSessionRuntimeId = Literal["codex_cli"]
 ManagedSessionProtocol = Literal["codex_app_server"]
 ManagedSessionContainerBackend = Literal["docker"]
 ManagedGitHubCredentialSource = Literal["secret_ref", "managed_secret", "environment"]
@@ -798,8 +798,6 @@ def managed_session_runtime_family_for_runtime_id(
     canonical = canonical_managed_session_runtime_id(runtime_id)
     if canonical == "codex_cli":
         return "codex"
-    if canonical == "claude_code":
-        return "claude_code"
     raise ValueError("runtimeId must identify a managed-session runtime")
 
 _ASSISTANT_TEXT_METADATA_KEYS = frozenset({"assistantText", "lastAssistantText"})

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -42,13 +42,9 @@ def test_managed_session_plane_contract_freezes_task_scoped_scope() -> None:
     )
     assert contract.clear_behavior == "new_thread_same_container_new_epoch"
 
-def test_managed_session_plane_contract_supports_claude_code_family() -> None:
-    contract = ManagedSessionPlaneContract(runtime_family="claude_code")
-
-    assert contract.runtime_family == "claude_code"
-    assert contract.protocol == "codex_app_server"
-    assert contract.container_backend == "docker"
-    assert contract.control_actions == MANAGED_SESSION_CONTROL_ACTIONS
+def test_managed_session_plane_contract_rejects_claude_code_until_session_controller_exists() -> None:
+    with pytest.raises(ValidationError, match="Input should be 'codex'"):
+        ManagedSessionPlaneContract(runtime_family="claude_code")
 
 def test_managed_session_runtime_id_canonicalizes_session_capable_runtimes() -> None:
     assert canonical_managed_session_runtime_id("codex") == "codex_cli"
@@ -178,21 +174,19 @@ def test_launch_codex_managed_session_request_freezes_remote_container_defaults(
     assert request.protocol == "codex_app_server"
     assert request.session_epoch == 1
 
-def test_launch_managed_session_request_accepts_claude_code_runtime_family() -> None:
-    request = LaunchCodexManagedSessionRequest(
-        runtimeFamily="claude_code",
-        taskRunId="task-123",
-        sessionId="sess-123",
-        threadId="thread-1",
-        workspacePath="/work/task/repo",
-        sessionWorkspacePath="/work/task/session",
-        artifactSpoolPath="/work/task/artifacts",
-        codexHomePath="/work/task/runtime-home",
-        imageRef="moonmind:latest",
-    )
-
-    assert request.runtime_family == "claude_code"
-    assert request.protocol == "codex_app_server"
+def test_launch_managed_session_request_rejects_claude_code_runtime_family() -> None:
+    with pytest.raises(ValidationError, match="Input should be 'codex'"):
+        LaunchCodexManagedSessionRequest(
+            runtimeFamily="claude_code",
+            taskRunId="task-123",
+            sessionId="sess-123",
+            threadId="thread-1",
+            workspacePath="/work/task/repo",
+            sessionWorkspacePath="/work/task/session",
+            artifactSpoolPath="/work/task/artifacts",
+            codexHomePath="/work/task/runtime-home",
+            imageRef="moonmind:latest",
+        )
 
 def test_mm693_launch_request_serializes_docker_capability_contract() -> None:
     request = LaunchCodexManagedSessionRequest(


### PR DESCRIPTION
Implement the described work remaining:

No. The issue is partially addressed in documentation, but I would not call it fixed.

The repo now claims Codex CLI and Claude Code are first-class task-scoped managed-session runtimes. The README says exactly that, and the architecture doc now says MoonMind.AgentSession, managedSession bindings, and the turn-level session-control catalog are runtime-neutral, with Codex CLI and Claude Code as the current session-capable set.  

But the code still has contradictions that would block Claude Code from actually entering the managed-session path:

The shared schema declares ManagedSessionRuntimeId = Literal["codex_cli", "claude_code"], but canonical_managed_session_runtime_id() only returns codex_cli; claude_code falls through to None. That makes managed_session_runtime_family_for_runtime_id("claude_code") effectively unreachable through the canonical path.  

The unit test locks in that bug/intentional gap: it asserts canonical_managed_session_runtime_id("claude_code") is None, while also testing that a launch request can carry runtimeFamily="claude_code".  

MoonMind.AgentSession was partly renamed to use a ManagedSessionPlaneContract, but it still accepts CodexManagedSessionWorkflowInput, builds CodexManagedSessionBinding, stores Codex request-tracking entries, and returns/uses Codex-shaped locators and payloads.  

MoonMind.AgentRun treats any managed request with managed_session as using the Codex session adapter. It then constructs CodexSessionAdapter, even though the docs now describe a runtime-neutral managed-session surface.  

CodexSessionAdapter has been text-renamed to “session-capable runtimes,” but its type surface is still Codex-shaped, and its start path uses canonical_managed_session_runtime_id(request.agent_id). Since that canonicalizer returns None for claude_code, a Claude Code session-backed run would fail with “only supports managed-session runtimes.”  

The Docker controller is also still materially Codex-specific: it is still DockerCodexManagedSessionController, uses _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime", names containers with mm-codex-session-*, stores session state in .moonmind-codex-session-state.json, and launches the container by running python3 -m moonmind.workflows.temporal.runtime.codex_session_runtime serve.  

So the current state is: the documentation has been updated to say the issue is fixed, but the implementation still appears Codex-session-first with a partial Claude label/path layered on top.

Proposed issue

Title: Finish Claude Code managed-session parity or revert docs to Codex-only session truth

Problem

The repository documentation now states that Codex CLI and Claude Code are both first-class task-scoped managed-session runtimes. However, the live managed-session implementation still blocks or routes session-backed execution through Codex-shaped contracts and runtime code.

Evidence:

* ManagedSessionRuntimeId includes claude_code, but canonical_managed_session_runtime_id() does not canonicalize claude_code, and tests assert that claude_code returns None.  
* MoonMind.AgentSession still uses CodexManagedSessionWorkflowInput, CodexManagedSessionBinding, CodexManagedSessionLocator, and Codex-shaped session payloads.  
* MoonMind.AgentRun selects the Codex session adapter for any managed request with managed_session, regardless of runtime.  
* CodexSessionAdapter is still the session-backed adapter and rejects runtimes not accepted by the canonical managed-session runtime ID function.  
* The Docker session controller still runs codex_session_runtime as the in-container control module.  
* Docs now claim the session-oriented activity surface is runtime-neutral and that Claude Code enters through the same ManagedSession* envelopes, which is ahead of the implementation.  

Expected behavior

MoonMind should have one of two truthful states:

1. Claude Code is truly session-capable.
    claude_code should canonicalize as a managed-session runtime, pass through MoonMind.AgentSession, launch a Claude Code session container/control surface, execute turns, publish summaries/artifacts, and pass unit/integration tests that exercise a real Claude session-backed AgentRun.
2. Claude Code is not yet session-capable.
    Documentation should say Claude Code is a first-class managed runtime/run target, while Codex CLI remains the live first-class task-scoped managed-session runtime.

Required work

* Fix canonical_managed_session_runtime_id() so it either accepts claude / claude_code as claude_code, or intentionally remove claude_code from ManagedSessionRuntimeId until implemented.
* Rename/extract Codex-shaped classes where they are now intended to be neutral:
    * CodexManagedSessionWorkflowInput
    * CodexManagedSessionBinding
    * CodexManagedSessionLocator
    * CodexManagedSessionHandle
    * CodexManagedSessionTurnResponse
    * CodexSessionAdapter
* Add runtime dispatch at the session adapter/controller boundary:
    * Codex CLI → Codex App Server / codex_session_runtime
    * Claude Code → Claude Code session runtime/control strategy
* Remove Codex-only launch assumptions from the shared path, including codexHomePath, _RUNTIME_MODULE = codex_session_runtime, Codex state filenames, and mm-codex-session-* naming where those are meant to apply to Claude Code too.
* Add tests that prove a claude_code request with managed_session can:
    * create CodexManagedSessionWorkflowInput’s neutral replacement or accepted alias,
    * construct a valid MoonMind.AgentSession,
    * choose the correct runtime-family adapter/controller,
    * launch/resume/send/clear/terminate through the session-control activity surface,
    * record runtimeId = "claude_code" for the right reason, not only because runtimeFamily was copied into metadata.
* If the implementation is not ready, revert or qualify docs in:
    * README.md
    * docs/MoonMindArchitecture.md
    * docs/Temporal/ActivityCatalogAndWorkerTopology.md
    * docs/ManagedAgents/ManagedAgentArchitecture.md
    * docs/ManagedAgents/SharedManagedAgentAbstractions.md
    * docs/ManagedAgents/ClaudeCodeManagedSessions.md

Acceptance criteria

* canonical_managed_session_runtime_id("claude_code") == "claude_code" if Claude sessions are supported.
* A session-backed Claude Code AgentExecutionRequest no longer fails the adapter/runtime canonicalization gate.
* The session controller does not hardwire Claude session launches through codex_session_runtime.
* Tests cover both codex_cli and claude_code on the session-capable path.
* Documentation and code agree: either both say Claude Code is session-capable, or both say Claude Code is managed-run-capable but not yet a managed-session runtime.