### PR TITLE
[codex] Defer managed session launch until slot admission

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -18,6 +18,11 @@ with workflow.unsafe.imports_passed_through():
         ProfileSelector,
         _MAX_SUMMARY_CHARS,
     )
+    from moonmind.schemas.managed_session_models import (
+        CodexManagedSessionBinding,
+        CodexManagedSessionWorkflowInput,
+        canonical_managed_session_runtime_id,
+    )
     from moonmind.schemas.temporal_activity_models import (
         AgentRuntimeCancelInput,
         AgentRuntimeFetchResultInput,
@@ -42,6 +47,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.temporal.activity_catalog import (
         TemporalActivityRoute,
+        WORKFLOW_TASK_QUEUE,
         build_default_activity_catalog,
     )
     from moonmind.workflows.temporal.runtime.store import ManagedRunStore
@@ -139,6 +145,9 @@ SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
 )
 PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID = (
     "agent-run-pin-provider-profile-before-slot-request-v1"
+)
+MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
+    "agent-run-managed-session-start-after-slot-v1"
 )
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
@@ -786,6 +795,136 @@ class MoonMindAgentRun:
     @staticmethod
     def _uses_codex_session_adapter(request: AgentExecutionRequest) -> bool:
         return request.agent_kind == "managed" and request.managed_session is not None
+
+    @staticmethod
+    def _deferred_managed_session_intent(
+        request: AgentExecutionRequest,
+    ) -> dict[str, Any] | None:
+        parameters = (
+            request.parameters if isinstance(request.parameters, Mapping) else {}
+        )
+        metadata = parameters.get("metadata")
+        metadata_map = metadata if isinstance(metadata, Mapping) else {}
+        moonmind = metadata_map.get("moonmind")
+        moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+        raw_intent = moonmind_map.get("deferManagedSessionUntilSlot")
+        if raw_intent is True:
+            return {}
+        if isinstance(raw_intent, Mapping):
+            return dict(raw_intent)
+        return None
+
+    @staticmethod
+    def _managed_session_runtime_id(
+        request: AgentExecutionRequest,
+    ) -> str | None:
+        if request.agent_kind != "managed":
+            return None
+        return canonical_managed_session_runtime_id(request.agent_id)
+
+    @staticmethod
+    def _task_scoped_session_workflow_id(
+        *,
+        task_workflow_id: str,
+        runtime_id: str,
+    ) -> str:
+        return f"{task_workflow_id}:session:{runtime_id}"
+
+    @staticmethod
+    def _task_scoped_session_visibility(
+        *,
+        binding: CodexManagedSessionBinding,
+    ) -> dict[str, Any]:
+        return {
+            "TaskRunId": [binding.task_run_id],
+            "RuntimeId": [binding.runtime_id],
+            "SessionId": [binding.session_id],
+            "SessionEpoch": [binding.session_epoch],
+            "SessionStatus": ["active"],
+            "IsDegraded": [False],
+        }
+
+    @staticmethod
+    def _task_scoped_session_static_details(
+        *,
+        binding: CodexManagedSessionBinding,
+    ) -> str:
+        return (
+            "Task-scoped managed runtime session | "
+            f"taskRunId={binding.task_run_id} | "
+            f"runtime={binding.runtime_id} | "
+            f"session={binding.session_id} | "
+            f"epoch={binding.session_epoch}"
+        )
+
+    async def _bind_deferred_task_scoped_session_after_slot(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        runtime_id: str,
+        parent_info: Any,
+    ) -> AgentExecutionRequest:
+        if request.managed_session is not None:
+            return request
+        if not workflow.patched(MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID):
+            return request
+        intent = self._deferred_managed_session_intent(request)
+        if intent is None:
+            return request
+        session_runtime_id = self._managed_session_runtime_id(request)
+        if session_runtime_id is None:
+            return request
+        if session_runtime_id != runtime_id:
+            raise ApplicationError(
+                "Deferred managed session runtime does not match assigned runtime",
+                type="ManagedSessionRuntimeMismatch",
+                non_retryable=True,
+            )
+
+        task_workflow_id = str(intent.get("taskRunId") or "").strip()
+        if not task_workflow_id and parent_info is not None:
+            task_workflow_id = str(parent_info.workflow_id or "").strip()
+        if not task_workflow_id:
+            task_workflow_id = workflow.info().workflow_id
+
+        session_input = CodexManagedSessionWorkflowInput(
+            taskRunId=task_workflow_id,
+            runtimeId=session_runtime_id,
+            executionProfileRef=request.execution_profile_ref,
+        )
+        session_workflow_id = self._task_scoped_session_workflow_id(
+            task_workflow_id=task_workflow_id,
+            runtime_id=session_runtime_id,
+        )
+        binding = CodexManagedSessionBinding.from_input(
+            workflow_id=session_workflow_id,
+            session_input=session_input,
+        )
+        await workflow.start_child_workflow(
+            "MoonMind.AgentSession",
+            session_input,
+            id=session_workflow_id,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+            search_attributes=self._task_scoped_session_visibility(binding=binding),
+            static_summary="Task-scoped managed runtime session",
+            static_details=self._task_scoped_session_static_details(binding=binding),
+        )
+
+        if parent_info is not None:
+            parent_handle = workflow.get_external_workflow_handle(
+                parent_info.workflow_id,
+                run_id=parent_info.run_id,
+            )
+            await parent_handle.signal(
+                "managed_session_bound",
+                {
+                    "binding": binding.model_dump(mode="json", by_alias=True),
+                    "child_workflow_id": workflow.info().workflow_id,
+                    "runtime_id": runtime_id,
+                },
+            )
+        return request.model_copy(update={"managed_session": binding})
 
     @staticmethod
     def _request_workspace_starting_branch(
@@ -1911,6 +2050,15 @@ class MoonMindAgentRun:
                                     "runtime_id": runtime_id,
                                 },
                             )
