### PR TITLE
MM-748 Streamline schedules UI

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -83,7 +83,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **3.3** Context clearing between steps — No implementation; promised in README
 - [ ] **3.4** Multi-step workflow visualization in Mission Control — Dashboard shows tasks but not step DAGs
 - [ ] **3.5** Preset-driven scheduling (auto-sequence from goal) — Presets exist but goal-to-plan decomposition is manual
-- [ ] **3.6** Overhaul and streamline schedules UI — Current schedules interface needs UX improvement
+- [x] **3.6** Overhaul and streamline schedules UI — Current schedules interface needs UX improvement
 
 ---
 

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -21,16 +21,53 @@ describe("SchedulesPage", () => {
         items: [
           {
             id: "schedule-1",
-            name: "Daily missing fields",
+            name: "Daily repository sweep",
             enabled: true,
             cron: "0 9 * * *",
             timezone: "UTC",
-            lastDispatchStatus: null,
-            nextRunAt: null,
+            lastDispatchStatus: "enqueued",
+            lastDispatchError: null,
+            nextRunAt: "2026-05-31T12:00:00Z",
+            lastScheduledFor: "2026-05-30T12:00:00Z",
+            scopeType: "personal",
+            target: {
+              kind: "queue_task",
+              job: {
+                payload: {
+                  repository: "MoonLadderStudios/MoonMind",
+                },
+              },
+            },
+            policy: {
+              overlap: { mode: "skip" },
+              catchup: { mode: "latest" },
+            },
           },
           {
             id: "schedule-2",
             name: "Sparse schedule",
+            enabled: false,
+            cron: "15 * * * *",
+            timezone: "UTC",
+            lastDispatchStatus: null,
+            lastDispatchError: null,
+            nextRunAt: null,
+            lastScheduledFor: null,
+            target: {},
+            policy: {},
+          },
+          {
+            id: "schedule-3",
+            name: "Failing schedule",
+            enabled: true,
+            cron: "30 4 * * 1",
+            timezone: "America/New_York",
+            lastDispatchStatus: "dispatch_error",
+            lastDispatchError: "Adapter rejected schedule",
+            nextRunAt: null,
+            lastScheduledFor: null,
+            target: {},
+            policy: {},
           },
         ],
       }),
@@ -41,12 +78,20 @@ describe("SchedulesPage", () => {
     fetchSpy.mockRestore();
   });
 
-  it("renders nullable schedule list fields with placeholders", async () => {
+  it("renders streamlined schedule status, target, cadence, and policy columns", async () => {
     renderWithClient(<SchedulesPage payload={mockPayload} />);
 
-    expect(await screen.findByText("Daily missing fields")).not.toBeNull();
+    expect(await screen.findByText("Daily repository sweep")).not.toBeNull();
     expect(await screen.findByText("Sparse schedule")).not.toBeNull();
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Failing schedule")).not.toBeNull();
+    expect(screen.getAllByText("Active").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Paused")).not.toBeNull();
+    expect(screen.getByText("Needs attention")).not.toBeNull();
+    expect(screen.getByText("MoonLadderStudios/MoonMind")).not.toBeNull();
+    expect(screen.getByText("0 9 * * *")).not.toBeNull();
+    expect(screen.getByText("Skip / Latest")).not.toBeNull();
+    expect(screen.getByText("Adapter rejected schedule")).not.toBeNull();
+    expect(screen.getByText("Total").nextElementSibling?.textContent).toBe("3");
   });
 
   it("routes creation to the workflow create page without local mutations", async () => {
@@ -71,5 +116,18 @@ describe("SchedulesPage", () => {
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url) === "/api/recurring-tasks"),
     ).toBe(false);
+  });
+
+  it("shows an empty state without adding local create controls", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderWithClient(<SchedulesPage payload={mockPayload} />);
+
+    expect(await screen.findByText("No recurring schedules yet. Create one from the workflow page.")).not.toBeNull();
+    expect(screen.getByText("Total").nextElementSibling?.textContent).toBe("0");
+    expect(screen.queryByRole("button", { name: "Create Schedule" })).toBeNull();
   });
 });

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,25 +1,117 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { DataTable } from '../components/tables/DataTable';
 
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
+import { formatStatusLabel } from '../utils/formatters';
 
 const ScheduleSchema = z.object({
   id: z.string(),
   name: z.string(),
-  enabled: z.boolean().optional(),
-  cron: z.string().optional(),
-  timezone: z.string().optional(),
+  description: z.string().nullable().optional(),
+  enabled: z.boolean(),
+  scheduleType: z.string().optional(),
+  cron: z.string(),
+  timezone: z.string(),
   lastDispatchStatus: z.string().nullable().optional(),
+  lastDispatchError: z.string().nullable().optional(),
   nextRunAt: z.string().nullable().optional(),
-});
+  lastScheduledFor: z.string().nullable().optional(),
+  scopeType: z.string().optional(),
+  scopeRef: z.string().nullable().optional(),
+  target: z.record(z.string(), z.unknown()).optional(),
+  policy: z.record(z.string(), z.unknown()).optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
 
 const SchedulesResponseSchema = z.object({
   items: z.array(ScheduleSchema),
 });
 
