### PR TITLE
[codex] Fix deployment update targeting and Codex auth seeding

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -462,11 +462,13 @@ class HostDockerComposeRunner:
         services = await self._run_compose_json(("ps", "--format", "json"))
         images = await self._run_compose_json(("images", "--format", "json"))
         configured_services = await self._run_compose_services()
+        configured_service_images = await self._run_compose_config_service_images()
         return {
             "stack": stack,
             "phase": phase,
             "projectName": self.project_name,
             "configuredServices": configured_services,
+            "configuredServiceImages": configured_service_images,
             "services": services,
             "images": images,
             "capturedAt": _utc_now(),
@@ -830,6 +832,53 @@ class HostDockerComposeRunner:
             if line.strip()
         )
 
+    async def _run_compose_config_service_images(self) -> Mapping[str, str]:
+        result = await self._run_compose_command(
+            ("docker", "compose", "config", "--format", "json"),
+            max_stdout_chars=None,
+            max_stderr_chars=2000,
+        )
+        _ensure_command_succeeded("config", result)
+        stdout = str(result.get("stdout") or "")
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Deployment compose config returned invalid JSON.",
+                retryable=False,
+                details={
+                    "phase": "config",
+                    "command": result.get("command"),
+                    "stdout": _tail_text(stdout.encode("utf-8"), max_chars=2000),
+                    "stderr": result.get("stderr"),
+                    "failureClass": "compose_config_validation_failure",
+                },
+            ) from exc
+        if not isinstance(parsed, Mapping):
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Deployment compose config returned an invalid payload.",
+                retryable=False,
+                details={
+                    "phase": "config",
+                    "command": result.get("command"),
+                    "stderr": result.get("stderr"),
+                    "failureClass": "compose_config_validation_failure",
+                },
+            )
+        services = parsed.get("services")
+        if not isinstance(services, Mapping):
+            return {}
+        configured_images: dict[str, str] = {}
+        for service_name, service_config in services.items():
+            if not isinstance(service_config, Mapping):
+                continue
+            image = str(service_config.get("image") or "").strip()
+            if image:
+                configured_images[str(service_name)] = image
+        return configured_images
+
     async def _inspect_image(self, requested_image: str) -> Mapping[str, Any]:
         process = await asyncio.create_subprocess_exec(
             "docker",
@@ -971,6 +1020,7 @@ class DeploymentUpdateExecutor:
                 command_plan = _command_plan_targeting_services(
                     command_plan,
                     before_state=before_state,
+                    requested_repository=str(parsed["image"]["repository"]),
                     excluded_services=self.excluded_services,
                 )
                 command_log["pull"]["command"] = list(command_plan.pull_args)
@@ -1264,23 +1314,35 @@ def _command_plan_targeting_services(
     command_plan: ComposeCommandPlan,
     *,
     before_state: Mapping[str, Any],
+    requested_repository: str,
     excluded_services: Sequence[str],
 ) -> ComposeCommandPlan:
     excluded = _normalized_service_names(excluded_services)
-    if not excluded:
+    target_candidates = _target_service_names_from_state(
+        before_state,
+        requested_repository=requested_repository,
+    )
+    if not target_candidates and not excluded and not isinstance(
+        before_state.get("configuredServiceImages"),
+        Mapping,
+    ):
         return command_plan
     services = tuple(
         service_name
-        for service_name in _target_service_names_from_state(before_state)
+        for service_name in target_candidates
         if not _service_is_excluded(service_name, excluded)
     )
     if not services:
         raise ToolFailure(
             error_code="DEPLOYMENT_RUNNER_UNSAFE",
-            message="Deployment update has no target services after runner exclusion.",
+            message=(
+                "Deployment update has no target services for the requested "
+                "image after applying service exclusions."
+            ),
             retryable=False,
             details={
                 "excludedServices": sorted(excluded),
+                "requestedRepository": requested_repository,
                 "failureClass": "runner_self_recreation_unsafe",
             },
         )
@@ -1291,7 +1353,17 @@ def _command_plan_targeting_services(
     )
 
 
-def _target_service_names_from_state(before_state: Mapping[str, Any]) -> tuple[str, ...]:
+def _target_service_names_from_state(
+    before_state: Mapping[str, Any],
+    *,
+    requested_repository: str,
+) -> tuple[str, ...]:
+    configured_image_targets = _target_service_names_from_configured_images(
+        before_state=before_state,
+        requested_repository=requested_repository,
+    )
+    if configured_image_targets:
+        return configured_image_targets
     names: list[str] = []
     seen: set[str] = set()
     for source in (
@@ -1304,6 +1376,45 @@ def _target_service_names_from_state(before_state: Mapping[str, Any]) -> tuple[s
                 continue
             seen.add(key)
             names.append(name)
+    return tuple(names)
+
+
+def _target_service_names_from_configured_images(
+    *,
+    before_state: Mapping[str, Any],
+    requested_repository: str,
+) -> tuple[str, ...]:
+    requested = str(requested_repository or "").strip().lower()
+    if not requested:
+        return ()
+    configured_images = before_state.get("configuredServiceImages")
+    if not isinstance(configured_images, Mapping):
+        return ()
+    configured_services = _service_names_from_state(
+        before_state.get("configuredServices")
+    )
+    service_order = [
+        *configured_services,
+        *(
+            str(service_name)
+            for service_name in configured_images
+            if str(service_name) not in configured_services
+        ),
+    ]
+    names: list[str] = []
+    seen: set[str] = set()
+    for service_name in service_order:
+        image = str(configured_images.get(service_name) or "").strip()
+        if not image:
+            continue
+        repository, _reference = _split_requested_image(image)
+        if repository.strip().lower() != requested:
+            continue
+        key = service_name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(service_name)
     return tuple(names)
 
 

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -1364,6 +1364,8 @@ def _target_service_names_from_state(
     )
     if configured_image_targets:
         return configured_image_targets
+    if isinstance(before_state.get("configuredServiceImages"), Mapping):
+        return ()
     names: list[str] = []
     seen: set[str] = set()
     for source in (

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -52,7 +52,7 @@ _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = (
     float(DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS)
 )
 _STDOUT_EOF = object()
-_AUTH_SEED_EXCLUDED_NAMES = frozenset({".tmp", "config.toml", "sessions"})
+_AUTH_SEED_EXCLUDED_NAMES = frozenset({".tmp", "config.toml", "sessions", "tmp"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -124,6 +124,11 @@ def test_runtime_launch_session_seeds_auth_volume_and_uses_per_run_codex_home(
     (auth_volume_path / "auth.json").write_text('{"token":"oauth"}', encoding="utf-8")
     (auth_volume_path / "logs_1.sqlite").write_text("runtime log", encoding="utf-8")
     (auth_volume_path / "sessions").mkdir()
+    transient_tmp_dir = auth_volume_path / "tmp" / "arg0" / "codex-helpers"
+    transient_tmp_dir.mkdir(parents=True)
+    (transient_tmp_dir / "apply_patch").symlink_to(
+        transient_tmp_dir / "missing-apply-patch"
+    )
 
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
@@ -142,6 +147,7 @@ def test_runtime_launch_session_seeds_auth_volume_and_uses_per_run_codex_home(
     assert Path(request.codex_home_path, "auth.json").is_file()
     assert not Path(request.codex_home_path, "logs_1.sqlite").exists()
     assert not Path(request.codex_home_path, "sessions").exists()
+    assert not Path(request.codex_home_path, "tmp").exists()
     assert codex_home_record_path.read_text(encoding="utf-8").splitlines()[-1] == str(
         Path(request.codex_home_path)
     )

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -3024,6 +3024,11 @@ def test_runtime_launch_session_seeds_auth_directories_and_excludes_sessions(
     tmp_dir = auth_volume_path / ".tmp" / "plugins" / ".git" / "objects" / "pack"
     tmp_dir.mkdir(parents=True)
     (tmp_dir / "pack-readonly.pack").write_text("plugin cache", encoding="utf-8")
+    transient_tmp_dir = auth_volume_path / "tmp" / "arg0" / "codex-helpers"
+    transient_tmp_dir.mkdir(parents=True)
+    (transient_tmp_dir / "apply_patch").symlink_to(
+        transient_tmp_dir / "missing-apply-patch"
+    )
     symlink_path = auth_volume_path / "linked-auth.json"
     symlink_path.symlink_to(auth_volume_path / "auth.json")
 
@@ -3045,6 +3050,7 @@ def test_runtime_launch_session_seeds_auth_directories_and_excludes_sessions(
     assert Path(request.codex_home_path, "accounts", "default.json").is_file()
     assert not Path(request.codex_home_path, "sessions").exists()
     assert not Path(request.codex_home_path, ".tmp").exists()
+    assert not Path(request.codex_home_path, "tmp").exists()
     assert not Path(request.codex_home_path, "linked-auth.json").exists()
 
 def test_runtime_launch_session_auth_seed_overwrites_read_only_files_on_retry(

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -869,6 +869,41 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
     assert "temporal" not in up_command
 
 
+@pytest.mark.asyncio
+async def test_configured_image_mismatch_fails_without_full_stack_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOSTNAME", "deploy123")
+    events: list[str] = []
+    runner = DeploymentControlRunner(events)
+    executor, store, evidence, _runner, _events = _executor(
+        runner=runner,
+        events=events,
+        excluded_services=("temporal-worker-deployment-control",),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(
+            _inputs(
+                image={
+                    "repository": "ghcr.io/moonladderstudios/unknown",
+                    "reference": "latest",
+                }
+            )
+        )
+
+    assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
+    assert exc_info.value.details["requestedRepository"] == (
+        "ghcr.io/moonladderstudios/unknown"
+    )
+    assert store.records == []
+    assert [kind for kind, _payload in evidence.records] == ["command-log"]
+    assert evidence.records[0][1]["error"]["error_code"] == "DEPLOYMENT_RUNNER_UNSAFE"
+    assert runner.commands == []
+    assert "runner:pull" not in events
+    assert "runner:up" not in events
+
+
 def test_service_exclusion_matches_compose_container_names() -> None:
     excluded = {"temporal-worker-deployment-control"}
 

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -201,12 +201,33 @@ class DeploymentControlRunner(RecordingRunner):
             "stack": stack,
             "phase": phase,
             "configuredServices": [
+                "postgres",
+                "docker-proxy",
+                "temporal",
                 "temporal-worker-deployment-control",
                 "temporal-worker-agent-runtime",
+                "init-db",
                 "api",
                 "new-worker",
             ],
+            "configuredServiceImages": {
+                "postgres": "postgres:17",
+                "docker-proxy": "tecnativa/docker-socket-proxy:0.1.1",
+                "temporal": "temporalio/auto-setup:1.29.1",
+                "temporal-worker-deployment-control": (
+                    "ghcr.io/moonladderstudios/moonmind:latest"
+                ),
+                "temporal-worker-agent-runtime": (
+                    "ghcr.io/moonladderstudios/moonmind:latest"
+                ),
+                "init-db": "ghcr.io/moonladderstudios/moonmind:latest",
+                "api": "ghcr.io/moonladderstudios/moonmind:latest",
+                "new-worker": "ghcr.io/moonladderstudios/moonmind:latest",
+            },
             "services": [
+                {"ID": "pg123", "Service": "postgres"},
+                {"ID": "proxy123", "Service": "docker-proxy"},
+                {"ID": "temporal123", "Service": "temporal"},
                 {"ID": "deploy123", "Service": "temporal-worker-deployment-control"},
                 {"ID": "agent456", "Service": "temporal-worker-agent-runtime"},
                 {"ID": "api789", "Service": "api"},
@@ -830,9 +851,22 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
     assert len(store.records) == 1
     pull_command = runner.commands[0][1]
     up_command = runner.commands[1][1]
-    assert pull_command[-3:] == ("temporal-worker-agent-runtime", "api", "new-worker")
-    assert up_command[-3:] == ("temporal-worker-agent-runtime", "api", "new-worker")
+    assert pull_command[-4:] == (
+        "temporal-worker-agent-runtime",
+        "init-db",
+        "api",
+        "new-worker",
+    )
+    assert up_command[-4:] == (
+        "temporal-worker-agent-runtime",
+        "init-db",
+        "api",
+        "new-worker",
+    )
     assert "temporal-worker-deployment-control" not in up_command
+    assert "postgres" not in up_command
+    assert "docker-proxy" not in up_command
+    assert "temporal" not in up_command
 
 
 def test_service_exclusion_matches_compose_container_names() -> None:
@@ -1539,7 +1573,20 @@ async def test_host_compose_runner_parses_full_json_stdout_with_stderr_warning(
         stderr: Any,
     ):
         calls.append(args)
-        if args[-2:] == ("config", "--services"):
+        if args[-3:] == ("config", "--format", "json"):
+            payload = json.dumps(
+                {
+                    "services": {
+                        "api": {
+                            "image": "ghcr.io/moonladderstudios/moonmind:latest"
+                        },
+                        "worker": {
+                            "image": "ghcr.io/moonladderstudios/moonmind:latest"
+                        },
+                    }
+                }
+            )
+        elif args[-2:] == ("config", "--services"):
             payload = "api\nworker\n"
         elif args[-3:] == ("images", "--format", "json"):
             payload = json.dumps(images_record) + "\n"
@@ -1560,7 +1607,11 @@ async def test_host_compose_runner_parses_full_json_stdout_with_stderr_warning(
     assert state["services"] == [large_service_record]
     assert state["images"] == [images_record]
     assert state["configuredServices"] == ("api", "worker")
-    assert len(calls) == 3
+    assert state["configuredServiceImages"] == {
+        "api": "ghcr.io/moonladderstudios/moonmind:latest",
+        "worker": "ghcr.io/moonladderstudios/moonmind:latest",
+    }
+    assert len(calls) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Target deployment update pull/up commands to Compose services that use the requested image repository, while preserving deployment-control self-exclusion.
- Capture configured Compose service images in deployment state so unrelated infrastructure services are not pulled or recreated for MoonMind image updates.
- Skip transient Codex `tmp` auth-home entries when seeding per-run Codex homes, preventing missing helper/cache files from failing managed-session launch.

## Root cause
Deployment updates inferred target services from running/image output, which could include unrelated services or miss configured image intent. The remediation workflow `mm:c57d8293-0b8e-4bb4-8ee5-c4e9444b2f28` then failed before it could continue because Codex OAuth home seeding copied transient `/home/app/.codex/tmp/...` helper paths into the per-run home; those cache files can disappear or contain dangling helper links.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/skills/test_deployment_update_execution.py` passed for Python tests; first run later hit an unrelated flaky frontend live-log assertion.
- Targeted integration: `pytest tests/integration/services/temporal/test_codex_session_runtime.py -m integration_ci --tb=short --timeout 120 --timeout-method=thread` passed in the test compose container.
- `./tools/test_unit.sh` passed: 5492 Python tests, 25 frontend test files.
- `docker compose ps` shows API and all Temporal workers healthy after restoring MinIO from the production compose file.