+
+                    request = await self._bind_deferred_task_scoped_session_after_slot(
+                        request=request,
+                        runtime_id=runtime_id,
+                        parent_info=parent_info,
+                    )
+                    uses_codex_session_adapter = self._uses_codex_session_adapter(
+                        request
+                    )
 
                     # Wire ManagedAgentAdapter with real DI callables.
                     # The slot_requester / slot_releaser / cooldown_reporter

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -267,6 +267,9 @@ RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
+RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
+    "run-defer-task-scoped-session-until-slot-v1"
+)
 RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
@@ -5460,6 +5463,34 @@ class MoonMindRunWorkflow:
     async def _maybe_bind_task_scoped_session(
         self, request: AgentExecutionRequest
     ) -> AgentExecutionRequest:
+        if workflow.patched(RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH):
+            runtime_id = self._managed_session_runtime_id(request)
+            if runtime_id is None:
+                return request
+            if self._codex_session_binding is not None:
+                return request.model_copy(
+                    update={"managed_session": self._codex_session_binding}
+                )
+
+            parameters = dict(request.parameters or {})
+            metadata = (
+                dict(parameters.get("metadata"))
+                if isinstance(parameters.get("metadata"), Mapping)
+                else {}
+            )
+            moonmind_metadata = (
+                dict(metadata.get("moonmind"))
+                if isinstance(metadata.get("moonmind"), Mapping)
+                else {}
+            )
+            moonmind_metadata["deferManagedSessionUntilSlot"] = {
+                "runtimeId": runtime_id,
+                "taskRunId": workflow.info().workflow_id,
+            }
+            metadata["moonmind"] = moonmind_metadata
+            parameters["metadata"] = metadata
+            return request.model_copy(update={"parameters": parameters})
+
         binding = await self._ensure_task_scoped_codex_session(request)
         if binding is None:
             return request
@@ -9276,6 +9307,27 @@ class MoonMindRunWorkflow:
             "Child workflow %s assigned profile %s",
             self._assigned_child_workflow_id,
             self._assigned_profile_id,
