### PR TITLE
MM-794 feed telemetry into proposal queue

### DIFF
--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -11982,8 +11982,8 @@ class CodexWorker:
                 origin["id"] = str(job.id)
             metadata = origin.get("metadata")
             metadata_dict = metadata if isinstance(metadata, Mapping) else {}
-            metadata_dict.setdefault("triggerRepo", project_repository)
-            metadata_dict.setdefault("triggerJobId", str(job.id))
+            metadata_dict.setdefault("trigger_repo", project_repository)
+            metadata_dict.setdefault("trigger_job_id", str(job.id))
             metadata_dict.setdefault("startingBranch", prepared.starting_branch)
             metadata_dict.setdefault("workingBranch", prepared.working_branch)
             if prepared.new_branch and "targetBranch" not in metadata_dict:

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -230,8 +230,12 @@ class TaskProposalService:
             raise TaskProposalValidationError(
                 "MoonMind proposals require at least one approved signal tag"
             )
-        trigger_repo = self._clean_str(metadata.get("triggerRepo"))
-        trigger_job = self._clean_str(metadata.get("triggerJobId"))
+        trigger_repo = self._clean_str(
+            metadata.get("trigger_repo") or metadata.get("triggerRepo")
+        )
+        trigger_job = self._clean_str(
+            metadata.get("trigger_job_id") or metadata.get("triggerJobId")
+        )
         signal_payload = metadata.get("signal")
         if not trigger_repo or not trigger_job:
             raise TaskProposalValidationError(
@@ -241,8 +245,8 @@ class TaskProposalService:
             raise TaskProposalValidationError(
                 "MoonMind proposals must provide origin_metadata.signal details"
             )
-        metadata["triggerRepo"] = trigger_repo
-        metadata["triggerJobId"] = trigger_job
+        metadata["trigger_repo"] = trigger_repo
+        metadata["trigger_job_id"] = trigger_job
         metadata["signal"] = dict(signal_payload)
         normalized_title = self._normalize_moonmind_title(title, allowed_tags)
         return normalized_category, allowed_tags, normalized_title

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -230,16 +230,12 @@ class TaskProposalService:
             raise TaskProposalValidationError(
                 "MoonMind proposals require at least one approved signal tag"
             )
-        trigger_repo = self._clean_str(
-            metadata.get("trigger_repo") or metadata.get("triggerRepo")
-        )
-        trigger_job = self._clean_str(
-            metadata.get("trigger_job_id") or metadata.get("triggerJobId")
-        )
+        trigger_repo = self._clean_str(metadata.get("trigger_repo"))
+        trigger_job = self._clean_str(metadata.get("trigger_job_id"))
         signal_payload = metadata.get("signal")
         if not trigger_repo or not trigger_job:
             raise TaskProposalValidationError(
-                "MoonMind proposals must include triggerRepo and triggerJobId metadata"
+                "MoonMind proposals must include trigger_repo and trigger_job_id metadata"
             )
         if not isinstance(signal_payload, dict):
             raise TaskProposalValidationError(
@@ -275,9 +271,7 @@ class TaskProposalService:
         if "conflicting_instructions" in tag_set:
             return TaskProposalReviewPriority.HIGH, "signal:conflicting_instructions"
         if "missing_ref" in tag_set:
-            missing_refs = signal_dict.get("missingRefs") or signal_dict.get(
-                "missing_refs"
-            )
+            missing_refs = signal_dict.get("missing_refs")
             if isinstance(missing_refs, (list, tuple)) and missing_refs:
                 return TaskProposalReviewPriority.HIGH, "signal:missing_ref"
         if "retry" in tag_set:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3427,7 +3427,7 @@ class TemporalProposalActivities:
 
             severity = cls._telemetry_signal_severity(signal, tags)
             diagnostics_ref = cls._normalize_proposal_text(
-                signal.get("diagnosticsRef") or signal.get("diagnostics_ref")
+                signal.get("diagnostics_ref")
             )
             runtime_node = task.get("runtime")
             runtime = dict(runtime_node) if isinstance(runtime_node, Mapping) else {}
@@ -3469,9 +3469,7 @@ class TemporalProposalActivities:
                     "message",
                     "reason",
                     "retries",
-                    "missingRefs",
                     "missing_refs",
-                    "diagnosticsRef",
                     "diagnostics_ref",
                 }
             }

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -188,6 +188,41 @@ async def _run_command(cmd, **kwargs):
     return CmdRes(stdout)
 
 logger = getLogger(__name__)
