### PR TITLE
MM-795 add operational execution metrics

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7217,19 +7217,25 @@ def _coerce_metric_float(value: Any) -> float | None:
 
 
 def _extract_cost_estimate_usd(*payloads: Any) -> float | None:
-    stack = list(payloads)
+    stack = [(payload, False) for payload in payloads]
     while stack:
-        value = stack.pop()
+        value, cost_context = stack.pop()
+        if cost_context:
+            candidate = _coerce_metric_float(value)
+            if candidate is not None:
+                return candidate
         if isinstance(value, dict):
             for key, nested in value.items():
                 if str(key) in _EXECUTION_COST_KEYS:
                     candidate = _coerce_metric_float(nested)
                     if candidate is not None:
                         return candidate
+                    if isinstance(nested, dict | list | tuple):
+                        stack.append((nested, True))
                 elif isinstance(nested, dict | list | tuple):
-                    stack.append(nested)
+                    stack.append((nested, False))
         elif isinstance(value, (list, tuple)):
-            stack.extend(value)
+            stack.extend((nested, cost_context) for nested in value)
     return None
 
 
@@ -7331,13 +7337,38 @@ async def get_execution_metrics(
         *,
         metric_state_in: str | None = None,
         include_order: bool = False,
-    ) -> str:
+    ) -> str | None:
+        metric_state_values = _split_temporal_values(
+            metric_state_in,
+            alias="metric_state_in",
+        )
+        state_values = _raw_query_values(request, "stateIn", state_in)
+        state_not_values = _raw_query_values(request, "stateNotIn", state_not_in)
+        if metric_state_values:
+            exact_state = str(state or "").strip()
+            if exact_state and not (state_values or state_not_values):
+                metric_state_values = [
+                    value for value in metric_state_values if value == exact_state
+                ]
+            if state_values:
+                allowed = set(state_values)
+                metric_state_values = [
+                    value for value in metric_state_values if value in allowed
+                ]
+            if state_not_values:
+                blocked = set(state_not_values)
+                metric_state_values = [
+                    value for value in metric_state_values if value not in blocked
+                ]
+            if not metric_state_values:
+                return None
+            metric_state_in = ",".join(metric_state_values)
         count_query, list_query = _build_temporal_execution_query(
             request=request,
             workflow_type=workflow_type,
-            state=state,
+            state=None if metric_state_values else state,
             state_in=metric_state_in or state_in,
-            state_not_in=None if metric_state_in else state_not_in,
+            state_not_in=None if metric_state_values else state_not_in,
             entry=entry,
             repo=repo,
             repo_exact=repo_exact,
@@ -7362,39 +7393,38 @@ async def get_execution_metrics(
             owner_id=effective_owner,
             sort="closedAt",
             sort_dir="desc",
-            exclude_aliases=(
-                frozenset({"state", "stateIn", "stateNotIn"})
-                if metric_state_in
-                else frozenset()
-            ),
             include_order=include_order,
         )
         return list_query if include_order else count_query
 
     try:
         client = temporal_client
-        total_count = await client.count_workflows(query=build_query())
-        completed_count = await client.count_workflows(
-            query=build_query(metric_state_in="completed")
-        )
-        failed_count = await client.count_workflows(
-            query=build_query(metric_state_in="failed")
-        )
-        canceled_count = await client.count_workflows(
-            query=build_query(metric_state_in="canceled")
+
+        async def count_matching_workflows(query: str | None) -> int:
+            if query is None:
+                return 0
+            count_result = await client.count_workflows(query=query)
+            return int(count_result.count)
+
+        total, completed, failed, canceled = await asyncio.gather(
+            count_matching_workflows(build_query()),
+            count_matching_workflows(build_query(metric_state_in="completed")),
+            count_matching_workflows(build_query(metric_state_in="failed")),
+            count_matching_workflows(build_query(metric_state_in="canceled")),
         )
 
         terminal_query = build_query(
             metric_state_in="completed,failed,canceled",
             include_order=True,
         )
-        iterator = client.list_workflows(
-            query=terminal_query,
-            page_size=sample_size,
-        )
-        await iterator.fetch_next_page()
-
-        page = iterator.current_page or []
+        page = []
+        if terminal_query is not None:
+            iterator = client.list_workflows(
+                query=terminal_query,
+                page_size=sample_size,
+            )
+            await iterator.fetch_next_page()
+            page = iterator.current_page or []
         canonical_map: dict[str, TemporalExecutionCanonicalRecord] = {}
         if page:
             workflow_ids = [wf.id for wf in page]
@@ -7426,13 +7456,10 @@ async def get_execution_metrics(
             if cost is not None:
                 costs.append(cost)
 
-        completed = int(completed_count.count)
-        failed = int(failed_count.count)
-        canceled = int(canceled_count.count)
         terminal = completed + failed + canceled
         success_rate = completed / terminal if terminal else None
         return ExecutionMetricsResponse(
-            totalRuns=int(total_count.count),
+            totalRuns=total,
             completedRuns=completed,
             failedRuns=failed,
             canceledRuns=canceled,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -63,6 +63,9 @@ from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProjectionDiagnosticModel,
     ExecutionListResponse,
+    ExecutionMetricsCostModel,
+    ExecutionMetricsDurationModel,
+    ExecutionMetricsResponse,
     ExecutionModel,
     ExecutionProgressModel,
     ExecutionReportProjectionModel,
@@ -188,6 +191,21 @@ _EXECUTION_FILTER_VALUE_LIMIT = 50
 _EXECUTION_FILTER_VALUE_MAX_LENGTH = 200
 _EXECUTION_TEXT_FILTER_MAX_LENGTH = 200
 _EXECUTION_FACET_PAGE_SIZE_LIMIT = 200
+_EXECUTION_METRICS_SAMPLE_SIZE_LIMIT = 500
+_EXECUTION_COST_KEYS = frozenset(
+    {
+        "costEstimateUsd",
+        "cost_estimate_usd",
+        "estimatedCostUsd",
+        "estimated_cost_usd",
+        "costUsd",
+        "cost_usd",
+        "totalCostUsd",
+        "total_cost_usd",
+        "mm_cost_estimate_usd",
+        "moonmind.cost_estimate_usd",
+    }
+)
 _EXECUTION_SORT_FIELDS = {
     "workflowId": "WorkflowId",
     "targetRuntime": "mm_target_runtime",
@@ -384,6 +402,35 @@ def _is_execution_admin(user: User | None) -> bool:
 def _owner_id(user: User | None) -> str | None:
     value = getattr(user, "id", None)
     return str(value) if value is not None else None
+
+
+def _effective_execution_owner_scope(
+    *,
+    user: User,
+    owner_type: str | None,
+    owner_id: str | None,
+) -> tuple[str | None, str | None]:
+    if _is_execution_admin(user):
+        return owner_type, owner_id
+
+    normalized_owner_type = str(owner_type or "").strip().lower()
+    if owner_type is not None and normalized_owner_type != "user":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "execution_forbidden",
+                "message": "Cannot list non-user executions.",
+            },
+        )
+    if owner_id is not None and owner_id != _owner_id(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "execution_forbidden",
+                "message": "Cannot list executions for another user.",
+            },
+        )
+    return ("user" if normalized_owner_type == "user" else None), _owner_id(user)
 
 
 def _normalize_temporal_list_scope(
@@ -6940,29 +6987,11 @@ async def list_executions(
     session: AsyncSession = Depends(get_async_session),
     temporal_client: Client = Depends(get_temporal_client),
 ) -> ExecutionListResponse:
-    if _is_execution_admin(user):
-        effective_owner_type = owner_type
-        effective_owner = owner_id
-    else:
-        normalized_owner_type = str(owner_type or "").strip().lower()
-        if owner_type is not None and owner_type != "user":
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "code": "execution_forbidden",
-                    "message": "Cannot list non-user executions.",
-                },
-            )
-        if owner_id is not None and owner_id != _owner_id(user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={
-                    "code": "execution_forbidden",
-                    "message": "Cannot list executions for another user.",
-                },
-            )
-        effective_owner = _owner_id(user)
-        effective_owner_type = "user" if normalized_owner_type == "user" else None
+    effective_owner_type, effective_owner = _effective_execution_owner_scope(
+        user=user,
+        owner_type=owner_type,
+        owner_id=owner_id,
+    )
 
     if source == "temporal":
         try:
@@ -7166,6 +7195,272 @@ async def list_executions(
             default=None,
         ),
     )
