### PR TITLE
MM-790 Artifact/memory portability across model switches

### DIFF
--- a/docs/Memory/MemoryArchitecture.md
+++ b/docs/Memory/MemoryArchitecture.md
@@ -167,6 +167,8 @@ Required metadata on every Mem0 entry:
 - `review_state` (`draft | approved | deprecated`)
 - `provenance` pointers (`workflowId`, `taskRunId` when applicable, commits, doc refs)
 
+Memory provenance must stay model-agnostic. It records durable evidence pointers, not the model or provider that happened to produce the memory contribution.
+
 ## 7) Integration Surfaces
 
 MoonMind implements this architecture with four small adapters/services:

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -251,7 +251,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [x] **10.1** Per-step model/runtime selection in multi-step flows — Authored task steps can independently select runtime/model settings
 - [ ] **10.2** Cost tracking / billing-aware routing — No cost instrumentation
 - [ ] **10.3** Model comparison mode (same task, different models) — README promises this; no implementation
-- [ ] **10.4** Artifact/memory portability across model switches — Artifacts are model-agnostic; memory doesn't track model provenance
+- [x] **10.4** Artifact/memory portability across model switches — Artifacts are model-agnostic; memory doesn't track model provenance
 
 ---
 

--- a/docs/Temporal/WorkflowArtifactSystemDesign.md
+++ b/docs/Temporal/WorkflowArtifactSystemDesign.md
@@ -66,6 +66,9 @@ This document defines the artifact system: storage, identity, linkage, authoriza
 7. **Canonical runtime result discipline** 
  True agent-runtime activities return compact canonical contracts, while large outputs and diagnostics live in artifacts referenced by those contracts.
 
+8. **Model-agnostic portability**
+ Artifact metadata and refs must not encode model or provider identity as provenance. Model-specific diagnostics may live inside artifact bytes when required, but the artifact contract remains portable across model switches.
+
 ---
 
 ## 3. Non-goals

--- a/moonmind/core/artifacts.py
+++ b/moonmind/core/artifacts.py
@@ -1,5 +1,5 @@
 import enum
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import Any
 
 class TemporalArtifactStorageBackend(str, enum.Enum):
@@ -40,20 +40,7 @@ class TemporalArtifactUploadMode(str, enum.Enum):
     MULTIPART = "multipart"
 
 
-_MODEL_PROVENANCE_KEYS = frozenset(
-    {
-        "model",
-        "modelid",
-        "modelname",
-        "modelprovider",
-        "modelproviderid",
-        "modelrevision",
-        "modelversion",
-        "provider",
-        "providerid",
-        "providername",
-    }
-)
+_MODEL_PROVENANCE_KEY_TERMS = frozenset({"model", "provider"})
 
 
 def assert_model_agnostic_metadata(
@@ -72,7 +59,7 @@ def assert_model_agnostic_metadata(
             for character in str(key).lower()
             if character.isalnum()
         )
-        if normalized in _MODEL_PROVENANCE_KEYS:
+        if any(term in normalized for term in _MODEL_PROVENANCE_KEY_TERMS):
             dotted_path = ".".join(str(part) for part in path)
             raise ValueError(
                 f"{field_name} must be model-agnostic; "
@@ -84,19 +71,17 @@ def _walk_metadata(
     value: Any,
     *,
     prefix: tuple[str, ...] = (),
-) -> list[tuple[tuple[str, ...], Any]]:
-    items: list[tuple[tuple[str, ...], Any]] = []
+) -> Iterator[tuple[tuple[str, ...], Any]]:
     if isinstance(value, Mapping):
         for key, child in value.items():
             path = (*prefix, str(key))
-            items.append((path, child))
-            items.extend(_walk_metadata(child, prefix=path))
+            yield path, child
+            yield from _walk_metadata(child, prefix=path)
     elif isinstance(value, Sequence) and not isinstance(
         value,
         (str, bytes, bytearray),
     ):
         for index, child in enumerate(value):
             path = (*prefix, str(index))
-            items.append((path, child))
-            items.extend(_walk_metadata(child, prefix=path))
-    return items
+            yield path, child
+            yield from _walk_metadata(child, prefix=path)

--- a/moonmind/core/artifacts.py
+++ b/moonmind/core/artifacts.py
@@ -1,4 +1,6 @@
 import enum
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 class TemporalArtifactStorageBackend(str, enum.Enum):
     """Supported backing stores for Temporal artifact bytes."""
@@ -36,3 +38,65 @@ class TemporalArtifactUploadMode(str, enum.Enum):
     """Upload mode selected when creating an artifact session."""
     SINGLE_PUT = "single_put"
     MULTIPART = "multipart"
+
+
+_MODEL_PROVENANCE_KEYS = frozenset(
+    {
+        "model",
+        "modelid",
+        "modelname",
+        "modelprovider",
+        "modelproviderid",
+        "modelrevision",
+        "modelversion",
+        "provider",
+        "providerid",
+        "providername",
+    }
+)
+
+
+def assert_model_agnostic_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    field_name: str = "metadata",
+) -> None:
+    """Reject model/provider identity keys in provenance-like metadata."""
+
+    if not metadata:
+        return
+    for path, _value in _walk_metadata(metadata):
+        key = path[-1]
+        normalized = "".join(
+            character
+            for character in str(key).lower()
+            if character.isalnum()
+        )
+        if normalized in _MODEL_PROVENANCE_KEYS:
+            dotted_path = ".".join(str(part) for part in path)
+            raise ValueError(
+                f"{field_name} must be model-agnostic; "
+                f"model/provider provenance key {dotted_path!r} is not allowed"
+            )
+
+
+def _walk_metadata(
+    value: Any,
+    *,
+    prefix: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], Any]]:
+    items: list[tuple[tuple[str, ...], Any]] = []
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            path = (*prefix, str(key))
+            items.append((path, child))
+            items.extend(_walk_metadata(child, prefix=path))
+    elif isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        for index, child in enumerate(value):
+            path = (*prefix, str(index))
+            items.append((path, child))
+            items.extend(_walk_metadata(child, prefix=path))
+    return items