+        )
+
+    @workflow.signal
+    def managed_session_bound(self, payload: dict) -> None:
+        """Record a task-scoped managed session started after slot admission."""
+
+        binding_payload = payload.get("binding") if isinstance(payload, dict) else None
+        if not isinstance(binding_payload, Mapping):
+            return
+        try:
+            binding = CodexManagedSessionBinding.model_validate(binding_payload)
+        except Exception as exc:
+            self._get_logger().warning(
+                "Ignoring invalid managed_session_bound payload",
+                extra={"error": str(exc)},
+            )
+            return
+        self._codex_session_binding = binding
+        self._get_logger().debug(
+            "Task-scoped managed session bound: %s",
+            binding.session_id,
         )
 
     @workflow.signal(name="DependencyResolved")

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -466,6 +466,203 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
         "agent_runtime.publish_artifacts",
     ]
 
+async def test_agent_run_starts_deferred_codex_session_only_after_slot_assignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_info = type(
+        "ParentInfo",
+        (),
+        {"workflow_id": "wf-task-1", "run_id": "parent-run-1"},
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-agent-run-1",
+            "run_id": "run-1",
+            "search_attributes": {},
+            "parent": parent_info,
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", _patch_all_enabled)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+
+    run = MoonMindAgentRun()
+    order: list[str] = []
+    parent_signals: list[tuple[str, Any]] = []
+    session_starts: list[tuple[str, Any, dict[str, Any]]] = []
+    session_adapter_requests: list[AgentExecutionRequest] = []
+
+    class _FakeParentHandle:
+        async def signal(
+            self, signal_name: str, payload: Any = None, **kwargs: Any
+        ) -> None:
+            parent_signals.append(
+                (signal_name, payload if payload is not None else kwargs.get("args"))
+            )
+
+    class _FakeSessionHandle:
+        async def signal(self, _signal_name: str, _payload: Any = None) -> None:
+            return None
+
+    async def fake_start_child_workflow(
+        workflow_name: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> _FakeSessionHandle:
+        order.append("start_session")
+        session_starts.append((workflow_name, payload, kwargs))
+        return _FakeSessionHandle()
+
+    class _FakeManagerHandle:
+        async def signal(self, _signal_name: str, _payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        if request_slot:
+            order.append("request_slot")
+            run._assigned_profile_id = execution_profile_ref or "codex-default"
+            run.slot_assigned_event.set()
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_id: str,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not run for deferred session intent"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            order.append("adapter_start")
+            session_adapter_requests.append(request)
+            return AgentRunHandle(
+                runId="managed-session-run-1",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Session-backed Codex step completed.", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeParentHandle(),
+    )
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "start_child_workflow",
+        fake_start_child_workflow,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "CodexSessionAdapter",
+        _FakeCodexSessionAdapter,
+    )
+    monkeypatch.setattr(
+        run,
+        "_ensure_manager_and_signal",
+        fake_ensure_manager_and_signal,
+    )
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId="corr-managed-deferred-1",
+        idempotencyKey="idem-managed-deferred-1",
+        instructionRef="artifact:instructions",
+        parameters={
+            "publishMode": "none",
+            "metadata": {
+                "moonmind": {
+                    "deferManagedSessionUntilSlot": {
+                        "runtimeId": "codex_cli",
+                        "taskRunId": "wf-task-1",
+                    }
+                }
+            },
+        },
+        workspaceSpec={},
+    )
+
+    result = await run.run(request)
+
+    assert order[:3] == ["request_slot", "start_session", "adapter_start"]
+    assert len(session_starts) == 1
+    workflow_name, session_input, kwargs = session_starts[0]
+    assert workflow_name == "MoonMind.AgentSession"
+    assert kwargs["id"] == "wf-task-1:session:codex_cli"
+    assert (
+        kwargs["parent_close_policy"]
+        == agent_run_module.workflow.ParentClosePolicy.ABANDON
+    )
+    assert session_input.task_run_id == "wf-task-1"
+    assert session_input.runtime_id == "codex_cli"
+    assert session_adapter_requests[0].managed_session is not None
+    assert session_adapter_requests[0].managed_session.session_id == (
+        "sess:wf-task-1:codex_cli"
+    )
+    assert (
+        "managed_session_bound",
+        {
+            "binding": session_adapter_requests[0].managed_session.model_dump(
+                mode="json",
+                by_alias=True,
+            ),
+            "child_workflow_id": "wf-agent-run-1",
+            "runtime_id": "codex_cli",
+        },
+    ) in parent_signals
+    assert result.summary == "Session-backed Codex step completed."
+
 async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -8,6 +8,7 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
@@ -32,6 +33,7 @@ def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(run_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_module.workflow, "logger", logger)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
 
 def _managed_request(agent_id: str = "codex") -> AgentExecutionRequest:
     return AgentExecutionRequest(
@@ -50,60 +52,55 @@ def _use_external_handle(monkeypatch: pytest.MonkeyPatch, handle: Any) -> None:
     )
 
 @pytest.mark.asyncio
-async def test_run_starts_one_task_scoped_codex_session_and_reuses_it(
+async def test_run_defers_task_scoped_codex_session_until_slot_when_unbound(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
-    start_calls: list[tuple[str, Any, str, str, dict[str, Any]]] = []
-
-    class _FakeHandle:
-        async def signal(self, _signal_name: str, _payload: Any = None) -> None:
-            return None
-
-    async def fake_start_child_workflow(
-        workflow_name: str,
-        payload: Any,
-        *,
-        id: str,
-        task_queue: str,
-        **kwargs: Any,
-    ) -> _FakeHandle:
-        start_calls.append((workflow_name, payload, id, task_queue, kwargs))
-        return _FakeHandle()
-
     monkeypatch.setattr(
         run_module.workflow,
-        "start_child_workflow",
-        fake_start_child_workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH,
+    )
+
+    async def fake_start_child_workflow(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("parent must not start AgentSession before slot admission")
+
+    monkeypatch.setattr(run_module.workflow, "start_child_workflow", fake_start_child_workflow)
+
+    request = await workflow._maybe_bind_task_scoped_session(_managed_request("codex"))
+
+    assert request.managed_session is None
+    assert request.parameters["metadata"]["moonmind"][
+        "deferManagedSessionUntilSlot"
+    ] == {
+        "runtimeId": "codex_cli",
+        "taskRunId": "wf-run-1",
+    }
+
+@pytest.mark.asyncio
+async def test_run_reuses_existing_task_scoped_codex_session_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH,
+    )
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
     )
 
     first = await workflow._maybe_bind_task_scoped_session(_managed_request("codex"))
-    second = await workflow._maybe_bind_task_scoped_session(
-        _managed_request("codex_cli")
-    )
+    second = await workflow._maybe_bind_task_scoped_session(_managed_request("codex_cli"))
 
-    assert len(start_calls) == 1
-    workflow_name, payload, workflow_id, task_queue, kwargs = start_calls[0]
-    assert workflow_name == "MoonMind.AgentSession"
-    assert workflow_id == "wf-run-1:session:codex_cli"
-    assert task_queue == run_module.WORKFLOW_TASK_QUEUE
-    assert payload.task_run_id == "wf-run-1"
-    assert payload.runtime_id == "codex_cli"
-    assert payload.execution_profile_ref == "codex-default"
-    assert kwargs["static_summary"] == "Task-scoped managed runtime session"
-    assert kwargs["static_details"] == (
-        "Task-scoped managed runtime session | taskRunId=wf-run-1 | "
-        "runtime=codex_cli | session=sess:wf-run-1:codex_cli | epoch=1"
-    )
-    assert kwargs["search_attributes"] == {
-        "TaskRunId": ["wf-run-1"],
-        "RuntimeId": ["codex_cli"],
-        "SessionId": ["sess:wf-run-1:codex_cli"],
-        "SessionEpoch": [1],
-        "SessionStatus": ["active"],
-        "IsDegraded": [False],
-    }
     assert first.managed_session is not None
     assert second.managed_session is not None
     assert first.managed_session == second.managed_session


### PR DESCRIPTION
## Summary
- stop MoonMind.Run from starting task-scoped Codex AgentSession workflows before provider slot admission
- have MoonMind.AgentRun start and bind the task-scoped session only after slot_assigned
- add workflow boundary tests for the no-pre-slot-container ordering and session reuse

## Why
Queued or awaiting-slot managed runs should remain cheap Temporal state. They should not allocate Codex session containers until provider capacity has actually been granted.

## Validation
- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
- ./tools/test_unit.sh