### PR TITLE
MM-782 File allowlist enforcement

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -223,9 +223,9 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Docker-socket-proxy (`tecnativa/docker-socket-proxy`) with restricted API endpoints
 - Agent workspace volume isolation
 - Auth-volume separation per runtime
+- File allowlist enforcement for sandbox command and patch activities (`MM-782`)
 
 ### Remaining tasks
-- [ ] **9.1** File allowlist enforcement — Promised in README, no implementation found
 - [ ] **9.2** Credential sanitization from logs — Agent rules prohibit secrets in output; no runtime log scrubber
 - [ ] **9.3** Per-runtime capability routing policy — Proxy limits Docker API endpoints, but not per-runtime policies
 - [ ] **9.4** Network egress policies for sandboxes — No outbound network restrictions on worker containers

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -532,6 +532,7 @@ class _SandboxFileSnapshotEntry:
     size: int
     mtime_ns: int
     digest: str
+    backup_path: Path | None = None
 
 @dataclass(frozen=True, slots=True)
 class IntegrationStartResult:
@@ -2152,35 +2153,73 @@ class TemporalSandboxActivities:
             allowed.add(resolved.relative_to(cwd).as_posix())
         return frozenset(allowed)
 
+    def _sandbox_path_is_allowed(
+        self,
+        rel_path: str,
+        allowed_paths: frozenset[str],
+    ) -> bool:
+        return any(
+            rel_path == allowed_path or rel_path.startswith(f"{allowed_path}/")
+            for allowed_path in allowed_paths
+        )
+
     def _sandbox_file_snapshot(
         self,
         cwd: Path,
+        *,
+        backup_root: Path | None = None,
+        allowed_paths: frozenset[str] | None = None,
     ) -> dict[str, _SandboxFileSnapshotEntry]:
         snapshot: dict[str, _SandboxFileSnapshotEntry] = {}
         for path in cwd.rglob("*"):
             try:
                 info = path.lstat()
-            except FileNotFoundError:
+            except OSError:
                 continue
             if stat.S_ISDIR(info.st_mode):
                 continue
             rel_path = path.relative_to(cwd).as_posix()
             if stat.S_ISREG(info.st_mode):
                 try:
-                    digest = hashlib.sha256(path.read_bytes()).hexdigest()
-                except FileNotFoundError:
+                    digest = self._sandbox_file_digest(path)
+                except OSError:
                     continue
             elif stat.S_ISLNK(info.st_mode):
-                digest = hashlib.sha256(os.readlink(path).encode("utf-8")).hexdigest()
+                try:
+                    digest = hashlib.sha256(
+                        os.readlink(path).encode("utf-8")
+                    ).hexdigest()
+                except OSError:
+                    continue
             else:
                 digest = hashlib.sha256(str(info.st_rdev).encode("utf-8")).hexdigest()
+            backup_path: Path | None = None
+            if (
+                backup_root is not None
+                and allowed_paths is not None
+                and not self._sandbox_path_is_allowed(rel_path, allowed_paths)
+            ):
+                backup_path = backup_root / rel_path
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    shutil.copy2(path, backup_path, follow_symlinks=False)
+                except OSError:
+                    backup_path = None
             snapshot[rel_path] = _SandboxFileSnapshotEntry(
-                mode=stat.S_IFMT(info.st_mode),
+                mode=int(info.st_mode),
                 size=int(info.st_size),
                 mtime_ns=int(info.st_mtime_ns),
                 digest=digest,
+                backup_path=backup_path,
             )
         return snapshot
