### PR TITLE
MM-793 Capture improvement signals

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -263,10 +263,11 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 - Temporal visibility / execution queries (spec 064)
 - Structured workflow run states in Postgres
 - Task finish summary system (spec 079)
+- Deterministic improvement signal capture for retry, loop/no-progress, and flaky-test run-quality proposals (MM-793)
 
 ### Remaining tasks
 - [ ] **11.1** Structured outcome summaries on every run — Spec 079 started; not fully wired
-- [ ] **11.2** Improvement signal capture (retries, loops, flaky tests) — Constitution X mandates this
+- [x] **11.2** Improvement signal capture (retries, loops, flaky tests) — Constitution X mandates this
 - [ ] **11.3** Reviewable improvement backlog / proposals queue — Task proposals exist; not fed by telemetry
 - [ ] **11.4** Metrics / dashboards (run duration, success rate, cost) — No operational metrics endpoint
 - [ ] **11.5** Structured logging enrichment (run IDs, worker IDs) — structlog in use; inconsistent enrichment

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -145,6 +145,18 @@ _MOONMIND_SIGNAL_TAGS = frozenset(
 _FIX_PROPOSAL_SKILL_ID = "fix-proposal"
 _CONTINUATION_PROPOSAL_SKILL_ID = "continuation-proposal"
 _PR_RESOLVER_SKILL_ID = "pr-resolver"
+_RUN_QUALITY_LOOP_PATTERN = re.compile(
+    r"\b(?:loop(?:ing|ed)?|stuck|no progress|repeated output|duplicate output)\b",
+    re.IGNORECASE,
+)
+_RUN_QUALITY_FLAKY_TEST_PATTERN = re.compile(
+    r"\b(?:flaky tests?|test flake|intermittent test|passed on retry|rerun passed)\b",
+    re.IGNORECASE,
+)
+_RUN_QUALITY_RETRY_PATTERN = re.compile(
+    r"\b(?:retry|retries|retried|attempt\s+\d+\s+of\s+\d+)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -445,6 +457,19 @@ def _append_tag_slug(title: str, tags: Sequence[str]) -> str:
     if marker in title:
         return title
     return f"{title} (tags: {slug_text})"
+
+
+def _readable_signal_phrase(tags: Sequence[str]) -> str:
+    """Return a compact human phrase for deterministic run-quality tags."""
+
+    if "loop_detected" in tags:
+        return "execution loop or no-progress behavior"
+    if "flaky_test" in tags:
+        return "flaky test behavior"
+    if "retry" in tags:
+        return "repeated retry behavior"
+    return "run-quality signal"
+
 
 class QueueClientError(RuntimeError):
     """Raised when queue API requests fail."""
@@ -8777,6 +8802,154 @@ class CodexWorker:
 
         return artifacts
 
+    def _build_improvement_signal_proposals(
+        self,
+        *,
+        job: ClaimedJob,
+        canonical_payload: Mapping[str, Any],
+        task_result: WorkerExecutionResult,
+    ) -> list[dict[str, Any]]:
+        """Build deterministic run-quality proposals from normalized telemetry."""
+
+        reason = (
+            dict(task_result.run_quality_reason)
+            if isinstance(task_result.run_quality_reason, Mapping)
+            else {}
+        )
+        reason_text = " ".join(
+            str(part or "")
+            for part in (
+                task_result.summary,
+                task_result.error_message,
+                reason.get("category"),
+                reason.get("code"),
+                reason.get("summary"),
+                reason.get("details"),
+            )
+        )
+        tags = _normalize_proposal_tags(reason.get("tags"))
+        signal_tags: list[str] = [
+            tag for tag in tags if tag in _MOONMIND_SIGNAL_TAGS
+        ]
+
+        details = reason.get("details")
+        details_map = details if isinstance(details, Mapping) else {}
+        failure_class = str(details_map.get("failureClass") or "").strip().lower()
+        reason_category = str(reason.get("category") or "").strip().lower()
+        reason_code = str(reason.get("code") or "").strip().lower()
+
+        if job.attempt > 1 or _RUN_QUALITY_RETRY_PATTERN.search(reason_text):
+            signal_tags.append("retry")
+        if (
+            _RUN_QUALITY_LOOP_PATTERN.search(reason_text)
+            or failure_class in {"stuck_no_progress", "stuck", "no_progress"}
+        ):
+            signal_tags.append("loop_detected")
+        if _RUN_QUALITY_FLAKY_TEST_PATTERN.search(reason_text):
+            signal_tags.append("flaky_test")
+        if reason_category == "self_heal" or reason_code == "step_retryable_exhausted":
+            signal_tags.append("retry")
+
+        signal_tags = [
+            tag
+            for tag in _normalize_proposal_tags(signal_tags)
+            if tag in _MOONMIND_SIGNAL_TAGS
+        ]
+        if not signal_tags:
+            return []
+
+        severity = "medium"
+        if "loop_detected" in signal_tags or (
+            job.max_attempts > 1 and job.attempt >= job.max_attempts
+        ):
+            severity = "high"
+        phrase = _readable_signal_phrase(signal_tags)
+        evidence_source = (
+            reason.get("summary")
+            or task_result.error_message
+            or task_result.summary
+            or phrase
+        )
+        evidence = self._redact_text(
+            str(evidence_source)
+        )[:500]
+        instructions = (
+            "MM-793 follow-up: investigate and harden MoonMind improvement-signal "
+            f"capture for {phrase}. Use the source run evidence, add regression "
+            "coverage, and keep the fix scoped to deterministic signal capture."
+        )
+        request = self._build_proposal_task_request_template(canonical_payload)
+        request_payload = request.get("payload")
+        payload = request_payload if isinstance(request_payload, dict) else {}
+        task_node = payload.get("task")
+        task = task_node if isinstance(task_node, dict) else {}
+        task["instructions"] = instructions
+        publish_node = task.get("publish")
+        publish = publish_node if isinstance(publish_node, dict) else {}
+        publish["commitMessage"] = "MM-793 Capture improvement signals"
+        publish["prTitle"] = "MM-793 Capture improvement signals"
+        task["publish"] = publish
+        payload["task"] = task
+        request["payload"] = payload
+
+        return [
+            {
+                "title": f"[run_quality] MM-793 Capture {phrase}",
+                "summary": (
+                    "Deterministic improvement signal captured from run telemetry: "
+                    f"{evidence or phrase}"
+                ),
+                "category": "run_quality",
+                "tags": signal_tags,
+                "signal": {
+                    "severity": severity,
+                    "evidence": evidence or phrase,
+                    "source": "codex_worker",
+                    "jobAttempt": job.attempt,
+                    "jobMaxAttempts": job.max_attempts,
+                    "reasonCode": reason.get("code"),
+                },
+                "taskCreateRequest": request,
+            }
+        ]
+
+    @staticmethod
+    def _write_task_proposal_seed(
+        *,
+        proposals_path: Path,
+        candidates: Sequence[Mapping[str, Any]],
+    ) -> str:
+        """Write deterministic proposal candidates and return the serialized text."""
+
+        proposal_text = json.dumps(list(candidates), indent=2, sort_keys=True) + "\n"
+        proposals_path.parent.mkdir(parents=True, exist_ok=True)
+        proposals_path.write_text(proposal_text, encoding="utf-8")
+        return proposal_text
+
+    def _proposal_artifact_for_seed(
+        self,
+        *,
+        prepared: PreparedTaskWorkspace,
+        candidates: Sequence[Mapping[str, Any]],
+    ) -> list[ArtifactUpload]:
+        """Persist deterministic proposal candidates as a proposal artifact."""
+
+        if not candidates:
+            return []
+        proposal_output_path = prepared.artifacts_dir / "task_proposals.json"
+        self._write_task_proposal_seed(
+            proposals_path=proposal_output_path,
+            candidates=candidates,
+        )
+        return [
+            ArtifactUpload(
+                path=proposal_output_path,
+                name="task_proposals.json",
+                content_type="application/json",
+                required=False,
+            )
+        ]
+
     async def _run_post_task_proposal_skills(
         self,
         *,
@@ -8791,6 +8964,11 @@ class CodexWorker:
     ) -> list[ArtifactUpload]:
         """Execute post-run proposal skills and collect generated artifacts."""
 
+        deterministic_candidates = self._build_improvement_signal_proposals(
+            job=job,
+            canonical_payload=canonical_payload,
+            task_result=task_result,
+        )
         hook_skill_ids = self._proposal_hook_skill_ids(
             include_continuation=task_result.succeeded
         )
@@ -8812,7 +8990,10 @@ class CodexWorker:
                     payload={"skills": skipped_skills},
                 )
         if not hook_skill_ids:
-            return []
+            return self._proposal_artifact_for_seed(
+                prepared=prepared,
+                candidates=deterministic_candidates,
+            )
         if not self._ensure_post_task_proposal_skills_materialized(
             job_id=job.id,
             prepared=prepared,
@@ -8825,15 +9006,23 @@ class CodexWorker:
                 message="task.proposalSkill.materializationFailed",
                 payload={"skills": list(hook_skill_ids)},
             )
-            return []
+            return self._proposal_artifact_for_seed(
+                prepared=prepared,
+                candidates=deterministic_candidates,
+            )
 
         proposal_output_path = prepared.artifacts_dir / "task_proposals.json"
-        proposal_output_path.write_text("[]\n", encoding="utf-8")
+        self._write_task_proposal_seed(
+            proposals_path=proposal_output_path,
+            candidates=deterministic_candidates,
+        )
         proposal_output_path_for_skill = (
             prepared.repo_dir / ".artifacts" / f"moonmind_task_proposals_{job.id}.json"
         )
-        proposal_output_path_for_skill.parent.mkdir(parents=True, exist_ok=True)
-        proposal_output_path_for_skill.write_text("[]\n", encoding="utf-8")
+        self._write_task_proposal_seed(
+            proposals_path=proposal_output_path_for_skill,
+            candidates=deterministic_candidates,
+        )
         initial_proposal_output_for_skill = proposal_output_path_for_skill.read_text(
             encoding="utf-8"
         )

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -8873,11 +8873,26 @@ class CodexWorker:
         evidence = self._redact_text(
             str(evidence_source)
         )[:500]
-        instructions = (
-            "MM-793 follow-up: investigate and harden MoonMind improvement-signal "
-            f"capture for {phrase}. Use the source run evidence, add regression "
-            "coverage, and keep the fix scoped to deterministic signal capture."
-        )
+        repository = str(canonical_payload.get("repository") or "").strip().lower()
+        is_moonmind_repository = repository == "moonladderstudios/moonmind"
+        if is_moonmind_repository:
+            instructions = (
+                "MM-793 follow-up: investigate and harden MoonMind improvement-signal "
+                f"capture for {phrase}. Use the source run evidence, add regression "
+                "coverage, and keep the fix scoped to deterministic signal capture."
+            )
+            title = f"[run_quality] MM-793 Capture {phrase}"
+            commit_message = "MM-793 Capture improvement signals"
+            pr_title = "MM-793 Capture improvement signals"
+        else:
+            instructions = (
+                f"Investigate and harden this project's run-quality handling for {phrase}. "
+                "Use the source run evidence, add regression coverage, and keep the fix "
+                "scoped to the observed retry, loop, or flaky-test behavior."
+            )
+            title = f"[run_quality] Capture {phrase}"
+            commit_message = f"Capture run-quality signals for {phrase}"
+            pr_title = f"Capture run-quality signals for {phrase}"
         request = self._build_proposal_task_request_template(canonical_payload)
         request_payload = request.get("payload")
         payload = request_payload if isinstance(request_payload, dict) else {}
@@ -8886,15 +8901,15 @@ class CodexWorker:
         task["instructions"] = instructions
         publish_node = task.get("publish")
         publish = publish_node if isinstance(publish_node, dict) else {}
-        publish["commitMessage"] = "MM-793 Capture improvement signals"
-        publish["prTitle"] = "MM-793 Capture improvement signals"
+        publish["commitMessage"] = commit_message
+        publish["prTitle"] = pr_title
         task["publish"] = publish
         payload["task"] = task
         request["payload"] = payload
 
         return [
             {
-                "title": f"[run_quality] MM-793 Capture {phrase}",
+                "title": title,
                 "summary": (
                     "Deterministic improvement signal captured from run telemetry: "
                     f"{evidence or phrase}"
@@ -9196,9 +9211,29 @@ class CodexWorker:
                         encoding="utf-8"
                     )
                     if skill_output != initial_proposal_output_for_skill:
-                        shutil.copy2(
-                            proposal_output_path_for_skill, proposal_output_path
+                        parsed_output = json.loads(skill_output)
+                        normalized_output = (
+                            parsed_output
+                            if isinstance(parsed_output, list)
+                            else [parsed_output]
                         )
+                        proposal_output_path.write_text(
+                            json.dumps(
+                                normalized_output,
+                                indent=2,
+                                sort_keys=True,
+                            )
+                            + "\n",
+                            encoding="utf-8",
+                        )
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping invalid proposal output copy from %s to %s for job %s",
+                    proposal_output_path_for_skill,
+                    proposal_output_path,
+                    job.id,
+                    exc_info=True,
+                )
             except OSError:
                 logger.warning(
                     "Failed to copy proposal output from %s to %s for job %s",

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1369,6 +1369,52 @@ async def test_worker_builds_deterministic_retry_loop_signal_proposal(
     assert "MM-793" in instructions
 
 
+async def test_worker_builds_project_safe_run_quality_signal_proposal(
+    tmp_path: Path,
+) -> None:
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+        ),
+    )  # type: ignore[arg-type]
+
+    proposals = worker._build_improvement_signal_proposals(
+        job=ClaimedJob(id=uuid4(), type="task", attempt=2, max_attempts=3, payload={}),
+        canonical_payload={
+            "repository": "ExampleOrg/ProjectRepo",
+            "task": {"git": {"startingBranch": "main"}},
+        },
+        task_result=WorkerExecutionResult(
+            succeeded=False,
+            summary="retry loop detected",
+            error_message="agent entered a loop after retry",
+        ),
+    )
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    serialized = json.dumps(proposal)
+    assert "MM-793" not in serialized
+    assert "MoonMind improvement-signal" not in serialized
+    assert proposal["taskCreateRequest"]["payload"]["repository"] == (
+        "ExampleOrg/ProjectRepo"
+    )
+    task = proposal["taskCreateRequest"]["payload"]["task"]
+    assert "this project's run-quality handling" in task["instructions"]
+    assert task["publish"]["commitMessage"].startswith("Capture run-quality signals")
+
+
 async def test_worker_builds_deterministic_flaky_test_signal_proposal(
     tmp_path: Path,
 ) -> None:
@@ -1472,6 +1518,85 @@ async def test_post_task_proposal_skills_seed_deterministic_signal_artifact(
     )
     assert proposals[0]["tags"] == ["retry", "loop_detected"]
     assert proposals[0]["signal"]["source"] == "codex_worker"
+
+
+async def test_post_task_proposal_skills_preserve_seed_on_invalid_hook_output(
+    tmp_path: Path,
+) -> None:
+    class CorruptingHandler(FakeHandler):
+        async def handle_skill(self, **kwargs):  # type: ignore[no-untyped-def]
+            payload = kwargs["payload"]
+            output_path = Path(payload["inputs"]["proposalOutputPath"])
+            output_path.write_text("{invalid json", encoding="utf-8")
+            return await super().handle_skill(**kwargs)
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    handler = CorruptingHandler(
+        WorkerExecutionResult(
+            succeeded=True,
+            summary="proposal skill wrote malformed output",
+            error_message=None,
+        )
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+    worker._active_cancel_event = asyncio.Event()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / "job",
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "artifacts",
+        publish_result_path=tmp_path / "publish-result.log",
+        default_branch="main",
+        starting_branch="main",
+        new_branch=None,
+        working_branch="feature/mm-793",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True)
+    prepared.artifacts_dir.mkdir(parents=True)
+
+    artifacts = await worker._run_post_task_proposal_skills(
+        job=ClaimedJob(id=uuid4(), type="task", attempt=2, max_attempts=3, payload={}),
+        canonical_payload={"repository": "MoonLadderStudios/MoonMind", "task": {}},
+        source_payload={},
+        runtime_mode="codex",
+        prepared=prepared,
+        task_result=WorkerExecutionResult(
+            succeeded=False,
+            summary="retry loop detected",
+            error_message="agent entered a loop after retry",
+        ),
+        selected_skills=("auto",),
+    )
+
+    assert "codex_skill:fix-proposal:True" in handler.calls
+    assert any(artifact.name == "task_proposals.json" for artifact in artifacts)
+    proposals = json.loads(
+        (prepared.artifacts_dir / "task_proposals.json").read_text(encoding="utf-8")
+    )
+    assert proposals[0]["tags"] == ["retry", "loop_detected"]
+    assert proposals[0]["signal"]["source"] == "codex_worker"
+    skill_output_path = next(
+        (prepared.repo_dir / ".artifacts").glob("moonmind_task_proposals_*.json")
+    )
+    assert skill_output_path.read_text(encoding="utf-8") == "{invalid json"
 
 
 async def test_worker_submission_outcome_preserves_delivery_failure_details() -> None:

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1313,6 +1313,166 @@ async def test_worker_submission_report_aggregates_delivery_outcomes(
         },
     )
 
+async def test_worker_builds_deterministic_retry_loop_signal_proposal(
+    tmp_path: Path,
+) -> None:
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+        ),
+    )  # type: ignore[arg-type]
+
+    proposals = worker._build_improvement_signal_proposals(
+        job=ClaimedJob(
+            id=uuid4(),
+            type="task",
+            attempt=3,
+            max_attempts=3,
+            payload={},
+        ),
+        canonical_payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "task": {"git": {"startingBranch": "main"}},
+        },
+        task_result=WorkerExecutionResult(
+            succeeded=False,
+            summary="step stuck with no progress after retries",
+            error_message="attempt 3 of 3 exhausted",
+            run_quality_reason={
+                "category": "self_heal",
+                "code": "step_retryable_exhausted",
+                "summary": "self-heal retries exhausted for retryable failure",
+                "tags": ["retry"],
+                "details": {"failureClass": "stuck_no_progress"},
+            },
+        ),
+    )
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal["category"] == "run_quality"
+    assert "retry" in proposal["tags"]
+    assert "loop_detected" in proposal["tags"]
+    assert proposal["signal"]["severity"] == "high"
+    instructions = proposal["taskCreateRequest"]["payload"]["task"]["instructions"]
+    assert "MM-793" in instructions
+
+
+async def test_worker_builds_deterministic_flaky_test_signal_proposal(
+    tmp_path: Path,
+) -> None:
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+        ),
+    )  # type: ignore[arg-type]
+
+    proposals = worker._build_improvement_signal_proposals(
+        job=ClaimedJob(id=uuid4(), type="task", attempt=1, max_attempts=3, payload={}),
+        canonical_payload={"repository": "MoonLadderStudios/MoonMind", "task": {}},
+        task_result=WorkerExecutionResult(
+            succeeded=False,
+            summary="pytest failed, then passed on retry; likely flaky test",
+            error_message="flaky tests detected in unit suite",
+        ),
+    )
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal["tags"] == ["retry", "flaky_test"]
+    assert proposal["signal"]["severity"] == "medium"
+    assert "flaky test behavior" in proposal["title"]
+
+
+async def test_post_task_proposal_skills_seed_deterministic_signal_artifact(
+    tmp_path: Path,
+) -> None:
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_task_proposals=True,
+    )
+    handler = FakeHandler(
+        WorkerExecutionResult(
+            succeeded=True,
+            summary="proposal skill left deterministic seed unchanged",
+            error_message=None,
+        )
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+    worker._active_cancel_event = asyncio.Event()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / "job",
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "artifacts",
+        publish_result_path=tmp_path / "publish-result.log",
+        default_branch="main",
+        starting_branch="main",
+        new_branch=None,
+        working_branch="feature/mm-793",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True)
+    prepared.artifacts_dir.mkdir(parents=True)
+
+    artifacts = await worker._run_post_task_proposal_skills(
+        job=ClaimedJob(id=uuid4(), type="task", attempt=2, max_attempts=3, payload={}),
+        canonical_payload={"repository": "MoonLadderStudios/MoonMind", "task": {}},
+        source_payload={},
+        runtime_mode="codex",
+        prepared=prepared,
+        task_result=WorkerExecutionResult(
+            succeeded=False,
+            summary="retry loop detected",
+            error_message="agent entered a loop after retry",
+        ),
+        selected_skills=("auto",),
+    )
+
+    assert "codex_skill:fix-proposal:True" in handler.calls
+    assert any(artifact.name == "task_proposals.json" for artifact in artifacts)
+    proposals = json.loads(
+        (prepared.artifacts_dir / "task_proposals.json").read_text(encoding="utf-8")
+    )
+    assert proposals[0]["tags"] == ["retry", "loop_detected"]
+    assert proposals[0]["signal"]["source"] == "codex_worker"
+
 
 async def test_worker_submission_outcome_preserves_delivery_failure_details() -> None:
     outcome = CodexWorker._proposal_submission_outcome(


### PR DESCRIPTION
Jira issue: MM-793

Summary:
- Adds deterministic run-quality improvement-signal proposal capture for retries, execution loops/no-progress, and flaky tests.
- Seeds captured signals into task_proposals.json so the existing proposal submission path can route them into reviewable follow-up proposal/backlog records.
- Updates roadmap status for Milestone 11 item 11.2 and adds focused worker unit coverage.

Tests run:
- python -m py_compile moonmind/agents/codex_worker/worker.py tests/unit/agents/codex_worker/test_worker.py
- git diff --check
- ./tools/test_unit.sh --python-only tests/unit/agents/codex_worker/test_worker.py -k 'deterministic_retry_loop_signal or deterministic_flaky_test_signal or post_task_proposal_skills_seed_deterministic_signal_artifact or worker_submission_report_aggregates_delivery_outcomes'
- ./tools/test_unit.sh --python-only tests/unit/agents/codex_worker/test_worker.py
- ./tools/test_unit.sh
- ./tools/test_integration.sh

Remaining risks:
- Signal detection is intentionally deterministic and regex/tag based; future telemetry categories may need explicit additions to avoid over-broad inference.
- The proposal hook path can still append or transform seeded proposals, so downstream policy/delivery configuration determines where captured signals are ultimately published.