+
+_PROPOSAL_TELEMETRY_SIGNAL_TAGS = {
+    "retry",
+    "duplicate_output",
+    "missing_ref",
+    "conflicting_instructions",
+    "flaky_test",
+    "loop_detected",
+    "artifact_gap",
+}
+_PROPOSAL_TELEMETRY_TAG_ALIASES = {
+    "artifact": "artifact_gap",
+    "artifact_missing": "artifact_gap",
+    "diagnostic_gap": "artifact_gap",
+    "duplicate": "duplicate_output",
+    "duplicate_outputs": "duplicate_output",
+    "flaky": "flaky_test",
+    "flaky_tests": "flaky_test",
+    "loop": "loop_detected",
+    "missing_file": "missing_ref",
+    "missing_files": "missing_ref",
+    "missing_reference": "missing_ref",
+    "missing_refs": "missing_ref",
+    "repeated_retry": "retry",
+    "retry_exhausted": "retry",
+}
+_PROPOSAL_TELEMETRY_TAG_LABELS = {
+    "artifact_gap": "artifact gap",
+    "conflicting_instructions": "conflicting instructions",
+    "duplicate_output": "duplicate output",
+    "flaky_test": "flaky test",
+    "loop_detected": "loop detection",
+    "missing_ref": "missing reference",
+    "retry": "retry",
+}
 _AUTO_SKILL_SENTINEL = "auto"
 _NON_SECRET_MANAGED_SESSION_ENV_KEYS: tuple[str, ...] = ("MOONMIND_URL",)
 _MANAGED_SESSION_TELEMETRY_KEYS: tuple[str, ...] = (
@@ -3275,6 +3310,192 @@ class TemporalProposalActivities:
         return str(runtime_node or "").strip()
 
     @classmethod
+    def _normalize_signal_tag(cls, value: object) -> str:
+        text = cls._normalize_proposal_text(value).lower()
+        text = re.sub(r"[^a-z0-9]+", "_", text).strip("_")
+        if not text:
+            return ""
+        text = _PROPOSAL_TELEMETRY_TAG_ALIASES.get(text, text)
+        if text in _PROPOSAL_TELEMETRY_SIGNAL_TAGS:
+            return text
+        return ""
+
+    @classmethod
+    def _telemetry_signal_tags(cls, signal: Mapping[str, Any]) -> list[str]:
+        raw_values: list[object] = []
+        for key in ("tag", "type", "kind", "code", "category"):
+            if key in signal:
+                raw_values.append(signal.get(key))
+        raw_tags = signal.get("tags")
+        if isinstance(raw_tags, Sequence) and not isinstance(raw_tags, (str, bytes)):
+            raw_values.extend(raw_tags)
+        elif raw_tags is not None:
+            raw_values.append(raw_tags)
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in raw_values:
+            tag = cls._normalize_signal_tag(value)
+            if not tag or tag in seen:
+                continue
+            normalized.append(tag)
+            seen.add(tag)
+        return normalized
+
+    @classmethod
+    def _telemetry_signal_severity(
+        cls, signal: Mapping[str, Any], tags: Sequence[str]
+    ) -> str:
+        severity = cls._normalize_proposal_text(signal.get("severity")).lower()
+        if severity in {"low", "medium", "normal", "high", "critical"}:
+            return severity
+        if any(tag in {"loop_detected", "conflicting_instructions"} for tag in tags):
+            return "high"
+        return "medium"
+
+    @classmethod
+    def _telemetry_signal_summary(cls, signal: Mapping[str, Any]) -> str:
+        for key in ("summary", "message", "reason", "details", "description"):
+            summary = cls._normalize_proposal_text(signal.get(key))
+            if summary:
+                return summary[:500]
+        tags = cls._telemetry_signal_tags(signal)
+        if tags:
+            label = _PROPOSAL_TELEMETRY_TAG_LABELS.get(tags[0], tags[0])
+            return f"Telemetry reported a {label} signal."
+        return ""
+
+    @classmethod
+    def _build_telemetry_signal_instructions(
+        cls,
+        *,
+        workflow_id: str,
+        label: str,
+        summary: str,
+        instructions: str,
+        diagnostics_ref: str,
+    ) -> str:
+        parts = [
+            (
+                "Investigate and address the run-quality telemetry signal "
+                f"'{label}' reported by workflow {workflow_id or 'unknown'}."
+            ),
+            f"Signal summary: {summary}",
+        ]
+        if diagnostics_ref:
+            parts.append(f"Diagnostics reference: {diagnostics_ref}")
+        if instructions:
+            parts.append(f"Context from the completed task:\n{instructions}")
+        return "\n\n".join(parts)
+
+    @classmethod
+    def _telemetry_signal_candidates(
+        cls,
+        *,
+        payload: Mapping[str, Any],
+        repo: str,
+        workflow_id: str,
+        instructions: str,
+        task: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        raw_signals = payload.get("telemetrySignals")
+        if not isinstance(raw_signals, Sequence) or isinstance(
+            raw_signals, (str, bytes)
+        ):
+            return []
+
+        candidates: list[dict[str, Any]] = []
+        for raw_signal in raw_signals[:3]:
+            if not isinstance(raw_signal, Mapping):
+                continue
+            signal = dict(raw_signal)
+            tags = cls._telemetry_signal_tags(signal)
+            if not tags:
+                continue
+            summary = cls._telemetry_signal_summary(signal)
+            if not summary:
+                continue
+            primary_tag = tags[0]
+            label = _PROPOSAL_TELEMETRY_TAG_LABELS.get(primary_tag, primary_tag)
+            title = cls._normalize_proposal_text(signal.get("title")) or (
+                f"Review {label} signal from workflow {workflow_id or 'unknown'}"
+            )
+            if not title.lower().startswith("[run_quality]"):
+                title = f"[run_quality] {title}"
+            if len(title) > 194:
+                title = title[:194].rstrip()
+
+            severity = cls._telemetry_signal_severity(signal, tags)
+            diagnostics_ref = cls._normalize_proposal_text(
+                signal.get("diagnosticsRef") or signal.get("diagnostics_ref")
+            )
+            runtime_node = task.get("runtime")
+            runtime = dict(runtime_node) if isinstance(runtime_node, Mapping) else {}
+            git_node = task.get("git")
+            git = dict(git_node) if isinstance(git_node, Mapping) else {}
+            publish_node = task.get("publish")
+            publish = dict(publish_node) if isinstance(publish_node, Mapping) else {}
+            task_create_request: dict[str, Any] = {
+                "type": "task",
+                "payload": {
+                    "repository": repo,
+                    "task": {
+                        "instructions": cls._build_telemetry_signal_instructions(
+                            workflow_id=workflow_id,
+                            label=label,
+                            summary=summary,
+                            instructions=instructions,
+                            diagnostics_ref=diagnostics_ref,
+                        ),
+                        "runtime": runtime,
+                        "git": git,
+                        "publish": publish,
+                    },
+                },
+            }
+            cls._preserve_compact_task_metadata(
+                source_task=task,
+                target_task=task_create_request["payload"]["task"],
+            )
+            candidate_signal = {
+                key: deepcopy(value)
+                for key, value in signal.items()
+                if key
+                in {
+                    "type",
+                    "kind",
+                    "severity",
+                    "summary",
+                    "message",
+                    "reason",
+                    "retries",
+                    "missingRefs",
+                    "missing_refs",
+                    "diagnosticsRef",
+                    "diagnostics_ref",
+                }
+            }
+            candidate_signal["type"] = primary_tag
+            candidate_signal["severity"] = severity
+            candidate_signal["tags"] = list(tags)
+            candidate_signal["summary"] = summary
+            candidates.append(
+                {
+                    "title": title,
+                    "summary": (
+                        f"Telemetry signal from workflow {workflow_id or 'unknown'}: "
+                        f"{summary}"
+                    ),
+                    "category": "run_quality",
+                    "tags": list(tags),
+                    "severity": severity,
+                    "signal": candidate_signal,
+                    "taskCreateRequest": task_create_request,
+                }
+            )
+        return candidates
+
+    @classmethod
     def _validate_candidate_task_create_request(
         cls, request: Mapping[str, Any], *, default_runtime: str | None
     ) -> dict[str, Any]:
@@ -3375,9 +3596,19 @@ class TemporalProposalActivities:
         )
 
         if not proposal_idea:
+            telemetry_candidates = self._telemetry_signal_candidates(
+                payload=payload,
+                repo=repo,
+                workflow_id=workflow_id,
+                instructions=instructions,
+                task=task,
+            )
+            if telemetry_candidates:
+                return telemetry_candidates
             # Do not create generic proposals whose title simply repeats the
             # completed workflow. The fallback path only emits a proposal when
-            # it receives an explicit next-step idea from upstream context.
+            # it receives an explicit next-step idea or telemetry signal from
+            # upstream context.
             return []
 
         normalized_title = proposal_idea
@@ -3707,6 +3938,18 @@ class TemporalProposalActivities:
                         )
 
                         origin_source = TaskProposalOriginSource.WORKFLOW
