### PR TITLE
MM-772 execution history audit view

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -188,7 +188,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **7.1** Migrate settings page to Mission Control — Settings currently in separate profile page, should be unified
 - [ ] **7.2** Artifact browsing UI (files/logs/patches) — API exists (`temporal_artifacts.py`), dashboard integration partial
 - [x] **7.3** Intervention request monitoring — Agent requests for human help surface through `intervention_requested` run status monitoring
-- [ ] **7.4** Execution history / audit trail view — Spec 067 (`run-history-rerun`), API exists, UI incomplete
+- [x] **7.4** Execution history / audit trail view — Spec 067 (`run-history-rerun`), `/workflows/{workflowId}/runs` now exposes the Mission Control execution history/audit view (MM-772)
 - [ ] **7.5** Side-by-side comparison view — README promises "run the same task with different models and runtimes to compare results"
 - [ ] **7.6** Multi-step / step DAG visualization — Steps are tracked but no graphical visualization
 - [ ] **7.7** Worker fleet health dashboard — No per-worker health view

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -4509,6 +4509,71 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('MM-772 renders duplicate related runs without duplicate React keys', async () => {
+    window.history.pushState({}, 'Runs Test', '/workflows/test-123/runs?source=temporal');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'History task',
+      summary: 'Audit history',
+      status: 'completed',
+      state: 'completed',
+      rawState: 'completed',
+      targetRuntime: 'codex_cli',
+      model: 'gpt-5',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {},
+      relatedRuns: [
+        {
+          workflowId: 'duplicate-workflow',
+          relationship: 'rerun',
+          status: 'failed',
+          href: '/workflows/duplicate-workflow/runs?source=temporal',
+        },
+        {
+          workflowId: 'duplicate-workflow',
+          relationship: 'rerun',
+          status: 'completed',
+          href: '/workflows/duplicate-workflow/runs?source=temporal',
+        },
+      ],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('duplicate-workflow').length).toBeGreaterThanOrEqual(2);
+    });
+    const duplicateKeyWarnings = consoleErrorSpy.mock.calls.filter(([message]) =>
+      String(message).includes('Encountered two children with the same key'),
+    );
+    expect(duplicateKeyWarnings).toHaveLength(0);
+  });
+
   it('routes Pause through the explicit signal endpoint without requiring live log fetches', async () => {
     const actionPayload: BootPayload = {
       ...mockPayload,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -3447,7 +3447,7 @@ describe('Workflow Detail Entrypoint', () => {
     });
 
     expect(screen.queryByText('PR Link')).toBeNull();
-    expect(screen.queryByRole('link')).toBeNull();
+    expect(document.querySelector('a[href^="javascript:"]')).toBeNull();
   });
 
   it('renders merge automation visibility from the run summary', async () => {
@@ -4432,6 +4432,80 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByText('current')).toBeTruthy();
       expect(screen.getByText('test-456')).toBeTruthy();
       expect(screen.getAllByText('gpt-5').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('MM-772 renders the runs subroute as a dedicated execution history view', async () => {
+    window.history.pushState({}, 'Runs Test', '/workflows/test-123/runs?source=temporal');
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'History task',
+      summary: 'Audit history',
+      status: 'completed',
+      state: 'completed',
+      rawState: 'completed',
+      targetRuntime: 'codex_cli',
+      model: 'gpt-5',
+      createdAt: '2026-03-28T00:00:00Z',
+      startedAt: '2026-03-28T00:00:01Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      closedAt: '2026-03-28T00:00:03Z',
+      closeStatus: 'completed',
+      actions: {},
+      interventionAudit: [
+        {
+          action: 'send_message',
+          transport: 'temporal_update',
+          summary: 'Operator guidance recorded.',
+          createdAt: '2026-03-28T00:00:02Z',
+        },
+      ],
+      relatedRuns: [
+        {
+          workflowId: 'test-456',
+          runId: '02-run',
+          relationship: 'rerun',
+          status: 'failed',
+          href: '/workflows/test-456/runs?source=temporal',
+        },
+      ],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('heading', { name: 'Execution History' }).length).toBeGreaterThan(1);
+      expect(screen.getByRole('link', { name: 'Runs' }).getAttribute('aria-current')).toBe('page');
+      expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('href')).toBe('/workflows/test-123?source=temporal');
+      expect(screen.getAllByText(/^Current Run ID:?$/).length).toBeGreaterThan(1);
+      expect(screen.getAllByText('01-run').length).toBeGreaterThan(0);
+      expect(screen.getByText('test-456')).toBeTruthy();
+      expect(screen.getByText('02-run')).toBeTruthy();
+      expect(screen.getByText('Operator guidance recorded.')).toBeTruthy();
+      expect(screen.queryByRole('heading', { name: 'Run Comparison' })).toBeNull();
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -90,6 +90,26 @@ function shouldUseStructuredHistory(config: DashboardConfig | undefined): boolea
   return config?.features?.liveLogsStructuredHistoryEnabled !== false;
 }
 
+type WorkflowDetailSubroute = 'overview' | 'steps' | 'artifacts' | 'runs';
+
+function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
+  const match = pathname.match(/^\/workflows\/[^/]+(?:\/(steps|artifacts|runs))?$/);
+  if (match?.[1] === 'steps' || match?.[1] === 'artifacts' || match?.[1] === 'runs') {
+    return match[1];
+  }
+  return 'overview';
+}
+
+function workflowDetailSubrouteHref(
+  workflowId: string,
+  subroute: WorkflowDetailSubroute,
+  search: URLSearchParams,
+): string {
+  const suffix = subroute === 'overview' ? '' : `/${subroute}`;
+  const query = search.toString();
+  return `/workflows/${encodeURIComponent(workflowId)}${suffix}${query ? `?${query}` : ''}`;
+}
+
 function detailObjectValue(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -4277,6 +4297,104 @@ function AuditTrailPanel({
   );
 }
 
+function WorkflowDetailSubrouteNav({
+  workflowId,
+  current,
+  search,
+}: {
+  workflowId: string;
+  current: WorkflowDetailSubroute;
+  search: URLSearchParams;
+}) {
+  const items: Array<{ route: WorkflowDetailSubroute; label: string }> = [
+    { route: 'overview', label: 'Overview' },
+    { route: 'steps', label: 'Steps' },
+    { route: 'artifacts', label: 'Artifacts' },
+    { route: 'runs', label: 'Runs' },
+  ];
+  return (
+    <nav className="td-subroute-nav" aria-label="Workflow detail sections">
+      {items.map((item) => (
+        <a
+          key={item.route}
+          href={workflowDetailSubrouteHref(workflowId, item.route, search)}
+          aria-current={current === item.route ? 'page' : undefined}
+        >
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+function ExecutionHistoryPanel({
+  execution,
+}: {
+  execution: z.infer<typeof ExecutionDetailSchema>;
+}) {
+  const currentStatus = execution.rawState || execution.state || execution.status;
+  const currentRunId = execution.runId || execution.temporalRunId || '—';
+  const rows = [
+    {
+      relationship: 'current',
+      workflowId: execution.workflowId || execution.taskId || '—',
+      runId: currentRunId,
+      status: currentStatus,
+      href: '',
+    },
+    ...(execution.relatedRuns || []).map((run) => ({
+      relationship: run.relationship,
+      workflowId: run.workflowId,
+      runId: run.runId || '—',
+      status: run.status || 'unknown',
+      href: run.href,
+    })),
+  ];
+  return (
+    <section className="stack td-runs-region td-evidence-region" data-mm-issue="MM-772">
+      <h3>Execution History</h3>
+      <div className="grid-2">
+        <Card label="Workflow ID">
+          <code className="text-xs break-all">{execution.workflowId || execution.taskId || '—'}</code>
+        </Card>
+        <Card label="Current Run ID">
+          <code className="text-xs break-all">{currentRunId}</code>
+        </Card>
+        <Card label="Workflow State">{formatStatusLabel(currentStatus)}</Card>
+        <Card label="Related Runs">{String(execution.relatedRuns?.length ?? 0)}</Card>
+      </div>
+      <div className="queue-table-wrapper td-evidence-slab" data-layout="table">
+        <table>
+          <thead>
+            <tr>
+              <th>Relation</th>
+              <th>Workflow</th>
+              <th>Run</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${row.relationship}-${row.workflowId}-${row.runId}`}>
+                <td>{formatStatusLabel(row.relationship)}</td>
+                <td>
+                  {row.href ? (
+                    <a href={row.href}><code>{row.workflowId}</code></a>
+                  ) : (
+                    <code>{row.workflowId}</code>
+                  )}
+                </td>
+                <td><code>{row.runId}</code></td>
+                <td>{formatStatusLabel(row.status)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
 function RunComparisonPanel({
   execution,
 }: {
@@ -4344,6 +4462,8 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
   const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const detailSubroute = workflowDetailSubrouteFromPath(window.location.pathname);
+  const isRunsSubroute = detailSubroute === 'runs';
   const sourceTemporal = search.get('source') === 'temporal';
 
   const [actionError, setActionError] = useState<string | null>(null);
@@ -4886,7 +5006,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     <div className="stack workflow-detail-page">
       <div className="toolbar">
         <div>
-          <h2 className="page-title">Workflow Detail</h2>
+          <h2 className="page-title">{isRunsSubroute ? 'Execution History' : 'Workflow Detail'}</h2>
           <div className="toolbar-identity-row">
             <p className="page-meta">Workflow {taskId || '—'}</p>
             {execution ? (
@@ -4910,6 +5030,14 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           </span>
         </div>
       </div>
+
+      {taskId ? (
+        <WorkflowDetailSubrouteNav
+          workflowId={taskId}
+          current={detailSubroute}
+          search={search}
+        />
+      ) : null}
 
       {actionError ? <div className="notice error">{actionError}</div> : null}
       {actionNotice ? (
@@ -4974,6 +5102,10 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
           {shouldShowRuntimeCommand ? (
             <RuntimeCommandDetail command={runtimeCommand} />
+          ) : null}
+
+          {isRunsSubroute ? (
+            <ExecutionHistoryPanel execution={execution} />
           ) : null}
 
           <div className="td-summary-block">
@@ -5367,7 +5499,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             </section>
           ) : null}
 
-          <RunComparisonPanel execution={execution} />
+          {isRunsSubroute ? null : <RunComparisonPanel execution={execution} />}
 
           <RemediationRelationshipsPanel
             inbound={inboundRemediationsQuery.data}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4374,8 +4374,8 @@ function ExecutionHistoryPanel({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => (
-              <tr key={`${row.relationship}-${row.workflowId}-${row.runId}`}>
+            {rows.map((row, index) => (
+              <tr key={`${row.relationship}-${row.workflowId}-${row.runId}-${index}`}>
                 <td>{formatStatusLabel(row.relationship)}</td>
                 <td>
                   {row.href ? (

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -5195,6 +5195,33 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   min-width: 0;
 }
 
+.td-subroute-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.35rem;
+  border: 1px solid rgb(var(--mm-border) / 0.46);
+  border-radius: 0.6rem;
+  background: rgb(var(--mm-panel) / 0.62);
+}
+
+.td-subroute-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.1rem;
+  padding: 0.42rem 0.68rem;
+  border-radius: 0.45rem;
+  color: rgb(var(--mm-muted) / 0.92);
+  text-decoration: none;
+  font-weight: 650;
+}
+
+.td-subroute-nav a:hover,
+.td-subroute-nav a[aria-current="page"] {
+  color: rgb(var(--mm-ink));
+  background: rgb(var(--mm-accent) / 0.12);
+}
+
 .td-facts-region {
   display: grid;
   gap: 0.2rem;
@@ -5215,6 +5242,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .td-steps-region,
 .td-artifacts-region,
 .td-remediation-region,
+.td-runs-region,
 .td-timeline-region,
 .td-observation-region {
   overflow-wrap: anywhere;


### PR DESCRIPTION
Jira issue key: MM-772

Summary:
- Adds a dedicated Mission Control execution history view for `/workflows/{workflowId}/runs`.
- Surfaces latest run identity, current and related run rows, and existing audit/timeline evidence without adding a new backend contract.
- Adds route-local navigation for Workflow Detail sections and marks roadmap item 7.4 complete.

Tests run:
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`
- `git diff --check`

Remaining risks:
- `./tools/test_unit.sh` could not run in this container because Python `pytest` is not installed.
- The view remains aligned to Spec 067 v1 latest-run semantics; it does not introduce a new immutable per-run backend projection.
