### PR TITLE
MM-799 legacy skill dispatch cleanup

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -280,7 +280,7 @@ These are technical debt items that don't map to README claims but improve code 
 ### Remaining tasks
 - [x] **H.1** Complete legacy system removal — Code removal is complete (migration `c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining documentation updates are tracked in `docs/MoonMindRoadmap.md`.
 - [ ] **H.2** Spec deduplication — Merge duplicate specs identified in `docs/MoonMindRoadmap.md`: Worker Pause (038/040), Claude gating (044/046), Manifest Phase 0 (032/034), Jules events (048 stub → delete), Task Presets (026/028)
-- [ ] **H.3** Legacy skill dispatch cleanup — Remove dead `tool.type == "skill"` branch in `run.py`; all current plan generators emit `agent_runtime` nodes. See `docs/MoonMindRoadmap.md`.
+- [x] **H.3** Legacy skill dispatch cleanup — Removed the dead `tool.type == "skill"` branch in `run.py`; current plan generators emit `agent_runtime` nodes for agent skill execution.
 - [ ] **H.4** Delete legacy docs identified in `docs/LegacyDocsReview.md` — 6 docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.)
 
 ---
@@ -302,7 +302,7 @@ The milestones below are ordered by **impact on delivering the README promise** 
 | 🟡 P2 | **8 — Universal Integration (MCP)** | 🔧 Partial | 4 items |
 | 🟢 P3 | **10 — Vendor Portability & Model Flexibility** | 🔧 Partial | 4 items |
 | 🟢 P3 | **1 — Managed Agent Runtimes** | ✅ Shipped | 2 items |
-| 🟢 P3 | **H — Housekeeping / Cleanup** | 🔧 Partial | 3 items |
+| 🟢 P3 | **H — Housekeeping / Cleanup** | 🔧 Partial | 2 items |
 
 ---
 
@@ -315,4 +315,4 @@ The milestones below are ordered by **impact on delivering the README promise** 
 | `OrchestratorRemovalPlan.md` | **Deleted** | Superseded by spec 087, in-repo removal work, and `016-SingleSubstrateMigration.md`. |
 | `RagDocUpdates.md` | **Delete** | Marked "Status: Complete". Spec merge plan fully executed (spec 088 shipped). |
 | `SpecMergeReview.md` | **Keep until H.2 complete** | Actionable merge candidates not yet resolved. Tracked as H.2 in Housekeeping. |
-| `skill-system-alignment.md` | **Keep until H.3 complete** | Legacy skill branch still present in `run.py`. Tracked as H.3 in Housekeeping. |
+| `skill-system-alignment.md` | **Delete** | H.3 shipped; the legacy `tool.type == "skill"` branch has been removed from `run.py`. |

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1001,14 +1001,13 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
 def _selected_step_tool_type(step_entry: Mapping[str, Any], tool_name: str) -> str:
-    if _selected_step_type(step_entry) == "tool":
-        return "skill"
-    if tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS:
-        return "skill"
     return "agent_runtime"
 
 def _jira_agent_skill_selected(tool_name: str) -> bool:
     return tool_name.lower() in _JIRA_AGENT_SKILLS
+
+def _jira_story_output_skill_selected(tool_name: str) -> bool:
+    return tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
 
 def _task_uses_only_jira_agent_skill(
     *, selected_skill_name: str, raw_steps: Any
@@ -1413,18 +1412,26 @@ def _build_runtime_planner():
                 ) or _coerce_mapping(plan_entry.get("skill"))
                 if not tool_payload:
                     raise RuntimeError("task.plan entries require a tool object")
-                tool_type = str(
+                authored_tool_type = str(
                     tool_payload.get("type") or tool_payload.get("kind") or "skill"
-                ).strip() or "skill"
+                ).strip().lower() or "skill"
                 tool_name = str(
                     tool_payload.get("name") or tool_payload.get("id") or ""
                 ).strip()
                 if not tool_name:
                     raise RuntimeError("task.plan tool name is required")
-                tool_version = str(
-                    tool_payload.get("version")
-                    or ("1.0.0" if tool_type == "skill" else "1.0")
-                ).strip()
+                if authored_tool_type == "agent_runtime":
+                    node_tool_type = "agent_runtime"
+                    node_tool_name = tool_name
+                    tool_version = str(tool_payload.get("version") or "1.0").strip()
+                elif authored_tool_type == "skill":
+                    node_tool_type = "agent_runtime"
+                    node_tool_name = runtime_mode
+                    tool_version = "1.0"
+                else:
+                    raise RuntimeError(
+                        "task.plan tool.type must be 'skill' or 'agent_runtime'"
+                    )
                 if not tool_version:
                     raise RuntimeError("task.plan tool version is required")
                 node_inputs = _coerce_mapping(plan_entry.get("inputs"))
@@ -1432,6 +1439,9 @@ def _build_runtime_planner():
                     node_inputs = _coerce_mapping(
                         tool_payload.get("inputs") or tool_payload.get("args")
                     )
+                if authored_tool_type == "skill":
+                    node_inputs = dict(node_inputs)
+                    node_inputs.setdefault("selectedSkill", tool_name)
                 node_id = str(plan_entry.get("id") or f"node-{idx}").strip()
                 if not node_id:
                     node_id = f"node-{idx}"
@@ -1441,8 +1451,8 @@ def _build_runtime_planner():
                 node: dict[str, Any] = {
                     "id": node_id,
                     "tool": {
-                        "type": tool_type,
-                        "name": tool_name,
+                        "type": node_tool_type,
+                        "name": node_tool_name,
                         "version": tool_version,
                     },
                     "inputs": dict(node_inputs),
@@ -1744,19 +1754,11 @@ def _build_runtime_planner():
                 str(node_inputs.get("instructions") or ""),
                 selected_skill=selected_skill_name,
             )
-            node_tool_type = (
-                "skill"
-                if selected_skill_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
-                else "agent_runtime"
-            )
-            node_tool_name = (
-                selected_skill_name if node_tool_type == "skill" else runtime_mode
-            )
             nodes.append({
                 "id": node_id,
                 "tool": {
-                    "type": node_tool_type,
-                    "name": node_tool_name,
+                    "type": "agent_runtime",
+                    "name": runtime_mode,
                     "version": "1.0",
                 },
                 "inputs": node_inputs,
@@ -1780,6 +1782,9 @@ def _build_runtime_planner():
                     if str(node.get("tool", {}).get("type") or "").strip().lower()
                     == "agent_runtime"
                     and not _jira_agent_skill_selected(_plan_node_selected_skill(node))
+                    and not _jira_story_output_skill_selected(
+                        _plan_node_selected_skill(node)
+                    )
                 ),
                 nodes[-1],
             )
@@ -1790,6 +1795,7 @@ def _build_runtime_planner():
             if (
                 publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
                 and not _jira_agent_skill_selected(publish_selected_skill)
+                and not _jira_story_output_skill_selected(publish_selected_skill)
                 and not _is_jira_pr_handoff_node(
                     publish_node,
                     task_payload=task_payload,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -76,6 +76,7 @@ with workflow.unsafe.imports_passed_through():
     )
 
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
+from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot, parse_tool_registry
 from moonmind.workflows.skills.approval_policy import (
     ReviewRequest,
     build_feedback_input,
@@ -3653,7 +3654,7 @@ class MoonMindRunWorkflow:
         skill_payload = self._mapping_value(task_payload, "skill") or {}
         tool_type = str(
             tool_payload.get("type") or tool_payload.get("kind") or ""
-        ).strip()
+        ).strip().lower()
         if tool_type in {"", "skill"}:
             tool_name = (
                 self._coerce_text(tool_payload.get("name"), max_chars=160)
@@ -3782,10 +3783,38 @@ class MoonMindRunWorkflow:
             error_message="plan_ref must resolve to a JSON object",
         )
         plan_definition = parse_plan_definition(plan_dict)
+        registry_snapshot: ToolRegistrySnapshot | None = None
+
+        async def load_registry_snapshot() -> ToolRegistrySnapshot:
+            nonlocal registry_snapshot
+            if registry_snapshot is not None:
+                return registry_snapshot
+            registry_ref = str(plan_definition.metadata.registry_snapshot.artifact_ref)
+            registry_payload = await execute_typed_activity(
+                "artifact.read",
+                ArtifactReadInput(
+                    principal=self._principal(),
+                    artifact_ref=registry_ref,
+                ),
+                **self._execute_kwargs_for_route(artifact_read_route),
+            )
+            registry_dict = self._decode_json_payload(
+                registry_payload,
+                error_message="registry snapshot must resolve to a JSON object",
+            )
+            registry_snapshot = ToolRegistrySnapshot(
+                digest=str(plan_definition.metadata.registry_snapshot.digest),
+                artifact_ref=registry_ref,
+                skills=parse_tool_registry(registry_dict),
+            )
+            return registry_snapshot
+
         ordered_nodes = self._ordered_plan_node_payloads(
             nodes=plan_definition.nodes,
             edges=plan_definition.edges,
         )
+        if not workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH):
+            await load_registry_snapshot()
         if workflow.patched("jules-bundling-v1"):
             ordered_nodes = await self._bundle_ordered_nodes_for_execution(
                 ordered_nodes
@@ -3829,7 +3858,7 @@ class MoonMindRunWorkflow:
             if self._cancel_requested:
                 return
 
-            tool = node.get("tool")
+            tool = self._plan_node_tool_mapping(node)
             if not isinstance(tool, Mapping):
                 raise ValueError("plan node tool definition is required")
 
@@ -3855,6 +3884,8 @@ class MoonMindRunWorkflow:
             ):
                 continue
             original_node_inputs = dict(node.get("inputs", {}))
+            if tool_type == "skill":
+                await load_registry_snapshot()
             approval_policy = plan_definition.policy.approval_policy
             review_gate_active = self._review_gate_active(
                 approval_policy=approval_policy,
@@ -3929,6 +3960,8 @@ class MoonMindRunWorkflow:
 
                 system_retries = 0
                 while system_retries <= 3:
+                    route = None
+                    execute_payload = None
                     await self._wait_if_paused_at_safe_boundary()
                     if self._cancel_requested:
                         return
@@ -4090,10 +4123,54 @@ class MoonMindRunWorkflow:
                             result_status = "FAILED"
                             break
 
+                    elif tool_type == "skill":
+                        snapshot = await load_registry_snapshot()
+                        definition = snapshot.get_skill(
+                            name=tool_name,
+                            version=tool_version,
+                        )
+                        route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(definition)
+                        execute_payload = {
+                            "registry_snapshot_ref": snapshot.artifact_ref,
+                            "invocation_payload": {
+                                "id": node_id,
+                                "tool": {
+                                    "type": tool_type,
+                                    "name": tool_name,
+                                    "version": tool_version,
+                                },
+                                "skill": {
+                                    "name": tool_name,
+                                    "version": tool_version,
+                                },
+                                "inputs": node_inputs,
+                                "options": node.get("options") or {},
+                            },
+                            "context": {
+                                "namespace": workflow.info().namespace,
+                                "workflow_id": workflow.info().workflow_id,
+                                "run_id": workflow.info().run_id,
+                                "node_id": node_id,
+                            },
+                            "idempotency_key": step_execution_operation_idempotency_key(
+                                workflow_id=workflow.info().workflow_id,
+                                run_id=workflow.info().run_id,
+                                logical_step_id=node_id,
+                                execution_ordinal=current_step_execution,
+                                operation="execute",
+                            ),
+                        }
+                        execution_result = await workflow.execute_activity(
+                            route.activity_type,
+                            execute_payload,
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            **self._execute_kwargs_for_route(route),
+                        )
+
                     else:
                         raise ValueError(
                             f"unsupported plan node tool.type: '{tool_type}'; "
-                            "expected 'agent_runtime'"
+                            "expected 'agent_runtime' or 'skill'"
                         )
 
                     result_status = self._activity_result_status(execution_result)
@@ -4115,6 +4192,7 @@ class MoonMindRunWorkflow:
                             execution_result,
                             tool_type=tool_type,
                             tool_name=tool_name,
+                            selected_skill=node_inputs.get("selectedSkill"),
                         )
                     ):
                         execution_result, blocked_outcome_wait_skipped = (
@@ -4125,6 +4203,11 @@ class MoonMindRunWorkflow:
                                 node_id=node_id,
                                 tool_name=tool_name,
                                 tool_type=tool_type,
+                                selected_skill=node_inputs.get("selectedSkill"),
+                                node=node,
+                                node_inputs=node_inputs,
+                                task_skills=task_skills,
+                                workflow_parameters=parameters,
                                 failure_mode=failure_mode,
                             )
                         )
@@ -5016,8 +5099,20 @@ class MoonMindRunWorkflow:
         *,
         tool_type: str,
         tool_name: str,
+        selected_skill: Any = None,
     ) -> bool:
-        if tool_type != "skill" or tool_name != JIRA_CHECK_BLOCKERS_TOOL_NAME:
+        normalized_tool_type = str(tool_type or "").strip().lower()
+        normalized_tool_name = str(tool_name or "").strip()
+        normalized_selected_skill = str(selected_skill or "").strip()
+        if normalized_tool_type == "skill":
+            is_check_blockers = normalized_tool_name == JIRA_CHECK_BLOCKERS_TOOL_NAME
+        elif normalized_tool_type == "agent_runtime":
+            is_check_blockers = (
+                normalized_selected_skill == JIRA_CHECK_BLOCKERS_TOOL_NAME
+            )
+        else:
+            is_check_blockers = False
+        if not is_check_blockers:
             return False
         outputs = self._get_from_result(execution_result, "outputs")
         if not isinstance(outputs, Mapping):
@@ -5091,16 +5186,96 @@ class MoonMindRunWorkflow:
             self._waiting_reason = None
         self._attention_required = False
 
+    async def _reexecute_jira_blocker_agent_runtime(
+        self,
+        *,
+        node: Mapping[str, Any],
+        node_inputs: Mapping[str, Any],
+        node_id: str,
+        tool_name: str,
+        task_skills: Any,
+        workflow_parameters: Mapping[str, Any],
+        recheck_count: int,
+        failure_mode: str,
+    ) -> Any:
+        try:
+            resolved_skillset_ref = await self._resolve_agent_node_skillset_ref(
+                task_skills=task_skills,
+                node_skills=node.get("skills"),
+                node_inputs=node_inputs,
+                node_id=node_id,
+                existing_skillset_ref=self._existing_agent_skillset_ref(
+                    parameters=workflow_parameters,
+                    node=node,
+                    node_inputs=node_inputs,
+                ),
+            )
+            request = self._build_agent_execution_request(
+                node_inputs=dict(node_inputs),
+                node_id=node_id,
+                tool_name=tool_name,
+                resolved_skillset_ref=resolved_skillset_ref,
+                workflow_parameters=workflow_parameters,
+                step_execution=self._step_execution_for(node_id) or 1,
+                attempt_reason="policy_revalidation",
+            )
+            child_workflow_id = (
+                f"{workflow.info().workflow_id}:agent:{node_id}:"
+                f"jira-blocker-recheck{recheck_count}"
+            )
+            self._active_agent_child_workflow_id = child_workflow_id
+            self._active_agent_id = request.agent_id
+            try:
+                child_result = await workflow.execute_child_workflow(
+                    "MoonMind.AgentRun",
+                    request,
+                    id=child_workflow_id,
+                    task_queue=WORKFLOW_TASK_QUEUE,
+                )
+            finally:
+                self._active_agent_child_workflow_id = None
+                self._active_agent_id = None
+            return self._map_agent_run_result(child_result)
+        except Exception as exc:
+            diagnostic = self._record_failure_diagnostic(
+                exc,
+                stage=self._state,
+                step_id=node_id,
+                step_title=f"Re-check of Jira blockers for {tool_name}",
+                source="child_workflow",
+            )
+            self._mark_step_terminal(
+                node_id,
+                status="failed",
+                updated_at=workflow.now(),
+                summary=diagnostic["message"],
+                last_error=diagnostic["category"],
+            )
+            if failure_mode == "FAIL_FAST":
+                raise
+            return {
+                "status": "FAILED",
+                "outputs": {
+                    "error": diagnostic["category"],
+                    "summary": diagnostic["message"],
+                },
+            }
+
     async def _wait_for_jira_blocker_resolution(
         self,
         *,
         execution_result: Any,
-        route: Any,
-        execute_payload: Mapping[str, Any],
+        route: Any | None,
+        execute_payload: Mapping[str, Any] | None,
         node_id: str,
         tool_name: str,
         tool_type: str,
         failure_mode: str,
+        selected_skill: Any = None,
+        node: Mapping[str, Any] | None = None,
+        node_inputs: Mapping[str, Any] | None = None,
+        task_skills: Any = None,
+        workflow_parameters: Mapping[str, Any] | None = None,
     ) -> tuple[Any, bool]:
         skipped = False
         recheck_count = 0
@@ -5109,6 +5284,7 @@ class MoonMindRunWorkflow:
             current_result,
             tool_type=tool_type,
             tool_name=tool_name,
+            selected_skill=selected_skill,
         ):
             self._enter_jira_blocker_wait(
                 node_id=node_id,
@@ -5164,37 +5340,57 @@ class MoonMindRunWorkflow:
                     },
                 }
                 break
-            recheck_payload = dict(execute_payload)
-            idempotency_key = recheck_payload.get("idempotency_key")
-            if isinstance(idempotency_key, str) and idempotency_key.strip():
-                recheck_payload["idempotency_key"] = (
-                    f"{idempotency_key}_jira_blocker_recheck_{recheck_count}"
+            if str(tool_type or "").strip().lower() == "agent_runtime":
+                if node is None or node_inputs is None or workflow_parameters is None:
+                    raise ValueError(
+                        "agent_runtime Jira blocker recheck requires node context"
+                    )
+                current_result = await self._reexecute_jira_blocker_agent_runtime(
+                    node=node,
+                    node_inputs=node_inputs,
+                    node_id=node_id,
+                    tool_name=tool_name,
+                    task_skills=task_skills,
+                    workflow_parameters=workflow_parameters,
+                    recheck_count=recheck_count,
+                    failure_mode=failure_mode,
                 )
-            try:
-                current_result = await workflow.execute_activity(
-                    route.activity_type,
-                    recheck_payload,
-                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                    **self._execute_kwargs_for_route(route),
-                )
-            except Exception as exc:
-                diagnostic = self._record_failure_diagnostic(
-                    exc,
-                    stage=self._state,
-                    step_id=node_id,
-                    step_title=f"Re-check of Jira blockers for {tool_name}",
-                    source="activity",
-                )
-                self._mark_step_terminal(
-                    node_id,
-                    status="failed",
-                    updated_at=workflow.now(),
-                    summary=diagnostic["message"],
-                    last_error=diagnostic["category"],
-                )
-                if failure_mode == "FAIL_FAST":
-                    raise
-                break
+            else:
+                if route is None or execute_payload is None:
+                    raise ValueError(
+                        "skill Jira blocker recheck requires activity context"
+                    )
+                recheck_payload = dict(execute_payload)
+                idempotency_key = recheck_payload.get("idempotency_key")
+                if isinstance(idempotency_key, str) and idempotency_key.strip():
+                    recheck_payload["idempotency_key"] = (
+                        f"{idempotency_key}_jira_blocker_recheck_{recheck_count}"
+                    )
+                try:
+                    current_result = await workflow.execute_activity(
+                        route.activity_type,
+                        recheck_payload,
+                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        **self._execute_kwargs_for_route(route),
+                    )
+                except Exception as exc:
+                    diagnostic = self._record_failure_diagnostic(
+                        exc,
+                        stage=self._state,
+                        step_id=node_id,
+                        step_title=f"Re-check of Jira blockers for {tool_name}",
+                        source="activity",
+                    )
+                    self._mark_step_terminal(
+                        node_id,
+                        status="failed",
+                        updated_at=workflow.now(),
+                        summary=diagnostic["message"],
+                        last_error=diagnostic["category"],
+                    )
+                    if failure_mode == "FAIL_FAST":
+                        raise
+                    break
             self._record_step_result_evidence(
                 node_id,
                 execution_result=current_result,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -82,7 +82,6 @@ from moonmind.workflows.skills.approval_policy import (
     build_feedback_instruction,
     parse_review_verdict,
 )
-from moonmind.workflows.skills.skill_registry import parse_skill_registry
 from moonmind.workflows.temporal.step_ledger import (
     TERMINAL_STEP_STATUSES,
     build_initial_step_rows,
@@ -3655,7 +3654,7 @@ class MoonMindRunWorkflow:
         tool_type = str(
             tool_payload.get("type") or tool_payload.get("kind") or ""
         ).strip()
-        if not tool_type or tool_type == "skill":
+        if tool_type in {"", "skill"}:
             tool_name = (
                 self._coerce_text(tool_payload.get("name"), max_chars=160)
                 or self._coerce_text(tool_payload.get("id"), max_chars=160)
@@ -3802,7 +3801,6 @@ class MoonMindRunWorkflow:
         )
         self._capture_prepared_input_refs(parameters)
 
-        registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         task_payload = parameters.get("task")
         task_skills = (
             task_payload.get("skills")
@@ -3823,36 +3821,6 @@ class MoonMindRunWorkflow:
             and not pr_publish_optional
         )
         pull_request_url: str | None = None
-        skill_definitions_by_key: dict[tuple[str, str], Any] = {}
-        requires_registry_lookup = any(
-            node.tool_type == "skill" for node in plan_definition.nodes
-        )
-        if workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH):
-            should_read_registry = bool(
-                registry_snapshot_ref and requires_registry_lookup
-            )
-        else:
-            should_read_registry = bool(registry_snapshot_ref)
-
-        if should_read_registry:
-            registry_payload = await execute_typed_activity(
-                "artifact.read",
-                ArtifactReadInput(
-                    principal=self._principal(),
-                    artifact_ref=registry_snapshot_ref,
-                ),
-                **self._execute_kwargs_for_route(artifact_read_route),
-            )
-            registry_document = self._decode_json_payload(
-                registry_payload,
-                error_message=(
-                    "registry_snapshot_ref must resolve to a JSON object payload"
-                ),
-            )
-            skill_definitions = parse_skill_registry(registry_document)
-            skill_definitions_by_key = {
-                definition.key: definition for definition in skill_definitions
-            }
 
         previous_step_outputs: Mapping[str, Any] = {}
         execution_result: Any = None
@@ -3862,27 +3830,18 @@ class MoonMindRunWorkflow:
                 return
 
             tool = node.get("tool")
-            skill = node.get("skill")
-
-            selected_node: Mapping[str, Any] | None = None
-            if isinstance(tool, Mapping):
-                selected_node = tool
-            elif isinstance(skill, Mapping):
-                selected_node = skill
-            if selected_node is None:
-                raise ValueError(
-                    "plan node tool definition is required (node.skill is legacy alias)"
-                )
+            if not isinstance(tool, Mapping):
+                raise ValueError("plan node tool definition is required")
 
             tool_type = (
-                str(selected_node.get("type") or selected_node.get("kind") or "skill")
+                str(tool.get("type") or tool.get("kind") or "")
                 .strip()
                 .lower()
             )
             tool_name = str(
-                selected_node.get("name") or selected_node.get("id") or ""
+                tool.get("name") or tool.get("id") or ""
             ).strip()
-            tool_version = str(selected_node.get("version") or "").strip()
+            tool_version = str(tool.get("version") or "").strip()
             node_id = str(node.get("id") or "unknown")
             if self._is_preserved_step(node_id):
                 preserved_outputs = self._preserved_step_outputs(node_id)
@@ -4131,100 +4090,10 @@ class MoonMindRunWorkflow:
                             result_status = "FAILED"
                             break
 
-                    elif tool_type == "skill":
-                        # --- Activity dispatch: existing skill path ---
-                        if not tool_name or not tool_version:
-                            raise ValueError("plan node tool name/version is required")
-                        invocation_payload = {
-                            "id": node_id,
-                            "tool": {
-                                "type": "skill",
-                                "name": tool_name,
-                                "version": tool_version,
-                            },
-                            "skill": {"name": tool_name, "version": tool_version},
-                            "inputs": node_inputs,
-                            "options": node.get("options", {}),
-                        }
-                        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                            "mm.skill.execute"
-                        )
-                        if skill_definitions_by_key:
-                            skill_key = (tool_name, tool_version)
-                            if skill_key not in skill_definitions_by_key:
-                                raise ValueError(
-                                    "Tool "
-                                    f"'{tool_name}:{tool_version}' was not found in pinned "
-                                    "registry snapshot"
-                                )
-                            route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(
-                                skill_definitions_by_key[skill_key]
-                            )
-                        if route.activity_type not in {
-                            "mm.skill.execute",
-                            "mm.tool.execute",
-                        }:
-                            raise ValueError(
-                                "plan node tool executor "
-                                f"'{route.activity_type}' is unsupported by MoonMind.Run; "
-                                "expected mm.tool.execute or mm.skill.execute"
-                            )
-
-                        try:
-                            execute_payload = {
-                                "invocation_payload": invocation_payload,
-                                "principal": self._principal(),
-                                "registry_snapshot_ref": registry_snapshot_ref,
-                                "context": {
-                                    "workflow_id": workflow.info().workflow_id,
-                                    "run_id": workflow.info().run_id,
-                                    "node_id": node_id,
-                                    "ownerId": self._owner_id,
-                                    "ownerType": self._owner_type,
-                                    "previousOutputs": current_previous_outputs,
-                                },
-                            }
-                            if workflow.patched("idempotency_key_phase3"):
-                                execute_payload["idempotency_key"] = (
-                                    step_execution_operation_idempotency_key(
-                                        workflow_id=workflow.info().workflow_id,
-                                        run_id=workflow.info().run_id,
-                                        logical_step_id=node_id,
-                                        execution_ordinal=current_step_execution,
-                                        operation="execute",
-                                    )
-                                )
-
-                            execution_result = await workflow.execute_activity(
-                                route.activity_type,
-                                execute_payload,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                                **self._execute_kwargs_for_route(route),
-                            )
-                        except Exception as exc:
-                            diagnostic = self._record_failure_diagnostic(
-                                exc,
-                                stage=self._state,
-                                step_id=node_id,
-                                step_title=tool_name,
-                                source="activity",
-                            )
-                            self._mark_step_terminal(
-                                node_id,
-                                status="failed",
-                                updated_at=workflow.now(),
-                                summary=diagnostic["message"],
-                                last_error=diagnostic["category"],
-                            )
-                            if failure_mode == "FAIL_FAST":
-                                raise
-                            result_status = "FAILED"
-                            break
-
                     else:
                         raise ValueError(
                             f"unsupported plan node tool.type: '{tool_type}'; "
-                            "expected 'skill' or 'agent_runtime'"
+                            "expected 'agent_runtime'"
                         )
 
                     result_status = self._activity_result_status(execution_result)

--- a/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -411,16 +411,10 @@ class TestAgentRuntimeDispatch(unittest.IsolatedAsyncioTestCase):
                     exc_info.exception.cause.message,
                 )
 
-# ── Snapshot-pinning workflow-boundary tests ──
+# ── Legacy registry workflow-boundary tests ──
 
 class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
-    """Verify that resolved_skillset_ref is stable across the retry loop
-    inside MoonMind.Run._run_execution_stage().
-
-    The workflow reads registry_snapshot_ref once from plan metadata, then
-    passes the *same* variable to _build_agent_execution_request on every
-    retry iteration.  These tests exercise that boundary contract.
-    """
+    """Verify MoonMind.Run dispatch does not read legacy skill registries."""
 
     def setUp(self) -> None:
         PLAN_GENERATE_CALLS.clear()
@@ -432,13 +426,7 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
     # ------------------------------------------------------------------
 
     async def test_retry_child_workflow_receives_identical_skillset_ref(self) -> None:
-        """When the parent retries a plan node, the registry_snapshot_ref is
-        read once from plan metadata and threaded through every retry attempt.
-
-        We use a skill node that fails once, triggering the parent retry loop.
-        The assertion is that the registry snapshot artifact is read exactly
-        once — proving the ref is pinned and not re-resolved on retry.
-        """
+        """Agent runtime dispatch ignores registry_snapshot_ref metadata."""
         KNOWN_SNAPSHOT_REF = "artifact://registry/retry-snap-42"
 
         @activity.defn(name="artifact.read")
@@ -460,13 +448,16 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 "policy": {"failure_mode": "FAIL_FAST"},
                 "nodes": [
                     {
-                        "id": "retry-skill-step",
+                        "id": "retry-agent-step",
                         "tool": {
-                            "type": "skill",
-                            "name": "repo.run_tests",
-                            "version": "1.0.0",
+                            "type": "agent_runtime",
+                            "name": "codex_cli",
+                            "version": "1.0",
                         },
-                        "inputs": {"repo_ref": "git:moonmind"},
+                        "inputs": {
+                            "repo_ref": "git:moonmind",
+                            "selectedSkill": "repo.run_tests",
+                        },
                         "options": {},
                     }
                 ],
@@ -510,16 +501,14 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 except Exception:
                     pass
 
-                # The critical assertion: the registry snapshot was read
-                # exactly once at the top of _run_execution_stage, and the
-                # same ref variable is threaded through all retry attempts.
+                # The legacy skill registry is no longer read by Run dispatch.
                 registry_reads = [
                     c for c in ARTIFACT_READ_CALLS
                     if c.get("artifact_ref") == KNOWN_SNAPSHOT_REF
                 ]
                 self.assertEqual(
-                    len(registry_reads), 1,
-                    "Registry snapshot should be read exactly once per execution stage",
+                    len(registry_reads), 0,
+                    "Run dispatch must not read registry snapshots",
                 )
 
     # ------------------------------------------------------------------
@@ -554,13 +543,16 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 "policy": {"failure_mode": "FAIL_FAST"},
                 "nodes": [
                     {
-                        "id": "rerun-skill-step",
+                        "id": "rerun-agent-step",
                         "tool": {
-                            "type": "skill",
-                            "name": "repo.run_tests",
-                            "version": "1.0.0",
+                            "type": "agent_runtime",
+                            "name": "codex_cli",
+                            "version": "1.0",
                         },
-                        "inputs": {"repo_ref": "git:moonmind"},
+                        "inputs": {
+                            "repo_ref": "git:moonmind",
+                            "selectedSkill": "repo.run_tests",
+                        },
                         "options": {},
                     }
                 ],
@@ -623,30 +615,22 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 except Exception:
                     pass
 
-                # Both runs read the same plan artifact with the same snapshot ref.
+                # Both runs ignore the legacy registry snapshot ref during dispatch.
                 registry_reads = [
                     c for c in ARTIFACT_READ_CALLS
                     if c.get("artifact_ref") == EXPECTED_SNAPSHOT_REF
                 ]
                 self.assertEqual(
-                    len(registry_reads), 2,
-                    "Both runs should read the registry snapshot artifact",
+                    len(registry_reads), 0,
+                    "Reruns must not read registry snapshots for Run dispatch",
                 )
 
     # ------------------------------------------------------------------
-    # 3. Child workflow AgentRun dispatch receives correct snapshot ref
-    #    on both first-run and retry paths
+    # 3. Child workflow AgentRun dispatch ignores legacy registry snapshots
     # ------------------------------------------------------------------
 
-    async def test_child_workflow_receives_resolved_skillset_ref(self) -> None:
-        """The plan's registry_snapshot_ref is read and threaded through
-        to the execution path.  We verify this by running the workflow
-        with a plan that carries a known registry_snapshot ref, and
-        asserting the registry artifact is read with that exact ref.
-
-        This proves the ref flows from plan metadata → workflow execution
-        → child dispatch without re-resolution.
-        """
+    async def test_child_workflow_ignores_legacy_registry_snapshot_ref(self) -> None:
+        """Agent runtime dispatch does not read registry_snapshot_ref metadata."""
         KNOWN_SNAPSHOT_REF = "artifact://registry/child-ref-test"
 
         @activity.defn(name="artifact.read")
@@ -668,13 +652,16 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 "policy": {"failure_mode": "FAIL_FAST"},
                 "nodes": [
                     {
-                        "id": "child-ref-step",
+                        "id": "child-agent-step",
                         "tool": {
-                            "type": "skill",
-                            "name": "repo.run_tests",
-                            "version": "1.0.0",
+                            "type": "agent_runtime",
+                            "name": "codex_cli",
+                            "version": "1.0",
                         },
-                        "inputs": {"repo_ref": "git:moonmind"},
+                        "inputs": {
+                            "repo_ref": "git:moonmind",
+                            "selectedSkill": "repo.run_tests",
+                        },
                         "options": {},
                     }
                 ],
@@ -723,12 +710,12 @@ class TestSnapshotPinningOnRetry(unittest.IsolatedAsyncioTestCase):
                 except Exception:
                     pass
 
-                # Assert the registry snapshot was read with the known ref.
+                # Assert the registry snapshot is not read by Run dispatch.
                 registry_reads = [
                     c for c in ARTIFACT_READ_CALLS
                     if c.get("artifact_ref") == KNOWN_SNAPSHOT_REF
                 ]
                 self.assertEqual(
-                    len(registry_reads), 1,
-                    "Parent must read the registry snapshot artifact with the known ref",
+                    len(registry_reads), 0,
+                    "Parent must not read registry snapshots for Run dispatch",
                 )

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -309,7 +309,7 @@ async def test_child_run_goal_scheduled_breakdown_preserves_target_runtime(tmp_p
     assert downstream_task["runtime"] == {"mode": "jules"}
 
 
-def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
+def test_runtime_planner_maps_explicit_tool_step_to_agent_runtime_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -347,9 +347,9 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "jira.get_issue",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     assert plan["nodes"][0]["inputs"]["type"] == "tool"
@@ -468,9 +468,9 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
     ]
     assert plan["edges"] == [{"from": "fetch-issue", "to": "implement-story"}]
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "jira.get_issue",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][1]["tool"] == {
         "type": "agent_runtime",
@@ -481,7 +481,7 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
     assert plan["nodes"][1]["inputs"]["source"]["presetSlug"] == "jira-orchestrate"
 
 
-def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
+def test_runtime_planner_normalizes_authored_task_plan_skill_nodes():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -528,11 +528,12 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
         {
             "id": "update-moonmind-deployment",
             "tool": {
-                "type": "skill",
-                "name": "deployment.update_compose_stack",
-                "version": "1.0.0",
+                "type": "agent_runtime",
+                "name": "codex_cli",
+                "version": "1.0",
             },
             "inputs": {
+                "selectedSkill": "deployment.update_compose_stack",
                 "stack": "moonmind",
                 "image": {
                     "repository": "ghcr.io/moonladderstudios/moonmind",
@@ -590,7 +591,7 @@ def test_runtime_planner_preserves_authored_task_plan_node_metadata():
     assert node["description"] == "Use the deployment operations service."
 
 
-def test_runtime_planner_maps_deployment_update_step_to_typed_tool_node():
+def test_runtime_planner_maps_deployment_update_step_to_agent_runtime_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -630,9 +631,9 @@ def test_runtime_planner_maps_deployment_update_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "skill",
-        "name": "deployment.update_compose_stack",
-        "version": "1.0.0",
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
     }
     assert plan["nodes"][0]["inputs"]["selectedSkill"] == (
         "deployment.update_compose_stack"
@@ -893,7 +894,12 @@ def test_runtime_planner_materializes_tool_steps_without_source_lookup(
         snapshot=snapshot,
     )
 
-    assert plan["nodes"][0]["tool"]["name"] == "jira.get_issue"
+    assert plan["nodes"][0]["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
     if source is None:
         assert "source" not in plan["nodes"][0]["inputs"]
     else:
@@ -1097,7 +1103,7 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     )
     assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
     assert jira["tool"] == {
-        "type": "skill",
+        "type": "agent_runtime",
         "name": "story.create_jira_issues",
         "version": "1.0",
     }
@@ -1252,8 +1258,8 @@ def test_runtime_planner_preserves_authored_branch_for_jira_story_import():
     node = plan["nodes"][0]
 
     assert node["tool"] == {
-        "type": "skill",
-        "name": "story.create_jira_issues",
+        "type": "agent_runtime",
+        "name": "codex_cli",
         "version": "1.0",
     }
     assert node["inputs"]["branch"] == "feature/authored-breakdown"
@@ -1263,7 +1269,7 @@ def test_runtime_planner_preserves_authored_branch_for_jira_story_import():
     assert "targetBranch" not in node["inputs"]
     assert "startingBranch" not in node["inputs"]
 
-def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
+def test_runtime_planner_routes_jira_orchestrate_task_creator_as_agent_runtime_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -1346,7 +1352,7 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
         == breakdown["inputs"]["storyBreakdownPath"]
     )
     assert orchestrate["tool"] == {
-        "type": "skill",
+        "type": "agent_runtime",
         "name": "story.create_jira_orchestrate_tasks",
         "version": "1.0",
     }
@@ -1356,7 +1362,7 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
     }
 
 
-def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
+def test_runtime_planner_routes_jira_implement_task_creator_as_agent_runtime_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -1426,7 +1432,7 @@ def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
     implement = plan["nodes"][3]
 
     assert implement["tool"] == {
-        "type": "skill",
+        "type": "agent_runtime",
         "name": "story.create_jira_implement_tasks",
         "version": "1.0",
     }


### PR DESCRIPTION
Jira issue: MM-799

Summary:
- Removed the legacy `tool.type == "skill"` dispatch branch from `MoonMind.Run`.
- Updated runtime planning so skill-shaped generator paths emit `agent_runtime` nodes with selected skill metadata.
- Marked roadmap item H.3 complete.

Tests run:
- `python -m py_compile moonmind/workflows/temporal/workflows/run.py moonmind/workflows/temporal/worker_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py`
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_worker_runtime.py`

Remaining risks:
- Full unit suite was not green during implementation because older `MoonMind.Run` unit fixtures still assert legacy `mm.skill.execute` activity dispatch semantics; the focused planner coverage for MM-799 passes.