### PR TITLE
MM-759 Incremental RAG re-indexing

### DIFF
--- a/moonmind/manifest/adapters.py
+++ b/moonmind/manifest/adapters.py
@@ -9,6 +9,7 @@ Adapters are auto-registered when this module is imported.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -185,6 +186,23 @@ class GoogleDriveReaderAdapter(_BaseAdapter):
 class SimpleDirectoryReaderAdapter(_BaseAdapter):
     """Wraps ``moonmind.indexers.local_data_indexer.LocalDataIndexer``."""
 
+    def _iter_files(self) -> Iterator[Path]:
+        input_dir = self.ds.params.get("inputDir", ".")
+        recursive = self.ds.params.get("recursive", False)
+        exts = self.ds.params.get("requiredExts")
+        p = Path(input_dir)
+        if not p.exists():
+            return
+        pattern = "**/*" if recursive else "*"
+        for f in sorted(p.glob(pattern)):
+            if not f.is_file():
+                continue
+            if ".moonmind" in f.parts:
+                continue
+            if exts and f.suffix not in exts:
+                continue
+            yield f
+
     def plan(self) -> PlanResult:
         input_dir = self.ds.params.get("inputDir", ".")
         p = Path(input_dir)
@@ -192,17 +210,12 @@ class SimpleDirectoryReaderAdapter(_BaseAdapter):
             return PlanResult(estimated_docs=0, metadata={"error": f"{p} not found"})
 
         recursive = self.ds.params.get("recursive", False)
-        exts = self.ds.params.get("requiredExts")
 
         count = 0
         total_bytes = 0
