### PR TITLE
MM-796 Enrich structured logging context

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -273,7 +273,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - [ ] **11.2** Improvement signal capture (retries, loops, flaky tests) — Constitution X mandates this
 - [ ] **11.3** Reviewable improvement backlog / proposals queue — Task proposals exist; not fed by telemetry
 - [ ] **11.4** Metrics / dashboards (run duration, success rate, cost) — No operational metrics endpoint
-- [ ] **11.5** Structured logging enrichment (run IDs, worker IDs) — structlog in use; inconsistent enrichment
+- [x] **11.5** Structured logging enrichment (run IDs, worker IDs) — MM-796 adds shared structlog JSON enrichment for run and worker correlation
 
 ---
 

--- a/moonmind/agents/codex_worker/cli.py
+++ b/moonmind/agents/codex_worker/cli.py
@@ -31,6 +31,7 @@ from moonmind.agents.codex_worker.worker import (
     QueueApiClient,
     QueueClientError,
 )
+from moonmind.config.logging import configure_logging, default_log_fields_from_env
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
 from moonmind.jules.runtime import (
     build_runtime_gate_state as build_jules_runtime_gate_state,
@@ -483,6 +484,11 @@ async def _run(args: argparse.Namespace) -> None:
 def main(argv: list[str] | None = None) -> int:
     """Entry point for `moonmind-codex-worker`."""
 
+    configure_logging(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        structured=None,
+        default_fields=default_log_fields_from_env(),
+    )
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/moonmind/config/logging.py
+++ b/moonmind/config/logging.py
@@ -3,7 +3,11 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from collections.abc import Callable
 from typing import Any, Mapping, Optional
+
+import structlog
+from structlog.stdlib import ProcessorFormatter
 
 _RESERVED_LOG_RECORD_FIELDS = {
     "name",
@@ -70,6 +74,103 @@ class StructuredLogFormatter(logging.Formatter):
 
         return json.dumps(payload, default=str)
 
+def _first_env_text(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return ""
+
+def _service_name_from_env() -> str:
+    configured = _first_env_text(
+        "MOONMIND_SERVICE_NAME",
+        "MOONMIND_SERVICE",
+        "OTEL_SERVICE_NAME",
+        "SERVICE_NAME",
+    )
+    if configured:
+        return configured
+
+    worker_fleet = _first_env_text("MOONMIND_WORKER_FLEET", "TEMPORAL_WORKER_FLEET")
+    if worker_fleet:
+        return f"temporal-worker-{worker_fleet.replace('_', '-')}"
+
+    worker_runtime = _first_env_text("MOONMIND_WORKER_RUNTIME")
+    if worker_runtime:
+        return f"moonmind-{worker_runtime.replace('_', '-')}-worker"
+
+    return "moonmind"
+
+def _component_name_from_env() -> str:
+    return (
+        _first_env_text(
+            "MOONMIND_COMPONENT",
+            "MOONMIND_COMPONENT_NAME",
+            "TEMPORAL_WORKER_FLEET",
+            "MOONMIND_WORKER_RUNTIME",
+        )
+        or "application"
+    )
+
+def _worker_fleet_from_env() -> str:
+    return _first_env_text(
+        "MOONMIND_WORKER_FLEET",
+        "TEMPORAL_WORKER_FLEET",
+        "MOONMIND_WORKER_RUNTIME",
+    )
+
+def default_log_fields_from_env() -> dict[str, str]:
+    """Return stable log enrichment fields shared by MoonMind services."""
+
+    return {
+        "service": _service_name_from_env(),
+        "component": _component_name_from_env(),
+        "worker_fleet": _worker_fleet_from_env(),
+        "worker_id": _first_env_text("MOONMIND_WORKER_ID", "HOSTNAME"),
+    }
+
+def _merge_default_fields(
+    default_fields: Mapping[str, Any],
+) -> Callable[[Any, str, dict[str, Any]], dict[str, Any]]:
+    def processor(
+        _logger: Any, _method_name: str, event_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        for key, value in default_fields.items():
+            event_dict.setdefault(key, value)
+        return event_dict
+
+    return processor
+
+def _configure_structlog(default_fields: Mapping[str, Any]) -> ProcessorFormatter:
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        _merge_default_fields(default_fields),
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+    return ProcessorFormatter(
+        foreign_pre_chain=[
+            *shared_processors,
+            structlog.stdlib.ExtraAdder(),
+        ],
+        processors=[
+            ProcessorFormatter.remove_processors_meta,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
 def configure_logging(
     level: str = "INFO",
     format_string: Optional[str] = None,
@@ -93,16 +194,17 @@ def configure_logging(
         env_value = (
             os.getenv("WORKFLOW_STRUCTURED_LOGS")
             or os.getenv("STRUCTURED_LOGS")
-            or os.getenv("WORKFLOW_STRUCTURED_LOGS")
+            or os.getenv("MOONMIND_STRUCTURED_LOGS")
         )
-        structured = env_value.lower() in {"1", "true", "yes"} if env_value else False
+        structured = env_value.lower() in {"1", "true", "yes"} if env_value else True
+
+    resolved_default_fields = {
+        **default_log_fields_from_env(),
+        **dict(default_fields or {}),
+    }
 
     if structured:
-        formatter: logging.Formatter = StructuredLogFormatter(
-            include_timestamp=include_timestamp,
-            include_module=include_module,
-            default_fields=default_fields,
-        )
+        formatter: logging.Formatter = _configure_structlog(resolved_default_fields)
     elif format_string is None:
         parts = []
         if include_timestamp:

--- a/moonmind/config/logging.py
+++ b/moonmind/config/logging.py
@@ -141,6 +141,20 @@ def _merge_default_fields(
 
     return processor
 
+def _extract_record_attributes(
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    record = event_dict.get("_record")
+    if record is None:
+        return event_dict
+
+    for key, value in record.__dict__.items():
+        if key in _RESERVED_LOG_RECORD_FIELDS or key in event_dict:
+            continue
+        event_dict[key] = value
+
+    return event_dict
+
 def _configure_structlog(default_fields: Mapping[str, Any]) -> ProcessorFormatter:
     shared_processors = [
         structlog.contextvars.merge_contextvars,
@@ -166,6 +180,7 @@ def _configure_structlog(default_fields: Mapping[str, Any]) -> ProcessorFormatte
             structlog.stdlib.ExtraAdder(),
         ],
         processors=[
+            _extract_record_attributes,
             ProcessorFormatter.remove_processors_meta,
             structlog.processors.JSONRenderer(),
         ],

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2284,8 +2284,13 @@ async def main_async() -> None:
 
 class OpenTelemetryLoggingFilter(logging.Filter):
     """Injects OpenTelemetry and Temporal trace context into standard logging."""
+
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name)
+        self._default_fields = default_log_fields_from_env()
+
     def filter(self, record: logging.LogRecord) -> bool:
-        for key, value in default_log_fields_from_env().items():
+        for key, value in self._default_fields.items():
             setattr(record, key, value)
         record.trace_id = ""
         record.span_id = ""

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -35,6 +35,7 @@ from temporalio.client import Client
 from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+from structlog.stdlib import ProcessorFormatter
 
 from api_service.db.base import get_async_session_context
 from api_service.db.models import (
@@ -43,6 +44,7 @@ from api_service.db.models import (
     TemporalExecutionOwnerType,
     TemporalExecutionRecord,
 )
+from moonmind.config.logging import configure_logging, default_log_fields_from_env
 from moonmind.config.settings import settings
 from moonmind.workflows.skills.deployment_execution import (
     DeploymentUpdateExecutor,
@@ -167,6 +169,8 @@ _MANAGED_SESSION_LOG_FIELD_MAP: tuple[tuple[str, str], ...] = (
 )
 _OPENTELEMETRY_LOG_FORMAT = (
     "%(asctime)s %(levelname)s [%(name)s] "
+    "[service=%(service)s component=%(component)s "
+    "worker_fleet=%(worker_fleet)s worker_id=%(worker_id)s] "
     "[trace_id=%(trace_id)s span_id=%(span_id)s] "
     "[workflow_id=%(temporal_workflow_id)s run_id=%(temporal_run_id)s "
     "activity_id=%(temporal_activity_id)s] "
@@ -2281,6 +2285,8 @@ async def main_async() -> None:
 class OpenTelemetryLoggingFilter(logging.Filter):
     """Injects OpenTelemetry and Temporal trace context into standard logging."""
     def filter(self, record: logging.LogRecord) -> bool:
+        for key, value in default_log_fields_from_env().items():
+            setattr(record, key, value)
         record.trace_id = ""
         record.span_id = ""
         record.temporal_workflow_id = ""
@@ -2337,14 +2343,17 @@ class OpenTelemetryLoggingFilter(logging.Filter):
         return True
 
 def _configure_worker_logging(*, enable_opentelemetry: bool) -> None:
+    configure_logging(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        structured=None,
+        default_fields=default_log_fields_from_env(),
+    )
     if not enable_opentelemetry:
-        logging.basicConfig(level=logging.INFO)
         return
 
-    logging.basicConfig(level=logging.INFO, format=_OPENTELEMETRY_LOG_FORMAT)
-    formatter = logging.Formatter(_OPENTELEMETRY_LOG_FORMAT)
     for handler in logging.root.handlers:
-        handler.setFormatter(formatter)
+        if not isinstance(handler.formatter, ProcessorFormatter):
+            handler.setFormatter(logging.Formatter(_OPENTELEMETRY_LOG_FORMAT))
         if not any(
             isinstance(existing_filter, OpenTelemetryLoggingFilter)
             for existing_filter in handler.filters

--- a/tests/unit/config/test_logging.py
+++ b/tests/unit/config/test_logging.py
@@ -64,3 +64,41 @@ def test_configure_logging_emits_structlog_json_with_execution_context(
     assert structlog_record["service"] == "api-service"
     assert structlog_record["workflow_id"] == "wf-2"
     assert structlog_record["run_id"] == "run-2"
+
+
+def test_configure_logging_preserves_filter_injected_fields_for_native_structlog(
+    capsys, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_STRUCTURED_LOGS", "1")
+    original_handlers = list(logging.root.handlers)
+
+    class InjectTraceFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            record.trace_id = "trace-from-filter"
+            record.workflow_id = "wf-from-filter"
+            return True
+
+    try:
+        configure_logging(level="INFO", structured=True)
+        for handler in logging.root.handlers:
+            handler.addFilter(InjectTraceFilter())
+
+        structlog.get_logger("moonmind.structlog.filter").info(
+            "structlog filtered event",
+            workflow_id="wf-from-event",
+        )
+    finally:
+        logging.root.handlers = original_handlers
+        structlog.reset_defaults()
+
+    records = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    structlog_record = next(
+        record for record in records if record.get("event") == "structlog filtered event"
+    )
+
+    assert structlog_record["trace_id"] == "trace-from-filter"
+    assert structlog_record["workflow_id"] == "wf-from-event"

--- a/tests/unit/config/test_logging.py
+++ b/tests/unit/config/test_logging.py
@@ -1,0 +1,66 @@
+import json
+import logging
+
+import structlog
+
+from moonmind.config.logging import configure_logging, default_log_fields_from_env
+
+
+def test_default_log_fields_from_env_includes_worker_identity(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "agent_runtime")
+    monkeypatch.setenv("MOONMIND_WORKER_ID", "worker-17")
+
+    fields = default_log_fields_from_env()
+
+    assert fields["service"] == "temporal-worker-agent-runtime"
+    assert fields["component"] == "agent_runtime"
+    assert fields["worker_fleet"] == "agent_runtime"
+    assert fields["worker_id"] == "worker-17"
+
+
+def test_configure_logging_emits_structlog_json_with_execution_context(
+    capsys, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_STRUCTURED_LOGS", "1")
+    monkeypatch.setenv("MOONMIND_SERVICE_NAME", "api-service")
+    monkeypatch.setenv("MOONMIND_COMPONENT", "api")
+    monkeypatch.setenv("MOONMIND_WORKER_ID", "api-worker-1")
+    monkeypatch.setenv("MOONMIND_WORKER_FLEET", "api")
+    original_handlers = list(logging.root.handlers)
+
+    try:
+        configure_logging(level="INFO", structured=None)
+        logging.getLogger("moonmind.test").info(
+            "stdlib event",
+            extra={"workflow_id": "wf-1", "run_id": "run-1"},
+        )
+        structlog.get_logger("moonmind.structlog.test").info(
+            "structlog event",
+            workflow_id="wf-2",
+            run_id="run-2",
+        )
+    finally:
+        logging.root.handlers = original_handlers
+        structlog.reset_defaults()
+
+    records = [
+        json.loads(line)
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    stdlib_record = next(
+        record for record in records if record.get("event") == "stdlib event"
+    )
+    structlog_record = next(
+        record for record in records if record.get("event") == "structlog event"
+    )
+
+    assert stdlib_record["service"] == "api-service"
+    assert stdlib_record["component"] == "api"
+    assert stdlib_record["worker_fleet"] == "api"
+    assert stdlib_record["worker_id"] == "api-worker-1"
+    assert stdlib_record["workflow_id"] == "wf-1"
+    assert stdlib_record["run_id"] == "run-1"
+    assert structlog_record["service"] == "api-service"
+    assert structlog_record["workflow_id"] == "wf-2"
+    assert structlog_record["run_id"] == "run-2"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -151,6 +151,41 @@ def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields(
     assert "rawLog" not in record.managed_session
     assert "token" not in record.managed_session
 
+
+def test_opentelemetry_logging_filter_caches_default_env_fields(monkeypatch) -> None:
+    calls = 0
+
+    def fake_default_fields() -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {
+            "service": "cached-service",
+            "component": "cached-component",
+            "worker_fleet": "cached-fleet",
+            "worker_id": "cached-worker",
+        }
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.worker_runtime.default_log_fields_from_env",
+        fake_default_fields,
+    )
+    otel_filter = OpenTelemetryLoggingFilter()
+
+    for _ in range(2):
+        record = logging.LogRecord(
+            name="moonmind.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="event",
+            args=(),
+            exc_info=None,
+        )
+        assert otel_filter.filter(record) is True
+        assert record.service == "cached-service"
+
+    assert calls == 1
+
 def test_opentelemetry_log_format_includes_session_locator_fields() -> None:
     assert "service=%(service)s" in _OPENTELEMETRY_LOG_FORMAT
     assert "component=%(component)s" in _OPENTELEMETRY_LOG_FORMAT

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -78,7 +78,11 @@ class _FakeTaskInputSnapshotArtifactService:
         return SimpleNamespace(artifact_id="art_task_snapshot_1")
 
 
-def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields() -> None:
+def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "agent_runtime")
+    monkeypatch.setenv("MOONMIND_WORKER_ID", "worker-otel-1")
     record = logging.LogRecord(
         name="moonmind.test",
         level=logging.INFO,
@@ -107,6 +111,10 @@ def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields() -
 
     assert OpenTelemetryLoggingFilter().filter(record) is True
 
+    assert record.service == "temporal-worker-agent-runtime"
+    assert record.component == "agent_runtime"
+    assert record.worker_fleet == "agent_runtime"
+    assert record.worker_id == "worker-otel-1"
     assert record.managed_session_task_run_id == "wf-run-1"
     assert record.managed_session_runtime_id == "codex_cli"
     assert record.managed_session_id == "sess:wf-run-1:codex_cli"
@@ -144,25 +152,31 @@ def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields() -
     assert "token" not in record.managed_session
 
 def test_opentelemetry_log_format_includes_session_locator_fields() -> None:
+    assert "service=%(service)s" in _OPENTELEMETRY_LOG_FORMAT
+    assert "component=%(component)s" in _OPENTELEMETRY_LOG_FORMAT
+    assert "worker_fleet=%(worker_fleet)s" in _OPENTELEMETRY_LOG_FORMAT
+    assert "worker_id=%(worker_id)s" in _OPENTELEMETRY_LOG_FORMAT
     assert "container_id=%(managed_session_container_id)s" in _OPENTELEMETRY_LOG_FORMAT
     assert "thread_id=%(managed_session_thread_id)s" in _OPENTELEMETRY_LOG_FORMAT
     assert "turn_id=%(managed_session_turn_id)s" in _OPENTELEMETRY_LOG_FORMAT
 
-def test_configure_worker_logging_applies_otel_formatter_to_existing_handlers() -> None:
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
+def test_configure_worker_logging_applies_otel_filter(monkeypatch) -> None:
+    monkeypatch.setenv("MOONMIND_STRUCTURED_LOGS", "1")
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "sandbox")
+    monkeypatch.setenv("MOONMIND_WORKER_ID", "worker-sandbox-1")
     original_handlers = list(logging.root.handlers)
-    logging.root.handlers = [handler]
 
     try:
         _configure_worker_logging(enable_opentelemetry=True)
     finally:
+        handlers = list(logging.root.handlers)
         logging.root.handlers = original_handlers
 
-    assert handler.formatter is not None
-    assert handler.formatter._fmt == _OPENTELEMETRY_LOG_FORMAT
+    assert handlers
+    assert all(handler.formatter is not None for handler in handlers)
     assert any(
         isinstance(existing_filter, OpenTelemetryLoggingFilter)
+        for handler in handlers
         for existing_filter in handler.filters
     )
 


### PR DESCRIPTION
Jira issue key: MM-796

Summary:
- Add shared structlog JSON configuration with service, component, worker_fleet, and worker_id enrichment.
- Preserve run/workflow correlation fields across stdlib and structlog records.
- Initialize shared logging for Temporal worker runtime and the Codex worker CLI.
- Mark roadmap item 11.5 complete.

Tests run:
- ./tools/test_unit.sh tests/unit/config/test_logging.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
- ./tools/test_integration.sh

Remaining risks:
- Existing deployment environments that explicitly disable structured logging will continue to emit non-JSON logs until their environment flags are changed.