+
+    def _sandbox_file_digest(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(65536), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
     def _changed_sandbox_files(
         self,
@@ -2190,22 +2229,43 @@ class TemporalSandboxActivities:
         changed: set[str] = set()
         for rel_path, before_entry in before.items():
             after_entry = after.get(rel_path)
-            if after_entry is None or after_entry != before_entry:
+            if after_entry is None or (
+                after_entry.mode,
+                after_entry.size,
+                after_entry.mtime_ns,
+                after_entry.digest,
+            ) != (
+                before_entry.mode,
+                before_entry.size,
+                before_entry.mtime_ns,
+                before_entry.digest,
+            ):
                 changed.add(rel_path)
         for rel_path in after:
             if rel_path not in before:
                 changed.add(rel_path)
         return changed
 
-    def _reject_disallowed_file_changes(
+    def _disallowed_sandbox_file_changes(
         self,
         *,
         changed_paths: Iterable[str],
         allowed_paths: frozenset[str] | None,
-    ) -> None:
+    ) -> list[str]:
         if allowed_paths is None:
-            return
-        disallowed = sorted(set(changed_paths) - set(allowed_paths))
+            return []
+        disallowed = sorted(
+            rel_path
+            for rel_path in set(changed_paths)
+            if not self._sandbox_path_is_allowed(rel_path, allowed_paths)
+        )
+        return disallowed
+
+    def _reject_disallowed_file_changes(
+        self,
+        disallowed_paths: Sequence[str],
+    ) -> None:
+        disallowed = list(disallowed_paths)
         if not disallowed:
             return
         preview = ", ".join(disallowed[:10])
@@ -2214,6 +2274,35 @@ class TemporalSandboxActivities:
             "sandbox command modified files outside the allowlist: "
             f"{preview}{extra}"
         )
+
+    def _restore_disallowed_sandbox_changes(
+        self,
+        cwd: Path,
+        *,
+        disallowed_paths: Iterable[str],
+        before: Mapping[str, _SandboxFileSnapshotEntry],
+    ) -> None:
+        for rel_path in sorted(
+            set(disallowed_paths),
+            key=lambda value: value.count("/"),
+            reverse=True,
+        ):
+            target = cwd / rel_path
+            before_entry = before.get(rel_path)
+            try:
+                if target.is_dir() and not target.is_symlink():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink(missing_ok=True)
+            except OSError:
+                continue
+            if before_entry is None or before_entry.backup_path is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(before_entry.backup_path, target, follow_symlinks=False)
+            except OSError:
+                continue
 
     def _resolve_checkout_source(self, repo_ref: str | Path) -> tuple[str, str | Path]:
         normalized = str(repo_ref).strip()
@@ -2410,11 +2499,25 @@ class TemporalSandboxActivities:
             cwd,
             allowed_file_paths,
         )
-        before_files = (
-            self._sandbox_file_snapshot(cwd)
-            if normalized_allowed_file_paths is not None
-            else None
-        )
+        backup_dir: tempfile.TemporaryDirectory[str] | None = None
+        backup_root: Path | None = None
+        if normalized_allowed_file_paths is not None:
+            backup_dir = tempfile.TemporaryDirectory(prefix="sandbox-allowlist-")
+            backup_root = Path(backup_dir.name)
+        try:
+            before_files = (
+                self._sandbox_file_snapshot(
+                    cwd,
+                    backup_root=backup_root,
+                    allowed_paths=normalized_allowed_file_paths,
+                )
+                if normalized_allowed_file_paths is not None
+                else None
+            )
+        except Exception:
+            if backup_dir is not None:
+                backup_dir.cleanup()
+            raise
 
         merged_env = os.environ.copy()
         if env:
@@ -2507,10 +2610,21 @@ class TemporalSandboxActivities:
         if before_files is not None:
             after_files = self._sandbox_file_snapshot(cwd)
             changed_paths = self._changed_sandbox_files(before_files, after_files)
