### PR TITLE
MM-779 add external agent callback API

### DIFF
--- a/api_service/api/routers/execution_integrations.py
+++ b/api_service/api/routers/execution_integrations.py
@@ -111,11 +111,24 @@ def _callback_profile(integration_name: str) -> _CallbackProfile:
         )
     return _CallbackProfile(
         normalized_name=normalized,
-        expected_token=None,
-        max_payload_bytes=_DEFAULT_CALLBACK_MAX_PAYLOAD_BYTES,
-        rate_limit_per_window=_DEFAULT_CALLBACK_RATE_LIMIT,
-        rate_limit_window_seconds=_DEFAULT_CALLBACK_RATE_LIMIT_WINDOW_SECONDS,
-        capture_artifacts=False,
+        expected_token=(
+            str(settings.integration_callbacks.callback_token or "").strip() or None
+        ),
+        max_payload_bytes=int(
+            settings.integration_callbacks.max_payload_bytes
+            or _DEFAULT_CALLBACK_MAX_PAYLOAD_BYTES
+        ),
+        rate_limit_per_window=int(
+            settings.integration_callbacks.rate_limit_per_window
+            or _DEFAULT_CALLBACK_RATE_LIMIT
+        ),
+        rate_limit_window_seconds=int(
+            settings.integration_callbacks.rate_limit_window_seconds
+            or _DEFAULT_CALLBACK_RATE_LIMIT_WINDOW_SECONDS
+        ),
+        capture_artifacts=bool(
+            settings.integration_callbacks.artifact_capture_enabled
+        ),
     )
 
 async def _validate_callback_request(

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -208,7 +208,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 ### Remaining tasks
 - [ ] **8.1** MCP Streamable HTTP Transport (2025 spec) — Current `/context` is REST-style; modern MCP uses streamable HTTP
 - [ ] **8.2** MCP resource & tool discovery — Clients can't discover what MoonMind offers via MCP
-- [ ] **8.3** Webhook / callback API for external agents — Jules external events started, no generic webhook receiver
+- [x] **8.3** Webhook / callback API for external agents — Generic integration callback receiver, correlation lookup, callback URL provisioning, and polling fallback are available for external agents that advertise callback support (MM-779)
 - [ ] **8.4** OpenAI Responses API compatibility — Only Chat Completions format supported
 
 ---

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2210,6 +2210,70 @@ class ExecutionNotificationSettings(BaseSettings):
         extra="ignore",
     )
 
