### PR TITLE
MM-797 clean up housekeeping backlog

### DIFF
--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -505,7 +505,7 @@ For external agents:
 
 For non-agent Docker workloads:
 
-1. A plan step invokes an executable tool, normally `tool.type = "skill"`.
+1. A plan step invokes an executable workload tool outside the current `MoonMind.Run` `agent_runtime` dispatch path.
 2. MoonMind resolves the tool and runner policy.
 3. A Docker-capable worker launches the approved workload container through the controlled Docker boundary.
 4. Outputs are captured as tool results and artifacts.

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -279,9 +279,9 @@ These are technical debt items that don't map to README claims but improve code 
 
 ### Remaining tasks
 - [x] **H.1** Complete legacy system removal — Code removal is complete (migration `c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining documentation updates are tracked in `docs/MoonMindRoadmap.md`.
-- [ ] **H.2** Spec deduplication — Merge duplicate specs identified in `docs/MoonMindRoadmap.md`: Worker Pause (038/040), Claude gating (044/046), Manifest Phase 0 (032/034), Jules events (048 stub → delete), Task Presets (026/028)
-- [ ] **H.3** Legacy skill dispatch cleanup — Remove dead `tool.type == "skill"` branch in `run.py`; all current plan generators emit `agent_runtime` nodes. See `docs/MoonMindRoadmap.md`.
-- [ ] **H.4** Delete legacy docs identified in `docs/LegacyDocsReview.md` — 6 docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.)
+- [x] **H.2** Spec deduplication — Duplicate spec directories were removed with the retired specs tree; no Worker Pause (038/040), Claude gating (044/046), Manifest Phase 0 (032/034), Jules events (048 stub), or Task Presets (026/028) duplicates remain.
+- [x] **H.3** Legacy skill dispatch cleanup — Removed the dead `tool.type == "skill"` dispatch branch from `MoonMind.Run`; current plan execution accepts `agent_runtime` nodes.
+- [x] **H.4** Delete legacy docs identified in `docs/LegacyDocsReview.md` — Removed the legacy docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.).
 
 ---
 
@@ -302,7 +302,7 @@ The milestones below are ordered by **impact on delivering the README promise** 
 | 🟡 P2 | **8 — Universal Integration (MCP)** | 🔧 Partial | 4 items |
 | 🟢 P3 | **10 — Vendor Portability & Model Flexibility** | 🔧 Partial | 4 items |
 | 🟢 P3 | **1 — Managed Agent Runtimes** | ✅ Shipped | 2 items |
-| 🟢 P3 | **H — Housekeeping / Cleanup** | 🔧 Partial | 3 items |
+| 🟢 P3 | **H — Housekeeping / Cleanup** | ✅ Shipped | 0 items |
 
 ---
 
@@ -314,5 +314,3 @@ The milestones below are ordered by **impact on delivering the README promise** 
 | `CancellationAnalysis.md` | **Delete** | Recommendations shipped (TRY_CANCEL in all activities, force-terminate path). Analysis preserved in Milestone 4 entries. |
 | `OrchestratorRemovalPlan.md` | **Deleted** | Superseded by spec 087, in-repo removal work, and `016-SingleSubstrateMigration.md`. |
 | `RagDocUpdates.md` | **Delete** | Marked "Status: Complete". Spec merge plan fully executed (spec 088 shipped). |
-| `SpecMergeReview.md` | **Keep until H.2 complete** | Actionable merge candidates not yet resolved. Tracked as H.2 in Housekeeping. |
-| `skill-system-alignment.md` | **Keep until H.3 complete** | Legacy skill branch still present in `run.py`. Tracked as H.3 in Housekeeping. |

--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -96,13 +96,13 @@ MoonMind's lifecycle model already expects `MoonMind.Run` to mix direct activiti
 
 ### 6.3 Why the resolver itself is a child `MoonMind.Run`
 
-The current MoonMind execution model dispatches `tool.type = "skill"` via activity execution inside `MoonMind.Run`, while `agent_runtime` work dispatches through `MoonMind.AgentRun` child workflows. `pr-resolver` is currently a **skill**, not a standalone workflow type, and it owns git/PR mutations and requires `publishMode = "none"`.
+The current MoonMind execution model dispatches plan execution through `agent_runtime` child workflows. `pr-resolver` is an agent skill selected for the resolver run, not a standalone workflow type, and it owns git/PR mutations and requires `publishMode = "none"`.
 
 Because of that, `MoonMind.MergeAutomation` SHOULD start a child **`MoonMind.Run`** for the resolver, rather than trying to execute the resolver skill directly inside the gate workflow. This reuses:
 
 - existing workspace/runtime setup,
 - artifact publishing,
-- skill execution routing,
+- agent-runtime routing,
 - logging and run summaries,
 - existing `pr-resolver` contract.
 

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -58,10 +58,10 @@ Canonical terminology for execution payloads is:
 * **step** (plan node)
 * **tool** (executable capability — Temporal contract object)
 
-There are two tool subtypes:
+The contract model recognizes two tool subtypes:
 
-* `tool.type = "skill"` — dispatched as a Temporal Activity (`mm.tool.execute` / `mm.skill.execute`). Uses a `ToolDefinition` from the tool registry snapshot.
-* `tool.type = "agent_runtime"` — dispatched as a child `MoonMind.AgentRun` workflow. Uses an `AgentExecutionRequest`.
+* `tool.type = "skill"` — activity-backed executable tool contract using a `ToolDefinition` from the tool registry snapshot. Current `MoonMind.Run` plans do not dispatch this legacy shape.
+* `tool.type = "agent_runtime"` — dispatched by `MoonMind.Run` as a child `MoonMind.AgentRun` workflow. Uses an `AgentExecutionRequest`.
 
 A runtime-native command is not a third `tool.type`.
 
@@ -102,7 +102,7 @@ Compatibility rule:
 
 * Legacy `Skill*` aliases are re-exported for backward compatibility during migration.
 * New code should import canonical `Tool*` names.
-* Legacy `skill` payload fields are accepted during migration, but should not be reused indefinitely.
+* Legacy `Skill*` Python aliases remain for registry/model compatibility. Current `MoonMind.Run` plan execution accepts `agent_runtime` nodes and rejects legacy `tool.type = "skill"` nodes.
 
 ---
 
@@ -169,15 +169,15 @@ A **Tool** is a named capability defined by:
 * default policies (timeouts, retries)
 * capability requirements (what worker fleet can run it)
 
-A Tool is not a workflow. Workflows interpret Plans and invoke Tools as Activities (or child workflows for `agent_runtime`).
+A Tool is not a workflow. `MoonMind.Run` interprets current Plans as child workflows for `agent_runtime`; activity-backed executable tool contracts remain registry concepts outside the active Run dispatch path.
 A `ToolDefinition` is **not** an `AgentSkillDefinition`. Executable tool execution and agent-skill materialization are adjacent but separate concerns.
 Note: An agent-runtime step may simultaneously receive a `resolved_skillset_ref` or equivalent execution context from the Agent Skill System, but that is resolved separately.
 
-Two tool subtypes are currently in use:
+The plan contract defines these tool subtypes:
 
 | `tool.type` | Dispatch mechanism | Contract |
 |---|---|---|
-| `skill` | Temporal Activity (`mm.tool.execute`) | `ToolDefinition` from tool registry snapshot |
+| `skill` | Legacy activity-backed executable tool contract; not dispatched by current `MoonMind.Run` plans | `ToolDefinition` from registry snapshot |
 | `agent_runtime` | Child `MoonMind.AgentRun` workflow | `AgentExecutionRequest` |
 
 ---

--- a/docs/Temporal/TemporalAgentExecution.md
+++ b/docs/Temporal/TemporalAgentExecution.md
@@ -154,11 +154,10 @@ _run_execution_stage()
   │   → start → wait → fetch_result → publish outputs
   │   → returns AgentRunResult { output_refs, summary, diagnostics, ... }
   │
-  └── tool.type == "skill" (or other activity-based types):
+  └── any other tool.type:
       │
       ▼
-    workflow.execute_activity("mm.skill.execute", ...)
-      → returns ToolResult { status, outputs, output_artifacts }
+    fail fast as unsupported by MoonMind.Run
 ```
 
 For **generic LLM text instructions** (no specific tool), planning produces
@@ -234,7 +233,6 @@ Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inpu
 |---------------|-------|------------|-------------|
 | `plan.generate` | llm | `mm.activity.llm` | LLM-driven plan generation |
 | `plan.validate` | llm | `mm.activity.llm` | Plan validation against registry |
-| `mm.skill.execute` | by_capability | `mm.activity.llm` (default) | Skill dispatch via registry |
 | `agent_runtime.publish_artifacts` | agent_runtime | `mm.activity.agent_runtime` | Publish agent run outputs |
 | `agent_runtime.cancel` | agent_runtime | `mm.activity.agent_runtime` | Cancel managed/external agent run |
 | `integration.resolve_adapter_metadata`| integrations | `mm.activity.integrations` | Single-hop adapter validation and resolution |

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1637,7 +1637,10 @@ def _build_runtime_planner():
                 effective_step_skill_name = step_tool_name or selected_skill_name
                 if step_tool_name:
                     step_node_inputs["selectedSkill"] = step_tool_name
-                    if _jira_agent_skill_selected(step_tool_name):
+                    if (
+                        _jira_agent_skill_selected(step_tool_name)
+                        and step_tool_name.lower() not in _MOONSPEC_BREAKDOWN_TOOLS
+                    ):
                         step_node_inputs["publishMode"] = "none"
                 if effective_step_skill_name:
                     step_node_inputs["instructions"] = _append_agent_skill_instructions(
@@ -1771,23 +1774,45 @@ def _build_runtime_planner():
             and publish_uses_git
         )
         if publish_requested or story_output_mode == "jira":
-            publish_node = next(
-                (
-                    node
-                    for node in reversed(nodes)
-                    if str(node.get("tool", {}).get("type") or "").strip().lower()
-                    == "agent_runtime"
-                    and not _jira_agent_skill_selected(_plan_node_selected_skill(node))
-                ),
-                nodes[-1],
-            )
+            if story_output_mode == "jira":
+                publish_node = next(
+                    (
+                        node
+                        for node in nodes
+                        if str(
+                            node.get("tool", {}).get("type") or ""
+                        ).strip().lower()
+                        == "agent_runtime"
+                        and _plan_node_selected_skill(node).lower()
+                        in _MOONSPEC_BREAKDOWN_TOOLS
+                    ),
+                    nodes[-1],
+                )
+            else:
+                publish_node = next(
+                    (
+                        node
+                        for node in reversed(nodes)
+                        if str(
+                            node.get("tool", {}).get("type") or ""
+                        ).strip().lower()
+                        == "agent_runtime"
+                        and not _jira_agent_skill_selected(
+                            _plan_node_selected_skill(node)
+                        )
+                    ),
+                    nodes[-1],
+                )
             publish_tool = str(
                 publish_node.get("tool", {}).get("name") or ""
             ).strip().lower()
             publish_selected_skill = _plan_node_selected_skill(publish_node)
             if (
                 publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
-                and not _jira_agent_skill_selected(publish_selected_skill)
+                and (
+                    not _jira_agent_skill_selected(publish_selected_skill)
+                    or publish_selected_skill.lower() in _MOONSPEC_BREAKDOWN_TOOLS
+                )
                 and not _is_jira_pr_handoff_node(
                     publish_node,
                     task_payload=task_payload,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1001,10 +1001,6 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
 def _selected_step_tool_type(step_entry: Mapping[str, Any], tool_name: str) -> str:
-    if _selected_step_type(step_entry) == "tool":
-        return "skill"
-    if tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS:
-        return "skill"
     return "agent_runtime"
 
 def _jira_agent_skill_selected(tool_name: str) -> bool:
@@ -1413,18 +1409,21 @@ def _build_runtime_planner():
                 ) or _coerce_mapping(plan_entry.get("skill"))
                 if not tool_payload:
                     raise RuntimeError("task.plan entries require a tool object")
-                tool_type = str(
-                    tool_payload.get("type") or tool_payload.get("kind") or "skill"
-                ).strip() or "skill"
-                tool_name = str(
+                authored_tool_type = str(
+                    tool_payload.get("type")
+                    or tool_payload.get("kind")
+                    or "agent_runtime"
+                ).strip().lower() or "agent_runtime"
+                authored_tool_name = str(
                     tool_payload.get("name") or tool_payload.get("id") or ""
                 ).strip()
-                if not tool_name:
+                if not authored_tool_name:
                     raise RuntimeError("task.plan tool name is required")
-                tool_version = str(
-                    tool_payload.get("version")
-                    or ("1.0.0" if tool_type == "skill" else "1.0")
-                ).strip()
+                tool_type = (
+                    "agent_runtime" if authored_tool_type == "skill" else authored_tool_type
+                )
+                tool_name = runtime_mode if authored_tool_type == "skill" else authored_tool_name
+                tool_version = str(tool_payload.get("version") or "1.0").strip()
                 if not tool_version:
                     raise RuntimeError("task.plan tool version is required")
                 node_inputs = _coerce_mapping(plan_entry.get("inputs"))
@@ -1432,6 +1431,13 @@ def _build_runtime_planner():
                     node_inputs = _coerce_mapping(
                         tool_payload.get("inputs") or tool_payload.get("args")
                     )
+                if authored_tool_type == "skill":
+                    node_inputs = {
+                        "instructions": f"Execute skill '{authored_tool_name}'",
+                        "runtime": dict(runtime_node),
+                        "selectedSkill": authored_tool_name,
+                        **dict(node_inputs),
+                    }
                 node_id = str(plan_entry.get("id") or f"node-{idx}").strip()
                 if not node_id:
                     node_id = f"node-{idx}"
@@ -1630,8 +1636,6 @@ def _build_runtime_planner():
                 tool_version = _selected_step_tool_version(step_entry)
                 effective_step_skill_name = step_tool_name or selected_skill_name
                 if step_tool_name:
-                    if tool_type == "skill" or not _selected_step_type(step_entry):
-                        step_runtime = step_tool_name
                     step_node_inputs["selectedSkill"] = step_tool_name
                     if _jira_agent_skill_selected(step_tool_name):
                         step_node_inputs["publishMode"] = "none"
@@ -1667,7 +1671,7 @@ def _build_runtime_planner():
                     "tool": {
                         "type": tool_type,
                         "name": step_runtime,
-                        "version": tool_version if tool_type == "skill" else "1.0",
+                        "version": "1.0",
                     },
                     "inputs": step_node_inputs,
                 })
@@ -1744,14 +1748,8 @@ def _build_runtime_planner():
                 str(node_inputs.get("instructions") or ""),
                 selected_skill=selected_skill_name,
             )
