### PR TITLE
MM-755 Add live manifest ingest provider checks

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -123,6 +123,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Manifest system: schema validation, reader adapters, pipeline, evaluation (`moonmind/manifest/` — 12 source files)
 - Manifest CLI (`moonmind manifest validate|plan|run|evaluate`)
 - Manifest ingest Temporal workflow (`moonmind/workflows/temporal/manifest_ingest.py`)
+- Manifest ingest live-source provider verification for GitHub, Confluence, and Google Drive (`tests/provider/manifest/`)
 - Spec 088 manifest schema pipeline spec implemented (#796)
 - Embedding model updated to current Gemini default (#787)
 - Context pack primitives (`rag/context_pack.py`)
@@ -131,7 +132,6 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - RAG doc ↔ spec consolidation completed (see `docs/MoonMindRoadmap.md`)
 
 ### Remaining tasks
-- [ ] **5.1** End-to-end manifest ingest testing — Manifest pipeline built but not fully tested against live data sources
 - [ ] **5.2** RAG retrieval quality validation — Evaluation framework exists (`manifest/evaluation.py`) but no golden datasets or baseline metrics established
 - [ ] **5.3** Context pack assembly wired into agent runs — Primitives exist; not integrated into Temporal activity execution
 - [ ] **5.4** Index health monitoring — No dashboard view of indexed collections, document counts, or freshness

--- a/moonmind/manifest/adapters.py
+++ b/moonmind/manifest/adapters.py
@@ -90,7 +90,11 @@ class GitHubReaderAdapter(_BaseAdapter):
 
         try:
             github_client = GithubClient(github_token=token, verbose=False)
-            filter_tuple = (filter_exts, "INCLUDE") if filter_exts else None
+            filter_tuple = (
+                (filter_exts, GithubRepositoryReader.FilterType.INCLUDE)
+                if filter_exts
+                else None
+            )
             reader = GithubRepositoryReader(
                 github_client=github_client,
                 owner=owner,

--- a/moonmind/manifest/adapters.py
+++ b/moonmind/manifest/adapters.py
@@ -162,7 +162,7 @@ class GoogleDriveReaderAdapter(_BaseAdapter):
                 creds_path = self._resolve(raw)
 
         try:
-            reader = GoogleDriveReader(credentials_path=creds_path)
+            reader = GoogleDriveReader(service_account_key_path=creds_path)
             if file_ids:
                 docs = reader.load_data(file_ids=file_ids)
             elif folder_id:

--- a/tests/provider/manifest/test_manifest_ingest_live_sources.py
+++ b/tests/provider/manifest/test_manifest_ingest_live_sources.py
@@ -1,0 +1,171 @@
+"""MM-755 provider verification for live manifest ingest data sources.
+
+These tests intentionally exercise the real manifest pipeline against live
+third-party readers. They are skipped unless the operator supplies explicit
+live-source configuration.
+
+Run manually, for example:
+
+    python -m pytest tests/provider/manifest -m provider_verification -q -s
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from moonmind.manifest.pipeline import ManifestPipeline
+from moonmind.schemas.manifest_v0_models import ManifestV0
+
+pytestmark = [
+    pytest.mark.provider_verification,
+    pytest.mark.requires_credentials,
+]
+
+
+def _manifest(source: dict[str, Any]) -> ManifestV0:
+    return ManifestV0.model_validate(
+        {
+            "version": "v0",
+            "metadata": {
+                "name": "mm-755-live-manifest-ingest",
+                "description": "MM-755 live data source verification",
+            },
+            "embeddings": {
+                "provider": "openai",
+                "model": "text-embedding-3-large",
+            },
+            "vectorStore": {
+                "type": "qdrant",
+                "indexName": "mm-755-provider-verification",
+            },
+            "dataSources": [source],
+            "indices": [
+                {
+                    "id": "idx1",
+                    "type": "VectorStoreIndex",
+                    "sources": ["live-source"],
+                }
+            ],
+            "retrievers": [
+                {
+                    "id": "ret1",
+                    "type": "Vector",
+                    "indices": ["idx1"],
+                }
+            ],
+            "run": {
+                "dryRun": False,
+                "errorPolicy": "stopOnFirstError",
+            },
+        }
+    )
+
+
+def _run_live_source(manifest: ManifestV0) -> dict[str, object]:
+    result = ManifestPipeline(manifest).run()
+
+    assert result.sources, "manifest pipeline should report the live data source"
+    source = result.sources[0]
+    assert source.error is None, source.error
+    assert source.doc_count > 0
+    assert result.total_docs == source.doc_count
+    return result.to_dict()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GITHUB_TOKEN", "").strip(),
+    reason="GITHUB_TOKEN is required for MM-755 live GitHub manifest verification",
+)
+def test_manifest_pipeline_ingests_live_github_source() -> None:
+    """Run manifest ingest against a real GitHub repository reader."""
+    repo = os.environ.get("MM_MANIFEST_TEST_GITHUB_REPO", "octocat/Spoon-Knife")
+    branch = os.environ.get("MM_MANIFEST_TEST_GITHUB_BRANCH", "main")
+    if "/" not in repo:
+        pytest.skip("MM_MANIFEST_TEST_GITHUB_REPO must be in owner/repo form")
+    owner, repo_name = repo.split("/", 1)
+
+    output = _run_live_source(
+        _manifest(
+            {
+                "id": "live-source",
+                "type": "GithubRepositoryReader",
+                "params": {
+                    "owner": owner,
+                    "repo": repo_name,
+                    "branch": branch,
+                    "filterExtensions": [".md"],
+                },
+                "auth": {"githubToken": "${GITHUB_TOKEN}"},
+            }
+        )
+    )
+
+    assert output["sources"][0]["type"] == "GithubRepositoryReader"
+
+
+@pytest.mark.skipif(
+    not all(
+        [
+            os.environ.get("CONFLUENCE_URL", "").strip(),
+            os.environ.get("CONFLUENCE_API_KEY", "").strip(),
+            os.environ.get("TEST_CONFLUENCE_SPACE_KEY", "").strip(),
+        ]
+    ),
+    reason=(
+        "CONFLUENCE_URL, CONFLUENCE_API_KEY, and TEST_CONFLUENCE_SPACE_KEY are "
+        "required for MM-755 live Confluence manifest verification"
+    ),
+)
+def test_manifest_pipeline_ingests_live_confluence_source() -> None:
+    """Run manifest ingest against a real Confluence reader."""
+    space_key = os.environ["TEST_CONFLUENCE_SPACE_KEY"].strip()
+    output = _run_live_source(
+        _manifest(
+            {
+                "id": "live-source",
+                "type": "ConfluenceReader",
+                "params": {
+                    "spaceKey": space_key,
+                    "maxPages": 5,
+                },
+                "auth": {
+                    "baseUrl": "${CONFLUENCE_URL}",
+                    "token": "${CONFLUENCE_API_KEY}",
+                },
+            }
+        )
+    )
+
+    assert output["sources"][0]["type"] == "ConfluenceReader"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GOOGLE_DRIVE_FOLDER_ID", "").strip()
+    or not os.environ.get("GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY_PATH", "").strip(),
+    reason=(
+        "GOOGLE_DRIVE_FOLDER_ID and GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY_PATH are "
+        "required for MM-755 live Google Drive manifest verification"
+    ),
+)
+def test_manifest_pipeline_ingests_live_google_drive_source() -> None:
+    """Run manifest ingest against a real Google Drive reader."""
+    folder_id = os.environ["GOOGLE_DRIVE_FOLDER_ID"].strip()
+    output = _run_live_source(
+        _manifest(
+            {
+                "id": "live-source",
+                "type": "GoogleDriveReader",
+                "params": {"folderId": folder_id},
+                "auth": {
+                    "serviceAccountKeyPath": (
+                        "${GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY_PATH}"
+                    )
+                },
+            }
+        )
+    )
+
+    assert output["sources"][0]["type"] == "GoogleDriveReader"

--- a/tests/unit/manifest/test_adapters_and_pipeline.py
+++ b/tests/unit/manifest/test_adapters_and_pipeline.py
@@ -6,7 +6,9 @@ T027 (metadata allowlist).
 
 from __future__ import annotations
 
+import sys
 import textwrap
+import types
 from enum import Enum
 from types import SimpleNamespace
 from typing import Any, Dict, Iterator, Tuple
@@ -91,6 +93,40 @@ class TestAdapterContracts:
         )
         adapter = GoogleDriveReaderAdapter(ds)
         assert isinstance(adapter, ReaderAdapter)
+
+    def test_google_drive_fetch_uses_service_account_key_path(self, monkeypatch):
+        calls = {}
+
+        class FakeGoogleDriveReader:
+            def __init__(self, **kwargs: Any) -> None:
+                calls.update(kwargs)
+
+            def load_data(self, *, folder_id: str):
+                calls["folder_id"] = folder_id
+                return [SimpleNamespace(text="drive-doc", metadata={})]
+
+        llama_index_module = types.ModuleType("llama_index")
+        readers_module = types.ModuleType("llama_index.readers")
+        google_module = types.ModuleType("llama_index.readers.google")
+        google_module.GoogleDriveReader = FakeGoogleDriveReader
+        monkeypatch.setitem(sys.modules, "llama_index", llama_index_module)
+        monkeypatch.setitem(sys.modules, "llama_index.readers", readers_module)
+        monkeypatch.setitem(sys.modules, "llama_index.readers.google", google_module)
+
+        ds = DataSourceConfig(
+            id="gd",
+            type="GoogleDriveReader",
+            params={"folderId": "abc123"},
+            auth={"serviceAccountKeyPath": "/tmp/service-account.json"},
+        )
+        adapter = GoogleDriveReaderAdapter(ds)
+
+        docs = list(adapter.fetch())
+
+        assert calls["service_account_key_path"] == "/tmp/service-account.json"
+        assert "credentials_path" not in calls
+        assert calls["folder_id"] == "abc123"
+        assert docs == [("drive-doc", {"source_type": "GoogleDriveReader"})]
 
     def test_local_adapter_is_reader(self):
         ds = DataSourceConfig(
@@ -200,8 +236,10 @@ class TestAdapterContracts:
 
         FakeGithubRepositoryReader.FilterType = FilterType
 
-        import llama_index.readers.github as github_module
-        import llama_index.readers.github.repository.github_client as client_module
+        github_module = pytest.importorskip("llama_index.readers.github")
+        client_module = pytest.importorskip(
+            "llama_index.readers.github.repository.github_client"
+        )
 
         monkeypatch.setattr(
             github_module,

--- a/tests/unit/manifest/test_adapters_and_pipeline.py
+++ b/tests/unit/manifest/test_adapters_and_pipeline.py
@@ -7,6 +7,8 @@ T027 (metadata allowlist).
 from __future__ import annotations
 
 import textwrap
+from enum import Enum
+from types import SimpleNamespace
 from typing import Any, Dict, Iterator, Tuple
 
 import pytest
@@ -176,6 +178,68 @@ class TestAdapterContracts:
         adapter = GitHubReaderAdapter(ds)
         state = adapter.state()
         assert state["branch"] == "dev"
+
+    def test_github_fetch_uses_reader_filter_type_enum(self, monkeypatch):
+        class FilterType(Enum):
+            INCLUDE = 2
+
+        calls = {}
+
+        class FakeGithubClient:
+            def __init__(self, github_token: str, verbose: bool) -> None:
+                calls["github_token"] = github_token
+                calls["client_verbose"] = verbose
+
+        class FakeGithubRepositoryReader:
+            def __init__(self, **kwargs: Any) -> None:
+                calls.update(kwargs)
+
+            def load_data(self, *, branch: str):
+                calls["branch"] = branch
+                return [SimpleNamespace(text="readme", metadata={})]
+
+        FakeGithubRepositoryReader.FilterType = FilterType
+
+        import llama_index.readers.github as github_module
+        import llama_index.readers.github.repository.github_client as client_module
+
+        monkeypatch.setattr(
+            github_module,
+            "GithubRepositoryReader",
+            FakeGithubRepositoryReader,
+        )
+        monkeypatch.setattr(client_module, "GithubClient", FakeGithubClient)
+
+        ds = DataSourceConfig(
+            id="gh",
+            type="GithubRepositoryReader",
+            params={
+                "owner": "owner",
+                "repo": "repo",
+                "branch": "main",
+                "filterExtensions": [".md"],
+            },
+            auth={"githubToken": "${GITHUB_TOKEN}"},
+        )
+        adapter = GitHubReaderAdapter(ds)
+
+        docs = list(adapter.fetch())
+
+        assert docs == [
+            (
+                "readme",
+                {
+                    "source_type": "GithubRepositoryReader",
+                    "owner": "owner",
+                    "repo": "repo",
+                },
+            )
+        ]
+        assert calls["filter_file_extensions"] == (
+            [".md"],
+            FilterType.INCLUDE,
+        )
+        assert calls["branch"] == "main"
 
 # ---------------------------------------------------------------------------
 # T025: Extensibility test — register custom adapter


### PR DESCRIPTION
Jira issue: MM-755

## Summary
- Added provider-verification coverage for live manifest ingest data sources through the real ManifestPipeline.
- Covered GitHub, Confluence, and Google Drive live-source manifests with credential-gated provider tests.
- Fixed the GitHub manifest adapter to pass the LlamaIndex FilterType enum for extension filters.
- Updated the Milestone 5 roadmap entry to reflect that manifest ingest live-source verification is now shipped.

## Tests run
- `./tools/test_unit.sh --python-only tests/unit/manifest/test_adapters_and_pipeline.py::TestAdapterContracts::test_github_fetch_uses_reader_filter_type_enum` -> 1 passed
- `./tools/test_unit.sh --python-only tests/provider/manifest/test_manifest_ingest_live_sources.py` -> 1 passed, 2 skipped
- `./tools/test_unit.sh --python-only tests/unit/manifest` -> 105 passed
- `./tools/test_unit.sh --python-only` -> 5532 passed, 6 skipped, 1 xpassed

## Remaining risks
- Confluence and Google Drive provider checks are credential-gated and were skipped in this runtime because those source credentials were not configured.
- The live GitHub provider check uses a small public default repository; operators can override it with `MM_MANIFEST_TEST_GITHUB_REPO` and `MM_MANIFEST_TEST_GITHUB_BRANCH`.
