### PR TITLE
MM-792 wire finish summary projections

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1946,7 +1946,7 @@ def _serialize_execution(
     proposal_outcomes = _proposal_outcomes_from_summary(proposal_summary)
     finish_summary_json = getattr(record, "finish_summary_json", None)
     finish_summary = (
-        dict(finish_summary_json) if isinstance(finish_summary_json, Mapping) else None
+        dict(finish_summary_json) if isinstance(finish_summary_json, dict) else None
     )
 
     started_at = getattr(record, "started_at", None)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1944,6 +1944,10 @@ def _serialize_execution(
     )
     proposal_summary = _proposal_summary_from_memo(memo)
     proposal_outcomes = _proposal_outcomes_from_summary(proposal_summary)
+    finish_summary_json = getattr(record, "finish_summary_json", None)
+    finish_summary = (
+        dict(finish_summary_json) if isinstance(finish_summary_json, Mapping) else None
+    )
 
     started_at = getattr(record, "started_at", None)
     created_at = getattr(record, "created_at", None) or started_at or record.updated_at
@@ -2034,6 +2038,8 @@ def _serialize_execution(
         target_diagnostics=target_diagnostics,
         proposal_summary=proposal_summary,
         proposal_outcomes=proposal_outcomes,
+        finish_outcome_code=getattr(record, "finish_outcome_code", None),
+        finish_summary=finish_summary,
         debug_fields=debug_fields,
         redirect_path=f"/workflows/{record.workflow_id}?source=temporal",
         integration=(

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -44,6 +44,8 @@ LOCAL_ONLY_EXECUTION_FIELDS = (
     "create_idempotency_key",
     "last_update_idempotency_key",
     "last_update_response",
+    "finish_outcome_code",
+    "finish_summary_json",
 )
 
 # Lifecycle states where the workflow has not yet begun real work. When a
@@ -75,6 +77,24 @@ def _sanitize_for_json(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_sanitize_for_json(item) for item in obj]
     return obj
+
+def _finish_summary_from_memo(memo: dict[str, Any]) -> dict[str, Any] | None:
+    finish_summary = memo.get("finishSummary") or memo.get("finish_summary")
+    if isinstance(finish_summary, dict):
+        sanitized = _sanitize_for_json(dict(finish_summary))
+        return sanitized if isinstance(sanitized, dict) else None
+    return None
+
+def _finish_outcome_code_from_summary(
+    finish_summary: dict[str, Any] | None,
+) -> str | None:
+    if not isinstance(finish_summary, dict):
+        return None
+    finish_outcome = finish_summary.get("finishOutcome")
+    if not isinstance(finish_outcome, dict):
+        return None
+    code = str(finish_outcome.get("code") or "").strip()
+    return code or None
 
 def _coerce_temporal_scalar(value: Any) -> str | None:
     if isinstance(value, list):
@@ -287,6 +307,7 @@ async def map_temporal_state_to_projection(
             if started_at is not None and started_at < scheduled_for:
                 started_at = scheduled_for
     sanitized_memo = _sanitize_for_json(dict(memo))
+    finish_summary = _finish_summary_from_memo(sanitized_memo)
     return {
         "workflow_id": desc.id,
         "run_id": desc.run_id,
@@ -300,6 +321,8 @@ async def map_temporal_state_to_projection(
         "search_attributes": _sanitize_for_json(search_attributes),
         "memo": sanitized_memo,
         "artifact_refs": artifact_refs,
+        "finish_outcome_code": _finish_outcome_code_from_summary(finish_summary),
+        "finish_summary_json": finish_summary,
         "input_ref": memo.get("input_ref"),
         "plan_ref": memo.get("plan_ref"),
         "manifest_ref": memo.get("manifest_ref"),

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -90,7 +90,9 @@ def _finish_outcome_code_from_summary(
 ) -> str | None:
     if not isinstance(finish_summary, dict):
         return None
-    finish_outcome = finish_summary.get("finishOutcome")
+    finish_outcome = finish_summary.get("finishOutcome") or finish_summary.get(
+        "finish_outcome"
+    )
     if not isinstance(finish_outcome, dict):
         return None
     code = str(finish_outcome.get("code") or "").strip()

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -981,7 +981,9 @@ class TemporalExecutionCanonicalRecord(Base):
     artifact_refs: Mapped[list[str]] = mapped_column(
         mutable_json_list(), nullable=False, default=list
     )
-    finish_outcome_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    finish_outcome_code: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True, index=True
+    )
     finish_summary_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
         mutable_json_dict(), nullable=True
     )
@@ -1210,7 +1212,9 @@ class TemporalExecutionRecord(Base):
     artifact_refs: Mapped[list[str]] = mapped_column(
         mutable_json_list(), nullable=False, default=list
     )
-    finish_outcome_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    finish_outcome_code: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True, index=True
+    )
     finish_summary_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
         mutable_json_dict(), nullable=True
     )

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -981,6 +981,10 @@ class TemporalExecutionCanonicalRecord(Base):
     artifact_refs: Mapped[list[str]] = mapped_column(
         mutable_json_list(), nullable=False, default=list
     )
+    finish_outcome_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    finish_summary_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True
+    )
     input_ref: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     plan_ref: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     manifest_ref: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
@@ -1205,6 +1209,10 @@ class TemporalExecutionRecord(Base):
     )
     artifact_refs: Mapped[list[str]] = mapped_column(
         mutable_json_list(), nullable=False, default=list
+    )
+    finish_outcome_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    finish_summary_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True
     )
     input_ref: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     plan_ref: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)

