### PR TITLE
MM-745 clear task-scoped context between steps

### DIFF
--- a/artifacts.root-mm745/context/rag-context-5f81e7187114.json
+++ b/artifacts.root-mm745/context/rag-context-5f81e7187114.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. moonmind/models_cache.py (score: 1.000, trust: canonical)\n    line 370: self.refresh_models_sync()  # Sleep for a short duration before checking again.\n2. moonmind/auth/env_shaping.py (score: 1.000, trust: canonical)\n    line 20: \"CODEX_API_KEY\",\n3. moonmind/workloads/registry.py (score: 1.000, trust: canonical)\n    line 310: except json.JSONDecodeError as exc:\n4. moonmind/workloads/docker_launcher.py (score: 1.000, trust: canonical)\n    line 118: def _decode_stream(data: bytes) -> str:\n5. docs/ManagedAgents/ManagedAgentsAuthentication.md (score: 1.000, trust: canonical)\n    line 25: | OAuth volume provisioning scripts | `tools/auth-gemini-volume.sh`, `tools/auth-codex-volume.sh`, `tools/auth-claude-volume.sh` |\n6. docs/ManagedAgents/CodexManagedSessionPlane.md (score: 1.000, trust: canonical)\n    line 1: # Codex Managed Session Plane\n7. docs/Steps/SkillsOnDemand.md (score: 1.000, trust: canonical)\n    line 18: 2. MoonMind resolves that intent into an immutable `ResolvedSkillSet` before runtime launch;\n8. docs/Steps/SlashCommands.md (score: 1.000, trust: canonical)\n    line 7: Related: `docs/UI/CreatePage.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Steps/SkillSystem.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/ClaudeCodeManagedSessions.md`",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "moonmind/models_cache.py",
+      "text": "line 370: self.refresh_models_sync()  # Sleep for a short duration before checking again.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 370,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/auth/env_shaping.py",
+      "text": "line 20: \"CODEX_API_KEY\",",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 20,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workloads/registry.py",
+      "text": "line 310: except json.JSONDecodeError as exc:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 310,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/workloads/docker_launcher.py",
+      "text": "line 118: def _decode_stream(data: bytes) -> str:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 118,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ManagedAgentsAuthentication.md",
+      "text": "line 25: | OAuth volume provisioning scripts | `tools/auth-gemini-volume.sh`, `tools/auth-codex-volume.sh`, `tools/auth-claude-volume.sh` |",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 25,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/CodexManagedSessionPlane.md",
+      "text": "line 1: # Codex Managed Session Plane",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Steps/SkillsOnDemand.md",
+      "text": "line 18: 2. MoonMind resolves that intent into an immutable `ResolvedSkillSet` before runtime launch;",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 18,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Steps/SlashCommands.md",
+      "text": "line 7: Related: `docs/UI/CreatePage.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Steps/SkillSystem.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/ClaudeCodeManagedSessions.md`",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 7,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-05-31T16:32:13Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -2,7 +2,7 @@
 
 > Tracking the major milestones remaining to fully deliver on the README promise.
 >
-> Last updated: 2026-03-21
+> Last updated: 2026-05-31
 
 ---
 
@@ -76,11 +76,13 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Manifest-based task submission (`manifest.schema.json`, `moonmind/manifest/`)
 - Task proposal queue for automated step generation
 - `proposal_generate` activity implemented
+- Context clearing between ordered Codex managed-session steps via the
+  task-scoped AgentSession reset boundary (MM-745)
 
 ### Remaining tasks
 - [ ] **3.1** Fix task proposal system end-to-end — `proposal_generate` activity exists but proposals not surfaced reliably in UI
 - [ ] **3.2** Automatic context injection per step — Context pack exists (`rag/context_pack.py`), not wired into step execution
-- [ ] **3.3** Context clearing between steps — No implementation; promised in README
+- [x] **3.3** Context clearing between steps — Task-scoped Codex managed sessions clear to a new epoch before reuse by a later ordered step (MM-745)
 - [ ] **3.4** Multi-step workflow visualization in Mission Control — Dashboard shows tasks but not step DAGs
 - [ ] **3.5** Preset-driven scheduling (auto-sequence from goal) — Presets exist but goal-to-plan decomposition is manual
 - [ ] **3.6** Overhaul and streamline schedules UI — Current schedules interface needs UX improvement

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -267,6 +267,9 @@ RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
+RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH = (
+    "run-task-scoped-session-clear-between-steps-v1"
+)
 RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
@@ -642,6 +645,7 @@ class MoonMindRunWorkflow:
         self._last_publish_repair_node_id: str | None = None
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
+        self._codex_session_cleared_before_step_ids: set[str] = set()
         self._trusted_jira_context: dict[str, Any] | None = None
         self._step_ledger_rows: list[dict[str, Any]] = []
         self._step_ledger_by_id: dict[str, dict[str, Any]] = {}
