### PR TITLE
MM-768 Complete Mission Control dashboard

### DIFF
--- a/artifacts.unwritable-context/context/rag-context-945b486041e9.json
+++ b/artifacts.unwritable-context/context/rag-context-945b486041e9.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. docs/Tasks/SkillAndPlanEvolution.md (score: 1.000, trust: canonical)\n    line 5: **Executive Summary:** The MoonMind system uses **tools** and **plans** atop Temporal to manage agent tasks. A *Tool* (`ToolDefinition`) is a named capability with input/output schemas, execution bindings, retries, etc. (not a workflow). A *Plan* is a DAG of tool invocations (Steps) with explicit dependencies and policies. This design leverages Temporal's deterministic workflows (orchestration) vs activities (side-effects). The codebase has completed a rename from `Skill*` to `Tool*` for Temporal contract objects; the term \"Skill\" is now reserved for agent instruction bundles (`.agents/skills/SKILL.md` files).\n2. docs/ReleaseNotes/MM-730-hard-switch-cutover.md (score: 1.000, trust: canonical)\n    line 5: This is a breaking release. Compatibility redirects and task-shaped aliases are not kept after the cutover boundary. Operators must keep the previous worker build draining on the legacy Task Queue for in-flight `MoonMind.Run` histories, or record an explicit pause/resume or terminate/restart decision before enabling `TEMPORAL_USER_WORKFLOW_CONTRACT_MODE=renamed_contract`.\n3. moonmind/integrations/jira/client.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"\n4. moonmind/integrations/jira/adf.py (score: 1.000, trust: canonical)\n    line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"\n5. moonmind/integrations/jira/auth.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"\n6. moonmind/integrations/jira/__init__.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"\n7. moonmind/integrations/jira/models.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"\n8. moonmind/integrations/jira/errors.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Sanitized Jira integration error types.\"\"\"",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "docs/Tasks/SkillAndPlanEvolution.md",
+      "text": "line 5: **Executive Summary:** The MoonMind system uses **tools** and **plans** atop Temporal to manage agent tasks. A *Tool* (`ToolDefinition`) is a named capability with input/output schemas, execution bindings, retries, etc. (not a workflow). A *Plan* is a DAG of tool invocations (Steps) with explicit dependencies and policies. This design leverages Temporal's deterministic workflows (orchestration) vs activities (side-effects). The codebase has completed a rename from `Skill*` to `Tool*` for Temporal contract objects; the term \"Skill\" is now reserved for agent instruction bundles (`.agents/skills/SKILL.md` files).",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 5,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ReleaseNotes/MM-730-hard-switch-cutover.md",
+      "text": "line 5: This is a breaking release. Compatibility redirects and task-shaped aliases are not kept after the cutover boundary. Operators must keep the previous worker build draining on the legacy Task Queue for in-flight `MoonMind.Run` histories, or record an explicit pause/resume or terminate/restart decision before enabling `TEMPORAL_USER_WORKFLOW_CONTRACT_MODE=renamed_contract`.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 5,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/client.py",
+      "text": "line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/adf.py",
+      "text": "line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 27,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/auth.py",
+      "text": "line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/__init__.py",
+      "text": "line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/models.py",
+      "text": "line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/errors.py",
+      "text": "line 1: \"\"\"Sanitized Jira integration error types.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-06-02T00:47:15Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -16,6 +16,7 @@ const workerSnapshot = {
     running: 2,
     staleRunning: 0,
     isDrained: true,