--- a/moonmind/rag/long_term_memory.py
+++ b/moonmind/rag/long_term_memory.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Mapping, MutableMapping, Protocol, Sequence
 
+from moonmind.core.artifacts import assert_model_agnostic_metadata
 from moonmind.rag.context_pack import ContextItem
 from moonmind.rag.settings import RagRuntimeSettings
 
@@ -191,6 +192,13 @@ class LongTermMemoryService:
         }
         if not normalized_provenance:
             raise LongTermMemoryError("provenance is required for long-term memory")
+        try:
+            assert_model_agnostic_metadata(
+                normalized_provenance,
+                field_name="memory provenance",
+            )
+        except ValueError as exc:
+            raise LongTermMemoryError(str(exc)) from exc
         return {
             "namespace_id": self._settings.memory_namespace_id,
             "repo": normalized_repo,

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -14,6 +14,7 @@ from moonmind.core.artifacts import (
     TemporalArtifactRetentionClass,
     TemporalArtifactRedactionLevel,
     TemporalArtifactUploadMode,
+    assert_model_agnostic_metadata,
 )
 from moonmind.schemas._validation import require_non_blank
 
@@ -94,6 +95,9 @@ class CreateArtifactRequest(BaseModel):
     encryption: TemporalArtifactEncryption = Field(
         TemporalArtifactEncryption.NONE
     )
+
+    def model_post_init(self, __context: Any) -> None:
+        assert_model_agnostic_metadata(self.metadata, field_name="metadata")
 
 class CreateArtifactResponse(BaseModel):
     """Creation response payload with artifact ref and upload hints."""

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db import models as db_models
 from moonmind.config.settings import settings
+from moonmind.core.artifacts import assert_model_agnostic_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -1318,6 +1319,13 @@ class TemporalArtifactService:
         redaction_level: db_models.TemporalArtifactRedactionLevel = db_models.TemporalArtifactRedactionLevel.NONE,
     ) -> tuple[db_models.TemporalArtifact, ArtifactUploadDescriptor]:
         now = datetime.now(UTC)
+        try:
+            assert_model_agnostic_metadata(
+                metadata_json,
+                field_name="artifact metadata",
+            )
+        except ValueError as exc:
+            raise TemporalArtifactValidationError(str(exc)) from exc
         _assert_not_reserved_input_attachment_metadata(metadata_json)
         declared_size: int | None = None
         if size_bytes is not None:

--- a/tests/schemas/test_temporal_activity_models.py
+++ b/tests/schemas/test_temporal_activity_models.py
@@ -8,7 +8,10 @@ from moonmind.schemas.temporal_activity_models import (
     ArtifactWriteCompleteInput,
     Base64Bytes,
 )
-from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
+from moonmind.schemas.temporal_artifact_models import (
+    ArtifactRefModel,
+    CreateArtifactRequest,
+)
 
 class DummyModel(BaseModel):
     data: Base64Bytes
@@ -53,6 +56,51 @@ def test_artifact_read_input_accepts_model():
         principal="user1"
     )
     assert model.artifact_ref == ref