+                        candidate_signal = candidate.get("signal")
+                        signal_metadata = (
+                            deepcopy(dict(candidate_signal))
+                            if isinstance(candidate_signal, Mapping)
+                            else {"severity": "normal", "type": "follow_up"}
+                        )
+                        signal_metadata.setdefault("severity", severity)
+                        if tags:
+                            signal_metadata.setdefault("tags", list(tags))
+                        if not signal_metadata.get("type") and tags:
+                            signal_metadata["type"] = tags[0]
+                        signal_metadata.setdefault("type", "follow_up")
                         origin_metadata = {
                             "source": "workflow",
                             "id": workflow_id,
@@ -3714,7 +3957,7 @@ class TemporalProposalActivities:
                             "temporal_run_id": run_id,
                             "trigger_repo": trigger_repo,
                             "trigger_job_id": trigger_job_id,
-                            "signal": {"severity": "normal", "type": "follow_up"},
+                            "signal": signal_metadata,
                         }
                         proposal = await service.create_proposal(
                             title=title,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5705,6 +5705,98 @@ class MoonMindRunWorkflow:
             return self._json_mapping(nested_publish, path="parameters.task.publish")
         return {}
 
+    def _proposal_telemetry_signals(self) -> list[dict[str, Any]]:
+        """Build compact run-quality signals for proposal generation."""
+
+        signals: list[dict[str, Any]] = []
+
+        def add_signal(
+            *,
+            signal_type: str,
+            summary: str | None,
+            severity: str = "medium",
+            diagnostics_ref: str | None = None,
+            extra: dict[str, Any] | None = None,
+        ) -> None:
+            bounded_summary = self._coerce_text(summary, max_chars=500)
+            if not bounded_summary:
+                return
+            signal: dict[str, Any] = {
+                "type": signal_type,
+                "tags": [signal_type],
+                "severity": severity,
+                "summary": bounded_summary,
+            }
+            bounded_ref = self._coerce_text(diagnostics_ref, max_chars=400)
+            if bounded_ref:
+                signal["diagnosticsRef"] = bounded_ref
+            if extra:
+                signal.update(extra)
+            signals.append(signal)
+
+        if self._publish_repair_attempts > 0:
+            add_signal(
+                signal_type="retry",
+                severity="high" if self._publish_repair_attempts >= 2 else "medium",
+                summary=(
+                    "Publish required "
+                    f"{self._publish_repair_attempts} repair attempt"
+                    f"{'s' if self._publish_repair_attempts != 1 else ''}."
+                ),
+                extra={"retries": self._publish_repair_attempts},
+            )
+
+        summary = self._coerce_text(self._last_step_summary, max_chars=500)
+        diagnostics_ref = self._coerce_text(self._last_diagnostics_ref, max_chars=400)
+        summary_lc = (summary or "").lower()
+        if summary:
+            if any(term in summary_lc for term in ("flaky", "flake")):
+                add_signal(
+                    signal_type="flaky_test",
+                    summary=summary,
+                    diagnostics_ref=diagnostics_ref,
+                )
+            if "retry" in summary_lc or "retried" in summary_lc:
+                add_signal(
+                    signal_type="retry",
+                    summary=summary,
+                    diagnostics_ref=diagnostics_ref,
+                )
+            if any(term in summary_lc for term in ("loop", "repeated")):
+                add_signal(
+                    signal_type="loop_detected",
+                    severity="high",
+                    summary=summary,
+                    diagnostics_ref=diagnostics_ref,
+                )
+            if any(
+                term in summary_lc
+                for term in ("missing file", "missing ref", "not found")
+            ):
+                add_signal(
+                    signal_type="missing_ref",
+                    severity="high",
+                    summary=summary,
+                    diagnostics_ref=diagnostics_ref,
+                )
+            if any(term in summary_lc for term in ("artifact", "diagnostic")):
+                add_signal(
+                    signal_type="artifact_gap",
+                    summary=summary,
+                    diagnostics_ref=diagnostics_ref,
+                )
+
+        if diagnostics_ref and not any(
+            "diagnosticsRef" in signal for signal in signals
+        ):
+            add_signal(
+                signal_type="artifact_gap",
+                summary="Run produced a diagnostics reference for proposal review.",
+                diagnostics_ref=diagnostics_ref,
+            )
+
+        return signals[:3]
+
     def _proposal_generation_requested(self, parameters: Mapping[str, Any]) -> bool:
         if workflow.patched("run-workflow-nested-propose-tasks"):
             task_node = parameters.get("task")
@@ -8676,6 +8768,9 @@ class MoonMindRunWorkflow:
                 "repo": self._repo,
                 "parameters": parameters,
             }