+
+def _coerce_metric_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        candidate = float(value)
+    elif isinstance(value, str):
+        text = value.strip().replace("$", "").replace(",", "")
+        if not text:
+            return None
+        try:
+            candidate = float(text)
+        except ValueError:
+            return None
+    else:
+        return None
+    if candidate < 0:
+        return None
+    return candidate
+
+
+def _extract_cost_estimate_usd(*payloads: Any) -> float | None:
+    stack = list(payloads)
+    while stack:
+        value = stack.pop()
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if str(key) in _EXECUTION_COST_KEYS:
+                    candidate = _coerce_metric_float(nested)
+                    if candidate is not None:
+                        return candidate
+                elif isinstance(nested, dict | list | tuple):
+                    stack.append(nested)
+        elif isinstance(value, (list, tuple)):
+            stack.extend(value)
+    return None
+
+
+def _duration_seconds_from_payload(payload: Mapping[str, Any]) -> float | None:
+    closed_at = payload.get("closed_at")
+    started_at = payload.get("started_at") or payload.get("created_at")
+    if not isinstance(closed_at, datetime) or not isinstance(started_at, datetime):
+        return None
+    duration = (closed_at - started_at).total_seconds()
+    return duration if duration >= 0 else None
+
+
+def _duration_metrics(values: list[float]) -> ExecutionMetricsDurationModel:
+    if not values:
+        return ExecutionMetricsDurationModel()
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        median = ordered[midpoint]
+    else:
+        median = (ordered[midpoint - 1] + ordered[midpoint]) / 2
+    return ExecutionMetricsDurationModel(
+        averageSeconds=sum(ordered) / len(ordered),
+        medianSeconds=median,
+        minSeconds=ordered[0],
+        maxSeconds=ordered[-1],
+        observedCount=len(ordered),
+    )
+
+
+def _cost_metrics(values: list[float]) -> ExecutionMetricsCostModel:
+    if not values:
+        return ExecutionMetricsCostModel()
+    total = sum(values)
+    return ExecutionMetricsCostModel(
+        totalEstimateUsd=total,
+        averageEstimateUsd=total / len(values),
+        observedCount=len(values),
+    )
+
+
+@router.get("/metrics", response_model=ExecutionMetricsResponse)
+async def get_execution_metrics(
+    *,
+    request: Request,
+    workflow_type: Optional[str] = Query(None, alias="workflowType"),
+    owner_type: Optional[str] = Query(None, alias="ownerType"),
+    state: Optional[str] = Query(None, alias="state"),
+    state_in: Optional[str] = Query(None, alias="stateIn"),
+    state_not_in: Optional[str] = Query(None, alias="stateNotIn"),
+    owner_id: Optional[str] = Query(None, alias="ownerId"),
+    entry: Optional[str] = Query(None, alias="entry"),
+    repo: Optional[str] = Query(None, alias="repo"),
+    repo_exact: Optional[str] = Query(None, alias="repoExact"),
+    repo_in: Optional[str] = Query(None, alias="repoIn"),
+    repo_not_in: Optional[str] = Query(None, alias="repoNotIn"),
+    integration: Optional[str] = Query(None, alias="integration"),
+    target_runtime: Optional[str] = Query(None, alias="targetRuntime"),
+    target_runtime_in: Optional[str] = Query(None, alias="targetRuntimeIn"),
+    target_runtime_not_in: Optional[str] = Query(None, alias="targetRuntimeNotIn"),
+    target_skill_in: Optional[str] = Query(None, alias="targetSkillIn"),
+    target_skill_not_in: Optional[str] = Query(None, alias="targetSkillNotIn"),
+    scheduled_from: Optional[str] = Query(None, alias="scheduledFrom"),
+    scheduled_to: Optional[str] = Query(None, alias="scheduledTo"),
+    scheduled_blank: Optional[str] = Query(None, alias="scheduledBlank"),
+    created_from: Optional[str] = Query(None, alias="createdFrom"),
+    created_to: Optional[str] = Query(None, alias="createdTo"),
+    finished_from: Optional[str] = Query(None, alias="finishedFrom"),
+    finished_to: Optional[str] = Query(None, alias="finishedTo"),
+    finished_blank: Optional[str] = Query(None, alias="finishedBlank"),
+    scope: Optional[str] = Query(None, alias="scope"),
+    source: Optional[str] = Query(None),
+    sample_size: int = Query(
+        200,
+        alias="sampleSize",
+        ge=1,
+        le=_EXECUTION_METRICS_SAMPLE_SIZE_LIMIT,
+    ),
+    user: User = Depends(get_current_user()),
+    session: AsyncSession = Depends(get_async_session),
+    temporal_client: Client = Depends(get_temporal_client),
+) -> ExecutionMetricsResponse:
+    if source not in {None, _TEMPORAL_SOURCE}:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_execution_query",
+                "message": "metrics currently support source=temporal only.",
+            },
+        )
+
+    effective_owner_type, effective_owner = _effective_execution_owner_scope(
+        user=user,
+        owner_type=owner_type,
+        owner_id=owner_id,
+    )
+
+    def build_query(
+        *,
+        metric_state_in: str | None = None,
+        include_order: bool = False,
+    ) -> str:
+        count_query, list_query = _build_temporal_execution_query(
+            request=request,
+            workflow_type=workflow_type,
+            state=state,
+            state_in=metric_state_in or state_in,
+            state_not_in=None if metric_state_in else state_not_in,
+            entry=entry,
+            repo=repo,
+            repo_exact=repo_exact,
+            repo_in=repo_in,
+            repo_not_in=repo_not_in,
+            integration=integration,
+            target_runtime=target_runtime,
+            target_runtime_in=target_runtime_in,
+            target_runtime_not_in=target_runtime_not_in,
+            target_skill_in=target_skill_in,
+            target_skill_not_in=target_skill_not_in,
+            scheduled_from=scheduled_from,
+            scheduled_to=scheduled_to,
+            scheduled_blank=scheduled_blank,
+            created_from=created_from,
+            created_to=created_to,
+            finished_from=finished_from,
+            finished_to=finished_to,
+            finished_blank=finished_blank,
+            scope=scope,
+            owner_type=effective_owner_type,
+            owner_id=effective_owner,
+            sort="closedAt",
+            sort_dir="desc",
+            exclude_aliases=(
+                frozenset({"state", "stateIn", "stateNotIn"})
+                if metric_state_in
+                else frozenset()
+            ),
+            include_order=include_order,
+        )
+        return list_query if include_order else count_query
+
+    try:
+        client = temporal_client
+        total_count = await client.count_workflows(query=build_query())
+        completed_count = await client.count_workflows(
+            query=build_query(metric_state_in="completed")
+        )
+        failed_count = await client.count_workflows(
+            query=build_query(metric_state_in="failed")
+        )
+        canceled_count = await client.count_workflows(
+            query=build_query(metric_state_in="canceled")
+        )
+
+        terminal_query = build_query(
+            metric_state_in="completed,failed,canceled",
+            include_order=True,
+        )
+        iterator = client.list_workflows(
+            query=terminal_query,
+            page_size=sample_size,
+        )
+        await iterator.fetch_next_page()
+
+        page = iterator.current_page or []
+        canonical_map: dict[str, TemporalExecutionCanonicalRecord] = {}
+        if page:
+            workflow_ids = [wf.id for wf in page]
+            stmt = select(TemporalExecutionCanonicalRecord).where(
+                TemporalExecutionCanonicalRecord.workflow_id.in_(workflow_ids)
+            )
+            canonical_rows = (await session.execute(stmt)).scalars().all()
+            canonical_map = {row.workflow_id: row for row in canonical_rows}
+
+        durations: list[float] = []
+        costs: list[float] = []
+        from api_service.core.sync import (
+            map_temporal_state_to_projection,
+            merged_parameters_for_projection,
+        )
+
+        for wf in page:
+            payload = await map_temporal_state_to_projection(wf)
+            canonical = canonical_map.get(wf.id)
+            payload["parameters"] = merged_parameters_for_projection(payload, canonical)
+            duration = _duration_seconds_from_payload(payload)
+            if duration is not None:
+                durations.append(duration)
+            cost = _extract_cost_estimate_usd(
+                payload.get("search_attributes"),
+                payload.get("memo"),
+                payload.get("parameters"),
+            )
+            if cost is not None:
+                costs.append(cost)
+
+        completed = int(completed_count.count)
+        failed = int(failed_count.count)
+        canceled = int(canceled_count.count)
+        terminal = completed + failed + canceled
+        success_rate = completed / terminal if terminal else None
+        return ExecutionMetricsResponse(
+            totalRuns=int(total_count.count),
+            completedRuns=completed,
+            failedRuns=failed,
+            canceledRuns=canceled,
+            terminalRuns=terminal,
+            successRate=success_rate,
+            duration=_duration_metrics(durations),
+            cost=_cost_metrics(costs),
+            sampleSize=len(page),
+            countMode="exact",
+            refreshedAt=datetime.now(UTC),
+        )
+    except TemporalExecutionValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_execution_query",
+                "message": str(exc),
+            },
+        ) from exc
+    except RPCError as exc:
+        logger.warning("Failed to read Temporal execution metrics: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": "temporal_unavailable",
+                "message": "Temporal service unavailable.",
+            },
+        ) from exc
 
 @router.get("/facets", response_model=ExecutionFacetResponse)
 async def list_execution_facets(

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -137,6 +137,65 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
+  it('renders the operational metrics dashboard from the metrics endpoint', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/executions/metrics?')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            totalRuns: 12,
+            completedRuns: 9,
+            failedRuns: 2,
+            canceledRuns: 1,
+            terminalRuns: 12,
+            successRate: 0.75,
+            duration: {
+              averageSeconds: 5400,
+              medianSeconds: 3600,
+              observedCount: 10,
+            },
+            cost: {
+              totalEstimateUsd: 3.5,
+              averageEstimateUsd: 0.35,
+              observedCount: 4,
+            },
+            sampleSize: 10,
+            countMode: 'exact',
+            refreshedAt: '2026-06-03T12:00:00Z',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              taskId: 'task-123',
+              source: 'temporal',
+              title: 'Example task',
+              status: 'completed',
+              state: 'completed',
+              rawState: 'completed',
+              createdAt: '2026-03-28T00:00:00Z',
+            },
+          ],
+          count: 12,
+        }),
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const metrics = screen.getByLabelText('Operational metrics');
+    expect(metrics.textContent).toContain('Runs12');
+    expect(metrics.textContent).toContain('Success rate75%9/12 terminal');
+    expect(metrics.textContent).toContain('Avg duration1.5h10 sampled');
+    expect(metrics.textContent).toContain('Cost$3.504 with cost');
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/metrics?'))).toBe(true);
+  });
+
   it('surfaces intervention requests in list rows and status filters', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -161,6 +161,30 @@ const ExecutionFacetResponseSchema = z.object({
 
 type ExecutionFacetResponse = z.infer<typeof ExecutionFacetResponseSchema>;
 
+const ExecutionMetricsResponseSchema = z.object({
+  totalRuns: z.number(),
+  completedRuns: z.number(),
+  failedRuns: z.number(),
+  canceledRuns: z.number(),
+  terminalRuns: z.number(),
+  successRate: z.number().nullable().optional(),
+  duration: z.object({
+    averageSeconds: z.number().nullable().optional(),
+    medianSeconds: z.number().nullable().optional(),
+    observedCount: z.number(),
+  }),
+  cost: z.object({
+    totalEstimateUsd: z.number(),
+    averageEstimateUsd: z.number().nullable().optional(),
+    observedCount: z.number(),
+  }),
+  sampleSize: z.number(),
+  countMode: z.string().optional(),
+  refreshedAt: z.string(),
+});
+
+type ExecutionMetricsResponse = z.infer<typeof ExecutionMetricsResponseSchema>;
+
 function readListDashboardConfig(payload: BootPayload): ListDashboardConfig | undefined {
   const raw = payload.initialData as { dashboardConfig?: ListDashboardConfig } | undefined;
   return raw?.dashboardConfig;
@@ -218,6 +242,29 @@ function displayTemporalCount(count: number | null | undefined, countMode: strin
     return '';
   }
   return countMode && countMode !== 'exact' ? `${count} (${countMode})` : String(count);
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDurationSeconds(value: number | null | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  if (value < 60) return `${Math.round(value)}s`;
+  if (value < 3600) return `${Math.round(value / 60)}m`;
+  const hours = value / 3600;
+  return `${hours >= 10 ? Math.round(hours) : hours.toFixed(1)}h`;
+}
+
+function formatUsd(value: number | null | undefined): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: value === 0 ? 2 : 2,
+    maximumFractionDigits: value < 1 ? 4 : 2,
+  }).format(value);
 }
 
 function sortRows(rows: ExecutionRow[], field: string, direction: 'asc' | 'desc'): ExecutionRow[] {
@@ -653,6 +700,27 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   useEffect(() => {
     syncUrl();
   }, [syncUrl]);
+
+  const {
+    data: metricsData,
+    isLoading: metricsLoading,
+    isError: metricsIsError,
+  } = useQuery({
+    queryKey: ['workflow-list-metrics', 'temporal', filters] as const,
+    enabled: listEnabled && filterValidationErrors.length === 0,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set('source', 'temporal');
+      params.set('scope', 'tasks');
+      appendFilterParams(params, filters);
+      const response = await fetch(`${payload.apiBase}/executions/metrics?${params}`);
+      if (!response.ok) {
+        throw new Error(await taskListErrorMessage(response));
+      }
+      return ExecutionMetricsResponseSchema.parse(await response.json());
+    },
+    refetchInterval: liveUpdates && listEnabled && !openFilter ? listPollMs : false,
+  });
 
   const queryKey = [
     'workflow-list',
@@ -1354,6 +1422,38 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     );
   };
 
