### PR TITLE
Title: Improve mobile workflow list layout by removing nested table wrapper styling

### DIFF
--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -286,6 +286,44 @@ describe('Mission Control shared entry', () => {
     expect(settingsPanelBlock).toContain('padding: 0');
   });
 
+  it('drops the workflow list table shell to a card-first layout on mobile viewports', async () => {
+    const isMobileWorkflowRule = (selector: string) => (rule: Rule) =>
+      normalizeCssSelector(rule.selector) === selector &&
+      rule.parent?.type === 'atrule' &&
+      rule.parent.name === 'media' &&
+      rule.parent.params.includes('max-width: 767px');
+
+    const mobileSlabBlock = cssRuleBlockMatching(
+      missionControlCss,
+      isMobileWorkflowRule('.workflow-list-data-slab'),
+    );
+    const mobileHeaderBlock = cssRuleBlockMatching(
+      missionControlCss,
+      isMobileWorkflowRule('.workflow-list-results-header'),
+    );
+    const mobileFooterBlock = cssRuleBlockMatching(
+      missionControlCss,
+      isMobileWorkflowRule('.workflow-list-data-slab .workflow-list-results-footer'),
+    );
+
+    expect(mobileSlabBlock).toContain('border: 0');
+    expect(mobileSlabBlock).toContain('border-radius: 0');
+    expect(mobileSlabBlock).toContain('background: transparent');
+    expect(mobileSlabBlock).toContain('box-shadow: none');
+    expect(mobileSlabBlock).toContain('padding: 0');
+
+    expect(mobileHeaderBlock).toContain('border-bottom: 0');
+    expect(mobileHeaderBlock).toContain('background: transparent');
+
+    expect(mobileFooterBlock).toContain('border-top: 0');
+
+    // Individual cards must keep their standalone card styling.
+    const cardBlock = cssRuleBlock(missionControlCss, '.queue-card');
+    expect(cardBlock).toContain('border: 1px solid rgb(var(--mm-border) / 0.8)');
+    expect(cardBlock).toContain('border-radius: 1rem');
+    expect(cardBlock).toContain('background: rgb(var(--mm-panel) / 0.78)');
+  });
+
   it('stacks Settings section radio controls on mobile viewports', async () => {
     const mobileSettingsNavBlock = cssRuleBlockMatching(missionControlCss, (rule) => {
       return (

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -316,6 +316,8 @@ describe('Mission Control shared entry', () => {
     expect(mobileHeaderBlock).toContain('background: transparent');
 
     expect(mobileFooterBlock).toContain('border-top: 0');
+    expect(mobileFooterBlock).toContain('padding-left: 0');
+    expect(mobileFooterBlock).toContain('padding-right: 0');
 
     // Individual cards must keep their standalone card styling.
     const cardBlock = cssRuleBlock(missionControlCss, '.queue-card');

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1957,6 +1957,24 @@ tr[data-proposal-id].proposal-consuming td {
     display: none;
   }
 
+  .workflow-list-data-slab {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  .workflow-list-results-header {
+    padding: 0 0 0.75rem;
+    border-bottom: 0;
+    background: transparent;
+  }
+
+  .workflow-list-data-slab .workflow-list-results-footer {
+    border-top: 0;
+  }
+
   .queue-card-list {
     display: grid;
   }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1973,6 +1973,8 @@ tr[data-proposal-id].proposal-consuming td {
 
   .workflow-list-data-slab .workflow-list-results-footer {
     border-top: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .queue-card-list {


### PR DESCRIPTION
Title: Improve mobile workflow list layout by removing nested table wrapper styling

Issue Type: Story / UI Improvement

Summary

On mobile, the Mission Control workflow list currently reuses the desktop table wrapper styling around individual workflow cards. This creates an awkward nested-border effect where the mobile cards appear to be cut out of the surrounding dark purple panel. Desktop still looks appropriate because the workflow list is presented as a table, but mobile should use a card-first layout without the table-style outer frame.

The goal is to keep the existing mobile workflow card formatting, but remove or simplify the surrounding wrapper on small screens so the cards feel like independent mobile cards rather than rows embedded inside a table container.

⸻

Background

The current mobile layout shows:

[ Workflows wrapper / table shell ]
  [ Workflow card ]

Because both the wrapper and card use dark backgrounds, borders, and rounded corners, the visual hierarchy feels muddled. The section wrapper looks like a table container, while the cards look like mobile cards, causing the border treatment to appear strange.

On desktop, the table wrapper should remain because the workflow list is rendered as a table and benefits from a contained panel.

On mobile, the preferred layout is:

Workflows
[ Workflow card ]
[ Workflow card ]
[ Workflow card ]

The section heading remains, but the outer table shell should become transparent and borderless.

⸻

Desired Behavior

For mobile breakpoints:

1. The outer workflows table/list wrapper should not have a visible border.
2. The outer wrapper should not have a strong panel background.
3. The outer wrapper should not clip child card borders or corners.
4. The “Workflows” heading should remain visible as a normal section heading.
5. Individual workflow cards should retain their current card styling:
    * rounded corners
    * subtle border
    * dark card background
    * internal padding
    * spacing between cards
6. Desktop table styling should remain unchanged.

⸻

Proposed Implementation

Update the responsive CSS for the workflows list/table container.

Example direction:

/* Desktop/table default */
.workflows-table-shell {
  border: 1px solid var(--border-purple);
  border-radius: 18px;
  background: var(--panel-bg);
  overflow: hidden;
}
/* Mobile/card layout */
@media (max-width: 700px) {
  .workflows-table-shell {
    border: 0;
    border-radius: 0;
    background: transparent;
    overflow: visible;
    padding: 0;
  }
  .workflows-heading {
    margin: 0 0 12px;
    padding: 0;
  }
  .workflow-card {
    border: 1px solid rgba(180, 165, 255, 0.28);
    border-radius: 22px;
    background: var(--card-bg);
    padding: 20px;
    margin-bottom: 14px;
  }
}

The exact class names should be adjusted to match the current Mission Control frontend implementation.

⸻

Acceptance Criteria

* On desktop, the workflows section still renders as a normal table inside a bordered panel.
* On mobile, the workflows section no longer appears as a bordered table wrapper around cards.
* Mobile workflow cards appear as standalone cards under the “Workflows” heading.
* No card appears visually clipped by the outer wrapper.
* The mobile layout keeps appropriate horizontal spacing from the viewport edge.
* Multiple workflow cards stack cleanly with consistent vertical spacing.
* The change does not regress filter controls, workflow status badges, runtime labels, repository labels, or workflow metadata display.
* The layout works at common mobile widths, including approximately 375px, 390px, 414px, and 430px wide.

⸻

Testing Notes

Test the Mission Control workflows page in:

* Mobile Safari or iOS simulator viewport
* Chrome DevTools mobile emulation
* Desktop viewport

Verify that the mobile card layout looks intentional and that the desktop table remains unchanged.