+            telemetry_signals = self._proposal_telemetry_signals()
+            if telemetry_signals:
+                generate_payload["telemetrySignals"] = telemetry_signals
             if workflow.patched("idempotency_key_phase3"):
                 generate_payload["idempotency_key"] = (
                     f"{workflow.info().workflow_id}_proposal_generate"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5729,7 +5729,7 @@ class MoonMindRunWorkflow:
             }
             bounded_ref = self._coerce_text(diagnostics_ref, max_chars=400)
             if bounded_ref:
-                signal["diagnosticsRef"] = bounded_ref
+                signal["diagnostics_ref"] = bounded_ref
             if extra:
                 signal.update(extra)
             signals.append(signal)
@@ -5785,15 +5785,6 @@ class MoonMindRunWorkflow:
                     summary=summary,
                     diagnostics_ref=diagnostics_ref,
                 )
-
-        if diagnostics_ref and not any(
-            "diagnosticsRef" in signal for signal in signals
-        ):
-            add_signal(
-                signal_type="artifact_gap",
-                summary="Run produced a diagnostics reference for proposal review.",
-                diagnostics_ref=diagnostics_ref,
-            )
 
         return signals[:3]
 

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -166,6 +166,25 @@ async def mock_skill_execute(args: Dict[str, Any]) -> Dict[str, Any]:
     return {"status": "COMPLETED", "outputs": {}}
 
 @activity.defn(name="mm.skill.execute")
