### PR TITLE
MM-742 Streamline recurring schedules UI

### DIFF
--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 import type { BootPayload } from "../boot/parseBootPayload";
 import { renderWithClient } from "../utils/test-utils";
@@ -8,68 +8,142 @@ import { SchedulesPage } from "./schedules";
 const mockPayload: BootPayload = {
   page: "schedules",
   apiBase: "/api",
-  initialData: {},
+  initialData: {
+    sources: {
+      schedules: {
+        list: "/api/recurring-tasks?scope=personal",
+        update: "/api/recurring-tasks/{id}",
+        runNow: "/api/recurring-tasks/{id}/run",
+      },
+    },
+  },
 };
+
+const scheduleOne = {
+  id: "schedule-1",
+  name: "Daily roadmap follow-up",
+  description: "Check Milestone 3 follow-up work.",
+  enabled: true,
+  scheduleType: "cron",
+  cron: "0 9 * * *",
+  timezone: "UTC",
+  lastDispatchStatus: "failed",
+  lastDispatchError: "Worker unavailable",
+  nextRunAt: "2026-06-01T09:00:00Z",
+  target: { kind: "queue_task", workflowType: "MoonMind.Run" },
+  policy: {},
+  updatedAt: "2026-05-31T16:00:00Z",
+};
+
+const scheduleTwo = {
+  id: "schedule-2",
+  name: "Sparse schedule",
+  enabled: false,
+  scheduleType: "cron",
+  cron: "*/30 * * * *",
+  timezone: "America/New_York",
+  lastDispatchStatus: null,
+  nextRunAt: null,
+  target: {},
+  policy: {},
+  updatedAt: "2026-05-31T16:00:00Z",
+};
+
+function response(body: unknown, ok = true): Response {
+  return {
+    ok,
+    statusText: ok ? "OK" : "Failure",
+    json: async () => body,
+  } as Response;
+}
 
 describe("SchedulesPage", () => {
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(window, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            id: "schedule-1",
-            name: "Daily missing fields",
-            enabled: true,
-            cron: "0 9 * * *",
-            timezone: "UTC",
-            lastDispatchStatus: null,
-            nextRunAt: null,
-          },
-          {
-            id: "schedule-2",
-            name: "Sparse schedule",
-          },
-        ],
-      }),
-    } as Response);
+    fetchSpy = vi.spyOn(window, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = String(init?.method || "GET").toUpperCase();
+      if (url === "/api/recurring-tasks?scope=personal" && method === "GET") {
+        return response({ items: [scheduleOne, scheduleTwo] });
+      }
+      if (url === "/api/recurring-tasks/schedule-1/run" && method === "POST") {
+        return response({
+          id: "run-1",
+          definitionId: "schedule-1",
+          scheduledFor: "2026-05-31T16:05:00Z",
+          trigger: "manual",
+          outcome: "enqueued",
+          dispatchAttempts: 1,
+          createdAt: "2026-05-31T16:05:00Z",
+          updatedAt: "2026-05-31T16:05:00Z",
+        }, true);
+      }
+      if (url === "/api/recurring-tasks/schedule-1" && method === "PATCH") {
+        return response({ ...scheduleOne, enabled: false });
+      }
+      return response({}, false);
+    });
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
   });
 
