### PR TITLE
MM-788 Cost tracking and billing-aware routing

### DIFF
--- a/api_service/api/routers/chat.py
+++ b/api_service/api/routers/chat.py
@@ -360,8 +360,16 @@ def _normalize_openai_response_payload(
     payload.setdefault("metadata", metadata)
     usage = payload.get("usage")
     if isinstance(usage, dict):
-        input_tokens = usage.get("input_tokens") or usage.get("prompt_tokens")
-        output_tokens = usage.get("output_tokens") or usage.get("completion_tokens")
+        input_tokens = (
+            usage.get("input_tokens")
+            if usage.get("input_tokens") is not None
+            else usage.get("prompt_tokens")
+        )
+        output_tokens = (
+            usage.get("output_tokens")
+            if usage.get("output_tokens") is not None
+            else usage.get("completion_tokens")
+        )
         estimate = estimate_model_cost(
             model=str(payload.get("model") or fallback_model),
             input_tokens=input_tokens,

--- a/api_service/api/routers/chat.py
+++ b/api_service/api/routers/chat.py
@@ -24,6 +24,7 @@ from moonmind.factories.anthropic_factory import AnthropicFactory
 from moonmind.factories.google_factory import get_google_model
 from moonmind.factories.openai_factory import get_openai_model
 from moonmind.models_cache import model_cache
+from moonmind.billing.costs import emit_llm_cost_telemetry, estimate_model_cost
 from moonmind.rag.retriever import QdrantRAG
 from moonmind.schemas.chat_models import (
     ChatCompletionRequest,
@@ -258,6 +259,34 @@ def _usage_from_chat_usage(usage: Usage | None) -> ResponseUsage | None:
         input_tokens=usage.prompt_tokens,
         output_tokens=usage.completion_tokens,
         total_tokens=usage.total_tokens,
+        cost_estimate_usd=usage.cost_estimate_usd,
+        pricing_source=usage.pricing_source,
+    )
+
+def _usage_with_cost(
+    *,
+    provider: str,
+    model: str,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+    total_tokens: int | None = None,
+) -> Usage:
+    estimate = estimate_model_cost(
+        model=model,
+        input_tokens=prompt_tokens,
+        output_tokens=completion_tokens,
+    )
+    emit_llm_cost_telemetry(provider=provider, model=model, estimate=estimate)
+    return Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=(
+            total_tokens
+            if total_tokens is not None
+            else int(prompt_tokens or 0) + int(completion_tokens or 0)
+        ),
+        cost_estimate_usd=estimate.cost_estimate_usd if estimate else None,
+        pricing_source=estimate.pricing_source if estimate else None,
     )
 
 def _responses_payload_from_chat(
@@ -329,6 +358,26 @@ def _normalize_openai_response_payload(
     )
     payload["output_text"] = text
     payload.setdefault("metadata", metadata)
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        input_tokens = usage.get("input_tokens") or usage.get("prompt_tokens")
+        output_tokens = usage.get("output_tokens") or usage.get("completion_tokens")
+        estimate = estimate_model_cost(
+            model=str(payload.get("model") or fallback_model),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+        if estimate:
+            usage.setdefault("cost_estimate_usd", estimate.cost_estimate_usd)
+            usage.setdefault("pricing_source", estimate.pricing_source)
+            billing = dict(payload.get("metadata") or {})
+            billing["billing"] = estimate.to_metadata()
+            payload["metadata"] = billing
+            emit_llm_cost_telemetry(
+                provider="OpenAI",
+                model=str(payload.get("model") or fallback_model),
+                estimate=estimate,
+            )
     return payload
 
 @router.post("/completions", response_model=ChatCompletionResponse)
@@ -630,7 +679,9 @@ async def handle_openai_request(
                 finish_reason=finish_reason,
             )
         ],
-        usage=Usage(  # Ensure these fields exist on usage_data
+        usage=_usage_with_cost(
+            provider="OpenAI",
+            model=getattr(openai_response, "model", model_to_use),
             prompt_tokens=getattr(
                 usage_data, "prompt_tokens", usage_data.get("prompt_tokens", 0)
             ),
@@ -749,7 +800,9 @@ async def handle_google_request(
                 finish_reason="stop",
             )
         ],
-        usage=Usage(
+        usage=_usage_with_cost(
+            provider="Google",
+            model=model_to_use,
             prompt_tokens=prompt_tokens_estimate,
             completion_tokens=completion_tokens_estimate,
             total_tokens=prompt_tokens_estimate + completion_tokens_estimate,
@@ -902,7 +955,9 @@ async def handle_anthropic_request(
                 finish_reason="stop",  # Or map from Anthropic's finish reasons
             )
         ],
-        usage=Usage(
+        usage=_usage_with_cost(
+            provider="Anthropic",
+            model=model_to_use,
             prompt_tokens=prompt_tokens_estimate,
             completion_tokens=completion_tokens_estimate,
             total_tokens=prompt_tokens_estimate + completion_tokens_estimate,

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -249,7 +249,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 
 ### Remaining tasks
 - [x] **10.1** Per-step model/runtime selection in multi-step flows — Authored task steps can independently select runtime/model settings
-- [ ] **10.2** Cost tracking / billing-aware routing — No cost instrumentation
+- [x] **10.2** Cost tracking / billing-aware routing — MM-788 adds token cost estimates, cost telemetry, and profile pricing-aware selection
 - [ ] **10.3** Model comparison mode (same task, different models) — README promises this; no implementation
 - [ ] **10.4** Artifact/memory portability across model switches — Artifacts are model-agnostic; memory doesn't track model provenance
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8264,6 +8264,10 @@ export interface components {
             completion_tokens?: number | null;
             /** Total Tokens */
             total_tokens?: number | null;
+            /** Cost Estimate Usd */
+            cost_estimate_usd?: number | null;
+            /** Pricing Source */
+            pricing_source?: string | null;
         };
         /** UserCreate */
         UserCreate: {

--- a/moonmind/billing/costs.py
+++ b/moonmind/billing/costs.py
@@ -1,0 +1,224 @@
+"""Billing-aware token cost helpers for model and provider routing."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from moonmind.utils.metrics import get_metrics_emitter
+
+logger = logging.getLogger(__name__)
+
+_ENV_PRICING_KEY = "MOONMIND_MODEL_PRICING_JSON"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelTokenPricing:
+    """Per-million-token price metadata for one model or profile."""
+
+    input_per_million_usd: float
+    output_per_million_usd: float
+    source: str = "configured"
+
+    @property
+    def blended_per_million_usd(self) -> float:
+        return self.input_per_million_usd + self.output_per_million_usd
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCostEstimate:
+    """Estimated provider cost for an LLM usage record."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cost_estimate_usd: float
+    input_per_million_usd: float
+    output_per_million_usd: float
+    pricing_source: str
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "inputTokens": self.input_tokens,
+            "outputTokens": self.output_tokens,
+            "totalTokens": self.total_tokens,
+            "costEstimateUsd": self.cost_estimate_usd,
+            "inputPerMillionUsd": self.input_per_million_usd,
+            "outputPerMillionUsd": self.output_per_million_usd,
+            "pricingSource": self.pricing_source,
+        }
+
+
+_DEFAULT_MODEL_PRICING: dict[str, ModelTokenPricing] = {
+    "gpt-4o-mini": ModelTokenPricing(0.15, 0.60, "built_in"),
+    "gpt-4o": ModelTokenPricing(5.00, 15.00, "built_in"),
+    "gpt-3.5-turbo": ModelTokenPricing(0.50, 1.50, "built_in"),
+    "claude-3-5-sonnet": ModelTokenPricing(3.00, 15.00, "built_in"),
+    "claude-sonnet": ModelTokenPricing(3.00, 15.00, "built_in"),
+    "claude-3-5-haiku": ModelTokenPricing(0.80, 4.00, "built_in"),
+    "claude-haiku": ModelTokenPricing(0.80, 4.00, "built_in"),
+    "gemini-1.5-flash": ModelTokenPricing(0.075, 0.30, "built_in"),
+    "gemini-1.5-pro": ModelTokenPricing(1.25, 5.00, "built_in"),
+    "gemini-pro": ModelTokenPricing(1.25, 5.00, "built_in"),
+}
+
+
+def _coerce_non_negative_float(value: object) -> float | None:
+    try:
+        parsed = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed
+
+
+def _pricing_from_mapping(
+    payload: Mapping[str, Any],
+    *,
+    source: str,
+) -> ModelTokenPricing | None:
+    input_price = _coerce_non_negative_float(
+        payload.get("inputPerMillionUsd")
+        or payload.get("input_per_million_usd")
+        or payload.get("promptPerMillionUsd")
+        or payload.get("prompt_per_million_usd")
+    )
+    output_price = _coerce_non_negative_float(
+        payload.get("outputPerMillionUsd")
+        or payload.get("output_per_million_usd")
+        or payload.get("completionPerMillionUsd")
+        or payload.get("completion_per_million_usd")
+    )
+    if input_price is None or output_price is None:
+        return None
+    return ModelTokenPricing(input_price, output_price, source)
+
+
+def _env_pricing() -> dict[str, ModelTokenPricing]:
+    raw = os.getenv(_ENV_PRICING_KEY)
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("%s is not valid JSON; ignoring model pricing override", _ENV_PRICING_KEY)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning("%s must be a JSON object; ignoring model pricing override", _ENV_PRICING_KEY)
+        return {}
+
+    pricing: dict[str, ModelTokenPricing] = {}
+    for model_id, model_payload in parsed.items():
+        if not isinstance(model_payload, Mapping):
+            continue
+        normalized = str(model_id or "").strip().lower()
+        if not normalized:
+            continue
+        model_pricing = _pricing_from_mapping(model_payload, source="env")
+        if model_pricing:
+            pricing[normalized] = model_pricing
+    return pricing
+
+
+def pricing_from_profile_metadata(
+    profile_metadata: Mapping[str, Any] | None,
+) -> ModelTokenPricing | None:
+    """Extract pricing from provider-profile metadata JSON fields."""
+
+    if not isinstance(profile_metadata, Mapping):
+        return None
+    for key in ("billing", "pricing", "cost"):
+        value = profile_metadata.get(key)
+        if isinstance(value, Mapping):
+            pricing = _pricing_from_mapping(value, source=f"profile.{key}")
+            if pricing:
+                return pricing
+    return _pricing_from_mapping(profile_metadata, source="profile")
+
+
+def pricing_for_model(model: str | None) -> ModelTokenPricing | None:
+    normalized_model = str(model or "").strip().lower()
+    if not normalized_model:
+        return None
+    env_pricing = _env_pricing()
+    if normalized_model in env_pricing:
+        return env_pricing[normalized_model]
+    for known_model, pricing in _DEFAULT_MODEL_PRICING.items():
+        if normalized_model == known_model or known_model in normalized_model:
+            return pricing
+    return None
+
+
+def estimate_model_cost(
+    *,
+    model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    pricing: ModelTokenPricing | None = None,
+) -> ModelCostEstimate | None:
+    resolved_pricing = pricing or pricing_for_model(model)
+    if resolved_pricing is None:
+        return None
+    safe_input_tokens = max(0, int(input_tokens or 0))
+    safe_output_tokens = max(0, int(output_tokens or 0))
+    total_tokens = safe_input_tokens + safe_output_tokens
+    cost = (
+        (safe_input_tokens * resolved_pricing.input_per_million_usd)
+        + (safe_output_tokens * resolved_pricing.output_per_million_usd)
+    ) / 1_000_000
+    return ModelCostEstimate(
+        input_tokens=safe_input_tokens,
+        output_tokens=safe_output_tokens,
+        total_tokens=total_tokens,
+        cost_estimate_usd=round(cost, 8),
+        input_per_million_usd=resolved_pricing.input_per_million_usd,
+        output_per_million_usd=resolved_pricing.output_per_million_usd,
+        pricing_source=resolved_pricing.source,
+    )
+
+
+def emit_llm_cost_telemetry(
+    *,
+    provider: str | None,
+    model: str | None,
+    estimate: ModelCostEstimate | None,
+) -> None:
+    """Emit best-effort operator-visible cost telemetry."""
+
+    if estimate is None:
+        return
+    tags = {
+        "provider": provider or "unknown",
+        "model": model or "unknown",
+        "pricing_source": estimate.pricing_source,
+    }
+    get_metrics_emitter().increment(
+        "llm_cost_estimate_usd_total",
+        value=estimate.cost_estimate_usd,
+        tags=tags,
+    )
+    logger.info(
+        "moonmind.cost_estimate_usd",
+        extra={
+            "moonmind.provider": provider or "unknown",
+            "moonmind.model": model or "unknown",
+            "moonmind.token_input": estimate.input_tokens,
+            "moonmind.token_output": estimate.output_tokens,
+            "moonmind.cost_estimate_usd": estimate.cost_estimate_usd,
+            "moonmind.pricing_source": estimate.pricing_source,
+        },
+    )
+
+
+__all__ = [
+    "ModelCostEstimate",
+    "ModelTokenPricing",
+    "emit_llm_cost_telemetry",
+    "estimate_model_cost",
+    "pricing_for_model",
+    "pricing_from_profile_metadata",
+]

--- a/moonmind/billing/costs.py
+++ b/moonmind/billing/costs.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Mapping
 
 from moonmind.utils.metrics import get_metrics_emitter
@@ -82,33 +83,52 @@ def _pricing_from_mapping(
     source: str,
 ) -> ModelTokenPricing | None:
     input_price = _coerce_non_negative_float(
-        payload.get("inputPerMillionUsd")
-        or payload.get("input_per_million_usd")
-        or payload.get("promptPerMillionUsd")
-        or payload.get("prompt_per_million_usd")
+        _first_present(
+            payload,
+            (
+                "inputPerMillionUsd",
+                "input_per_million_usd",
+                "promptPerMillionUsd",
+                "prompt_per_million_usd",
+            ),
+        )
     )
     output_price = _coerce_non_negative_float(
-        payload.get("outputPerMillionUsd")
-        or payload.get("output_per_million_usd")
-        or payload.get("completionPerMillionUsd")
-        or payload.get("completion_per_million_usd")
+        _first_present(
+            payload,
+            (
+                "outputPerMillionUsd",
+                "output_per_million_usd",
+                "completionPerMillionUsd",
+                "completion_per_million_usd",
+            ),
+        )
     )
     if input_price is None or output_price is None:
         return None
     return ModelTokenPricing(input_price, output_price, source)
 
 
-def _env_pricing() -> dict[str, ModelTokenPricing]:
-    raw = os.getenv(_ENV_PRICING_KEY)
-    if not raw:
-        return {}
+def _first_present(payload: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in payload:
+            return payload[key]
+    return None
+
+
+@lru_cache(maxsize=16)
+def _parse_env_pricing(raw: str) -> dict[str, ModelTokenPricing]:
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
-        logger.warning("%s is not valid JSON; ignoring model pricing override", _ENV_PRICING_KEY)
+        logger.warning(
+            "%s is not valid JSON; ignoring model pricing override", _ENV_PRICING_KEY
+        )
         return {}
     if not isinstance(parsed, dict):
-        logger.warning("%s must be a JSON object; ignoring model pricing override", _ENV_PRICING_KEY)
+        logger.warning(
+            "%s must be a JSON object; ignoring model pricing override", _ENV_PRICING_KEY
+        )
         return {}
 
     pricing: dict[str, ModelTokenPricing] = {}
@@ -122,6 +142,13 @@ def _env_pricing() -> dict[str, ModelTokenPricing]:
         if model_pricing:
             pricing[normalized] = model_pricing
     return pricing
+
+
+def _env_pricing() -> dict[str, ModelTokenPricing]:
+    raw = os.getenv(_ENV_PRICING_KEY)
+    if not raw:
+        return {}
+    return _parse_env_pricing(raw)
 
 
 def pricing_from_profile_metadata(
@@ -147,9 +174,11 @@ def pricing_for_model(model: str | None) -> ModelTokenPricing | None:
     env_pricing = _env_pricing()
     if normalized_model in env_pricing:
         return env_pricing[normalized_model]
-    for known_model, pricing in _DEFAULT_MODEL_PRICING.items():
-        if normalized_model == known_model or known_model in normalized_model:
-            return pricing
+    if normalized_model in _DEFAULT_MODEL_PRICING:
+        return _DEFAULT_MODEL_PRICING[normalized_model]
+    for known_model in sorted(_DEFAULT_MODEL_PRICING, key=len, reverse=True):
+        if known_model in normalized_model:
+            return _DEFAULT_MODEL_PRICING[known_model]
     return None
 
 

--- a/moonmind/schemas/chat_models.py
+++ b/moonmind/schemas/chat_models.py
@@ -36,6 +36,8 @@ class Usage(BaseModel):
     prompt_tokens: Optional[int] = None  # Made fields optional as per original
     completion_tokens: Optional[int] = None
     total_tokens: Optional[int] = None  # Made field optional
+    cost_estimate_usd: Optional[float] = None
+    pricing_source: Optional[str] = None
 
 class ChatCompletionResponse(BaseModel):
     id: str = "cmpl-xxxxxxxxxxxxxxxxxxxxxxx"
@@ -110,6 +112,8 @@ class ResponseUsage(BaseModel):
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
+    cost_estimate_usd: Optional[float] = None
+    pricing_source: Optional[str] = None
 
 class ResponseCreateResponse(BaseModel):
     id: str

--- a/moonmind/utils/metrics.py
+++ b/moonmind/utils/metrics.py
@@ -117,7 +117,7 @@ class _MetricsEmitter:
             )
 
     def increment(
-        self, metric: str, *, value: int = 1, tags: Optional[Mapping[str, Any]] = None
+        self, metric: str, *, value: float = 1, tags: Optional[Mapping[str, Any]] = None
     ) -> None:
         if not self.enabled:
             return

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2782,6 +2782,17 @@ class TemporalArtifactActivities:
 
         profiles = []
         for row in rows:
+            command_behavior = row.command_behavior or {}
+            billing_metadata = (
+                command_behavior.get("billing")
+                if isinstance(command_behavior, dict)
+                else None
+            )
+            pricing_metadata = (
+                command_behavior.get("pricing")
+                if isinstance(command_behavior, dict)
+                else None
+            )
             profiles.append(
                 {
                     "profile_id": row.profile_id,
@@ -2801,7 +2812,8 @@ class TemporalArtifactActivities:
                     "env_template": row.env_template or {},
                     "file_templates": row.file_templates or [],
                     "home_path_overrides": row.home_path_overrides or {},
-                    "command_behavior": row.command_behavior or {},
+                    "command_behavior": command_behavior,
+                    "billing": billing_metadata or pricing_metadata or {},
                     "default_model": row.default_model,
                     "model_overrides": row.model_overrides or {},
                     "max_parallel_runs": row.max_parallel_runs,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -24,6 +24,7 @@ from temporalio import exceptions, workflow
 
 with workflow.unsafe.imports_passed_through():
     from temporalio.common import RetryPolicy
+    from moonmind.billing.costs import pricing_from_profile_metadata
 
 WORKFLOW_NAME = "MoonMind.ProviderProfileManager"
 WORKFLOW_TASK_QUEUE = "mm.workflow"
@@ -42,6 +43,9 @@ DB_AUTHORITATIVE_PROFILE_SYNC_PATCH = (
 VERIFY_PENDING_REQUESTS_PATCH = "provider-profile-manager-verify-pending-requests-v1"
 DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH = (
     "provider-profile-manager-default-profile-exclusive-selection-v1"
+)
+BILLING_AWARE_PROFILE_SELECTION_PATCH = (
+    "provider-profile-manager-billing-aware-selection-v1"
 )
 
 # Continue-as-new threshold to bound history growth.
@@ -133,6 +137,9 @@ class ProfileSlotState:
     tags: list[str] = field(default_factory=list)
     priority: int = 100
     runtime_materialization_mode: Optional[str] = None
+    input_per_million_usd: Optional[float] = None
+    output_per_million_usd: Optional[float] = None
+    pricing_source: Optional[str] = None
 
     @property
     def available_slots(self) -> int:
@@ -201,7 +208,16 @@ class ProfileSlotState:
             "tags": list(self.tags),
             "priority": self.priority,
             "runtime_materialization_mode": self.runtime_materialization_mode,
+            "input_per_million_usd": self.input_per_million_usd,
+            "output_per_million_usd": self.output_per_million_usd,
+            "pricing_source": self.pricing_source,
         }
+
+    @property
+    def blended_per_million_usd(self) -> Optional[float]:
+        if self.input_per_million_usd is None or self.output_per_million_usd is None:
+            return None
+        return self.input_per_million_usd + self.output_per_million_usd
 
 @dataclass
 class PendingRequest:
@@ -581,6 +597,9 @@ class MoonMindProviderProfileManagerWorkflow:
                 tags=p.get("tags") or [],
                 priority=p.get("priority", 100),
                 runtime_materialization_mode=p.get("runtime_materialization_mode"),
+                input_per_million_usd=p.get("input_per_million_usd"),
+                output_per_million_usd=p.get("output_per_million_usd"),
+                pricing_source=p.get("pricing_source"),
             )
             self._profiles[pid] = state
 
@@ -613,7 +632,9 @@ class MoonMindProviderProfileManagerWorkflow:
                 existing.runtime_materialization_mode = p.get(
                     "runtime_materialization_mode", existing.runtime_materialization_mode
                 )
+                self._apply_profile_pricing(existing, p)
             else:
+                pricing = pricing_from_profile_metadata(p)
                 self._profiles[pid] = ProfileSlotState(
                     profile_id=pid,
                     max_parallel_runs=p.get("max_parallel_runs", 1),
@@ -630,6 +651,13 @@ class MoonMindProviderProfileManagerWorkflow:
                     tags=p.get("tags") or [],
                     priority=p.get("priority", 100),
                     runtime_materialization_mode=p.get("runtime_materialization_mode"),
+                    input_per_million_usd=(
+                        pricing.input_per_million_usd if pricing else None
+                    ),
+                    output_per_million_usd=(
+                        pricing.output_per_million_usd if pricing else None
+                    ),
+                    pricing_source=pricing.source if pricing else None,
                 )
 
         # Disable profiles that were removed from DB (but don't drop leases).
@@ -643,6 +671,21 @@ class MoonMindProviderProfileManagerWorkflow:
         for pid, profile in list(self._profiles.items()):
             if not profile.enabled and not profile.current_leases:
                 self._profiles.pop(pid, None)
+
+    @staticmethod
+    def _apply_profile_pricing(
+        profile: ProfileSlotState,
+        payload: dict[str, Any],
+    ) -> None:
+        pricing = pricing_from_profile_metadata(payload)
+        if pricing is None:
+            profile.input_per_million_usd = None
+            profile.output_per_million_usd = None
+            profile.pricing_source = None
+            return
+        profile.input_per_million_usd = pricing.input_per_million_usd
+        profile.output_per_million_usd = pricing.output_per_million_usd
+        profile.pricing_source = pricing.source
 
     @staticmethod
     def _normalize_optional_string(value: object) -> str | None:
@@ -869,10 +912,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     return None
                 elif len(eligible_profiles) == 1:
                     return eligible_profiles[0]
-                eligible_profiles.sort(
-                    key=lambda p: (p.priority, p.available_slots),
-                    reverse=True,
-                )
+                self._sort_profiles_for_selection(eligible_profiles)
                 return eligible_profiles[0]
             if len(default_profiles) == 1:
                 return default_profiles[0]
@@ -888,9 +928,28 @@ class MoonMindProviderProfileManagerWorkflow:
                 return eligible_profiles[0]
             return None
 
-        # Sort descending by priority, then by available slots
-        eligible_profiles.sort(key=lambda p: (p.priority, p.available_slots), reverse=True)
+        self._sort_profiles_for_selection(eligible_profiles)
         return eligible_profiles[0]
+
+    @staticmethod
+    def _billing_sort_key(profile: ProfileSlotState) -> tuple[int, float, int, int]:
+        blended_price = profile.blended_per_million_usd
+        has_price = 0 if blended_price is not None else 1
+        price = blended_price if blended_price is not None else float("inf")
+        return (has_price, price, -profile.priority, -profile.available_slots)
+
+    @staticmethod
+    def _workflow_patch_enabled(patch_id: str) -> bool:
+        try:
+            return workflow.patched(patch_id)
+        except Exception:
+            return False
+
+    def _sort_profiles_for_selection(self, profiles: list[ProfileSlotState]) -> None:
+        if self._workflow_patch_enabled(BILLING_AWARE_PROFILE_SELECTION_PATCH):
+            profiles.sort(key=self._billing_sort_key)
+            return
+        profiles.sort(key=lambda p: (p.priority, p.available_slots), reverse=True)
 
     async def _signal_slot_assigned(
         self, requester_workflow_id: str, profile_id: str
@@ -1097,6 +1156,9 @@ class MoonMindProviderProfileManagerWorkflow:
                     "tags": list(state.tags),
                     "priority": state.priority,
                     "runtime_materialization_mode": state.runtime_materialization_mode,
+                    "input_per_million_usd": state.input_per_million_usd,
+                    "output_per_million_usd": state.output_per_million_usd,
+                    "pricing_source": state.pricing_source,
                 }
             )
             if state.current_leases:

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -247,6 +247,8 @@ def test_chat_completions_openai_via_cache(
     json_response = response.json()
     # Assertions need to align with mock_openai_chat_response structure (which should mimic new SDK)
     assert json_response["model"] == mock_openai_chat_response.model
+    assert json_response["usage"]["cost_estimate_usd"] == 0.000045
+    assert json_response["usage"]["pricing_source"] == "built_in"
     assert (
         json_response["choices"][0]["message"]["content"]
         == mock_openai_chat_response.choices[0].message.content
@@ -327,6 +329,8 @@ def test_chat_completions_google_via_cache(
     assert response.status_code == 200
     json_response = response.json()
     assert json_response["model"] == chat_request_google_model.model
+    assert json_response["usage"]["cost_estimate_usd"] is not None
+    assert json_response["usage"]["pricing_source"] == "built_in"
     assert (
         json_response["choices"][0]["message"]["content"]
         == mock_google_chat_response.candidates[0].content.parts[0].text.strip()

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 # If chat.py is in api_service.api.routers.chat, this should be fine.
 from api_service.api.routers.chat import (
     _extract_openai_response_text,
+    _normalize_openai_response_payload,
     _response_content_to_text,
     responses_router,
     router as chat_router,
@@ -293,6 +294,28 @@ def test_chat_completions_endpoint_success_corrected_path(
     mock_get_provider.assert_called_once_with(chat_request_openai_model.model)
     mock_async_openai_client.assert_called_once_with(api_key="sk-test-user-key")
     mock_client_instance.chat.completions.create.assert_called_once()
+
+
+def test_openai_response_normalization_preserves_zero_token_usage() -> None:
+    payload = _normalize_openai_response_payload(
+        {
+            "model": "gpt-4o-mini",
+            "output_text": "ok",
+            "usage": {
+                "input_tokens": 0,
+                "prompt_tokens": 1_000,
+                "output_tokens": 0,
+                "completion_tokens": 1_000,
+            },
+        },
+        fallback_model="gpt-4o-mini",
+        metadata={},
+    )
+
+    assert payload["usage"]["cost_estimate_usd"] == 0
+    assert payload["metadata"]["billing"]["inputTokens"] == 0
+    assert payload["metadata"]["billing"]["outputTokens"] == 0
+
 
 @patch("google.generativeai.configure")
 @patch("api_service.api.routers.chat.get_google_model")

--- a/tests/unit/billing/test_costs.py
+++ b/tests/unit/billing/test_costs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from moonmind.billing.costs import (
+    ModelTokenPricing,
+    estimate_model_cost,
+    pricing_from_profile_metadata,
+)
+
+
+def test_estimate_model_cost_uses_known_model_pricing() -> None:
+    estimate = estimate_model_cost(
+        model="gpt-4o-mini",
+        input_tokens=1_000_000,
+        output_tokens=500_000,
+    )
+
+    assert estimate is not None
+    assert estimate.cost_estimate_usd == 0.45
+    assert estimate.pricing_source == "built_in"
+
+
+def test_estimate_model_cost_uses_explicit_pricing() -> None:
+    estimate = estimate_model_cost(
+        model="unlisted-provider-model",
+        input_tokens=2000,
+        output_tokens=1000,
+        pricing=ModelTokenPricing(2.0, 10.0, "profile.billing"),
+    )
+
+    assert estimate is not None
+    assert estimate.cost_estimate_usd == 0.014
+    assert estimate.pricing_source == "profile.billing"
+
+
+def test_unknown_model_without_pricing_does_not_fabricate_cost() -> None:
+    assert (
+        estimate_model_cost(
+            model="unknown-model",
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        is None
+    )
+
+
+def test_pricing_from_profile_metadata_accepts_operator_billing_shape() -> None:
+    pricing = pricing_from_profile_metadata(
+        {
+            "billing": {
+                "inputPerMillionUsd": 1.25,
+                "outputPerMillionUsd": 5.0,
+            }
+        }
+    )
+
+    assert pricing is not None
+    assert pricing.input_per_million_usd == 1.25
+    assert pricing.output_per_million_usd == 5.0
+    assert pricing.source == "profile.billing"

--- a/tests/unit/billing/test_costs.py
+++ b/tests/unit/billing/test_costs.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from moonmind.billing import costs
 from moonmind.billing.costs import (
     ModelTokenPricing,
     estimate_model_cost,
+    pricing_for_model,
     pricing_from_profile_metadata,
 )
 
@@ -57,3 +59,53 @@ def test_pricing_from_profile_metadata_accepts_operator_billing_shape() -> None:
     assert pricing.input_per_million_usd == 1.25
     assert pricing.output_per_million_usd == 5.0
     assert pricing.source == "profile.billing"
+
+
+def test_pricing_from_profile_metadata_preserves_zero_prices() -> None:
+    pricing = pricing_from_profile_metadata(
+        {
+            "billing": {
+                "inputPerMillionUsd": 0,
+                "outputPerMillionUsd": 0.0,
+            }
+        }
+    )
+
+    assert pricing is not None
+    assert pricing.input_per_million_usd == 0
+    assert pricing.output_per_million_usd == 0
+
+
+def test_env_pricing_preserves_zero_prices_and_caches_by_raw_payload(
+    monkeypatch,
+) -> None:
+    raw = '{"local-free":{"inputPerMillionUsd":0,"outputPerMillionUsd":0}}'
+    calls = 0
+    real_loads = costs.json.loads
+    costs._parse_env_pricing.cache_clear()
+
+    def counting_loads(value: str):
+        nonlocal calls
+        calls += 1
+        return real_loads(value)
+
+    monkeypatch.setenv("MOONMIND_MODEL_PRICING_JSON", raw)
+    monkeypatch.setattr(costs.json, "loads", counting_loads)
+
+    first = pricing_for_model("local-free")
+    second = pricing_for_model("local-free")
+
+    assert first is not None
+    assert first.input_per_million_usd == 0
+    assert first.output_per_million_usd == 0
+    assert second == first
+    assert calls == 1
+    costs._parse_env_pricing.cache_clear()
+
+
+def test_pricing_for_model_prefers_longest_builtin_substring_match() -> None:
+    pricing = pricing_for_model("azure/gpt-4o-mini-latest")
+
+    assert pricing is not None
+    assert pricing.input_per_million_usd == 0.15
+    assert pricing.output_per_million_usd == 0.60

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1110,7 +1110,13 @@ async def test_provider_profile_list_preserves_path_aware_codex_materialization_
                     home_path_overrides={
                         "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
                     },
-                    command_behavior={"suppress_default_model_flag": True},
+                    command_behavior={
+                        "suppress_default_model_flag": True,
+                        "billing": {
+                            "inputPerMillionUsd": 0.2,
+                            "outputPerMillionUsd": 0.8,
+                        },
+                    },
                     max_parallel_runs=4,
                     cooldown_after_429_seconds=300,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
@@ -1154,7 +1160,15 @@ async def test_provider_profile_list_preserves_path_aware_codex_materialization_
             "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
         }
         assert profiles[0]["command_behavior"] == {
-            "suppress_default_model_flag": True
+            "suppress_default_model_flag": True,
+            "billing": {
+                "inputPerMillionUsd": 0.2,
+                "outputPerMillionUsd": 0.8,
+            },
+        }
+        assert profiles[0]["billing"] == {
+            "inputPerMillionUsd": 0.2,
+            "outputPerMillionUsd": 0.8,
         }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    BILLING_AWARE_PROFILE_SELECTION_PATCH,
     DB_AUTHORITATIVE_PROFILE_SYNC_PATCH,
     DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH,
     HandoffReservation,
@@ -223,6 +224,28 @@ class TestProviderProfileManagerHelpers:
         assert wf._profiles["p1"].rate_limit_policy == "queue"
         # Leases should be preserved across sync.
         assert wf._profiles["p1"].current_leases == ["wf1"]
+
+    def test_apply_profile_sync_loads_operator_billing_metadata(self):
+        wf = self._make_workflow()
+        wf._apply_profile_sync(
+            [
+                {
+                    "profile_id": "cheap",
+                    "max_parallel_runs": 1,
+                    "rate_limit_policy": "backoff",
+                    "enabled": True,
+                    "billing": {
+                        "inputPerMillionUsd": 0.10,
+                        "outputPerMillionUsd": 0.40,
+                    },
+                }
+            ]
+        )
+
+        profile = wf._profiles["cheap"]
+        assert profile.input_per_million_usd == 0.10
+        assert profile.output_per_million_usd == 0.40
+        assert profile.pricing_source == "profile.billing"
 
     def test_apply_profile_sync_disables_removed_profiles_without_leases(self):
         wf = self._make_workflow()
@@ -673,6 +696,42 @@ class TestProviderProfileManagerHelpers:
 
         assert best is not None
         assert best.profile_id == "p2"
+
+    def test_find_available_profile_prefers_lower_cost_when_billing_patch_enabled(self):
+        wf = self._make_workflow()
+        wf._profiles["expensive"] = ProfileSlotState(
+            profile_id="expensive",
+            max_parallel_runs=3,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            provider_id="openai",
+            priority=500,
+            input_per_million_usd=5.0,
+            output_per_million_usd=15.0,
+        )
+        wf._profiles["cheap"] = ProfileSlotState(
+            profile_id="cheap",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            provider_id="openai",
+            priority=10,
+            input_per_million_usd=0.1,
+            output_per_million_usd=0.4,
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == BILLING_AWARE_PROFILE_SELECTION_PATCH
+            )
+            best = wf._find_available_profile({"providerId": "openai"})
+
+        assert best is not None
+        assert best.profile_id == "cheap"
 
     def test_find_available_profile_none_available(self):
         wf = self._make_workflow()


### PR DESCRIPTION
Jira issue: MM-788

Summary:
- Add a shared billing cost estimator for token-based model usage.
- Surface cost estimates and pricing source in chat and Responses API usage payloads.
- Emit best-effort operator cost telemetry and expose provider-profile billing metadata to runtime profile snapshots.
- Make provider-profile selection billing-aware when pricing metadata is available, with coverage for the Temporal manager boundary.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/billing/test_costs.py tests/unit/api/test_chat.py tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/adapters/test_managed_agent_adapter.py
- ./tools/test_unit.sh --python-only tests/integration/test_multi_profile_openrouter.py
- ./tools/test_unit.sh --python-only

Remaining risks:
- Cost estimates depend on configured or built-in per-million-token pricing and are best-effort, not authoritative billing statements.
- Provider models without known pricing intentionally omit cost estimates until operators configure pricing metadata.