+async def mock_skill_execute_with_telemetry(args: Dict[str, Any]) -> Dict[str, Any]:
+    SKILL_EXECUTE_CALLS.append(args)
+    if "idempotency_key" in args:
+        context = args.get("context", {})
+        workflow_id = context.get("workflow_id")
+        node_id = context.get("node_id")
+        if workflow_id and node_id:
+            assert args["idempotency_key"] == f"{workflow_id}_{node_id}_execute"
+        else:
+            assert "_execute" in args["idempotency_key"]
+    return {
+        "status": "COMPLETED",
+        "outputs": {
+            "summary": "Retried a flaky test and wrote diagnostics for review.",
+            "diagnostics_ref": "artifact://diag-mm-794",
+        },
+    }
+
+@activity.defn(name="mm.skill.execute")
 async def mock_skill_execute_failed(args: Dict[str, Any]) -> Dict[str, Any]:
     SKILL_EXECUTE_CALLS.append(args)
     return {
@@ -604,7 +623,10 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     Worker(
                         env.client,
                         task_queue=SANDBOX_TASK_QUEUE,
-                        activities=[mock_sandbox_command, mock_skill_execute],
+                        activities=[
+                            mock_sandbox_command,
+                            mock_skill_execute_with_telemetry,
+                        ],
                     ),
                     Worker(
                         env.client,
@@ -635,6 +657,32 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
 
                 self.assertEqual(result["status"], "success")
                 self.assertEqual(len(PROPOSAL_GENERATE_CALLS), 1)
+                self.assertEqual(
+                    PROPOSAL_GENERATE_CALLS[0].get("telemetrySignals"),
+                    [
+                        {
+                            "type": "flaky_test",
+                            "tags": ["flaky_test"],
+                            "severity": "medium",
+                            "summary": "Retried a flaky test and wrote diagnostics for review.",
+                            "diagnostics_ref": "artifact://diag-mm-794",
+                        },
+                        {
+                            "type": "retry",
+                            "tags": ["retry"],
+                            "severity": "medium",
+                            "summary": "Retried a flaky test and wrote diagnostics for review.",
+                            "diagnostics_ref": "artifact://diag-mm-794",
+                        },
+                        {
+                            "type": "artifact_gap",
+                            "tags": ["artifact_gap"],
+                            "severity": "medium",
+                            "summary": "Retried a flaky test and wrote diagnostics for review.",
+                            "diagnostics_ref": "artifact://diag-mm-794",
+                        },
+                    ],
+                )
                 self.assertEqual(len(PROPOSAL_SUBMIT_CALLS), 1)
                 self.assertEqual(result.get("proposals_generated"), 1)
                 self.assertEqual(result.get("proposals_submitted"), 1)

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -347,6 +347,62 @@ async def test_create_proposal_overrides_priority_for_moonmind() -> None:
     assert kwargs["priority_override_reason"] == "signal:loop_detected"
 
 @pytest.mark.asyncio
+async def test_create_proposal_accepts_snake_case_moonmind_signal_metadata() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Run Quality",
+        summary="Fix retry",
+        category="run_quality",
+        tags=["retry"],
+        repository="MoonLadderStudios/MoonMind",
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={},
+        task_create_request={},
+    )
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+    service._emit_notification = AsyncMock()
+
+    await service.create_proposal(
+        title="[run_quality] Fix retry",
+        summary="Detected retry signal",
+        category="run_quality",
+        tags=["retry"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {"repository": "MoonLadderStudios/MoonMind"},
+        },
+        origin_source="workflow",
+        origin_id=None,
+        origin_metadata={
+            "trigger_repo": "moon/org",
+            "trigger_job_id": str(uuid4()),
+            "signal": {"severity": "high", "retries": 2},
+        },
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+    )
+
+    kwargs = repo.create_proposal.await_args.kwargs
+    assert kwargs["origin_metadata"]["trigger_repo"] == "moon/org"
+    assert "triggerRepo" not in kwargs["origin_metadata"]
+    assert kwargs["review_priority"] is TaskProposalReviewPriority.HIGH
+    assert kwargs["priority_override_reason"] == "signal:severity"
+
+@pytest.mark.asyncio
 async def test_create_proposal_honors_requested_priority_when_higher() -> None:
     repo = AsyncMock()
     record = SimpleNamespace(

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -334,8 +334,8 @@ async def test_create_proposal_overrides_priority_for_moonmind() -> None:
         origin_source="queue",
         origin_id=None,
         origin_metadata={
-            "triggerRepo": "moon/org",
-            "triggerJobId": str(uuid4()),
+            "trigger_repo": "moon/org",
+            "trigger_job_id": str(uuid4()),
             "signal": {"severity": "medium"},
         },
         proposed_by_worker_id="worker-1",
@@ -444,8 +444,8 @@ async def test_create_proposal_honors_requested_priority_when_higher() -> None:
         origin_source="queue",
         origin_id=None,
         origin_metadata={
-            "triggerRepo": "moon/org",
-            "triggerJobId": str(uuid4()),
+            "trigger_repo": "moon/org",
+            "trigger_job_id": str(uuid4()),
             "signal": {"severity": "medium", "retries": 1},
         },
         proposed_by_worker_id="worker-1",

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -111,6 +111,50 @@ class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, [])
 
+    async def test_proposal_generate_creates_candidate_from_telemetry_signal(self) -> None:
+        activities = TemporalProposalActivities()
+
+        result = await activities.proposal_generate(
+            {
+                "workflow_id": "wf-mm-794",
+                "repo": "MoonLadderStudios/MoonMind",
+                "parameters": {
+                    "task": {
+                        "instructions": "Run the proposal telemetry checks",
+                        "runtime": {"mode": "codex"},
+                    }
+                },
+                "telemetrySignals": [
+                    {
+                        "type": "retry_exhausted",
+                        "severity": "high",
+                        "summary": "The run retried the same failed check twice.",
+                        "retries": 2,
+                        "diagnosticsRef": "artifact://diag-1",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(len(result), 1)
+        candidate = result[0]
+        self.assertEqual(
+            candidate["title"],
+            "[run_quality] Review retry signal from workflow wf-mm-794",
+        )
+        self.assertEqual(candidate["tags"], ["retry"])
+        self.assertEqual(candidate["severity"], "high")
+        self.assertEqual(candidate["signal"]["type"], "retry")
+        self.assertEqual(candidate["signal"]["retries"], 2)
+        self.assertEqual(candidate["signal"]["diagnosticsRef"], "artifact://diag-1")
+        task = candidate["taskCreateRequest"]["payload"]["task"]
+        self.assertEqual(task["runtime"], {"mode": "codex"})
+        self.assertIn(
+            "The run retried the same failed check twice.",
+            task["instructions"],
+        )
+        self.assertIn("artifact://diag-1", task["instructions"])
+
     async def test_proposal_generate_rejects_structured_proposal_text(self) -> None:
         activities = TemporalProposalActivities()
 
@@ -1213,6 +1257,64 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_kwargs["category"], "run_quality")
         self.assertEqual(call_kwargs["tags"], ["loop_detected"])
         self.assertEqual(result["delivery_decisions"][0]["target"], "moonmind")
+
+    async def test_submit_preserves_telemetry_signal_metadata(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix retry loop",
+                        "summary": "Retry signal was detected",
+                        "category": "run_quality",
+                        "tags": ["retry"],
+                        "severity": "high",
+                        "signal": {
+                            "type": "retry",
+                            "severity": "high",
+                            "summary": "The run retried the same failed check twice.",
+                            "retries": 2,
+                            "diagnosticsRef": "artifact://diag-1",
+                        },
+                        "taskCreateRequest": {
+                            "payload": {"repository": "MoonLadderStudios/MoonMind"}
+                        },
+                    }
+                ],
+                "policy": {
+                    "targets": ["moonmind"],
+                    "minSeverityForMoonMind": "medium",
+                },
+                "origin": {
+                    "workflow_id": "wf-mm-794",
+                    "temporal_run_id": "run-mm-794",
+                    "trigger_repo": "org/repo",
+                    "trigger_job_id": "job-mm-794",
+                },
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        call_kwargs = mock_service.create_proposal.await_args.kwargs
+        self.assertEqual(call_kwargs["origin_metadata"]["trigger_repo"], "org/repo")
+        self.assertEqual(call_kwargs["origin_metadata"]["trigger_job_id"], "job-mm-794")
+        self.assertEqual(
+            call_kwargs["origin_metadata"]["signal"],
+            {
+                "type": "retry",
+                "severity": "high",
+                "summary": "The run retried the same failed check twice.",
+                "retries": 2,
+                "diagnosticsRef": "artifact://diag-1",
+                "tags": ["retry"],
+            },
+        )
 
     async def test_project_target_preserves_candidate_repository(self) -> None:
         mock_service = AsyncMock()

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -130,7 +130,7 @@ class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
                         "severity": "high",
                         "summary": "The run retried the same failed check twice.",
                         "retries": 2,
-                        "diagnosticsRef": "artifact://diag-1",
+                        "diagnostics_ref": "artifact://diag-1",
                     }
                 ],
             }