@@ -4046,6 +4050,10 @@ class MoonMindRunWorkflow:
                                     ordered_nodes=ordered_nodes,
                                     current_index=index,
                                 )
+                            await self._maybe_clear_task_scoped_session_before_step(
+                                request=request,
+                                logical_step_id=node_id,
+                            )
                             request = await self._maybe_bind_task_scoped_session(request)
                             selected_skill_for_repair = node_inputs.get(
                                 "selectedSkill"
@@ -5464,6 +5472,47 @@ class MoonMindRunWorkflow:
         if binding is None:
             return request
         return request.model_copy(update={"managed_session": binding})
+
+    async def _maybe_clear_task_scoped_session_before_step(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        logical_step_id: str,
+    ) -> None:
+        if not workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH):
+            return
+        if logical_step_id in self._codex_session_cleared_before_step_ids:
+            return
+        binding = self._codex_session_binding
+        if binding is None:
+            return
+        if self._managed_session_runtime_id(request) != binding.runtime_id:
+            return
+        session_handle = workflow.get_external_workflow_handle(binding.workflow_id)
+        reason = f"Clearing task-scoped context before step {logical_step_id}"
+        result = await session_handle.execute_update(
+            "ClearSession",
+            {
+                "reason": reason,
+                "requestId": step_execution_operation_idempotency_key(
+                    workflow_id=workflow.info().workflow_id,
+                    run_id=workflow.info().run_id,
+                    logical_step_id=logical_step_id,
+                    execution_ordinal=self._step_execution_for(logical_step_id) or 1,
+                    operation="clear_session",
+                ),
+            },
+        )
+        session_state = self._get_from_result(
+            result, "sessionState"
+        ) or self._get_from_result(result, "session_state")
+        if isinstance(session_state, Mapping):
+            session_epoch = self._get_from_result(session_state, "sessionEpoch")
+            if isinstance(session_epoch, int) and session_epoch >= 1:
+                self._codex_session_binding = binding.model_copy(
+                    update={"session_epoch": session_epoch}
+                )
+        self._codex_session_cleared_before_step_ids.add(logical_step_id)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
         binding = self._codex_session_binding

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -8,6 +8,7 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
+    RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
@@ -171,6 +172,112 @@ async def test_run_skips_task_scoped_session_for_non_session_managed_runtime(
 
     assert request.managed_session is None
     assert started is False
+
+@pytest.mark.asyncio
+async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def execute_update(
+            self, update_name: str, payload: Any = None
+        ) -> dict[str, Any]:
+            update_calls.append((update_name, payload))
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread:sess:wf-run-1:codex_cli:2",
+                },
+                "latestResetBoundaryRef": "artifact://reset-boundary-1",
+            }
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+    )
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    assert update_calls == [
+        (
+            "ClearSession",
+            {
+                "reason": "Clearing task-scoped context before step step-2",
+                "requestId": "wf-run-1:run-1:step-2:execution:1:clear_session",
+            },
+        )
+    ]
+    assert workflow._codex_session_binding is not None
+    assert workflow._codex_session_binding.session_epoch == 2
+    assert "step-2" in workflow._codex_session_cleared_before_step_ids
+
+
+@pytest.mark.asyncio
+async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def execute_update(
+            self, update_name: str, payload: Any = None
+        ) -> dict[str, Any]:
+            update_calls.append((update_name, payload))
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread:sess:wf-run-1:codex_cli:2",
+                },
+            }
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+    )
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    assert len(update_calls) == 1
+
 
 def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:
     workflow = MoonMindRunWorkflow()


### PR DESCRIPTION
## Jira
MM-745: 3.3 Context clearing between steps

## Summary
- Clear task-scoped Codex managed-session context before reusing the session for a later ordered step.
- Carry the new session epoch into the next AgentRun request after the AgentSession ClearSession update publishes reset evidence.
- Mark roadmap item 3.3 as shipped for MM-745.

## Tests run
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py` (Python target passed; global frontend Vitest portion reported unrelated existing failures)
- `./tools/test_unit.sh tests/unit/schemas/test_managed_session_models.py` (Python target passed; global frontend Vitest portion reported unrelated existing failures)
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k "managed_session_steps or context"` (Python target passed; global frontend Vitest portion reported unrelated existing failures)
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/services/temporal/workflows/test_agent_session_lifecycle.py -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/workflows/temporal/test_managed_session_retrieval_durability.py -q --tb=short`

## Remaining risks
- The reset is implemented for task-scoped Codex managed sessions; other runtime adapters still depend on their own session-control support.
- The full `./tools/test_unit.sh` runner remains blocked by unrelated frontend Vitest failures outside the MM-745 code path.

Merge Automation: enabled for MM-745.