-            self._reject_disallowed_file_changes(
+            disallowed_paths = self._disallowed_sandbox_file_changes(
                 changed_paths=changed_paths,
                 allowed_paths=normalized_allowed_file_paths,
             )
+            if disallowed_paths:
+                self._restore_disallowed_sandbox_changes(
+                    cwd,
+                    disallowed_paths=disallowed_paths,
+                    before=before_files,
+                )
+            if backup_dir is not None:
+                backup_dir.cleanup()
+            self._reject_disallowed_file_changes(disallowed_paths)
+        elif backup_dir is not None:
+            backup_dir.cleanup()
 
         return SandboxCommandResult(
             exit_code=int(process.returncode or 0),

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import shutil
 import smtplib
+import stat
 import tempfile
 import time
 from dataclasses import dataclass
@@ -522,6 +523,15 @@ class SandboxCommandResult:
     stdout_tail: str
     stderr_tail: str
     diagnostics_ref: ArtifactRef | None
+
+@dataclass(frozen=True, slots=True)
+class _SandboxFileSnapshotEntry:
+    """Compact file state used to detect sandbox write-policy violations."""
+
+    mode: int
+    size: int
+    mtime_ns: int
+    digest: str
 
 @dataclass(frozen=True, slots=True)
 class IntegrationStartResult:
@@ -2103,6 +2113,108 @@ class TemporalSandboxActivities:
             raise TemporalActivityRuntimeError(f"workspace does not exist: {workspace}")
         return workspace
 
+    def _normalize_allowed_file_paths(
+        self,
+        cwd: Path,
+        allowed_file_paths: Sequence[str | Path] | None,
+    ) -> frozenset[str] | None:
+        if allowed_file_paths is None:
+            return None
+        if isinstance(allowed_file_paths, (str, bytes, bytearray)) or not isinstance(
+            allowed_file_paths,
+            Sequence,
+        ):
+            raise TemporalActivityRuntimeError(
+                "sandbox file allowlist must be a list of relative file paths"
+            )
+
+        allowed: set[str] = set()
+        for raw_path in allowed_file_paths:
+            if not isinstance(raw_path, (str, Path)):
+                raise TemporalActivityRuntimeError(
+                    "sandbox file allowlist entries must be relative file paths"
+                )
+            raw_text = str(raw_path).strip()
+            if not raw_text:
+                raise TemporalActivityRuntimeError(
+                    "sandbox file allowlist entries must not be empty"
+                )
+            candidate = Path(raw_text)
+            if candidate.is_absolute():
+                raise TemporalActivityRuntimeError(
+                    "sandbox file allowlist entries must be relative file paths"
+                )
+            resolved = (cwd / candidate).resolve()
+            if not resolved.is_relative_to(cwd):
+                raise TemporalActivityRuntimeError(
+                    "sandbox file allowlist entries must stay within the workspace"
+                )
+            allowed.add(resolved.relative_to(cwd).as_posix())
+        return frozenset(allowed)
+
+    def _sandbox_file_snapshot(
+        self,
+        cwd: Path,
+    ) -> dict[str, _SandboxFileSnapshotEntry]:
+        snapshot: dict[str, _SandboxFileSnapshotEntry] = {}
+        for path in cwd.rglob("*"):
+            try:
+                info = path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISDIR(info.st_mode):
+                continue
+            rel_path = path.relative_to(cwd).as_posix()
+            if stat.S_ISREG(info.st_mode):
+                try:
+                    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                except FileNotFoundError:
+                    continue
+            elif stat.S_ISLNK(info.st_mode):
+                digest = hashlib.sha256(os.readlink(path).encode("utf-8")).hexdigest()
+            else:
+                digest = hashlib.sha256(str(info.st_rdev).encode("utf-8")).hexdigest()
+            snapshot[rel_path] = _SandboxFileSnapshotEntry(
+                mode=stat.S_IFMT(info.st_mode),
+                size=int(info.st_size),
+                mtime_ns=int(info.st_mtime_ns),
+                digest=digest,
+            )
+        return snapshot
+
+    def _changed_sandbox_files(
+        self,
+        before: Mapping[str, _SandboxFileSnapshotEntry],
+        after: Mapping[str, _SandboxFileSnapshotEntry],
+    ) -> set[str]:
+        changed: set[str] = set()
+        for rel_path, before_entry in before.items():
+            after_entry = after.get(rel_path)
+            if after_entry is None or after_entry != before_entry:
+                changed.add(rel_path)
+        for rel_path in after:
+            if rel_path not in before:
+                changed.add(rel_path)
+        return changed
+
+    def _reject_disallowed_file_changes(
+        self,
+        *,
+        changed_paths: Iterable[str],
+        allowed_paths: frozenset[str] | None,
+    ) -> None:
+        if allowed_paths is None:
+            return
+        disallowed = sorted(set(changed_paths) - set(allowed_paths))
+        if not disallowed:
+            return
+        preview = ", ".join(disallowed[:10])
+        extra = "" if len(disallowed) <= 10 else f", ... ({len(disallowed)} total)"
+        raise TemporalActivityRuntimeError(
+            "sandbox command modified files outside the allowlist: "
+            f"{preview}{extra}"
+        )
+
     def _resolve_checkout_source(self, repo_ref: str | Path) -> tuple[str, str | Path]:
         normalized = str(repo_ref).strip()
         if not normalized:
@@ -2187,6 +2299,7 @@ class TemporalSandboxActivities:
         workspace_ref: str | Path,
         patch_ref: ArtifactRef | str,
         principal: str,
+        allowed_file_paths: Sequence[str | Path] | None = None,
         strip: int = 0,
         timeout_seconds: float | None = None,
         heartbeat: HeartbeatCallback | None = None,
@@ -2228,6 +2341,9 @@ class TemporalSandboxActivities:
                     "workspace_ref": str(cwd),
                     "cmd": list(command),
                     "principal": principal,
+                    "allowed_file_paths": list(allowed_file_paths)
+                    if allowed_file_paths is not None
+                    else None,
                     "timeout_seconds": timeout_seconds,
                 },
                 heartbeat=heartbeat,
@@ -2251,6 +2367,7 @@ class TemporalSandboxActivities:
         principal: str | None = None,
         env: Mapping[str, str | None] | None = None,
         execution_ref: ExecutionRef | dict[str, Any] | None = None,
+        allowed_file_paths: Sequence[str | Path] | None = None,
         timeout_seconds: float | None = None,
         heartbeat: HeartbeatCallback | None = None,
     ) -> SandboxCommandResult:
@@ -2268,6 +2385,8 @@ class TemporalSandboxActivities:
                 env = request_payload.get("env")
             if execution_ref is None:
                 execution_ref = request_payload.get("execution_ref")
+            if allowed_file_paths is None:
+                allowed_file_paths = request_payload.get("allowed_file_paths")
             if timeout_seconds is None:
                 timeout_seconds = request_payload.get("timeout_seconds")
 
@@ -2286,6 +2405,16 @@ class TemporalSandboxActivities:
             command = tuple(str(part) for part in cmd)
         if not command:
             raise TemporalActivityRuntimeError("sandbox command must not be empty")
+
+        normalized_allowed_file_paths = self._normalize_allowed_file_paths(
+            cwd,
+            allowed_file_paths,
+        )
+        before_files = (
+            self._sandbox_file_snapshot(cwd)
+            if normalized_allowed_file_paths is not None
+            else None
+        )
 
         merged_env = os.environ.copy()
         if env:
@@ -2374,6 +2503,14 @@ class TemporalSandboxActivities:
                 content_type="text/plain",
             )
             diagnostics_ref = build_artifact_ref(completed)
+
+        if before_files is not None:
+            after_files = self._sandbox_file_snapshot(cwd)
+            changed_paths = self._changed_sandbox_files(before_files, after_files)
+            self._reject_disallowed_file_changes(
+                changed_paths=changed_paths,
+                allowed_paths=normalized_allowed_file_paths,
+            )
 
         return SandboxCommandResult(
             exit_code=int(process.returncode or 0),

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1374,6 +1375,91 @@ async def test_sandbox_checkout_rejects_local_path_outside_workspace_root(
             repo_ref=source,
             idempotency_key="checkout-outside",
         )
+
+async def test_sandbox_run_command_allows_allowlisted_file_change(tmp_path: Path):
+    activities = TemporalSandboxActivities(workspace_root=tmp_path / "workspaces")
+    workspace = tmp_path / "workspaces" / "temporal_sandbox" / "allowlisted"
+    workspace.mkdir(parents=True)
+    target = workspace / "allowed.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    result = await activities.sandbox_run_command(
+        workspace_ref=workspace,
+        cmd=(
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path('allowed.txt').write_text('after\\n')",
+        ),
+        allowed_file_paths=("allowed.txt",),
+    )
+
+    assert result.exit_code == 0
+    assert target.read_text(encoding="utf-8") == "after\n"
+
+async def test_sandbox_run_command_rejects_file_change_outside_allowlist(
+    tmp_path: Path,
+):
+    activities = TemporalSandboxActivities(workspace_root=tmp_path / "workspaces")
+    workspace = tmp_path / "workspaces" / "temporal_sandbox" / "blocked"
+    workspace.mkdir(parents=True)
+    allowed = workspace / "allowed.txt"
+    blocked = workspace / "blocked.txt"
+    allowed.write_text("allowed\n", encoding="utf-8")
+    blocked.write_text("before\n", encoding="utf-8")
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="modified files outside the allowlist: blocked.txt",
+    ):
+        await activities.sandbox_run_command(
+            workspace_ref=workspace,
+            cmd=(
+                sys.executable,
+                "-c",
+                "from pathlib import Path; Path('blocked.txt').write_text('after\\n')",
+            ),
+            allowed_file_paths=("allowed.txt",),
+        )
+
+async def test_sandbox_apply_patch_enforces_file_allowlist(tmp_path: Path):
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            workspace = tmp_path / "workspaces" / "temporal_sandbox" / "patch-blocked"
+            workspace.mkdir(parents=True)
+            (workspace / "blocked.txt").write_text("before\n", encoding="utf-8")
+
+            patch_artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="text/plain",
+            )
+            await service.write_complete(
+                artifact_id=patch_artifact.artifact_id,
+                principal="user-1",
+                payload=(
+                    "--- blocked.txt\n+++ blocked.txt\n@@ -1 +1 @@\n-before\n+after\n"
+                ).encode("utf-8"),
+                content_type="text/plain",
+            )
+
+            activities = TemporalSandboxActivities(
+                artifact_service=service,
+                workspace_root=tmp_path / "workspaces",
+            )
+
+            with pytest.raises(
+                TemporalActivityRuntimeError,
+                match="modified files outside the allowlist: blocked.txt",
+            ):
+                await activities.sandbox_apply_patch(
+                    workspace_ref=workspace,
+                    patch_ref=patch_artifact.artifact_id,
+                    principal="user-1",
+                    allowed_file_paths=("allowed.txt",),
+                )
 
 async def test_sandbox_checkout_repo_clones_github_slug_and_revision(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import stat
 import sys
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -1396,6 +1397,29 @@ async def test_sandbox_run_command_allows_allowlisted_file_change(tmp_path: Path
     assert result.exit_code == 0
     assert target.read_text(encoding="utf-8") == "after\n"
 
+async def test_sandbox_run_command_allows_directory_allowlisted_file_change(
+    tmp_path: Path,
+):
+    activities = TemporalSandboxActivities(workspace_root=tmp_path / "workspaces")
+    workspace = tmp_path / "workspaces" / "temporal_sandbox" / "allowlisted-dir"
+    workspace.mkdir(parents=True)
+    target = workspace / "allowed" / "nested.txt"
+    target.parent.mkdir()
+    target.write_text("before\n", encoding="utf-8")
+
+    result = await activities.sandbox_run_command(
+        workspace_ref=workspace,
+        cmd=(
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path('allowed/nested.txt').write_text('after\\n')",
+        ),
+        allowed_file_paths=("allowed",),
+    )
+
+    assert result.exit_code == 0
+    assert target.read_text(encoding="utf-8") == "after\n"
+
 async def test_sandbox_run_command_rejects_file_change_outside_allowlist(
     tmp_path: Path,
 ):
@@ -1420,6 +1444,36 @@ async def test_sandbox_run_command_rejects_file_change_outside_allowlist(
             ),
             allowed_file_paths=("allowed.txt",),
         )
+
+    assert blocked.read_text(encoding="utf-8") == "before\n"
+
+async def test_sandbox_run_command_rejects_permission_change_outside_allowlist(
+    tmp_path: Path,
+):
+    activities = TemporalSandboxActivities(workspace_root=tmp_path / "workspaces")
+    workspace = tmp_path / "workspaces" / "temporal_sandbox" / "blocked-mode"
+    workspace.mkdir(parents=True)
+    allowed = workspace / "allowed.txt"
+    blocked = workspace / "blocked.sh"
+    allowed.write_text("allowed\n", encoding="utf-8")
+    blocked.write_text("#!/bin/sh\n", encoding="utf-8")
+    blocked.chmod(0o644)
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="modified files outside the allowlist: blocked.sh",
+    ):
+        await activities.sandbox_run_command(
+            workspace_ref=workspace,
+            cmd=(
+                sys.executable,
+                "-c",
+                "from pathlib import Path; Path('blocked.sh').chmod(0o755)",
+            ),
+            allowed_file_paths=("allowed.txt",),
+        )
+
+    assert stat.S_IMODE(blocked.stat().st_mode) == 0o644
 
 async def test_sandbox_apply_patch_enforces_file_allowlist(tmp_path: Path):
     async with temporal_db(tmp_path) as session_maker:
@@ -1460,6 +1514,8 @@ async def test_sandbox_apply_patch_enforces_file_allowlist(tmp_path: Path):
                     principal="user-1",
                     allowed_file_paths=("allowed.txt",),
                 )
+
+            assert (workspace / "blocked.txt").read_text(encoding="utf-8") == "before\n"
 
 async def test_sandbox_checkout_repo_clones_github_slug_and_revision(
     tmp_path: Path,


### PR DESCRIPTION
## Jira
MM-782

## Summary
- Adds sandbox file allowlist enforcement for `sandbox.run_command` by snapshotting workspace file state and rejecting changed paths outside `allowed_file_paths`.
- Propagates the same allowlist through `sandbox.apply_patch`.
- Updates the roadmap source item to record MM-782 as shipped.

## Tests run
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_activity_runtime.py -k 'sandbox_run_command_allows_allowlisted_file_change or sandbox_run_command_rejects_file_change_outside_allowlist or sandbox_apply_patch_enforces_file_allowlist or sandbox_checkout_apply_patch_and_run_tests'` -> 4 passed
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_activity_runtime.py` -> 60 passed
- `./tools/test_unit.sh` -> Python 5697 passed, 6 skipped, 1 xpassed; frontend 409 passed, 233 skipped
- `./tools/test_unit.sh --python-only tests/integration/temporal/test_activity_worker_topology.py` -> 1 passed

## Remaining risks
- Enforcement is activity-boundary detection after command execution; callers must pass `allowed_file_paths` for the policy to apply.