@@ -146,7 +146,7 @@ class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(candidate["severity"], "high")
         self.assertEqual(candidate["signal"]["type"], "retry")
         self.assertEqual(candidate["signal"]["retries"], 2)
-        self.assertEqual(candidate["signal"]["diagnosticsRef"], "artifact://diag-1")
+        self.assertEqual(candidate["signal"]["diagnostics_ref"], "artifact://diag-1")
         task = candidate["taskCreateRequest"]["payload"]["task"]
         self.assertEqual(task["runtime"], {"mode": "codex"})
         self.assertIn(
@@ -1280,7 +1280,7 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
                             "severity": "high",
                             "summary": "The run retried the same failed check twice.",
                             "retries": 2,
-                            "diagnosticsRef": "artifact://diag-1",
+                            "diagnostics_ref": "artifact://diag-1",
                         },
                         "taskCreateRequest": {
                             "payload": {"repository": "MoonLadderStudios/MoonMind"}
@@ -1311,7 +1311,7 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
                 "severity": "high",
                 "summary": "The run retried the same failed check twice.",
                 "retries": 2,
-                "diagnosticsRef": "artifact://diag-1",
+                "diagnostics_ref": "artifact://diag-1",
                 "tags": ["retry"],
             },
         )

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -130,23 +130,53 @@ async def test_run_proposals_stage_passes_compact_telemetry_signals(
             "tags": ["flaky_test"],
             "severity": "medium",
             "summary": "Retried a flaky test and wrote diagnostics for review.",
-            "diagnosticsRef": "artifact://diag-mm-794",
+            "diagnostics_ref": "artifact://diag-mm-794",
         },
         {
             "type": "retry",
             "tags": ["retry"],
             "severity": "medium",
             "summary": "Retried a flaky test and wrote diagnostics for review.",
-            "diagnosticsRef": "artifact://diag-mm-794",
+            "diagnostics_ref": "artifact://diag-mm-794",
         },
         {
             "type": "artifact_gap",
             "tags": ["artifact_gap"],
             "severity": "medium",
             "summary": "Retried a flaky test and wrote diagnostics for review.",
-            "diagnosticsRef": "artifact://diag-mm-794",
+            "diagnostics_ref": "artifact://diag-mm-794",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_proposals_stage_does_not_fabricate_signal_from_diagnostics_ref(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_generate_payload: dict[str, Any] = {}
+    mock_run_workflow._last_step_summary = "Completed successfully."
+    mock_run_workflow._last_diagnostics_ref = "artifact://diag-mm-794"
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "proposal.generate":
+            captured_generate_payload.update(
+                json.loads(json.dumps(payload, default=_to_serializable))
+            )
+            return []
+        return {}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    await mock_run_workflow._run_proposals_stage(
+        parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
+    )
+
+    assert "telemetrySignals" not in captured_generate_payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -95,6 +95,61 @@ async def test_run_proposals_stage_propagates_policy(
 
 
 @pytest.mark.asyncio
+async def test_run_proposals_stage_passes_compact_telemetry_signals(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_generate_payload: dict[str, Any] = {}
+    mock_run_workflow._last_step_summary = (
+        "Retried a flaky test and wrote diagnostics for review."
+    )
+    mock_run_workflow._last_diagnostics_ref = "artifact://diag-mm-794"
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "proposal.generate":
+            captured_generate_payload.update(
+                json.loads(json.dumps(payload, default=_to_serializable))
+            )
+            return []
+        return {}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    await mock_run_workflow._run_proposals_stage(
+        parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
+    )
+
+    signals = captured_generate_payload["telemetrySignals"]
+    assert signals == [
+        {
+            "type": "flaky_test",
+            "tags": ["flaky_test"],
+            "severity": "medium",
+            "summary": "Retried a flaky test and wrote diagnostics for review.",
+            "diagnosticsRef": "artifact://diag-mm-794",
+        },
+        {
+            "type": "retry",
+            "tags": ["retry"],
+            "severity": "medium",
+            "summary": "Retried a flaky test and wrote diagnostics for review.",
+            "diagnosticsRef": "artifact://diag-mm-794",
+        },
+        {
+            "type": "artifact_gap",
+            "tags": ["artifact_gap"],
+            "severity": "medium",
+            "summary": "Retried a flaky test and wrote diagnostics for review.",
+            "diagnosticsRef": "artifact://diag-mm-794",
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_run_proposals_stage_records_operator_visible_outcomes(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Jira issue key: MM-794

Summary:
- Feeds compact workflow telemetry signals into proposal generation.
- Creates run-quality task proposal candidates from telemetry when no explicit proposal idea exists.
- Preserves signal metadata through proposal submission and normalizes MoonMind proposal origin metadata.
- Adds unit coverage for telemetry candidate generation, workflow payload propagation, submission metadata, and service metadata handling.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/workflows/temporal/workflows/test_run_proposals.py tests/unit/workflows/task_proposals/test_service.py` - 93 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-list.test.tsx -t "shows clickable active column filter chips and removes individual filters from the chip row"` - 1 passed, 43 skipped
- Full Python unit suite during wrapper rerun - 5708 passed, 6 skipped, 1 xpassed
- `./tools/test_integration.sh` - 269 passed, 1 skipped, 80 deselected

Remaining risks:
- Telemetry signal extraction is intentionally conservative and only converts known run-quality patterns into proposals.
- Broader telemetry sources can add more signal types later without changing the review queue contract.
