### PR TITLE
MM-747 preset-driven goal scheduling

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11,6 +11,7 @@ import os
 import re
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, Literal, Optional
 from urllib.parse import quote, urlsplit
 from uuid import uuid4
@@ -108,6 +109,12 @@ from moonmind.workflows.temporal.report_artifacts import build_report_projection
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.client import TemporalClientAdapter, query_workflow
 from moonmind.workflows.tasks.model_resolver import resolve_effective_model
+from moonmind.workflows.tasks.preset_goal_scheduler import (
+    GoalPresetSchedule,
+    goal_from_payloads,
+    schedule_preset_from_goal,
+    task_is_already_authored,
+)
 from moonmind.workflows.tasks.runtime_defaults import normalize_runtime_id
 from moonmind.workflows.tasks.runtime_inheritance import (
     RuntimeInheritanceError,
@@ -4403,6 +4410,135 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
 
     return normalized_steps
 
+
+def _task_template_seed_dir() -> Path:
+    import api_service
+
+    return Path(api_service.__file__).resolve().parent / "data" / "task_step_templates"
+
+
+def _apply_goal_schedule_metadata(
+    *,
+    task_payload: dict[str, Any],
+    schedule: GoalPresetSchedule,
+    expanded: Mapping[str, Any],
+) -> None:
+    applied_template = (
+        expanded.get("appliedTemplate")
+        if isinstance(expanded.get("appliedTemplate"), Mapping)
+        else {}
+    )
+    applied_template_payload = {
+        "slug": str(applied_template.get("slug") or schedule.slug),
+        "version": str(applied_template.get("version") or schedule.version),
+        "inputs": (
+            dict(applied_template.get("inputs"))
+            if isinstance(applied_template.get("inputs"), Mapping)
+            else dict(schedule.inputs)
+        ),
+        "stepIds": list(applied_template.get("stepIds") or []),
+        "appliedAt": str(applied_template.get("appliedAt") or ""),
+        "capabilities": list(expanded.get("capabilities") or []),
+    }
+    composition = applied_template.get("composition") or expanded.get("composition")
+    if isinstance(composition, Mapping):
+        applied_template_payload["composition"] = dict(composition)
+
+    authored_presets = applied_template.get("authoredPresets") or expanded.get(
+        "authoredPresets"
+    )
+    if isinstance(authored_presets, list):
+        task_payload["authoredPresets"] = [
+            dict(item) if isinstance(item, Mapping) else item
+            for item in authored_presets
+        ]
+
+    task_payload["appliedStepTemplates"] = [applied_template_payload]
+    task_payload["taskTemplate"] = {
+        "slug": str(applied_template.get("slug") or schedule.slug),
+        "version": str(applied_template.get("version") or schedule.version),
+        "scope": "global",
+    }
+    task_payload["presetSchedule"] = {
+        "source": "goal",
+        "reason": schedule.reason,
+        "presetSlug": schedule.slug,
+        "presetVersion": schedule.version,
+        "jiraIssueKey": schedule.issue_key,
+    }
+
+
+async def _expand_goal_preset_for_task_submission(
+    *,
+    task_payload: dict[str, Any],
+    request_payload: Mapping[str, Any],
+    session: Any,
+    user_id: Any,
+) -> None:
+    if task_is_already_authored(task_payload):
+        return
+
+    schedule = schedule_preset_from_goal(
+        goal_from_payloads(task_payload=task_payload, parameter_payload=request_payload)
+    )
+    if schedule is None:
+        return
+
+    from api_service.services.task_templates.catalog import (
+        ExpandOptions,
+        TaskTemplateCatalogService,
+        TaskTemplateNotFoundError,
+    )
+
+    catalog = TaskTemplateCatalogService(session)
+    existing_inputs = (
+        dict(task_payload.get("inputs")) if isinstance(task_payload.get("inputs"), Mapping) else {}
+    )
+    template_inputs = {**schedule.inputs, **existing_inputs}
+    context: dict[str, Any] = {}
+    repository = request_payload.get("repository") or task_payload.get("repository")
+    if isinstance(repository, str) and repository.strip():
+        context["repository"] = repository.strip()
+        context["repo"] = repository.strip()
+    runtime_payload = (
+        task_payload.get("runtime") if isinstance(task_payload.get("runtime"), Mapping) else {}
+    )
+    target_runtime = request_payload.get("targetRuntime") or runtime_payload.get("mode")
+    if isinstance(target_runtime, str) and target_runtime.strip():
+        context["targetRuntime"] = target_runtime.strip()
+
+    expand_kwargs = {
+        "slug": schedule.slug,
+        "scope": "global",
+        "scope_ref": None,
+        "version": schedule.version,
+        "inputs": template_inputs,
+        "context": context,
+        "options": ExpandOptions(should_enforce_step_limit=True),
+        "user_id": user_id,
+    }
+    try:
+        expanded = await catalog.expand_template(**expand_kwargs)
+    except TaskTemplateNotFoundError:
+        await catalog.sync_seed_templates(seed_dir=_task_template_seed_dir())
+        expanded = await catalog.expand_template(**expand_kwargs)
+
+    expanded_steps = expanded.get("steps") if isinstance(expanded, Mapping) else None
+    if not isinstance(expanded_steps, list) or not expanded_steps:
+        raise _invalid_task_request(
+            f"Goal preset '{schedule.slug}' expansion produced no executable steps."
+        )
+
+    task_payload["goal"] = schedule.goal
+    task_payload.setdefault("instructions", schedule.goal)
+    task_payload["inputs"] = template_inputs
+    task_payload["steps"] = list(expanded_steps)
+    _apply_goal_schedule_metadata(
+        task_payload=task_payload,
+        schedule=schedule,
+        expanded=expanded,
+    )
+
 def _normalize_publish_payload(raw_publish: Any) -> dict[str, Any]:
     publish_payload = _coerce_mapping(raw_publish)
     if not publish_payload:
@@ -5528,6 +5664,15 @@ async def _create_execution_from_task_request(
 
     if len(depends_on) > 10:
         raise _invalid_task_request(f"{field_name} can have a maximum of 10 items.")
+
+    if session is not None:
+        await _expand_goal_preset_for_task_submission(
+            task_payload=task_payload,
+            request_payload=payload,
+            session=session,
+            user_id=user.id,
+        )
+
     (
         objective_attachment_refs,
         step_attachment_refs,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5833,6 +5833,12 @@ async def _create_execution_from_task_request(
         value = task_payload.get(key)
         if isinstance(value, str) and value.strip():
             normalized_task_for_planner[key] = value.strip()
+    if isinstance(task_payload.get("taskTemplate"), Mapping):
+        normalized_task_for_planner["taskTemplate"] = dict(task_payload["taskTemplate"])
+    if isinstance(task_payload.get("presetSchedule"), Mapping):
+        normalized_task_for_planner["presetSchedule"] = dict(
+            task_payload["presetSchedule"]
+        )
     for key in ("authoredPresets", "appliedStepTemplates"):
         value = task_payload.get(key)
         if isinstance(value, list):

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -82,7 +82,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **3.2** Automatic context injection per step — Context pack exists (`rag/context_pack.py`), not wired into step execution
 - [ ] **3.3** Context clearing between steps — No implementation; promised in README
 - [ ] **3.4** Multi-step workflow visualization in Mission Control — Dashboard shows tasks but not step DAGs
-- [ ] **3.5** Preset-driven scheduling (auto-sequence from goal) — Presets exist but goal-to-plan decomposition is manual
+- [x] **3.5** Preset-driven scheduling (auto-sequence from goal) — Goal-only task submissions are deterministically mapped to seeded presets before backend expansion (MM-747)
 - [ ] **3.6** Overhaul and streamline schedules UI — Current schedules interface needs UX improvement
 
 ---

--- a/docs/Tasks/TaskPresetsSystem.md
+++ b/docs/Tasks/TaskPresetsSystem.md
@@ -354,6 +354,7 @@ The same path is used by:
 - task submission with unexpanded presets
 - API-created tasks
 - task edit and re-run flows that reconstruct preset-originated steps
+- goal-only task submissions that are first mapped to a seeded preset
 
 Expansion must:
 
@@ -445,6 +446,27 @@ The user may click Create Task while one or more preset steps are still unexpand
 5. Submit the task.
 
 If a required preset input is missing, Create Task is blocked and the missing field is highlighted. If backend expansion fails, the Create page displays the field-addressable errors and preserves the user's entered values.
+
+## Goal-Driven Preset Scheduling
+
+When a task is submitted with a plain `goal` and without already-authored
+steps, an explicit plan, a selected tool/skill, or a selected preset, MoonMind
+may map that goal to a seeded preset before normal submit-time expansion. This
+keeps the fast path from requiring manual preset selection while preserving the
+same deterministic expansion, validation, and provenance used by explicit
+preset submissions.
+
+The initial selector is deterministic and conservative:
+
+- a goal containing a Jira issue key maps to a Jira implementation or
+  orchestration preset, depending on the goal wording
+- a breakdown/story-generation goal maps to the Jira breakdown orchestration
+  preset
+- a general implementation goal maps to MoonSpec Orchestrate
+
+The submitted task records `presetSchedule` metadata with the goal source,
+selected preset, preset version, and reason. Once the preset is selected, the
+normal backend expansion service owns the executable step list.
 
 ## Apply and Reapply
 

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -33,8 +33,10 @@ The page should support simple one-step tasks while also scaling to advanced wor
 1. User enters task instructions.
 2. User selects repository and branch context if needed.
 3. User accepts the default single step or chooses a step type.
-4. User clicks **Create Task**.
-5. MoonMind validates inputs and starts the workflow.
+4. If the draft provides a plain goal and no explicit steps, tool/skill, plan,
+   or preset, the backend may map the goal to a seeded preset and expand it.
+5. User clicks **Create Task**.
+6. MoonMind validates inputs and starts the workflow.
 
 ### Preset Path
 
@@ -324,6 +326,19 @@ Example error:
 ```
 
 The user's entered values must be preserved after validation failures.
+
+## Goal-Driven Preset Scheduling
+
+The Create page may submit a task with a plain `goal` instead of a manually
+selected preset. When no explicit execution shape is present, the backend
+selects a seeded preset from the goal, expands it through the same authoritative
+template service used by apply and submit-time expansion, and stores the
+selected preset in task provenance.
+
+This is not a separate Create page mode. The page still submits structured task
+data, and the backend remains responsible for selecting and expanding the
+preset. Authored steps, selected tools/skills, explicit plans, and explicit
+presets always take precedence over goal-driven scheduling.
 
 ## Validation UX
 

--- a/moonmind/workflows/tasks/preset_goal_scheduler.py
+++ b/moonmind/workflows/tasks/preset_goal_scheduler.py
@@ -1,0 +1,167 @@
+"""Deterministic preset selection for goal-only task submissions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Mapping
+
+_JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+
+
+@dataclass(frozen=True, slots=True)
+class GoalPresetSchedule:
+    """Preset selected from a plain goal before task-template expansion."""
+
+    goal: str
+    slug: str
+    version: str
+    inputs: dict[str, Any]
+    reason: str
+    issue_key: str | None = None
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        candidate = _text(value)
+        if candidate:
+            return candidate
+    return ""
+
+
+def _contains_any(value: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in value for needle in needles)
+
+
+def _jira_project_key(goal: str) -> str:
+    match = re.search(r"\bproject\s+([A-Z][A-Z0-9]+)\b", goal, flags=re.IGNORECASE)
+    return match.group(1).upper() if match else "MM"
+
+
+def _issue_key(goal: str) -> str | None:
+    match = _JIRA_ISSUE_KEY_PATTERN.search(goal)
+    return match.group(1).upper() if match else None
+
+
+def goal_from_payloads(
+    *,
+    task_payload: Mapping[str, Any],
+    input_payload: Mapping[str, Any] | None = None,
+    parameter_payload: Mapping[str, Any] | None = None,
+) -> str:
+    """Return the explicit goal text from supported task payload locations."""
+
+    return _first_text(
+        task_payload.get("goal"),
+        task_payload.get("objective"),
+        (input_payload or {}).get("goal"),
+        (input_payload or {}).get("objective"),
+        (parameter_payload or {}).get("goal"),
+        (parameter_payload or {}).get("objective"),
+    )
+
+
+def task_is_already_authored(task_payload: Mapping[str, Any]) -> bool:
+    """Return whether the task already carries an explicit execution shape."""
+
+    if isinstance(task_payload.get("steps"), list) and task_payload.get("steps"):
+        return True
+    if isinstance(task_payload.get("plan"), list) and task_payload.get("plan"):
+        return True
+    if isinstance(task_payload.get("taskTemplate"), Mapping):
+        return True
+    if isinstance(task_payload.get("task_template"), Mapping):
+        return True
+    if isinstance(task_payload.get("tool"), Mapping):
+        return True
+    if isinstance(task_payload.get("skill"), Mapping):
+        return True
+    return False
+
+
+def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
+    """Select a seeded task preset from a plain goal.
+
+    The selector is intentionally deterministic and conservative: it uses
+    stable Jira-key and task-shape signals, then falls back to MoonSpec
+    orchestration for a general implementation goal.
+    """
+
+    normalized_goal = _text(goal)
+    if not normalized_goal:
+        return None
+
+    lowered = normalized_goal.lower()
+    issue_key = _issue_key(normalized_goal)
+    wants_breakdown = _contains_any(
+        lowered,
+        ("break down", "breakdown", "split ", "stories", "story candidates"),
+    )
+    wants_implementation = _contains_any(
+        lowered,
+        ("implement", "complete", "fix", "build", "deliver", "code"),
+    )
+    wants_orchestration = _contains_any(
+        lowered,
+        ("orchestrate", "moonspec", "moon spec", "spec-driven"),
+    )
+
+    if issue_key:
+        slug = (
+            "jira-orchestrate"
+            if wants_orchestration and not wants_implementation
+            else "jira-implement"
+        )
+        return GoalPresetSchedule(
+            goal=normalized_goal,
+            slug=slug,
+            version="1.0.0",
+            issue_key=issue_key,
+            inputs={
+                "jira_issue_key": issue_key,
+                "source_design_path": "",
+                "constraints": "",
+            },
+            reason="jira_issue_goal",
+        )
+
+    if wants_breakdown:
+        return GoalPresetSchedule(
+            goal=normalized_goal,
+            slug="jira-breakdown-orchestrate",
+            version="1.0.0",
+            inputs={
+                "feature_request": normalized_goal,
+                "jira_project_key": _jira_project_key(normalized_goal),
+                "jira_issue_type": "Story",
+                "jira_board_id": "",
+                "jira_dependency_mode": "linear_blocker_chain",
+                "publish_mode": "pr_with_merge_automation",
+                "source_issue_key": "",
+            },
+            reason="story_breakdown_goal",
+        )
+
+    return GoalPresetSchedule(
+        goal=normalized_goal,
+        slug="moonspec-orchestrate",
+        version="1.0.0",
+        inputs={
+            "feature_request": normalized_goal,
+            "source_design_path": "",
+            "constraints": "",
+        },
+        reason="implementation_goal",
+    )
+
+
+__all__ = [
+    "GoalPresetSchedule",
+    "goal_from_payloads",
+    "schedule_preset_from_goal",
+    "task_is_already_authored",
+]

--- a/moonmind/workflows/tasks/preset_goal_scheduler.py
+++ b/moonmind/workflows/tasks/preset_goal_scheduler.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import re
 from typing import Any, Mapping
 
-_JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+_JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,7 +34,10 @@ def _first_text(*values: Any) -> str:
 
 
 def _contains_any(value: str, needles: tuple[str, ...]) -> bool:
-    return any(needle in value for needle in needles)
+    return any(
+        re.search(r"\b" + re.escape(needle) + r"\b", value) is not None
+        for needle in needles
+    )
 
 
 def _jira_project_key(goal: str) -> str:
@@ -99,7 +102,7 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
     issue_key = _issue_key(normalized_goal)
     wants_breakdown = _contains_any(
         lowered,
-        ("break down", "breakdown", "split ", "stories", "story candidates"),
+        ("break down", "breakdown", "split", "stories", "story candidates"),
     )
     wants_implementation = _contains_any(
         lowered,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -83,6 +83,11 @@ from moonmind.workflows.temporal.workers import (
 from moonmind.workflows.tasks.task_contract import (
     build_authoritative_task_input_snapshot,
 )
+from moonmind.workflows.tasks.preset_goal_scheduler import (
+    goal_from_payloads,
+    schedule_preset_from_goal,
+    task_is_already_authored,
+)
 from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow as MoonMindProviderProfileManager
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
@@ -219,7 +224,35 @@ async def _expand_task_template_for_child_run(
     )
     template_slug = _template_slug_from_task(task_payload)
     if not template_slug:
-        return parameters
+        goal = goal_from_payloads(
+            task_payload=task_payload,
+            parameter_payload=parameters,
+        )
+        schedule = (
+            None
+            if task_is_already_authored(task_payload)
+            else schedule_preset_from_goal(goal)
+        )
+        if schedule is None:
+            return parameters
+        template_slug = schedule.slug
+        template_payload = {
+            "slug": schedule.slug,
+            "version": schedule.version,
+            "scope": "global",
+        }
+        existing_inputs = _coerce_mapping(task_payload.get("inputs"))
+        task_payload["inputs"] = {**schedule.inputs, **existing_inputs}
+        task_payload["goal"] = schedule.goal
+        task_payload.setdefault("instructions", schedule.goal)
+        task_payload["taskTemplate"] = dict(template_payload)
+        task_payload["presetSchedule"] = {
+            "source": "goal",
+            "reason": schedule.reason,
+            "presetSlug": schedule.slug,
+            "presetVersion": schedule.version,
+            "jiraIssueKey": schedule.issue_key,
+        }
 
     from api_service.services.task_templates.catalog import (
         ExpandOptions,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -277,6 +277,9 @@ async def _expand_task_template_for_child_run(
     if isinstance(repository, str) and repository.strip():
         template_context["repository"] = repository.strip()
         template_context["repo"] = repository.strip()
+    target_runtime = parameters.get("targetRuntime")
+    if isinstance(target_runtime, str) and target_runtime.strip():
+        template_context["targetRuntime"] = target_runtime.strip()
     catalog = TaskTemplateCatalogService(session)
     expand_kwargs = {
         "slug": template_slug,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3261,6 +3261,74 @@ def test_create_task_shaped_execution_defaults_runtime_into_parameters(
     assert initial_parameters["targetRuntime"] == "codex_cli"
     assert initial_parameters["task"]["runtime"]["mode"] == "codex_cli"
 
+
+def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "task": {
+                    "title": "MM-747 goal",
+                    "instructions": "Complete Jira issue MM-747.",
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "title": "Implement",
+                            "instructions": "Implement MM-747.",
+                        }
+                    ],
+                    "taskTemplate": {
+                        "slug": "jira-implement",
+                        "version": "1.0.0",
+                        "scope": "global",
+                    },
+                    "presetSchedule": {
+                        "source": "goal",
+                        "reason": "jira_issue_goal",
+                        "presetSlug": "jira-implement",
+                        "presetVersion": "1.0.0",
+                        "jiraIssueKey": "MM-747",
+                    },
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "jira-implement",
+                            "version": "1.0.0",
+                            "stepIds": ["step-1"],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    task = initial_parameters["task"]
+    assert task["taskTemplate"] == {
+        "slug": "jira-implement",
+        "version": "1.0.0",
+        "scope": "global",
+    }
+    assert task["presetSchedule"] == {
+        "source": "goal",
+        "reason": "jira_issue_goal",
+        "presetSlug": "jira-implement",
+        "presetVersion": "1.0.0",
+        "jiraIssueKey": "MM-747",
+    }
+    assert task["appliedStepTemplates"][0]["slug"] == "jira-implement"
+
+
 def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaults(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -23,6 +23,7 @@ from api_service.api.routers.executions import (
     _get_service,
     _artifact_id_from_ref,
     _build_original_task_input_snapshot_payload,
+    _expand_goal_preset_for_task_submission,
     _merge_task_preserving_artifact_instructions,
     _recovery_not_available_reason,
     _reuse_original_task_input_snapshot_from_source,
@@ -202,6 +203,45 @@ def _mm639_authored_task_payload() -> dict[str, Any]:
             },
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_goal_preset_submission_expands_before_planner(tmp_path) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/goal_preset_submission.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            task_payload = {
+                "title": "MM-747 goal",
+                "goal": "Complete Jira issue MM-747 using preset scheduling.",
+            }
+            await _expand_goal_preset_for_task_submission(
+                task_payload=task_payload,
+                request_payload={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+                session=session,
+                user_id=uuid4(),
+            )
+    finally:
+        await engine.dispose()
+
+    assert task_payload["taskTemplate"] == {
+        "slug": "jira-implement",
+        "version": "1.0.0",
+        "scope": "global",
+    }
+    assert task_payload["inputs"]["jira_issue_key"] == "MM-747"
+    assert task_payload["presetSchedule"]["presetSlug"] == "jira-implement"
+    assert task_payload["steps"][0]["title"] == "Load Jira preset brief"
+    assert task_payload["steps"][1]["title"] == "Assess existing implementation state"
+    assert task_payload["appliedStepTemplates"][0]["slug"] == "jira-implement"
+
 
 class _QueryHandle:
     def __init__(

--- a/tests/unit/workflows/tasks/test_preset_goal_scheduler.py
+++ b/tests/unit/workflows/tasks/test_preset_goal_scheduler.py
@@ -1,0 +1,52 @@
+from moonmind.workflows.tasks.preset_goal_scheduler import (
+    goal_from_payloads,
+    schedule_preset_from_goal,
+    task_is_already_authored,
+)
+
+
+def test_schedule_preset_from_goal_selects_jira_implement_for_issue_goal() -> None:
+    schedule = schedule_preset_from_goal("Complete MM-747 from the roadmap.")
+
+    assert schedule is not None
+    assert schedule.slug == "jira-implement"
+    assert schedule.version == "1.0.0"
+    assert schedule.issue_key == "MM-747"
+    assert schedule.inputs["jira_issue_key"] == "MM-747"
+
+
+def test_schedule_preset_from_goal_selects_breakdown_orchestrate_for_story_goal() -> None:
+    schedule = schedule_preset_from_goal(
+        "Break down docs/Design.md into Jira stories for project TOOL."
+    )
+
+    assert schedule is not None
+    assert schedule.slug == "jira-breakdown-orchestrate"
+    assert schedule.inputs["feature_request"].startswith("Break down docs/Design.md")
+    assert schedule.inputs["jira_project_key"] == "TOOL"
+    assert schedule.inputs["publish_mode"] == "pr_with_merge_automation"
+
+
+def test_schedule_preset_from_goal_defaults_to_moonspec_orchestrate() -> None:
+    schedule = schedule_preset_from_goal("Add a repository dropdown to Create.")
+
+    assert schedule is not None
+    assert schedule.slug == "moonspec-orchestrate"
+    assert schedule.inputs["feature_request"] == "Add a repository dropdown to Create."
+
+
+def test_goal_scheduler_skips_authored_tasks() -> None:
+    assert task_is_already_authored({"steps": [{"title": "Already selected"}]})
+    assert task_is_already_authored({"taskTemplate": {"slug": "jira-implement"}})
+    assert task_is_already_authored({"tool": {"id": "jira-issue-updater"}})
+
+
+def test_goal_from_payloads_prefers_task_goal() -> None:
+    assert (
+        goal_from_payloads(
+            task_payload={"goal": "task goal"},
+            input_payload={"goal": "input goal"},
+            parameter_payload={"goal": "parameter goal"},
+        )
+        == "task goal"
+    )

--- a/tests/unit/workflows/tasks/test_preset_goal_scheduler.py
+++ b/tests/unit/workflows/tasks/test_preset_goal_scheduler.py
@@ -15,6 +15,15 @@ def test_schedule_preset_from_goal_selects_jira_implement_for_issue_goal() -> No
     assert schedule.inputs["jira_issue_key"] == "MM-747"
 
 
+def test_schedule_preset_from_goal_accepts_lowercase_jira_issue_key() -> None:
+    schedule = schedule_preset_from_goal("Complete mm-747 from the roadmap.")
+
+    assert schedule is not None
+    assert schedule.slug == "jira-implement"
+    assert schedule.issue_key == "MM-747"
+    assert schedule.inputs["jira_issue_key"] == "MM-747"
+
+
 def test_schedule_preset_from_goal_selects_breakdown_orchestrate_for_story_goal() -> None:
     schedule = schedule_preset_from_goal(
         "Break down docs/Design.md into Jira stories for project TOOL."
@@ -25,6 +34,22 @@ def test_schedule_preset_from_goal_selects_breakdown_orchestrate_for_story_goal(
     assert schedule.inputs["feature_request"].startswith("Break down docs/Design.md")
     assert schedule.inputs["jira_project_key"] == "TOOL"
     assert schedule.inputs["publish_mode"] == "pr_with_merge_automation"
+
+
+def test_schedule_preset_from_goal_does_not_treat_runtime_names_as_code_keywords() -> None:
+    schedule = schedule_preset_from_goal(
+        "Orchestrate Jira issue MM-747 with claude_code."
+    )
+
+    assert schedule is not None
+    assert schedule.slug == "jira-orchestrate"
+
+
+def test_schedule_preset_from_goal_matches_split_as_a_word() -> None:
+    schedule = schedule_preset_from_goal("Split docs/Design.md into Jira stories.")
+
+    assert schedule is not None
+    assert schedule.slug == "jira-breakdown-orchestrate"
 
 
 def test_schedule_preset_from_goal_defaults_to_moonspec_orchestrate() -> None:

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -242,6 +242,47 @@ def test_runtime_planner_promotes_profile_id_to_runtime_node():
     assert runtime_node["profileId"] == "codex-provider-profile"
     assert runtime_node["providerProfile"] == "codex-provider-profile"
 
+
+@pytest.mark.asyncio
+async def test_child_run_auto_sequences_jira_goal_through_implement_preset(tmp_path):
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_task_template_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "task",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                    "publishMode": "pr",
+                    "task": {
+                        "title": "MM-747 goal",
+                        "goal": "Implement Jira issue MM-747 using the right preset.",
+                    },
+                },
+            )
+
+    task = expanded_parameters["task"]
+    assert task["taskTemplate"] == {
+        "slug": "jira-implement",
+        "version": "1.0.0",
+        "scope": "global",
+    }
+    assert task["presetSchedule"] == {
+        "source": "goal",
+        "reason": "jira_issue_goal",
+        "presetSlug": "jira-implement",
+        "presetVersion": "1.0.0",
+        "jiraIssueKey": "MM-747",
+    }
+    assert task["inputs"]["jira_issue_key"] == "MM-747"
+    assert task["instructions"] == "Implement Jira issue MM-747 using the right preset."
+    assert expanded_parameters["stepCount"] == len(task["steps"])
+    assert task["steps"][0]["title"] == "Load Jira preset brief"
+    assert task["steps"][1]["title"] == "Assess existing implementation state"
+    assert task["steps"][-1]["title"] == "Finalize Jira status"
+    assert task["appliedStepTemplates"][0]["slug"] == "jira-implement"
+    assert task["authoredPresets"][0]["presetSlug"] == "jira-implement"
+
 def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -283,6 +283,32 @@ async def test_child_run_auto_sequences_jira_goal_through_implement_preset(tmp_p
     assert task["appliedStepTemplates"][0]["slug"] == "jira-implement"
     assert task["authoredPresets"][0]["presetSlug"] == "jira-implement"
 
+
+@pytest.mark.asyncio
+async def test_child_run_goal_scheduled_breakdown_preserves_target_runtime(tmp_path):
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_task_template_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "task",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "jules",
+                    "publishMode": "pr",
+                    "task": {
+                        "title": "Break down feature",
+                        "goal": "Split docs/Design.md into Jira stories.",
+                    },
+                },
+            )
+
+    downstream_task = expanded_parameters["task"]["steps"][3]["jiraOrchestration"][
+        "task"
+    ]
+    assert downstream_task["repository"] == "MoonLadderStudios/MoonMind"
+    assert downstream_task["runtime"] == {"mode": "jules"}
+
+
 def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
Jira issue key: MM-747

Summary:
- Adds deterministic goal-driven preset scheduling for plain task goals before normal preset expansion.
- Wires goal scheduling into API task submission and Temporal child-run template expansion.
- Records preset provenance metadata and updates roadmap/task preset/Create page documentation.
- Adds unit coverage for scheduler selection, API submit-time expansion, and child-run auto-sequencing.

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/tasks/test_preset_goal_scheduler.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/api/routers/test_executions.py

Remaining risks:
- The initial selector is intentionally conservative and keyword-based; broader goal interpretation may need future refinement as preset coverage grows.
