### PR TITLE
MM-773 Side-by-side comparison view

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2338,9 +2338,7 @@ def _build_related_runs(
             )
 
     task_payload = params.get("task") if isinstance(params.get("task"), Mapping) else {}
-    comparison_source = (
-        task_payload.get("comparison") if isinstance(task_payload, Mapping) else None
-    )
+    comparison_source = task_payload.get("comparison")
     if isinstance(comparison_source, Mapping):
         source_workflow_id = str(
             comparison_source.get("sourceWorkflowId")
@@ -2368,9 +2366,7 @@ def _build_related_runs(
 def _execution_related_run_metadata(record: TemporalExecutionRecord) -> dict[str, Any]:
     params = record.parameters if isinstance(record.parameters, Mapping) else {}
     task_payload = params.get("task") if isinstance(params.get("task"), Mapping) else {}
-    runtime_payload = (
-        task_payload.get("runtime") if isinstance(task_payload, Mapping) else None
-    )
+    runtime_payload = task_payload.get("runtime")
     if not isinstance(runtime_payload, Mapping):
         runtime_payload = {}
     state_value = _enum_value(getattr(record, "state", None)) or None
@@ -2395,10 +2391,25 @@ def _execution_related_run_metadata(record: TemporalExecutionRecord) -> dict[str
     }
 
 
+def _execution_record_visible_to_user(
+    record: TemporalExecutionRecord,
+    user: User,
+) -> bool:
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    record_owner_type = _enum_value(getattr(record, "owner_type", None))
+    if record_owner_type is None:
+        record_owner_type = _normalize_owner_type(record, search_attributes)
+    record_owner_id = str(getattr(record, "owner_id", "") or "").strip()
+    if not record_owner_id:
+        record_owner_id = _coerce_temporal_scalar(search_attributes.get("mm_owner_id"))
+    return record_owner_type == "user" and record_owner_id == _owner_id(user)
+
+
 async def _hydrate_related_run_metadata(
     execution: ExecutionModel,
     *,
     session: AsyncSession | None,
+    user: User | None = None,
 ) -> ExecutionModel:
     if session is None or not execution.related_runs:
         return execution
@@ -2417,6 +2428,13 @@ async def _hydrate_related_run_metadata(
             hydrated.append(related_run)
             continue
         if record is None:
+            hydrated.append(related_run)
+            continue
+        if (
+            user is not None
+            and not _is_execution_admin(user)
+            and not _execution_record_visible_to_user(record, user)
+        ):
             hydrated.append(related_run)
             continue
         metadata = _execution_related_run_metadata(record)
@@ -7520,7 +7538,11 @@ async def describe_execution(
         )
     execution = _serialize_execution(record, user=user)
     execution = await _enrich_execution_dependencies(execution, service=service)
-    execution = await _hydrate_related_run_metadata(execution, session=session)
+    execution = await _hydrate_related_run_metadata(
+        execution,
+        session=session,
+        user=user,
+    )
     execution = await _hydrate_provider_profile_metadata(execution, session)
     if execution.workflow_type == "MoonMind.Run":
         if _execution_uses_live_workflow_queries(execution):

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1926,7 +1926,7 @@ def _serialize_execution(
         else None
     )
     resume_summary = _build_recovery_summary(record, actions=actions)
-    related_runs = _build_recovery_related_runs(record, params=params)
+    related_runs = _build_related_runs(record, params=params)
     target_diagnostics = _build_target_diagnostics(
         record,
         params=params,
@@ -2302,35 +2302,134 @@ def _build_recovery_summary(
         disabledReason=actions.disabled_reasons.get("canRecoverFromFailedStep"),
     )
 
-def _build_recovery_related_runs(
+def _related_run_href(workflow_id: str) -> str:
+    return f"/workflows/{quote(workflow_id, safe='')}?source=temporal"
+
+
+def _build_related_runs(
     record,
     *,
     params: Mapping[str, Any],
 ) -> list[ExecutionRelatedRunModel]:
+    related_runs: list[ExecutionRelatedRunModel] = []
     recovery_source = params.get("recoverySource")
     if not isinstance(recovery_source, Mapping):
         recovery_source = params.get("recovery_source")
-    if not isinstance(recovery_source, Mapping):
-        return []
-    source_workflow_id = str(
-        recovery_source.get("sourceWorkflowId")
-        or recovery_source.get("source_workflow_id")
-        or ""
-    ).strip()
-    if not source_workflow_id:
-        return []
-    source_run_id = str(
-        recovery_source.get("sourceRunId") or recovery_source.get("source_run_id") or ""
-    ).strip() or None
-    return [
-        ExecutionRelatedRunModel(
-            workflowId=source_workflow_id,
-            runId=source_run_id,
-            relationship="Recovered from failed step",
-            status="failed",
-            href=f"/workflows/{source_workflow_id}",
+    if isinstance(recovery_source, Mapping):
+        source_workflow_id = str(
+            recovery_source.get("sourceWorkflowId")
+            or recovery_source.get("source_workflow_id")
+            or ""
+        ).strip()
+        if source_workflow_id:
+            source_run_id = str(
+                recovery_source.get("sourceRunId")
+                or recovery_source.get("source_run_id")
+                or ""
+            ).strip() or None
+            related_runs.append(
+                ExecutionRelatedRunModel(
+                    workflowId=source_workflow_id,
+                    runId=source_run_id,
+                    relationship="Recovered from failed step",
+                    status="failed",
+                    href=_related_run_href(source_workflow_id),
+                )
+            )
+
+    task_payload = params.get("task") if isinstance(params.get("task"), Mapping) else {}
+    comparison_source = (
+        task_payload.get("comparison") if isinstance(task_payload, Mapping) else None
+    )
+    if isinstance(comparison_source, Mapping):
+        source_workflow_id = str(
+            comparison_source.get("sourceWorkflowId")
+            or comparison_source.get("source_workflow_id")
+            or ""
+        ).strip()
+        if source_workflow_id:
+            source_run_id = str(
+                comparison_source.get("sourceRunId")
+                or comparison_source.get("source_run_id")
+                or ""
+            ).strip() or None
+            related_runs.append(
+                ExecutionRelatedRunModel(
+                    workflowId=source_workflow_id,
+                    runId=source_run_id,
+                    relationship="Comparison source",
+                    href=_related_run_href(source_workflow_id),
+                )
+            )
+
+    return related_runs
+
+
+def _execution_related_run_metadata(record: TemporalExecutionRecord) -> dict[str, Any]:
+    params = record.parameters if isinstance(record.parameters, Mapping) else {}
+    task_payload = params.get("task") if isinstance(params.get("task"), Mapping) else {}
+    runtime_payload = (
+        task_payload.get("runtime") if isinstance(task_payload, Mapping) else None
+    )
+    if not isinstance(runtime_payload, Mapping):
+        runtime_payload = {}
+    state_value = _enum_value(getattr(record, "state", None)) or None
+    close_status = _enum_value(getattr(record, "close_status", None)) or None
+    return {
+        "run_id": str(getattr(record, "run_id", "") or "").strip() or None,
+        "status": close_status or state_value,
+        "target_runtime": (
+            _coerce_temporal_scalar(params.get("targetRuntime"))
+            or _coerce_temporal_scalar(runtime_payload.get("mode"))
+            or None
+        ),
+        "model": _coerce_temporal_scalar(params.get("model")) or None,
+        "requested_model": _coerce_temporal_scalar(params.get("requestedModel")) or None,
+        "resolved_model": _coerce_temporal_scalar(params.get("resolvedModel")) or None,
+        "effort": (
+            _coerce_temporal_scalar(params.get("effort"))
+            or _coerce_temporal_scalar(runtime_payload.get("effort"))
+            or None
+        ),
+        "created_at": getattr(record, "created_at", None),
+    }
+
+
+async def _hydrate_related_run_metadata(
+    execution: ExecutionModel,
+    *,
+    session: AsyncSession | None,
+) -> ExecutionModel:
+    if session is None or not execution.related_runs:
+        return execution
+    hydrated: list[ExecutionRelatedRunModel] = []
+    for related_run in execution.related_runs:
+        try:
+            record = await session.get(TemporalExecutionRecord, related_run.workflow_id)
+        except Exception as exc:
+            logger.warning(
+                "Failed to hydrate related run %s for execution %s: %s",
+                related_run.workflow_id,
+                execution.workflow_id,
+                exc,
+                exc_info=True,
+            )
+            hydrated.append(related_run)
+            continue
+        if record is None:
+            hydrated.append(related_run)
+            continue
+        metadata = _execution_related_run_metadata(record)
+        hydrated.append(
+            related_run.model_copy(
+                update={
+                    key: value
+                    for key, value in metadata.items()
+                    if value is not None
+                }
+            )
         )
-    ]
+    return execution.model_copy(update={"related_runs": hydrated})
 
 def _target_diagnostics_block(
     *,
@@ -7421,6 +7520,7 @@ async def describe_execution(
         )
     execution = _serialize_execution(record, user=user)
     execution = await _enrich_execution_dependencies(execution, service=service)
+    execution = await _hydrate_related_run_metadata(execution, session=session)
     execution = await _hydrate_provider_profile_metadata(execution, session)
     if execution.workflow_type == "MoonMind.Run":
         if _execution_uses_live_workflow_queries(execution):

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -10,6 +10,7 @@ import {
   WorkflowDetailPage,
 } from './workflow-detail';
 import {
+  taskCompareHref,
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
@@ -4396,13 +4397,16 @@ describe('Workflow Detail Entrypoint', () => {
       model: 'gpt-5',
       createdAt: '2026-03-28T00:00:00Z',
       updatedAt: '2026-03-28T00:00:02Z',
-      actions: {},
+      actions: { canEditForRerun: true },
       relatedRuns: [
         {
           workflowId: 'test-456',
           runId: '02-run',
-          relationship: 'rerun',
+          relationship: 'Comparison source',
           status: 'failed',
+          targetRuntime: 'gemini_cli',
+          model: 'gemini-2.5-pro',
+          effort: 'high',
           href: '/workflows/test-456?source=temporal',
         },
       ],
@@ -4425,13 +4429,32 @@ describe('Workflow Detail Entrypoint', () => {
       } as Response);
     });
 
-    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+    const comparisonPayload: BootPayload = {
+      ...mockPayload,
+      initialData: {
+        dashboardConfig: {
+          features: {
+            temporalDashboard: {
+              actionsEnabled: true,
+              temporalTaskEditing: true,
+            },
+          },
+        },
+      },
+    };
+
+    renderWithClient(<WorkflowDetailPage payload={comparisonPayload} />);
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Run Comparison' })).toBeTruthy();
       expect(screen.getByText('current')).toBeTruthy();
       expect(screen.getByText('test-456')).toBeTruthy();
       expect(screen.getAllByText('gpt-5').length).toBeGreaterThan(0);
+      expect(screen.getByText('Gemini CLI')).toBeTruthy();
+      expect(screen.getByText('gemini-2.5-pro')).toBeTruthy();
+      expect(screen.getByRole('link', { name: 'Compare run' }).getAttribute('href')).toBe(
+        taskCompareHref('test-123'),
+      );
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -10,6 +10,7 @@ import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge'
 import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
 import {
   recordTemporalTaskEditingClientEvent,
+  taskCompareHref,
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
@@ -566,6 +567,11 @@ const ExecutionDetailSchema = z
             runId: z.string().nullable().optional(),
             relationship: z.string(),
             status: z.string().nullable().optional(),
+            targetRuntime: z.string().nullable().optional(),
+            model: z.string().nullable().optional(),
+            requestedModel: z.string().nullable().optional(),
+            resolvedModel: z.string().nullable().optional(),
+            effort: z.string().nullable().optional(),
             href: z.string(),
           })
           .passthrough(),
@@ -4316,8 +4322,8 @@ function RunComparisonPanel({
                 <td><a href={run.href}><code>{run.workflowId}</code></a></td>
                 <td><code>{run.runId || '—'}</code></td>
                 <td>{formatStatusLabel(run.status || 'unknown')}</td>
-                <td>—</td>
-                <td>—</td>
+                <td>{formatRuntimeLabel(run.targetRuntime)}</td>
+                <td>{run.model || run.resolvedModel || run.requestedModel || '—'}</td>
               </tr>
             ))}
           </tbody>
@@ -4789,9 +4795,11 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       ? taskEditForRerunHref(workflowId)
       : taskEditHref(workflowId)
     : '';
+  const compareHref =
+    workflowId && actions?.canEditForRerun ? taskCompareHref(workflowId) : '';
   const onTaskEditingNavigation = (
     event: MouseEvent<HTMLAnchorElement>,
-    telemetryEvent: 'detail_edit_click',
+    telemetryEvent: 'detail_edit_click' | 'detail_compare_click',
   ) => {
     if (busy) {
       event.preventDefault();
@@ -4848,6 +4856,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const hasTaskEditingActions = taskEditingOn && Boolean(
     canShowEditWorkflow ||
       actions?.canRerun ||
+      compareHref ||
       canFailedStepResume ||
       editTaskUnavailableReason ||
       rerunUnavailableReason,
@@ -5453,6 +5462,16 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                     onClick={(event) => onTaskEditingNavigation(event, 'detail_edit_click')}
                   >
                     Edit task
+                  </a>
+                ) : null}
+                {taskEditingOn && compareHref ? (
+                  <a
+                    className="button secondary"
+                    href={compareHref}
+                    aria-disabled={busy}
+                    onClick={(event) => onTaskEditingNavigation(event, 'detail_compare_click')}
+                  >
+                    Compare run
                   </a>
                 ) : null}
                 {taskEditingOn && actions.canRerun ? (

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -2616,6 +2616,13 @@ describe.skip("Task Create Entrypoint", () => {
       intent: "edit-for-rerun",
       executionId: "mm:rerun",
     });
+    expect(
+      resolveTaskSubmitPageMode("?rerunExecutionId=mm%3Arerun&mode=compare"),
+    ).toEqual({
+      mode: "rerun",
+      intent: "comparison",
+      executionId: "mm:rerun",
+    });
   });
 
   it("builds the canonical Temporal UpdateInputs payload without mutating historical artifacts", () => {
@@ -4000,6 +4007,51 @@ describe.skip("Task Create Entrypoint", () => {
         },
       },
     });
+  });
+
+  it("submits MM-773 comparison runs as fresh task creations with source lineage", async () => {
+    window.history.pushState(
+      {},
+      "Task Comparison",
+      "/workflows/new?rerunExecutionId=mm%3Acomplex-rerun&mode=compare",
+    );
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Compare Workflow" })).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "You are starting a comparison run. Choose a different runtime or model to compare results with the source run.",
+      ),
+    ).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Runtime"), {
+      target: { value: "gemini_cli" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Comparison Run" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions"),
+      ).toBe(true);
+    });
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url]) => String(url) === "/api/executions/mm%3Acomplex-rerun/update",
+      ),
+    ).toBe(false);
+    const createCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(createCall?.[1]?.body));
+
+    expect(request.payload.targetRuntime).toBe("gemini_cli");
+    expect(request.payload.task.comparison).toEqual({
+      kind: "model_runtime_comparison",
+      sourceWorkflowId: "mm:complex-rerun",
+      sourceRunId: "run-complex-source",
+    });
+    expect(request.payload.task.recovery).toBeUndefined();
+    expect(request.payload.task.resume).toBeUndefined();
   });
 
   it("reports current preview version drift without mutating source-run command metadata", () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -7859,7 +7859,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         );
       }
       const editParametersPatch =
