### PR TITLE
MM-752 Surface intervention requests

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -170,11 +170,12 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Task detail fields: Runtime, Model, Effort
 - Fast cancellation UX (TRY_CANCEL + force-terminate)
 - External runs integrated into main task dashboard
+- Intervention requests surface as the `intervention_requested` execution state in the task dashboard and live status stream
 
 ### Remaining tasks
 - [ ] **7.1** Migrate settings page to Mission Control — Settings currently in separate profile page, should be unified
 - [ ] **7.2** Artifact browsing UI (files/logs/patches) — API exists (`temporal_artifacts.py`), dashboard integration partial
-- [ ] **7.3** Intervention request monitoring — Not implemented
+- [x] **7.3** Intervention request monitoring — Agent requests for human help surface through `intervention_requested` run status monitoring
 - [ ] **7.4** Execution history / audit trail view — Spec 067 (`run-history-rerun`), API exists, UI incomplete
 - [ ] **7.5** Side-by-side comparison view — README promises "run the same task with different models and runtimes to compare results"
 - [ ] **7.6** Multi-step / step DAG visualization — Steps are tracked but no graphical visualization

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2771,12 +2771,40 @@ class MoonMindAgentRun:
                                     if not aa_enabled or self._auto_answer_count >= aa_max:
                                         # Opt-out or max cycles exhausted → escalate
                                         self.run_status = "intervention_requested"
+                                        auto_answer_reason = (
+                                            "jules_auto_answer_disabled"
+                                            if not aa_enabled
+                                            else "jules_auto_answer_exhausted"
+                                        )
+                                        self.final_result = self._intervention_result(
+                                            summary=(
+                                                "Jules requested human feedback; "
+                                                "operator intervention is required."
+                                            ),
+                                            request=request,
+                                            metadata={
+                                                "reason": "agent_requested_feedback",
+                                                "julesAutoAnswerReason": auto_answer_reason,
+                                                "julesAutoAnswerCount": self._auto_answer_count,
+                                                "julesAutoAnswerMax": aa_max,
+                                                "resiliencyPolicy": dict(resiliency_policy),
+                                                "lastStatus": status_obj.model_dump(
+                                                    mode="json",
+                                                    by_alias=True,
+                                                ),
+                                            },
+                                        )
                                         self._get_logger().warning(
                                             "Jules auto-answer %s for session %s (count=%d, max=%d)",
                                             "disabled" if not aa_enabled else "exhausted",
                                             self.run_id,
                                             self._auto_answer_count,
                                             aa_max,
+                                        )
+                                        await self._signal_parent_child_state_changed(
+                                            parent_info,
+                                            "intervention_requested",
+                                            "Jules requested human feedback.",
                                         )
                                         break
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -257,6 +257,73 @@ async def test_agent_run_external_poll_and_fetch_use_typed_activity_inputs(
     assert isinstance(fetch_payload, ExternalAgentRunInput)
     assert fetch_payload.run_id == "session-typed-1"
 
+async def test_agent_run_jules_feedback_with_auto_answer_disabled_signals_intervention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+    parent_signals: list[tuple[str, str]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "integration.resolve_adapter_metadata":
+            return {"agent_id": "jules", "execution_style": "polling"}
+        if activity_name == "integration.jules.start":
+            return {"external_id": "jules-session-1", "status": "running"}
+        if activity_name == "integration.jules.status":
+            return AgentRunStatus(
+                runId="jules-session-1",
+                agentKind="external",
+                agentId="jules",
+                status="awaiting_feedback",
+                metadata={"activityId": "activity-1"},
+            )
+        if activity_name == "integration.jules.list_activities":
+            return {
+                "activityId": "activity-1",
+                "latestAgentQuestion": "Which branch should I use?",
+            }
+        if activity_name == "integration.jules.get_auto_answer_config":
+            return {"enabled": False, "max_answers": 3}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    async def fake_signal_parent_child_state_changed(
+        parent_info: Any,
+        state: str,
+        reason: str,
+    ) -> None:
+        parent_signals.append((state, reason))
+
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(
+        run,
+        "_signal_parent_child_state_changed",
+        fake_signal_parent_child_state_changed,
+    )
+
+    result = await run.run(_request())
+
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "intervention_requested"
+    assert result.metadata["status"] == "intervention_requested"
+    assert result.metadata["reason"] == "agent_requested_feedback"
+    assert result.metadata["julesAutoAnswerReason"] == "jules_auto_answer_disabled"
+    assert result.metadata["lastStatus"]["status"] == "awaiting_feedback"
+    assert ("intervention_requested", "Jules requested human feedback.") in parent_signals
+    assert all(name != "integration.jules.fetch_result" for name, _ in routed_calls)
+
 
 async def test_resolve_adapter_metadata_normalizes_case_for_activity_routing(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Jira issue: MM-752

Summary:
- Escalates Jules human-feedback requests to an `intervention_requested` terminal result when auto-answer is disabled or exhausted.
- Signals the parent workflow when the Jules feedback escalation occurs so the broader run can observe the intervention request.
- Updates the roadmap dashboard section to reflect intervention request monitoring through the `intervention_requested` run status.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py -q` -> 9 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` -> Python: 5532 passed, 6 skipped, 1 xpassed; frontend: 26 files passed, 400 passed, 232 skipped
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py -k jules_feedback_with_auto_answer_disabled_signals_intervention` -> 1 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/integration/services/temporal/workflows/test_agent_run.py -k test_agent_run_escalates_external_feedback_request_to_parent_intervention` -> 1 passed, 15 deselected

Remaining risks:
- This change covers the existing Jules polling/auto-answer path and existing parent state-change signal; it does not add a new dedicated intervention inbox beyond the current run status monitoring surface.
