### PR TITLE
MM-775 Worker fleet health dashboard

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -763,6 +763,7 @@ async def task_settings_route(
         "workerPause": {
             "get": "/api/system/worker-pause",
             "post": "/api/system/worker-pause",
+            "shardHealth": "/api/workflows/codex/shards",
         },
         "runtimeConfig": runtime_config,
         "settingsPermissions": sorted(settings_permissions_for_user(_user)),

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -191,7 +191,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **7.4** Execution history / audit trail view — Spec 067 (`run-history-rerun`), API exists, UI incomplete
 - [ ] **7.5** Side-by-side comparison view — README promises "run the same task with different models and runtimes to compare results"
 - [ ] **7.6** Multi-step / step DAG visualization — Steps are tracked but no graphical visualization
-- [ ] **7.7** Worker fleet health dashboard — No per-worker health view
+- [x] **7.7** Worker fleet health dashboard — Per-worker Codex shard health view in Settings Operations (MM-775)
 
 ---
 

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -66,6 +66,37 @@ const workerSnapshot = {
   },
 };
 
+const workerShardHealth = {
+  shards: [
+    {
+      queueName: 'codex-shard-0',
+      status: 'active',
+      hashModulo: 4,
+      workerHostname: 'codex-worker-0',
+      volumeName: 'codex-auth-0',
+      volumeStatus: 'verified',
+      volumeLastVerifiedAt: '2026-04-26T00:02:00Z',
+      latestRunId: '00000000-0000-0000-0000-000000000010',
+      latestRunStatus: 'completed',
+      latestPreflightStatus: 'passed',
+      latestPreflightCheckedAt: '2026-04-26T00:02:00Z',
+    },
+    {
+      queueName: 'codex-shard-1',
+      status: 'offline',
+      hashModulo: 4,
+      workerHostname: 'codex-worker-1',
+      volumeName: 'codex-auth-1',
+      volumeStatus: 'missing',
+      latestRunId: '00000000-0000-0000-0000-000000000011',
+      latestRunStatus: 'failed',
+      latestPreflightStatus: 'failed',
+      latestPreflightMessage: 'Auth volume missing',
+      latestPreflightCheckedAt: '2026-04-26T00:03:00Z',
+    },
+  ],
+};
+
 const stackState = {
   stack: 'moonmind',
   projectName: 'moonmind',
@@ -170,6 +201,12 @@ describe('OperationsSettingsSection deployment update card', () => {
           json: async () => workerSnapshot,
         } as Response);
       }