-        temporalDraftData
+        temporalDraftData && pageMode.intent !== "comparison"
           ? buildEditParametersPatch({
               execution: temporalDraftData.execution,
               artifactInput: temporalDraftData.artifactInput,
@@ -7895,6 +7895,35 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         };
         delete editedTaskPayload.resume;
         artifactPayload.task = editedTaskPayload;
+      }
+      if (
+        pageMode.intent === "comparison" &&
+        pageMode.executionId &&
+        temporalDraftData?.execution
+      ) {
+        const sourceWorkflowId = String(pageMode.executionId).trim();
+        const sourceRunId = String(
+          temporalDraftData.execution.runId ||
+            temporalDraftData.execution.temporalRunId ||
+            "",
+        ).trim();
+        if (!sourceWorkflowId || !sourceRunId) {
+          throw new Error(
+            "Cannot start comparison because the source execution identity is missing.",
+          );
+        }
+        const comparisonTaskPayload: Record<string, unknown> = {
+          ...recordValue(artifactPayload.task ?? taskPayload),
+          comparison: {
+            kind: "model_runtime_comparison",
+            sourceWorkflowId,
+            sourceRunId,
+          },
+        };
+        delete comparisonTaskPayload.recovery;
+        delete comparisonTaskPayload.resume;
+        artifactPayload.task = comparisonTaskPayload;
+        requestBody.payload = artifactPayload;
       }
       const rerunDraft = temporalDraftData?.draft;
       const rerunFormChanged = isExactRerunRequest
