### PR TITLE
[codex] Fix init-db Alembic revision length

### DIFF
--- a/api_service/migrations/versions/312_workflow_execution_source_mapping_cutover.py
+++ b/api_service/migrations/versions/312_workflow_execution_source_mapping_cutover.py
@@ -1,6 +1,6 @@
 """Convert legacy task source mappings to workflow execution source mappings.
 
-Revision ID: 312_workflow_execution_source_mapping_cutover
+Revision ID: 312_source_mapping_cutover
 Revises: 311_proposal_delivery_records
 Create Date: 2026-05-21
 
@@ -15,7 +15,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "312_workflow_execution_source_mapping_cutover"
+revision: str = "312_source_mapping_cutover"
 down_revision: Union[str, None] = "311_proposal_delivery_records"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -27,11 +27,17 @@ def _module_assignment_value(path: Path, name: str):
     module = ast.parse(path.read_text(encoding="utf-8"))
     for node in module.body:
         if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.target.id == name:
-                return ast.literal_eval(node.value)
+            if node.target.id == name and node.value is not None:
+                try:
+                    return ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    pass
         if isinstance(node, ast.Assign):
             if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
-                return ast.literal_eval(node.value)
+                try:
+                    return ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    pass
     return None
 
 
@@ -41,6 +47,8 @@ def test_alembic_revision_ids_fit_default_version_column():
     assert migration_dir.exists(), "Alembic versions directory is missing"
 
     for migration_path in migration_dir.glob("*.py"):
+        if migration_path.name == "__init__.py":
+            continue
         revision = _module_assignment_value(migration_path, "revision")
         assert isinstance(revision, str), (
             f"{migration_path} must declare a string Alembic revision id"

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import yaml
@@ -20,6 +21,34 @@ def _has_volume_mount(service_config: dict, source: str, target: str) -> bool:
             if volume.get("source") == source and volume.get("target") == target:
                 return True
     return False
+
+
+def _module_assignment_value(path: Path, name: str):
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == name:
+                return ast.literal_eval(node.value)
+        if isinstance(node, ast.Assign):
+            if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+                return ast.literal_eval(node.value)
+    return None
+
+
+def test_alembic_revision_ids_fit_default_version_column():
+    """Alembic's default version table stores revision ids in VARCHAR(32)."""
+    migration_dir = Path("api_service/migrations/versions")
+    assert migration_dir.exists(), "Alembic versions directory is missing"
+
+    for migration_path in migration_dir.glob("*.py"):
+        revision = _module_assignment_value(migration_path, "revision")
+        assert isinstance(revision, str), (
+            f"{migration_path} must declare a string Alembic revision id"
+        )
+        assert len(revision) <= 32, (
+            f"{migration_path} revision id is too long for alembic_version.version_num: "
+            f"{revision!r}"
+        )
 
 
 def test_docker_compose_has_temporal_worker_auto_start_configured():


### PR DESCRIPTION
## Summary

Fixes the Docker Compose startup failure where the `init-db` one-shot container exited during Alembic migration stamping.

## Root Cause

The migration revision id `312_workflow_execution_source_mapping_cutover` exceeded Alembic's default `alembic_version.version_num` column width of 32 characters. Postgres rejected the version update, which caused `docker compose up -d` to fail while waiting for `init-db` to complete.

## Changes

- Shortened the migration revision id to `312_source_mapping_cutover`.
- Added a local-dev regression test that fails when any Alembic revision id exceeds 32 characters.

## Validation

- `docker compose up -d`
- Confirmed `init-db` exited 0 and `api` became healthy.
- Confirmed database `alembic_version` is `312_source_mapping_cutover`.
- `./tools/test_unit.sh tests/unit/api/test_workflow_execution_source_mapping.py tests/test_local_dev.py -q`