-            node_tool_type = (
-                "skill"
-                if selected_skill_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
-                else "agent_runtime"
-            )
-            node_tool_name = (
-                selected_skill_name if node_tool_type == "skill" else runtime_mode
-            )
+            node_tool_type = "agent_runtime"
+            node_tool_name = runtime_mode
             nodes.append({
                 "id": node_id,
                 "tool": {

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4128,8 +4128,7 @@ class MoonMindRunWorkflow:
                         execution_result, blocked_outcome_wait_skipped = (
                             await self._wait_for_jira_blocker_resolution(
                                 execution_result=execution_result,
-                                route=route,
-                                execute_payload=execute_payload,
+                                agent_request=request,
                                 node_id=node_id,
                                 tool_name=tool_name,
                                 tool_type=tool_type,
@@ -5025,7 +5024,7 @@ class MoonMindRunWorkflow:
         tool_type: str,
         tool_name: str,
     ) -> bool:
-        if tool_type != "skill" or tool_name != JIRA_CHECK_BLOCKERS_TOOL_NAME:
+        if tool_type != "agent_runtime" or tool_name != JIRA_CHECK_BLOCKERS_TOOL_NAME:
             return False
         outputs = self._get_from_result(execution_result, "outputs")
         if not isinstance(outputs, Mapping):
@@ -5103,8 +5102,7 @@ class MoonMindRunWorkflow:
         self,
         *,
         execution_result: Any,
-        route: Any,
-        execute_payload: Mapping[str, Any],
+        agent_request: Any,
         node_id: str,
         tool_name: str,
         tool_type: str,
@@ -5172,26 +5170,28 @@ class MoonMindRunWorkflow:
                     },
                 }
                 break
-            recheck_payload = dict(execute_payload)
-            idempotency_key = recheck_payload.get("idempotency_key")
-            if isinstance(idempotency_key, str) and idempotency_key.strip():
-                recheck_payload["idempotency_key"] = (
-                    f"{idempotency_key}_jira_blocker_recheck_{recheck_count}"
-                )
+            child_workflow_id = (
+                f"{workflow.info().workflow_id}:agent:{node_id}:"
+                f"jira-blocker-recheck{recheck_count}"
+            )
             try:
-                current_result = await workflow.execute_activity(
-                    route.activity_type,
-                    recheck_payload,
-                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                    **self._execute_kwargs_for_route(route),
+                self._active_agent_child_workflow_id = child_workflow_id
+                self._active_agent_id = getattr(agent_request, "agent_id", None)
+                child_result = await workflow.execute_child_workflow(
+                    "MoonMind.AgentRun",
+                    agent_request,
+                    id=child_workflow_id,
+                    task_queue=WORKFLOW_TASK_QUEUE,
                 )
+                current_result = self._map_agent_run_result(child_result)
             except Exception as exc:
                 diagnostic = self._record_failure_diagnostic(
                     exc,
                     stage=self._state,
                     step_id=node_id,
                     step_title=f"Re-check of Jira blockers for {tool_name}",
-                    source="activity",
+                    source="child_workflow",
+                    child_workflow_id=child_workflow_id,
                 )
                 self._mark_step_terminal(
                     node_id,
@@ -5203,6 +5203,9 @@ class MoonMindRunWorkflow:
                 if failure_mode == "FAIL_FAST":
                     raise
                 break
+            finally:
+                self._active_agent_child_workflow_id = None
+                self._active_agent_id = None
             self._record_step_result_evidence(
                 node_id,
                 execution_result=current_result,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -82,7 +82,6 @@ from moonmind.workflows.skills.approval_policy import (
     build_feedback_instruction,
     parse_review_verdict,
 )
-from moonmind.workflows.skills.skill_registry import parse_skill_registry
 from moonmind.workflows.temporal.step_ledger import (
     TERMINAL_STEP_STATUSES,
     build_initial_step_rows,
@@ -3802,7 +3801,6 @@ class MoonMindRunWorkflow:
         )
         self._capture_prepared_input_refs(parameters)
 
-        registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         task_payload = parameters.get("task")
         task_skills = (
             task_payload.get("skills")
@@ -3823,37 +3821,6 @@ class MoonMindRunWorkflow:
             and not pr_publish_optional
         )
         pull_request_url: str | None = None
-        skill_definitions_by_key: dict[tuple[str, str], Any] = {}
-        requires_registry_lookup = any(
-            node.tool_type == "skill" for node in plan_definition.nodes
-        )
-        if workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH):
-            should_read_registry = bool(
-                registry_snapshot_ref and requires_registry_lookup
-            )
-        else:
-            should_read_registry = bool(registry_snapshot_ref)
-
-        if should_read_registry:
-            registry_payload = await execute_typed_activity(
-                "artifact.read",
-                ArtifactReadInput(
-                    principal=self._principal(),
-                    artifact_ref=registry_snapshot_ref,
-                ),
-                **self._execute_kwargs_for_route(artifact_read_route),
-            )
-            registry_document = self._decode_json_payload(
-                registry_payload,
-                error_message=(
-                    "registry_snapshot_ref must resolve to a JSON object payload"
-                ),
-            )
-            skill_definitions = parse_skill_registry(registry_document)
-            skill_definitions_by_key = {
-                definition.key: definition for definition in skill_definitions
-            }
-
         previous_step_outputs: Mapping[str, Any] = {}
         execution_result: Any = None
         for index, node in enumerate(ordered_nodes, start=1):
@@ -4131,100 +4098,10 @@ class MoonMindRunWorkflow:
                             result_status = "FAILED"
                             break
 
-                    elif tool_type == "skill":
-                        # --- Activity dispatch: existing skill path ---
-                        if not tool_name or not tool_version:
-                            raise ValueError("plan node tool name/version is required")
-                        invocation_payload = {
-                            "id": node_id,
-                            "tool": {
-                                "type": "skill",
-                                "name": tool_name,
-                                "version": tool_version,
-                            },
-                            "skill": {"name": tool_name, "version": tool_version},
-                            "inputs": node_inputs,
-                            "options": node.get("options", {}),
-                        }
-                        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                            "mm.skill.execute"
-                        )
-                        if skill_definitions_by_key:
-                            skill_key = (tool_name, tool_version)
-                            if skill_key not in skill_definitions_by_key:
-                                raise ValueError(
-                                    "Tool "
-                                    f"'{tool_name}:{tool_version}' was not found in pinned "
-                                    "registry snapshot"
-                                )
-                            route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(
-                                skill_definitions_by_key[skill_key]
-                            )
-                        if route.activity_type not in {
-                            "mm.skill.execute",
-                            "mm.tool.execute",
-                        }:
-                            raise ValueError(
-                                "plan node tool executor "
-                                f"'{route.activity_type}' is unsupported by MoonMind.Run; "
-                                "expected mm.tool.execute or mm.skill.execute"
-                            )
-
-                        try:
-                            execute_payload = {
-                                "invocation_payload": invocation_payload,
-                                "principal": self._principal(),
-                                "registry_snapshot_ref": registry_snapshot_ref,
-                                "context": {
-                                    "workflow_id": workflow.info().workflow_id,
-                                    "run_id": workflow.info().run_id,
-                                    "node_id": node_id,
-                                    "ownerId": self._owner_id,
-                                    "ownerType": self._owner_type,
-                                    "previousOutputs": current_previous_outputs,
-                                },
-                            }
-                            if workflow.patched("idempotency_key_phase3"):
-                                execute_payload["idempotency_key"] = (
-                                    step_execution_operation_idempotency_key(
-                                        workflow_id=workflow.info().workflow_id,
-                                        run_id=workflow.info().run_id,
-                                        logical_step_id=node_id,
-                                        execution_ordinal=current_step_execution,
-                                        operation="execute",
-                                    )
-                                )
-
-                            execution_result = await workflow.execute_activity(
-                                route.activity_type,
-                                execute_payload,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                                **self._execute_kwargs_for_route(route),
-                            )
-                        except Exception as exc:
-                            diagnostic = self._record_failure_diagnostic(
-                                exc,
-                                stage=self._state,
-                                step_id=node_id,
-                                step_title=tool_name,
-                                source="activity",
-                            )
-                            self._mark_step_terminal(
-                                node_id,
-                                status="failed",
-                                updated_at=workflow.now(),
-                                summary=diagnostic["message"],
-                                last_error=diagnostic["category"],
-                            )
-                            if failure_mode == "FAIL_FAST":
-                                raise
-                            result_status = "FAILED"
-                            break
-
                     else:
                         raise ValueError(
                             f"unsupported plan node tool.type: '{tool_type}'; "
-                            "expected 'skill' or 'agent_runtime'"
+                            "expected 'agent_runtime'"
                         )
 
                     result_status = self._activity_result_status(execution_result)

--- a/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -353,8 +353,87 @@ class TestAgentRuntimeDispatch(unittest.IsolatedAsyncioTestCase):
                         search_attributes=_trusted_search_attributes(),
                     )
                 self.assertIn(
-                    "must be 'skill' or 'agent_runtime'",
+                    "expected 'agent_runtime'",
                     exc_info.exception.cause.message,
+                )
+
+    async def test_legacy_skill_tool_type_is_rejected(self) -> None:
+        """Legacy tool.type='skill' plan nodes are no longer dispatched by MoonMind.Run."""
+
+        @activity.defn(name="artifact.read")
+        async def legacy_skill_plan_reader(args: Dict[str, Any]) -> bytes:
+            ARTIFACT_READ_CALLS.append(args)
+            plan = {
+                "plan_version": "1.0",
+                "metadata": {
+                    "title": "Legacy skill plan",
+                    "created_at": "2026-06-03T00:00:00Z",
+                    "registry_snapshot": {
+                        "digest": "reg:sha256:" + ("e" * 64),
+                        "artifact_ref": "artifact://registry/legacy-skill",
+                    },
+                },
+                "policy": {"failure_mode": "FAIL_FAST"},
+                "nodes": [
+                    {
+                        "id": "legacy-skill-step",
+                        "tool": {
+                            "type": "skill",
+                            "name": "repo.run_tests",
+                            "version": "1.0.0",
+                        },
+                        "inputs": {},
+                    }
+                ],
+            }
+            return json.dumps(plan).encode("utf-8")
+
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _register_test_search_attributes(env)
+            async with (
+                Worker(
+                    env.client,
+                    task_queue=LLM_TASK_QUEUE,
+                    activities=[mock_plan_generate_agent],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=ARTIFACTS_TASK_QUEUE,
+                    activities=[
+                        legacy_skill_plan_reader,
+                        mock_artifact_create,
+                        mock_artifact_write_complete,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=SANDBOX_TASK_QUEUE,
+                    activities=[mock_skill_execute_agent],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="test-task-queue",
+                    workflows=[MoonMindRunWorkflow],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+            ):
+                with self.assertRaises(client.WorkflowFailureError) as exc_info:
+                    await env.client.execute_workflow(
+                        MoonMindRunWorkflow.run,
+                        {"workflowType": "MoonMind.Run"},
+                        id="test-legacy-skill-tool-type-rejected",
+                        task_queue="test-task-queue",
+                        search_attributes=_trusted_search_attributes(),
+                    )
+
+                self.assertIn(
+                    "unsupported plan node tool.type: 'skill'; expected 'agent_runtime'",
+                    exc_info.exception.cause.message,
+                )
+                self.assertEqual(SKILL_EXECUTE_CALLS, [])
+                self.assertNotIn(
+                    "artifact://registry/legacy-skill",
+                    [call.get("artifact_ref") for call in ARTIFACT_READ_CALLS],
                 )
 
     async def test_jules_agent_runtime_pr_publish_without_pr_fails_in_finalization(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1013,7 +1013,9 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
         failure_mode="FAIL_FAST",
     )
 
-    assert result == continue_result
+    assert result["status"] == continue_result["status"]
+    assert result["outputs"]["decision"] == "continue"
+    assert result["outputs"]["blockingIssues"] == []
     assert skipped is False
     assert events == [
         "pause-observed",

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -40,6 +40,33 @@ async def _timeout_wait_condition(
     assert predicate() is False
     raise asyncio.TimeoutError
 
+def _agent_runtime_step(
+    step_id: str = "step-1",
+    *,
+    instructions: str = "Run the requested work.",
+) -> dict[str, Any]:
+    return {
+        "id": step_id,
+        "tool": {
+            "type": "agent_runtime",
+            "name": "codex_cli",
+            "version": "1.0",
+        },
+        "inputs": {"instructions": instructions},
+        "options": {},
+    }
+
+async def _completed_child_workflow(
+    _workflow_type: str,
+    _args: object,
+    **_kwargs: object,
+) -> object:
+    return {
+        "summary": "Agent finished",
+        "metadata": {"push_status": "not_requested"},
+        "output_refs": [],
+    }
+
 def test_initialize_from_payload_captures_input_and_plan_refs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -166,32 +193,6 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         if activity_type == "provider_profile.list":
             return {"profiles": []}
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                                "description": "Run tests",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.skill.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 3},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -204,14 +205,7 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
                         },
                     },
                     "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
-                    "nodes": [
-                        {
-                            "id": "step-1",
-                            "skill": {"name": "repo.run_tests", "version": "1.0.0"},
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        }
-                    ],
+                    "nodes": [_agent_runtime_step()],
                     "edges": [],
                 }
             ).encode("utf-8")
@@ -221,6 +215,11 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         run_workflow_module.workflow,
         "execute_activity",
         fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        _completed_child_workflow,
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -251,15 +250,16 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
     )
 
     # provider_profile.list calls (3) happen first, then artifact.read for plan,