@@ -7956,7 +7985,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         stripOversizedInlineInstructions({ payload: artifactPayload });
       }
 
-      if (pageMode.mode === "edit" || pageMode.mode === "rerun") {
+      if (
+        pageMode.mode === "edit" ||
+        (pageMode.mode === "rerun" && pageMode.intent !== "comparison")
+      ) {
         const workflowId = String(pageMode.executionId || "").trim();
         if (!workflowId) {
           throw new Error(
@@ -8056,13 +8088,17 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   }
 
   const pageTitle =
-    pageMode.intent === "edit" || pageMode.intent === "edit-for-rerun"
-      ? "Edit Workflow"
-      : pageMode.mode === "rerun"
-        ? "Start New Run"
-        : "Start Workflow";
+    pageMode.intent === "comparison"
+      ? "Compare Workflow"
+      : pageMode.intent === "edit" || pageMode.intent === "edit-for-rerun"
+        ? "Edit Workflow"
+        : pageMode.mode === "rerun"
+          ? "Start New Run"
+          : "Start Workflow";
   const primaryCta =
-    pageMode.intent === "edit"
+    pageMode.intent === "comparison"
+      ? "Start Comparison Run"
+      : pageMode.intent === "edit"
       ? "Save Changes"
       : pageMode.intent === "edit-for-rerun"
         ? "Run edited workflow"
@@ -8071,7 +8107,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         : "Create";
   const showPrimaryCtaArrow = true;
   const primaryCtaTooltip =
-    pageMode.intent === "edit"
+    pageMode.intent === "comparison"
+      ? "Start a new comparison run from this task draft"
+      : pageMode.intent === "edit"
       ? "Save changes to this workflow draft"
       : pageMode.intent === "edit-for-rerun"
         ? "Start a new run from this edited task draft"
@@ -8169,6 +8207,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         <p className="notice" role="status">
           You are editing a previous task. Your changes will create a new run.
           The original run will remain unchanged.
+        </p>
+      ) : null}
+
+      {pageMode.intent === "comparison" && !modeLoadError ? (
+        <p className="notice" role="status">
+          You are starting a comparison run. Choose a different runtime or model
+          to compare results with the source run.
         </p>
       ) : null}
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4608,6 +4608,16 @@ export interface components {
             relationship: string;
             /** Status */
             status?: string | null;
+            /** Targetruntime */
+            targetRuntime?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Requestedmodel */
+            requestedModel?: string | null;
+            /** Resolvedmodel */
+            resolvedModel?: string | null;
+            /** Effort */
+            effort?: string | null;
             /** Createdat */
             createdAt?: string | null;
             /** Href */

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -3,7 +3,8 @@ export type TaskSubmitPageIntent =
   | 'create'
   | 'edit'
   | 'rerun'
-  | 'edit-for-rerun';
+  | 'edit-for-rerun'
+  | 'comparison';
 
 export type TaskSubmitPageModeResolution = {
   mode: TaskSubmitPageMode;
@@ -146,6 +147,7 @@ export type TemporalTaskEditUpdateName = 'UpdateInputs' | 'RequestRerun';
 
 export type TemporalTaskEditingTelemetryEvent =
   | 'detail_edit_click'
+  | 'detail_compare_click'
   | 'detail_rerun_click'
   | 'draft_reconstruction_success'
   | 'draft_reconstruction_failure'
@@ -274,6 +276,10 @@ export function taskEditForRerunHref(workflowId: string): string {
   return `${taskCreateHref()}?rerunExecutionId=${encodeURIComponent(workflowId)}&mode=edit`;
 }
 
+export function taskCompareHref(workflowId: string): string {
+  return `${taskCreateHref()}?rerunExecutionId=${encodeURIComponent(workflowId)}&mode=compare`;
+}
+
 export function resolveTaskSubmitPageMode(
   search: string | URLSearchParams,
 ): TaskSubmitPageModeResolution {
@@ -281,10 +287,18 @@ export function resolveTaskSubmitPageMode(
     typeof search === 'string' ? new URLSearchParams(search) : search;
   const rerunExecutionId = String(params.get('rerunExecutionId') || '').trim();
   if (rerunExecutionId) {
-    if (String(params.get('mode') || '').trim().toLowerCase() === 'edit') {
+    const mode = String(params.get('mode') || '').trim().toLowerCase();
+    if (mode === 'edit') {
       return {
         mode: 'rerun',
         intent: 'edit-for-rerun',
+        executionId: rerunExecutionId,
+      };
+    }
+    if (mode === 'compare') {
+      return {
+        mode: 'rerun',
+        intent: 'comparison',
         executionId: rerunExecutionId,
       };
     }

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1866,6 +1866,11 @@ class ExecutionRelatedRunModel(BaseModel):
     run_id: Optional[str] = Field(None, alias="runId")
     relationship: str = Field(..., alias="relationship", min_length=1)
     status: Optional[str] = Field(None, alias="status")
+    target_runtime: Optional[str] = Field(None, alias="targetRuntime")
+    model: Optional[str] = Field(None, alias="model")
+    requested_model: Optional[str] = Field(None, alias="requestedModel")
+    resolved_model: Optional[str] = Field(None, alias="resolvedModel")
+    effort: Optional[str] = Field(None, alias="effort")
     created_at: Optional[datetime] = Field(None, alias="createdAt")
     href: str = Field(..., alias="href", min_length=1)
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -24,6 +24,7 @@ from api_service.api.routers.executions import (
     _artifact_id_from_ref,
     _build_original_task_input_snapshot_payload,
     _expand_goal_preset_for_task_submission,
+    _hydrate_related_run_metadata,
     _merge_task_preserving_artifact_instructions,
     _recovery_not_available_reason,
     _reuse_original_task_input_snapshot_from_source,
@@ -38,6 +39,7 @@ from api_service.db.base import get_async_session
 from api_service.db.models import (
     Base,
     MoonMindWorkflowState,
+    TemporalExecutionCloseStatus,
     TemporalArtifact,
     TemporalArtifactEncryption,
     TemporalArtifactRedactionLevel,
@@ -8942,6 +8944,78 @@ def test_failed_step_recovery_request_rejects_edited_task_payload_fields(
     body = response.json()["detail"]
     assert body["code"] == "recovery_payload_not_allowed"
     assert body["fields"] == expected_fields
+
+
+def test_mm773_serialize_execution_surfaces_comparison_source_related_run() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+    record.parameters = {
+        "targetRuntime": "codex_cli",
+        "model": "gpt-5.4",
+        "task": {
+            "runtime": {"mode": "codex_cli", "model": "gpt-5.4"},
+            "comparison": {
+                "kind": "model_runtime_comparison",
+                "sourceWorkflowId": "mm:source-run",
+                "sourceRunId": "run-source",
+            },
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["relatedRuns"] == [
+        {
+            "workflowId": "mm:source-run",
+            "runId": "run-source",
+            "relationship": "Comparison source",
+            "status": None,
+            "targetRuntime": None,
+            "model": None,
+            "requestedModel": None,
+            "resolvedModel": None,
+            "effort": None,
+            "createdAt": None,
+            "href": "/workflows/mm%3Asource-run?source=temporal",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mm773_hydrates_related_run_runtime_model_metadata() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+    record.parameters = {
+        "task": {
+            "comparison": {
+                "kind": "model_runtime_comparison",
+                "sourceWorkflowId": "mm:source-run",
+                "sourceRunId": "run-source",
+            },
+        },
+    }
+    execution = _serialize_execution(record)
+    source = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+    source.workflow_id = "mm:source-run"
+    source.run_id = "run-source"
+    source.close_status = TemporalExecutionCloseStatus.COMPLETED
+    source.parameters = {
+        "targetRuntime": "gemini_cli",
+        "model": "gemini-2.5-pro",
+        "requestedModel": "gemini-2.5-pro",
+        "effort": "medium",
+        "task": {"runtime": {"mode": "gemini_cli", "effort": "medium"}},
+    }
+    session = SimpleNamespace(get=AsyncMock(return_value=source))
+
+    hydrated = await _hydrate_related_run_metadata(execution, session=session)
+    related = hydrated.model_dump(by_alias=True)["relatedRuns"][0]
+
+    assert related["workflowId"] == "mm:source-run"
+    assert related["runId"] == "run-source"
+    assert related["status"] == "completed"
+    assert related["targetRuntime"] == "gemini_cli"
+    assert related["model"] == "gemini-2.5-pro"
+    assert related["requestedModel"] == "gemini-2.5-pro"
+    assert related["effort"] == "medium"
 
 
 def test_failed_step_recovery_hydrates_checkpoint_artifact(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -9018,6 +9018,75 @@ async def test_mm773_hydrates_related_run_runtime_model_metadata() -> None:
     assert related["effort"] == "medium"
 
 
+@pytest.mark.asyncio
+async def test_mm773_hydrates_related_run_metadata_for_same_owner() -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    record = _build_execution_record(owner_id=str(user.id))
+    record.parameters = {
+        "task": {
+            "comparison": {
+                "kind": "model_runtime_comparison",
+                "sourceWorkflowId": "mm:source-run",
+            },
+        },
+    }
+    execution = _serialize_execution(record, user=user)
+    source = _build_execution_record(
+        state=MoonMindWorkflowState.COMPLETED,
+        owner_id=str(user.id),
+    )
+    source.workflow_id = "mm:source-run"
+    source.close_status = TemporalExecutionCloseStatus.COMPLETED
+    source.parameters = {"targetRuntime": "codex_cli", "model": "gpt-5.4"}
+    session = SimpleNamespace(get=AsyncMock(return_value=source))
+
+    hydrated = await _hydrate_related_run_metadata(
+        execution,
+        session=session,
+        user=user,
+    )
+    related = hydrated.model_dump(by_alias=True)["relatedRuns"][0]
+
+    assert related["status"] == "completed"
+    assert related["targetRuntime"] == "codex_cli"
+    assert related["model"] == "gpt-5.4"
+
+
+@pytest.mark.asyncio
+async def test_mm773_skips_related_run_metadata_for_foreign_owner() -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    record = _build_execution_record(owner_id=str(user.id))
+    record.parameters = {
+        "task": {
+            "comparison": {
+                "kind": "model_runtime_comparison",
+                "sourceWorkflowId": "mm:source-run",
+            },
+        },
+    }
+    execution = _serialize_execution(record, user=user)
+    source = _build_execution_record(
+        state=MoonMindWorkflowState.COMPLETED,
+        owner_id=str(uuid4()),
+    )
+    source.workflow_id = "mm:source-run"
+    source.close_status = TemporalExecutionCloseStatus.COMPLETED
+    source.parameters = {"targetRuntime": "codex_cli", "model": "gpt-5.4"}
+    session = SimpleNamespace(get=AsyncMock(return_value=source))
+
+    hydrated = await _hydrate_related_run_metadata(
+        execution,
+        session=session,
+        user=user,
+    )
+    related = hydrated.model_dump(by_alias=True)["relatedRuns"][0]
+
+    assert related["workflowId"] == "mm:source-run"
+    assert related["status"] is None
+    assert related["targetRuntime"] is None
+    assert related["model"] is None
+
+
 def test_failed_step_recovery_hydrates_checkpoint_artifact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Jira issue: MM-773

Summary:
- Adds comparison lineage metadata for task executions so comparison runs can point back to their source workflow.
- Surfaces runtime and model fields for related runs in the workflow detail comparison table.
- Adds a Mission Control Compare run action that starts a fresh execution from the same task draft with comparison source metadata.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k mm773
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-start.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx
- git diff --check origin/main..HEAD

Remaining risks:
- No live end-to-end provider comparison run was executed; coverage is unit-level around API serialization and Mission Control interaction paths.
