### PR TITLE
[codex] Restore run registry patch marker

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3784,10 +3784,6 @@ class MoonMindRunWorkflow:
             error_message="plan_ref must resolve to a JSON object",
         )
         plan_definition = parse_plan_definition(plan_dict)
-        # Keep this patch command for histories that recorded the registry-read
-        # branch before registry loading became lazy. Removing it strands
-        # in-flight MoonMind.Run histories before cancellation/failure handling.
-        workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH)
         registry_snapshot: ToolRegistrySnapshot | None = None
 
         async def load_registry_snapshot() -> ToolRegistrySnapshot:
@@ -3853,6 +3849,11 @@ class MoonMindRunWorkflow:
             and not pr_publish_optional
         )
         pull_request_url: str | None = None
+        # Keep this patch command in its historical position, after the
+        # jules-bundling marker and before any lazy registry read. Removing or
+        # reordering it strands in-flight MoonMind.Run histories before
+        # cancellation/failure handling.
+        workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH)
         previous_step_outputs: Mapping[str, Any] = {}
         execution_result: Any = None
         for index, node in enumerate(ordered_nodes, start=1):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3784,6 +3784,10 @@ class MoonMindRunWorkflow:
             error_message="plan_ref must resolve to a JSON object",
         )
         plan_definition = parse_plan_definition(plan_dict)
+        # Keep this patch command for histories that recorded the registry-read
+        # branch before registry loading became lazy. Removing it strands
+        # in-flight MoonMind.Run histories before cancellation/failure handling.
+        workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH)
         registry_snapshot: ToolRegistrySnapshot | None = None
 
         async def load_registry_snapshot() -> ToolRegistrySnapshot:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 from datetime import datetime, timezone, timedelta
 from typing import Any, Callable
 
@@ -12,6 +13,7 @@ from moonmind.workflows.temporal.workflows.run import (
     NATIVE_PR_BRANCH_DEFAULTS_PATCH,
     NATIVE_PR_LEASE_CONFLICT_GATE_PATCH,
     NATIVE_PR_PUSH_STATUS_GATE_PATCH,
+    RUN_CONDITIONAL_REGISTRY_READ_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
@@ -46,6 +48,16 @@ async def _immediate_wait_condition(
     **_kwargs: Any,
 ) -> None:
     assert predicate() is True
+
+def test_run_execution_stage_preserves_conditional_registry_patch_marker() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow._run_execution_stage)
+
+    patch_call = f"workflow.patched({RUN_CONDITIONAL_REGISTRY_READ_PATCH!r})"
+    constant_call = "workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH)"
+    assert constant_call in source or patch_call in source
+    assert source.index("workflow.patched") < source.index(
+        "async def load_registry_snapshot"
+    )
 
 @pytest.fixture
 def mock_run_workflow(monkeypatch: pytest.MonkeyPatch) -> MoonMindRunWorkflow:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -55,9 +55,11 @@ def test_run_execution_stage_preserves_conditional_registry_patch_marker() -> No
     patch_call = f"workflow.patched({RUN_CONDITIONAL_REGISTRY_READ_PATCH!r})"
     constant_call = "workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH)"
     assert constant_call in source or patch_call in source
-    assert source.index("workflow.patched") < source.index(
-        "async def load_registry_snapshot"
+    call_string = constant_call if constant_call in source else patch_call
+    assert source.index('workflow.patched("jules-bundling-v1")') < source.index(
+        call_string
     )
+    assert source.index(call_string) < source.index("await load_registry_snapshot()")
 
 @pytest.fixture
 def mock_run_workflow(monkeypatch: pytest.MonkeyPatch) -> MoonMindRunWorkflow:


### PR DESCRIPTION
## Summary

- Restore the `run-conditional-registry-read-v1` workflow patch command in `MoonMind.Run` so histories that recorded the marker can replay after lazy registry loading.
- Add a regression test that keeps the marker before lazy registry snapshot loading.

## Root Cause

A prior cleanup left `RUN_CONDITIONAL_REGISTRY_READ_PATCH` defined but stopped emitting the matching `workflow.patched(...)` command. Live histories containing that non-deprecated marker then failed replay before they could process failure or cancellation handling.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_integration.py::test_run_execution_stage_preserves_conditional_registry_patch_marker`
- `git diff --check`

Note: A broader wrapper run also executed the Python regression successfully, then failed later on an unrelated frontend `workflow-list.test.tsx` timeout.