-    # artifact.read for registry, then the step execution manifest's artifact.create
-    # is recorded before the actual mm.skill.execute dispatch.
+    # then the step execution manifest artifact.create is recorded before
+    # child workflow dispatch.
     assert captured[3][0] == "artifact.read"
     assert captured[3][1]["artifact_ref"] == "art_plan_1"
-    assert captured[4][0] == "artifact.read"
-    assert captured[4][1]["artifact_ref"] == "artifact://registry/1"
-    assert captured[5][0] == "artifact.create"
-    assert captured[6][0] == "mm.skill.execute"
-    assert captured[6][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    assert captured[4][0] == "artifact.create"
+    assert not any(
+        payload.get("artifact_ref") == "artifact://registry/1"
+        for activity_type, payload in captured
+        if activity_type == "artifact.read"
+    )
 
 @pytest.mark.asyncio
 async def test_run_finalizing_stage_writes_dependency_summary_metadata(
@@ -339,7 +339,7 @@ async def test_run_finalizing_stage_writes_dependency_summary_metadata(
     }
 
 @pytest.mark.asyncio
-async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
+async def test_run_execution_stage_rejects_legacy_skill_registry_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -355,32 +355,6 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
         if activity_type == "provider_profile.list":
             return {"profiles": []}
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                                "description": "Run tests",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.tool.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 3},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -438,17 +412,20 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
     monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
 
-    await workflow._run_execution_stage(
-        parameters={"repo": "MoonLadderStudios/MoonMind"},
-        plan_ref="art_plan_1",
-    )
+    with pytest.raises(
+        ValueError,
+        match="unsupported plan node tool.type: 'skill'; expected 'agent_runtime'",
+    ):
+        await workflow._run_execution_stage(
+            parameters={"repo": "MoonLadderStudios/MoonMind"},
+            plan_ref="art_plan_1",
+        )
 
-    # provider_profile.list calls (3) happen first, then artifact.read for plan,
-    # artifact.read for registry, then the step execution manifest's artifact.create
-    # is recorded before the actual mm.tool.execute dispatch.
-    assert captured[5][0] == "artifact.create"
-    assert captured[6][0] == "mm.tool.execute"
-    assert captured[6][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    assert not any(
+        payload.get("artifact_ref") == "artifact://registry/1"
+        for activity_type, payload in captured
+        if activity_type == "artifact.read"
+    )
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_plan(
@@ -726,7 +703,7 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
     assert steps[1]["status"] == "skipped"
 
 @pytest.mark.asyncio
-async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
+async def test_run_execution_stage_rejects_legacy_jira_blocker_skill_plan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -920,25 +897,18 @@ async def test_run_execution_stage_rechecks_jira_blockers_in_dependency_wait(
         _timeout_wait_condition,
     )
 
-    await workflow._run_execution_stage(
-        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "none"},
-        plan_ref="art_plan_1",
-    )
+    with pytest.raises(
+        ValueError,
+        match="unsupported plan node tool.type: 'skill'; expected 'agent_runtime'",
+    ):
+        await workflow._run_execution_stage(
+            parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "none"},
+            plan_ref="art_plan_1",
+        )
 
-    steps = workflow.get_step_ledger()["steps"]
-    assert [call[0] for call in skill_calls] == [
-        "jira.check_blockers",
-        "jira.check_blockers",
-        "repo.run_tests",
-    ]
-    assert skill_calls[1][1] == (
-        "wf-1:run-1:check-blockers:execution:1:execute_jira_blocker_recheck_1"
-    )
-    assert workflow._plan_blocked_message is None
+    assert skill_calls == []
     assert workflow._jira_blocker_wait_active is False
     assert workflow._waiting_reason is None
-    assert steps[0]["status"] == "succeeded"
-    assert steps[1]["status"] == "succeeded"
 
 @pytest.mark.asyncio
 async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
@@ -1154,7 +1124,7 @@ def test_skip_dependency_wait_allows_active_jira_wait_without_issue_keys() -> No
     workflow.validate_skip_dependency_wait()
 
 @pytest.mark.asyncio
-async def test_run_execution_stage_preserves_registry_read_for_unpatched_histories(
+async def test_run_execution_stage_skips_registry_read_for_unpatched_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -1287,7 +1257,7 @@ async def test_run_execution_stage_preserves_registry_read_for_unpatched_histori
         for activity_type, payload in captured
         if activity_type == "artifact.read"
     ]
-    assert artifact_reads == ["art_plan_1", "artifact://registry/empty"]
+    assert artifact_reads == ["art_plan_1"]
 
 def test_build_agent_execution_request_includes_bundle_metadata(
     monkeypatch: pytest.MonkeyPatch,
@@ -1334,32 +1304,6 @@ async def test_run_execution_stage_fail_fast_raises_when_tool_returns_failed_sta
         **_kwargs: object,
     ) -> object:
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                                "description": "Run tests",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.tool.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 1},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -1372,28 +1316,26 @@ async def test_run_execution_stage_fail_fast_raises_when_tool_returns_failed_sta
                         },
                     },
                     "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
