### PR TITLE
When batch-pr-resolver is called using Claude Code, the child pr-resolver workflows seem to be queuing with Codex. They should use Claude Code as well

### DIFF
--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -398,22 +398,35 @@ def _resolve_runtime_selection(args: argparse.Namespace) -> RuntimeSelection:
     configured_default_mode = _normalize_runtime_mode(
         os.getenv("MOONMIND_DEFAULT_TASK_RUNTIME")
     )
-    runtime_mode = _normalize_runtime_mode(args.runtime_mode) or (
-        inherited.mode if inherited else configured_default_mode
-    )
-    runtime_model = _runtime_text(args.runtime_model)
-    runtime_effort = _runtime_text(args.runtime_effort)
-    runtime_provider_profile = _runtime_text(
-        getattr(args, "runtime_provider_profile", None)
-    )
     runtime_execution_profile_ref = _runtime_text(
         os.getenv("MOONMIND_EXECUTION_PROFILE_REF")
     )
     runtime_execution_profile_runtime = _runtime_text(
         os.getenv("MOONMIND_EXECUTION_PROFILE_RUNTIME")
     )
-    if runtime_mode is None and runtime_execution_profile_ref:
-        runtime_mode = _normalize_runtime_mode(runtime_execution_profile_runtime)
+    # Resolution order, most to least specific: explicit args, the parent
+    # runtime copied from task_context.json, the caller's own execution
+    # profile (the runtime this skill is currently executing under), and
+    # finally the generic system default. The execution profile must beat
+    # MOONMIND_DEFAULT_TASK_RUNTIME: when batch-pr-resolver runs under Claude
+    # Code the default is still codex_cli, so preferring it would queue the
+    # children on Codex instead of inheriting the caller's Claude Code runtime.
+    execution_profile_mode = (
+        _normalize_runtime_mode(runtime_execution_profile_runtime)
+        if runtime_execution_profile_ref
+        else None
+    )
+    runtime_mode = (
+        _normalize_runtime_mode(args.runtime_mode)
+        or (inherited.mode if inherited else None)
+        or execution_profile_mode
+        or configured_default_mode
+    )
+    runtime_model = _runtime_text(args.runtime_model)
+    runtime_effort = _runtime_text(args.runtime_effort)
+    runtime_provider_profile = _runtime_text(
+        getattr(args, "runtime_provider_profile", None)
+    )
     if runtime_model is None and inherited is not None:
         runtime_model = inherited.model
     if runtime_effort is None and inherited is not None:

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -432,6 +432,35 @@ def test_resolve_runtime_selection_uses_execution_profile_env(
     assert runtime.mode == "codex_cli"
     assert runtime.provider_profile == "codex_default"
 
+def test_resolve_runtime_selection_prefers_execution_profile_over_default(
+    monkeypatch: Any,
+) -> None:
+    module = _load_module()
+    resolve_runtime_selection = module["_resolve_runtime_selection"]
+
+    # The caller runs under Claude Code (execution profile) while the system
+    # default task runtime is still codex_cli. The child must inherit the
+    # caller's Claude Code runtime/profile, not fall back to the codex default.
+    monkeypatch.setenv("MOONMIND_DEFAULT_TASK_RUNTIME", "codex_cli")
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_REF", "claude_anthropic")
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_RUNTIME", "claude_code")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "task_context_path": None,
+            "runtime_mode": None,
+            "runtime_model": None,
+            "runtime_effort": None,
+            "runtime_provider_profile": None,
+        },
+    )()
+
+    runtime = resolve_runtime_selection(args)
+    assert runtime.mode == "claude_code"
+    assert runtime.provider_profile == "claude_anthropic"
+
 def test_resolve_runtime_selection_ignores_env_profile_for_other_runtime(
     monkeypatch: Any,
 ) -> None:
@@ -515,6 +544,8 @@ def test_resolve_runtime_selection_uses_default_runtime_env(monkeypatch: Any):
     resolve_runtime_selection = module["_resolve_runtime_selection"]
 
     monkeypatch.setenv("MOONMIND_DEFAULT_TASK_RUNTIME", "claude")
+    monkeypatch.delenv("MOONMIND_EXECUTION_PROFILE_REF", raising=False)
+    monkeypatch.delenv("MOONMIND_EXECUTION_PROFILE_RUNTIME", raising=False)
 
     args = type(
         "Args",


### PR DESCRIPTION
When batch-pr-resolver is called using Claude Code, the child pr-resolver workflows seem to be queuing with Codex. They should use Claude Code as well and the same provider profile. I thought this was already fixed once, but it seems to have gone awry again.