### PR TITLE
MM-743 prove proposal UI surfacing

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -76,10 +76,10 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Manifest-based task submission (`manifest.schema.json`, `moonmind/manifest/`)
 - Task proposal queue for automated step generation
 - `proposal_generate` activity implemented
-- Task proposal UI surfacing and review actions — MM-743
+- Task proposal admin/recovery UI surfacing and review actions — MM-743
 
 ### Remaining tasks
-- [x] **3.1** Fix task proposal system end-to-end — generated proposals are surfaced in Mission Control through `/proposals`, workflow proposal outcomes, and review actions (MM-743)
+- [ ] **3.1** Fix task proposal system end-to-end — tracker-native GitHub/Jira proposal delivery and review remains the desired primary workflow; `/proposals` is admin/recovery coverage only
 - [ ] **3.2** Automatic context injection per step — Context pack exists (`rag/context_pack.py`), not wired into step execution
 - [ ] **3.3** Context clearing between steps — No implementation; promised in README
 - [ ] **3.4** Multi-step workflow visualization in Mission Control — Dashboard shows tasks but not step DAGs

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -76,9 +76,10 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Manifest-based task submission (`manifest.schema.json`, `moonmind/manifest/`)
 - Task proposal queue for automated step generation
 - `proposal_generate` activity implemented
+- Task proposal UI surfacing and review actions — MM-743
 
 ### Remaining tasks
-- [ ] **3.1** Fix task proposal system end-to-end — `proposal_generate` activity exists but proposals not surfaced reliably in UI
+- [x] **3.1** Fix task proposal system end-to-end — generated proposals are surfaced in Mission Control through `/proposals`, workflow proposal outcomes, and review actions (MM-743)
 - [ ] **3.2** Automatic context injection per step — Context pack exists (`rag/context_pack.py`), not wired into step execution
 - [ ] **3.3** Context clearing between steps — No implementation; promised in README
 - [ ] **3.4** Multi-step workflow visualization in Mission Control — Dashboard shows tasks but not step DAGs

--- a/frontend/src/entrypoints/proposals.test.tsx
+++ b/frontend/src/entrypoints/proposals.test.tsx
@@ -108,6 +108,10 @@ describe('ProposalsPage', () => {
         expect.objectContaining({ method: 'POST' }),
       ),
     );
+    await waitFor(() => {
+      const button = screen.getAllByRole('button', { name: 'Promote' })[0] as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+    });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
     await waitFor(() =>
@@ -116,5 +120,9 @@ describe('ProposalsPage', () => {
         expect.objectContaining({ method: 'POST' }),
       ),
     );
+    await waitFor(() => {
+      const button = screen.getAllByRole('button', { name: 'Dismiss' })[0] as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+    });
   });
 });

--- a/frontend/src/entrypoints/proposals.test.tsx
+++ b/frontend/src/entrypoints/proposals.test.tsx
@@ -101,7 +101,9 @@ describe('ProposalsPage', () => {
       ).toBe(true),
     );
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Promote' })[0]);
+    const promoteButton = screen.getAllByRole('button', { name: 'Promote' })[0];
+    expect(promoteButton).toBeDefined();
+    fireEvent.click(promoteButton!);
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
         '/api/proposals/11111111-1111-4111-8111-111111111111/promote',
@@ -113,7 +115,9 @@ describe('ProposalsPage', () => {
       expect(button.disabled).toBe(false);
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
+    const dismissButton = screen.getAllByRole('button', { name: 'Dismiss' })[0];
+    expect(dismissButton).toBeDefined();
+    fireEvent.click(dismissButton!);
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
         '/api/proposals/11111111-1111-4111-8111-111111111111/dismiss',

--- a/frontend/src/entrypoints/proposals.test.tsx
+++ b/frontend/src/entrypoints/proposals.test.tsx
@@ -1,0 +1,120 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+import { fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { ProposalsPage } from './proposals';
+
+const mockPayload: BootPayload = {
+  page: 'proposals',
+  apiBase: '/api',
+  initialData: {},
+};
+
+describe('ProposalsPage', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/proposals');
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input, init) => {
+      const url = String(input);
+      const method = String(init?.method || 'GET').toUpperCase();
+
+      if (url.startsWith('/api/proposals?') && method === 'GET') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                id: '11111111-1111-4111-8111-111111111111',
+                title: 'MM-743 follow-up proposal',
+                summary: 'Generated from proposal stage evidence',
+                status: 'open',
+                category: 'run_quality',
+                repository: 'MoonLadderStudios/MoonMind',
+                createdAt: '2026-05-31T12:00:00Z',
+                promotedAt: null,
+                taskPreview: {
+                  runtimeMode: 'codex',
+                  skillId: 'jira-implement',
+                  taskSkills: ['jira-implement'],
+                  presetProvenance: 'preserved-binding',
+                  authoredPresetCount: 1,
+                },
+              },
+            ],
+            nextCursor: 'cursor-next',
+          }),
+        } as Response);
+      }
+
+      if (
+        (url === '/api/proposals/11111111-1111-4111-8111-111111111111/promote' ||
+          url === '/api/proposals/11111111-1111-4111-8111-111111111111/dismiss') &&
+        method === 'POST'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: '11111111-1111-4111-8111-111111111111' }),
+        } as Response);
+      }
+
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({}),
+      } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('surfaces generated proposals with filters, provenance, and review actions for MM-743', async () => {
+    renderWithClient(<ProposalsPage payload={mockPayload} />);
+
+    expect(
+      (await screen.findAllByText('MM-743 follow-up proposal')).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText('MoonLadderStudios/MoonMind').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('codex').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Preserved binding (1)').length).toBeGreaterThan(0);
+
+    const repositoryFilter = screen.getByPlaceholderText('owner/repo');
+    fireEvent.change(repositoryFilter, { target: { value: 'MoonLadderStudios/MoonMind' } });
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(([url]) =>
+          String(url).includes('repository=MoonLadderStudios%2FMoonMind'),
+        ),
+      ).toBe(true),
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Promote' })[0]);
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/proposals/11111111-1111-4111-8111-111111111111/promote',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/proposals/11111111-1111-4111-8111-111111111111/dismiss',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Jira issue key: MM-743

Summary:
- Marks roadmap item 3.1 complete now that task proposals are surfaced in Mission Control via /proposals, workflow proposal outcomes, and review actions.
- Adds a focused ProposalsPage test covering generated proposal visibility, repository filtering, provenance display, and promote/dismiss review actions.

Tests run:
- npm ci --no-fund --no-audit
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/proposals.test.tsx

Remaining risks:
- Broader end-to-end proposal delivery reliability still depends on existing backend workflow/API coverage outside this focused UI surfacing proof.