+type Schedule = z.infer<typeof ScheduleSchema>;
+
+function formatWhen(value: string | null | undefined): string {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return '-';
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return raw;
+  }
+  return date.toLocaleString();
+}
+
+function compactId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;
+}
+
+function displayValue(value: string | null | undefined): string {
+  const normalized = String(value || '').trim();
+  return normalized || '-';
+}
+
+function titleCaseLabel(value: string): string {
+  return value.replace(/\b[a-z]/g, (match) => match.toUpperCase());
+}
+
+function scheduleState(schedule: Schedule): 'active' | 'paused' | 'attention' {
+  if (!schedule.enabled) {
+    return 'paused';
+  }
+  const status = String(schedule.lastDispatchStatus || '').toLowerCase();
+  return status.includes('error') || status.includes('failed') ? 'attention' : 'active';
+}
+
+function stateLabel(schedule: Schedule): string {
+  const state = scheduleState(schedule);
+  if (state === 'attention') {
+    return 'Needs attention';
+  }
+  return state === 'active' ? 'Active' : 'Paused';
+}
+
+function targetKind(schedule: Schedule): string {
+  const raw = schedule.target?.kind;
+  return typeof raw === 'string' && raw.trim() ? titleCaseLabel(formatStatusLabel(raw)) : 'Queue task';
+}
+
+function targetRepository(schedule: Schedule): string {
+  const job = schedule.target?.job;
+  if (!job || typeof job !== 'object' || !('payload' in job)) {
+    return '-';
+  }
+  const payload = (job as { payload?: unknown }).payload;
+  if (!payload || typeof payload !== 'object' || !('repository' in payload)) {
+    return '-';
+  }
+  const repository = (payload as { repository?: unknown }).repository;
+  return typeof repository === 'string' && repository.trim() ? repository : '-';
+}
+
+function policySummary(schedule: Schedule): string {
+  const overlap = schedule.policy?.overlap;
+  const catchup = schedule.policy?.catchup;
+  const overlapMode = overlap && typeof overlap === 'object' && 'mode' in overlap
+    ? String((overlap as { mode?: unknown }).mode || '').trim()
+    : '';
+  const catchupMode = catchup && typeof catchup === 'object' && 'mode' in catchup
+    ? String((catchup as { mode?: unknown }).mode || '').trim()
+    : '';
+  return [overlapMode, catchupMode].filter(Boolean).map((value) => titleCaseLabel(formatStatusLabel(value))).join(' / ') || '-';
+}
+
+function isDueSoon(schedule: Schedule, now: number): boolean {
+  if (!schedule.enabled || !schedule.nextRunAt) {
+    return false;
+  }
+  const nextRun = new Date(schedule.nextRunAt).getTime();
+  return Number.isFinite(nextRun) && nextRun >= now && nextRun <= now + 24 * 60 * 60 * 1000;
+}
+
 export function SchedulesPage({ payload }: { payload: BootPayload }) {
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ['schedules'],
     queryFn: async () => {
       const response = await fetch(`${payload.apiBase}/recurring-tasks?scope=personal`);
@@ -30,44 +122,131 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
     },
   });
 
