### PR TITLE
MM-778 MCP resource and tool discovery

### DIFF
--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -134,7 +134,7 @@ async def list_resources(
     _user: User = Depends(get_current_user()),
 ) -> ResourceListResponse:
     """Return MoonMind MCP resource definitions."""
-    return ResourceListResponse(resources=list(_resources))
+    return ResourceListResponse(resources=_resources)
 
 @router.get("/tools", response_model=ToolListResponse)
 async def list_tools(

--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -24,6 +24,8 @@ from moonmind.mcp.jules_tool_registry import (
 from moonmind.mcp.tool_registry import (
     QueueToolExecutionContext,
     QueueToolRegistry,
+    ResourceListResponse,
+    ResourceMetadata,
     ToolArgumentsValidationError,
     ToolCallRequest,
     ToolCallResponse,
@@ -42,6 +44,26 @@ _jira_registry: JiraToolRegistry | None = None
 _jira_service: JiraToolService | None = None
 _jules_registry: JulesToolRegistry | None = None
 _jules_client: JulesClient | None = None
+
+_resources = (
+    ResourceMetadata(
+        uri="moonmind://context",
+        name="context-completion",
+        description=(
+            "Chat-style context completion endpoint with optional RAG, available "
+            "through POST /context."
+        ),
+        mime_type="application/json",
+    ),
+    ResourceMetadata(
+        uri="moonmind://mcp/tools",
+        name="tool-catalog",
+        description=(
+            "Registered MoonMind tool catalog, available through GET /mcp/tools."
+        ),
+        mime_type="application/json",
+    ),
+)
 
 if settings.atlassian.jira.jira_tool_enabled:
     _jira_service = JiraToolService(atlassian_settings=settings.atlassian)
@@ -105,6 +127,14 @@ def _to_http_exception(exc: Exception) -> HTTPException:
             "message": "An unexpected MCP tool error occurred.",
         },
     )
+
+
+@router.get("/resources", response_model=ResourceListResponse)
+async def list_resources(
+    _user: User = Depends(get_current_user()),
+) -> ResourceListResponse:
+    """Return MoonMind MCP resource definitions."""
+    return ResourceListResponse(resources=list(_resources))
 
 @router.get("/tools", response_model=ToolListResponse)
 async def list_tools(

--- a/docs/ExternalAgents/ModelContextProtocol.md
+++ b/docs/ExternalAgents/ModelContextProtocol.md
@@ -1,6 +1,6 @@
 # Model Context Protocol in MoonMind
 
-This document describes how MoonMind exposes **agent-facing HTTP surfaces** related to the Model Context Protocol (MCP) ecosystem: a **context-style chat completion** endpoint and a small **MCP tool HTTP API** for discovery and invocation. Together they replace the older standalone `docs/CodexMcpToolsAdapter.md` guide; operational detail for Jules-specific behavior lives in [`docs/ExternalAgents/JulesAdapter.md`](JulesAdapter.md) (§ MCP tooling posture).
+This document describes how MoonMind exposes **agent-facing HTTP surfaces** related to the Model Context Protocol (MCP) ecosystem: a **context-style chat completion** endpoint and a small **MCP HTTP API** for resource discovery, tool discovery, and tool invocation. Together they replace the older standalone `docs/CodexMcpToolsAdapter.md` guide; operational detail for Jules-specific behavior lives in [`docs/ExternalAgents/JulesAdapter.md`](JulesAdapter.md) (§ MCP tooling posture).
 
 MoonMind does **not** implement the full MCP streamable-HTTP or JSON-RPC transport on `/context`; that route is a **REST JSON** contract documented below. Tooling uses **JSON over HTTP** at `/mcp/*`, which clients such as Codex CLI can configure as an HTTP MCP tool server.
 
@@ -9,6 +9,7 @@ MoonMind does **not** implement the full MCP streamable-HTTP or JSON-RPC transpo
 | Surface | Method and path | Purpose |
 | -------- | ---------------- | ------- |
 | Context completion | `POST /context` | Chat-style generation with optional RAG; backed by **Google Gemini** in the current implementation. |
+| Resource discovery | `GET /mcp/resources` | Lists MoonMind MCP-facing resources with stable URIs, descriptions, and MIME types. |
 | Tool discovery | `GET /mcp/tools` | Lists tool names, descriptions, and JSON Schemas (`inputSchema`). |
 | Tool invocation | `POST /mcp/tools/call` | Dispatches one tool by name with a JSON `arguments` object. |
 
@@ -84,6 +85,33 @@ Optional **RAG**: when RAG is enabled and a vector index is available, the **las
 
 Token counts in `usage` are **estimates** (word-split based) for observability, not billing-grade provider totals.
 
+## `GET /mcp/resources` — HTTP MCP resources
+
+This route provides a minimal resource catalog so clients can discover MoonMind's MCP-facing resources before deciding which surface to use.
+
+Returns:
+
+```json
+{
+  "resources": [
+    {
+      "uri": "moonmind://context",
+      "name": "context-completion",
+      "description": "Chat-style context completion endpoint with optional RAG, available through POST /context.",
+      "mimeType": "application/json"
+    },
+    {
+      "uri": "moonmind://mcp/tools",
+      "name": "tool-catalog",
+      "description": "Registered MoonMind tool catalog, available through GET /mcp/tools.",
+      "mimeType": "application/json"
+    }
+  ]
+}
+```
+
+Field names match the Pydantic models in [`moonmind/mcp/tool_registry.py`](../moonmind/mcp/tool_registry.py) (`uri`, `name`, `description`, `mimeType`).
+
 ## `GET /mcp/tools` and `POST /mcp/tools/call` — HTTP MCP tools
 
 These routes provide a minimal **list-tools / call-tool** pair over HTTPS. They are suitable for agents and CLIs that can target a **base URL** plus paths, with JSON request and response bodies.
@@ -144,6 +172,7 @@ The shape of `result` is tool-specific (for Jules tools, task payloads are JSON-
 Point your tool server at the **MoonMind API base** (for example `http://localhost:8000` from the host, or `http://api:8000` from another compose service). Use:
 
 - **List tools**: `GET {base}/mcp/tools`
+- **List resources**: `GET {base}/mcp/resources`
 - **Call tool**: `POST {base}/mcp/tools/call` with `Content-Type: application/json`
 
 Configure whatever fields your client uses for **authentication headers** so requests match your `AUTH_PROVIDER` setup. Exact config keys depend on the Codex (or other) release; this repository previously documented Codex-specific filenames in `CodexMcpToolsAdapter.md` — that file was removed in favor of this section plus upstream client docs.

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -201,13 +201,13 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 
 ### What's shipped
 - MCP server endpoint (`/context` — `context_protocol.py`)
-- MCP tools wrapper (`mcp_tools.py`)
+- MCP resource and tools wrapper (`mcp_tools.py`)
 - OpenAI-compatible chat API (`chat.py`)
 - Operator doc [`docs/ModelContextProtocol.md`](../ModelContextProtocol.md) (context endpoint + `/mcp` HTTP tools; supersedes removed `CodexMcpToolsAdapter.md`)
 
 ### Remaining tasks
 - [ ] **8.1** MCP Streamable HTTP Transport (2025 spec) — Current `/context` is REST-style; modern MCP uses streamable HTTP
-- [ ] **8.2** MCP resource & tool discovery — Clients can't discover what MoonMind offers via MCP
+- [x] **8.2** MCP resource & tool discovery — Clients can list MoonMind MCP resources and tools
 - [ ] **8.3** Webhook / callback API for external agents — Jules external events started, no generic webhook receiver
 - [ ] **8.4** OpenAI Responses API compatibility — Only Chat Completions format supported
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -248,6 +248,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/mcp/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Resources
+         * @description Return MoonMind MCP resource definitions.
+         */
+        get: operations["list_resources_mcp_resources_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/mcp/tools": {
         parameters: {
             query?: never;
@@ -6348,6 +6368,28 @@ export interface components {
              */
             scheduledFor: string;
         };
+        /**
+         * ResourceListResponse
+         * @description Resource discovery response envelope.
+         */
+        ResourceListResponse: {
+            /** Resources */
+            resources?: components["schemas"]["ResourceMetadata"][];
+        };
+        /**
+         * ResourceMetadata
+         * @description Resource definition payload returned by discovery endpoint.
+         */
+        ResourceMetadata: {
+            /** Uri */
+            uri: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** Mimetype */
+            mimeType: string;
+        };
         /** ResumeExecutionRefModel */
         ResumeExecutionRefModel: {
             /** Workflowid */
@@ -8778,6 +8820,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_resources_mcp_resources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceListResponse"];
                 };
             };
         };

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6386,9 +6386,9 @@ export interface components {
             /** Name */
             name: string;
             /** Description */
-            description: string;
+            description?: string | null;
             /** Mimetype */
-            mimeType: string;
+            mimeType?: string | null;
         };
         /** ResumeExecutionRefModel */
         ResumeExecutionRefModel: {

--- a/moonmind/mcp/__init__.py
+++ b/moonmind/mcp/__init__.py
@@ -11,6 +11,8 @@ from moonmind.mcp.jules_tool_registry import (
 from moonmind.mcp.tool_registry import (
     QueueToolExecutionContext,
     QueueToolRegistry,
+    ResourceListResponse,
+    ResourceMetadata,
     ToolArgumentsValidationError,
     ToolCallRequest,
     ToolCallResponse,
@@ -26,6 +28,8 @@ __all__ = [
     "JulesToolRegistry",
     "QueueToolExecutionContext",
     "QueueToolRegistry",
+    "ResourceListResponse",
+    "ResourceMetadata",
     "ToolArgumentsValidationError",
     "ToolCallRequest",
     "ToolCallResponse",

--- a/moonmind/mcp/tool_registry.py
+++ b/moonmind/mcp/tool_registry.py
@@ -69,8 +69,8 @@ class ResourceMetadata(BaseModel):
 
     uri: str = Field(..., alias="uri")
     name: str = Field(..., alias="name")
-    description: str = Field(..., alias="description")
-    mime_type: str = Field(..., alias="mimeType")
+    description: str | None = Field(None, alias="description")
+    mime_type: str | None = Field(None, alias="mimeType")
 
 
 class ResourceListResponse(BaseModel):

--- a/moonmind/mcp/tool_registry.py
+++ b/moonmind/mcp/tool_registry.py
@@ -61,6 +61,26 @@ class ToolListResponse(BaseModel):
 
     tools: list[ToolMetadata] = Field(default_factory=list, alias="tools")
 
+
+class ResourceMetadata(BaseModel):
+    """Resource definition payload returned by discovery endpoint."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    uri: str = Field(..., alias="uri")
+    name: str = Field(..., alias="name")
+    description: str = Field(..., alias="description")
+    mime_type: str = Field(..., alias="mimeType")
+
+
+class ResourceListResponse(BaseModel):
+    """Resource discovery response envelope."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resources: list[ResourceMetadata] = Field(default_factory=list, alias="resources")
+
+
 @dataclass(frozen=True, slots=True)
 class QueueToolExecutionContext:
     """Dependencies available to tool handlers.
@@ -144,6 +164,8 @@ class QueueToolRegistry:
 
 __all__ = [
     "QueueToolRegistry",
+    "ResourceListResponse",
+    "ResourceMetadata",
     "ToolArgumentsValidationError",
     "ToolCallRequest",
     "ToolCallResponse",

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -87,6 +87,31 @@ async def test_list_tools_includes_curated_pentest_execution_tool(
         == "temporal_task_submission"
     )
 
+async def test_list_resources_returns_mcp_resource_catalog(
+    router_app: FastAPI,
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=router_app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/mcp/resources")
+
+    assert response.status_code == 200
+    resources = {
+        resource["name"]: resource for resource in response.json()["resources"]
+    }
+    assert resources["context-completion"] == {
+        "uri": "moonmind://context",
+        "name": "context-completion",
+        "description": (
+            "Chat-style context completion endpoint with optional RAG, available "
+            "through POST /context."
+        ),
+        "mimeType": "application/json",
+    }
+    assert resources["tool-catalog"]["uri"] == "moonmind://mcp/tools"
+    assert resources["tool-catalog"]["mimeType"] == "application/json"
+
 async def test_call_curated_execution_tool_requires_task_submission(
     router_app: FastAPI,
 ) -> None:

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -13,7 +13,7 @@ from api_service.api.routers import mcp_tools as mcp_tools_router
 from api_service.auth_providers import get_current_user
 from moonmind.integrations.jira.errors import JiraToolError
 from moonmind.mcp.jira_tool_registry import JiraToolRegistry
-from moonmind.mcp.tool_registry import QueueToolRegistry
+from moonmind.mcp.tool_registry import QueueToolRegistry, ResourceListResponse
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -111,6 +111,22 @@ async def test_list_resources_returns_mcp_resource_catalog(
     }
     assert resources["tool-catalog"]["uri"] == "moonmind://mcp/tools"
     assert resources["tool-catalog"]["mimeType"] == "application/json"
+
+async def test_resource_metadata_allows_optional_mcp_fields() -> None:
+    response = ResourceListResponse(
+        resources=[{"uri": "moonmind://minimal", "name": "minimal"}]
+    )
+
+    assert response.model_dump(by_alias=True) == {
+        "resources": [
+            {
+                "uri": "moonmind://minimal",
+                "name": "minimal",
+                "description": None,
+                "mimeType": None,
+            }
+        ]
+    }
 
 async def test_call_curated_execution_tool_requires_task_submission(
     router_app: FastAPI,


### PR DESCRIPTION
Jira issue key: MM-778

Summary:
- Adds authenticated MCP resource discovery at `GET /mcp/resources`.
- Adds resource discovery response models and exports alongside existing MCP tool models.
- Documents resource discovery, updates the Milestone 8 roadmap entry, and regenerates frontend OpenAPI types.
- Adds router coverage for the resource catalog while preserving existing tool discovery behavior.

Tests run:
- `./tools/test_unit.sh --python-only tests/unit/api/test_mcp_tools_router.py tests/unit/mcp/test_jira_tool_registry.py tests/unit/mcp/test_jules_tool_registry.py` -> 21 passed
- `./tools/test_unit.sh` -> Python 5662 passed, frontend 406 passed

Remaining risks:
- No MCP resource/tool discovery integration test exists under `tests/integration`; coverage is currently router/unit-level.
- `/mcp/resources` is a minimal HTTP JSON discovery catalog and does not implement full MCP streamable HTTP or JSON-RPC transport.