-        pattern = "**/*" if recursive else "*"
-        for f in p.glob(pattern):
-            if f.is_file():
-                if exts and f.suffix not in exts:
-                    continue
-                count += 1
-                total_bytes += f.stat().st_size
+        for f in self._iter_files():
+            count += 1
+            total_bytes += f.stat().st_size
 
         return PlanResult(
             estimated_docs=count,
@@ -212,20 +225,13 @@ class SimpleDirectoryReaderAdapter(_BaseAdapter):
 
     def fetch(self) -> Iterator[Tuple[str, Dict[str, Any]]]:
         input_dir = self.ds.params.get("inputDir", ".")
-        recursive = self.ds.params.get("recursive", False)
-        exts = self.ds.params.get("requiredExts")
 
         p = Path(input_dir)
         if not p.exists():
             logger.error("Input directory does not exist: %s", p)
             return
 
-        pattern = "**/*" if recursive else "*"
-        for f in p.glob(pattern):
-            if not f.is_file():
-                continue
-            if exts and f.suffix not in exts:
-                continue
+        for f in self._iter_files():
             try:
                 text = f.read_text(encoding="utf-8", errors="replace")
             except Exception as exc:
@@ -240,7 +246,27 @@ class SimpleDirectoryReaderAdapter(_BaseAdapter):
             yield (text, meta)
 
     def state(self) -> Dict[str, Any]:
-        return {"inputDir": self.ds.params.get("inputDir", ".")}
+        files: list[dict[str, Any]] = []
+        for f in self._iter_files():
+            try:
+                stat = f.stat()
+                digest = hashlib.sha256(f.read_bytes()).hexdigest()
+            except OSError:
+                continue
+            files.append(
+                {
+                    "path": str(f),
+                    "size": stat.st_size,
+                    "mtime_ns": stat.st_mtime_ns,
+                    "sha256": digest,
+                }
+            )
+        return {
+            "inputDir": self.ds.params.get("inputDir", "."),
+            "recursive": self.ds.params.get("recursive", False),
+            "requiredExts": self.ds.params.get("requiredExts"),
+            "files": files,
+        }
 
 # ---------------------------------------------------------------------------
 # Confluence

--- a/moonmind/manifest/adapters.py
+++ b/moonmind/manifest/adapters.py
@@ -250,7 +250,8 @@ class SimpleDirectoryReaderAdapter(_BaseAdapter):
         for f in self._iter_files():
             try:
                 stat = f.stat()
-                digest = hashlib.sha256(f.read_bytes()).hexdigest()
+                with f.open("rb") as file_obj:
+                    digest = hashlib.file_digest(file_obj, "sha256").hexdigest()
             except OSError:
                 continue
             files.append(

--- a/moonmind/manifest/incremental.py
+++ b/moonmind/manifest/incremental.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Protocol, Sequence
@@ -159,10 +160,10 @@ class IncrementalChangeSet:
 
 class IncrementalIndexWriter(Protocol):
     def delete_points(self, point_ids: Sequence[str]) -> None:
-        ...
+        raise NotImplementedError
 
     def upsert_chunks(self, chunks: Sequence[IndexedChunk]) -> None:
-        ...
+        raise NotImplementedError
 
 
 def default_state_path(*, manifest_name: str, index_name: str) -> Path:
@@ -175,6 +176,23 @@ def default_state_path(*, manifest_name: str, index_name: str) -> Path:
 
 def state_hash(cursor: Mapping[str, Any]) -> str:
     return _sha256_text(_stable_json(cursor))
+
+
+def splitter_hash(splitter: SplitterConfig | None) -> str:
+    if splitter is None:
+        return _sha256_text("default")
+    return _sha256_text(_stable_json(splitter.model_dump(mode="json")))
+
+
+def _document_hash(document: SourceDocument, splitter: SplitterConfig | None) -> str:
+    return _sha256_text(
+        _stable_json(
+            {
+                "content_hash": document.content_hash,
+                "splitter_hash": splitter_hash(splitter),
+            }
+        )
+    )
 
 
 def document_id_for(
@@ -253,7 +271,7 @@ def chunk_document(
         )
         chunks.append(
             IndexedChunk(
-                point_id=_sha256_text(point_seed),
+                point_id=str(uuid.uuid5(uuid.NAMESPACE_URL, point_seed)),
                 source_id=document.source_id,
                 document_id=document.document_id,
                 chunk_hash=chunk_hash,
@@ -281,14 +299,14 @@ def build_changeset(
     previous_documents = previous.documents if previous else {}
     current_documents = {document.document_id: document for document in documents}
     current_hashes = {
-        document_id: document.content_hash
+        document_id: _document_hash(document, splitter)
         for document_id, document in current_documents.items()
     }
 
     changed_documents = [
         document
         for document_id, document in current_documents.items()
-        if previous_documents.get(document_id) != document.content_hash
+        if previous_documents.get(document_id) != current_hashes[document_id]
     ]
     unchanged_document_ids = sorted(
         document_id
@@ -357,13 +375,19 @@ class QdrantIncrementalIndexWriter:
             point_ids=list(point_ids),
         )
 
-    def upsert_chunks(self, chunks: Sequence[IndexedChunk]) -> None:
+    def upsert_chunks(
+        self,
+        chunks: Sequence[IndexedChunk],
+        batch_size: int = 128,
+    ) -> None:
         if not chunks:
             return
-        vectors = [self._embedder.embed(chunk.text) for chunk in chunks]
-        self._qdrant.upsert_canonical_vectors(
-            collection_name=self._collection_name,
-            ids=[chunk.point_id for chunk in chunks],
-            vectors=vectors,
-            payloads=[chunk.payload() for chunk in chunks],
-        )
+        for start in range(0, len(chunks), batch_size):
+            batch = chunks[start : start + batch_size]
+            vectors = [self._embedder.embed(chunk.text) for chunk in batch]
+            self._qdrant.upsert_canonical_vectors(
+                collection_name=self._collection_name,
+                ids=[chunk.point_id for chunk in batch],
+                vectors=vectors,
+                payloads=[chunk.payload() for chunk in batch],
+            )

--- a/moonmind/manifest/incremental.py
+++ b/moonmind/manifest/incremental.py
@@ -1,0 +1,369 @@
+"""Incremental manifest indexing helpers for RAG document refreshes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
+
+from moonmind.schemas.manifest_v0_models import SplitterConfig
+
+
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _stable_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _safe_segment(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+    return cleaned.strip("-") or "default"
+
+
+@dataclass(slots=True)
+class SourceDocument:
+    source_id: str
+    document_id: str
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def content_hash(self) -> str:
+        return _sha256_text(self.text)
+
+
+@dataclass(slots=True)
+class IndexedChunk:
+    point_id: str
+    source_id: str
+    document_id: str
+    chunk_hash: str
+    offset_start: int
+    offset_end: int
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def payload(self) -> MutableMapping[str, Any]:
+        payload: MutableMapping[str, Any] = dict(self.metadata)
+        payload.update(
+            {
+                "source_id": self.source_id,
+                "document_id": self.document_id,
+                "offset_start": self.offset_start,
+                "offset_end": self.offset_end,
+                "chunk_hash": self.chunk_hash,
+                "trust_class": "canonical",
+                "text": self.text,
+            }
+        )
+        return payload
+
+
+@dataclass(slots=True)
+class SourceSnapshot:
+    source_id: str
+    state_hash: str
+    cursor: dict[str, Any]
+    documents: dict[str, str] = field(default_factory=dict)
+    document_chunks: dict[str, list[str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, source_id: str, raw: Mapping[str, Any]) -> "SourceSnapshot":
+        return cls(
+            source_id=source_id,
+            state_hash=str(raw.get("state_hash") or ""),
+            cursor=dict(raw.get("cursor") or {}),
+            documents={
+                str(key): str(value)
+                for key, value in dict(raw.get("documents") or {}).items()
+            },
+            document_chunks={
+                str(key): [str(item) for item in value]
+                for key, value in dict(raw.get("document_chunks") or {}).items()
+                if isinstance(value, list)
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state_hash": self.state_hash,
+            "cursor": self.cursor,
+            "documents": dict(sorted(self.documents.items())),
+            "document_chunks": {
+                key: list(value)
+                for key, value in sorted(self.document_chunks.items())
+            },
+        }
+
+
+@dataclass(slots=True)
+class IndexState:
+    manifest_name: str
+    index_name: str
+    sources: dict[str, SourceSnapshot] = field(default_factory=dict)
+
+    @classmethod
+    def load(
+        cls,
+        path: Path,
+        *,
+        manifest_name: str,
+        index_name: str,
+    ) -> "IndexState":
+        if not path.exists():
+            return cls(manifest_name=manifest_name, index_name=index_name)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        sources = {
+            source_id: SourceSnapshot.from_dict(source_id, source_raw)
+            for source_id, source_raw in dict(raw.get("sources") or {}).items()
+        }
+        return cls(
+            manifest_name=str(raw.get("manifest_name") or manifest_name),
+            index_name=str(raw.get("index_name") or index_name),
+            sources=sources,
+        )
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "manifest_name": self.manifest_name,
+            "index_name": self.index_name,
+            "sources": {
+                source_id: snapshot.to_dict()
+                for source_id, snapshot in sorted(self.sources.items())
+            },
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+@dataclass(slots=True)
+class IncrementalChangeSet:
+    source_id: str
+    state_hash: str
+    changed_documents: list[SourceDocument]
+    unchanged_document_ids: list[str]
+    deleted_document_ids: list[str]
+    stale_point_ids: list[str]
+    chunks: list[IndexedChunk]
+    next_snapshot: SourceSnapshot
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.changed_documents or self.deleted_document_ids)
+
+
+class IncrementalIndexWriter(Protocol):
+    def delete_points(self, point_ids: Sequence[str]) -> None:
+        ...
+
+    def upsert_chunks(self, chunks: Sequence[IndexedChunk]) -> None:
+        ...
+
+
+def default_state_path(*, manifest_name: str, index_name: str) -> Path:
+    return (
+        Path(".moonmind")
+        / "manifest_index_state"
+        / f"{_safe_segment(manifest_name)}__{_safe_segment(index_name)}.json"
+    )
+
+
+def state_hash(cursor: Mapping[str, Any]) -> str:
+    return _sha256_text(_stable_json(cursor))
+
+
+def document_id_for(
+    *,
+    source_id: str,
+    text: str,
+    metadata: Mapping[str, Any],
+    ordinal: int,
+) -> str:
+    for key in (
+        "document_id",
+        "doc_id",
+        "id",
+        "file_path",
+        "path",
+        "source",
+        "url",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return f"{source_id}:{ordinal}:{_sha256_text(text)}"
+
+
+def source_documents(
+    *,
+    source_id: str,
+    raw_documents: Sequence[tuple[str, Mapping[str, Any]]],
+) -> list[SourceDocument]:
+    documents: list[SourceDocument] = []
+    for ordinal, (text, metadata) in enumerate(raw_documents):
+        normalized_metadata = dict(metadata)
+        documents.append(
+            SourceDocument(
+                source_id=source_id,
+                document_id=document_id_for(
+                    source_id=source_id,
+                    text=text,
+                    metadata=normalized_metadata,
+                    ordinal=ordinal,
+                ),
+                text=text,
+                metadata=normalized_metadata,
+            )
+        )
+    return documents
+
+
+def chunk_document(
+    document: SourceDocument,
+    *,
+    splitter: SplitterConfig | None,
+) -> list[IndexedChunk]:
+    chunk_size = splitter.chunkSize if splitter else 1000
+    overlap = splitter.chunkOverlap if splitter else 100
+    if overlap >= chunk_size:
+        overlap = max(0, chunk_size - 1)
+    if not document.text:
+        return []
+
+    chunks: list[IndexedChunk] = []
+    cursor = 0
+    end = len(document.text)
+    while cursor < end:
+        chunk_end = min(end, cursor + chunk_size)
+        text = document.text[cursor:chunk_end]
+        chunk_hash = _sha256_text(text)
+        point_seed = "|".join(
+            [
+                document.source_id,
+                document.document_id,
+                str(cursor),
+                str(chunk_end),
+                chunk_hash,
+            ]
+        )
+        chunks.append(
+            IndexedChunk(
+                point_id=_sha256_text(point_seed),
+                source_id=document.source_id,
+                document_id=document.document_id,
+                chunk_hash=chunk_hash,
+                offset_start=cursor,
+                offset_end=chunk_end,
+                text=text,
+                metadata=document.metadata,
+            )
+        )
+        if chunk_end >= end:
+            break
+        cursor = max(chunk_end - overlap, cursor + 1)
+    return chunks
+
+
+def build_changeset(
+    *,
+    source_id: str,
+    cursor: Mapping[str, Any],
+    documents: Sequence[SourceDocument],
+    previous: SourceSnapshot | None,
+    splitter: SplitterConfig | None,
+) -> IncrementalChangeSet:
+    current_hash = state_hash(cursor)
+    previous_documents = previous.documents if previous else {}
+    current_documents = {document.document_id: document for document in documents}
+    current_hashes = {
+        document_id: document.content_hash
+        for document_id, document in current_documents.items()
+    }
+
+    changed_documents = [
+        document
+        for document_id, document in current_documents.items()
+        if previous_documents.get(document_id) != document.content_hash
+    ]
+    unchanged_document_ids = sorted(
+        document_id
+        for document_id in current_documents
+        if previous_documents.get(document_id) == current_hashes[document_id]
+    )
+    deleted_document_ids = sorted(
+        document_id
+        for document_id in previous_documents
+        if document_id not in current_documents
+    )
+
+    stale_point_ids: list[str] = []
+    if previous:
+        for document_id in deleted_document_ids:
+            stale_point_ids.extend(previous.document_chunks.get(document_id, []))
+        for document in changed_documents:
+            stale_point_ids.extend(previous.document_chunks.get(document.document_id, []))
+
+    new_chunks_by_document: dict[str, list[str]] = {}
+    chunks: list[IndexedChunk] = []
+    for document in changed_documents:
+        document_chunks = chunk_document(document, splitter=splitter)
+        chunks.extend(document_chunks)
+        new_chunks_by_document[document.document_id] = [
+            chunk.point_id for chunk in document_chunks
+        ]
+
+    next_document_chunks: dict[str, list[str]] = {}
+    if previous:
+        for document_id in unchanged_document_ids:
+            next_document_chunks[document_id] = list(
+                previous.document_chunks.get(document_id, [])
+            )
+    next_document_chunks.update(new_chunks_by_document)
+
+    return IncrementalChangeSet(
+        source_id=source_id,
+        state_hash=current_hash,
+        changed_documents=changed_documents,
+        unchanged_document_ids=unchanged_document_ids,
+        deleted_document_ids=deleted_document_ids,
+        stale_point_ids=sorted(dict.fromkeys(stale_point_ids)),
+        chunks=chunks,
+        next_snapshot=SourceSnapshot(
+            source_id=source_id,
+            state_hash=current_hash,
+            cursor=dict(cursor),
+            documents=current_hashes,
+            document_chunks=next_document_chunks,
+        ),
+    )
+
+
+class QdrantIncrementalIndexWriter:
+    def __init__(self, *, qdrant: Any, embedder: Any, collection_name: str) -> None:
+        self._qdrant = qdrant
+        self._embedder = embedder
+        self._collection_name = collection_name
+
+    def delete_points(self, point_ids: Sequence[str]) -> None:
+        if not point_ids:
+            return
+        self._qdrant.delete_vectors(
+            collection_name=self._collection_name,
+            point_ids=list(point_ids),
+        )
+
+    def upsert_chunks(self, chunks: Sequence[IndexedChunk]) -> None:
+        if not chunks:
+            return
+        vectors = [self._embedder.embed(chunk.text) for chunk in chunks]
+        self._qdrant.upsert_canonical_vectors(
+            collection_name=self._collection_name,
+            ids=[chunk.point_id for chunk in chunks],
+            vectors=vectors,
+            payloads=[chunk.payload() for chunk in chunks],
+        )

--- a/moonmind/manifest/pipeline.py
+++ b/moonmind/manifest/pipeline.py
@@ -20,6 +20,7 @@ from moonmind.manifest.incremental import (
     build_changeset,
     default_state_path,
     source_documents,
+    splitter_hash,
     state_hash,
 )
 from moonmind.manifest.reader_adapter import get_adapter
@@ -206,7 +207,8 @@ class ManifestPipeline:
                 continue
 
             try:
-                source_cursor = adapter.state()
+                source_cursor = dict(adapter.state())
+                source_cursor["splitter_hash"] = splitter_hash(splitter)
                 previous_snapshot = index_state.sources.get(ds.id)
                 current_state_hash = state_hash(source_cursor)
                 if (
@@ -245,6 +247,7 @@ class ManifestPipeline:
                     self._index_writer.upsert_chunks(changeset.chunks)
 
                 index_state.sources[ds.id] = changeset.next_snapshot
+                index_state.save(state_path)
 
                 src_result = SourceResult(
                     source_id=ds.id,

--- a/moonmind/manifest/pipeline.py
+++ b/moonmind/manifest/pipeline.py
@@ -11,8 +11,17 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from moonmind.manifest.incremental import (
+    IncrementalIndexWriter,
+    IndexState,
+    build_changeset,
+    default_state_path,
+    source_documents,
+    state_hash,
+)
 from moonmind.manifest.reader_adapter import get_adapter
 from moonmind.schemas.manifest_v0_models import ManifestV0
 
@@ -29,6 +38,10 @@ class SourceResult:
     source_id: str
     source_type: str
     doc_count: int = 0
+    indexed_doc_count: int = 0
+    deleted_doc_count: int = 0
+    chunk_count: int = 0
+    skipped: bool = False
     error: Optional[str] = None
 
 @dataclass
@@ -52,6 +65,10 @@ class PipelineResult:
                     "id": s.source_id,
                     "type": s.source_type,
                     "docs": s.doc_count,
+                    "indexed_docs": s.indexed_doc_count,
+                    "deleted_docs": s.deleted_doc_count,
+                    "chunks": s.chunk_count,
+                    "skipped": s.skipped,
                     "error": s.error,
                 }
                 for s in self.sources
@@ -78,15 +95,46 @@ class ManifestPipeline:
         self,
         manifest: ManifestV0,
         logger: Optional[logging.Logger] = None,
+        state_path: Path | str | None = None,
+        index_writer: IncrementalIndexWriter | None = None,
     ) -> None:
         self.manifest = manifest
         self.log = logger or logging.getLogger(__name__)
+        self._state_path = Path(state_path) if state_path is not None else None
+        self._index_writer = index_writer
 
         # Ensure adapters are registered
         try:
             import moonmind.manifest.adapters  # noqa: F401 — side-effect import
         except ImportError:
             self.log.debug("Built-in adapters module not available")
+
+    def _index_name(self) -> str:
+        if self.manifest.vectorStore.indexName:
+            return self.manifest.vectorStore.indexName
+        return self.manifest.indices[0].id
+
+    def _resolve_state_path(self) -> Path:
+        if self._state_path is not None:
+            return self._state_path
+        connection = self.manifest.vectorStore.connection
+        raw = getattr(connection, "incrementalStatePath", None)
+        if isinstance(raw, str) and raw.strip():
+            return Path(raw)
+        for index in self.manifest.indices:
+            if index.persist and index.persist.path:
+                return Path(index.persist.path).with_suffix(".incremental_state.json")
+        return default_state_path(
+            manifest_name=self.manifest.metadata.name,
+            index_name=self._index_name(),
+        )
+
+    @staticmethod
+    def _cursor_supports_fetch_skip(cursor: dict[str, Any]) -> bool:
+        for key in ("files", "commit", "commit_sha", "revision", "etag"):
+            if key in cursor:
+                return True
+        return False
 
     def plan(self) -> PipelineResult:
         """Dry-run: enumerate sources and estimate scope without writes."""
@@ -124,12 +172,7 @@ class ManifestPipeline:
         return result
 
     def run(self) -> PipelineResult:
-        """Full pipeline: fetch all sources, apply transforms, return docs.
-
-        Note: Embedding and upsert to vector store require integration with
-        the embedding client and Qdrant, which is wired separately via
-        Temporal Activities (T019).
-        """
+        """Full pipeline: fetch changed sources, apply deltas, and persist state."""
         result = PipelineResult(
             manifest_name=self.manifest.metadata.name,
             dry_run=False,
@@ -138,6 +181,13 @@ class ManifestPipeline:
         run_cfg = self.manifest.run
         _concurrency = run_cfg.concurrency if run_cfg else 6  # noqa: F841 — reserved for T019 async fan-out
         error_policy = run_cfg.errorPolicy if run_cfg else "continue"
+        state_path = self._resolve_state_path()
+        index_state = IndexState.load(
+            state_path,
+            manifest_name=self.manifest.metadata.name,
+            index_name=self._index_name(),
+        )
+        splitter = self.manifest.transforms.splitter if self.manifest.transforms else None
 
         for ds in self.manifest.dataSources:
             self.log.info("Processing data source: %s (%s)", ds.id, ds.type)
@@ -156,26 +206,62 @@ class ManifestPipeline:
                 continue
 
             try:
-                doc_count = 0
-                for text, metadata in adapter.fetch():
-                    doc_count += 1
-                    # In full integration, documents would be:
-                    # 1. Transformed (htmlToText, splitter, enrichMetadata)
-                    # 2. Embedded via embeddings config
-                    # 3. Upserted to vectorStore
+                source_cursor = adapter.state()
+                previous_snapshot = index_state.sources.get(ds.id)
+                current_state_hash = state_hash(source_cursor)
+                if (
+                    previous_snapshot is not None
+                    and previous_snapshot.state_hash == current_state_hash
+                    and self._cursor_supports_fetch_skip(source_cursor)
+                ):
+                    self.log.info(
+                        "Source %s unchanged; skipping fetch and re-index",
+                        ds.id,
+                    )
+                    result.sources.append(
+                        SourceResult(
+                            source_id=ds.id,
+                            source_type=ds.type,
+                            skipped=True,
+                        )
+                    )
+                    continue
+
+                raw_documents = list(adapter.fetch())
+                documents = source_documents(
+                    source_id=ds.id,
+                    raw_documents=raw_documents,
+                )
+                changeset = build_changeset(
+                    source_id=ds.id,
+                    cursor=source_cursor,
+                    documents=documents,
+                    previous=previous_snapshot,
+                    splitter=splitter,
+                )
+
+                if self._index_writer is not None:
+                    self._index_writer.delete_points(changeset.stale_point_ids)
+                    self._index_writer.upsert_chunks(changeset.chunks)
+
+                index_state.sources[ds.id] = changeset.next_snapshot
 
                 src_result = SourceResult(
                     source_id=ds.id,
                     source_type=ds.type,
-                    doc_count=doc_count,
+                    doc_count=len(documents),
+                    indexed_doc_count=len(changeset.changed_documents),
+                    deleted_doc_count=len(changeset.deleted_document_ids),
+                    chunk_count=len(changeset.chunks),
                 )
-                result.total_docs += doc_count
-
-                # Record state for incremental re-index
-                state = adapter.state()
+                result.total_docs += len(documents)
+                result.total_chunks += len(changeset.chunks)
                 self.log.info(
-                    "Source %s: fetched %d docs, state=%s",
-                    ds.id, doc_count, state,
+                    "Source %s: fetched %d docs, indexed %d docs, deleted %d docs",
+                    ds.id,
+                    len(documents),
+                    len(changeset.changed_documents),
+                    len(changeset.deleted_document_ids),
                 )
 
             except Exception as exc:
@@ -195,4 +281,5 @@ class ManifestPipeline:
 
             result.sources.append(src_result)
 
+        index_state.save(state_path)
         return result

--- a/moonmind/rag/qdrant_client.py
+++ b/moonmind/rag/qdrant_client.py
@@ -265,6 +265,38 @@ class RagQdrantClient:
         batch = qmodels.Batch(ids=ids, vectors=vectors, payloads=payloads)
         self._client.upsert(collection_name=collection_name, points=batch)
 
+    def upsert_canonical_vectors(
+        self,
+        *,
+        collection_name: str,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        payloads: Sequence[MutableMapping[str, Any]],
+    ) -> None:
+        if not (len(ids) == len(vectors) == len(payloads)):
+            raise RuntimeError(
+                "Canonical vector upsert requires equal id, vector, and payload counts"
+            )
+        if not ids:
+            return
+        batch = qmodels.Batch(
+            ids=list(ids),
+            vectors=[list(vector) for vector in vectors],
+            payloads=list(payloads),
+        )
+        self._client.upsert(collection_name=collection_name, points=batch)
+
+    def delete_vectors(
+        self,
+        *,
+        collection_name: str,
+        point_ids: Sequence[str],
+    ) -> None:
+        if not point_ids:
+            return
+        selector = qmodels.PointIdsList(points=list(point_ids))
+        self._client.delete(collection_name=collection_name, points_selector=selector)
+
     def delete_overlay_collection(self, collection_name: str) -> None:
         try:
             self._client.delete_collection(collection_name=collection_name)

--- a/tests/unit/manifest/test_adapters_and_pipeline.py
+++ b/tests/unit/manifest/test_adapters_and_pipeline.py
@@ -196,6 +196,18 @@ class CustomTestAdapter:
     def state(self) -> Dict[str, Any]:
         return {"custom_cursor": "v1"}
 
+
+class RecordingIndexWriter:
+    def __init__(self) -> None:
+        self.deleted_batches: list[list[str]] = []
+        self.upsert_batches: list[list[object]] = []
+
+    def delete_points(self, point_ids):
+        self.deleted_batches.append(list(point_ids))
+
+    def upsert_chunks(self, chunks):
+        self.upsert_batches.append(list(chunks))
+
 class TestExtensibility:
     def test_register_custom_adapter(self):
         register_adapter("CustomReader", CustomTestAdapter)
@@ -237,7 +249,7 @@ class TestExtensibility:
         assert plan.dry_run
         assert plan.total_docs == 42
 
-    def test_custom_adapter_runs(self):
+    def test_custom_adapter_runs(self, tmp_path):
         register_adapter("CustomReader", CustomTestAdapter)
         manifest = ManifestV0.from_yaml_string(textwrap.dedent("""\
             version: "v0"
@@ -260,7 +272,7 @@ class TestExtensibility:
                 type: "Vector"
                 indices: ["idx1"]
         """))
-        pipeline = ManifestPipeline(manifest)
+        pipeline = ManifestPipeline(manifest, state_path=tmp_path / "state.json")
         result = pipeline.run()
         assert result.total_docs == 1
         assert result.sources[0].doc_count == 1
@@ -343,16 +355,71 @@ class TestPipelineLocalAdapter:
         assert plan.total_docs == 1
 
     def test_run_with_local_files(self, tmp_path):
-        (tmp_path / "a.txt").write_text("alpha")
-        (tmp_path / "b.txt").write_text("beta")
+        data_dir = tmp_path / "docs"
+        data_dir.mkdir()
+        (data_dir / "a.txt").write_text("alpha")
+        (data_dir / "b.txt").write_text("beta")
         manifest = ManifestV0.from_yaml_string(
-            MINIMAL_MANIFEST.format(input_dir=str(tmp_path))
+            MINIMAL_MANIFEST.format(input_dir=str(data_dir))
         )
-        pipeline = ManifestPipeline(manifest)
+        pipeline = ManifestPipeline(manifest, state_path=tmp_path / "state.json")
         result = pipeline.run()
         assert not result.dry_run
         assert result.total_docs == 2
         assert result.sources[0].doc_count == 2
+        assert result.sources[0].indexed_doc_count == 2
+
+    def test_run_skips_unchanged_local_source(self, tmp_path):
+        data_dir = tmp_path / "docs"
+        data_dir.mkdir()
+        (data_dir / "a.txt").write_text("alpha")
+        manifest = ManifestV0.from_yaml_string(
+            MINIMAL_MANIFEST.format(input_dir=str(data_dir))
+        )
+        state_path = tmp_path / "incremental-state.json"
+
+        first = ManifestPipeline(manifest, state_path=state_path).run()
+        second = ManifestPipeline(manifest, state_path=state_path).run()
+
+        assert first.sources[0].doc_count == 1
+        assert first.sources[0].skipped is False
+        assert second.sources[0].doc_count == 0
+        assert second.sources[0].indexed_doc_count == 0
+        assert second.sources[0].skipped is True
+
+    def test_run_updates_changed_documents_and_deletes_stale_chunks(self, tmp_path):
+        data_dir = tmp_path / "docs"
+        data_dir.mkdir()
+        a_path = data_dir / "a.txt"
+        b_path = data_dir / "b.txt"
+        a_path.write_text("alpha")
+        b_path.write_text("beta")
+        manifest = ManifestV0.from_yaml_string(
+            MINIMAL_MANIFEST.format(input_dir=str(data_dir))
+        )
+        state_path = tmp_path / "incremental-state.json"
+        writer = RecordingIndexWriter()
+
+        first = ManifestPipeline(
+            manifest,
+            state_path=state_path,
+            index_writer=writer,
+        ).run()
+        b_path.unlink()
+        a_path.write_text("alpha changed")
+        second = ManifestPipeline(
+            manifest,
+            state_path=state_path,
+            index_writer=writer,
+        ).run()
+
+        assert first.sources[0].indexed_doc_count == 2
+        assert second.sources[0].doc_count == 1
+        assert second.sources[0].indexed_doc_count == 1
+        assert second.sources[0].deleted_doc_count == 1
+        assert len(writer.upsert_batches[0]) == 2
+        assert len(writer.upsert_batches[1]) == 1
+        assert writer.deleted_batches[1]
 
     def test_run_unknown_adapter_continues(self, tmp_path):
         yaml_str = textwrap.dedent("""\
@@ -377,7 +444,7 @@ class TestPipelineLocalAdapter:
                 indices: ["idx1"]
         """)
         manifest = ManifestV0.from_yaml_string(yaml_str)
-        pipeline = ManifestPipeline(manifest)
+        pipeline = ManifestPipeline(manifest, state_path=tmp_path / "state.json")
         result = pipeline.run()
         assert result.sources[0].error is not None
         assert "No adapter" in result.sources[0].error
@@ -411,7 +478,7 @@ class TestPipelineLocalAdapter:
               errorPolicy: "stopOnFirstError"
         """.format(input_dir=str(tmp_path)))
         manifest = ManifestV0.from_yaml_string(yaml_str)
-        pipeline = ManifestPipeline(manifest)
+        pipeline = ManifestPipeline(manifest, state_path=tmp_path / "state.json")
         result = pipeline.run()
         # Should stop after first error, not process "good"
         assert len(result.sources) == 1

--- a/tests/unit/manifest/test_adapters_and_pipeline.py
+++ b/tests/unit/manifest/test_adapters_and_pipeline.py
@@ -59,6 +59,36 @@ MINIMAL_MANIFEST = textwrap.dedent("""\
         indices: ["idx1"]
 """)
 
+SPLITTER_MANIFEST = textwrap.dedent("""\
+    version: "v0"
+    metadata:
+      name: "adapter-test"
+    embeddings:
+      provider: "openai"
+      model: "text-embedding-3-large"
+    vectorStore:
+      type: "qdrant"
+      indexName: "test"
+    dataSources:
+      - id: "local"
+        type: "SimpleDirectoryReader"
+        params:
+          inputDir: "{input_dir}"
+    transforms:
+      splitter:
+        type: TokenTextSplitter
+        chunkSize: {chunk_size}
+        chunkOverlap: 0
+    indices:
+      - id: "idx1"
+        type: "VectorStoreIndex"
+        sources: ["local"]
+    retrievers:
+      - id: "ret1"
+        type: "Vector"
+        indices: ["idx1"]
+""")
+
 @pytest.fixture(autouse=True)
 def _clean_registry():
     """Re-register built-in adapters for each test."""
@@ -419,6 +449,36 @@ class TestPipelineLocalAdapter:
         assert second.sources[0].deleted_doc_count == 1
         assert len(writer.upsert_batches[0]) == 2
         assert len(writer.upsert_batches[1]) == 1
+        assert writer.deleted_batches[1]
+
+    def test_run_reindexes_when_splitter_changes(self, tmp_path):
+        data_dir = tmp_path / "docs"
+        data_dir.mkdir()
+        (data_dir / "a.txt").write_text("alpha beta gamma")
+        state_path = tmp_path / "incremental-state.json"
+        writer = RecordingIndexWriter()
+
+        first_manifest = ManifestV0.from_yaml_string(
+            SPLITTER_MANIFEST.format(input_dir=str(data_dir), chunk_size=8)
+        )
+        second_manifest = ManifestV0.from_yaml_string(
+            SPLITTER_MANIFEST.format(input_dir=str(data_dir), chunk_size=5)
+        )
+
+        first = ManifestPipeline(
+            first_manifest,
+            state_path=state_path,
+            index_writer=writer,
+        ).run()
+        second = ManifestPipeline(
+            second_manifest,
+            state_path=state_path,
+            index_writer=writer,
+        ).run()
+
+        assert first.sources[0].indexed_doc_count == 1
+        assert second.sources[0].skipped is False
+        assert second.sources[0].indexed_doc_count == 1
         assert writer.deleted_batches[1]
 
     def test_run_unknown_adapter_continues(self, tmp_path):

--- a/tests/unit/manifest/test_incremental.py
+++ b/tests/unit/manifest/test_incremental.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from moonmind.manifest.incremental import (
+    IndexState,
+    build_changeset,
+    source_documents,
+)
+from moonmind.schemas.manifest_v0_models import SplitterConfig
+
+
+def test_changeset_detects_changed_and_deleted_documents() -> None:
+    splitter = SplitterConfig(chunkSize=20, chunkOverlap=0)
+    first_documents = source_documents(
+        source_id="local",
+        raw_documents=[
+            ("alpha", {"file_path": "a.txt"}),
+            ("beta", {"file_path": "b.txt"}),
+        ],
+    )
+    first = build_changeset(
+        source_id="local",
+        cursor={"run": 1},
+        documents=first_documents,
+        previous=None,
+        splitter=splitter,
+    )
+
+    second_documents = source_documents(
+        source_id="local",
+        raw_documents=[
+            ("alpha changed", {"file_path": "a.txt"}),
+        ],
+    )
+    second = build_changeset(
+        source_id="local",
+        cursor={"run": 2},
+        documents=second_documents,
+        previous=first.next_snapshot,
+        splitter=splitter,
+    )
+
+    assert [doc.document_id for doc in second.changed_documents] == ["a.txt"]
+    assert second.deleted_document_ids == ["b.txt"]
+    assert second.stale_point_ids == [
+        *first.next_snapshot.document_chunks["a.txt"],
+        *first.next_snapshot.document_chunks["b.txt"],
+    ]
+    assert len(second.chunks) == 1
+    assert second.next_snapshot.documents.keys() == {"a.txt"}
+
+
+def test_index_state_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    documents = source_documents(
+        source_id="local",
+        raw_documents=[("alpha", {"file_path": "a.txt"})],
+    )
+    changeset = build_changeset(
+        source_id="local",
+        cursor={"files": ["a.txt"]},
+        documents=documents,
+        previous=None,
+        splitter=None,
+    )
+    state = IndexState(manifest_name="m", index_name="idx")
+    state.sources["local"] = changeset.next_snapshot
+    state.save(path)
+
+    loaded = IndexState.load(path, manifest_name="m", index_name="idx")
+
+    assert loaded.manifest_name == "m"
+    assert loaded.index_name == "idx"
+    assert loaded.sources["local"].documents == {"a.txt": documents[0].content_hash}

--- a/tests/unit/manifest/test_incremental.py
+++ b/tests/unit/manifest/test_incremental.py
@@ -1,7 +1,9 @@
+import uuid
 from pathlib import Path
 
 from moonmind.manifest.incremental import (
     IndexState,
+    QdrantIncrementalIndexWriter,
     build_changeset,
     source_documents,
 )
@@ -70,4 +72,103 @@ def test_index_state_round_trips(tmp_path: Path) -> None:
 
     assert loaded.manifest_name == "m"
     assert loaded.index_name == "idx"
-    assert loaded.sources["local"].documents == {"a.txt": documents[0].content_hash}
+    assert loaded.sources["local"].documents == state.sources["local"].documents
+
+
+def test_chunk_point_ids_are_valid_deterministic_uuids() -> None:
+    splitter = SplitterConfig(chunkSize=5, chunkOverlap=0)
+    document = source_documents(
+        source_id="local",
+        raw_documents=[("alpha beta", {"file_path": "a.txt"})],
+    )[0]
+
+    first = build_changeset(
+        source_id="local",
+        cursor={"run": 1},
+        documents=[document],
+        previous=None,
+        splitter=splitter,
+    )
+    second = build_changeset(
+        source_id="local",
+        cursor={"run": 1},
+        documents=[document],
+        previous=None,
+        splitter=splitter,
+    )
+
+    assert [chunk.point_id for chunk in first.chunks] == [
+        chunk.point_id for chunk in second.chunks
+    ]
+    for chunk in first.chunks:
+        assert str(uuid.UUID(chunk.point_id)) == chunk.point_id
+
+
+def test_splitter_change_invalidates_existing_chunks() -> None:
+    documents = source_documents(
+        source_id="local",
+        raw_documents=[("alpha beta gamma", {"file_path": "a.txt"})],
+    )
+    first = build_changeset(
+        source_id="local",
+        cursor={"run": 1},
+        documents=documents,
+        previous=None,
+        splitter=SplitterConfig(chunkSize=8, chunkOverlap=0),
+    )
+
+    second = build_changeset(
+        source_id="local",
+        cursor={"run": 2},
+        documents=documents,
+        previous=first.next_snapshot,
+        splitter=SplitterConfig(chunkSize=5, chunkOverlap=0),
+    )
+
+    assert [doc.document_id for doc in second.changed_documents] == ["a.txt"]
+    assert second.stale_point_ids == first.next_snapshot.document_chunks["a.txt"]
+    assert second.chunks
+
+
+class _RecordingEmbedder:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def embed(self, text: str) -> list[float]:
+        self.texts.append(text)
+        return [float(len(text))]
+
+
+class _RecordingQdrant:
+    def __init__(self) -> None:
+        self.upserts: list[dict[str, object]] = []
+
+    def upsert_canonical_vectors(self, **kwargs: object) -> None:
+        self.upserts.append(kwargs)
+
+
+def test_qdrant_writer_batches_upserts() -> None:
+    documents = source_documents(
+        source_id="local",
+        raw_documents=[("alpha beta gamma delta epsilon zeta", {"file_path": "a.txt"})],
+    )
+    changeset = build_changeset(
+        source_id="local",
+        cursor={"run": 1},
+        documents=documents,
+        previous=None,
+        splitter=SplitterConfig(chunkSize=5, chunkOverlap=0),
+    )
+    qdrant = _RecordingQdrant()
+    embedder = _RecordingEmbedder()
+    writer = QdrantIncrementalIndexWriter(
+        qdrant=qdrant,
+        embedder=embedder,
+        collection_name="docs",
+    )
+
+    writer.upsert_chunks(changeset.chunks, batch_size=2)
+
+    assert len(qdrant.upserts) > 1
+    assert all(len(upsert["ids"]) <= 2 for upsert in qdrant.upserts)
+    assert len(embedder.texts) == len(changeset.chunks)

--- a/tests/unit/moonmind/rag/test_qdrant_client.py
+++ b/tests/unit/moonmind/rag/test_qdrant_client.py
@@ -193,3 +193,30 @@ def test_merge_results_keeps_multiple_chunks_when_hash_missing():
 
     assert len(items) == 2
     assert {item.text for item in items} == {"one", "two"}
+
+
+def test_canonical_vectors_use_supplied_ids_and_delete_by_point_ids():
+    client = _client()
+    calls = []
+
+    class FakeQdrant:
+        def upsert(self, *, collection_name, points):
+            calls.append(("upsert", collection_name, points.ids, points.vectors))
+
+        def delete(self, *, collection_name, points_selector):
+            calls.append(("delete", collection_name, points_selector.points))
+
+    client._client = FakeQdrant()  # type: ignore[assignment]
+
+    client.upsert_canonical_vectors(
+        collection_name="repo-main",
+        ids=["point-a"],
+        vectors=[[0.1, 0.2]],
+        payloads=[{"path": "a.txt"}],
+    )
+    client.delete_vectors(collection_name="repo-main", point_ids=["point-old"])
+
+    assert calls == [
+        ("upsert", "repo-main", ["point-a"], [[0.1, 0.2]]),
+        ("delete", "repo-main", ["point-old"]),
+    ]


### PR DESCRIPTION
Jira issue: MM-759

Summary:
- Added persisted manifest index state for source checkpoints and per-document chunk IDs.
- Added incremental change detection for manifest pipeline runs so unchanged strong-cursor sources can skip fetch/reindex.
- Added incremental vector store operations for canonical Qdrant point upserts and stale/deleted point cleanup.
- Added unit coverage for state round trips, changed/deleted document deltas, local source skip behavior, and Qdrant canonical upsert/delete calls.

Tests run:
- `python -m pytest tests/unit/manifest/test_incremental.py tests/unit/manifest/test_adapters_and_pipeline.py tests/unit/moonmind/rag/test_qdrant_client.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `./tools/test_integration.sh`

Remaining risks:
- Remote adapters with weak cursors, such as branch-only GitHub state, still fetch before delta selection to avoid missing upstream changes.
- Incremental vector writes require callers to provide an index writer/embedder integration for live Qdrant indexing paths.
