### PR TITLE
MM-753 add email completion notifications

### DIFF
--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2065,7 +2065,7 @@ class ExecutionNotificationSettings(BaseSettings):
     enabled: bool = Field(
         False,
         alias="MOONMIND_EXECUTION_NOTIFICATIONS_ENABLED",
-        description="Emit webhook notifications when an agent run reaches a terminal result.",
+        description="Emit notifications when an agent run reaches a terminal result.",
     )
     webhook_url: Optional[str] = Field(
         None,
@@ -2082,6 +2082,48 @@ class ExecutionNotificationSettings(BaseSettings):
         alias="MOONMIND_EXECUTION_NOTIFICATIONS_TIMEOUT_SECONDS",
         description="Webhook timeout in seconds.",
         gt=0,
+    )
+    email_to: Optional[str] = Field(
+        None,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_EMAIL_TO",
+        description="Comma-separated recipient list for completion notification email.",
+    )
+    email_from: Optional[str] = Field(
+        None,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_EMAIL_FROM",
+        description="Sender address for completion notification email.",
+    )
+    smtp_host: Optional[str] = Field(
+        None,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_HOST",
+        description="SMTP host used for completion notification email.",
+    )
+    smtp_port: int = Field(
+        587,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_PORT",
+        description="SMTP port used for completion notification email.",
+        gt=0,
+    )
+    smtp_username: Optional[str] = Field(
+        None,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_USERNAME",
+        description="Optional SMTP username for completion notification email.",
+    )
+    smtp_password: Optional[str] = Field(
+        None,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_PASSWORD",
+        description="Optional SMTP password for completion notification email.",
+        exclude=True,
+    )
+    smtp_use_tls: bool = Field(
+        True,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_USE_TLS",
+        description="Use STARTTLS for completion notification email.",
+    )
+    smtp_use_ssl: bool = Field(
+        False,
+        alias="MOONMIND_EXECUTION_NOTIFICATIONS_SMTP_USE_SSL",
+        description="Use implicit TLS for completion notification email.",
     )
 
     model_config = SettingsConfigDict(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from email.message import EmailMessage
 import hashlib
 import httpx
 import inspect
@@ -14,6 +15,7 @@ import os
 import re
 import shlex
 import shutil
+import smtplib
 import tempfile
 import time
 from dataclasses import dataclass
@@ -1373,6 +1375,24 @@ def _redacted_webhook_target(webhook_url: str) -> str:
         return ""
     return webhook_url.split("?", 1)[0]
 
+
+def _coerce_notification_recipients(value: str | Sequence[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_values = value.split(",")
+    else:
+        raw_values = [str(item) for item in value]
+    return [item.strip() for item in raw_values if item.strip()]
+
+
+def _redacted_email_target(recipients: Sequence[str]) -> str:
+    count = len([recipient for recipient in recipients if str(recipient).strip()])
+    if count == 1:
+        return "email:1 recipient"
+    return f"email:{count} recipients"
+
+
 def _build_execution_notification_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     result_payload = payload.get("result")
     if isinstance(result_payload, BaseModel):
@@ -1404,6 +1424,53 @@ def _build_execution_notification_payload(payload: Mapping[str, Any]) -> dict[st
         if value is not None:
             event[key] = value
     return redact_sensitive_payload(event)
+
+
+def _build_execution_notification_email(
+    event: Mapping[str, Any],
+    *,
+    sender: str,
+    recipients: Sequence[str],
+) -> EmailMessage:
+    status = str(event.get("status") or "completed")
+    workflow_id = str(event.get("workflowId") or "unknown-workflow")
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = ", ".join(recipients)
+    message["Subject"] = f"MoonMind execution {status}: {workflow_id}"
+    message.set_content(
+        "MoonMind execution completed.\n\n"
+        + json.dumps(dict(event), indent=2, sort_keys=True)
+        + "\n"
+    )
+    return message
+
+
+def _send_execution_notification_email(
+    event: Mapping[str, Any],
+    *,
+    sender: str,
+    recipients: Sequence[str],
+    smtp_host: str,
+    smtp_port: int,
+    smtp_username: str | None,
+    smtp_password: str | None,
+    smtp_use_tls: bool,
+    smtp_use_ssl: bool,
+    timeout_seconds: int,
+) -> None:
+    message = _build_execution_notification_email(
+        event,
+        sender=sender,
+        recipients=recipients,
+    )
+    smtp_cls = smtplib.SMTP_SSL if smtp_use_ssl else smtplib.SMTP
+    with smtp_cls(smtp_host, smtp_port, timeout=timeout_seconds) as client:
+        if smtp_use_tls and not smtp_use_ssl:
+            client.starttls()
+        if smtp_username:
+            client.login(smtp_username, smtp_password or "")
+        client.send_message(message)
 
 def _validate_external_agent_run_input(payload: Any) -> ExternalAgentRunInput:
     """Validate external activity input, including scalar legacy histories."""
@@ -3619,33 +3686,81 @@ class TemporalAgentRuntimeActivities:
         )
         notification_settings = settings.execution_notifications
         webhook_url = str(notification_settings.webhook_url or "").strip()
-        if not notification_settings.enabled or not webhook_url:
+        email_recipients = _coerce_notification_recipients(
+            notification_settings.email_to
+        )
+        email_sender = str(notification_settings.email_from or "").strip()
+        smtp_host = str(notification_settings.smtp_host or "").strip()
+        email_configured = bool(email_recipients and email_sender and smtp_host)
+        if not notification_settings.enabled:
             return {"status": "skipped", "reason": "disabled"}
-
-        headers = {"Content-Type": "application/json"}
-        authorization = str(notification_settings.authorization or "").strip()
-        if authorization:
-            headers["Authorization"] = authorization
+        if not webhook_url and not email_configured:
+            return {"status": "skipped", "reason": "no_channels"}
 
         event = _build_execution_notification_payload(payload)
-        try:
-            async with httpx.AsyncClient(
-                timeout=max(1, int(notification_settings.timeout_seconds or 5))
-            ) as client:
-                response = await client.post(
-                    webhook_url,
-                    json=event,
-                    headers=headers,
+        results: list[dict[str, str]] = []
+        timeout_seconds = max(1, int(notification_settings.timeout_seconds or 5))
+        if webhook_url:
+            headers = {"Content-Type": "application/json"}
+            authorization = str(notification_settings.authorization or "").strip()
+            if authorization:
+                headers["Authorization"] = authorization
+            try:
+                async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+                    response = await client.post(
+                        webhook_url,
+                        json=event,
+                        headers=headers,
+                    )
+                    response.raise_for_status()
+            except Exception as exc:  # pragma: no cover - best effort telemetry
+                logger.warning("Execution completion webhook failed: %s", exc)
+                return {
+                    "status": "failed",
+                    "reason": redact_sensitive_text(str(exc)),
+                    "target": _redacted_webhook_target(webhook_url),
+                }
+            results.append(
+                {
+                    "channel": "webhook",
+                    "target": _redacted_webhook_target(webhook_url),
+                }
+            )
+        if email_configured:
+            try:
+                await asyncio.to_thread(
+                    _send_execution_notification_email,
+                    event,
+                    sender=email_sender,
+                    recipients=email_recipients,
+                    smtp_host=smtp_host,
+                    smtp_port=int(notification_settings.smtp_port),
+                    smtp_username=notification_settings.smtp_username,
+                    smtp_password=notification_settings.smtp_password,
+                    smtp_use_tls=bool(notification_settings.smtp_use_tls),
+                    smtp_use_ssl=bool(notification_settings.smtp_use_ssl),
+                    timeout_seconds=timeout_seconds,
                 )
-                response.raise_for_status()
-        except Exception as exc:  # pragma: no cover - best effort telemetry
-            logger.warning("Execution completion notification failed: %s", exc)
-            return {
-                "status": "failed",
-                "reason": redact_sensitive_text(str(exc)),
-                "target": _redacted_webhook_target(webhook_url),
-            }
-        return {"status": "sent", "target": _redacted_webhook_target(webhook_url)}
+            except Exception as exc:  # pragma: no cover - best effort telemetry
+                logger.warning("Execution completion email failed: %s", exc)
+                return {
+                    "status": "failed",
+                    "reason": redact_sensitive_text(str(exc)),
+                    "target": _redacted_email_target(email_recipients),
+                }
+            results.append(
+                {
+                    "channel": "email",
+                    "target": _redacted_email_target(email_recipients),
+                }
+            )
+        if len(results) == 1:
+            return {"status": "sent", "target": results[0]["target"]}
+        return {
+            "status": "sent",
+            "channels": [result["channel"] for result in results],
+            "targets": [result["target"] for result in results],
+        }
 
     async def oauth_session_ensure_volume(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3699,6 +3699,7 @@ class TemporalAgentRuntimeActivities:
 
         event = _build_execution_notification_payload(payload)
         results: list[dict[str, str]] = []
+        errors: list[dict[str, str]] = []
         timeout_seconds = max(1, int(notification_settings.timeout_seconds or 5))
         if webhook_url:
             headers = {"Content-Type": "application/json"}
@@ -3715,17 +3716,20 @@ class TemporalAgentRuntimeActivities:
                     response.raise_for_status()
             except Exception as exc:  # pragma: no cover - best effort telemetry
                 logger.warning("Execution completion webhook failed: %s", exc)
-                return {
-                    "status": "failed",
-                    "reason": redact_sensitive_text(str(exc)),
-                    "target": _redacted_webhook_target(webhook_url),
-                }
-            results.append(
-                {
-                    "channel": "webhook",
-                    "target": _redacted_webhook_target(webhook_url),
-                }
-            )
+                errors.append(
+                    {
+                        "channel": "webhook",
+                        "reason": redact_sensitive_text(str(exc)),
+                        "target": _redacted_webhook_target(webhook_url),
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "channel": "webhook",
+                        "target": _redacted_webhook_target(webhook_url),
+                    }
+                )
         if email_configured:
             try:
                 await asyncio.to_thread(
@@ -3743,24 +3747,41 @@ class TemporalAgentRuntimeActivities:
                 )
             except Exception as exc:  # pragma: no cover - best effort telemetry
                 logger.warning("Execution completion email failed: %s", exc)
+                errors.append(
+                    {
+                        "channel": "email",
+                        "reason": redact_sensitive_text(str(exc)),
+                        "target": _redacted_email_target(email_recipients),
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "channel": "email",
+                        "target": _redacted_email_target(email_recipients),
+                    }
+                )
+        if errors and not results:
+            if len(errors) == 1:
                 return {
                     "status": "failed",
-                    "reason": redact_sensitive_text(str(exc)),
-                    "target": _redacted_email_target(email_recipients),
+                    "reason": errors[0]["reason"],
+                    "target": errors[0]["target"],
                 }
-            results.append(
-                {
-                    "channel": "email",
-                    "target": _redacted_email_target(email_recipients),
-                }
-            )
+            return {"status": "failed", "errors": errors}
         if len(results) == 1:
-            return {"status": "sent", "target": results[0]["target"]}
-        return {
+            result: dict[str, Any] = {"status": "sent", "target": results[0]["target"]}
+            if errors:
+                result["errors"] = errors
+            return result
+        result = {
             "status": "sent",
             "channels": [result["channel"] for result in results],
             "targets": [result["target"] for result in results],
         }
+        if errors:
+            result["errors"] = errors
+        return result
 
     async def oauth_session_ensure_volume(
         self,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -316,6 +316,236 @@ async def test_execution_notify_completion_sends_email_channel(monkeypatch) -> N
     assert "task-email" in sent["body"]
 
 
+async def test_execution_notify_completion_continues_to_email_after_webhook_failure(
+    monkeypatch,
+) -> None:
+    email_calls: list[dict[str, Any]] = []
+
+    class _Client:
+        def __init__(self, *, timeout: int) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            headers: dict[str, str],
+        ) -> object:
+            del url, json, headers
+            raise RuntimeError("token=secret webhook down")
+
+    def fake_send_email(*_args: Any, **kwargs: Any) -> None:
+        email_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "webhook_url",
+        "https://hooks.example.test/notify?token=secret",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "authorization",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_to",
+        "ops@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_from",
+        "moonmind@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_host",
+        "smtp.example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_port",
+        2525,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_username",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_password",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_tls",
+        False,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_ssl",
+        False,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "timeout_seconds",
+        5,
+    )
+    monkeypatch.setattr(activity_runtime_module.httpx, "AsyncClient", _Client)
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_send_execution_notification_email",
+        fake_send_email,
+    )
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.execution_notify_completion(
+        {"workflowId": "wf-partial", "status": "completed"}
+    )
+
+    assert result == {
+        "status": "sent",
+        "target": "email:1 recipient",
+        "errors": [
+            {
+                "channel": "webhook",
+                "reason": "token=[REDACTED] webhook down",
+                "target": "https://hooks.example.test/notify",
+            }
+        ],
+    }
+    assert len(email_calls) == 1
+    assert email_calls[0]["recipients"] == ["ops@example.test"]
+
+
+async def test_execution_notify_completion_reports_email_failure_after_webhook_success(
+    monkeypatch,
+) -> None:
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+    class _Client:
+        def __init__(self, *, timeout: int) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            headers: dict[str, str],
+        ) -> _Response:
+            del url, json, headers
+            return _Response()
+
+    def fake_send_email(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("password=secret smtp down")
+
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "webhook_url",
+        "https://hooks.example.test/notify",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "authorization",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_to",
+        "ops@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_from",
+        "moonmind@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_host",
+        "smtp.example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_port",
+        2525,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_username",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_password",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_tls",
+        False,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_ssl",
+        False,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "timeout_seconds",
+        5,
+    )
+    monkeypatch.setattr(activity_runtime_module.httpx, "AsyncClient", _Client)
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_send_execution_notification_email",
+        fake_send_email,
+    )
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.execution_notify_completion(
+        {"workflowId": "wf-partial", "status": "completed"}
+    )
+
+    assert result == {
+        "status": "sent",
+        "target": "https://hooks.example.test/notify",
+        "errors": [
+            {
+                "channel": "email",
+                "reason": "password=[REDACTED] smtp down",
+                "target": "email:1 recipient",
+            }
+        ],
+    }
+
+
 async def test_publish_artifacts_notifies_terminal_result(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -145,6 +145,21 @@ async def test_execution_notify_completion_posts_sanitized_payload(monkeypatch) 
         "timeout_seconds",
         7,
     )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_to",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_from",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_host",
+        None,
+    )
     monkeypatch.setattr(activity_runtime_module.httpx, "AsyncClient", _Client)
 
     activities = TemporalAgentRuntimeActivities()
@@ -171,6 +186,135 @@ async def test_execution_notify_completion_posts_sanitized_payload(monkeypatch) 
     assert calls[0]["json"]["event"] == "moonmind.execution.completed"
     assert calls[0]["json"]["summary"] == "token=[REDACTED]"
     assert calls[0]["json"]["taskRunId"] == "task-1"
+
+
+async def test_execution_notify_completion_sends_email_channel(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class _SMTP:
+        def __init__(self, host: str, port: int, *, timeout: int) -> None:
+            calls.append(
+                {"action": "connect", "host": host, "port": port, "timeout": timeout}
+            )
+
+        def __enter__(self) -> "_SMTP":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def starttls(self) -> None:
+            calls.append({"action": "starttls"})
+
+        def login(self, username: str, password: str) -> None:
+            calls.append(
+                {"action": "login", "username": username, "password": password}
+            )
+
+        def send_message(self, message: Any) -> None:
+            calls.append(
+                {
+                    "action": "send_message",
+                    "from": message["From"],
+                    "to": message["To"],
+                    "subject": message["Subject"],
+                    "body": message.get_content(),
+                }
+            )
+
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "webhook_url",
+        None,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_to",
+        "ops@example.test, owner@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "email_from",
+        "moonmind@example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_host",
+        "smtp.example.test",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_port",
+        2525,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_username",
+        "smtp-user",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_password",
+        "smtp-secret",
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_tls",
+        True,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "smtp_use_ssl",
+        False,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.settings.execution_notifications,
+        "timeout_seconds",
+        9,
+    )
+    monkeypatch.setattr(activity_runtime_module.smtplib, "SMTP", _SMTP)
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.execution_notify_completion(
+        {
+            "workflowId": "wf-email",
+            "runId": "run-email",
+            "agentId": "codex_cli",
+            "agentKind": "managed",
+            "status": "failed",
+            "result": {
+                "summary": "password=secret",
+                "failureClass": "permanent",
+                "metadata": {"taskRunId": "task-email"},
+            },
+        }
+    )
+
+    assert result == {"status": "sent", "target": "email:2 recipients"}
+    assert calls[0] == {
+        "action": "connect",
+        "host": "smtp.example.test",
+        "port": 2525,
+        "timeout": 9,
+    }
+    assert {"action": "starttls"} in calls
+    assert {
+        "action": "login",
+        "username": "smtp-user",
+        "password": "smtp-secret",
+    } in calls
+    sent = [call for call in calls if call["action"] == "send_message"][0]
+    assert sent["from"] == "moonmind@example.test"
+    assert sent["to"] == "ops@example.test, owner@example.test"
+    assert sent["subject"] == "MoonMind execution failed: wf-email"
+    assert "password=[REDACTED]" in sent["body"]
+    assert "task-email" in sent["body"]
+
 
 async def test_publish_artifacts_notifies_terminal_result(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []


### PR DESCRIPTION
Jira issue: MM-753

Summary:
- Adds SMTP-backed email completion notifications to the existing execution notification path.
- Keeps existing webhook completion notifications intact.
- Adds operator configuration under MOONMIND_EXECUTION_NOTIFICATIONS_* for email recipients, sender, SMTP host/port, auth, and TLS mode.
- Adds unit coverage for email-only completion notification delivery and preserves webhook-only behavior.

Tests run:
- python -m py_compile moonmind/config/settings.py moonmind/workflows/temporal/activity_runtime.py tests/unit/workflows/temporal/test_agent_runtime_activities.py
- git diff --check
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_agent_runtime_activities.py (108 passed, 15 warnings)

Remaining risks:
- No existing focused integration test covers execution.notify_completion or completion notification SMTP delivery; coverage is unit-level with a mocked SMTP client.
- Live SMTP behavior depends on operator-provided server configuration and credentials.