+class IntegrationCallbackSettings(BaseSettings):
+    """Generic external integration callback ingress settings."""
+
+    base_url: Optional[str] = Field(
+        None,
+        alias="MOONMIND_INTEGRATION_CALLBACK_BASE_URL",
+        description=(
+            "Absolute public base URL used to build external integration callback URLs."
+        ),
+    )
+    callback_token: Optional[str] = Field(
+        None,
+        alias="MOONMIND_INTEGRATION_CALLBACK_TOKEN",
+        description="Optional shared bearer/header token for generic integration callbacks.",
+    )
+    max_payload_bytes: int = Field(
+        64 * 1024,
+        alias="MOONMIND_INTEGRATION_CALLBACK_MAX_PAYLOAD_BYTES",
+        ge=1,
+        description="Maximum callback payload size for generic integrations.",
+    )
+    rate_limit_per_window: int = Field(
+        30,
+        alias="MOONMIND_INTEGRATION_CALLBACK_RATE_LIMIT_PER_WINDOW",
+        ge=1,
+        description="Generic integration callback requests allowed per window.",
+    )
+    rate_limit_window_seconds: int = Field(
+        60,
+        alias="MOONMIND_INTEGRATION_CALLBACK_RATE_LIMIT_WINDOW_SECONDS",
+        ge=1,
+        description="Generic integration callback rate limit window in seconds.",
+    )
+    artifact_capture_enabled: bool = Field(
+        False,
+        alias="MOONMIND_INTEGRATION_CALLBACK_ARTIFACT_CAPTURE_ENABLED",
+        description="Capture raw generic integration callback payloads as artifacts.",
+    )
+
+    @field_validator("base_url", mode="after")
+    @classmethod
+    def _normalize_base_url(cls, value: Optional[str]) -> Optional[str]:
+        text = str(value or "").strip().rstrip("/")
+        if not text:
+            return None
+        parsed = urlsplit(text)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(
+                "MOONMIND_INTEGRATION_CALLBACK_BASE_URL must be an absolute http(s) URL"
+            )
+        if parsed.query or parsed.fragment:
+            raise ValueError(
+                "MOONMIND_INTEGRATION_CALLBACK_BASE_URL must not include query or fragment"
+            )
+        return text
+
+    model_config = SettingsConfigDict(
+        populate_by_name=True,
+        env_prefix="",
+        env_file=str(ENV_FILE),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
 class AppSettings(BaseSettings):
     """Main application settings"""
 
@@ -2237,6 +2301,9 @@ class AppSettings(BaseSettings):
     task_proposals: TaskProposalSettings = Field(default_factory=TaskProposalSettings)
     execution_notifications: ExecutionNotificationSettings = Field(
         default_factory=ExecutionNotificationSettings
+    )
+    integration_callbacks: IntegrationCallbackSettings = Field(
+        default_factory=IntegrationCallbackSettings
     )
     jules: JulesSettings = Field(default_factory=JulesSettings)
     worker_enable_task_proposals: Optional[bool] = Field(

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -417,6 +417,10 @@ class AgentExecutionRequest(BaseModel):
     callback_policy: dict[str, Any] = Field(
         default_factory=dict, alias="callbackPolicy"
     )
+    callback_url: str | None = Field(None, alias="callbackUrl")
+    callback_correlation_key: str | None = Field(
+        None, alias="callbackCorrelationKey"
+    )
     profile_selector: ProfileSelector = Field(
         default_factory=ProfileSelector, alias="profileSelector"
     )
@@ -446,6 +450,14 @@ class AgentExecutionRequest(BaseModel):
         if resolved_skillset_ref is not None:
             self.resolved_skillset_ref = require_non_blank(
                 resolved_skillset_ref, field_name="resolvedSkillsetRef"
+            )
+        if self.callback_url is not None:
+            self.callback_url = require_non_blank(
+                self.callback_url, field_name="callbackUrl"
+            )
+        if self.callback_correlation_key is not None:
+            self.callback_correlation_key = require_non_blank(
+                self.callback_correlation_key, field_name="callbackCorrelationKey"
             )
         if self.managed_session is not None:
             canonical_runtime_id = canonical_managed_session_runtime_id(self.agent_id)

--- a/moonmind/workflows/adapters/base_external_agent_adapter.py
+++ b/moonmind/workflows/adapters/base_external_agent_adapter.py
@@ -98,6 +98,7 @@ class BaseExternalAgentAdapter(abc.ABC):
         metadata = self._inject_correlation_metadata(
             metadata, request.correlation_id, request.idempotency_key
         )
+        metadata = self._inject_callback_metadata(metadata, request)
 
         handle = await self.do_start(request, title, description, metadata)
 
@@ -212,6 +213,27 @@ class BaseExternalAgentAdapter(abc.ABC):
         return metadata
 
     @staticmethod
+    def _inject_callback_metadata(
+        metadata: dict[str, Any],
+        request: AgentExecutionRequest,
+    ) -> dict[str, Any]:
+        """Inject workflow-provisioned callback hints into provider metadata."""
+
+        if not request.callback_url and not request.callback_correlation_key:
+            return metadata
+        moonmind_meta = metadata.setdefault("moonmind", {})
+        if isinstance(moonmind_meta, Mapping):
+            moonmind_payload = dict(moonmind_meta)
+            if request.callback_url:
+                moonmind_payload.setdefault("callbackUrl", request.callback_url)
+            if request.callback_correlation_key:
+                moonmind_payload.setdefault(
+                    "callbackCorrelationKey", request.callback_correlation_key
+                )
+            metadata["moonmind"] = moonmind_payload
+        return metadata
+
+    @staticmethod
     def build_handle(
         *,
         run_id: str,
@@ -220,20 +242,26 @@ class BaseExternalAgentAdapter(abc.ABC):
         provider_status: str,
         normalized_status: str,
         external_url: str | None = None,
+        callback_supported: bool = False,
+        callback_correlation_key: str | None = None,
     ) -> AgentRunHandle:
         """Build a standard ``AgentRunHandle`` with canonical metadata."""
 
+        metadata: dict[str, Any] = {
+            "providerStatus": provider_status,
+            "normalizedStatus": normalized_status,
+            "externalUrl": external_url,
+            "callbackSupported": bool(callback_supported),
+        }
+        if callback_correlation_key:
+            metadata["callbackCorrelationKey"] = callback_correlation_key
         return AgentRunHandle(
             runId=run_id,
             agentKind="external",
             agentId=agent_id,
             status=status,
             startedAt=datetime.now(tz=UTC),
-            metadata={
-                "providerStatus": provider_status,
-                "normalizedStatus": normalized_status,
-                "externalUrl": external_url,
-            },
+            metadata=metadata,
         )
 
     @staticmethod

--- a/moonmind/workflows/adapters/base_external_agent_adapter.py
+++ b/moonmind/workflows/adapters/base_external_agent_adapter.py
@@ -98,7 +98,8 @@ class BaseExternalAgentAdapter(abc.ABC):
         metadata = self._inject_correlation_metadata(
             metadata, request.correlation_id, request.idempotency_key
         )
-        metadata = self._inject_callback_metadata(metadata, request)
+        if self.provider_capability.supports_callbacks:
+            metadata = self._inject_callback_metadata(metadata, request)
 
         handle = await self.do_start(request, title, description, metadata)
 

--- a/moonmind/workflows/adapters/jules_agent_adapter.py
+++ b/moonmind/workflows/adapters/jules_agent_adapter.py
@@ -58,7 +58,7 @@ def _preferred_external_url(response: JulesTaskResponse) -> str | None:
 
 _JULES_CAPABILITY = ProviderCapabilityDescriptor(
     providerName="jules",
-    supportsCallbacks=True,
+    supportsCallbacks=False,
     supportsCancel=True,
     supportsResultFetch=True,
     defaultPollHintSeconds=15,
@@ -142,8 +142,8 @@ class JulesAgentAdapter(BaseExternalAgentAdapter):
             provider_status=provider_status,
             normalized_status=normalized_status,
             external_url=_preferred_external_url(response),
-            callback_supported=bool(request.callback_url),
-            callback_correlation_key=request.callback_correlation_key,
+            callback_supported=False,
+            callback_correlation_key=None,
         )
         if response.pull_request_url:
             metadata = dict(handle.metadata)

--- a/moonmind/workflows/adapters/jules_agent_adapter.py
+++ b/moonmind/workflows/adapters/jules_agent_adapter.py
@@ -58,7 +58,7 @@ def _preferred_external_url(response: JulesTaskResponse) -> str | None:
 
 _JULES_CAPABILITY = ProviderCapabilityDescriptor(
     providerName="jules",
-    supportsCallbacks=False,
+    supportsCallbacks=True,
     supportsCancel=True,
     supportsResultFetch=True,
     defaultPollHintSeconds=15,
@@ -142,6 +142,8 @@ class JulesAgentAdapter(BaseExternalAgentAdapter):
             provider_status=provider_status,
             normalized_status=normalized_status,
             external_url=_preferred_external_url(response),
+            callback_supported=bool(request.callback_url),
+            callback_correlation_key=request.callback_correlation_key,
         )
         if response.pull_request_url:
             metadata = dict(handle.metadata)

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
@@ -118,6 +119,7 @@ def _setdefault_compact_ref_metadata(
 # Default workflow-level execution timeouts
 DEFAULT_MANAGED_TIMEOUT_SECONDS = 3600      # 1 hour
 DEFAULT_EXTERNAL_TIMEOUT_SECONDS = 21600    # 6 hours
+_CALLBACK_KEY_SAFE_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
 
 STREAMING_EXTERNAL_HEARTBEAT_TIMEOUT = timedelta(seconds=120)
 MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
@@ -284,9 +286,20 @@ async def resolve_adapter_metadata(agent_id: str) -> dict:
     resolved_agent_id = str(agent_id).strip().lower()
     adapter = registry.create(resolved_agent_id)
     execution_style = "polling"
+    supports_callbacks = False
     if isinstance(adapter, BaseExternalAgentAdapter):
-        execution_style = adapter.provider_capability.execution_style
-    return {"agent_id": resolved_agent_id, "execution_style": execution_style}
+        capability = adapter.provider_capability
+        execution_style = capability.execution_style
+        supports_callbacks = capability.supports_callbacks
+
+    from moonmind.config.settings import settings
+
+    return {
+        "agent_id": resolved_agent_id,
+        "execution_style": execution_style,
+        "supports_callbacks": supports_callbacks,
+        "callback_base_url": settings.integration_callbacks.base_url,
+    }
 
 # --- In-flight compatibility shims (spec #285) ---
 # These activities were superseded by resolve_adapter_metadata but must remain
@@ -361,6 +374,87 @@ class MoonMindAgentRun:
         self._slot_wait_timeout_override_seconds: int | None = None
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
+
+    @staticmethod
+    def _safe_callback_key(*parts: str) -> str:
+        raw = "-".join(
+            str(part or "").strip() for part in parts if str(part or "").strip()
+        )
+        safe = _CALLBACK_KEY_SAFE_PATTERN.sub("-", raw).strip("-")
+        return safe or "callback"
+
+    @staticmethod
+    def _external_callback_url(
+        *,
+        base_url: str,
+        integration_name: str,
+        callback_correlation_key: str,
+    ) -> str:
+        base = str(base_url or "").strip().rstrip("/")
+        integration = str(integration_name or "").strip().lower()
+        key = str(callback_correlation_key or "").strip()
+        return f"{base}/api/integrations/{integration}/callbacks/{key}"
+
+    def _with_external_callback_ingress(
+        self,
+        request: AgentExecutionRequest,
+        *,
+        integration_name: str,
+        supports_callbacks: bool,
+        callback_base_url: str | None,
+    ) -> AgentExecutionRequest:
+        if not supports_callbacks:
+            return request
+
+        policy = (
+            request.callback_policy if isinstance(request.callback_policy, dict) else {}
+        )
+        if policy.get("enabled") is False:
+            return request
+
+        explicit_url = str(
+            policy.get("callbackUrl") or policy.get("url") or request.callback_url or ""
+        ).strip()
+        explicit_key = str(
+            policy.get("callbackCorrelationKey")
+            or request.callback_correlation_key
+            or ""
+        ).strip()
+        key = explicit_key or self._safe_callback_key(
+            workflow.info().workflow_id,
+            integration_name,
+            request.correlation_id,
+            request.idempotency_key,
+        )
+
+        if explicit_url:
+            callback_url = explicit_url
+        else:
+            base_url = str(
+                policy.get("callbackBaseUrl")
+                or policy.get("baseUrl")
+                or callback_base_url
+                or ""
+            ).strip()
+            if not base_url:
+                return request
+            callback_url = self._external_callback_url(
+                base_url=base_url,
+                integration_name=integration_name,
+                callback_correlation_key=key,
+            )
+
+        next_policy = dict(policy)
+        next_policy.setdefault("enabled", True)
+        next_policy["callbackUrl"] = callback_url
+        next_policy["callbackCorrelationKey"] = key
+        return request.model_copy(
+            update={
+                "callback_policy": next_policy,
+                "callback_url": callback_url,
+                "callback_correlation_key": key,
+            }
+        )
 
     # --- Deterministic catalog-based routing (new path) ---
 
@@ -2515,6 +2609,14 @@ class MoonMindAgentRun:
                     )
                     validated_id = adapter_meta["agent_id"]
                     execution_style = adapter_meta["execution_style"]
+                    request = self._with_external_callback_ingress(
+                        request,
+                        integration_name=validated_id,
+                        supports_callbacks=bool(
+                            adapter_meta.get("supports_callbacks", False)
+                        ),
+                        callback_base_url=adapter_meta.get("callback_base_url"),
+                    )
                     # Store the validated agent_id for activity routing.
                     self._external_agent_id = validated_id
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -412,14 +412,15 @@ class MoonMindAgentRun:
         if policy.get("enabled") is False:
             return request
 
-        explicit_url = str(
-            policy.get("callbackUrl") or policy.get("url") or request.callback_url or ""
-        ).strip()
-        explicit_key = str(
-            policy.get("callbackCorrelationKey")
-            or request.callback_correlation_key
-            or ""
-        ).strip()
+        explicit_url = (
+            str(policy.get("callbackUrl") or "").strip()
+            or str(policy.get("url") or "").strip()
+            or str(request.callback_url or "").strip()
+        )
+        explicit_key = (
+            str(policy.get("callbackCorrelationKey") or "").strip()
+            or str(request.callback_correlation_key or "").strip()
+        )
         key = explicit_key or self._safe_callback_key(
             workflow.info().workflow_id,
             integration_name,

--- a/tests/unit/api/routers/test_execution_integrations.py
+++ b/tests/unit/api/routers/test_execution_integrations.py
@@ -107,6 +107,7 @@ async def _create_monitored_execution(
     client: AsyncClient,
     *,
     execution_suffix: str = "default",
+    integration_name: str = "jules",
 ) -> tuple[str, str]:
     create_response = await client.post(
         "/api/executions",
@@ -122,7 +123,7 @@ async def _create_monitored_execution(
     configure_response = await client.post(
         f"/api/executions/{workflow_id}/integration",
         json={
-            "integrationName": "jules",
+            "integrationName": integration_name,
             "externalOperationId": f"task-{execution_suffix}",
             "normalizedStatus": "running",
             "providerStatus": "running",
@@ -185,6 +186,42 @@ async def test_callback_accepts_matching_bearer_token(monkeypatch):
 
     assert response.status_code == 202
     assert response.json()["integration"]["normalizedStatus"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_generic_callback_profile_accepts_matching_bearer_token(monkeypatch):
+    shared_user_id = uuid4()
+    monkeypatch.setattr(settings.integration_callbacks, "callback_token", "generic-secret")
+
+    async with _shared_client(shared_user_id) as client:
+        _workflow_id, callback_key = await _create_monitored_execution(
+            client,
+            execution_suffix=f"generic-auth-{uuid4().hex[:8]}",
+            integration_name="codex_cloud",
+        )
+        unauthorized = await client.post(
+            f"/api/integrations/codex_cloud/callbacks/{callback_key}",
+            json={
+                "eventType": "completed",
+                "normalizedStatus": "completed",
+            },
+        )
+        accepted = await client.post(
+            f"/api/integrations/codex_cloud/callbacks/{callback_key}",
+            headers={"Authorization": "Bearer generic-secret"},
+            json={
+                "eventType": "completed",
+                "providerEventId": "evt-generic",
+                "normalizedStatus": "completed",
+            },
+        )
+
+    assert unauthorized.status_code == 401
+    assert unauthorized.json()["detail"]["code"] == "integration_callback_unauthorized"
+    assert accepted.status_code == 202
+    assert accepted.json()["integration"]["integrationName"] == "codex_cloud"
+    assert accepted.json()["integration"]["normalizedStatus"] == "completed"
+
 
 @pytest.mark.asyncio
 async def test_callback_rejects_payload_over_limit(monkeypatch):

--- a/tests/unit/workflows/adapters/test_base_external_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_base_external_agent_adapter.py
@@ -19,14 +19,6 @@ from moonmind.workflows.adapters.base_external_agent_adapter import (
 
 pytestmark = [pytest.mark.asyncio]
 
-_STUB_CAPABILITY = ProviderCapabilityDescriptor(
-    providerName="stub",
-    supportsCallbacks=False,
-    supportsCancel=True,
-    supportsResultFetch=True,
-    defaultPollHintSeconds=10,
-)
-
 class _StubAdapter(BaseExternalAgentAdapter):
     """Concrete stub for testing the base class."""
 
@@ -35,9 +27,11 @@ class _StubAdapter(BaseExternalAgentAdapter):
         *,
         accepted_agent_ids: frozenset[str] = frozenset({"stub"}),
         start_run_id: str = "run-1",
+        supports_callbacks: bool = False,
     ) -> None:
         super().__init__(accepted_agent_ids=accepted_agent_ids)
         self.start_run_id = start_run_id
+        self._supports_callbacks = supports_callbacks
         self.do_start_calls: list[dict[str, Any]] = []
         self.do_status_calls: list[str] = []
         self.do_fetch_result_calls: list[str] = []
@@ -45,7 +39,13 @@ class _StubAdapter(BaseExternalAgentAdapter):
 
     @property
     def provider_capability(self) -> ProviderCapabilityDescriptor:
-        return _STUB_CAPABILITY
+        return ProviderCapabilityDescriptor(
+            providerName="stub",
+            supportsCallbacks=self._supports_callbacks,
+            supportsCancel=True,
+            supportsResultFetch=True,
+            defaultPollHintSeconds=10,
+        )
 
     async def do_start(
         self,
@@ -174,7 +174,7 @@ async def test_start_injects_correlation_metadata():
 
 
 async def test_start_injects_callback_metadata_and_returns_handle_flag():
-    adapter = _StubAdapter()
+    adapter = _StubAdapter(supports_callbacks=True)
     req = _request().model_copy(
         update={
             "callback_url": "https://moonmind.example.test/api/integrations/stub/callbacks/cb-1",
@@ -189,6 +189,23 @@ async def test_start_injects_callback_metadata_and_returns_handle_flag():
     assert moonmind["callbackUrl"].endswith("/api/integrations/stub/callbacks/cb-1")
     assert moonmind["callbackCorrelationKey"] == "cb-1"
     assert handle.metadata["callbackSupported"] is False
+
+
+async def test_start_skips_callback_metadata_when_provider_does_not_support_callbacks():
+    adapter = _StubAdapter(supports_callbacks=False)
+    req = _request().model_copy(
+        update={
+            "callback_url": "https://moonmind.example.test/api/integrations/stub/callbacks/cb-1",
+            "callback_correlation_key": "cb-1",
+        }
+    )
+
+    await adapter.start(req)
+
+    call = adapter.do_start_calls[0]
+    moonmind = call["metadata"].get("moonmind", {})
+    assert "callbackUrl" not in moonmind
+    assert "callbackCorrelationKey" not in moonmind
 
 
 async def test_start_forwards_raw_refs_without_mutating_prepared_context_metadata():
@@ -341,7 +358,7 @@ async def test_start_populates_poll_hint_from_capability():
     the provider hook returns a handle without it."""
     adapter = _StubAdapter()
     handle = await adapter.start(_request())
-    assert handle.poll_hint_seconds == _STUB_CAPABILITY.default_poll_hint_seconds
+    assert handle.poll_hint_seconds == adapter.provider_capability.default_poll_hint_seconds
 
 async def test_start_preserves_explicit_poll_hint():
     """If do_start returns a handle with poll_hint_seconds already set,

--- a/tests/unit/workflows/adapters/test_base_external_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_base_external_agent_adapter.py
@@ -173,6 +173,24 @@ async def test_start_injects_correlation_metadata():
     assert moonmind.get("idempotencyKey") == "idem-1"
 
 
+async def test_start_injects_callback_metadata_and_returns_handle_flag():
+    adapter = _StubAdapter()
+    req = _request().model_copy(
+        update={
+            "callback_url": "https://moonmind.example.test/api/integrations/stub/callbacks/cb-1",
+            "callback_correlation_key": "cb-1",
+        }
+    )
+
+    handle = await adapter.start(req)
+
+    call = adapter.do_start_calls[0]
+    moonmind = call["metadata"].get("moonmind", {})
+    assert moonmind["callbackUrl"].endswith("/api/integrations/stub/callbacks/cb-1")
+    assert moonmind["callbackCorrelationKey"] == "cb-1"
+    assert handle.metadata["callbackSupported"] is False
+
+
 async def test_start_forwards_raw_refs_without_mutating_prepared_context_metadata():
     adapter = _StubAdapter()
     req = _request().model_copy(

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -99,6 +99,30 @@ async def test_start_returns_canonical_handle_and_reuses_idempotency_key():
     assert second.run_id == first.run_id
     assert len(client.created) == 1
 
+
+async def test_start_marks_callback_supported_when_callback_ingress_is_provisioned():
+    client = _FakeJulesAdapterClient()
+    adapter = JulesAgentAdapter(client_factory=lambda: client)
+
+    handle = await adapter.start(
+        _request().model_copy(
+            update={
+                "callback_url": "https://moonmind.example.test/api/integrations/jules/callbacks/cb-1",
+                "callback_correlation_key": "cb-1",
+            }
+        )
+    )
+
+    assert adapter.provider_capability.supports_callbacks is True
+    assert handle.metadata["callbackSupported"] is True
+    assert handle.metadata["callbackCorrelationKey"] == "cb-1"
+    create_req = client.created[0]
+    assert create_req.metadata["moonmind"]["callbackCorrelationKey"] == "cb-1"
+    assert create_req.metadata["moonmind"]["callbackUrl"].endswith(
+        "/api/integrations/jules/callbacks/cb-1"
+    )
+
+
 async def test_status_and_fetch_result_normalize_provider_states():
     client = _FakeJulesAdapterClient(get_status="completed")
     adapter = JulesAgentAdapter(client_factory=lambda: client)

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -100,7 +100,7 @@ async def test_start_returns_canonical_handle_and_reuses_idempotency_key():
     assert len(client.created) == 1
 
 
-async def test_start_marks_callback_supported_when_callback_ingress_is_provisioned():
+async def test_start_keeps_callback_unsupported_for_polling_only_jules():
     client = _FakeJulesAdapterClient()
     adapter = JulesAgentAdapter(client_factory=lambda: client)
 
@@ -113,14 +113,12 @@ async def test_start_marks_callback_supported_when_callback_ingress_is_provision
         )
     )
 
-    assert adapter.provider_capability.supports_callbacks is True
-    assert handle.metadata["callbackSupported"] is True
-    assert handle.metadata["callbackCorrelationKey"] == "cb-1"
+    assert adapter.provider_capability.supports_callbacks is False
+    assert handle.metadata["callbackSupported"] is False
+    assert "callbackCorrelationKey" not in handle.metadata
     create_req = client.created[0]
-    assert create_req.metadata["moonmind"]["callbackCorrelationKey"] == "cb-1"
-    assert create_req.metadata["moonmind"]["callbackUrl"].endswith(
-        "/api/integrations/jules/callbacks/cb-1"
-    )
+    assert "callbackCorrelationKey" not in create_req.metadata["moonmind"]
+    assert "callbackUrl" not in create_req.metadata["moonmind"]
 
 
 async def test_status_and_fetch_result_normalize_provider_states():

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -110,6 +110,65 @@ async def test_agent_run_jules_starts_new_run_instead_of_continuation(
     assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
     assert result.metadata["childRunId"] == "run-1"
 
+
+async def test_agent_run_provisions_external_callback_url_before_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "integration.resolve_adapter_metadata":
+            return {
+                "agent_id": "jules",
+                "execution_style": "polling",
+                "supports_callbacks": True,
+                "callback_base_url": "https://moonmind.example.test",
+            }
+        if activity_name == "integration.jules.start":
+            assert isinstance(payload, AgentExecutionRequest)
+            assert payload.callback_correlation_key
+            assert payload.callback_url == (
+                "https://moonmind.example.test/api/integrations/jules/callbacks/"
+                f"{payload.callback_correlation_key}"
+            )
+            assert payload.callback_policy["callbackUrl"] == payload.callback_url
+            assert payload.callback_policy["callbackCorrelationKey"] == (
+                payload.callback_correlation_key
+            )
+            return {
+                "external_id": "new-session-1",
+                "status": "queued",
+                "callback_supported": True,
+                "callback_correlation_key": payload.callback_correlation_key,
+            }
+        if activity_name == "integration.jules.status":
+            return {"normalized_status": "completed"}
+        if activity_name == "integration.jules.fetch_result":
+            return {"summary": "Done", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_request())
+
+    assert routed_calls[1][0] == "integration.jules.start"
+    assert result.failure_class is None
+
+
 async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -348,6 +407,8 @@ async def test_resolve_adapter_metadata_normalizes_case_for_activity_routing(
     assert metadata == {
         "agent_id": "openclaw",
         "execution_style": "streaming_gateway",
+        "supports_callbacks": False,
+        "callback_base_url": None,
     }
 
 async def test_agent_run_streaming_gateway_uses_validated_provider_execute_activity(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -169,6 +169,34 @@ async def test_agent_run_provisions_external_callback_url_before_start(
     assert result.failure_class is None
 
 
+async def test_external_callback_ingress_strips_candidates_before_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    _configure_workflow_runtime(monkeypatch)
+
+    request = _request(
+        callbackPolicy={
+            "callbackUrl": "   ",
+            "url": " https://moonmind.example.test/explicit-callback ",
+            "callbackCorrelationKey": "   ",
+        },
+        callbackCorrelationKey=" request-key ",
+    )
+
+    updated = run._with_external_callback_ingress(
+        request,
+        integration_name="jules",
+        supports_callbacks=True,
+        callback_base_url="https://moonmind.example.test",
+    )
+
+    assert updated.callback_url == "https://moonmind.example.test/explicit-callback"
+    assert updated.callback_correlation_key == "request-key"
+    assert updated.callback_policy["callbackUrl"] == updated.callback_url
+    assert updated.callback_policy["callbackCorrelationKey"] == "request-key"
+
+
 async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Jira issue: MM-779

Summary:
- Adds generic integration callback configuration for external-agent webhook/callback ingress.
- Wires non-Jules callback receiver profiles to generic token, payload limit, rate limit, and artifact-capture settings.
- Adds external agent callback URL and correlation fields, provisions callback ingress in the agent workflow, and injects callback metadata into external adapter requests/handles.
- Marks Jules callback-capable when callback ingress is provisioned and updates the roadmap entry for MM-779.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_base_external_agent_adapter.py tests/unit/workflows/adapters/test_jules_agent_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/api/routers/test_execution_integrations.py tests/integration/temporal/test_integrations_monitoring.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Remaining risks:
- Generic callback ingress depends on operators configuring `MOONMIND_INTEGRATION_CALLBACK_BASE_URL` for providers that need MoonMind to generate a public callback URL.
- End-to-end provider callback delivery still depends on each external provider honoring the supplied metadata contract.