+  const metrics = metricsData as ExecutionMetricsResponse | undefined;
+  const metricsSummary = metrics ? (
+    <section className="workflow-list-metrics" aria-label="Operational metrics">
+      <div className="workflow-list-metric">
+        <span>Runs</span>
+        <strong>{metrics.totalRuns}</strong>
+      </div>
+      <div className="workflow-list-metric">
+        <span>Success rate</span>
+        <strong>{formatPercent(metrics.successRate)}</strong>
+        <small>{metrics.completedRuns}/{metrics.terminalRuns || 0} terminal</small>
+      </div>
+      <div className="workflow-list-metric">
+        <span>Avg duration</span>
+        <strong>{formatDurationSeconds(metrics.duration.averageSeconds)}</strong>
+        <small>{metrics.duration.observedCount} sampled</small>
+      </div>
+      <div className="workflow-list-metric">
+        <span>Cost</span>
+        <strong>{formatUsd(metrics.cost.totalEstimateUsd)}</strong>
+        <small>{metrics.cost.observedCount} with cost</small>
+      </div>
+    </section>
+  ) : (
+    <section className="workflow-list-metrics is-loading" aria-label="Operational metrics">
+      <div className="workflow-list-metric">
+        <span>{metricsIsError ? 'Metrics unavailable' : metricsLoading ? 'Loading metrics' : 'Metrics'}</span>
+        <strong>—</strong>
+      </div>
+    </section>
+  );
+
   return (
     <div className="stack">
       <section className="workflow-list-control-deck" aria-label="Workflow list filters">
@@ -1443,6 +1543,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
         <header className="workflow-list-results-header">
           <h2 className="page-title" id="workflow-list-title">Workflows</h2>
         </header>
+        {metricsSummary}
         {isLoading ? (
           <p className="loading workflow-list-empty-message">Loading workflows...</p>
         ) : isError ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1392,6 +1392,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Execution Metrics */
+        get: operations["get_execution_metrics_api_executions_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions/facets": {
         parameters: {
             query?: never;
@@ -4332,6 +4349,94 @@ export interface components {
             status?: string | null;
             /** Detailhref */
             detailHref?: string | null;
+        };
+        /**
+         * ExecutionMetricsCostModel
+         * @description Cost aggregates for runs that publish bounded cost metadata.
+         */
+        ExecutionMetricsCostModel: {
+            /**
+             * Totalestimateusd
+             * @default 0
+             */
+            totalEstimateUsd: number;
+            /** Averageestimateusd */
+            averageEstimateUsd?: number | null;
+            /**
+             * Observedcount
+             * @default 0
+             */
+            observedCount: number;
+        };
+        /**
+         * ExecutionMetricsDurationModel
+         * @description Run-duration aggregates for the operational metrics dashboard.
+         */
+        ExecutionMetricsDurationModel: {
+            /** Averageseconds */
+            averageSeconds?: number | null;
+            /** Medianseconds */
+            medianSeconds?: number | null;
+            /** Minseconds */
+            minSeconds?: number | null;
+            /** Maxseconds */
+            maxSeconds?: number | null;
+            /**
+             * Observedcount
+             * @default 0
+             */
+            observedCount: number;
+        };
+        /**
+         * ExecutionMetricsResponse
+         * @description Operational run metrics for Mission Control dashboards.
+         */
+        ExecutionMetricsResponse: {
+            /**
+             * Totalruns
+             * @default 0
+             */
+            totalRuns: number;
+            /**
+             * Completedruns
+             * @default 0
+             */
+            completedRuns: number;
+            /**
+             * Failedruns
+             * @default 0
+             */
+            failedRuns: number;
+            /**
+             * Canceledruns
+             * @default 0
+             */
+            canceledRuns: number;
+            /**
+             * Terminalruns
+             * @default 0
+             */
+            terminalRuns: number;
+            /** Successrate */
+            successRate?: number | null;
+            duration?: components["schemas"]["ExecutionMetricsDurationModel"];
+            cost?: components["schemas"]["ExecutionMetricsCostModel"];
+            /**
+             * Samplesize
+             * @default 0
+             */
+            sampleSize: number;
+            /**
+             * Countmode
+             * @default exact
+             * @enum {string}
+             */
+            countMode: "exact" | "estimated_or_unknown";
+            /**
+             * Refreshedat
+             * Format: date-time
+             */
+            refreshedAt: string;
         };
         /**
          * ExecutionModel
@@ -11388,6 +11493,64 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExecutionModel"] | components["schemas"]["ScheduleCreatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_execution_metrics_api_executions_metrics_get: {
+        parameters: {
+            query?: {
+                workflowType?: string | null;
+                ownerType?: string | null;
+                state?: string | null;
+                stateIn?: string | null;
+                stateNotIn?: string | null;
+                ownerId?: string | null;
+                entry?: string | null;
+                repo?: string | null;
+                repoExact?: string | null;
+                repoIn?: string | null;
+                repoNotIn?: string | null;
+                integration?: string | null;
+                targetRuntime?: string | null;
+                targetRuntimeIn?: string | null;
+                targetRuntimeNotIn?: string | null;
+                targetSkillIn?: string | null;
+                targetSkillNotIn?: string | null;
+                scheduledFrom?: string | null;
+                scheduledTo?: string | null;
+                scheduledBlank?: string | null;
+                createdFrom?: string | null;
+                createdTo?: string | null;
+                finishedFrom?: string | null;
+                finishedTo?: string | null;
+                finishedBlank?: string | null;
+                scope?: string | null;
+                source?: string | null;
+                sampleSize?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionMetricsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1460,6 +1460,36 @@ tbody tr:hover {
   letter-spacing: 0.01em;
 }
 
+.workflow-list-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
+}
+
+.workflow-list-metric {
+  min-width: 0;
+  border: 1px solid rgb(var(--mm-border) / 0.3);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: rgb(var(--mm-panel-muted) / 0.72);
+}
+
+.workflow-list-metric span,
+.workflow-list-metric small {
+  display: block;
+  color: rgb(var(--mm-muted));
+}
+
+.workflow-list-metric strong {
+  display: block;
+  margin-top: 0.2rem;
+  color: rgb(var(--mm-text));
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
 .workflow-list-empty-message {
   margin: 0;
   padding: 1rem;
@@ -1951,6 +1981,10 @@ tr[data-proposal-id].proposal-consuming td {
   .workflow-list-footer-page-summary {
     justify-content: flex-end;
     text-align: right;
+  }
+
+  .workflow-list-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .queue-table-wrapper {

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2196,6 +2196,53 @@ class ExecutionListResponse(BaseModel):
     degraded_count: bool = Field(False, alias="degradedCount")
     refreshed_at: datetime | None = Field(None, alias="refreshedAt")
 
+class ExecutionMetricsDurationModel(BaseModel):
+    """Run-duration aggregates for the operational metrics dashboard."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    average_seconds: float | None = Field(None, alias="averageSeconds", ge=0)
+    median_seconds: float | None = Field(None, alias="medianSeconds", ge=0)
+    min_seconds: float | None = Field(None, alias="minSeconds", ge=0)
+    max_seconds: float | None = Field(None, alias="maxSeconds", ge=0)
+    observed_count: int = Field(0, alias="observedCount", ge=0)
+
+
+class ExecutionMetricsCostModel(BaseModel):
+    """Cost aggregates for runs that publish bounded cost metadata."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    total_estimate_usd: float = Field(0.0, alias="totalEstimateUsd", ge=0)
+    average_estimate_usd: float | None = Field(
+        None, alias="averageEstimateUsd", ge=0
+    )
+    observed_count: int = Field(0, alias="observedCount", ge=0)
+
+
+class ExecutionMetricsResponse(BaseModel):
+    """Operational run metrics for Mission Control dashboards."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    total_runs: int = Field(0, alias="totalRuns", ge=0)
+    completed_runs: int = Field(0, alias="completedRuns", ge=0)
+    failed_runs: int = Field(0, alias="failedRuns", ge=0)
+    canceled_runs: int = Field(0, alias="canceledRuns", ge=0)
+    terminal_runs: int = Field(0, alias="terminalRuns", ge=0)
+    success_rate: float | None = Field(None, alias="successRate", ge=0, le=1)
+    duration: ExecutionMetricsDurationModel = Field(
+        default_factory=ExecutionMetricsDurationModel, alias="duration"
+    )
+    cost: ExecutionMetricsCostModel = Field(
+        default_factory=ExecutionMetricsCostModel, alias="cost"
+    )
+    sample_size: int = Field(0, alias="sampleSize", ge=0)
+    count_mode: Literal["exact", "estimated_or_unknown"] = Field(
+        "exact", alias="countMode"
+    )
+    refreshed_at: datetime = Field(..., alias="refreshedAt")
+
 class ExecutionFacetItemModel(BaseModel):
     """One value bucket returned by an execution list facet query."""
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -24,6 +24,7 @@ from api_service.api.routers.executions import (
     _artifact_id_from_ref,
     _build_original_task_input_snapshot_payload,
     _expand_goal_preset_for_task_submission,
+    _extract_cost_estimate_usd,
     _hydrate_related_run_metadata,
     _merge_task_preserving_artifact_instructions,
     _recovery_not_available_reason,
@@ -1212,6 +1213,109 @@ def test_execution_facets_exclude_requested_facet_filter_and_keep_task_scope() -
     assert body["items"] == [{"value": "claude_code", "label": "Claude Code", "count": 7}]
     assert body["blankCount"] == 0
     assert body["source"] == "authoritative"
+
+
+def test_execution_metrics_cost_extraction_unwraps_search_attribute_lists() -> None:
+    assert (
+        _extract_cost_estimate_usd(
+            {
+                "mm_cost_estimate_usd": [
+                    None,
+                    "2.50",
+                ]
+            }
+        )
+        == 2.5
+    )
+
+
+def test_execution_metrics_status_filter_limits_metric_buckets() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = _empty_session_override
+    _override_user_dependencies(app, is_superuser=False)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(
+            side_effect=[SimpleNamespace(count=5), SimpleNamespace(count=3)]
+        ),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/metrics",
+            params={"source": "temporal", "stateIn": "failed"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["totalRuns"] == 5
+    assert body["completedRuns"] == 0
+    assert body["failedRuns"] == 3
+    assert body["canceledRuns"] == 0
+    assert body["terminalRuns"] == 3
+    assert body["successRate"] == 0
+    count_queries = [
+        call.kwargs["query"] for call in temporal_client.count_workflows.await_args_list
+    ]
+    assert len(count_queries) == 2
+    assert all('ExecutionStatus="Failed"' in query for query in count_queries)
+    assert temporal_client.list_workflows.call_args.kwargs["query"].count(
+        'ExecutionStatus="Failed"'
+    ) == 1
+
+
+def test_execution_metrics_counts_workflows_concurrently() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = _empty_session_override
+    _override_user_dependencies(app, is_superuser=False)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    active_calls = 0
+    max_active_calls = 0
+
+    async def _count_workflows(*, query: str) -> SimpleNamespace:
+        nonlocal active_calls, max_active_calls
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        await asyncio.sleep(0)
+        active_calls -= 1
+        return SimpleNamespace(count=1)
+
+    temporal_client = SimpleNamespace(
+        count_workflows=AsyncMock(side_effect=_count_workflows),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/metrics",
+            params={"source": "temporal"},
+        )
+
+    assert response.status_code == 200
+    assert temporal_client.count_workflows.await_count == 4
+    assert max_active_calls > 1
+
 
 def test_execution_status_facet_counts_static_status_values_with_task_scope() -> None:
     app = FastAPI()

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -241,6 +242,94 @@ def test_list_executions_source_temporal_scope_all_fails_safe_to_task_query(
         )
         mock_client.count_workflows.assert_awaited_once_with(query=expected_query)
         assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
+
+
+def test_execution_metrics_source_temporal_returns_operational_aggregates(
+    client,
+) -> None:
+    test_client, _service, _user, mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        started = datetime(2026, 6, 3, 10, 0, tzinfo=UTC)
+
+        def _workflow(
+            workflow_id: str,
+            *,
+            duration_seconds: int,
+            cost: float,
+        ) -> SimpleNamespace:
+            async def _memo() -> dict[str, object]:
+                return {"costEstimateUsd": cost}
+
+            return SimpleNamespace(
+                id=workflow_id,
+                run_id=f"run-{workflow_id}",
+                namespace="moonmind",
+                workflow_type="MoonMind.Run",
+                status=2,
+                memo=_memo,
+                search_attributes={
+                    "mm_entry": b'["user_workflow"]',
+                    "mm_owner_id": b'["user-123"]',
+                },
+                start_time=started,
+                execution_time=started,
+                close_time=started + timedelta(seconds=duration_seconds),
+            )
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = [
+            _workflow("mm:wf-1", duration_seconds=3600, cost=1.25),
+            _workflow("mm:wf-2", duration_seconds=7200, cost=2.75),
+        ]
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(
+            side_effect=[
+                SimpleNamespace(count=4),
+                SimpleNamespace(count=2),
+                SimpleNamespace(count=1),
+                SimpleNamespace(count=1),
+            ]
+        )
+
+        response = test_client.get(
+            "/api/executions/metrics",
+            params={"source": "temporal", "repoExact": "MoonLadderStudios/MoonMind"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["totalRuns"] == 4
+    assert body["completedRuns"] == 2
+    assert body["failedRuns"] == 1
+    assert body["canceledRuns"] == 1
+    assert body["terminalRuns"] == 4
+    assert body["successRate"] == 0.5
+    assert body["duration"]["averageSeconds"] == 5400
+    assert body["duration"]["medianSeconds"] == 5400
+    assert body["duration"]["observedCount"] == 2
+    assert body["cost"]["totalEstimateUsd"] == 4
+    assert body["cost"]["averageEstimateUsd"] == 2
+    assert body["cost"]["observedCount"] == 2
+    assert body["sampleSize"] == 2
+    assert mock_client.count_workflows.await_count == 4
+    assert mock_client.list_workflows.call_args.kwargs["page_size"] == 200
+    assert 'mm_repo="MoonLadderStudios/MoonMind"' in mock_client.list_workflows.call_args.kwargs["query"]
 
 
 def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_task_list(


### PR DESCRIPTION
Jira issue key: MM-795

Summary:
- Adds a Temporal-backed `/api/executions/metrics` endpoint for operational run metrics.
- Reports total runs, terminal success rate, sampled run duration aggregates, and observed cost estimates.
- Adds an Operational metrics dashboard band to the Mission Control workflow list.
- Covers the API aggregate behavior and dashboard rendering with focused tests.

Tests run:
- `./tools/test_unit.sh --python-only tests/unit/api/test_executions_temporal.py -q`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-list.test.tsx`
- `./tools/test_integration.sh`

Remaining risks:
- Cost totals depend on executions publishing recognized cost metadata keys; runs without cost metadata are counted separately as unobserved.
- Duration and cost aggregates are sampled from recent terminal runs, while run and success-rate counts are exact Temporal counts.
