### PR TITLE
MM-741 Generalize external-agent adapter pattern

### DIFF
--- a/docs/ExternalAgents/AddingExternalProvider.md
+++ b/docs/ExternalAgents/AddingExternalProvider.md
@@ -522,16 +522,20 @@ For a normal polling or callback provider using:
 
 This is the preferred provider integration path.
 
-## 12.2 Streaming gateway exception
+## 12.2 Streaming gateway provider path
 
-If the provider uses a one-shot streaming gateway execution style, workflow changes may still be required unless the runtime has already been generalized for `integration.<provider>.execute`.
+For a one-shot streaming gateway provider using:
 
-Today, that path is not yet fully generalized for arbitrary new providers.
+* `integration.<provider>.execute`
 
-So the accurate guidance is:
+`MoonMind.AgentRun` should not require provider-specific workflow changes once:
 
-* **standard polling/callback providers:** no workflow changes expected
-* **new streaming-gateway providers:** expect runtime generalization work unless the workflow has first been extended to support generic `integration.<provider>.execute`
+* the adapter is registered with `execution_style="streaming_gateway"`
+* the execute activity type is in the catalog
+* the execute activity handler is deployed
+
+The workflow resolves the adapter metadata, validates the provider id, and then
+routes to `integration.<provider>.execute` dynamically.
 
 ---
 

--- a/docs/ExternalAgents/AddingExternalProvider.md
+++ b/docs/ExternalAgents/AddingExternalProvider.md
@@ -92,18 +92,21 @@ Use this for most new providers.
 
 ## 3.2 Streaming gateway provider
 
-This is a special-case path for providers that execute through one long-running activity and directly produce a terminal result.
+This path is for providers that execute through one long-running activity and directly produce a terminal result.
 
-Current example:
+Activity shape:
+
+- `integration.<provider>.execute`
+
+Current provider example:
 
 - `integration.openclaw.execute`
 
-At the moment, MoonMind’s workflow path is still specialized for this style rather than fully generalized for arbitrary `integration.<provider>.execute` activity names.
-
-That means:
-
-- new providers should strongly prefer the standard polling/callback pattern
-- adding a second streaming-gateway-style provider may require runtime generalization work in `MoonMind.AgentRun` before the provider is truly plug-and-play
+`MoonMind.AgentRun` selects this path from adapter metadata and invokes
+`integration.<provider>.execute` using the validated provider id. A new
+streaming-gateway provider still needs its adapter registration, activity
+implementation, catalog entry, and worker binding, but it does not require a
+provider-specific workflow branch.
 
 ---
 
@@ -428,6 +431,30 @@ If the provider supports additional operations, you may add narrowly scoped prov
 These are provider-specific extensions, not part of the core required lifecycle set.
 
 Only add them when the provider’s product semantics actually need them.
+
+## 9.3 Streaming gateway activity
+
+For a streaming-gateway provider, add one activity instead of the polling
+lifecycle set:
+
+```python id="81378"
+from temporalio import activity
+
+from moonmind.schemas.agent_runtime_models import (
+ AgentExecutionRequest,
+ AgentRunResult,
+)
+
+@activity.defn(name="integration.<provider>.execute")
+async def provider_execute_activity(
+ request: AgentExecutionRequest,
+) -> AgentRunResult:
+ ...
+```
+
+The activity must return a canonical `AgentRunResult`. Provider-native stream
+chunks, usage records, trace identifiers, and URLs belong in `metadata` or
+artifact refs, not provider-shaped top-level fields.
 
 ---
 

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -62,7 +62,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [x] **2.1** Jules end-to-end external event workflow — Spec 048/066, adapter exists, event wiring complete
 - [x] **2.2** Remove External Runs tab — External runs integrated into main dashboard
 - [ ] **2.3** Codex Cloud integration adapter — No adapter yet for the hosted Codex product
-- [ ] **2.4** Generic external-agent adapter pattern — Designed in `ExternalAgentIntegrationSystem.md`, not generalized in code
+- [x] **2.4** Generic external-agent adapter pattern — MM-741; shared adapter contract, registry-based provider selection, polling and streaming-gateway execution styles
 
 ---
 

--- a/moonmind/workflows/temporal/typed_execution.py
+++ b/moonmind/workflows/temporal/typed_execution.py
@@ -247,7 +247,8 @@ async def execute_external_start_activity(
 ) -> AgentRunHandle:
     """Execute any provider start activity that returns ``AgentRunHandle``."""
 