-                    "nodes": [
-                        {
-                            "id": "step-1",
-                            "tool": {
-                                "type": "skill",
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                            },
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        }
-                    ],
+                    "nodes": [_agent_runtime_step()],
                     "edges": [],
                 }
             ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
         return {
-            "status": "FAILED",
-            "outputs": {"error": "gemini CLI command failed"},
-            "progress": {"details": "Failed to execute generic LLM handler"},
+            "summary": "Failed to execute generic LLM handler",
+            "failureClass": "gemini CLI command failed",
+            "metadata": {},
+            "output_refs": [],
         }
 
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -1424,41 +1366,14 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
 ) -> None:
     workflow = MoonMindRunWorkflow()
     workflow._owner_id = "owner-1"
-    skill_calls = 0
+    child_calls = 0
 
     async def fake_execute_activity(
         activity_type: str,
         payload: dict[str, object],
         **_kwargs: object,
     ) -> object:
-        nonlocal skill_calls
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                                "description": "Run tests",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.tool.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 1},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -1472,42 +1387,36 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
                     },
                     "policy": {"failure_mode": "CONTINUE", "max_concurrency": 1},
                     "nodes": [
-                        {
-                            "id": "step-1",
-                            "tool": {
-                                "type": "skill",
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                            },
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        },
-                        {
-                            "id": "step-2",
-                            "tool": {
-                                "type": "skill",
-                                "name": "repo.run_tests",
-                                "version": "1.0.0",
-                            },
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        },
+                        _agent_runtime_step("step-1"),
+                        _agent_runtime_step("step-2"),
                     ],
                     "edges": [],
                 }
             ).encode("utf-8")