+    metricsSource: 'temporal',
   },
   commands: [
     {
@@ -259,6 +260,11 @@ describe('OperationsSettingsSection deployment update card', () => {
     renderOperations();
 
     const workerCard = await screen.findByRole('region', { name: /worker operations/i });
+    expect(await within(workerCard).findByRole('heading', { name: /worker fleet health/i })).toBeTruthy();
+    expect(within(workerCard).getByText('Healthy')).toBeTruthy();
+    expect(within(workerCard).getByText('temporal')).toBeTruthy();
+    expect(within(workerCard).getByText(/workers, scheduler/i)).toBeTruthy();
+    expect(within(workerCard).getAllByText('1').length).toBeGreaterThan(0);
     expect(await within(workerCard).findByText('Pause Workers')).toBeTruthy();
     expect(within(workerCard).getByText('Resume Workers')).toBeTruthy();
     expect(within(workerCard).getByText('Enable Maintenance Mode')).toBeTruthy();

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -1094,7 +1094,7 @@ export function OperationsSettingsSection({
                     Metrics source
                   </div>
                   <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
-                    {String((metrics as Record<string, unknown>).metricsSource || 'temporal')}
+                    {metrics.metricsSource || 'temporal'}
                   </div>
                 </div>
                 <div className="rounded-2xl bg-slate-50 dark:bg-slate-800/50 p-4">

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -20,6 +20,7 @@ const WorkerSnapshotSchema = z.object({
       running: z.number().optional(),
       staleRunning: z.number().optional(),
       isDrained: z.boolean().optional(),
+      metricsSource: z.string().optional(),
     })
     .optional(),
   audit: z
@@ -634,6 +635,13 @@ export function OperationsSettingsSection({
   const system = snapshot?.system ?? {};
   const metrics = snapshot?.metrics ?? {};
   const commands = snapshot?.commands ?? [];
+  const unavailableCommands = commands.filter((command) => !command.available);
+  const commandTargets = uniqueStrings(commands.map((command) => command.target || 'workers'));
+  const fleetHealthStatus = metrics.staleRunning && metrics.staleRunning > 0
+    ? 'Attention required'
+    : isError
+      ? 'Unavailable'
+      : 'Healthy';
   const isPaused = Boolean(system.workersPaused);
   const stateLabel = isPaused
     ? system.mode === 'quiesce'
@@ -1059,6 +1067,54 @@ export function OperationsSettingsSection({
                 </div>
               </div>
             </div>
+
+            <section className="rounded-3xl border border-slate-200 dark:border-slate-800 p-5">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <h4 className="text-base font-semibold text-slate-900 dark:text-white">
+                    Worker Fleet Health
+                  </h4>
+                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                    Snapshot combines worker pause state, Temporal-backed queue counters, stale-running detection, and operation command availability.
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    fleetHealthStatus === 'Healthy'
+                      ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+                      : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+                  }`}
+                >
+                  {fleetHealthStatus}
+                </span>
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-3">
+                <div className="rounded-2xl bg-slate-50 dark:bg-slate-800/50 p-4">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Metrics source
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {String((metrics as Record<string, unknown>).metricsSource || 'temporal')}
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 dark:bg-slate-800/50 p-4">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Command targets
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {commandTargets.length > 0 ? commandTargets.join(', ') : 'workers'}
+                  </div>
+                </div>
+                <div className="rounded-2xl bg-slate-50 dark:bg-slate-800/50 p-4">
+                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                    Unavailable commands
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-slate-900 dark:text-white">
+                    {String(unavailableCommands.length)}
+                  </div>
+                </div>
+              </div>
+            </section>
 
             <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
               <section className="rounded-3xl border border-slate-200 dark:border-slate-800 p-5">

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -379,9 +379,11 @@ describe('Workflow Detail Entrypoint', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
-      expect(screen.getByText('Plan work')).toBeTruthy();
-      expect(screen.getByText('Apply patch')).toBeTruthy();
-      expect(screen.getByText('Verify tests')).toBeTruthy();
+      expect(screen.getAllByText('Plan work').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Apply patch').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Verify tests').length).toBeGreaterThan(0);
+      expect(screen.getByRole('heading', { name: 'Step DAG' })).toBeTruthy();
+      expect(screen.getByText('Depends on: plan')).toBeTruthy();
       expect(screen.getByText('Merge Automation').closest('div')?.textContent).toContain('—');
       expect(screen.getByText(/^Current Run ID:?$/)).toBeTruthy();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
@@ -466,6 +468,87 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.queryByText(/^Task ID:?$/)).toBeNull();
       expect(screen.queryByText(/^Task Detail:?$/)).toBeNull();
       expect(screen.queryByText(/^Step Attempt:?$/)).toBeNull();
+    });
+  });
+
+  it('groups workflow artifacts and folds step and intervention events into the audit timeline', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Artifact browser task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      startedAt: '2026-04-09T00:00:01Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+      interventionAudit: [
+        {
+          action: 'send_message',
+          transport: 'temporal_update',
+          summary: 'Operator sent guidance.',
+          createdAt: '2026-04-09T00:00:05Z',
+        },
+      ],
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            artifacts: [
+              {
+                artifactId: 'art-log',
+                contentType: 'text/plain',
+                sizeBytes: 120,
+                status: 'complete',
+                metadata: { filename: 'runtime.log' },
+              },
+              {
+                artifactId: 'art-patch',
+                contentType: 'text/x-diff',
+                sizeBytes: 80,
+                status: 'complete',
+                metadata: { filename: 'fix.patch' },
+              },
+            ],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Workflow Artifacts' })).toBeTruthy();
+      expect(screen.getByText(/Artifact Browser/)).toBeTruthy();
+      expect(screen.getByText('runtime.log')).toBeTruthy();
+      expect(screen.getByText('fix.patch')).toBeTruthy();
+      expect(screen.getByText('Operator sent guidance.')).toBeTruthy();
+      expect(screen.getAllByText((_, element) => element?.textContent?.includes('Verify tests: ready') ?? false).length).toBeGreaterThan(0);
     });
   });
 
@@ -2387,7 +2470,7 @@ describe('Workflow Detail Entrypoint', () => {
     });
     expect(screen.getByRole('heading', { name: 'Target Diagnostics' })).toBeTruthy();
     expect(screen.getAllByText('Workflow objective').length).toBeGreaterThan(0);
-    expect(screen.getByText('objective.png')).toBeTruthy();
+    expect(screen.getAllByText('objective.png').length).toBeGreaterThan(0);
     expect(screen.getByText('Inspect screenshot')).toBeTruthy();
     expect(screen.getByText('Attachment download failed before step execution.')).toBeTruthy();
     expect(screen.getByText('artifact://diagnostics/input-manifest')).toBeTruthy();
@@ -4192,9 +4275,9 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByRole('heading', { name: 'Objective' })).toBeTruthy();
       expect(screen.getByRole('heading', { name: 'Step 2' })).toBeTruthy();
       expect(screen.getAllByRole('heading', { name: 'Step 2' })).toHaveLength(1);
-      expect(screen.getByText('objective.png')).toBeTruthy();
-      expect(screen.getByText('step.webp')).toBeTruthy();
-      expect(screen.getByText('step-second.jpg')).toBeTruthy();
+      expect(screen.getAllByText('objective.png').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('step.webp').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('step-second.jpg').length).toBeGreaterThan(0);
     });
 
     const objectivePreview = screen.getByAltText('Preview of Objective attachment objective.png');
@@ -4236,6 +4319,8 @@ describe('Workflow Detail Entrypoint', () => {
       status: 'waiting',
       state: 'awaiting_external',
       rawState: 'awaiting_external',
+      waitingReason: 'Agent requested human feedback.',
+      attentionRequired: true,
       createdAt: '2026-03-28T00:00:00Z',
       updatedAt: '2026-03-28T00:00:02Z',
       actions: {
@@ -4277,9 +4362,68 @@ describe('Workflow Detail Entrypoint', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Intervention' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Intervention Monitor' })).toBeTruthy();
+      expect(screen.getAllByText('Agent requested human feedback.').length).toBeGreaterThan(0);
       expect(screen.getByRole('heading', { name: 'Observation' })).toBeTruthy();
-      expect(screen.getByText(/Pause requested\./)).toBeTruthy();
+      expect(screen.getAllByText(/Pause requested\./).length).toBeGreaterThan(0);
       expect(screen.getByText(/Live logs are passive observation only/i)).toBeTruthy();
+    });
+  });
+
+  it('renders a side-by-side run comparison for related executions', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Comparison task',
+      summary: 'Compare runs',
+      status: 'completed',
+      state: 'completed',
+      rawState: 'completed',
+      targetRuntime: 'codex_cli',
+      model: 'gpt-5',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {},
+      relatedRuns: [
+        {
+          workflowId: 'test-456',
+          runId: '02-run',
+          relationship: 'rerun',
+          status: 'failed',
+          href: '/workflows/test-456?source=temporal',
+        },
+      ],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Run Comparison' })).toBeTruthy();
+      expect(screen.getByText('current')).toBeTruthy();
+      expect(screen.getByText('test-456')).toBeTruthy();
+      expect(screen.getAllByText('gpt-5').length).toBeGreaterThan(0);
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -530,6 +530,13 @@ describe('Workflow Detail Entrypoint', () => {
                 status: 'complete',
                 metadata: { filename: 'fix.patch' },
               },
+              {
+                artifactId: 'art-report-by-type',
+                contentType: 'text/plain',
+                sizeBytes: 256,
+                status: 'complete',
+                metadata: { filename: 'output.txt', artifact_type: 'report.primary' },
+              },
             ],
           }),
         } as Response);
@@ -547,6 +554,7 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByText(/Artifact Browser/)).toBeTruthy();
       expect(screen.getByText('runtime.log')).toBeTruthy();
       expect(screen.getByText('fix.patch')).toBeTruthy();
+      expect(screen.getByText('output.txt').closest('tr')?.textContent).toContain('reports');
       expect(screen.getByText('Operator sent guidance.')).toBeTruthy();
       expect(screen.getAllByText((_, element) => element?.textContent?.includes('Verify tests: ready') ?? false).length).toBeGreaterThan(0);
     });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1993,6 +1993,16 @@ function metadataString(metadata: Record<string, unknown>, ...keys: string[]): s
   return '';
 }
 
+function metadataStrings(metadata: Record<string, unknown>, ...keys: string[]): string {
+  return keys
+    .map((key) => {
+      const value = metadata[key];
+      return typeof value === 'string' ? value.trim() : '';
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
 function artifactReportLinkType(
   artifact: z.infer<typeof ArtifactSummarySchema>,
 ): string | null {
@@ -4034,7 +4044,7 @@ function artifactBrowserCategory(artifact: z.infer<typeof ArtifactSummarySchema>
   const searchText = [
     artifact.artifactId,
     artifact.contentType,
-    metadataString(metadata, 'filename', 'name', 'label', 'artifact_type', 'artifactType', 'render_hint', 'renderHint'),
+    metadataStrings(metadata, 'filename', 'name', 'label', 'artifact_type', 'artifactType', 'render_hint', 'renderHint'),
     artifact.links.map((link) => `${link.linkType} ${link.label || ''}`).join(' '),
   ]
     .join(' ')
@@ -4254,7 +4264,7 @@ function AuditTrailPanel({
           </thead>
           <tbody>
             {rows.map((row, index) => (
-              <tr key={`${row.stage}-${row.timestamp || index}`}>
+              <tr key={`${row.stage}-${row.timestamp || ''}-${index}`}>
                 <td>{row.stage}</td>
                 <td>{formatWhen(row.timestamp)}</td>
                 <td>{row.detail}</td>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4027,6 +4027,296 @@ function RemediationEvidencePanel({
   );
 }
 
+type ArtifactCategory = 'files' | 'logs' | 'patches' | 'reports' | 'other';
+
+function artifactBrowserCategory(artifact: z.infer<typeof ArtifactSummarySchema>): ArtifactCategory {
+  const metadata = artifact.metadata || {};
+  const searchText = [
+    artifact.artifactId,
+    artifact.contentType,
+    metadataString(metadata, 'filename', 'name', 'label', 'artifact_type', 'artifactType', 'render_hint', 'renderHint'),
+    artifact.links.map((link) => `${link.linkType} ${link.label || ''}`).join(' '),
+  ]
+    .join(' ')
+    .toLowerCase();
+  if (searchText.includes('report')) return 'reports';
+  if (/\b(log|stdout|stderr|diagnostic|trace)\b/.test(searchText)) return 'logs';
+  if (/\b(patch|diff|apply_output)\b/.test(searchText)) return 'patches';
+  if (/\b(file|attachment|input|context|summary|checkpoint)\b/.test(searchText)) return 'files';
+  return 'other';
+}
+
+function ArtifactBrowserPanel({
+  artifacts,
+  apiBase,
+  isLoading,
+  error,
+}: {
+  artifacts: z.infer<typeof ArtifactSummarySchema>[];
+  apiBase: string;
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  const grouped = artifacts.reduce<Record<ArtifactCategory, z.infer<typeof ArtifactSummarySchema>[]>>(
+    (acc, artifact) => {
+      acc[artifactBrowserCategory(artifact)].push(artifact);
+      return acc;
+    },
+    { files: [], logs: [], patches: [], reports: [], other: [] },
+  );
+  const categoryRows = (Object.keys(grouped) as ArtifactCategory[]).filter(
+    (category) => grouped[category].length > 0,
+  );
+
+  return (
+    <section className="stack td-artifacts-region td-evidence-region">
+      <div className="step-tl-section-header">
+        <h3>Workflow Artifacts</h3>
+        <span className="step-tl-count">
+          Artifact Browser | {artifacts.length} artifact{artifacts.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      {isLoading ? (
+        <p className="loading">Loading artifacts...</p>
+      ) : error ? (
+        <div className="notice error">{error.message}</div>
+      ) : artifacts.length === 0 ? (
+        <p className="small">No artifacts.</p>
+      ) : (
+        <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
+          <table>
+            <thead>
+              <tr>
+                <th>Group</th>
+                <th>Artifact</th>
+                <th>Size</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categoryRows.flatMap((category) =>
+                grouped[category].map((artifact) => (
+                  <tr key={`${category}-${artifact.artifactId}`}>
+                    <td>{formatStatusLabel(category)}</td>
+                    <td>
+                      <code>{metadataString(artifact.metadata, 'filename', 'name', 'label') || artifact.artifactId}</code>
+                      {artifact.contentType ? <div className="small">{artifact.contentType}</div> : null}
+                    </td>
+                    <td>{artifact.sizeBytes ?? '—'}</td>
+                    <td>{formatStatusLabel(artifact.status)}</td>
+                    <td>
+                      <div className="actions">
+                        <a
+                          className="button secondary"
+                          href={artifactDownloadHref(apiBase, artifact)}
+                          title="Download artifact"
+                        >
+                          Download
+                        </a>
+                        <a
+                          className="button secondary"
+                          href={reportOpenHref(apiBase, artifact)}
+                          title="Open readable artifact content"
+                        >
+                          Open
+                        </a>
+                      </div>
+                    </td>
+                  </tr>
+                )),
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StepDagOverview({
+  snapshot,
+}: {
+  snapshot: z.infer<typeof StepLedgerSnapshotSchema>;
+}) {
+  return (
+    <section className="step-dag-panel" aria-label="Step DAG visualization">
+      <h4>Step DAG</h4>
+      <div className="step-dag-grid">
+        {snapshot.steps.map((step) => (
+          <article key={step.logicalStepId} className="step-dag-node">
+            <div className="step-dag-node-header">
+              <strong>{step.title}</strong>
+              <span {...executionStatusPillProps(step.status)}>
+                {formatStatusLabel(step.status)}
+              </span>
+            </div>
+            <div className="small">
+              <code>{step.logicalStepId}</code>
+            </div>
+            <div className="small">
+              Depends on: {step.dependsOn.length > 0 ? step.dependsOn.join(', ') : 'start'}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function InterventionMonitorPanel({
+  execution,
+}: {
+  execution: z.infer<typeof ExecutionDetailSchema>;
+}) {
+  const state = execution.rawState || execution.state || execution.status;
+  const requested = execution.attentionRequired || state === 'intervention_requested';
+  const auditCount = execution.interventionAudit?.length ?? 0;
+  if (!requested && auditCount === 0 && !execution.waitingReason) {
+    return null;
+  }
+  return (
+    <section className="stack td-intervention-monitor-region td-evidence-region">
+      <h3>Intervention Monitor</h3>
+      <div className="grid-2">
+        <Card label="Request State">{requested ? 'Intervention requested' : 'No active request'}</Card>
+        <Card label="Workflow State">{formatStatusLabel(state)}</Card>
+        <Card label="Audit Entries">{String(auditCount)}</Card>
+        <Card label="Waiting Reason">{execution.waitingReason || '—'}</Card>
+      </div>
+    </section>
+  );
+}
+
+function AuditTrailPanel({
+  execution,
+  steps,
+}: {
+  execution: z.infer<typeof ExecutionDetailSchema>;
+  steps: z.infer<typeof StepLedgerSnapshotSchema> | null | undefined;
+}) {
+  const rows: Array<{ stage: string; timestamp: string | null | undefined; detail: ReactNode }> = [
+    { stage: 'Started', timestamp: execution.startedAt, detail: 'Execution created.' },
+    {
+      stage: 'Last update',
+      timestamp: execution.updatedAt,
+      detail: <>State: {formatStatusLabel(execution.state, '')}</>,
+    },
+  ];
+  if (execution.waitingReason || execution.attentionRequired) {
+    rows.push({
+      stage: 'Waiting',
+      timestamp: execution.updatedAt,
+      detail: `${execution.waitingReason || 'Awaiting external input.'}${execution.attentionRequired ? ' Attention required.' : ''}`,
+    });
+  }
+  for (const step of steps?.steps ?? []) {
+    rows.push({
+      stage: `Step ${step.order}`,
+      timestamp: step.updatedAt || step.startedAt,
+      detail: (
+        <>
+          {step.title}: {formatStatusLabel(step.status)}
+        </>
+      ),
+    });
+  }
+  for (const entry of execution.interventionAudit || []) {
+    rows.push({
+      stage: 'Intervention',
+      timestamp: entry.createdAt,
+      detail: (
+        <>
+          {entry.summary} <code className="text-xs">{entry.transport}</code>
+        </>
+      ),
+    });
+  }
+  if (execution.closedAt) {
+    rows.push({
+      stage: 'Closed',
+      timestamp: execution.closedAt,
+      detail: <>Close status: {formatStatusLabel(execution.closeStatus || execution.temporalStatus)}</>,
+    });
+  }
+
+  return (
+    <section className="stack td-timeline-region td-evidence-region">
+      <h3>Timeline</h3>
+      <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
+        <table>
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>Timestamp</th>
+              <th>Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr key={`${row.stage}-${row.timestamp || index}`}>
+                <td>{row.stage}</td>
+                <td>{formatWhen(row.timestamp)}</td>
+                <td>{row.detail}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function RunComparisonPanel({
+  execution,
+}: {
+  execution: z.infer<typeof ExecutionDetailSchema>;
+}) {
+  if (!execution.relatedRuns || execution.relatedRuns.length === 0) {
+    return null;
+  }
+  const currentStatus = execution.rawState || execution.state || execution.status;
+  return (
+    <section className="stack td-comparison-region td-evidence-region">
+      <h3>Run Comparison</h3>
+      <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
+        <table>
+          <thead>
+            <tr>
+              <th>Relation</th>
+              <th>Workflow</th>
+              <th>Run</th>
+              <th>Status</th>
+              <th>Runtime</th>
+              <th>Model</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>current</td>
+              <td><code>{execution.workflowId || execution.taskId}</code></td>
+              <td><code>{execution.runId || execution.temporalRunId || '—'}</code></td>
+              <td>{formatStatusLabel(currentStatus)}</td>
+              <td>{formatRuntimeLabel(execution.targetRuntime)}</td>
+              <td>{execution.model || execution.resolvedModel || execution.requestedModel || '—'}</td>
+            </tr>
+            {execution.relatedRuns.map((run) => (
+              <tr key={`${run.relationship}-${run.workflowId}-${run.runId || ''}`}>
+                <td>{formatStatusLabel(run.relationship)}</td>
+                <td><a href={run.href}><code>{run.workflowId}</code></a></td>
+                <td><code>{run.runId || '—'}</code></td>
+                <td>{formatStatusLabel(run.status || 'unknown')}</td>
+                <td>—</td>
+                <td>—</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const cfg = readDashboardConfig(payload);
@@ -4923,28 +5213,33 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
               ) : stepsQuery.isError ? (
                 <div className="notice error">{(stepsQuery.error as Error).message}</div>
               ) : stepsQuery.data ? (
-                <div className="step-tl-list">
-                  {stepsQuery.data.steps.map((row, idx) => (
-                    <StepLedgerRowCard
-                      key={row.logicalStepId}
-                      apiBase={payload.apiBase}
-                      logStreamingEnabled={logStreamingEnabled}
-                      sessionTimelineEnabled={sessionTimelineEnabled}
-                      structuredHistoryEnabled={structuredHistoryEnabled}
-                      row={row}
-                      runId={latestRunId}
-                      expanded={Boolean(expandedSteps[row.logicalStepId])}
-                      onToggle={() => toggleStep(row.logicalStepId)}
-                      isLast={idx === stepsQuery.data.steps.length - 1}
-                      routes={taskRunRoutes}
-                    />
-                  ))}
-                </div>
+                <>
+                  <StepDagOverview snapshot={stepsQuery.data} />
+                  <div className="step-tl-list">
+                    {stepsQuery.data.steps.map((row, idx) => (
+                      <StepLedgerRowCard
+                        key={row.logicalStepId}
+                        apiBase={payload.apiBase}
+                        logStreamingEnabled={logStreamingEnabled}
+                        sessionTimelineEnabled={sessionTimelineEnabled}
+                        structuredHistoryEnabled={structuredHistoryEnabled}
+                        row={row}
+                        runId={latestRunId}
+                        expanded={Boolean(expandedSteps[row.logicalStepId])}
+                        onToggle={() => toggleStep(row.logicalStepId)}
+                        isLast={idx === stepsQuery.data.steps.length - 1}
+                        routes={taskRunRoutes}
+                      />
+                    ))}
+                  </div>
+                </>
               ) : (
                 <p className="small">No step ledger available for this execution.</p>
               )}
             </section>
           ) : null}
+
+          <InterventionMonitorPanel execution={execution} />
 
           {execution.attentionRequired ? (
             <section className="notice">
@@ -5061,6 +5356,8 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
               </div>
             </section>
           ) : null}
+
+          <RunComparisonPanel execution={execution} />
 
           <RemediationRelationshipsPanel
             inbound={inboundRemediationsQuery.data}
@@ -5246,97 +5543,14 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             showEmpty={shouldFetchRemediationLinks && artifactsQuery.isSuccess}
           />
 
-          <section className="stack td-timeline-region td-evidence-region">
-            <h3>Timeline</h3>
-            <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Stage</th>
-                    <th>Timestamp</th>
-                    <th>Detail</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Started</td>
-                    <td>{formatWhen(execution.startedAt)}</td>
-                    <td>Execution created.</td>
-                  </tr>
-                  <tr>
-                    <td>Last update</td>
-                    <td>{formatWhen(execution.updatedAt)}</td>
-                    <td>State: {formatStatusLabel(execution.state, '')}</td>
-                  </tr>
-                  {execution.waitingReason || execution.attentionRequired ? (
-                    <tr>
-                      <td>Waiting</td>
-                      <td>{formatWhen(execution.updatedAt)}</td>
-                      <td>
-                        {execution.waitingReason || 'Awaiting external input.'}
-                        {execution.attentionRequired ? ' Attention required.' : ''}
-                      </td>
-                    </tr>
-                  ) : null}
-                  {execution.closedAt ? (
-                    <tr>
-                      <td>Closed</td>
-                      <td>{formatWhen(execution.closedAt)}</td>
-                      <td>Close status: {formatStatusLabel(execution.closeStatus || execution.temporalStatus)}</td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </section>
+          <AuditTrailPanel execution={execution} steps={stepsQuery.data} />
 
-          <section className="stack td-artifacts-region td-evidence-region">
-            <h3>Workflow Artifacts</h3>
-            {artifactsQuery.isLoading ? (
-              <p className="loading">Loading artifacts...</p>
-            ) : artifactsQuery.isError ? (
-              <div className="notice error">{(artifactsQuery.error as Error).message}</div>
-            ) : (
-              <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Artifact</th>
-                      <th>Size</th>
-                      <th>Status</th>
-                      <th>Action</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {(artifactsQuery.data?.artifacts || []).length === 0 ? (
-                      <tr>
-                        <td colSpan={4}>No artifacts.</td>
-                      </tr>
-                    ) : (
-                      (artifactsQuery.data?.artifacts || []).map((artifact) => (
-                        <tr key={artifact.artifactId}>
-                          <td>
-                            <code>{artifact.artifactId}</code>
-                          </td>
-                          <td>{artifact.sizeBytes ?? '—'}</td>
-                          <td>{formatStatusLabel(artifact.status)}</td>
-                          <td>
-                            <a
-                              className="button secondary"
-                              href={artifactDownloadHref(payload.apiBase, artifact)}
-                              title="Download artifact"
-                            >
-                              Download
-                            </a>
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
+          <ArtifactBrowserPanel
+            artifacts={artifactsQuery.data?.artifacts || []}
+            apiBase={payload.apiBase}
+            isLoading={artifactsQuery.isLoading}
+            error={artifactsQuery.isError ? (artifactsQuery.error as Error) : null}
+          />
 
           {showExecutionObservationFallback ? (
             <section className="stack td-observation-region td-evidence-region">

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -137,6 +137,37 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
+  it('surfaces intervention requests in list rows and status filters', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'task-needs-human',
+            source: 'temporal',
+            title: 'Needs operator input',
+            status: 'intervention_requested',
+            state: 'intervention_requested',
+            rawState: 'intervention_requested',
+            attentionRequired: true,
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Needs operator input');
+    expect(screen.getAllByText('Intervention requested').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    const statusFilter = screen.getByLabelText('Status filter value') as HTMLSelectElement;
+    expect(
+      Array.from(statusFilter.options).some((option) => option.value === 'intervention_requested'),
+    ).toBe(true);
+  });
+
   it('separates desktop header sorting from filter popovers', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
@@ -625,6 +656,7 @@ describe('Workflows Entrypoint', () => {
       'executing',
       'proposals',
       'awaiting_external',
+      'intervention_requested',
       'finalizing',
       'completed',
       'failed',
@@ -639,6 +671,7 @@ describe('Workflows Entrypoint', () => {
       'executing',
       'proposals',
       'awaiting external',
+      'intervention requested',
       'finalizing',
       'completed',
       'failed',

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -27,6 +27,7 @@ const TEMPORAL_STATUSES = [
   'executing',
   'proposals',
   'awaiting_external',
+  'intervention_requested',
   'finalizing',
   'completed',
   'failed',
@@ -125,6 +126,7 @@ const ExecutionRowSchema = z
     entry: z.string().optional(),
     dependsOn: z.array(z.string()).optional(),
     blockedOnDependencies: z.boolean().optional(),
+    attentionRequired: z.boolean().optional(),
   })
   .passthrough();
 
@@ -201,6 +203,14 @@ function dependencyListSummary(row: ExecutionRow): string {
   const count = row.dependsOn?.length || 0;
   if (count <= 0) return 'Blocked on dependencies';
   return `Blocked by ${count} prerequisite${count === 1 ? '' : 's'}`;
+}
+
+function interventionListSummary(row: ExecutionRow): string {
+  const state = String(row.rawState || row.state || row.status || '').toLowerCase();
+  if (row.attentionRequired || state === 'intervention_requested') {
+    return 'Intervention requested';
+  }
+  return '';
 }
 
 function displayTemporalCount(count: number | null | undefined, countMode: string | undefined): string {
@@ -1527,6 +1537,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   <tbody>
                     {sortedItems.map((row) => {
                       const depsSummary = dependencyListSummary(row);
+                      const interventionSummary = interventionListSummary(row);
                       return (
                         <tr key={rowWorkflowId(row)}>
                           <td className="queue-table-cell-id">
@@ -1544,6 +1555,9 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                           </td>
                           <td className="queue-table-cell-title">
                             <div>{row.title}</div>
+                            {interventionSummary ? (
+                              <div className="small">{interventionSummary}</div>
+                            ) : null}
                             {depsSummary ? (
                               <div className="small">{depsSummary}</div>
                             ) : null}
@@ -1560,6 +1574,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               <ul className="queue-card-list" data-layout="card" role="list">
                 {sortedItems.map((row) => {
                       const depsSummary = dependencyListSummary(row);
+                      const interventionSummary = interventionListSummary(row);
                       return (
                   <li key={rowWorkflowId(row)} className="queue-card">
                     <div className="queue-card-header">
@@ -1618,6 +1633,12 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <div>
                           <dt>Dependencies</dt>
                           <dd>{depsSummary}</dd>
+                        </div>
+                      ) : null}
+                      {interventionSummary ? (
+                        <div>
+                          <dt>Intervention</dt>
+                          <dd>{interventionSummary}</dd>
                         </div>
                       ) : null}
                     </dl>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2818,6 +2818,65 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   flex-direction: column;
 }
 
+.step-dag-panel {
+  border: 1px solid rgb(226 232 240);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: rgb(248 250 252 / 0.72);
+}
+
+.dark .step-dag-panel {
+  border-color: rgb(30 41 59);
+  background: rgb(15 23 42 / 0.48);
+}
+
+.step-dag-panel h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.step-dag-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.step-dag-node {
+  position: relative;
+  min-height: 7rem;
+  border: 1px solid rgb(203 213 225);
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+  background: white;
+}
+
+.dark .step-dag-node {
+  border-color: rgb(51 65 85);
+  background: rgb(15 23 42);
+}
+
+.step-dag-node::after {
+  content: "";
+  position: absolute;
+  right: -0.55rem;
+  top: 50%;
+  width: 0.55rem;
+  border-top: 2px solid rgb(148 163 184);
+}
+
+.step-dag-node:last-child::after {
+  display: none;
+}
+
+.step-dag-node-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .step-tl-row {
   display: grid;
   grid-template-columns: 1.6rem 1fr;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2869,6 +2869,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   display: none;
 }
 
+@media (max-width: 720px) {
+  .step-dag-node::after {
+    display: none;
+  }
+}
+
 .step-dag-node-header {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Jira issue: MM-768

Summary:
- Completes the remaining Mission Control dashboard surfaces from Milestone 7.
- Adds grouped artifact browsing for files, logs, patches, reports, and other workflow artifacts.
- Adds intervention request visibility, execution audit timeline enrichment, side-by-side run comparison, step DAG visualization, and worker fleet health status.
- Updates focused Mission Control tests for the new workflow detail, workflow list, and operations settings behavior.

Tests run:
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx frontend/src/components/settings/OperationsSettingsSection.test.tsx` -> 158 passed
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` -> passed
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/mission-control.test.tsx` -> 35 passed
- `git diff --check origin/main...HEAD` -> passed

Remaining risks:
- Full `./tools/test_unit.sh --dashboard-only` was order/timing unstable in this workspace: one run failed an OAuth terminal test that passed in isolation, and a retry failed timing-sensitive workflow tests after the focused MM-768 suite passed.
- No backend integration tests were run because this change is limited to Mission Control frontend UI and tests.