-    return await execute_typed_activity(activity, arg, **kwargs)
+    result = await execute_typed_activity(activity, arg, **kwargs)
+    return AgentRunHandle(**result) if isinstance(result, dict) else result
 
 
 async def execute_external_status_activity(
@@ -257,7 +258,8 @@ async def execute_external_status_activity(
 ) -> AgentRunStatus:
     """Execute any provider status activity that returns ``AgentRunStatus``."""
 
-    return await execute_typed_activity(activity, arg, **kwargs)
+    result = await execute_typed_activity(activity, arg, **kwargs)
+    return AgentRunStatus(**result) if isinstance(result, dict) else result
 
 
 async def execute_external_fetch_result_activity(
@@ -267,7 +269,8 @@ async def execute_external_fetch_result_activity(
 ) -> AgentRunResult:
     """Execute any provider fetch activity that returns ``AgentRunResult``."""
 
-    return await execute_typed_activity(activity, arg, **kwargs)
+    result = await execute_typed_activity(activity, arg, **kwargs)
+    return AgentRunResult(**result) if isinstance(result, dict) else result
 
 
 async def execute_external_cancel_activity(
@@ -277,7 +280,8 @@ async def execute_external_cancel_activity(
 ) -> AgentRunStatus:
     """Execute any provider cancel activity that returns ``AgentRunStatus``."""
 
-    return await execute_typed_activity(activity, arg, **kwargs)
+    result = await execute_typed_activity(activity, arg, **kwargs)
+    return AgentRunStatus(**result) if isinstance(result, dict) else result
 
 
 async def execute_external_streaming_activity(
@@ -287,4 +291,5 @@ async def execute_external_streaming_activity(
 ) -> AgentRunResult:
     """Execute any streaming-gateway provider activity returning ``AgentRunResult``."""
 
-    return await execute_typed_activity(activity, arg, **kwargs)
+    result = await execute_typed_activity(activity, arg, **kwargs)
+    return AgentRunResult(**result) if isinstance(result, dict) else result

--- a/moonmind/workflows/temporal/typed_execution.py
+++ b/moonmind/workflows/temporal/typed_execution.py
@@ -72,6 +72,21 @@ async def execute_typed_activity(
 
 @overload
 async def execute_typed_activity(
+    activity: Literal["integration.openclaw.execute"],
+    arg: AgentExecutionRequest,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunResult:
+    pass
+
+@overload
+async def execute_typed_activity(
     activity: Literal["integration.jules.start", "integration.codex_cloud.start"],
     arg: AgentExecutionRequest,
     *,
@@ -223,3 +238,53 @@ async def execute_typed_activity(
     filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     return await workflow.execute_activity(activity, arg, **filtered_kwargs)
+
+
+async def execute_external_start_activity(
+    activity: str,
+    arg: AgentExecutionRequest,
+    **kwargs: Any,
+) -> AgentRunHandle:
+    """Execute any provider start activity that returns ``AgentRunHandle``."""
+
+    return await execute_typed_activity(activity, arg, **kwargs)
+
+
+async def execute_external_status_activity(
+    activity: str,
+    arg: ExternalAgentRunInput,
+    **kwargs: Any,
+) -> AgentRunStatus:
+    """Execute any provider status activity that returns ``AgentRunStatus``."""
+
+    return await execute_typed_activity(activity, arg, **kwargs)
+
+
+async def execute_external_fetch_result_activity(
+    activity: str,
+    arg: ExternalAgentRunInput,
+    **kwargs: Any,
+) -> AgentRunResult:
+    """Execute any provider fetch activity that returns ``AgentRunResult``."""
+
+    return await execute_typed_activity(activity, arg, **kwargs)
+
+
+async def execute_external_cancel_activity(
+    activity: str,
+    arg: ExternalAgentRunInput,
+    **kwargs: Any,
+) -> AgentRunStatus:
+    """Execute any provider cancel activity that returns ``AgentRunStatus``."""
+
+    return await execute_typed_activity(activity, arg, **kwargs)
+
+
+async def execute_external_streaming_activity(
+    activity: str,
+    arg: AgentExecutionRequest,
+    **kwargs: Any,
+) -> AgentRunResult:
+    """Execute any streaming-gateway provider activity returning ``AgentRunResult``."""
+
+    return await execute_typed_activity(activity, arg, **kwargs)

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2212,9 +2212,12 @@ class MoonMindAgentRun:
                             max(int(timeout_seconds), 60),
                             86400,
                         )
+                        act_name = f"integration.{validated_id}.execute"
                         result_payload = await self._execute_routed_activity(
-                            "integration.openclaw.execute",
+                            act_name,
                             request,
+                            start_to_close_timeout=timedelta(seconds=stc_seconds),
+                            schedule_to_close_timeout=timedelta(seconds=stc_seconds),
                             heartbeat_timeout=STREAMING_EXTERNAL_HEARTBEAT_TIMEOUT,
                             cancellation_type=ActivityCancellationType.TRY_CANCEL,
                         )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -270,11 +270,12 @@ async def resolve_adapter_metadata(agent_id: str) -> dict:
     raises if no adapter is registered for *agent_id*.
     """
     registry = build_default_registry()
-    adapter = registry.create(agent_id)
+    resolved_agent_id = str(agent_id).strip().lower()
+    adapter = registry.create(resolved_agent_id)
     execution_style = "polling"
     if isinstance(adapter, BaseExternalAgentAdapter):
         execution_style = adapter.provider_capability.execution_style
-    return {"agent_id": agent_id, "execution_style": execution_style}
+    return {"agent_id": resolved_agent_id, "execution_style": execution_style}
 
 # --- In-flight compatibility shims (spec #285) ---
 # These activities were superseded by resolve_adapter_metadata but must remain

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -14,7 +14,11 @@ from moonmind.schemas.temporal_activity_models import (
     ExternalAgentRunInput,
 )
 from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
-from moonmind.workflows.temporal.typed_execution import execute_typed_activity
+from moonmind.workflows.temporal import typed_execution as typed_execution_module
+from moonmind.workflows.temporal.typed_execution import (
+    execute_external_status_activity,
+    execute_typed_activity,
+)
 
 def test_external_agent_run_input_rejects_unknown_fields() -> None:
     with pytest.raises(ValidationError):
@@ -50,6 +54,46 @@ def test_agent_runtime_fetch_result_input_normalizes_parent_and_fetch_fields() -
     assert request.commit_message == "Use typed payloads"
     assert request.target_branch == "main"
     assert request.head_branch is None
+
+@pytest.mark.asyncio
+async def test_external_lifecycle_helper_accepts_provider_neutral_activity_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    async def fake_execute_typed_activity(
+        activity: str,
+        arg: object,
+        **_kwargs: object,
+    ) -> AgentRunStatus:
+        calls.append((activity, arg))
+        assert isinstance(arg, ExternalAgentRunInput)
+        return AgentRunStatus(
+            runId=arg.run_id,
+            agentKind="external",
+            agentId="future_provider",
+            status="running",
+        )
+
+    monkeypatch.setattr(
+        typed_execution_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+
+    result = await execute_external_status_activity(
+        "integration.future_provider.status",
+        ExternalAgentRunInput(runId="future-run-1"),
+    )
+
+    assert calls == [
+        (
+            "integration.future_provider.status",
+            ExternalAgentRunInput(runId="future-run-1"),
+        )
+    ]
+    assert result.agent_id == "future_provider"
+    assert result.status == "running"
 
 @activity.defn(name="typed.boundary.status")
 async def _typed_status_activity(request: ExternalAgentRunInput) -> AgentRunStatus:

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -8,7 +9,12 @@ from temporalio import activity, workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from moonmind.schemas.agent_runtime_models import AgentRunStatus
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
 from moonmind.schemas.temporal_activity_models import (
     AgentRuntimeFetchResultInput,
     ExternalAgentRunInput,
@@ -16,7 +22,11 @@ from moonmind.schemas.temporal_activity_models import (
 from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
 from moonmind.workflows.temporal import typed_execution as typed_execution_module
 from moonmind.workflows.temporal.typed_execution import (
+    execute_external_cancel_activity,
+    execute_external_fetch_result_activity,
+    execute_external_start_activity,
     execute_external_status_activity,
+    execute_external_streaming_activity,
     execute_typed_activity,
 )
 
@@ -65,15 +75,15 @@ async def test_external_lifecycle_helper_accepts_provider_neutral_activity_name(
         activity: str,
         arg: object,
         **_kwargs: object,
-    ) -> AgentRunStatus:
+    ) -> dict[str, object]:
         calls.append((activity, arg))
         assert isinstance(arg, ExternalAgentRunInput)
-        return AgentRunStatus(
-            runId=arg.run_id,
-            agentKind="external",
-            agentId="future_provider",
-            status="running",
-        )
+        return {
+            "runId": arg.run_id,
+            "agentKind": "external",
+            "agentId": "future_provider",
+            "status": "running",
+        }
 
     monkeypatch.setattr(
         typed_execution_module,
@@ -94,6 +104,86 @@ async def test_external_lifecycle_helper_accepts_provider_neutral_activity_name(
     ]
     assert result.agent_id == "future_provider"
     assert result.status == "running"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("helper", "arg", "payload", "expected_type"),
+    [
+        (
+            execute_external_start_activity,
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="future_provider",
+                correlationId="corr-1",
+                idempotencyKey="idem-1",
+                instructionRef="Run it",
+                workspaceSpec={},
+            ),
+            {
+                "runId": "future-run-1",
+                "agentKind": "external",
+                "agentId": "future_provider",
+                "status": "running",
+                "startedAt": datetime(2026, 1, 1, tzinfo=UTC),
+            },
+            AgentRunHandle,
+        ),
+        (
+            execute_external_cancel_activity,
+            ExternalAgentRunInput(runId="future-run-1"),
+            {
+                "runId": "future-run-1",
+                "agentKind": "external",
+                "agentId": "future_provider",
+                "status": "canceled",
+            },
+            AgentRunStatus,
+        ),
+        (
+            execute_external_fetch_result_activity,
+            ExternalAgentRunInput(runId="future-run-1"),
+            {"summary": "done", "metadata": {"provider": "future_provider"}},
+            AgentRunResult,
+        ),
+        (
+            execute_external_streaming_activity,
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="future_provider",
+                correlationId="corr-1",
+                idempotencyKey="idem-1",
+                instructionRef="Run it",
+                workspaceSpec={},
+            ),
+            {"summary": "streamed", "metadata": {"provider": "future_provider"}},
+            AgentRunResult,
+        ),
+    ],
+)
+async def test_external_lifecycle_helpers_convert_raw_dict_results(
+    monkeypatch: pytest.MonkeyPatch,
+    helper: Any,
+    arg: object,
+    payload: dict[str, object],
+    expected_type: type[object],
+) -> None:
+    async def fake_execute_typed_activity(
+        _activity: str,
+        _arg: object,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        return payload
+
+    monkeypatch.setattr(
+        typed_execution_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+
+    result = await helper("integration.future_provider.execute", arg)
+
+    assert isinstance(result, expected_type)
 
 @activity.defn(name="typed.boundary.status")
 async def _typed_status_activity(request: ExternalAgentRunInput) -> AgentRunStatus:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -257,6 +257,32 @@ async def test_agent_run_external_poll_and_fetch_use_typed_activity_inputs(
     assert isinstance(fetch_payload, ExternalAgentRunInput)
     assert fetch_payload.run_id == "session-typed-1"
 
+
+async def test_resolve_adapter_metadata_normalizes_case_for_activity_routing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.workflows.adapters.external_adapter_registry import (
+        ExternalAdapterRegistry,
+    )
+    from moonmind.workflows.adapters.openclaw_agent_adapter import (
+        OpenClawExternalAdapter,
+    )
+
+    registry = ExternalAdapterRegistry()
+    registry.register("openclaw", OpenClawExternalAdapter)
+    monkeypatch.setattr(
+        agent_run_module,
+        "build_default_registry",
+        lambda: registry,
+    )
+
+    metadata = await agent_run_module.resolve_adapter_metadata("OpenClaw")
+
+    assert metadata == {
+        "agent_id": "openclaw",
+        "execution_style": "streaming_gateway",
+    }
+
 async def test_agent_run_streaming_gateway_uses_validated_provider_execute_activity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -257,6 +257,50 @@ async def test_agent_run_external_poll_and_fetch_use_typed_activity_inputs(
     assert isinstance(fetch_payload, ExternalAgentRunInput)
     assert fetch_payload.run_id == "session-typed-1"
 
+async def test_agent_run_streaming_gateway_uses_validated_provider_execute_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any, dict[str, Any]]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload, kwargs))
+        if activity_name == "integration.resolve_adapter_metadata":
+            return {"agent_id": "stream_test", "execution_style": "streaming_gateway"}
+        if activity_name == "integration.stream_test.execute":
+            assert isinstance(payload, AgentExecutionRequest)
+            return AgentRunResult(summary="Stream complete", metadata={})
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(
+        _request(
+            agentId="stream_test",
+            executionProfileRef="profile:stream-test",
+        )
+    )
+
+    execute_call = next(
+        call for call in routed_calls if call[0] == "integration.stream_test.execute"
+    )
+    assert execute_call[0] == "integration.stream_test.execute"
+    assert (
+        execute_call[2]["heartbeat_timeout"]
+        == agent_run_module.STREAMING_EXTERNAL_HEARTBEAT_TIMEOUT
+    )
+    assert all(name != "integration.openclaw.execute" for name, _, _ in routed_calls)
+    assert result.summary == "Stream complete"
+    assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
+
 async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Jira issue key: MM-741

Summary:
- Generalizes external-agent workflow execution so streaming gateway providers resolve through adapter metadata instead of a hard-coded OpenClaw activity.
- Adds typed Temporal activity boundaries for streaming gateway execution and expands workflow-boundary tests for Jules and generic streaming providers.
- Updates the external-provider guide and roadmap tracking for the generic external-agent adapter pattern.

Tests run:
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_typed_activity_boundaries.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py` (13 Python tests passed; frontend wrapper suite also completed with 25 files passed, 396 passed, 232 skipped)

Remaining risks:
- Branch is currently two commits behind the latest `origin/main`; GitHub review/CI should validate the merge result against the updated base.
- Provider-specific live execution was not run in this PR step.