-  it("renders nullable schedule list fields with placeholders", async () => {
+  it("renders operational schedule summary, rows, and nullable fields", async () => {
     renderWithClient(<SchedulesPage payload={mockPayload} />);
 
-    expect(await screen.findByText("Daily missing fields")).not.toBeNull();
-    expect(await screen.findByText("Sparse schedule")).not.toBeNull();
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(await screen.findByText("Daily roadmap follow-up")).not.toBeNull();
+    expect(screen.getByText("Sparse schedule")).not.toBeNull();
+    expect(screen.getByText("Total")).not.toBeNull();
+    expect(screen.getAllByText("Enabled").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Paused").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Needs Attention")).not.toBeNull();
+    expect(screen.getByText("Worker unavailable")).not.toBeNull();
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("routes creation to the workflow create page without local mutations", async () => {
+  it("filters schedules that need attention", async () => {
     renderWithClient(<SchedulesPage payload={mockPayload} />);
 
-    const createLink = await screen.findByRole("link", {
-      name: "Create from workflow page",
-    });
-    expect(createLink.getAttribute("href")).toBe(
-      "/workflows/new?scheduleMode=recurring",
-    );
-    expect(screen.queryByRole("button", { name: "Create Schedule" })).toBeNull();
-    expect(screen.queryByText("Edit")).toBeNull();
-    expect(screen.queryByText("Schedule (Cron)")).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: /Needs Attention/i }));
 
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
-    const mutationCalls = fetchSpy.mock.calls.filter(([, init]) => {
-      const method = String(init?.method || "GET").toUpperCase();
-      return method === "POST" || method === "PUT";
-    });
-    expect(mutationCalls).toEqual([]);
+    expect(screen.getByText("Daily roadmap follow-up")).not.toBeNull();
+    expect(screen.queryByText("Sparse schedule")).toBeNull();
+  });
+
+  it("routes creation to the workflow create page and exposes schedule actions", async () => {
+    renderWithClient(<SchedulesPage payload={mockPayload} />);
+
+    const createLink = await screen.findByRole("link", { name: "Create Schedule" });
+    expect(createLink.getAttribute("href")).toBe("/workflows/new?scheduleMode=recurring");
+    await screen.findByText("Daily roadmap follow-up");
+
+    const runNowButton = screen.getAllByRole("button", { name: "Run Now" })[0];
+    if (!runNowButton) throw new Error("Run Now button was not rendered.");
+    fireEvent.click(runNowButton);
+    await screen.findByText("Daily roadmap follow-up queued for an immediate run.");
+
+    const pauseButton = screen.getAllByRole("button", { name: "Pause" })[0];
+    if (!pauseButton) throw new Error("Pause button was not rendered.");
+    fireEvent.click(pauseButton);
+    await screen.findByText("Daily roadmap follow-up paused.");
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([url, init]) =>
+            String(url) === "/api/recurring-tasks/schedule-1/run" &&
+            String(init?.method).toUpperCase() === "POST",
+        ),
+      ).toBe(true),
+    );
     expect(
-      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/recurring-tasks"),
-    ).toBe(false);
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url) === "/api/recurring-tasks/schedule-1" &&
+          String(init?.method).toUpperCase() === "PATCH",
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -100,6 +100,13 @@ describe("SchedulesPage", () => {
     expect(screen.getAllByText("Paused").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Needs Attention")).not.toBeNull();
     expect(screen.getByText("Worker unavailable")).not.toBeNull();
+    expect(
+      screen.getByText(
+        new Date(scheduleOne.nextRunAt).toLocaleString(undefined, {
+          timeZone: scheduleOne.timezone,
+        }),
+      ),
+    ).not.toBeNull();
     expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -145,5 +152,75 @@ describe("SchedulesPage", () => {
           String(init?.method).toUpperCase() === "PATCH",
       ),
     ).toBe(true);
+  });
+
+  it("honors dashboard schedule sources from the boot payload", async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = String(init?.method || "GET").toUpperCase();
+      if (url === "/console/schedules?scope=personal" && method === "GET") {
+        return response({ items: [scheduleOne] });
+      }
+      if (url === "/console/schedules/schedule-1/toggle" && method === "PATCH") {
+        return response({ ...scheduleOne, name: "Server schedule", enabled: false });
+      }
+      return response({}, false);
+    });
+
+    renderWithClient(
+      <SchedulesPage
+        payload={{
+          page: "schedules",
+          apiBase: "/tenant/api",
+          initialData: {
+            dashboardConfig: {
+              sources: {
+                schedules: {
+                  list: "/console/schedules?scope=personal",
+                  update: "/console/schedules/{id}/toggle",
+                  runNow: "/console/schedules/{id}/run-now",
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    await screen.findByText("Daily roadmap follow-up");
+    fireEvent.click(screen.getByRole("button", { name: "Pause" }));
+    await screen.findByText("Server schedule paused.");
+
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, init]) =>
+          String(url) === "/console/schedules/schedule-1/toggle" &&
+          String(init?.method).toUpperCase() === "PATCH",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses apiBase for default schedule endpoints", async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = String(init?.method || "GET").toUpperCase();
+      if (url === "/tenant/api/recurring-tasks?scope=personal" && method === "GET") {
+        return response({ items: [scheduleOne] });
+      }
+      return response({}, false);
+    });
+
+    renderWithClient(
+      <SchedulesPage
+        payload={{
+          page: "schedules",
+          apiBase: "/tenant/api",
+          initialData: {},
+        }}
+      />,
+    );
+
+    await screen.findByText("Daily roadmap follow-up");
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("/tenant/api/recurring-tasks?scope=personal");
   });
 });

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,28 +1,131 @@
-import { useQuery } from '@tanstack/react-query';
-import { DataTable } from '../components/tables/DataTable';
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
 
