### PR TITLE
MM-784 enforce per-runtime Docker policy

### DIFF
--- a/docs/ManagedAgents/DockerSidecarRuntime.md
+++ b/docs/ManagedAgents/DockerSidecarRuntime.md
@@ -246,6 +246,14 @@ from unrelated ambient task text. The `docker-sidecar-rootless` mode remains a
 profile contract target, but Docker launcher materialization fails closed until
 that runtime shape is implemented.
 
+MM-784's per-runtime policy rule is fail-closed: an explicit `no-docker`,
+`disabled`, `none`, or `off` managed-session Docker mode cannot be overridden by
+deployment-wide unrestricted Docker workflow mode. A runtime that is not allowed
+Docker capability must not receive `DOCKER_HOST` for the Docker proxy. When a
+launch inherits unrestricted workflow mode without an explicit no-Docker runtime
+policy, the launcher materializes the per-session sidecar path instead of
+passing host/proxy Docker authority into the agent container.
+
 The Docker sidecar image defaults to the pinned generic image `docker:27-dind`.
 Operators may override it with `MOONMIND_MANAGED_SESSION_DOCKER_SIDECAR_IMAGE`,
 but the value must remain pinned to a non-`latest` tag or digest.

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -223,11 +223,16 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Docker-socket-proxy (`tecnativa/docker-socket-proxy`) with restricted API endpoints
 - Agent workspace volume isolation
 - Auth-volume separation per runtime
+- Per-runtime managed-session Docker capability policy (MM-784): explicit
+  `no-docker`/disabled runtime policy cannot inherit unrestricted Docker proxy
+  access, and unrestricted workflow mode uses the per-session sidecar path
+  instead of passing proxy authority into the agent
 
 ### Remaining tasks
 - [ ] **9.1** File allowlist enforcement — Promised in README, no implementation found
 - [ ] **9.2** Credential sanitization from logs — Agent rules prohibit secrets in output; no runtime log scrubber
-- [ ] **9.3** Per-runtime capability routing policy — Proxy limits Docker API endpoints, but not per-runtime policies
+- [x] **9.3** Per-runtime capability routing policy — MM-784 enforces
+  managed-session Docker mode before Docker proxy exposure
 - [ ] **9.4** Network egress policies for sandboxes — No outbound network restrictions on worker containers
 
 ---

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -240,13 +240,22 @@ class DockerCodexManagedSessionController:
             or ""
         ).strip().lower()
 
+    @staticmethod
+    def _workflow_docker_mode_source(
+        session_environment: Mapping[str, str],
+    ) -> str | None:
+        raw_mode = session_environment.get("MOONMIND_WORKFLOW_DOCKER_MODE")
+        if raw_mode is None:
+            raw_mode = os.environ.get("MOONMIND_WORKFLOW_DOCKER_MODE")
+        if raw_mode is None:
+            return None
+        return str(raw_mode).strip()
+
     def _apply_unrestricted_docker_session_environment(
         self,
         session_environment: dict[str, str],
     ) -> bool:
-        raw_mode = session_environment.get("MOONMIND_WORKFLOW_DOCKER_MODE")
-        if raw_mode is None:
-            raw_mode = os.environ.get("MOONMIND_WORKFLOW_DOCKER_MODE")
+        raw_mode = self._workflow_docker_mode_source(session_environment)
         workflow_docker_mode = normalize_workflow_docker_mode(raw_mode)
         if workflow_docker_mode != "unrestricted":
             return False
@@ -343,7 +352,7 @@ class DockerCodexManagedSessionController:
                 "Unsupported MOONMIND_MANAGED_SESSION_DOCKER_MODE "
                 f"{raw_mode!r}; expected one of {', '.join(allowed)}"
             )
-        workflow_source = session_environment.get("MOONMIND_WORKFLOW_DOCKER_MODE")
+        workflow_source = self._workflow_docker_mode_source(session_environment)
         if workflow_source is None:
             return False
         workflow_mode = normalize_workflow_docker_mode(workflow_source)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -230,6 +230,16 @@ class DockerCodexManagedSessionController:
             env["DOCKER_HOST"] = self._docker_host
         return env
 
