### PR TITLE
[codex] Fix Codex managed session home env

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -544,12 +544,17 @@ class CodexManagedSessionRuntime:
 
     def _app_server_client(self) -> CodexAppServerRpcClient:
         if self._client is None:
+            codex_home = str(self._codex_home_path)
             self._client = CodexAppServerRpcClient(
                 command=self._app_server_command,
                 client_name="MoonMind",
                 client_version="phase4",
                 cwd=str(self._workspace_path),
-                env={"CODEX_HOME": str(self._codex_home_path)},
+                env={
+                    "CODEX_HOME": codex_home,
+                    "CODEX_CONFIG_HOME": codex_home,
+                    "CODEX_CONFIG_PATH": str(self._codex_home_path / "config.toml"),
+                },
                 notification_timeout_seconds=self._turn_completion_timeout_seconds,
             )
         return self._client

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1997,7 +1997,7 @@ class DockerCodexManagedSessionController:
         session_environment["CODEX_HOME"] = request.codex_home_path
         session_environment["CODEX_CONFIG_HOME"] = request.codex_home_path
         session_environment["CODEX_CONFIG_PATH"] = str(
-            Path(request.codex_home_path) / "config.toml"
+            PurePosixPath(request.codex_home_path) / "config.toml"
         )
         if request.workflow_id:
             session_environment.setdefault(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1994,6 +1994,11 @@ class DockerCodexManagedSessionController:
         await self._ensure_workspace_paths(request)
         session_environment = dict(request.environment)
         session_environment.pop("GITHUB_TOKEN", None)
+        session_environment["CODEX_HOME"] = request.codex_home_path
+        session_environment["CODEX_CONFIG_HOME"] = request.codex_home_path
+        session_environment["CODEX_CONFIG_PATH"] = str(
+            Path(request.codex_home_path) / "config.toml"
+        )
         if request.workflow_id:
             session_environment.setdefault(
                 "MOONMIND_TASK_WORKFLOW_ID",

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -3160,6 +3160,36 @@ def test_runtime_launch_session_rejects_auth_volume_equal_to_codex_home(
     ):
         runtime.launch_session(request)
 
+def test_runtime_launch_session_points_codex_config_env_at_per_run_home(
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    (auth_volume_path / "auth.json").write_text('{"token":"oauth"}', encoding="utf-8")
+
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    runtime.launch_session(request)
+
+    assert runtime._client is not None
+    assert runtime._client._env["CODEX_HOME"] == request.codex_home_path
+    assert runtime._client._env["CODEX_CONFIG_HOME"] == request.codex_home_path
+    assert runtime._client._env["CODEX_CONFIG_PATH"] == str(
+        Path(request.codex_home_path) / "config.toml"
+    )
+
 def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     workspace_path = tmp_path / "repo"
     workspace_path.mkdir()

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4638,9 +4638,12 @@ async def test_controller_launch_mounts_auth_volume_at_separate_managed_auth_pat
     }
     assert run_env["CODEX_HOME"] == request.codex_home_path
     assert run_env["CODEX_CONFIG_HOME"] == request.codex_home_path
+    from pathlib import PurePosixPath
+
     assert run_env["CODEX_CONFIG_PATH"] == str(
-        Path(request.codex_home_path) / "config.toml"
+        PurePosixPath(request.codex_home_path) / "config.toml"
     )
+
 
 @pytest.mark.asyncio
 async def test_controller_launch_normalizes_materialized_codex_home_for_container_user(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4574,7 +4574,12 @@ async def test_controller_launch_mounts_auth_volume_at_separate_managed_auth_pat
         artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
         codexHomePath=str(workspace_root / "task-1" / ".moonmind" / "codex-home"),
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
-        environment={"MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth"},
+        environment={
+            "MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth",
+            "CODEX_HOME": "/home/app/.codex",
+            "CODEX_CONFIG_HOME": "/home/app/.codex",
+            "CODEX_CONFIG_PATH": "/home/app/.codex/config.toml",
+        },
     )
     commands: list[tuple[str, ...]] = []
 
@@ -4625,6 +4630,16 @@ async def test_controller_launch_mounts_auth_volume_at_separate_managed_auth_pat
     assert (
         f"type=volume,src=codex_auth_volume,dst={request.codex_home_path}"
         not in run_command
+    )
+    run_env = {
+        value.split("=", 1)[0]: value.split("=", 1)[1]
+        for index, value in enumerate(run_command)
+        if index > 0 and run_command[index - 1] == "-e" and "=" in value
+    }
+    assert run_env["CODEX_HOME"] == request.codex_home_path
+    assert run_env["CODEX_CONFIG_HOME"] == request.codex_home_path
+    assert run_env["CODEX_CONFIG_PATH"] == str(
+        Path(request.codex_home_path) / "config.toml"
     )
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- force Codex managed-session containers to use the per-run `.moonmind/codex-home` for `CODEX_HOME`, `CODEX_CONFIG_HOME`, and `CODEX_CONFIG_PATH`
- pass the same per-run config environment to the Codex app-server subprocess
- add regression coverage for auth-volume env leakage into managed sessions

## Root cause
A failed workflow showed Codex launch reading transient helper paths from the durable auth volume at `/home/app/.codex/tmp/arg0/...`. Those auth-volume paths can contain short-lived symlinks from a prior Codex process and must not be treated as the live session config home. The managed runtime now keeps the auth volume as a seed source only and pins the live Codex home/config to the run-scoped workspace path.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` (`131 passed`)
- `./tools/test_unit.sh` Python suite passed (`5493 passed, 6 skipped, 1 xpassed`); dashboard/Vitest then failed on unrelated `LiveLogsPanel > keeps panels expanded when operators use their controls` missing `/live log data/`