-        if activity_type == "mm.tool.execute":
-            skill_calls += 1
-            if skill_calls == 1:
-                return {
-                    "status": "FAILED",
-                    "outputs": {"error": "first step failed"},
-                    "progress": {"details": "intentional failure"},
-                }
-            return {"status": "COMPLETED", "outputs": {}}
         return {"status": "COMPLETED", "outputs": {}}
 
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal child_calls
+        child_calls += 1
+        if child_calls == 1:
+            return {
+                "summary": "intentional failure",
+                "failureClass": "first step failed",
+                "metadata": {},
+                "output_refs": [],
+            }
+        return {
+            "summary": "Agent finished",
+            "metadata": {"push_status": "not_requested"},
+            "output_refs": [],
+        }
+
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -1528,7 +1437,7 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
         plan_ref="art_plan_1",
     )
 
-    assert skill_calls == 2
+    assert child_calls == 2
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
@@ -1543,32 +1452,6 @@ async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
         **_kwargs: object,
     ) -> object:
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.publish",
-                                "version": "1.0.0",
-                                "description": "Publish",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.tool.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 1},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -1581,27 +1464,25 @@ async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
                         },
                     },
                     "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
-                    "nodes": [
-                        {
-                            "id": "step-1",
-                            "tool": {
-                                "type": "skill",
-                                "name": "repo.publish",
-                                "version": "1.0.0",
-                            },
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        }
-                    ],
+                    "nodes": [_agent_runtime_step()],
                     "edges": [],
                 }
             ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
         return {
-            "status": "COMPLETED",
-            "outputs": {"stdout_tail": "Applied requested changes."},
+            "summary": "Applied requested changes.",
+            "metadata": {"stdout_tail": "Applied requested changes."},
+            "output_refs": [],
         }
 
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -1639,32 +1520,6 @@ async def test_run_execution_stage_publish_mode_pr_accepts_github_pull_request_u
         **_kwargs: object,
     ) -> object:
         if activity_type == "artifact.read":
-            if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
-                return json.dumps(
-                    {
-                        "skills": [
-                            {
-                                "name": "repo.publish",
-                                "version": "1.0.0",
-                                "description": "Publish",
-                                "inputs": {"schema": {"type": "object"}},
-                                "outputs": {"schema": {"type": "object"}},
-                                "executor": {
-                                    "activity_type": "mm.tool.execute",
-                                    "selector": {"mode": "by_capability"},
-                                },
-                                "requirements": {"capabilities": ["sandbox"]},
-                                "policies": {
-                                    "timeouts": {
-                                        "start_to_close_seconds": 1800,
-                                        "schedule_to_close_seconds": 3600,
-                                    },
-                                    "retries": {"max_attempts": 1},
-                                },
-                            }
-                        ]
-                    }
-                ).encode("utf-8")
             return json.dumps(
                 {
                     "plan_version": "1.0",
@@ -1677,29 +1532,27 @@ async def test_run_execution_stage_publish_mode_pr_accepts_github_pull_request_u
                         },
                     },
                     "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