-import { z } from 'zod';
-import { BootPayload } from '../boot/parseBootPayload';
+import { BootPayload } from "../boot/parseBootPayload";
+import { DataTable } from "../components/tables/DataTable";
 
-const ScheduleSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  enabled: z.boolean().optional(),
-  cron: z.string().optional(),
-  timezone: z.string().optional(),
-  lastDispatchStatus: z.string().nullable().optional(),
-  nextRunAt: z.string().nullable().optional(),
-});
+const ScheduleSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    enabled: z.boolean().default(true),
+    scheduleType: z.string().optional(),
+    cron: z.string().optional(),
+    timezone: z.string().optional(),
+    nextRunAt: z.string().nullable().optional(),
+    lastScheduledFor: z.string().nullable().optional(),
+    lastDispatchStatus: z.string().nullable().optional(),
+    lastDispatchError: z.string().nullable().optional(),
+    scopeType: z.string().nullable().optional(),
+    scopeRef: z.string().nullable().optional(),
+    target: z.record(z.string(), z.unknown()).optional(),
+    policy: z.record(z.string(), z.unknown()).optional(),
+    updatedAt: z.string().nullable().optional(),
+  })
+  .passthrough();
 
 const SchedulesResponseSchema = z.object({
   items: z.array(ScheduleSchema),
 });
 