+      if (url === '/api/workflows/codex/shards') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workerShardHealth,
+        } as Response);
+      }
       if (url === '/api/worker-action') {
         return Promise.resolve({
           ok: true,
@@ -220,6 +257,7 @@ describe('OperationsSettingsSection deployment update card', () => {
         workerPauseConfig={{
           get: '/api/workers',
           post: '/api/worker-action',
+          shardHealth: '/api/workflows/codex/shards',
           pollIntervalMs: 60_000,
         }}
       />,
@@ -261,10 +299,18 @@ describe('OperationsSettingsSection deployment update card', () => {
 
     const workerCard = await screen.findByRole('region', { name: /worker operations/i });
     expect(await within(workerCard).findByRole('heading', { name: /worker fleet health/i })).toBeTruthy();
-    expect(within(workerCard).getByText('Healthy')).toBeTruthy();
+    expect(within(workerCard).getByText('Attention required')).toBeTruthy();
     expect(within(workerCard).getByText('temporal')).toBeTruthy();
     expect(within(workerCard).getByText(/workers, scheduler/i)).toBeTruthy();
     expect(within(workerCard).getAllByText('1').length).toBeGreaterThan(0);
+    expect(within(workerCard).getByRole('heading', { name: /per-worker health/i })).toBeTruthy();
+    expect(await within(workerCard).findByText('codex-worker-0')).toBeTruthy();
+    expect(within(workerCard).getByText('codex-shard-0')).toBeTruthy();
+    expect(within(workerCard).getByText('codex-auth-0')).toBeTruthy();
+    expect(within(workerCard).getByText(/preflight passed/i)).toBeTruthy();
+    expect(within(workerCard).getByText('codex-worker-1')).toBeTruthy();
+    expect(within(workerCard).getByText('codex-shard-1')).toBeTruthy();
+    expect(within(workerCard).getByText(/auth volume missing/i)).toBeTruthy();
     expect(await within(workerCard).findByText('Pause Workers')).toBeTruthy();
     expect(within(workerCard).getByText('Resume Workers')).toBeTruthy();
     expect(within(workerCard).getByText('Enable Maintenance Mode')).toBeTruthy();
@@ -312,6 +358,12 @@ describe('OperationsSettingsSection deployment update card', () => {
         return Promise.resolve({
           ok: true,
           json: async () => workerSnapshot,
+        } as Response);
+      }
+      if (url === '/api/workflows/codex/shards') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => workerShardHealth,
         } as Response);
       }
       if (url === '/api/v1/operations/deployment/stacks/moonmind') {
@@ -411,6 +463,9 @@ describe('OperationsSettingsSection deployment update card', () => {
       if (url === '/api/workers') {
         return Promise.resolve({ ok: true, json: async () => workerSnapshot } as Response);
       }
+      if (url === '/api/workflows/codex/shards') {
+        return Promise.resolve({ ok: true, json: async () => workerShardHealth } as Response);
+      }
       if (url === '/api/v1/operations/deployment/stacks/moonmind') {
         return Promise.resolve({
           ok: true,
@@ -436,6 +491,9 @@ describe('OperationsSettingsSection deployment update card', () => {
       const url = String(input);
       if (url === '/api/workers') {
         return Promise.resolve({ ok: true, json: async () => workerSnapshot } as Response);
+      }
+      if (url === '/api/workflows/codex/shards') {
+        return Promise.resolve({ ok: true, json: async () => workerShardHealth } as Response);
       }
       if (url === '/api/v1/operations/deployment/stacks/moonmind') {
         return Promise.resolve({

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -251,13 +251,14 @@ describe('OperationsSettingsSection deployment update card', () => {
     confirmSpy.mockRestore();
   });
 
-  function renderOperations() {
+  function renderOperations(options: { includeShardHealth?: boolean } = {}) {
+    const { includeShardHealth = true } = options;
     renderWithClient(
       <OperationsSettingsSection
         workerPauseConfig={{
           get: '/api/workers',
           post: '/api/worker-action',
-          shardHealth: '/api/workflows/codex/shards',
+          ...(includeShardHealth ? { shardHealth: '/api/workflows/codex/shards' } : {}),
           pollIntervalMs: 60_000,
         }}
       />,
@@ -320,6 +321,18 @@ describe('OperationsSettingsSection deployment update card', () => {
     expect(within(workerCard).getByText(/result: succeeded/i)).toBeTruthy();
     expect(within(workerCard).getByText(/actor: 00000000-0000-0000-0000-000000000001/i)).toBeTruthy();
     expect(within(workerCard).getByText(/idempotency: previous-key/i)).toBeTruthy();
+  });
+
+  it('hides per-worker health when shard health is not configured', async () => {
+    renderOperations({ includeShardHealth: false });
+
+    const workerCard = await screen.findByRole('region', { name: /worker operations/i });
+    expect(await within(workerCard).findByRole('heading', { name: /worker fleet health/i })).toBeTruthy();
+    expect(within(workerCard).queryByRole('heading', { name: /per-worker health/i })).toBeNull();
+    expect(within(workerCard).queryByText(/no worker shards registered/i)).toBeNull();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === '/api/workflows/codex/shards'),
+    ).toBe(false);
   });
 
   it('renders deployment state inside Operations without top-level deployment navigation', async () => {

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -699,6 +699,7 @@ export function OperationsSettingsSection({
   const system = snapshot?.system ?? {};
   const metrics = snapshot?.metrics ?? {};
   const commands = snapshot?.commands ?? [];
+  const hasShardHealthConfig = Boolean(workerPauseConfig?.shardHealth);
   const workerShards = shardHealth?.shards ?? [];
   const unavailableCommands = commands.filter((command) => !command.available);
   const commandTargets = uniqueStrings(commands.map((command) => command.target || 'workers'));
@@ -1174,100 +1175,102 @@ export function OperationsSettingsSection({
                   </div>
                 </div>
               </div>
-              <div className="mt-5">
-                <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
-                  Per-worker health
-                </h5>
-                {isShardHealthLoading ? (
-                  <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-                    Loading per-worker health...
-                  </p>
-                ) : isShardHealthError ? (
-                  <p className="mt-3 text-sm text-rose-700 dark:text-rose-400">
-                    {(shardHealthError as Error).message}
-                  </p>
-                ) : workerShards.length > 0 ? (
-                  <div className="mt-3 overflow-x-auto">
-                    <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800">
-                      <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
-                        <tr>
-                          <th scope="col" className="px-3 py-2 font-semibold">
-                            Worker
-                          </th>
-                          <th scope="col" className="px-3 py-2 font-semibold">
-                            Status
-                          </th>
-                          <th scope="col" className="px-3 py-2 font-semibold">
-                            Queue
-                          </th>
-                          <th scope="col" className="px-3 py-2 font-semibold">
-                            Auth volume
-                          </th>
-                          <th scope="col" className="px-3 py-2 font-semibold">
-                            Latest run
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                        {workerShards.map((shard) => (
-                          <tr key={shard.queueName}>
-                            <td className="px-3 py-3 align-top font-medium text-slate-900 dark:text-white">
-                              {workerDisplayName(shard)}
-                            </td>
-                            <td className="px-3 py-3 align-top">
-                              <span
-                                className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${workerStatusTone(
-                                  shard.status,
-                                )}`}
-                              >
-                                {formatStatusLabel(shard.status)}
-                              </span>
-                            </td>
-                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
-                              <div>{shard.queueName}</div>
-                              {shard.hashModulo ? (
-                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                                  Hash modulo {shard.hashModulo}
-                                </div>
-                              ) : null}
-                            </td>
-                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
-                              <div>{shard.volumeName || 'No auth volume'}</div>
-                              {shard.volumeStatus ? (
-                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                                  {formatStatusLabel(shard.volumeStatus)}
-                                  {shard.volumeLastVerifiedAt
-                                    ? ` | Verified ${shard.volumeLastVerifiedAt}`
-                                    : ''}
-                                </div>
-                              ) : null}
-                            </td>
-                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
-                              <div>
-                                {shard.latestRunStatus
-                                  ? formatStatusLabel(shard.latestRunStatus)
-                                  : 'No runs'}
-                              </div>
-                              {shard.latestPreflightStatus ? (
-                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                                  Preflight {formatStatusLabel(shard.latestPreflightStatus)}
-                                  {shard.latestPreflightMessage
-                                    ? ` | ${shard.latestPreflightMessage}`
-                                    : ''}
-                                </div>
-                              ) : null}
-                            </td>
+              {hasShardHealthConfig ? (
+                <div className="mt-5">
+                  <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
+                    Per-worker health
+                  </h5>
+                  {isShardHealthLoading ? (
+                    <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                      Loading per-worker health...
+                    </p>
+                  ) : isShardHealthError ? (
+                    <p className="mt-3 text-sm text-rose-700 dark:text-rose-400">
+                      {(shardHealthError as Error).message}
+                    </p>
+                  ) : workerShards.length > 0 ? (
+                    <div className="mt-3 overflow-x-auto">
+                      <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800">
+                        <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
+                          <tr>
+                            <th scope="col" className="px-3 py-2 font-semibold">
+                              Worker
+                            </th>
+                            <th scope="col" className="px-3 py-2 font-semibold">
+                              Status
+                            </th>
+                            <th scope="col" className="px-3 py-2 font-semibold">
+                              Queue
+                            </th>
+                            <th scope="col" className="px-3 py-2 font-semibold">
+                              Auth volume
+                            </th>
+                            <th scope="col" className="px-3 py-2 font-semibold">
+                              Latest run
+                            </th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                ) : (
-                  <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-                    No worker shards registered.
-                  </p>
-                )}
-              </div>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                          {workerShards.map((shard) => (
+                            <tr key={shard.queueName}>
+                              <td className="px-3 py-3 align-top font-medium text-slate-900 dark:text-white">
+                                {workerDisplayName(shard)}
+                              </td>
+                              <td className="px-3 py-3 align-top">
+                                <span
+                                  className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${workerStatusTone(
+                                    shard.status,
+                                  )}`}
+                                >
+                                  {formatStatusLabel(shard.status)}
+                                </span>
+                              </td>
+                              <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                                <div>{shard.queueName}</div>
+                                {shard.hashModulo ? (
+                                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                    Hash modulo {shard.hashModulo}
+                                  </div>
+                                ) : null}
+                              </td>
+                              <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                                <div>{shard.volumeName || 'No auth volume'}</div>
+                                {shard.volumeStatus ? (
+                                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                    {formatStatusLabel(shard.volumeStatus)}
+                                    {shard.volumeLastVerifiedAt
+                                      ? ` | Verified ${shard.volumeLastVerifiedAt}`
+                                      : ''}
+                                  </div>
+                                ) : null}
+                              </td>
+                              <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                                <div>
+                                  {shard.latestRunStatus
+                                    ? formatStatusLabel(shard.latestRunStatus)
+                                    : 'No runs'}
+                                </div>
+                                {shard.latestPreflightStatus ? (
+                                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                    Preflight {formatStatusLabel(shard.latestPreflightStatus)}
+                                    {shard.latestPreflightMessage
+                                      ? ` | ${shard.latestPreflightMessage}`
+                                      : ''}
+                                  </div>
+                                ) : null}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                      No worker shards registered.
+                    </p>
+                  )}
+                </div>
+              ) : null}
             </section>
 
             <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -61,6 +61,32 @@ const WorkerSnapshotSchema = z.object({
 
 type WorkerSnapshot = z.infer<typeof WorkerSnapshotSchema>;
 
+const WorkerShardHealthSchema = z.object({
+  shards: z
+    .array(
+      z.object({
+        queueName: z.string(),
+        status: z.string(),
+        hashModulo: z.number().optional(),
+        workerHostname: z.string().nullable().optional(),
+        volumeName: z.string().nullable().optional(),
+        volumeStatus: z.string().nullable().optional(),
+        volumeLastVerifiedAt: z.string().nullable().optional(),
+        volumeWorkerAffinity: z.string().nullable().optional(),
+        volumeNotes: z.string().nullable().optional(),
+        latestRunId: z.string().nullable().optional(),
+        latestRunStatus: z.string().nullable().optional(),
+        latestPreflightStatus: z.string().nullable().optional(),
+        latestPreflightMessage: z.string().nullable().optional(),
+        latestPreflightCheckedAt: z.string().nullable().optional(),
+      }),
+    )
+    .default([]),
+});
+
+type WorkerShardHealth = z.infer<typeof WorkerShardHealthSchema>;
+type WorkerShard = WorkerShardHealth['shards'][number];
+
 const DeploymentStackStateSchema = z
   .object({
     stack: z.string(),
@@ -159,6 +185,7 @@ type DeploymentAction = DeploymentStackState['recentActions'][number];
 export interface WorkerPauseConfig {
   get: string;
   post: string;
+  shardHealth?: string;
   pollIntervalMs?: number;
 }
 
@@ -220,6 +247,21 @@ function operationIdempotencyKey(action: string): string {
   return `worker-${action}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function workerStatusTone(status: string | null | undefined): string {
+  const normalized = String(status || '').toLowerCase();
+  if (normalized === 'active' || normalized === 'healthy' || normalized === 'passed') {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300';
+  }
+  if (normalized === 'offline' || normalized === 'failed' || normalized === 'error') {
+    return 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300';
+  }
+  return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300';
+}
+
+function workerDisplayName(shard: WorkerShard): string {
+  return shard.workerHostname || shard.queueName;
+}
+
 export function OperationsSettingsSection({
   workerPauseConfig,
 }: {
@@ -267,6 +309,32 @@ export function OperationsSettingsSection({
     enabled: workerPauseConfig !== null,
     refetchInterval:
       workerPauseConfig !== null
+        ? Math.max(1000, Number(workerPauseConfig.pollIntervalMs) || 5000)
+        : false,
+  });
+
+  const {
+    data: shardHealth,
+    isLoading: isShardHealthLoading,
+    isError: isShardHealthError,
+    error: shardHealthError,
+  } = useQuery<WorkerShardHealth>({
+    queryKey: ['worker-shard-health'],
+    queryFn: async () => {
+      if (!workerPauseConfig?.shardHealth) {
+        throw new Error('Worker shard health is not configured for this deployment.');
+      }
+      const response = await fetch(workerPauseConfig.shardHealth, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch worker shard health: ${response.statusText}`);
+      }
+      return WorkerShardHealthSchema.parse(await response.json());
+    },
+    enabled: Boolean(workerPauseConfig?.shardHealth),
+    refetchInterval:
+      workerPauseConfig?.shardHealth
         ? Math.max(1000, Number(workerPauseConfig.pollIntervalMs) || 5000)
         : false,
   });
@@ -631,13 +699,20 @@ export function OperationsSettingsSection({
   const system = snapshot?.system ?? {};
   const metrics = snapshot?.metrics ?? {};
   const commands = snapshot?.commands ?? [];
+  const workerShards = shardHealth?.shards ?? [];
   const unavailableCommands = commands.filter((command) => !command.available);
   const commandTargets = uniqueStrings(commands.map((command) => command.target || 'workers'));
-  const fleetHealthStatus = metrics.staleRunning && metrics.staleRunning > 0
-    ? 'Attention required'
-    : isError
-      ? 'Unavailable'
-      : 'Healthy';
+  const hasUnavailableWorker = workerShards.some((shard) => {
+    const status = String(shard.status || '').toLowerCase();
+    const preflightStatus = String(shard.latestPreflightStatus || '').toLowerCase();
+    return status === 'offline' || preflightStatus === 'failed';
+  });
+  const fleetHealthStatus =
+    (metrics.staleRunning && metrics.staleRunning > 0) || hasUnavailableWorker
+      ? 'Attention required'
+      : isError || isShardHealthError
+        ? 'Unavailable'
+        : 'Healthy';
   const isPaused = Boolean(system.workersPaused);
   const stateLabel = isPaused
     ? system.mode === 'quiesce'
@@ -1098,6 +1173,100 @@ export function OperationsSettingsSection({
                     {String(unavailableCommands.length)}
                   </div>
                 </div>
+              </div>
+              <div className="mt-5">
+                <h5 className="text-sm font-semibold text-slate-900 dark:text-white">
+                  Per-worker health
+                </h5>
+                {isShardHealthLoading ? (
+                  <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                    Loading per-worker health...
+                  </p>
+                ) : isShardHealthError ? (
+                  <p className="mt-3 text-sm text-rose-700 dark:text-rose-400">
+                    {(shardHealthError as Error).message}
+                  </p>
+                ) : workerShards.length > 0 ? (
+                  <div className="mt-3 overflow-x-auto">
+                    <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800">
+                      <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
+                        <tr>
+                          <th scope="col" className="px-3 py-2 font-semibold">
+                            Worker
+                          </th>
+                          <th scope="col" className="px-3 py-2 font-semibold">
+                            Status
+                          </th>
+                          <th scope="col" className="px-3 py-2 font-semibold">
+                            Queue
+                          </th>
+                          <th scope="col" className="px-3 py-2 font-semibold">
+                            Auth volume
+                          </th>
+                          <th scope="col" className="px-3 py-2 font-semibold">
+                            Latest run
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                        {workerShards.map((shard) => (
+                          <tr key={shard.queueName}>
+                            <td className="px-3 py-3 align-top font-medium text-slate-900 dark:text-white">
+                              {workerDisplayName(shard)}
+                            </td>
+                            <td className="px-3 py-3 align-top">
+                              <span
+                                className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${workerStatusTone(
+                                  shard.status,
+                                )}`}
+                              >
+                                {formatStatusLabel(shard.status)}
+                              </span>
+                            </td>
+                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                              <div>{shard.queueName}</div>
+                              {shard.hashModulo ? (
+                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                  Hash modulo {shard.hashModulo}
+                                </div>
+                              ) : null}
+                            </td>
+                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                              <div>{shard.volumeName || 'No auth volume'}</div>
+                              {shard.volumeStatus ? (
+                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                  {formatStatusLabel(shard.volumeStatus)}
+                                  {shard.volumeLastVerifiedAt
+                                    ? ` | Verified ${shard.volumeLastVerifiedAt}`
+                                    : ''}
+                                </div>
+                              ) : null}
+                            </td>
+                            <td className="px-3 py-3 align-top text-slate-600 dark:text-slate-300">
+                              <div>
+                                {shard.latestRunStatus
+                                  ? formatStatusLabel(shard.latestRunStatus)
+                                  : 'No runs'}
+                              </div>
+                              {shard.latestPreflightStatus ? (
+                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                  Preflight {formatStatusLabel(shard.latestPreflightStatus)}
+                                  {shard.latestPreflightMessage
+                                    ? ` | ${shard.latestPreflightMessage}`
+                                    : ''}
+                                </div>
+                              ) : null}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                    No worker shards registered.
+                  </p>
+                )}
               </div>
             </section>
 


### PR DESCRIPTION
Jira issue key: MM-775

Summary:
- Wires Settings Operations to the existing Codex shard health endpoint.
- Adds a per-worker health table showing worker identity, status, queue, auth volume, latest run, and preflight details.
- Rolls offline or failed-preflight workers into the Worker Fleet Health attention state.
- Marks roadmap item 7.7 complete for MM-775.

Tests run:
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/settings/OperationsSettingsSection.test.tsx
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- ./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/components/settings/OperationsSettingsSection.tsx frontend/src/components/settings/OperationsSettingsSection.test.tsx
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts
- git diff --check

Remaining risks:
- ./tools/test_unit.sh could not run in the managed container because Python pytest is not installed: /usr/local/bin/python: No module named pytest.
- No Docker-backed integration suite was run; this change is limited to Settings UI wiring and an existing API endpoint reference.
