### PR TITLE
[codex] Fix Claude Jira skill tool hints

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -57,6 +57,9 @@ from moonmind.workflows.tasks.prepared_context import (
 from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
 )
+from moonmind.workflows.temporal.jira_tool_hints import (
+    append_selected_jira_tool_hint,
+)
 from moonmind.auth.env_shaping import _should_filter_base_env_var
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
@@ -5413,98 +5416,7 @@ class TemporalAgentRuntimeActivities:
         *,
         parameters: Mapping[str, Any] | None,
     ) -> str:
-        params = parameters if isinstance(parameters, Mapping) else {}
-        selected_skill = selected_agent_skill(params)
-        if selected_skill not in JIRA_AGENT_SKILLS:
-            return instructions
-        if "MoonMind trusted Jira tools" in instructions:
-            return instructions
-        tool_lines = [
-            "- Use the internal MoonMind API from the managed session via "
-            "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
-            "credentials in the shell.",
-            "- List available tools with `GET $MOONMIND_URL/mcp/tools`.",
-            "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call`.",
-        ]
-        if selected_skill == "jira-issue-creator":
-            story_breakdown_path = str(params.get("storyBreakdownPath") or "").strip()
-            if story_breakdown_path:
-                tool_lines.insert(
-                    0,
-                    f"- Read MoonSpec story candidates from `{story_breakdown_path}`.",
-                )
-            tool_lines.extend(
-                [
-                    "- Example create-metadata call: "
-                    '`{"tool":"jira.list_create_issue_types",'
-                    '"arguments":{"projectKey":"<PROJECT_KEY>"}}`.',
-                    "- Resolve the Story issue type through "
-                    "`jira.list_create_issue_types` and create issues through "
-                    "`jira.create_issue`.",
-                    "- Treat the task as blocked if Jira tool calls are unavailable "
-                    "or no Jira issue key is returned.",
-                ]
-            )
-        elif selected_skill == "jira-issue-updater":
-            tool_lines.extend(
-                [
-                    "- Fetch the Jira issue through `jira.get_issue` when current "
-                    + "fields or status are needed.",
-                    "- For status changes, call `jira.get_transitions`, match the "
-                    + "target status against transition names or target statuses, "
-                    + "then call `jira.transition_issue` with Jira's returned ID.",
-                    "- Example transitions call: "
-                    + '`{"tool":"jira.get_transitions",'
-                    + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                    + '"expandFields":true}}`.',
-                    "- Example transition call: "
-                    + '`{"tool":"jira.transition_issue",'
-                    + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                    + '"transitionId":"<TRANSITION_ID>"}}`.',
-                    "- Treat the task as blocked if trusted Jira tool calls are "
-                    + "unavailable, the transition is denied, or no matching "
-                    + "transition exists.",
-                ]
-            )
-        elif selected_skill == "jira-pr-verify":
-            tool_lines.extend(
-                [
-                    "- Fetch the Jira issue body through `jira.get_issue` before "
-                    "verifying PR coverage.",
-                    "- Example issue fetch call: "
-                    + '`{"tool":"jira.get_issue",'
-                    + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
-                    "- Treat the task as blocked if trusted Jira tool calls are "
-                    "unavailable or the issue fetch is denied.",
-                ]
-            )
-        else:
-            tool_lines.extend(
-                [
-                    "- Fetch the Jira issue body through `jira.get_issue` before "
-                    "verifying branch coverage.",
-                    "- Example issue fetch call: "
-                    + '`{"tool":"jira.get_issue",'
-                    + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
-                    "- Inspect the current branch against its base, classify the "
-                    "result as PASS, PARTIAL, FAIL, or BLOCKED, and summarize "
-                    "the branch evidence without pasting long private Jira text.",
-                    "- Post the verification result through `jira.add_comment` "
-                    "after scanning the comment body for secrets.",
-                    "- Example comment call: "
-                    + '`{"tool":"jira.add_comment",'
-                    + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                    + '"body":"<COMMENT_TEXT>"}}`.',
-                    "- Treat the task as blocked if trusted Jira tool calls are "
-                    "unavailable, the issue fetch is denied, or comment posting "
-                    "fails.",
-                ]
-            )
-        return (
-            instructions.rstrip()
-            + "\n\nMoonMind trusted Jira tools:\n"
-            + "\n".join(tool_lines)
-        )
+        return append_selected_jira_tool_hint(instructions, parameters=parameters)
 
     async def agent_runtime_send_turn(
         self,

--- a/moonmind/workflows/temporal/jira_tool_hints.py
+++ b/moonmind/workflows/temporal/jira_tool_hints.py
@@ -1,0 +1,110 @@
+"""Managed-runtime prompt hints for MoonMind trusted Jira tools."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from moonmind.workflows.agent_skills.selection import selected_agent_skill
+from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
+
+
+def append_selected_jira_tool_hint(
+    instructions: str,
+    *,
+    parameters: Mapping[str, Any] | None,
+) -> str:
+    """Append trusted Jira tool instructions for Jira-oriented agent skills."""
+
+    params = parameters if isinstance(parameters, Mapping) else {}
+    selected_skill = selected_agent_skill(params)
+    if selected_skill not in JIRA_AGENT_SKILLS:
+        return instructions
+    if "MoonMind trusted Jira tools" in instructions:
+        return instructions
+    tool_lines = [
+        "- Use the internal MoonMind API from the managed session via "
+        "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
+        "credentials in the shell.",
+        "- List available tools with `GET $MOONMIND_URL/mcp/tools`.",
+        "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call`.",
+    ]
+    if selected_skill == "jira-issue-creator":
+        story_breakdown_path = str(params.get("storyBreakdownPath") or "").strip()
+        if story_breakdown_path:
+            tool_lines.insert(
+                0,
+                f"- Read MoonSpec story candidates from `{story_breakdown_path}`.",
+            )
+        tool_lines.extend(
+            [
+                "- Example create-metadata call: "
+                '`{"tool":"jira.list_create_issue_types",'
+                '"arguments":{"projectKey":"<PROJECT_KEY>"}}`.',
+                "- Resolve the Story issue type through "
+                "`jira.list_create_issue_types` and create issues through "
+                "`jira.create_issue`.",
+                "- Treat the task as blocked if Jira tool calls are unavailable "
+                "or no Jira issue key is returned.",
+            ]
+        )
+    elif selected_skill == "jira-issue-updater":
+        tool_lines.extend(
+            [
+                "- Fetch the Jira issue through `jira.get_issue` when current "
+                + "fields or status are needed.",
+                "- For status changes, call `jira.get_transitions`, match the "
+                + "target status against transition names or target statuses, "
+                + "then call `jira.transition_issue` with Jira's returned ID.",
+                "- Example transitions call: "
+                + '`{"tool":"jira.get_transitions",'
+                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
+                + '"expandFields":true}}`.',
+                "- Example transition call: "
+                + '`{"tool":"jira.transition_issue",'
+                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
+                + '"transitionId":"<TRANSITION_ID>"}}`.',
+                "- Treat the task as blocked if trusted Jira tool calls are "
+                + "unavailable, the transition is denied, or no matching "
+                + "transition exists.",
+            ]
+        )
+    elif selected_skill == "jira-pr-verify":
+        tool_lines.extend(
+            [
+                "- Fetch the Jira issue body through `jira.get_issue` before "
+                "verifying PR coverage.",
+                "- Example issue fetch call: "
+                + '`{"tool":"jira.get_issue",'
+                + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
+                "- Treat the task as blocked if trusted Jira tool calls are "
+                "unavailable or the issue fetch is denied.",
+            ]
+        )
+    else:
+        tool_lines.extend(
+            [
+                "- Fetch the Jira issue body through `jira.get_issue` before "
+                "verifying branch coverage.",
+                "- Example issue fetch call: "
+                + '`{"tool":"jira.get_issue",'
+                + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
+                "- Inspect the current branch against its base, classify the "
+                "result as PASS, PARTIAL, FAIL, or BLOCKED, and summarize "
+                "the branch evidence without pasting long private Jira text.",
+                "- Post the verification result through `jira.add_comment` "
+                "after scanning the comment body for secrets.",
+                "- Example comment call: "
+                + '`{"tool":"jira.add_comment",'
+                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
+                + '"body":"<COMMENT_TEXT>"}}`.',
+                "- Treat the task as blocked if trusted Jira tool calls are "
+                "unavailable, the issue fetch is denied, or comment posting "
+                "fails.",
+            ]
+        )
+    return (
+        instructions.rstrip()
+        + "\n\nMoonMind trusted Jira tools:\n"
+        + "\n".join(tool_lines)
+    )

--- a/moonmind/workflows/temporal/jira_tool_hints.py
+++ b/moonmind/workflows/temporal/jira_tool_hints.py
@@ -9,6 +9,90 @@ from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 
 
+_JIRA_API_HINT = (
+    "- Use the internal MoonMind API from the managed session via "
+    "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
+    "credentials in the shell."
+)
+_CREATE_METADATA_CALL_HINT = (
+    "- Example create-metadata call: "
+    '`{"tool":"jira.list_create_issue_types",'
+    '"arguments":{"projectKey":"<PROJECT_KEY>"}}`.'
+)
+_CREATE_ISSUE_TYPE_HINT = (
+    "- Resolve the Story issue type through "
+    "`jira.list_create_issue_types` and create issues through "
+    "`jira.create_issue`."
+)
+_CREATOR_BLOCKED_HINT = (
+    "- Treat the task as blocked if Jira tool calls are unavailable "
+    "or no Jira issue key is returned."
+)
+_UPDATER_FETCH_HINT = (
+    "- Fetch the Jira issue through `jira.get_issue` when current "
+    "fields or status are needed."
+)
+_UPDATER_TRANSITIONS_HINT = (
+    "- For status changes, call `jira.get_transitions`, match the "
+    "target status against transition names or target statuses, "
+    "then call `jira.transition_issue` with Jira's returned ID."
+)
+_TRANSITIONS_CALL_HINT = (
+    "- Example transitions call: "
+    '`{"tool":"jira.get_transitions",'
+    '"arguments":{"issueKey":"<ISSUE_KEY>",'
+    '"expandFields":true}}`.'
+)
+_TRANSITION_CALL_HINT = (
+    "- Example transition call: "
+    '`{"tool":"jira.transition_issue",'
+    '"arguments":{"issueKey":"<ISSUE_KEY>",'
+    '"transitionId":"<TRANSITION_ID>"}}`.'
+)
+_UPDATER_BLOCKED_HINT = (
+    "- Treat the task as blocked if trusted Jira tool calls are "
+    "unavailable, the transition is denied, or no matching "
+    "transition exists."
+)
+_PR_VERIFY_FETCH_HINT = (
+    "- Fetch the Jira issue body through `jira.get_issue` before "
+    "verifying PR coverage."
+)
+_ISSUE_FETCH_CALL_HINT = (
+    "- Example issue fetch call: "
+    '`{"tool":"jira.get_issue",'
+    '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.'
+)
+_PR_VERIFY_BLOCKED_HINT = (
+    "- Treat the task as blocked if trusted Jira tool calls are "
+    "unavailable or the issue fetch is denied."
+)
+_BRANCH_VERIFY_FETCH_HINT = (
+    "- Fetch the Jira issue body through `jira.get_issue` before "
+    "verifying branch coverage."
+)
+_BRANCH_VERIFY_CLASSIFY_HINT = (
+    "- Inspect the current branch against its base, classify the "
+    "result as PASS, PARTIAL, FAIL, or BLOCKED, and summarize "
+    "the branch evidence without pasting long private Jira text."
+)
+_BRANCH_VERIFY_COMMENT_HINT = (
+    "- Post the verification result through `jira.add_comment` "
+    "after scanning the comment body for secrets."
+)
+_COMMENT_CALL_HINT = (
+    "- Example comment call: "
+    '`{"tool":"jira.add_comment",'
+    '"arguments":{"issueKey":"<ISSUE_KEY>",'
+    '"body":"<COMMENT_TEXT>"}}`.'
+)
+_BRANCH_VERIFY_BLOCKED_HINT = (
+    "- Treat the task as blocked if trusted Jira tool calls are "
+    "unavailable, the issue fetch is denied, or comment posting "
+    "fails."
+)
+
+
 def append_selected_jira_tool_hint(
     instructions: str,
     *,
@@ -23,9 +107,7 @@ def append_selected_jira_tool_hint(
     if "MoonMind trusted Jira tools" in instructions:
         return instructions
     tool_lines = [
-        "- Use the internal MoonMind API from the managed session via "
-        "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
-        "credentials in the shell.",
+        _JIRA_API_HINT,
         "- List available tools with `GET $MOONMIND_URL/mcp/tools`.",
         "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call`.",
     ]
@@ -38,69 +120,38 @@ def append_selected_jira_tool_hint(
             )
         tool_lines.extend(
             [
-                "- Example create-metadata call: "
-                '`{"tool":"jira.list_create_issue_types",'
-                '"arguments":{"projectKey":"<PROJECT_KEY>"}}`.',
-                "- Resolve the Story issue type through "
-                "`jira.list_create_issue_types` and create issues through "
-                "`jira.create_issue`.",
-                "- Treat the task as blocked if Jira tool calls are unavailable "
-                "or no Jira issue key is returned.",
+                _CREATE_METADATA_CALL_HINT,
+                _CREATE_ISSUE_TYPE_HINT,
+                _CREATOR_BLOCKED_HINT,
             ]
         )
     elif selected_skill == "jira-issue-updater":
         tool_lines.extend(
             [
-                "- Fetch the Jira issue through `jira.get_issue` when current "
-                + "fields or status are needed.",
-                "- For status changes, call `jira.get_transitions`, match the "
-                + "target status against transition names or target statuses, "
-                + "then call `jira.transition_issue` with Jira's returned ID.",
-                "- Example transitions call: "
-                + '`{"tool":"jira.get_transitions",'
-                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                + '"expandFields":true}}`.',
-                "- Example transition call: "
-                + '`{"tool":"jira.transition_issue",'
-                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                + '"transitionId":"<TRANSITION_ID>"}}`.',
-                "- Treat the task as blocked if trusted Jira tool calls are "
-                + "unavailable, the transition is denied, or no matching "
-                + "transition exists.",
+                _UPDATER_FETCH_HINT,
+                _UPDATER_TRANSITIONS_HINT,
+                _TRANSITIONS_CALL_HINT,
+                _TRANSITION_CALL_HINT,
+                _UPDATER_BLOCKED_HINT,
             ]
         )
     elif selected_skill == "jira-pr-verify":
         tool_lines.extend(
             [
-                "- Fetch the Jira issue body through `jira.get_issue` before "
-                "verifying PR coverage.",
-                "- Example issue fetch call: "
-                + '`{"tool":"jira.get_issue",'
-                + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
-                "- Treat the task as blocked if trusted Jira tool calls are "
-                "unavailable or the issue fetch is denied.",
+                _PR_VERIFY_FETCH_HINT,
+                _ISSUE_FETCH_CALL_HINT,
+                _PR_VERIFY_BLOCKED_HINT,
             ]
         )
     else:
         tool_lines.extend(
             [
-                "- Fetch the Jira issue body through `jira.get_issue` before "
-                "verifying branch coverage.",
-                "- Example issue fetch call: "
-                + '`{"tool":"jira.get_issue",'
-                + '"arguments":{"issueKey":"<ISSUE_KEY>"}}`.',
-                "- Inspect the current branch against its base, classify the "
-                "result as PASS, PARTIAL, FAIL, or BLOCKED, and summarize "
-                "the branch evidence without pasting long private Jira text.",
-                "- Post the verification result through `jira.add_comment` "
-                "after scanning the comment body for secrets.",
-                "- Example comment call: "
-                + '`{"tool":"jira.add_comment",'
-                + '"arguments":{"issueKey":"<ISSUE_KEY>",'
-                + '"body":"<COMMENT_TEXT>"}}`.',
-                "- Treat the task as blocked if trusted Jira tool calls are "
-                "unavailable, the issue fetch is denied, or comment posting "
-                "fails.",
+                _BRANCH_VERIFY_FETCH_HINT,
+                _ISSUE_FETCH_CALL_HINT,
+                _BRANCH_VERIFY_CLASSIFY_HINT,
+                _BRANCH_VERIFY_COMMENT_HINT,
+                _COMMENT_CALL_HINT,
+                _BRANCH_VERIFY_BLOCKED_HINT,
             ]
         )
     return (

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -28,6 +28,9 @@ from moonmind.workflows.skills.run_projection import (
     prepend_skill_activation_summary,
     verify_skill_projection,
 )
+from moonmind.workflows.temporal.jira_tool_hints import (
+    append_selected_jira_tool_hint,
+)
 
 from .github_auth_broker import GitHubAuthBrokerManager
 from .git_auth import build_github_token_git_environment
@@ -1108,6 +1111,10 @@ class ManagedRuntimeLauncher:
                     request=request,
                     strategy=strategy,
                 )
+            request.instruction_ref = append_selected_jira_tool_hint(
+                str(request.instruction_ref or ""),
+                parameters=request.parameters,
+            )
 
             cmd = self.build_command(profile, request, strategy=strategy)
             self._reset_live_log_spool(resolved_workspace_path)

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -857,7 +857,11 @@ class ManagedRuntimeLauncher:
         if result.status in {"failed", "unsupported"}:
             reason = result.failure_reason or "runtime_command_render_failed"
             raise RuntimeError(reason)
-        if result.rendered_instruction is not None:
+        if result.rendered_instruction is not None and (
+            result.rendered_instruction
+            or request.instruction_ref is not None
+            or request.runtime_command is not None
+        ):
             request.instruction_ref = result.rendered_instruction
 
     async def _project_run_skill_snapshot(
@@ -1111,10 +1115,12 @@ class ManagedRuntimeLauncher:
                     request=request,
                     strategy=strategy,
                 )
-            request.instruction_ref = append_selected_jira_tool_hint(
-                str(request.instruction_ref or ""),
+            hinted_instruction_ref = append_selected_jira_tool_hint(
+                request.instruction_ref or "",
                 parameters=request.parameters,
             )
+            if hinted_instruction_ref:
+                request.instruction_ref = hinted_instruction_ref
 
             cmd = self.build_command(profile, request, strategy=strategy)
             self._reset_live_log_spool(resolved_workspace_path)

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2869,6 +2869,87 @@ async def test_launch_projects_resolved_skill_snapshot_for_claude_code(
 
 
 @pytest.mark.asyncio
+async def test_launch_adds_trusted_jira_tool_hint_for_claude_jira_skill(
+    tmp_path, monkeypatch
+):
+    """Claude Code direct launches must receive the trusted Jira tool surface hint."""
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    snapshot_payload, skill_payloads = _build_skill_snapshot_artifact(
+        "snap-jira-1", ["jira-issue-creator"]
+    )
+    artifact_service = _SkillArtifactService(
+        {"resolved-set-jira": snapshot_payload, **skill_payloads}
+    )
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store, artifact_service=artifact_service)
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(
+        instruction_ref="Create THOR stories.",
+        resolved_skillset_ref="resolved-set-jira",
+        parameters={
+            "selectedSkill": "jira-issue-creator",
+            "storyBreakdownPath": "artifacts/story-breakdowns/demo/stories.json",
+        },
+    )
+    workspace = tmp_path / "workspaces" / "run-jira" / "repo"
+    workspace.mkdir(parents=True)
+
+    captured_args: tuple[object, ...] = ()
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4244
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    _record, process, _cleanup, _deferred = await launcher.launch(
+        run_id="run-jira",
+        request=request,
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    prompt_args = [arg for arg in captured_args if isinstance(arg, str)]
+    assert any("Active MoonMind skill snapshot:" in arg for arg in prompt_args)
+    assert any("Selected skill: jira-issue-creator" in arg for arg in prompt_args)
+    assert any("MoonMind trusted Jira tools:" in arg for arg in prompt_args)
+    assert any("POST $MOONMIND_URL/mcp/tools/call" in arg for arg in prompt_args)
+    assert any("jira.create_issue" in arg for arg in prompt_args)
+    assert any(
+        "artifacts/story-breakdowns/demo/stories.json" in arg for arg in prompt_args
+    )
+
+
+@pytest.mark.asyncio
 async def test_launch_skips_skill_projection_when_no_snapshot_ref(tmp_path, monkeypatch):
     """Without ``resolved_skillset_ref`` the launcher leaves instruction_ref alone."""
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2950,6 +2950,64 @@ async def test_launch_adds_trusted_jira_tool_hint_for_claude_jira_skill(
 
 
 @pytest.mark.asyncio
+async def test_launch_preserves_missing_instruction_ref_without_jira_skill(
+    tmp_path, monkeypatch
+):
+    """Non-Jira launches should not normalize a missing instruction ref to blank."""
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(
+        store, artifact_service=_SkillArtifactService({})
+    )
+
+    profile = _make_profile(
+        runtime_id="claude_code", command_template=["claude", "-p"]
+    )
+    request = _make_request(instruction_ref=None, parameters={})
+    workspace = tmp_path / "workspaces" / "run-no-jira" / "repo"
+    workspace.mkdir(parents=True)
+
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4245
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    _record, process, _cleanup, _deferred = await launcher.launch(
+        run_id="run-no-jira",
+        request=request,
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    assert request.instruction_ref is None
+
+
+@pytest.mark.asyncio
 async def test_launch_skips_skill_projection_when_no_snapshot_ref(tmp_path, monkeypatch):
     """Without ``resolved_skillset_ref`` the launcher leaves instruction_ref alone."""
 


### PR DESCRIPTION
## Summary
- add a shared trusted Jira tool hint builder for managed runtime prompts
- reuse the helper in the existing Codex turn-preparation path
- append the same trusted Jira tool instructions before direct Claude Code launches build their command
- add a launcher regression test proving a selected `jira-issue-creator` skill reaches Claude Code with the MoonMind MCP Jira tool instructions

## Root Cause
Jira skills projected correctly for direct Claude Code runs, but only Codex managed-session turn preparation received the trusted MoonMind Jira tool prompt. Claude Code therefore fell back to its own Atlassian connector and could see the wrong Jira site.

## Verification
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py -q`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -q`
- `./tools/test_unit.sh`