+type Schedule = z.infer<typeof ScheduleSchema>;
+type ScheduleFilter = "all" | "enabled" | "paused" | "needs_attention";
+
+const SchedulesBootDataSchema = z
+  .object({
+    sources: z
+      .object({
+        schedules: z
+          .object({
+            list: z.string().optional(),
+            update: z.string().optional(),
+            runNow: z.string().optional(),
+          })
+          .partial()
+          .optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .passthrough();
+
+function endpoint(template: string, scheduleId: string): string {
+  return template.replace("{id}", encodeURIComponent(scheduleId));
+}
+
+function scheduleSources(payload: BootPayload) {
+  const parsed = SchedulesBootDataSchema.safeParse(payload.initialData || {});
+  const schedules = parsed.success ? parsed.data.sources?.schedules : undefined;
+  return {
+    list: schedules?.list || "/api/recurring-tasks?scope=personal",
+    update: schedules?.update || "/api/recurring-tasks/{id}",
+    runNow: schedules?.runNow || "/api/recurring-tasks/{id}/run",
+  };
+}
+
+function formatWhen(iso: string | null | undefined): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+function formatStatus(value: string | null | undefined): string {
+  if (!value) return "No dispatch yet";
+  return value
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function targetLabel(schedule: Schedule): string {
+  const target = schedule.target || {};
+  const kind = typeof target.kind === "string" ? target.kind : "";
+  const workflow =
+    typeof target.workflowType === "string"
+      ? target.workflowType
+      : typeof target.workflow_type === "string"
+        ? target.workflow_type
+        : "";
+  if (kind && workflow) return `${kind} -> ${workflow}`;
+  if (kind) return kind;
+  if (workflow) return workflow;
+  return "Task";
+}
+
+function needsAttention(schedule: Schedule): boolean {
+  const status = (schedule.lastDispatchStatus || "").toLowerCase();
+  return (
+    Boolean(schedule.lastDispatchError) ||
+    status.includes("fail") ||
+    status.includes("error")
+  );
+}
+
+function filterSchedules(items: Schedule[], filter: ScheduleFilter): Schedule[] {
+  if (filter === "enabled") return items.filter((item) => item.enabled);
+  if (filter === "paused") return items.filter((item) => !item.enabled);
+  if (filter === "needs_attention") return items.filter(needsAttention);
+  return items;
+}
+
 export function SchedulesPage({ payload }: { payload: BootPayload }) {
+  const queryClient = useQueryClient();
+  const sources = useMemo(() => scheduleSources(payload), [payload]);
+  const [filter, setFilter] = useState<ScheduleFilter>("all");
+  const [feedback, setFeedback] = useState<{
+    tone: "ok" | "error";
+    text: string;
+  } | null>(null);
+
+  const queryKey = ["schedules", sources.list] as const;
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ['schedules'],
+    queryKey,
     queryFn: async () => {
-      const response = await fetch(`${payload.apiBase}/recurring-tasks?scope=personal`);
+      const response = await fetch(sources.list, { credentials: "include" });
       if (!response.ok) {
         throw new Error(`Failed to fetch: ${response.statusText}`);
       }
@@ -30,45 +133,231 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
     },
   });
 
+  const toggleMutation = useMutation({
+    mutationFn: async (schedule: Schedule) => {
+      const response = await fetch(endpoint(sources.update, schedule.id), {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ enabled: !schedule.enabled }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to update schedule: ${response.statusText}`);
+      }
+      return ScheduleSchema.parse(await response.json());
+    },
+    onSuccess: (_result, schedule) => {
+      setFeedback({
+        tone: "ok",
+        text: `${schedule.name} ${schedule.enabled ? "paused" : "enabled"}.`,
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (mutationError) => {
+      const message =
+        mutationError instanceof Error
+          ? mutationError.message
+          : "Schedule update failed.";
+      setFeedback({ tone: "error", text: message });
+    },
+  });
+
+  const runNowMutation = useMutation({
+    mutationFn: async (schedule: Schedule) => {
+      const response = await fetch(endpoint(sources.runNow, schedule.id), {
+        method: "POST",
+        credentials: "include",
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to run schedule: ${response.statusText}`);
+      }
+      return response.json();
+    },
+    onSuccess: (_result, schedule) => {
+      setFeedback({
+        tone: "ok",
+        text: `${schedule.name} queued for an immediate run.`,
+      });
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (mutationError) => {
+      const message =
+        mutationError instanceof Error
+          ? mutationError.message
+          : "Run-now request failed.";
+      setFeedback({ tone: "error", text: message });
+    },
+  });
+
+  const schedules = data?.items || [];
+  const filteredSchedules = filterSchedules(schedules, filter);
+  const enabledCount = schedules.filter((item) => item.enabled).length;
+  const pausedCount = schedules.length - enabledCount;
+  const attentionCount = schedules.filter(needsAttention).length;
+
   return (
-    <div className="max-w-6xl mx-auto p-6 space-y-6">
-      <header className="border-b border-gray-200 pb-4 mb-6 flex justify-between items-center">
+    <div className="stack">
+      <div className="toolbar">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 tracking-tight">Recurring Schedules</h2>
-          <p className="text-sm text-gray-500 mt-1">Managed recurring schedules for queue and manifest targets.</p>
+          <h2 className="page-title">Recurring Schedules</h2>
+          <p className="page-meta">
+            Review cadence, target, dispatch health, and manual controls for
+            scheduled workflows.
+          </p>
         </div>
-        <a href="/workflows/new?scheduleMode=recurring" className="text-blue-600 hover:underline">
-          Create from workflow page
-        </a>
-      </header>
-      <div className="bg-white rounded-lg shadow-sm p-6 border border-gray-100">
-        {isLoading ? (
-          <p className="text-gray-500 italic animate-pulse">Loading recurring schedules...</p>
-        ) : isError ? (
-          <div className="p-4 rounded-md bg-red-50 text-red-700 border border-red-200 mb-4">{(error as Error).message}</div>
-        ) : (
-          <DataTable
-            data={data?.items || []}
-            columns={[
-              { key: 'id', header: 'ID' },
-              { key: 'name', header: 'Name' },
-              {
-                key: 'lastDispatchStatus',
-                header: 'Last Dispatch Status',
-                render: (item) => item.lastDispatchStatus ?? '—',
-              },
-              {
-                key: 'nextRunAt',
-                header: 'Next Run At',
-                render: (item) => item.nextRunAt ? new Date(item.nextRunAt).toLocaleString() : '—',
-              },
-            ]}
-            emptyMessage="No recurring schedules found."
-            getRowKey={(item) => item.id}
-          />
-        )}
+        <div className="toolbar-controls">
+          <a href="/workflows/new?scheduleMode=recurring" className="button">
+            Create Schedule
+          </a>
+        </div>
       </div>
+
+      <div className="schedule-summary-grid" aria-label="Schedule summary">
+        <button
+          type="button"
+          className={`schedule-summary-tile${filter === "all" ? " active" : ""}`}
+          onClick={() => setFilter("all")}
+        >
+          <span className="schedule-summary-value">{schedules.length}</span>
+          <span className="schedule-summary-label">Total</span>
+        </button>
+        <button
+          type="button"
+          className={`schedule-summary-tile${
+            filter === "enabled" ? " active" : ""
+          }`}
+          onClick={() => setFilter("enabled")}
+        >
+          <span className="schedule-summary-value">{enabledCount}</span>
+          <span className="schedule-summary-label">Enabled</span>
+        </button>
+        <button
+          type="button"
+          className={`schedule-summary-tile${
+            filter === "paused" ? " active" : ""
+          }`}
+          onClick={() => setFilter("paused")}
+        >
+          <span className="schedule-summary-value">{pausedCount}</span>
+          <span className="schedule-summary-label">Paused</span>
+        </button>
+        <button
+          type="button"
+          className={`schedule-summary-tile${
+            filter === "needs_attention" ? " active" : ""
+          }`}
+          onClick={() => setFilter("needs_attention")}
+        >
+          <span className="schedule-summary-value">{attentionCount}</span>
+          <span className="schedule-summary-label">Needs Attention</span>
+        </button>
+      </div>
+
+      {feedback ? <div className={`notice ${feedback.tone}`}>{feedback.text}</div> : null}
+
+      {isLoading ? (
+        <p className="loading">Loading recurring schedules...</p>
+      ) : isError ? (
+        <div className="notice error">{(error as Error).message}</div>
+      ) : (
+        <DataTable
+          ariaLabel="Recurring schedules"
+          data={filteredSchedules}
+          columns={[
+            {
+              key: "name",
+              header: "Schedule",
+              render: (item) => (
+                <div className="schedule-name-cell">
+                  <strong>{item.name}</strong>
+                  {item.description ? (
+                    <span>{item.description}</span>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              key: "enabled",
+              header: "State",
+              render: (item) => (
+                <span
+                  className={`status ${
+                    item.enabled ? "status-completed" : "status-neutral"
+                  }`}
+                >
+                  {item.enabled ? "Enabled" : "Paused"}
+                </span>
+              ),
+            },
+            { key: "cron", header: "Cron", render: (item) => item.cron || "-" },
+            {
+              key: "timezone",
+              header: "Timezone",
+              render: (item) => item.timezone || "UTC",
+            },
+            { key: "target", header: "Target", render: targetLabel },
+            {
+              key: "lastDispatchStatus",
+              header: "Last Dispatch",
+              render: (item) => (
+                <div className="schedule-dispatch-cell">
+                  <span>{formatStatus(item.lastDispatchStatus)}</span>
+                  {item.lastDispatchError ? (
+                    <span className="schedule-dispatch-error">
+                      {item.lastDispatchError}
+                    </span>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              key: "nextRunAt",
+              header: "Next Run",
+              render: (item) => formatWhen(item.nextRunAt),
+            },
+            {
+              key: "actions",
+              header: "Actions",
+              render: (item) => (
+                <div className="schedule-actions">
+                  <button
+                    type="button"
+                    className="button small-button"
+                    disabled={
+                      runNowMutation.isPending || toggleMutation.isPending
+                    }
+                    onClick={() => runNowMutation.mutate(item)}
+                  >
+                    Run Now
+                  </button>
+                  <button
+                    type="button"
+                    className="button secondary small-button"
+                    disabled={
+                      runNowMutation.isPending || toggleMutation.isPending
+                    }
+                    onClick={() => toggleMutation.mutate(item)}
+                  >
+                    {item.enabled ? "Pause" : "Enable"}
+                  </button>
+                </div>
+              ),
+            },
+          ]}
+          emptyMessage={
+            filter === "all"
+              ? "No recurring schedules found."
+              : "No schedules match this filter."
+          }
+          getRowKey={(item) => item.id}
+        />
+      )}
     </div>
   );
 }
+
 export default SchedulesPage;

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -35,6 +35,24 @@ type ScheduleFilter = "all" | "enabled" | "paused" | "needs_attention";
 
 const SchedulesBootDataSchema = z
   .object({
+    dashboardConfig: z
+      .object({
+        sources: z
+          .object({
+            schedules: z
+              .object({
+                list: z.string().optional(),
+                update: z.string().optional(),
+                runNow: z.string().optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
+      })
+      .partial()
+      .optional(),
     sources: z
       .object({
         schedules: z
@@ -57,18 +75,28 @@ function endpoint(template: string, scheduleId: string): string {
 
 function scheduleSources(payload: BootPayload) {
   const parsed = SchedulesBootDataSchema.safeParse(payload.initialData || {});
-  const schedules = parsed.success ? parsed.data.sources?.schedules : undefined;
+  const schedules = parsed.success
+    ? parsed.data.dashboardConfig?.sources?.schedules || parsed.data.sources?.schedules
+    : undefined;
+  const base = payload.apiBase || "/api";
   return {
-    list: schedules?.list || "/api/recurring-tasks?scope=personal",
-    update: schedules?.update || "/api/recurring-tasks/{id}",
-    runNow: schedules?.runNow || "/api/recurring-tasks/{id}/run",
+    list: schedules?.list || `${base}/recurring-tasks?scope=personal`,
+    update: schedules?.update || `${base}/recurring-tasks/{id}`,
+    runNow: schedules?.runNow || `${base}/recurring-tasks/{id}/run`,
   };
 }
 
-function formatWhen(iso: string | null | undefined): string {
+function formatWhen(iso: string | null | undefined, timezone?: string): string {
   if (!iso) return "-";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
+  if (timezone) {
+    try {
+      return date.toLocaleString(undefined, { timeZone: timezone });
+    } catch {
+      // Fall back to local formatting when a persisted timezone is unsupported.
+    }
+  }
   return date.toLocaleString();
 }
 
@@ -149,10 +177,10 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
       }
       return ScheduleSchema.parse(await response.json());
     },
-    onSuccess: (_result, schedule) => {
+    onSuccess: (result) => {
       setFeedback({
         tone: "ok",
-        text: `${schedule.name} ${schedule.enabled ? "paused" : "enabled"}.`,
+        text: `${result.name} ${result.enabled ? "enabled" : "paused"}.`,
       });
       queryClient.invalidateQueries({ queryKey });
     },
@@ -317,7 +345,7 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
             {
               key: "nextRunAt",
               header: "Next Run",
-              render: (item) => formatWhen(item.nextRunAt),
+              render: (item) => formatWhen(item.nextRunAt, item.timezone),
             },
             {
               key: "actions",

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2259,6 +2259,7 @@ tr[data-proposal-id].proposal-consuming td {
   flex-direction: column;
   align-items: flex-start;
   gap: 0.25rem;
+  width: 100%;
   min-height: 5.6rem;
   padding: 0.9rem;
   border: 1px solid rgb(var(--mm-border));

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2248,6 +2248,76 @@ tr[data-proposal-id].proposal-consuming td {
   min-height: 3.2rem;
 }
 
+.schedule-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.schedule-summary-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  min-height: 5.6rem;
+  padding: 0.9rem;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-panel) / 0.74);
+  color: rgb(var(--mm-ink));
+  text-align: left;
+  box-shadow: 0 18px 44px -34px rgb(var(--mm-ink) / 0.5);
+}
+
+.schedule-summary-tile:hover,
+.schedule-summary-tile:focus-visible,
+.schedule-summary-tile.active {
+  border-color: rgb(var(--mm-accent) / 0.58);
+  background: rgb(var(--mm-accent) / 0.08);
+  transform: none;
+}
+
+.schedule-summary-value {
+  font-size: 1.65rem;
+  font-weight: 740;
+  line-height: 1;
+}
+
+.schedule-summary-label {
+  color: rgb(var(--mm-muted));
+  font-size: 0.85rem;
+  font-weight: 650;
+}
+
+.schedule-name-cell,
+.schedule-dispatch-cell,
+.schedule-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.schedule-name-cell span,
+.schedule-dispatch-cell span {
+  color: rgb(var(--mm-muted));
+  font-size: 0.82rem;
+}
+
+.schedule-dispatch-error {
+  color: rgb(var(--mm-danger)) !important;
+}
+
+.schedule-actions {
+  min-width: 7.5rem;
+}
+
+.small-button {
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.62rem;
+  font-size: 0.8rem;
+}
+
 .small {
   font-size: 0.85rem;
   color: rgb(var(--mm-muted));
@@ -3072,6 +3142,14 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 @media (max-width: 720px) {
+  .schedule-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .schedule-actions {
+    min-width: 0;
+  }
+
   .step-tl-row {
     grid-template-columns: 1.3rem 1fr;
     gap: 0 0.45rem;


### PR DESCRIPTION
## Jira

MM-742

## Summary

- Streamlines the recurring schedules Mission Control page with operational summary filters for total, enabled, paused, and schedules needing attention.
- Adds richer schedule rows showing state, cadence, timezone, target, dispatch status, next run, and dispatch errors.
- Adds ready-to-use schedule actions for running a schedule immediately and pausing or enabling a schedule, backed by existing recurring-task endpoints.
- Adds focused UI coverage for summary rendering, attention filtering, and schedule actions.

## Tests run

- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/schedules.test.tsx`
- `pytest tests/integration/api/test_recurring_schedule_creation.py -q --tb=short`

## Remaining risks

- MM-742 is an epic. This PR addresses the recurring schedules UI portion; other Milestone 3 roadmap items still need separate implementation and verification.
- The schedules page actions depend on the existing recurring-task API behavior and runtime authorization in deployed environments.