-                    "nodes": [
-                        {
-                            "id": "step-1",
-                            "tool": {
-                                "type": "skill",
-                                "name": "repo.publish",
-                                "version": "1.0.0",
-                            },
-                            "inputs": {"repo_ref": "git:org/repo#branch"},
-                            "options": {},
-                        }
-                    ],
+                    "nodes": [_agent_runtime_step()],
                     "edges": [],
                 }
             ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
         return {
-            "status": "COMPLETED",
-            "outputs": {
+            "summary": "Opened PR: https://github.com/org/repo/pull/123",
+            "metadata": {
                 "stdout_tail": "Opened PR: https://github.com/org/repo/pull/123"
             },
+            "output_refs": [],
         }
 
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
     monkeypatch.setattr(
         run_workflow_module.workflow,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -916,7 +916,7 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     events: list[str] = []
-    route = type("Route", (), {"activity_type": "mm.skill.execute"})()
+    agent_request = type("AgentRequest", (), {"agent_id": "agent-1"})()
     blocked_result = {
         "status": "COMPLETED",
         "outputs": {
@@ -944,16 +944,15 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
         events.append("pause-boundary")
         self._paused = False
 
-    async def fake_execute_activity(
-        activity_type: str,
-        payload: Any,
-        **_kwargs: Any,
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        request: Any,
+        **kwargs: Any,
     ) -> Any:
-        events.append(f"activity:{activity_type}")
-        assert events[-2:] == ["pause-boundary", "activity:mm.skill.execute"]
-        assert _normalize_payload(payload)["idempotency_key"].endswith(
-            "_jira_blocker_recheck_1"
-        )
+        events.append(f"child:{workflow_type}")
+        assert events[-2:] == ["pause-boundary", "child:MoonMind.AgentRun"]
+        assert request is agent_request
+        assert kwargs["id"].endswith(":agent:check-blockers:jira-blocker-recheck1")
         return continue_result
 
     monkeypatch.setattr(
@@ -983,27 +982,26 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,
-        "execute_activity",
-        fake_execute_activity,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: type("WorkflowInfo", (), {"workflow_id": "wf-1"})(),
     )
     monkeypatch.setattr(
         MoonMindRunWorkflow,
         "_wait_if_paused_at_safe_boundary",
         fake_pause_boundary,
     )
-    monkeypatch.setattr(
-        MoonMindRunWorkflow,
-        "_execute_kwargs_for_route",
-        lambda self, route: {},
-    )
 
     result, skipped = await workflow._wait_for_jira_blocker_resolution(
         execution_result=blocked_result,
-        route=route,
-        execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+        agent_request=agent_request,
         node_id="check-blockers",
         tool_name="jira.check_blockers",
-        tool_type="skill",
+        tool_type="agent_runtime",
         failure_mode="FAIL_FAST",
     )
 
@@ -1012,7 +1010,7 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
     assert events == [
         "pause-observed",
         "pause-boundary",
-        "activity:mm.skill.execute",
+        "child:MoonMind.AgentRun",
     ]
     assert workflow._jira_blocker_wait_active is False
     assert workflow._jira_blocker_wait_started_at is None
@@ -1025,7 +1023,7 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
-    route = type("Route", (), {"activity_type": "mm.skill.execute"})()
+    agent_request = type("AgentRequest", (), {"agent_id": "agent-1"})()
     blocked_result = {
         "status": "COMPLETED",
         "outputs": {
@@ -1035,11 +1033,7 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
         },
     }
 
-    async def fake_execute_activity(
-        _activity_type: str,
-        _payload: Any,
-        **_kwargs: Any,
-    ) -> Any:
+    async def fake_execute_child_workflow(*_args: Any, **_kwargs: Any) -> Any:
         raise RuntimeError("worker unavailable")
 
     async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
@@ -1072,27 +1066,26 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,
-        "execute_activity",
-        fake_execute_activity,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: type("WorkflowInfo", (), {"workflow_id": "wf-1"})(),
     )
     monkeypatch.setattr(
         MoonMindRunWorkflow,
         "_wait_if_paused_at_safe_boundary",
         fake_noop_async,
     )
-    monkeypatch.setattr(
-        MoonMindRunWorkflow,
-        "_execute_kwargs_for_route",
-        lambda self, route: {},
-    )
 
     result, skipped = await workflow._wait_for_jira_blocker_resolution(
         execution_result=blocked_result,
-        route=route,
-        execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+        agent_request=agent_request,
         node_id="check-blockers",
         tool_name="jira.check_blockers",
-        tool_type="skill",
+        tool_type="agent_runtime",
         failure_mode="CONTINUE",
     )
 
@@ -1106,11 +1099,10 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
     with pytest.raises(RuntimeError, match="worker unavailable"):
         await workflow._wait_for_jira_blocker_resolution(
             execution_result=blocked_result,
-            route=route,
-            execute_payload={"idempotency_key": "wf-1_check-blockers_execute"},
+            agent_request=agent_request,
             node_id="check-blockers",
             tool_name="jira.check_blockers",
-            tool_type="skill",
+            tool_type="agent_runtime",
             failure_mode="FAIL_FAST",
         )
 
@@ -2075,11 +2067,10 @@ async def test_skipped_jira_blocker_wait_restores_executing_state(
                 "summary": "Blocked by upstream Jira work.",
             },
         },
-        route=type("Route", (), {"activity_type": "mm.skill.execute"})(),
-        execute_payload={},
+        agent_request=type("AgentRequest", (), {"agent_id": "agent-1"})(),
         node_id="check-blockers",
         tool_name=run_workflow_module.JIRA_CHECK_BLOCKERS_TOOL_NAME,
-        tool_type="skill",
+        tool_type="agent_runtime",
         failure_mode="FAIL_FAST",
     )
 

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -980,6 +980,9 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
         "wait_condition",
         fake_wait_condition,
     )
+    def fake_workflow_info() -> Any:
+        return type("WorkflowInfo", (), {"workflow_id": "wf-1"})()
+
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_child_workflow",
@@ -988,7 +991,7 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "info",
-        lambda: type("WorkflowInfo", (), {"workflow_id": "wf-1"})(),
+        fake_workflow_info,
     )
     monkeypatch.setattr(
         MoonMindRunWorkflow,
@@ -1064,6 +1067,9 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
         "wait_condition",
         _timeout_wait_condition,
     )