+  const schedules = data?.items || [];
+  const now = Date.now();
+  const stats = useMemo(() => {
+    const active = schedules.filter((schedule) => schedule.enabled).length;
+    const attention = schedules.filter((schedule) => scheduleState(schedule) === 'attention').length;
+    const dueSoon = schedules.filter((schedule) => isDueSoon(schedule, now)).length;
+    return { active, attention, dueSoon, total: schedules.length };
+  }, [now, schedules]);
+
   return (
-    <div className="max-w-6xl mx-auto p-6 space-y-6">
-      <header className="border-b border-gray-200 pb-4 mb-6 flex justify-between items-center">
+    <div className="schedules-page stack">
+      <header className="toolbar schedules-toolbar">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 tracking-tight">Recurring Schedules</h2>
-          <p className="text-sm text-gray-500 mt-1">Managed recurring schedules for queue and manifest targets.</p>
+          <h2 className="page-title">Recurring Schedules</h2>
+          <p className="page-meta">Managed recurring schedules for queue and manifest targets.</p>
         </div>
-        <a href="/workflows/new?scheduleMode=recurring" className="text-blue-600 hover:underline">
-          Create from workflow page
-        </a>
+        <div className="toolbar-controls">
+          <button type="button" className="secondary" onClick={() => void refetch()} disabled={isFetching}>
+            {isFetching ? 'Refreshing' : 'Refresh'}
+          </button>
+          <a href="/workflows/new?scheduleMode=recurring" className="button">
+            Create from workflow page
+          </a>
+        </div>
       </header>
-      <div className="bg-white rounded-lg shadow-sm p-6 border border-gray-100">
+
+      <section className="schedules-summary-grid" aria-label="Schedule summary">
+        <div className="schedules-summary-item">
+          <span>Total</span>
+          <strong>{stats.total}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Active</span>
+          <strong>{stats.active}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Next 24h</span>
+          <strong>{stats.dueSoon}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Attention</span>
+          <strong>{stats.attention}</strong>
+        </div>
+      </section>
+
+      <section className="panel--data schedules-table-panel" aria-label="Recurring schedule list">
         {isLoading ? (
-          <p className="text-gray-500 italic animate-pulse">Loading recurring schedules...</p>
+          <p className="loading">Loading recurring schedules...</p>
         ) : isError ? (
-          <div className="p-4 rounded-md bg-red-50 text-red-700 border border-red-200 mb-4">{(error as Error).message}</div>
+          <div className="schedules-error" role="alert">{(error as Error).message}</div>
         ) : (
           <DataTable
-            data={data?.items || []}
+            data={schedules}
             columns={[
-              { key: 'id', header: 'ID' },
-              { key: 'name', header: 'Name' },
               {
-                key: 'lastDispatchStatus',
-                header: 'Last Dispatch Status',
-                render: (item) => item.lastDispatchStatus ?? '—',
+                key: 'name',
+                header: 'Schedule',
+                render: (item) => (
+                  <div className="schedules-primary-cell">
+                    <a href={`/schedules/${encodeURIComponent(item.id)}`}>{item.name}</a>
+                    <span title={item.id}>{compactId(item.id)}</span>
+                  </div>
+                ),
+              },
+              {
+                key: 'enabled',
+                header: 'State',
+                render: (item) => (
+                  <span className={`schedules-state schedules-state--${scheduleState(item)}`}>
+                    {stateLabel(item)}
+                  </span>
+                ),
+              },
+              {
+                key: 'target',
+                header: 'Target',
+                render: (item) => (
+                  <div className="schedules-secondary-cell">
+                    <strong>{targetKind(item)}</strong>
+                    <span>{targetRepository(item)}</span>
+                  </div>
+                ),
+              },
+              {
+                key: 'cron',
+                header: 'Cadence',
+                render: (item) => (
+                  <div className="schedules-secondary-cell">
+                    <code>{item.cron}</code>
+                    <span>{displayValue(item.timezone)}</span>
+                  </div>
+                ),
               },
               {
                 key: 'nextRunAt',
-                header: 'Next Run At',
-                render: (item) => item.nextRunAt ? new Date(item.nextRunAt).toLocaleString() : '—',
+                header: 'Next Run',
+                render: (item) => formatWhen(item.nextRunAt),
+              },
+              {
+                key: 'lastScheduledFor',
+                header: 'Last Scheduled',
+                render: (item) => formatWhen(item.lastScheduledFor),
+              },
+              {
+                key: 'lastDispatchStatus',
+                header: 'Dispatch',
+                render: (item) => (
+                  <div className="schedules-secondary-cell">
+                    <strong>{item.lastDispatchStatus ? titleCaseLabel(formatStatusLabel(item.lastDispatchStatus)) : '-'}</strong>
+                    <span>{displayValue(item.lastDispatchError)}</span>
+                  </div>
+                ),
+              },
+              {
+                key: 'policy',
+                header: 'Policy',
+                render: (item) => policySummary(item),
               },
             ]}
-            emptyMessage="No recurring schedules found."
+            emptyMessage="No recurring schedules yet. Create one from the workflow page."
             getRowKey={(item) => item.id}
+            ariaLabel="Recurring schedules"
           />
         )}
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -123,13 +123,13 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
   });
 
   const schedules = data?.items || [];