+
+def test_create_artifact_request_rejects_model_provenance_metadata():
+    with pytest.raises(ValidationError, match="model/provider provenance"):
+        CreateArtifactRequest.model_validate(
+            {
+                "content_type": "text/plain",
+                "metadata": {
+                    "provenance": {
+                        "workflowId": "wf-1",
+                        "modelName": "expensive-model",
+                    }
+                },
+            }
+        )
+
+    with pytest.raises(ValidationError, match="model/provider provenance"):
+        CreateArtifactRequest.model_validate(
+            {
+                "content_type": "text/plain",
+                "metadata": {
+                    "trace": [
+                        {
+                            "artifactRef": "art_1",
+                            "provider": "openai",
+                        }
+                    ]
+                },
+            }
+        )
+
+def test_create_artifact_request_allows_model_agnostic_evidence_metadata():
+    model = CreateArtifactRequest.model_validate(
+        {
+            "content_type": "text/plain",
+            "metadata": {
+                "provenance": {
+                    "workflowId": "wf-1",
+                    "artifactRefs": ["art_1"],
+                },
+                "artifactKind": "runtime_stdout",
+            },
+        }
+    )
+
+    assert model.metadata["provenance"]["workflowId"] == "wf-1"
 
 def test_artifact_write_complete_input():
     model = ArtifactWriteCompleteInput(

--- a/tests/schemas/test_temporal_activity_models.py
+++ b/tests/schemas/test_temporal_activity_models.py
@@ -86,6 +86,23 @@ def test_create_artifact_request_rejects_model_provenance_metadata():
             }
         )
 
+    with pytest.raises(ValidationError, match="model/provider provenance"):
+        CreateArtifactRequest.model_validate(
+            {
+                "content_type": "text/plain",
+                "metadata": {
+                    "trace": [
+                        {
+                            "artifactRef": "art_1",
+                            "selectedModel": "expensive-model",
+                        },
+                        {"runtimeProvider": "openai"},
+                        {"llm_model": "gpt-5"},
+                    ]
+                },
+            }
+        )
+
 def test_create_artifact_request_allows_model_agnostic_evidence_metadata():
     model = CreateArtifactRequest.model_validate(
         {

--- a/tests/unit/rag/test_long_term_memory.py
+++ b/tests/unit/rag/test_long_term_memory.py
@@ -135,6 +135,14 @@ def test_add_or_update_rejects_model_provenance_metadata() -> None:
         )
 
 
+    with pytest.raises(LongTermMemoryError, match="model/provider provenance"):
+        service.add_or_update(
+            text="Stable convention.",
+            repo="MoonLadderStudios/MoonMind",
+            provenance={"workflowId": "wf-1", "runtimeProvider": "openai"},
+        )
+
+
 def test_add_or_update_sends_required_mem0_metadata() -> None:
     client = _Mem0Stub()
     service = LongTermMemoryService(settings=_settings(), client=client)

--- a/tests/unit/rag/test_long_term_memory.py
+++ b/tests/unit/rag/test_long_term_memory.py
@@ -124,6 +124,17 @@ def test_add_or_update_requires_provenance_metadata() -> None:
         )
 
 
+def test_add_or_update_rejects_model_provenance_metadata() -> None:
+    service = LongTermMemoryService(settings=_settings(), client=_Mem0Stub())
+
+    with pytest.raises(LongTermMemoryError, match="model/provider provenance"):
+        service.add_or_update(
+            text="Stable convention.",
+            repo="MoonLadderStudios/MoonMind",
+            provenance={"workflowId": "wf-1", "modelName": "expensive-model"},
+        )
+
+
 def test_add_or_update_sends_required_mem0_metadata() -> None:
     client = _Mem0Stub()
     service = LongTermMemoryService(settings=_settings(), client=client)

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -270,6 +270,32 @@ async def test_create_write_read_and_list_for_execution(tmp_path: Path) -> None:
             )
             assert [item.artifact_id for item in listed] == [artifact.artifact_id]
 
+async def test_create_rejects_model_provenance_metadata(tmp_path: Path) -> None:
+    """MM-790: Artifacts must not carry model/provider provenance in metadata."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="model/provider provenance",
+            ):
+                await service.create(
+                    principal="user-1",
+                    content_type="text/plain",
+                    metadata_json={
+                        "provenance": {
+                            "workflowId": "wf-1",
+                            "providerId": "openai",
+                        }
+                    },
+                )
+
 async def test_report_artifact_contract_accepts_supported_link_types() -> None:
     """MM-492: Report artifact link types should be explicit and stable."""
 


### PR DESCRIPTION
Jira issue: MM-790

Summary:
- Adds a shared model-agnostic metadata guard for artifact and memory provenance.
- Rejects model/provider identity keys at artifact API schema, Temporal artifact service, and Mem0 long-term memory boundaries.
- Adds regression tests for artifact metadata and memory provenance portability.
- Updates canonical docs and marks roadmap item 10.4 complete.

Tests run:
- ./tools/test_unit.sh --python-only tests/schemas/test_temporal_activity_models.py
- ./tools/test_unit.sh --python-only tests/unit/rag/test_long_term_memory.py
- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_artifacts.py
- python -m pytest tests/integration/temporal/test_temporal_artifact_lifecycle.py -q
- ./tools/test_unit.sh

Remaining risks:
- Provider/model details may still appear inside artifact bytes for diagnostics; this change prevents those identities from becoming artifact or memory provenance metadata.