--- a/api_service/migrations/versions/313_finish_summary_projection_fields.py
+++ b/api_service/migrations/versions/313_finish_summary_projection_fields.py
@@ -30,6 +30,12 @@ def upgrade() -> None:
             table_name,
             sa.Column("finish_outcome_code", sa.String(length=64), nullable=True),
         )
+        op.create_index(
+            f"ix_{table_name}_finish_outcome_code",
+            table_name,
+            ["finish_outcome_code"],
+            unique=False,
+        )
         op.add_column(
             table_name,
             sa.Column("finish_summary_json", _json_type(), nullable=True),
@@ -38,5 +44,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     for table_name in ("temporal_executions", "temporal_execution_sources"):
+        op.drop_index(f"ix_{table_name}_finish_outcome_code", table_name=table_name)
         op.drop_column(table_name, "finish_summary_json")
         op.drop_column(table_name, "finish_outcome_code")

--- a/api_service/migrations/versions/313_finish_summary_projection_fields.py
+++ b/api_service/migrations/versions/313_finish_summary_projection_fields.py
@@ -1,0 +1,42 @@
+"""Add finish summary projection fields.
+
+Revision ID: 313_finish_summary_projection_fields
+Revises: 312_source_mapping_cutover
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "313_finish_summary_projection_fields"
+down_revision: Union[str, None] = "312_source_mapping_cutover"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _json_type() -> sa.types.TypeEngine:
+    return postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite")
+
+
+def upgrade() -> None:
+    for table_name in ("temporal_execution_sources", "temporal_executions"):
+        op.add_column(
+            table_name,
+            sa.Column("finish_outcome_code", sa.String(length=64), nullable=True),
+        )
+        op.add_column(
+            table_name,
+            sa.Column("finish_summary_json", _json_type(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for table_name in ("temporal_executions", "temporal_execution_sources"):
+        op.drop_column(table_name, "finish_summary_json")
+        op.drop_column(table_name, "finish_outcome_code")

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -265,7 +265,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Task finish summary system (spec 079)
 
 ### Remaining tasks
-- [ ] **11.1** Structured outcome summaries on every run — Spec 079 started; not fully wired
+- [x] **11.1** Structured outcome summaries on every run — MM-792 wires the finish summary artifact into indexed execution projections
 - [ ] **11.2** Improvement signal capture (retries, loops, flaky tests) — Constitution X mandates this
 - [ ] **11.3** Reviewable improvement backlog / proposals queue — Task proposals exist; not fed by telemetry
 - [ ] **11.4** Metrics / dashboards (run duration, success rate, cost) — No operational metrics endpoint

--- a/docs/Tasks/TaskFinishSummarySystem.md
+++ b/docs/Tasks/TaskFinishSummarySystem.md
@@ -186,7 +186,9 @@ Inside the Python Temporal workflow logic (`MoonMind.Run`):
 1. The Workflow coordinates stage timings across all child Activities.
 2. Even in failure or `CancelledError` paths, a `finally:` or `except:` block captures the execution state.
 3. The Workflow saves `reports/run_summary.json` to the unified Artifacts API.
-4. The Workflow returns a final typed Result payload that the API syncs (or reads via Webhooks) into the Postgres `agent_jobs` table columns (`finish_outcome_code`, `finish_summary_json`) to make List queries faster in the UI.
+4. The Workflow records the final typed terminal-state payload into the Postgres
+   execution source and projection columns (`finish_outcome_code`,
+   `finish_summary_json`) to make List queries faster in the UI.
 
 ## 4. Proposals Integration
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4478,6 +4478,12 @@ export interface components {
             proposalOutcomes?: {
                 [key: string]: unknown;
             }[];
+            /** Finishoutcomecode */
+            finishOutcomeCode?: string | null;
+            /** Finishsummary */
+            finishSummary?: {
+                [key: string]: unknown;
+            } | null;
             debugFields?: components["schemas"]["ExecutionDebugFieldsModel"] | null;
             /** Redirectpath */
             redirectPath?: string | null;

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -176,6 +176,10 @@ class ExecutionTerminalStateInput(BaseModel):
         "timed_out",
     ] | None = Field(None, alias="closeStatus")
     summary: str | None = Field(None, alias="summary")
+    finish_outcome_code: str | None = Field(None, alias="finishOutcomeCode")
+    finish_outcome_stage: str | None = Field(None, alias="finishOutcomeStage")
+    finish_outcome_reason: str | None = Field(None, alias="finishOutcomeReason")
+    finish_summary: dict[str, Any] | None = Field(None, alias="finishSummary")
     error_category: Literal[
         "user_error",
         "integration_error",

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2088,6 +2088,8 @@ class ExecutionModel(BaseModel):
     proposal_outcomes: list[dict[str, Any]] = Field(
         default_factory=list, alias="proposalOutcomes"
     )
+    finish_outcome_code: str | None = Field(None, alias="finishOutcomeCode")
+    finish_summary: dict[str, Any] | None = Field(None, alias="finishSummary")
     debug_fields: Optional[ExecutionDebugFieldsModel] = Field(None, alias="debugFields")
     redirect_path: Optional[str] = Field(None, alias="redirectPath")
     manifest_artifact_ref: Optional[str] = Field(None, alias="manifestArtifactRef")

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2599,6 +2599,8 @@ class TemporalArtifactActivities:
                 close_status=model.close_status,
                 summary=model.summary,
                 error_category=model.error_category,
+                finish_outcome_code=model.finish_outcome_code,
+                finish_summary=model.finish_summary,
             )
 
         await self._write_run_digest_best_effort(record)

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2144,6 +2144,8 @@ class TemporalExecutionService:
         close_status: str | None = None,
         summary: str | None = None,
         error_category: str | None = None,
+        finish_outcome_code: str | None = None,
+        finish_summary: dict[str, Any] | None = None,
     ) -> TemporalExecutionRecord | TemporalExecutionCanonicalRecord:
         normalized_state = str(state or "").strip().lower()
         state_by_value = {item.value: item for item in MoonMindWorkflowState}
@@ -2169,6 +2171,11 @@ class TemporalExecutionService:
                 f"Execution already terminal as {record.state.value}."
             )
         if record.state in TERMINAL_STATES:
+            self._record_finish_summary(
+                record,
+                finish_outcome_code=finish_outcome_code,
+                finish_summary=finish_summary,
+            )
             if record.close_status is None:
                 self._set_state(record, target_state, close_status=target_close_status)
                 await self._sync_integration_correlation_record(record)
@@ -2178,6 +2185,11 @@ class TemporalExecutionService:
             return await self._sync_projection_best_effort(record)
 
         self._set_state(record, target_state, close_status=target_close_status)
+        self._record_finish_summary(
+            record,
+            finish_outcome_code=finish_outcome_code,
+            finish_summary=finish_summary,
+        )
         if summary:
             if target_state is MoonMindWorkflowState.FAILED:
                 category = str(error_category or "execution_error").strip()
@@ -2196,6 +2208,29 @@ class TemporalExecutionService:
         await self._session.refresh(record)
         await self._fan_out_dependency_resolution(record)
         return await self._sync_projection_best_effort(record)
+
+    def _record_finish_summary(
+        self,
+        record: TemporalExecutionCanonicalRecord,
+        *,
+        finish_outcome_code: str | None,
+        finish_summary: dict[str, Any] | None,
+    ) -> None:
+        if finish_summary is None:
+            return
+        normalized_summary = dict(finish_summary)
+        finish_outcome = normalized_summary.get("finishOutcome")
+        outcome_code = str(
+            finish_outcome_code
+            or (
+                finish_outcome.get("code")
+                if isinstance(finish_outcome, dict)
+                else None
+            )
+            or ""
+        ).strip()
+        record.finish_outcome_code = outcome_code or None
+        record.finish_summary_json = normalized_summary
 
     async def mark_execution_planning(
         self,
@@ -3999,6 +4034,12 @@ class TemporalExecutionService:
             "search_attributes": dict(source.search_attributes or {}),
             "memo": dict(source.memo or {}),
             "artifact_refs": list(source.artifact_refs or []),
+            "finish_outcome_code": source.finish_outcome_code,
+            "finish_summary_json": (
+                dict(source.finish_summary_json)
+                if isinstance(source.finish_summary_json, dict)
+                else None
+            ),
             "input_ref": source.input_ref,
             "plan_ref": source.plan_ref,
             "manifest_ref": source.manifest_ref,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2219,7 +2219,9 @@ class TemporalExecutionService:
         if finish_summary is None:
             return
         normalized_summary = dict(finish_summary)
-        finish_outcome = normalized_summary.get("finishOutcome")
+        finish_outcome = normalized_summary.get(
+            "finishOutcome"
+        ) or normalized_summary.get("finish_outcome")
         outcome_code = str(
             finish_outcome_code
             or (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -9017,6 +9017,7 @@ class MoonMindRunWorkflow:
             )
             finish_outcome = (
                 self._finish_summary.get("finishOutcome")
+                or self._finish_summary.get("finish_outcome")
                 if isinstance(self._finish_summary, dict)
                 else None
             )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -581,6 +581,7 @@ class MoonMindRunWorkflow:
         self._plan_ref: Optional[str] = None
         self._logs_ref: Optional[str] = None
         self._summary_ref: Optional[str] = None
+        self._finish_summary: dict[str, Any] | None = None
         self._recovery_source: dict[str, Any] | None = None
         self._recovery_failed_step_id: str | None = None
         self._recovery_workspace: dict[str, Any] = {}
@@ -8961,6 +8962,8 @@ class MoonMindRunWorkflow:
             if status == "failed" and isinstance(self._failure_diagnostic, dict):
                 finish_summary["failure"] = dict(self._failure_diagnostic)
 
+            self._finish_summary = finish_summary
+
             artifact_create_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
                 "artifact.create"
             )
@@ -9012,6 +9015,13 @@ class MoonMindRunWorkflow:
             terminal_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
                 "execution.record_terminal_state"
             )
+            finish_outcome = (
+                self._finish_summary.get("finishOutcome")
+                if isinstance(self._finish_summary, dict)
+                else None
+            )
+            if not isinstance(finish_outcome, dict):
+                finish_outcome = {}
             activity_task = asyncio.create_task(
                 execute_typed_activity(
                     "execution.record_terminal_state",
@@ -9020,6 +9030,16 @@ class MoonMindRunWorkflow:
                         state=state,
                         closeStatus=close_status,
                         summary=summary,
+                        finishOutcomeCode=(
+                            str(finish_outcome.get("code") or "").strip() or None
+                        ),
+                        finishOutcomeStage=(
+                            str(finish_outcome.get("stage") or "").strip() or None
+                        ),
+                        finishOutcomeReason=(
+                            str(finish_outcome.get("reason") or "").strip() or None
+                        ),
+                        finishSummary=self._finish_summary,
                         errorCategory=error_category,
                     ),
                     cancellation_type=ActivityCancellationType.ABANDON,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -472,6 +472,8 @@ def _build_execution_record(
             ),
         },
         artifact_refs=["art_123"],
+        finish_outcome_code=None,
+        finish_summary_json=None,
         manifest_ref=(
             "art_manifest_1"
             if workflow_type is TemporalWorkflowType.MANIFEST_INGEST
@@ -509,6 +511,24 @@ def _build_execution_record(
         entry=entry,
         integration_state=None,
     )
+
+def test_serialize_execution_includes_finish_summary_projection_fields():
+    record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+    record.close_status = TemporalExecutionCloseStatus.COMPLETED
+    record.finish_outcome_code = "NO_CHANGES"
+    record.finish_summary_json = {
+        "schemaVersion": "v1",
+        "finishOutcome": {
+            "code": "NO_CHANGES",
+            "stage": "publish",
+            "reason": "publish skipped: no local changes",
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["finishOutcomeCode"] == "NO_CHANGES"
+    assert payload["finishSummary"] == record.finish_summary_json
 
 def _override_temporal_client(app: FastAPI) -> AsyncMock:
     client = AsyncMock()

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -80,6 +80,37 @@ def test_map_temporal_state_to_projection_success():
     assert result["search_attributes"]["mm_custom"] == {"key": "value"}
     assert result["updated_at"] == updated_at
 
+def test_map_temporal_state_to_projection_extracts_finish_summary():
+    start_time = datetime.now(UTC)
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = "mm:finish-summary"
+    desc.run_id = "run-finish-summary"
+    desc.namespace = "moonmind"
+    desc.workflow_type = "MoonMind.Run"
+    desc.status = WorkflowExecutionStatus.COMPLETED
+    desc.start_time = start_time
+    desc.execution_time = start_time
+    desc.close_time = start_time
+    desc.search_attributes = {}
+    finish_summary = {
+        "schemaVersion": "v1",
+        "finishOutcome": {
+            "code": "PUBLISHED_BRANCH",
+            "stage": "publish",
+            "reason": "published branch",
+        },
+    }
+
+    async def _memo() -> dict[str, object]:
+        return {"entry": "run", "finishSummary": finish_summary}
+
+    desc.memo = _memo
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["finish_outcome_code"] == "PUBLISHED_BRANCH"
+    assert result["finish_summary_json"] == finish_summary
+
 def test_map_temporal_state_to_projection_uses_search_attributes_for_owner_fields():
     start_time = datetime.now(UTC)
     desc = Mock(spec=WorkflowExecutionDescription)
@@ -445,6 +476,11 @@ async def test_sync_execution_projection_preserves_metadata_when_temporal_memo_d
                 search_attributes={"mm_state": "initializing", "mm_entry": "run"},
                 memo={"title": "Task", "summary": "Existing summary"},
                 artifact_refs=[],
+                finish_outcome_code="FAILED",
+                finish_summary_json={
+                    "schemaVersion": "v1",
+                    "finishOutcome": {"code": "FAILED"},
+                },
                 input_ref="input-1",
                 parameters={"targetRuntime": "codex_cli"},
                 create_idempotency_key="create-key-2",
@@ -490,6 +526,11 @@ async def test_sync_execution_projection_preserves_metadata_when_temporal_memo_d
             assert refreshed.run_id == "run-new"
             assert refreshed.state == MoonMindWorkflowState.EXECUTING
             assert refreshed.memo["summary"] == "Existing summary"
+            assert refreshed.finish_outcome_code == "FAILED"
+            assert refreshed.finish_summary_json == {
+                "schemaVersion": "v1",
+                "finishOutcome": {"code": "FAILED"},
+            }
             assert refreshed.input_ref == "input-1"
             assert refreshed.create_idempotency_key == "create-key-2"
             assert refreshed.last_update_idempotency_key == "update-key-2"

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -111,6 +111,39 @@ def test_map_temporal_state_to_projection_extracts_finish_summary():
     assert result["finish_outcome_code"] == "PUBLISHED_BRANCH"
     assert result["finish_summary_json"] == finish_summary
 
+
+def test_map_temporal_state_to_projection_extracts_snake_case_finish_outcome():
+    start_time = datetime.now(UTC)
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = "mm:finish-summary-snake"
+    desc.run_id = "run-finish-summary-snake"
+    desc.namespace = "moonmind"
+    desc.workflow_type = "MoonMind.Run"
+    desc.status = WorkflowExecutionStatus.COMPLETED
+    desc.start_time = start_time
+    desc.execution_time = start_time
+    desc.close_time = start_time
+    desc.search_attributes = {}
+    finish_summary = {
+        "schema_version": "v1",
+        "finish_outcome": {
+            "code": "PUBLISH_DISABLED",
+            "stage": "publish",
+            "reason": "publishing disabled",
+        },
+    }
+
+    async def _memo() -> dict[str, object]:
+        return {"entry": "run", "finish_summary": finish_summary}
+
+    desc.memo = _memo
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["finish_outcome_code"] == "PUBLISH_DISABLED"
+    assert result["finish_summary_json"] == finish_summary
+
+
 def test_map_temporal_state_to_projection_uses_search_attributes_for_owner_fields():
     start_time = datetime.now(UTC)
     desc = Mock(spec=WorkflowExecutionDescription)

--- a/tests/unit/workflows/temporal/test_artifacts_activities.py
+++ b/tests/unit/workflows/temporal/test_artifacts_activities.py
@@ -150,6 +150,15 @@ async def test_execution_record_terminal_state_indexes_run_digest_best_effort(
             "state": "completed",
             "closeStatus": "completed",
             "summary": "Workflow completed successfully",
+            "finishOutcomeCode": "PUBLISHED_PR",
+            "finishSummary": {
+                "schemaVersion": "v1",
+                "finishOutcome": {
+                    "code": "PUBLISHED_PR",
+                    "stage": "publish",
+                    "reason": "published pull request",
+                },
+            },
         }
     )
 
@@ -160,6 +169,15 @@ async def test_execution_record_terminal_state_indexes_run_digest_best_effort(
             "close_status": "completed",
             "summary": "Workflow completed successfully",
             "error_category": None,
+            "finish_outcome_code": "PUBLISHED_PR",
+            "finish_summary": {
+                "schemaVersion": "v1",
+                "finishOutcome": {
+                    "code": "PUBLISHED_PR",
+                    "stage": "publish",
+                    "reason": "published pull request",
+                },
+            },
         }
     ]
     assert digest_calls == ["mm:run:123"]

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1691,6 +1691,55 @@ async def test_record_terminal_state_preserves_existing_terminal_summary(
 
 
 @pytest.mark.asyncio
+async def test_record_terminal_state_indexes_finish_summary(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="Finish summary run",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        finish_summary = {
+            "schemaVersion": "v1",
+            "jobId": created.workflow_id,
+            "finishOutcome": {
+                "code": "NO_CHANGES",
+                "stage": "publish",
+                "reason": "publish skipped: no local changes",
+            },
+            "publish": {"status": "skipped"},
+        }
+
+        projection = await service.record_terminal_state(
+            workflow_id=created.workflow_id,
+            state="completed",
+            close_status="completed",
+            summary="Workflow completed with no changes.",
+            finish_outcome_code="NO_CHANGES",
+            finish_summary=finish_summary,
+        )
+
+        source = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert source is not None
+        assert source.finish_outcome_code == "NO_CHANGES"
+        assert source.finish_summary_json == finish_summary
+        assert isinstance(projection, TemporalExecutionRecord)
+        assert projection.finish_outcome_code == "NO_CHANGES"
+        assert projection.finish_summary_json == finish_summary
+
+
+@pytest.mark.asyncio
 async def test_dependency_status_snapshot_repairs_stale_terminal_prerequisite(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1740,6 +1740,54 @@ async def test_record_terminal_state_indexes_finish_summary(
 
 
 @pytest.mark.asyncio
+async def test_record_terminal_state_derives_snake_case_finish_outcome_code(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="Snake finish summary run",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        finish_summary = {
+            "schema_version": "v1",
+            "job_id": created.workflow_id,
+            "finish_outcome": {
+                "code": "PUBLISH_DISABLED",
+                "stage": "publish",
+                "reason": "publishing disabled",
+            },
+        }
+
+        projection = await service.record_terminal_state(
+            workflow_id=created.workflow_id,
+            state="completed",
+            close_status="completed",
+            summary="Workflow completed without publishing.",
+            finish_outcome_code=None,
+            finish_summary=finish_summary,
+        )
+
+        source = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert source is not None
+        assert source.finish_outcome_code == "PUBLISH_DISABLED"
+        assert source.finish_summary_json == finish_summary
+        assert isinstance(projection, TemporalExecutionRecord)
+        assert projection.finish_outcome_code == "PUBLISH_DISABLED"
+        assert projection.finish_summary_json == finish_summary
+
+
+@pytest.mark.asyncio
 async def test_dependency_status_snapshot_repairs_stale_terminal_prerequisite(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -641,6 +641,62 @@ async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_record_terminal_state_supports_snake_case_finish_outcome(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    captured = {}
+
+    async def fake_execute_typed_activity(activity_type, payload, **kwargs):
+        captured["activity_type"] = activity_type
+        captured["payload"] = payload.model_dump(by_alias=True)
+        captured["kwargs"] = kwargs
+        return {
+            "workflowId": "wf-terminal-snake",
+            "state": "completed",
+            "closeStatus": "completed",
+        }
+
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-terminal-snake",
+            "run_id": "run-terminal-snake",
+            "search_attributes": {},
+        },
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info())
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    workflow_instance._finish_summary = {
+        "schema_version": "v1",
+        "finish_outcome": {
+            "code": "PUBLISH_DISABLED",
+            "stage": "publish",
+            "reason": "publishing disabled",
+        },
+    }
+
+    await workflow_instance._record_terminal_state(
+        state="completed",
+        close_status="completed",
+        summary="Workflow completed successfully",
+    )
+
+    assert captured["activity_type"] == "execution.record_terminal_state"
+    assert captured["payload"]["finishOutcomeCode"] == "PUBLISH_DISABLED"
+    assert captured["payload"]["finishOutcomeStage"] == "publish"
+    assert captured["payload"]["finishOutcomeReason"] == "publishing disabled"
+    assert captured["payload"]["finishSummary"] == workflow_instance._finish_summary
+    assert captured["kwargs"]["task_queue"] == ARTIFACTS_TASK_QUEUE
+    assert captured["kwargs"]["cancellation_type"] == ActivityCancellationType.ABANDON
+
+
+@pytest.mark.asyncio
 async def test_record_terminal_state_skips_activity_without_patch(monkeypatch):
     workflow_instance = MoonMindRunWorkflow()
 

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -602,6 +602,14 @@ async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatc
         "execute_typed_activity",
         fake_execute_typed_activity,
     )
+    workflow_instance._finish_summary = {
+        "schemaVersion": "v1",
+        "finishOutcome": {
+            "code": "PUBLISH_DISABLED",
+            "stage": "publish",
+            "reason": "publishing disabled",
+        },
+    }
 
     await workflow_instance._record_terminal_state(
         state="completed",
@@ -615,6 +623,17 @@ async def test_record_terminal_state_uses_canonical_activity_boundary(monkeypatc
         "state": "completed",
         "closeStatus": "completed",
         "summary": "Workflow completed successfully",
+        "finishOutcomeCode": "PUBLISH_DISABLED",
+        "finishOutcomeStage": "publish",
+        "finishOutcomeReason": "publishing disabled",
+        "finishSummary": {
+            "schemaVersion": "v1",
+            "finishOutcome": {
+                "code": "PUBLISH_DISABLED",
+                "stage": "publish",
+                "reason": "publishing disabled",
+            },
+        },
         "errorCategory": None,
     }
     assert captured["kwargs"]["task_queue"] == ARTIFACTS_TASK_QUEUE


### PR DESCRIPTION
Jira issue: MM-792

Summary:
- Adds indexed finish summary fields to Temporal execution source and projection records.
- Propagates the existing reports/run_summary.json payload through terminal-state recording.
- Exposes finishOutcomeCode and finishSummary in execution API serialization.
- Preserves finish-summary projection fields across Temporal sync and marks roadmap item 11.1 complete.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_indexes_finish_summary tests/unit/workflows/temporal/test_artifacts_activities.py::test_execution_record_terminal_state_indexes_run_digest_best_effort tests/unit/workflows/temporal/workflows/test_run_signals_updates.py::test_record_terminal_state_uses_canonical_activity_boundary tests/unit/test_sync.py::test_map_temporal_state_to_projection_extracts_finish_summary tests/unit/test_sync.py::test_sync_execution_projection_preserves_metadata_when_temporal_memo_decode_fails tests/unit/api/routers/test_executions.py::test_serialize_execution_includes_finish_summary_projection_fields
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist
- MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest -q tests/integration/temporal/test_exact_full_rerun_workflow.py tests/integration/temporal/test_editable_full_retry_workflow.py
- git diff --check
- python -m compileall -q on touched Python files

Remaining risks:
- Frontend/dashboard rendering still depends on existing execution API consumers adopting the new finishSummary fields where desired.
- The migration is additive and nullable, so existing executions will only have indexed finish summary fields after terminal-state recording or a future backfill.