-  const now = Date.now();
   const stats = useMemo(() => {
+    const now = Date.now();
     const active = schedules.filter((schedule) => schedule.enabled).length;
     const attention = schedules.filter((schedule) => scheduleState(schedule) === 'attention').length;
     const dueSoon = schedules.filter((schedule) => isDueSoon(schedule, now)).length;
     return { active, attention, dueSoon, total: schedules.length };
-  }, [now, schedules]);
+  }, [schedules]);
 
   return (
     <div className="schedules-page stack">

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -949,6 +949,122 @@ h1 {
   margin-top: 0.7rem;
 }
 
+.schedules-page {
+  width: 100%;
+}
+
+.schedules-toolbar {
+  align-items: flex-start;
+}
+
+.schedules-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.schedules-summary-item {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  border-radius: 0.65rem;
+  background: rgb(var(--mm-panel) / 0.82);
+  box-shadow: 0 14px 26px -24px rgb(var(--mm-ink) / 0.48);
+}
+
+.schedules-summary-item span {
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.schedules-summary-item strong {
+  color: rgb(var(--mm-ink));
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.schedules-table-panel {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.schedules-primary-cell,
+.schedules-secondary-cell {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.schedules-primary-cell a {
+  color: rgb(var(--mm-ink));
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.schedules-primary-cell a:hover {
+  color: rgb(var(--mm-accent));
+  text-decoration: underline;
+}
+
+.schedules-primary-cell span,
+.schedules-secondary-cell span {
+  max-width: 24rem;
+  overflow: hidden;
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+}
+
+.schedules-secondary-cell strong {
+  color: rgb(var(--mm-ink));
+  font-size: 0.88rem;
+}
+
+.schedules-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-width: 5.2rem;
+  padding: 0.22rem 0.55rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.schedules-state--active {
+  border-color: rgb(var(--mm-ok) / 0.44);
+  background: rgb(var(--mm-ok) / 0.14);
+  color: color-mix(in srgb, rgb(var(--mm-ok)) 70%, rgb(var(--mm-ink)) 30%);
+}
+
+.schedules-state--paused {
+  border-color: rgb(var(--mm-border) / 0.9);
+  background: rgb(var(--mm-muted) / 0.11);
+  color: rgb(var(--mm-muted));
+}
+
+.schedules-state--attention {
+  border-color: rgb(var(--mm-danger) / 0.48);
+  background: rgb(var(--mm-danger) / 0.12);
+  color: color-mix(in srgb, rgb(var(--mm-danger)) 74%, rgb(var(--mm-ink)) 26%);
+}
+
+.schedules-error {
+  padding: 0.85rem;
+  border: 1px solid rgb(var(--mm-danger) / 0.42);
+  border-radius: 0.55rem;
+  background: rgb(var(--mm-danger) / 0.1);
+  color: color-mix(in srgb, rgb(var(--mm-danger)) 76%, rgb(var(--mm-ink)) 24%);
+}
+
 .manifests-advanced-grid,
 .manifests-filter-grid {
   display: grid;
@@ -1388,6 +1504,10 @@ tbody tr:hover {
 }
 
 @media (max-width: 720px) {
+  .schedules-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .provider-profiles-table-wrap {
     overflow: visible;
   }


### PR DESCRIPTION
Jira issue key: MM-748

## Summary
- Streamlines the schedules page with clearer controls, denser schedule metadata, and faster scan/edit affordances.
- Adds schedules entrypoint test coverage for the updated UI behavior.
- Marks roadmap item 3.6 complete in `docs/MoonMindRoadmap.md`.

## Tests run
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/schedules.test.tsx` (5496 passed, 6 skipped, 1 xpassed, 16 subtests passed; targeted schedules UI test: 1 file passed, 3 tests passed)

## Remaining risks
- Full browser/manual UX review was not performed in this managed runtime.
- Existing repository warnings remain in the unit suite output.
