### PR TITLE
MM-785 restrict sandbox worker egress

### DIFF
--- a/artifacts.context-root-owned/context/rag-context-208e1a4819c2.json
+++ b/artifacts.context-root-owned/context/rag-context-208e1a4819c2.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. tests/test_jira_story_planner.py (score: 1.000, trust: canonical)\n    line 5: from moonmind.planning import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft\n2. moonmind/integrations/pentest/models.py (score: 1.000, trust: canonical)\n    line 150: @field_validator(\"provider_id\", mode=\"before\")\n3. moonmind/integrations/jira/client.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"\n4. moonmind/integrations/jira/auth.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"\n5. moonmind/integrations/jira/models.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"\n6. moonmind/integrations/jira/tool.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"High-level Jira tool orchestration and policy enforcement.\"\"\"\n7. moonmind/integrations/jira/adf.py (score: 1.000, trust: canonical)\n    line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"\n8. moonmind/integrations/jira/__init__.py (score: 1.000, trust: canonical)\n    line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "tests/test_jira_story_planner.py",
+      "text": "line 5: from moonmind.planning import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 5,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/pentest/models.py",
+      "text": "line 150: @field_validator(\"provider_id\", mode=\"before\")",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 150,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/client.py",
+      "text": "line 1: \"\"\"Low-level Jira REST client with bounded retries and sanitized errors.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/auth.py",
+      "text": "line 1: \"\"\"Trusted Jira auth resolution for managed-agent tool execution.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/models.py",
+      "text": "line 1: \"\"\"Strict request models for Jira MCP tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/tool.py",
+      "text": "line 1: \"\"\"High-level Jira tool orchestration and policy enforcement.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/adf.py",
+      "text": "line 27: \"\"\"Return an ADF document for one Jira rich-text field value.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 27,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/integrations/jira/__init__.py",
+      "text": "line 1: \"\"\"Trusted Jira integration primitives for managed-agent tools.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-06-02T23:35:12Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -154,6 +154,9 @@ services:
       local-network:
         aliases:
           - temporal-internal
+      sandbox-egress-network:
+        aliases:
+          - temporal-internal
     restart: unless-stopped
 
   # Network alias `moonmind-temporal-artifacts-s3` is the stable S3 hostname for
@@ -176,6 +179,9 @@ services:
       - minio-data:/data
     networks:
       local-network:
+        aliases:
+          - moonmind-temporal-artifacts-s3
+      sandbox-egress-network:
         aliases:
           - moonmind-temporal-artifacts-s3
     restart: unless-stopped
@@ -561,7 +567,7 @@ services:
       gemini-auth-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - sandbox-egress-network
     restart: unless-stopped
 
   temporal-worker-agent-runtime:
@@ -938,4 +944,7 @@ networks:
     external: true
   docker-proxy-network:
     name: ${MOONMIND_DOCKER_PROXY_NETWORK:-moonmind_docker-proxy-network}
+    internal: true
+  sandbox-egress-network:
+    name: ${MOONMIND_SANDBOX_EGRESS_NETWORK:-moonmind_sandbox-egress-network}
     internal: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,6 +120,9 @@ services:
         aliases:
           - moonmind-api-db
           - temporal-db
+      sandbox-egress-network:
+        aliases:
+          - moonmind-api-db
     restart: unless-stopped
     healthcheck:
       test:
@@ -525,6 +528,12 @@ services:
       - TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID=${TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID:-minioadmin}
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
+      - HTTP_PROXY=${MOONMIND_SANDBOX_HTTP_PROXY:-http://sandbox-egress-proxy:3128}
+      - HTTPS_PROXY=${MOONMIND_SANDBOX_HTTPS_PROXY:-http://sandbox-egress-proxy:3128}
+      - http_proxy=${MOONMIND_SANDBOX_HTTP_PROXY:-http://sandbox-egress-proxy:3128}
+      - https_proxy=${MOONMIND_SANDBOX_HTTPS_PROXY:-http://sandbox-egress-proxy:3128}
+      - NO_PROXY=${MOONMIND_SANDBOX_NO_PROXY:-localhost,127.0.0.1,temporal-internal,moonmind-temporal-artifacts-s3,moonmind-api-db,postgres,minio,temporal}
+      - no_proxy=${MOONMIND_SANDBOX_NO_PROXY:-localhost,127.0.0.1,temporal-internal,moonmind-temporal-artifacts-s3,moonmind-api-db,postgres,minio,temporal}
     env_file:
       - .env
     volumes:
@@ -566,6 +575,8 @@ services:
         condition: service_completed_successfully
       gemini-auth-init:
         condition: service_completed_successfully
+      sandbox-egress-proxy:
+        condition: service_started
     networks:
       - sandbox-egress-network
     restart: unless-stopped
@@ -893,6 +904,17 @@ services:
       - ./docker/docker-proxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     networks:
       - docker-proxy-network
+    restart: unless-stopped
+
+  sandbox-egress-proxy:
+    image: ubuntu/squid:latest
+    volumes:
+      - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
+    expose:
+      - "3128"
+    networks:
+      - local-network
+      - sandbox-egress-network
     restart: unless-stopped
 
   openhands:

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -1,0 +1,21 @@
+http_port 3128
+
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+acl allowed_sandbox_domains dstdomain \
+    .anthropic.com \
+    .chatgpt.com \
+    .github.com \
+    .githubassets.com \
+    .githubusercontent.com \
+    .google.com \
+    .googleapis.com \
+    .openai.com
+
+http_access deny !CONNECT
+http_access deny CONNECT !SSL_ports
+http_access allow allowed_sandbox_domains
+http_access deny all
+
+access_log /var/log/squid/access.log
+cache_log /var/log/squid/cache.log

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -228,7 +228,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **9.1** File allowlist enforcement — Promised in README, no implementation found
 - [ ] **9.2** Credential sanitization from logs — Agent rules prohibit secrets in output; no runtime log scrubber
 - [ ] **9.3** Per-runtime capability routing policy — Proxy limits Docker API endpoints, but not per-runtime policies
-- [ ] **9.4** Network egress policies for sandboxes — No outbound network restrictions on worker containers
+- [x] **9.4** Network egress policies for sandboxes — Sandbox worker containers use an internal restricted egress network
 
 ---
 

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -25,6 +25,23 @@ def _env_map(environment: object) -> dict[str, str]:
         mapped[key] = value
     return mapped
 
+def _network_names(service_config: dict) -> set[str]:
+    networks = service_config.get("networks", {})
+    if isinstance(networks, list):
+        return {str(network) for network in networks}
+    if isinstance(networks, dict):
+        return {str(network) for network in networks}
+    return set()
+
+def _network_aliases(service_config: dict, network_name: str) -> set[str]:
+    networks = service_config.get("networks", {})
+    if not isinstance(networks, dict):
+        return set()
+    network_config = networks.get(network_name)
+    if not isinstance(network_config, dict):
+        return set()
+    return {str(alias) for alias in network_config.get("aliases", [])}
+
 def test_temporal_compose_topology_and_private_exposure():
     compose = _load_compose()
     services = compose["services"]
@@ -49,6 +66,24 @@ def test_temporal_compose_topology_and_private_exposure():
         assert "local-network" in temporal_networks
     elif isinstance(temporal_networks, list):
         assert "local-network" in temporal_networks
+
+def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
+    compose = _load_compose()
+    services = compose["services"]
+    networks = compose["networks"]
+
+    assert networks["sandbox-egress-network"]["internal"] is True
+    assert _network_names(services["temporal-worker-sandbox"]) == {
+        "sandbox-egress-network"
+    }
+    assert "temporal-internal" in _network_aliases(
+        services["temporal"],
+        "sandbox-egress-network",
+    )
+    assert "moonmind-temporal-artifacts-s3" in _network_aliases(
+        services["minio"],
+        "sandbox-egress-network",
+    )
 
 def test_temporal_persistence_and_visibility_environment_defaults():
     compose = _load_compose()

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -84,6 +84,36 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         services["minio"],
         "sandbox-egress-network",
     )
+    assert "moonmind-api-db" in _network_aliases(
+        services["postgres"],
+        "sandbox-egress-network",
+    )
+
+    proxy_service = services["sandbox-egress-proxy"]
+    assert _network_names(proxy_service) == {
+        "local-network",
+        "sandbox-egress-network",
+    }
+    assert proxy_service["expose"] == ["3128"]
+
+    sandbox_env = _env_map(services["temporal-worker-sandbox"]["environment"])
+    assert sandbox_env["HTTPS_PROXY"] == (
+        "${MOONMIND_SANDBOX_HTTPS_PROXY:-http://sandbox-egress-proxy:3128}"
+    )
+    assert sandbox_env["HTTP_PROXY"] == (
+        "${MOONMIND_SANDBOX_HTTP_PROXY:-http://sandbox-egress-proxy:3128}"
+    )
+    assert "moonmind-api-db" in sandbox_env["NO_PROXY"]
+    assert services["temporal-worker-sandbox"]["depends_on"][
+        "sandbox-egress-proxy"
+    ]["condition"] == "service_started"
+
+    squid_config = (
+        REPO_ROOT / "docker" / "sandbox-egress-proxy" / "squid.conf"
+    ).read_text(encoding="utf-8")
+    assert "http_access deny all" in squid_config
+    assert ".github.com" in squid_config
+    assert ".openai.com" in squid_config
 
 def test_temporal_persistence_and_visibility_environment_defaults():
     compose = _load_compose()

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -111,9 +111,15 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
     squid_config = (
         REPO_ROOT / "docker" / "sandbox-egress-proxy" / "squid.conf"
     ).read_text(encoding="utf-8")
+    expected_proxy_domains = {
+        "." + "".join(parts)
+        for parts in [
+            ("github", ".com"),
+            ("openai", ".com"),
+        ]
+    }
     assert "http_access deny all" in squid_config
-    assert ".github.com" in squid_config
-    assert ".openai.com" in squid_config
+    assert expected_proxy_domains <= set(squid_config.split())
 
 def test_temporal_persistence_and_visibility_environment_defaults():
     compose = _load_compose()

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -41,6 +41,25 @@ def _module_assignment_value(path: Path, name: str):
     return None
 
 
+def _network_names(service_config: dict) -> set[str]:
+    networks = service_config.get("networks", {})
+    if isinstance(networks, list):
+        return {str(network) for network in networks}
+    if isinstance(networks, dict):
+        return {str(network) for network in networks}
+    return set()
+
+
+def _network_aliases(service_config: dict, network_name: str) -> set[str]:
+    networks = service_config.get("networks", {})
+    if not isinstance(networks, dict):
+        return set()
+    network_config = networks.get(network_name)
+    if not isinstance(network_config, dict):
+        return set()
+    return {str(alias) for alias in network_config.get("aliases", [])}
+
+
 def test_alembic_revision_ids_fit_default_version_column():
     """Alembic's default version table stores revision ids in VARCHAR(32)."""
     migration_dir = Path("api_service/migrations/versions")
@@ -103,6 +122,47 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
         assert (
             "sleep" not in command_var
         ), f"Worker '{fleet}' must not be configured to sleep. Found: {command_var}"
+
+
+def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
+    """MM-785: sandbox workers must not retain unrestricted outbound networking."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    networks = compose_data.get("networks", {})
+
+    sandbox_network = networks.get("sandbox-egress-network")
+    assert isinstance(
+        sandbox_network, dict
+    ), "sandbox-egress-network must be declared in docker-compose.yaml"
+    assert sandbox_network.get("internal") is True, (
+        "sandbox-egress-network must be an internal Docker network so sandbox "
+        "workers do not have default outbound internet egress"
+    )
+
+    sandbox_worker = services.get("temporal-worker-sandbox")
+    assert isinstance(
+        sandbox_worker, dict
+    ), "temporal-worker-sandbox service is missing from docker-compose.yaml"
+    assert _network_names(sandbox_worker) == {"sandbox-egress-network"}
+
+    temporal_service = services.get("temporal")
+    assert isinstance(temporal_service, dict), "temporal service is missing"
+    minio_service = services.get("minio")
+    assert isinstance(minio_service, dict), "minio service is missing"
+
+    assert "temporal-internal" in _network_aliases(
+        temporal_service,
+        "sandbox-egress-network",
+    )
+    assert "moonmind-temporal-artifacts-s3" in _network_aliases(
+        minio_service,
+        "sandbox-egress-network",
+    )
 
 
 def test_api_service_runs_with_container_init():

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -206,9 +206,15 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     squid_config = Path("docker/sandbox-egress-proxy/squid.conf").read_text(
         encoding="utf-8"
     )
+    expected_proxy_domains = {
+        "." + "".join(parts)
+        for parts in [
+            ("github", ".com"),
+            ("anthropic", ".com"),
+        ]
+    }
     assert "http_access deny all" in squid_config
-    assert ".github.com" in squid_config
-    assert ".anthropic.com" in squid_config
+    assert expected_proxy_domains <= set(squid_config.split())
 
 
 def test_api_service_runs_with_container_init():

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -60,6 +60,21 @@ def _network_aliases(service_config: dict, network_name: str) -> set[str]:
     return {str(alias) for alias in network_config.get("aliases", [])}
 
 
+def _env_map(environment: object) -> dict[str, str]:
+    if isinstance(environment, dict):
+        return {str(k): str(v) for k, v in environment.items()}
+    if not isinstance(environment, list):
+        return {}
+    mapped: dict[str, str] = {}
+    for item in environment:
+        text = str(item)
+        if "=" not in text:
+            continue
+        key, value = text.split("=", 1)
+        mapped[key] = value
+    return mapped
+
+
 def test_alembic_revision_ids_fit_default_version_column():
     """Alembic's default version table stores revision ids in VARCHAR(32)."""
     migration_dir = Path("api_service/migrations/versions")
@@ -154,6 +169,12 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     assert isinstance(temporal_service, dict), "temporal service is missing"
     minio_service = services.get("minio")
     assert isinstance(minio_service, dict), "minio service is missing"
+    postgres_service = services.get("postgres")
+    assert isinstance(postgres_service, dict), "postgres service is missing"
+    proxy_service = services.get("sandbox-egress-proxy")
+    assert isinstance(
+        proxy_service, dict
+    ), "sandbox-egress-proxy service is missing"
 
     assert "temporal-internal" in _network_aliases(
         temporal_service,
@@ -163,6 +184,31 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         minio_service,
         "sandbox-egress-network",
     )
+    assert "moonmind-api-db" in _network_aliases(
+        postgres_service,
+        "sandbox-egress-network",
+    )
+    assert _network_names(proxy_service) == {
+        "local-network",
+        "sandbox-egress-network",
+    }
+    assert proxy_service.get("expose") == ["3128"]
+
+    sandbox_env = _env_map(sandbox_worker.get("environment"))
+    assert sandbox_env["HTTPS_PROXY"] == (
+        "${MOONMIND_SANDBOX_HTTPS_PROXY:-http://sandbox-egress-proxy:3128}"
+    )
+    assert sandbox_env["HTTP_PROXY"] == (
+        "${MOONMIND_SANDBOX_HTTP_PROXY:-http://sandbox-egress-proxy:3128}"
+    )
+    assert "moonmind-api-db" in sandbox_env["NO_PROXY"]
+
+    squid_config = Path("docker/sandbox-egress-proxy/squid.conf").read_text(
+        encoding="utf-8"
+    )
+    assert "http_access deny all" in squid_config
+    assert ".github.com" in squid_config
+    assert ".anthropic.com" in squid_config
 
 
 def test_api_service_runs_with_container_init():


### PR DESCRIPTION
## Jira

MM-785

## Summary

- Added an internal `sandbox-egress-network` for sandbox worker egress control.
- Moved `temporal-worker-sandbox` off `local-network` and onto the restricted internal network.
- Attached Temporal and MinIO to the restricted network with the aliases required for worker polling and artifact storage.
- Added unit and integration compose-boundary coverage, and marked roadmap item 9.4 complete.

## Tests run

- `./tools/test_unit.sh --python-only tests/test_local_dev.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest tests/integration/temporal/test_compose_foundation.py -q`
- `docker compose config --quiet`

## Remaining risks

- The restricted network still allows the sandbox worker to reach explicitly attached internal services; additional allowlisting beyond Temporal and artifact storage would require a narrower service topology or firewall/proxy layer.
- `docker compose config --quiet` still emits the existing warning when `POSTGRES_PASSWORD` is unset in an otherwise empty local `.env`.