+    @staticmethod
+    def _managed_session_docker_mode(
+        session_environment: Mapping[str, str],
+    ) -> str:
+        return (
+            session_environment.get("MOONMIND_MANAGED_SESSION_DOCKER_MODE")
+            or os.environ.get("MOONMIND_MANAGED_SESSION_DOCKER_MODE")
+            or ""
+        ).strip().lower()
+
     def _apply_unrestricted_docker_session_environment(
         self,
         session_environment: dict[str, str],
@@ -240,6 +250,20 @@ class DockerCodexManagedSessionController:
         workflow_docker_mode = normalize_workflow_docker_mode(raw_mode)
         if workflow_docker_mode != "unrestricted":
             return False
+
+        managed_session_docker_mode = self._managed_session_docker_mode(
+            session_environment
+        )
+        if (
+            raw_mode is not None
+            and managed_session_docker_mode in _SESSION_DOCKER_MODE_DISABLED_VALUES
+        ):
+            raise RuntimeError(
+                "MM-784 per-runtime Docker policy denied: "
+                "MOONMIND_MANAGED_SESSION_DOCKER_MODE="
+                f"{managed_session_docker_mode} cannot receive unrestricted "
+                "Docker proxy access"
+            )
 
         session_environment["MOONMIND_WORKFLOW_DOCKER_MODE"] = "unrestricted"
         if self._docker_host:
@@ -299,11 +323,7 @@ class DockerCodexManagedSessionController:
         self,
         session_environment: Mapping[str, str],
     ) -> bool:
-        raw_mode = (
-            session_environment.get("MOONMIND_MANAGED_SESSION_DOCKER_MODE")
-            or os.environ.get("MOONMIND_MANAGED_SESSION_DOCKER_MODE")
-            or ""
-        ).strip().lower()
+        raw_mode = self._managed_session_docker_mode(session_environment)
         if raw_mode in _SESSION_DOCKER_MODE_DISABLED_VALUES:
             return False
         if raw_mode == "docker-sidecar-rootless":

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -762,7 +762,7 @@ async def test_controller_uses_request_moonmind_url_for_docker_network(
     assert "local-network" in run_command
 
 @pytest.mark.asyncio
-async def test_controller_launch_unrestricted_session_exposes_docker_proxy(
+async def test_mm784_no_docker_session_rejects_unrestricted_docker_proxy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -826,30 +826,19 @@ async def test_controller_launch_unrestricted_session_exposes_docker_proxy(
         ready_poll_interval_seconds=0,
     )
 
-    await controller.launch_session(request)
+    with pytest.raises(RuntimeError, match="MM-784 per-runtime Docker policy denied"):
+        await controller.launch_session(request)
 
-    run_command = next(
-        command for command in commands if command[:2] == ("docker", "run")
-    )
-    assert "DOCKER_HOST=tcp://docker-proxy:2375" in run_command
-    assert "SYSTEM_DOCKER_HOST=tcp://docker-proxy:2375" in run_command
-    assert "MOONMIND_WORKFLOW_DOCKER_MODE=unrestricted" in run_command
-    assert (
-        "docker",
-        "network",
-        "connect",
-        "docker-proxy-test",
-        "ctr-1",
-    ) in commands
+    assert not any(command[:2] == ("docker", "run") for command in commands)
 
 @pytest.mark.asyncio
-async def test_controller_launch_removes_container_when_proxy_network_attach_fails(
+async def test_mm784_request_unrestricted_mode_uses_sidecar_policy(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
     monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
-    monkeypatch.setenv("MOONMIND_DOCKER_PROXY_NETWORK", "missing-proxy-network")
+    monkeypatch.setenv("MOONMIND_DOCKER_PROXY_NETWORK", "docker-proxy-test")
     workspace_root = tmp_path / "agent_jobs"
     request = LaunchCodexManagedSessionRequest(
         taskRunId="task-1",
@@ -863,7 +852,6 @@ async def test_controller_launch_removes_container_when_proxy_network_attach_fai
         environment={
             "MOONMIND_URL": "http://api:8000",
             "MOONMIND_WORKFLOW_DOCKER_MODE": "unrestricted",
-            "MOONMIND_MANAGED_SESSION_DOCKER_MODE": "no-docker",
         },
     )
     commands: list[tuple[str, ...]] = []
@@ -877,10 +865,33 @@ async def test_controller_launch_removes_container_when_proxy_network_attach_fai
         commands.append(command)
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
+        if command[:3] == ("docker", "volume", "rm"):
+            return 1, "", "No such volume"
+        if command[:3] == ("docker", "volume", "create"):
+            return 0, command[3] + "\n", ""
         if command[:2] == ("docker", "run"):
-            return 0, "ctr-1\n", ""
-        if command[:3] == ("docker", "network", "connect"):
-            return 1, "", "network not found"
+            name = command[command.index("--name") + 1]
+            if name.endswith("-docker"):
+                return 0, "sidecar-ctr\n", ""
+            if name.endswith("-agent"):
+                return 0, "agent-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "docker" in command:
+            return 0, '"27.0.0"\n', ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "agent-ctr",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://moonmind-session-sess-1-agent",
+            }
+            return 0, json.dumps(payload), ""
         raise AssertionError(f"unexpected command: {command}")
 
     controller = DockerCodexManagedSessionController(
@@ -892,10 +903,19 @@ async def test_controller_launch_removes_container_when_proxy_network_attach_fai
         ready_poll_interval_seconds=0,
     )
 
-    with pytest.raises(RuntimeError, match="network not found"):
-        await controller.launch_session(request)
+    await controller.launch_session(request)
 
-    assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
+    agent_run = next(
+        command
+        for command in commands
+        if command[:2] == ("docker", "run")
+        and "moonmind-session-sess-1-agent" in command
+    )
+    assert "DOCKER_HOST=unix:///var/run/moonmind-docker/docker.sock" in agent_run
+    assert "DOCKER_HOST=tcp://docker-proxy:2375" not in agent_run
+    assert not any(
+        command[:3] == ("docker", "network", "connect") for command in commands
+    )
 
 @pytest.mark.asyncio
 async def test_controller_replaces_blank_request_moonmind_url(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -36,6 +36,15 @@ from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
 )
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 
+
+@pytest.fixture(autouse=True)
+def _clear_managed_session_docker_policy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", raising=False)
+
+
 class _LocalArtifactStorage:
     def __init__(self, root: Path) -> None:
         self._root = root
@@ -853,6 +862,91 @@ async def test_mm784_request_unrestricted_mode_uses_sidecar_policy(
             "MOONMIND_URL": "http://api:8000",
             "MOONMIND_WORKFLOW_DOCKER_MODE": "unrestricted",
         },
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:3] == ("docker", "volume", "rm"):
+            return 1, "", "No such volume"
+        if command[:3] == ("docker", "volume", "create"):
+            return 0, command[3] + "\n", ""
+        if command[:2] == ("docker", "run"):
+            name = command[command.index("--name") + 1]
+            if name.endswith("-docker"):
+                return 0, "sidecar-ctr\n", ""
+            if name.endswith("-agent"):
+                return 0, "agent-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "docker" in command:
+            return 0, '"27.0.0"\n', ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "agent-ctr",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://moonmind-session-sess-1-agent",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        docker_host="tcp://docker-proxy:2375",
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    agent_run = next(
+        command
+        for command in commands
+        if command[:2] == ("docker", "run")
+        and "moonmind-session-sess-1-agent" in command
+    )
+    assert "DOCKER_HOST=unix:///var/run/moonmind-docker/docker.sock" in agent_run
+    assert "DOCKER_HOST=tcp://docker-proxy:2375" not in agent_run
+    assert not any(
+        command[:3] == ("docker", "network", "connect") for command in commands
+    )
+
+@pytest.mark.asyncio
+async def test_mm784_env_unrestricted_mode_uses_sidecar_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    monkeypatch.setenv("MOONMIND_WORKFLOW_DOCKER_MODE", "unrestricted")
+    monkeypatch.setenv("MOONMIND_DOCKER_PROXY_NETWORK", "docker-proxy-test")
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"MOONMIND_URL": "http://api:8000"},
     )
     commands: list[tuple[str, ...]] = []
 


### PR DESCRIPTION
Jira issue: MM-784

## Summary
- Enforce per-runtime managed-session Docker policy before exposing unrestricted Docker proxy access.
- Fail closed when explicit `no-docker`/disabled managed-session mode is combined with unrestricted workflow Docker mode.
- Keep unrestricted workflow mode on the per-session sidecar path when runtime policy allows Docker, and document MM-784 as the completed Milestone 9.3 item.

## Tests run
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `./tools/test_unit.sh --python-only tests/unit/schemas/test_agent_runtime_models.py tests/integration/schemas/test_managed_runtime_profile_contract.py`
- `./tools/test_unit.sh`

## Remaining risks
- The enforcement is scoped to managed-session launch policy. Broader sandbox controls such as file allowlists and network egress remain separate roadmap items.