+    def fake_workflow_info() -> Any:
+        return type("WorkflowInfo", (), {"workflow_id": "wf-1"})()
+
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "execute_child_workflow",
@@ -1072,7 +1078,7 @@ async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "info",
-        lambda: type("WorkflowInfo", (), {"workflow_id": "wf-1"})(),
+        fake_workflow_info,
     )
     monkeypatch.setattr(
         MoonMindRunWorkflow,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -953,7 +953,12 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
         assert events[-2:] == ["pause-boundary", "child:MoonMind.AgentRun"]
         assert request is agent_request
         assert kwargs["id"].endswith(":agent:check-blockers:jira-blocker-recheck1")
-        return continue_result
+        return {
+            "metadata": {
+                "decision": "continue",
+                "blockingIssues": [],
+            }
+        }
 
     monkeypatch.setattr(
         run_workflow_module.workflow,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -896,7 +896,8 @@ def test_runtime_planner_materializes_tool_steps_without_source_lookup(
         snapshot=snapshot,
     )
 
-    assert plan["nodes"][0]["tool"]["name"] == "jira.get_issue"
+    assert plan["nodes"][0]["tool"]["name"] == "codex_cli"
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     if source is None:
         assert "source" not in plan["nodes"][0]["inputs"]
     else:
@@ -1010,7 +1011,7 @@ def test_runtime_planner_routes_jira_issue_creator_as_agent_skill_step():
     jira = plan["nodes"][1]
 
     assert breakdown["tool"]["type"] == "agent_runtime"
-    assert breakdown["tool"]["name"] == "moonspec-breakdown"
+    assert breakdown["tool"]["name"] == "codex_cli"
     assert breakdown["inputs"]["selectedSkill"] == "moonspec-breakdown"
     assert "Do not create or modify any `spec.md`" in breakdown["inputs"]["instructions"]
     assert breakdown["inputs"]["storyBreakdownPath"].startswith(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -347,9 +347,9 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "jira.get_issue",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     assert plan["nodes"][0]["inputs"]["type"] == "tool"
@@ -468,9 +468,9 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
     ]
     assert plan["edges"] == [{"from": "fetch-issue", "to": "implement-story"}]
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "jira.get_issue",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][1]["tool"] == {
         "type": "agent_runtime",
@@ -528,11 +528,14 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
         {
             "id": "update-moonmind-deployment",
             "tool": {
-                "type": "skill",
-                "name": "deployment.update_compose_stack",
+                "type": "agent_runtime",
+                "name": "codex_cli",
                 "version": "1.0.0",
             },
             "inputs": {
+                "instructions": "Execute skill 'deployment.update_compose_stack'",
+                "runtime": {"mode": "codex_cli"},
+                "selectedSkill": "deployment.update_compose_stack",
                 "stack": "moonmind",
                 "image": {
                     "repository": "ghcr.io/moonladderstudios/moonmind",
@@ -630,9 +633,9 @@ def test_runtime_planner_maps_deployment_update_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "deployment.update_compose_stack",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == (
         "deployment.update_compose_stack"
@@ -1023,7 +1026,7 @@ def test_runtime_planner_routes_jira_issue_creator_as_agent_skill_step():
 
     assert jira["tool"] == {
         "type": "agent_runtime",
-        "name": "jira-issue-creator",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert jira["inputs"]["selectedSkill"] == "jira-issue-creator"
@@ -1097,8 +1100,8 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     )
     assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
     assert jira["tool"] == {
-        "type": "skill",
-        "name": "story.create_jira_issues",
+        "type": "agent_runtime",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert jira["inputs"]["selectedSkill"] == "story.create_jira_issues"
@@ -1252,8 +1255,8 @@ def test_runtime_planner_preserves_authored_branch_for_jira_story_import():
     node = plan["nodes"][0]
 
     assert node["tool"] == {
-        "type": "skill",
-        "name": "story.create_jira_issues",
+        "type": "agent_runtime",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert node["inputs"]["branch"] == "feature/authored-breakdown"
@@ -1333,7 +1336,7 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     orchestrate = plan["nodes"][3]
     assert reconcile["tool"] == {
         "type": "agent_runtime",
-        "name": "story-reconcile-implementation",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert reconcile["inputs"]["selectedSkill"] == "story-reconcile-implementation"
@@ -1346,8 +1349,8 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
         == breakdown["inputs"]["storyBreakdownPath"]
     )
     assert orchestrate["tool"] == {
-        "type": "skill",
-        "name": "story.create_jira_orchestrate_tasks",
+        "type": "agent_runtime",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert orchestrate["inputs"]["selectedSkill"] == "story.create_jira_orchestrate_tasks"
@@ -1426,8 +1429,8 @@ def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
     implement = plan["nodes"][3]
 
     assert implement["tool"] == {
-        "type": "skill",
-        "name": "story.create_jira_implement_tasks",
+        "type": "agent_runtime",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert implement["inputs"]["selectedSkill"] == "story.create_jira_implement_tasks"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -114,15 +114,26 @@ async def test_run_execution_stage_skips_integration_after_merge_gate_cancellati
                     {
                         "id": "step-1",
                         "tool": {
-                            "type": "skill",
-                            "name": "repo.noop",
+                            "type": "agent_runtime",
+                            "name": "jules",
                             "version": "1.0",
                         },
-                        "inputs": {},
+                        "inputs": {"instructions": "Do nothing."},
                     }
                 ]
             )
         return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        return {
+            "summary": "No-op completed",
+            "metadata": {"push_status": "not_requested"},
+            "output_refs": [],
+        }
 
     async def fake_merge_gate(
         *,
@@ -143,6 +154,11 @@ async def test_run_execution_stage_skips_integration_after_merge_gate_cancellati
         run_workflow_module.workflow,
         "execute_activity",
         fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
     )
     monkeypatch.setattr(mock_run_workflow, "_maybe_start_merge_gate", fake_merge_gate)
     monkeypatch.setattr(
@@ -388,7 +404,7 @@ async def test_run_execution_stage_bundles_consecutive_jules_nodes(
     assert request.parameters["metadata"]["moonmind"]["bundleStrategy"] == "one_shot_jules"
 
 @pytest.mark.asyncio
-async def test_run_execution_stage_routes_dood_skill_tool_to_agent_runtime_activity(
+async def test_run_execution_stage_rejects_dood_skill_tool_in_run_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -461,7 +477,7 @@ async def test_run_execution_stage_routes_dood_skill_tool_to_agent_runtime_activ
     )
 
     async def fail_if_child_workflow_starts(*_args: Any, **_kwargs: Any) -> Any:
-        raise AssertionError("DooD skill tools must not start MoonMind.AgentRun")
+        raise AssertionError("legacy DooD skill tools must be rejected before child dispatch")
 
     monkeypatch.setattr(
         run_workflow_module.workflow,
@@ -506,19 +522,14 @@ async def test_run_execution_stage_routes_dood_skill_tool_to_agent_runtime_activ
         ),
     )
 
-    await workflow._run_execution_stage(parameters={}, plan_ref="art:sha256:plan")
+    with pytest.raises(
+        ValueError,
+        match="unsupported plan node tool.type: 'skill'; expected 'agent_runtime'",
+    ):
+        await workflow._run_execution_stage(parameters={}, plan_ref="art:sha256:plan")
 
     tool_calls = [call for call in captured if call[0] == "mm.tool.execute"]
-    assert len(tool_calls) == 1
-    payload = tool_calls[0][1]
-    assert payload["invocation_payload"]["tool"] == {
-        "type": "skill",
-        "name": "container.run_workload",
-        "version": "1.0",
-    }
-    assert payload["context"]["workflow_id"] == "wf-1"
-    assert payload["context"]["node_id"] == "workload-step"
-    assert tool_calls[0][2]["task_queue"] == "mm.activity.agent_runtime"
+    assert tool_calls == []
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_skips_integration_after_merge_automation_cancels(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -48,12 +48,12 @@ def _ordered_nodes() -> list[dict]:
     return [
         {
             "id": "prepare",
-            "tool": {"type": "skill", "name": "repo.prepare", "version": "1"},
+            "tool": {"type": "agent_runtime", "name": "codex_cli", "version": "1"},
             "inputs": {"title": "Prepare workspace"},
         },
         {
             "id": "run-tests",
-            "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+            "tool": {"type": "agent_runtime", "name": "codex_cli", "version": "1"},
             "inputs": {"title": "Run tests"},
         },
     ]
@@ -87,11 +87,11 @@ def _approval_policy_plan_payload() -> dict[str, Any]:
             {
                 "id": "apply-patch",
                 "tool": {
-                    "type": "skill",
-                    "name": "repo.apply_patch",
+                    "type": "agent_runtime",
+                    "name": "codex_cli",
                     "version": "1.0.0",
                 },
-                "inputs": {"instruction": "Apply the patch"},
+                "inputs": {"instructions": "Apply the patch"},
                 "options": {},
             }
         ],
@@ -1299,12 +1299,6 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
                     {"upload_url": "unused"},
                 )
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
-        if activity_type == "mm.skill.execute":
-            return {
-                "status": "COMPLETED",
-                "summary": "Patch applied cleanly",
-                "outputs": {"outputSummaryRef": "art_summary_1"},
-            }
         if activity_type == "step.review":
             step = workflow.get_step_ledger()["steps"][0]
             review_snapshots.append(step)
@@ -1315,6 +1309,17 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
                 "issues": [],
             }
         raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        return {
+            "summary": "Patch applied cleanly",
+            "metadata": {"outputSummaryRef": "art_summary_1"},
+            "output_refs": [],
+        }
 
     async def fake_execute_typed_activity(
         activity_type: str,
@@ -1354,6 +1359,11 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
         run_module.workflow,
         "execute_activity",
         fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
     )
     monkeypatch.setattr(
         run_module,
@@ -1455,20 +1465,24 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
                     {"upload_url": "unused"},
                 )
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
-        if activity_type == "mm.skill.execute":
-            invocation_payload = payload["invocation_payload"]
-            skill_inputs.append(dict(invocation_payload["inputs"]))
-            return {
-                "status": "COMPLETED",
-                "summary": "Patch applied cleanly",
-                "outputs": {
-                    "outputSummaryRef": f"art_summary_{len(skill_inputs)}",
-                    "stateCheckpointRef": f"art_checkpoint_{len(skill_inputs)}",
-                },
-            }
         if activity_type == "step.review":
             return next(review_verdicts)
         raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        request: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        skill_inputs.append({"instructions": request.instruction_ref})
+        return {
+            "summary": "Patch applied cleanly",
+            "metadata": {
+                "outputSummaryRef": f"art_summary_{len(skill_inputs)}",
+                "stateCheckpointRef": f"art_checkpoint_{len(skill_inputs)}",
+            },
+            "output_refs": [],
+        }
 
     async def fake_execute_typed_activity(
         activity_type: str,
@@ -1510,6 +1524,11 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
         fake_execute_activity,
     )
     monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
         run_module,
         "execute_typed_activity",
         fake_execute_typed_activity,
@@ -1522,18 +1541,8 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     )
 
     assert len(skill_inputs) == 2
-    assert "_review_feedback" not in skill_inputs[0]
-    assert skill_inputs[1]["_review_feedback"] == {
-        "attempt": 1,
-        "feedback": "Tests still fail because the import is missing.",
-        "issues": [
-            {
-                "severity": "error",
-                "description": "Missing import",
-                "evidence": "stderr tail",
-            }
-        ],
-    }
+    assert "Tests still fail because the import is missing." not in skill_inputs[0]["instructions"]
+    assert "Tests still fail because the import is missing." in skill_inputs[1]["instructions"]
     step = workflow.get_step_ledger()["steps"][0]
     assert step["executionOrdinal"] == 2
     assert step["status"] == "succeeded"
@@ -1574,14 +1583,14 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
     plan_payload["nodes"] = [
         {
             "id": "implement",
-            "tool": {"type": "skill", "name": "repo.apply_patch", "version": "1.0.0"},
-            "inputs": {"instruction": "Apply patch"},
+            "tool": {"type": "agent_runtime", "name": "repo.apply_patch", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Apply patch"},
             "options": {},
         },
         {
             "id": "publish",
-            "tool": {"type": "skill", "name": "repo.publish", "version": "1.0.0"},
-            "inputs": {"instruction": "Publish"},
+            "tool": {"type": "agent_runtime", "name": "repo.publish", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Publish"},
             "options": {},
         },
     ]
@@ -1610,14 +1619,6 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
             return {"profiles": []}
         if activity_type == "artifact.create":
             return ({"artifact_id": next(artifact_ids)}, {"upload_url": "unused"})
-        if activity_type == "mm.skill.execute":
-            invocation_payload = payload["invocation_payload"]
-            invoked_skills.append(invocation_payload["skill"]["name"])
-            return {
-                "status": "COMPLETED",
-                "summary": "Patch applied",
-                "outputs": {"outputSummaryRef": "art_summary_1"},
-            }
         if activity_type == "step.review":
             return {
                 "verdict": "ADDITIONAL_WORK_NEEDED",
@@ -1628,6 +1629,18 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
                 "recommendedNextAction": "needs_human",
             }
         raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        invoked_skills.append(str(kwargs["id"]).rsplit(":agent:", 1)[1])
+        return {
+            "summary": "Patch applied",
+            "metadata": {"outputSummaryRef": "art_summary_1"},
+            "output_refs": [],
+        }
 
     async def fake_execute_typed_activity(
         activity_type: str,
@@ -1655,6 +1668,11 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
         fake_execute_activity,
     )
     monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
         run_module,
         "execute_typed_activity",
         fake_execute_typed_activity,
@@ -1666,7 +1684,7 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
         plan_ref="art_plan_1",
     )
 
-    assert invoked_skills == ["repo.apply_patch"]
+    assert invoked_skills == ["implement"]
     step = workflow.get_step_ledger()["steps"][0]
     assert step["status"] == "failed"
     assert workflow._publish_status == "not_required"
@@ -1709,14 +1727,14 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
     plan_payload["nodes"] = [
         {
             "id": "implement",
-            "tool": {"type": "skill", "name": "repo.apply_patch", "version": "1.0.0"},
-            "inputs": {"instruction": "Apply patch"},
+            "tool": {"type": "agent_runtime", "name": "repo.apply_patch", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Apply patch"},
             "options": {},
         },
         {
             "id": "publish",
-            "tool": {"type": "skill", "name": "repo.publish", "version": "1.0.0"},
-            "inputs": {"instruction": "Publish independent report"},
+            "tool": {"type": "agent_runtime", "name": "repo.publish", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Publish independent report"},
             "options": {},
         },
     ]
@@ -1747,14 +1765,6 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
             return {"profiles": []}
         if activity_type == "artifact.create":
             return ({"artifact_id": next(artifact_ids)}, {"upload_url": "unused"})
-        if activity_type == "mm.skill.execute":
-            invocation_payload = payload["invocation_payload"]
-            invoked_skills.append(invocation_payload["skill"]["name"])
-            return {
-                "status": "COMPLETED",
-                "summary": "Step complete",
-                "outputs": {"outputSummaryRef": "art_summary_1"},
-            }
         if activity_type == "step.review":
             return {
                 "verdict": "ADDITIONAL_WORK_NEEDED",
@@ -1765,6 +1775,18 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
                 "recommendedNextAction": "needs_human",
             }
         raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        invoked_skills.append(str(kwargs["id"]).rsplit(":agent:", 1)[1])
+        return {
+            "summary": "Step complete",
+            "metadata": {"outputSummaryRef": "art_summary_1"},
+            "output_refs": [],
+        }
 
     async def fake_execute_typed_activity(
         activity_type: str,
@@ -1792,6 +1814,11 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
         fake_execute_activity,
     )
     monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
         run_module,
         "execute_typed_activity",
         fake_execute_typed_activity,
@@ -1803,7 +1830,7 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
         plan_ref="art_plan_1",
     )
 
-    assert invoked_skills == ["repo.apply_patch", "repo.publish"]
+    assert invoked_skills == ["implement", "publish"]
     ledger = workflow.get_step_ledger()["steps"]
     assert ledger[0]["status"] == "failed"
     assert ledger[1]["status"] == "succeeded"


### PR DESCRIPTION
Jira issue: MM-797

## Summary
- Marked the completed Housekeeping cleanup items H.2/H.3/H.4 in `docs/MoonMindRoadmap.md`, including the summary table.
- Removed the legacy `tool.type == "skill"` dispatch branch from `MoonMind.Run`; legacy skill-shaped plan nodes now fail fast and current Run execution remains on `agent_runtime` nodes.
- Updated Run dispatch docs and workflow/unit boundary tests to cover agent-runtime execution and legacy skill rejection.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` -> passed (`5704 passed, 6 skipped, 1 xpassed`; frontend `409 passed, 234 skipped`).
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` -> passed (`132 passed`).
- `timeout 180 python -m pytest tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py::TestAgentRuntimeDispatch::test_legacy_skill_tool_type_is_rejected -q --tb=short` -> timed out with no output in this managed workspace.

## Remaining risks
- The focused non-`integration_ci` Temporal time-skipping integration test timed out locally, matching the known slow behavior of this class of tests in the repo instructions. Unit coverage for the changed Run dispatch paths passes.
