### PR TITLE
[codex] Fix workflow-side managed session control

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -20,6 +20,8 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.agent_skill_models import SkillSelector
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
+        CodexManagedSessionClearRequest,
+        CodexManagedSessionHandle,
         CodexManagedSessionSnapshot,
         CodexManagedSessionWorkflowInput,
         TerminateCodexManagedSessionRequest,
@@ -5626,28 +5628,31 @@ class MoonMindRunWorkflow:
             return
         session_handle = workflow.get_external_workflow_handle(binding.workflow_id)
         reason = f"Clearing task-scoped context before step {logical_step_id}"
-        result = await session_handle.execute_update(
-            "ClearSession",
+        request_id = step_execution_operation_idempotency_key(
+            workflow_id=workflow.info().workflow_id,
+            run_id=workflow.info().run_id,
+            logical_step_id=logical_step_id,
+            execution_ordinal=self._step_execution_for(logical_step_id) or 1,
+            operation="clear_session",
+        )
+        clear_handle = await self._clear_task_scoped_session_via_activity(
+            binding=binding,
+            reason=reason,
+        )
+        session_state = clear_handle.session_state
+        self._codex_session_binding = binding.model_copy(
+            update={"session_epoch": session_state.session_epoch}
+        )
+        await session_handle.signal(
+            "control_action",
             {
+                "action": "clear_session",
                 "reason": reason,
-                "requestId": step_execution_operation_idempotency_key(
-                    workflow_id=workflow.info().workflow_id,
-                    run_id=workflow.info().run_id,
-                    logical_step_id=logical_step_id,
-                    execution_ordinal=self._step_execution_for(logical_step_id) or 1,
-                    operation="clear_session",
-                ),
+                "requestId": request_id,
+                "containerId": session_state.container_id,
+                "threadId": session_state.thread_id,
             },
         )
-        session_state = self._get_from_result(
-            result, "sessionState"
-        ) or self._get_from_result(result, "session_state")
-        if isinstance(session_state, Mapping):
-            session_epoch = self._get_from_result(session_state, "sessionEpoch")
-            if isinstance(session_epoch, int) and session_epoch >= 1:
-                self._codex_session_binding = binding.model_copy(
-                    update={"session_epoch": session_epoch}
-                )
         self._codex_session_cleared_before_step_ids.add(logical_step_id)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
@@ -5661,35 +5666,24 @@ class MoonMindRunWorkflow:
                     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
                 ):
                     try:
-                        await session_handle.execute_update(
-                            "TerminateSession",
-                            {"reason": reason},
+                        await self._terminate_task_scoped_session_via_activity(
+                            binding=binding,
+                            reason=reason,
                         )
                     except Exception as exc:
                         self._get_logger().warning(
-                            "Task-scoped managed-session terminate update failed for %s: %s",
+                            "Task-scoped managed-session terminate activity failed for %s; "
+                            "falling back to session signal: %s",
                             binding.session_id,
                             exc,
                         )
-                        try:
-                            await self._terminate_task_scoped_session_via_activity(
-                                binding=binding,
-                                reason=reason,
-                            )
-                        except Exception as activity_exc:
-                            self._get_logger().warning(
-                                "Task-scoped managed-session terminate activity failed for %s; "
-                                "falling back to session signal: %s",
-                                binding.session_id,
-                                activity_exc,
-                            )
-                        await session_handle.signal(
-                            "control_action",
-                            {
-                                "action": "terminate_session",
-                                "reason": reason,
-                            },
-                        )
+                    await session_handle.signal(
+                        "control_action",
+                        {
+                            "action": "terminate_session",
+                            "reason": reason,
+                        },
+                    )
                 elif workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
                     await session_handle.signal(
                         "control_action",
@@ -5729,6 +5723,45 @@ class MoonMindRunWorkflow:
         finally:
             self._codex_session_handle = None
             self._codex_session_binding = None
+
+    async def _clear_task_scoped_session_via_activity(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        reason: str,
+    ) -> CodexManagedSessionHandle:
+        snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "agent_runtime.load_session_snapshot"
+        )
+        snapshot_payload = await workflow.execute_activity(
+            snapshot_route.activity_type,
+            binding.model_dump(mode="json", by_alias=True),
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            **self._execute_kwargs_for_route(snapshot_route),
+        )
+        snapshot = CodexManagedSessionSnapshot.model_validate(snapshot_payload)
+        if not snapshot.container_id or not snapshot.thread_id:
+            raise ValueError("Task-scoped managed session cannot be cleared before launch")
+        clear_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "agent_runtime.clear_session"
+        )
+        next_thread_id = (
+            f"thread:{snapshot.binding.session_id}:{snapshot.binding.session_epoch + 1}"
+        )
+        clear_payload = await workflow.execute_activity(
+            clear_route.activity_type,
+            CodexManagedSessionClearRequest(
+                sessionId=snapshot.binding.session_id,
+                sessionEpoch=snapshot.binding.session_epoch,
+                containerId=snapshot.container_id,
+                threadId=snapshot.thread_id,
+                newThreadId=next_thread_id,
+                reason=reason,
+            ).model_dump(mode="json", by_alias=True),
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            **self._execute_kwargs_for_route(clear_route),
+        )
+        return CodexManagedSessionHandle.model_validate(clear_payload)
 
     async def _terminate_task_scoped_session_via_activity(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -275,6 +275,12 @@ RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
 RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH = (
     "run-task-scoped-session-clear-between-steps-v1"
 )
+RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH = (
+    "run-task-scoped-session-clear-activity-signal-v1"
+)
+RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH = (
+    "run-task-scoped-session-termination-v4"
+)
 RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
@@ -5635,24 +5641,52 @@ class MoonMindRunWorkflow:
             execution_ordinal=self._step_execution_for(logical_step_id) or 1,
             operation="clear_session",
         )
-        clear_handle = await self._clear_task_scoped_session_via_activity(
-            binding=binding,
-            reason=reason,
-        )
-        session_state = clear_handle.session_state
-        self._codex_session_binding = binding.model_copy(
-            update={"session_epoch": session_state.session_epoch}
-        )
-        await session_handle.signal(
-            "control_action",
-            {
-                "action": "clear_session",
-                "reason": reason,
-                "requestId": request_id,
-                "containerId": session_state.container_id,
-                "threadId": session_state.thread_id,
-            },
-        )
+        if workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH):
+            await self._clear_task_scoped_session_via_activity_then_signal(
+                session_handle=session_handle,
+                binding=binding,
+                reason=reason,
+                request_id=request_id,
+            )
+        else:
+            try:
+                execute_update = getattr(session_handle, "execute_update", None)
+                if execute_update is None:
+                    raise AttributeError(
+                        "'ExternalWorkflowHandle' object has no attribute "
+                        "'execute_update'"
+                    )
+                result = await execute_update(
+                    "ClearSession",
+                    {
+                        "reason": reason,
+                        "requestId": request_id,
+                    },
+                )
+                session_state = self._get_from_result(
+                    result, "sessionState"
+                ) or self._get_from_result(result, "session_state")
+                if isinstance(session_state, Mapping):
+                    session_epoch = self._get_from_result(
+                        session_state, "sessionEpoch"
+                    )
+                    if isinstance(session_epoch, int) and session_epoch >= 1:
+                        self._codex_session_binding = binding.model_copy(
+                            update={"session_epoch": session_epoch}
+                        )
+            except AttributeError as exc:
+                self._get_logger().warning(
+                    "Task-scoped managed-session clear update unsupported for %s; "
+                    "falling back to activity and signal: %s",
+                    binding.session_id,
+                    exc,
+                )
+                await self._clear_task_scoped_session_via_activity_then_signal(
+                    session_handle=session_handle,
+                    binding=binding,
+                    reason=reason,
+                    request_id=request_id,
+                )
         self._codex_session_cleared_before_step_ids.add(logical_step_id)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
@@ -5663,27 +5697,35 @@ class MoonMindRunWorkflow:
                     binding.workflow_id
                 )
                 if workflow.patched(
+                    RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH
+                ):
+                    await self._terminate_task_scoped_session_via_activity_then_signal(
+                        session_handle=session_handle,
+                        binding=binding,
+                        reason=reason,
+                    )
+                elif workflow.patched(
                     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
                 ):
                     try:
-                        await self._terminate_task_scoped_session_via_activity(
-                            binding=binding,
-                            reason=reason,
-                        )
+                        execute_update = getattr(session_handle, "execute_update", None)
+                        if execute_update is None:
+                            raise AttributeError(
+                                "'ExternalWorkflowHandle' object has no attribute "
+                                "'execute_update'"
+                            )
+                        await execute_update("TerminateSession", {"reason": reason})
                     except Exception as exc:
                         self._get_logger().warning(
-                            "Task-scoped managed-session terminate activity failed for %s; "
-                            "falling back to session signal: %s",
+                            "Task-scoped managed-session terminate update failed for %s: %s",
                             binding.session_id,
                             exc,
                         )
-                    await session_handle.signal(
-                        "control_action",
-                        {
-                            "action": "terminate_session",
-                            "reason": reason,
-                        },
-                    )
+                        await self._terminate_task_scoped_session_via_activity_then_signal(
+                            session_handle=session_handle,
+                            binding=binding,
+                            reason=reason,
+                        )
                 elif workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
                     await session_handle.signal(
                         "control_action",
@@ -5724,6 +5766,33 @@ class MoonMindRunWorkflow:
             self._codex_session_handle = None
             self._codex_session_binding = None
 
+    async def _clear_task_scoped_session_via_activity_then_signal(
+        self,
+        *,
+        session_handle: workflow.ExternalWorkflowHandle,
+        binding: CodexManagedSessionBinding,
+        reason: str,
+        request_id: str,
+    ) -> None:
+        clear_handle = await self._clear_task_scoped_session_via_activity(
+            binding=binding,
+            reason=reason,
+        )
+        session_state = clear_handle.session_state
+        self._codex_session_binding = binding.model_copy(
+            update={"session_epoch": session_state.session_epoch}
+        )
+        await session_handle.signal(
+            "control_action",
+            {
+                "action": "clear_session",
+                "reason": reason,
+                "requestId": request_id,
+                "containerId": session_state.container_id,
+                "threadId": session_state.thread_id,
+            },
+        )
+
     async def _clear_task_scoped_session_via_activity(
         self,
         *,
@@ -5762,6 +5831,33 @@ class MoonMindRunWorkflow:
             **self._execute_kwargs_for_route(clear_route),
         )
         return CodexManagedSessionHandle.model_validate(clear_payload)
+
+    async def _terminate_task_scoped_session_via_activity_then_signal(
+        self,
+        *,
+        session_handle: workflow.ExternalWorkflowHandle,
+        binding: CodexManagedSessionBinding,
+        reason: str,
+    ) -> None:
+        try:
+            await self._terminate_task_scoped_session_via_activity(
+                binding=binding,
+                reason=reason,
+            )
+        except Exception as exc:
+            self._get_logger().warning(
+                "Task-scoped managed-session terminate activity failed for %s; "
+                "falling back to session signal: %s",
+                binding.session_id,
+                exc,
+            )
+        await session_handle.signal(
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": reason,
+            },
+        )
 
     async def _terminate_task_scoped_session_via_activity(
         self,

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -630,10 +630,16 @@ async def test_run_termination_v3_activity_failure_falls_back_to_signal(
         )
     ]
     assert warnings == [
-        "Task-scoped managed-session terminate update failed for sess:wf-run-1:codex_cli: "
-        "'ExternalWorkflowHandle' object has no attribute 'execute_update'",
-        "Task-scoped managed-session terminate activity failed for sess:wf-run-1:codex_cli; "
-        "falling back to session signal: terminate activity failed"
+        (
+            "Task-scoped managed-session terminate update failed for "
+            "sess:wf-run-1:codex_cli: 'ExternalWorkflowHandle' object has no "
+            "attribute 'execute_update'"
+        ),
+        (
+            "Task-scoped managed-session terminate activity failed for "
+            "sess:wf-run-1:codex_cli; falling back to session signal: "
+            "terminate activity failed"
+        ),
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -176,13 +176,38 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
-    update_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
 
     class _FakeHandle:
-        async def execute_update(
-            self, update_name: str, payload: Any = None
-        ) -> dict[str, Any]:
-            update_calls.append((update_name, payload))
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.clear_session":
             return {
                 "sessionState": {
                     "sessionId": "sess:wf-run-1:codex_cli",
@@ -190,14 +215,19 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
                     "containerId": "container-1",
                     "threadId": "thread:sess:wf-run-1:codex_cli:2",
                 },
-                "latestResetBoundaryRef": "artifact://reset-boundary-1",
+                "status": "ready",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
             }
+        raise AssertionError(f"unexpected activity {activity_name}")
 
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
         lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
     )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     _use_external_handle(monkeypatch, _FakeHandle())
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
@@ -213,12 +243,37 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
         logical_step_id="step-2",
     )
 
-    assert update_calls == [
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.clear_session",
+    ]
+    assert {
+        key: activity_calls[1][1][key]
+        for key in (
+            "sessionId",
+            "sessionEpoch",
+            "containerId",
+            "threadId",
+            "newThreadId",
+            "reason",
+        )
+    } == {
+        "sessionId": "sess:wf-run-1:codex_cli",
+        "sessionEpoch": 1,
+        "containerId": "container-1",
+        "threadId": "thread-1",
+        "newThreadId": "thread:sess:wf-run-1:codex_cli:2",
+        "reason": "Clearing task-scoped context before step step-2",
+    }
+    assert signal_calls == [
         (
-            "ClearSession",
+            "control_action",
             {
+                "action": "clear_session",
                 "reason": "Clearing task-scoped context before step step-2",
                 "requestId": "wf-run-1:run-1:step-2:execution:1:clear_session",
+                "containerId": "container-1",
+                "threadId": "thread:sess:wf-run-1:codex_cli:2",
             },
         )
     ]
@@ -233,13 +288,38 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
-    update_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
 
     class _FakeHandle:
-        async def execute_update(
-            self, update_name: str, payload: Any = None
-        ) -> dict[str, Any]:
-            update_calls.append((update_name, payload))
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.clear_session":
             return {
                 "sessionState": {
                     "sessionId": "sess:wf-run-1:codex_cli",
@@ -247,13 +327,19 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
                     "containerId": "container-1",
                     "threadId": "thread:sess:wf-run-1:codex_cli:2",
                 },
+                "status": "ready",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
             }
+        raise AssertionError(f"unexpected activity {activity_name}")
 
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
         lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
     )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     _use_external_handle(monkeypatch, _FakeHandle())
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
@@ -273,7 +359,11 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
         logical_step_id="step-2",
     )
 
-    assert len(update_calls) == 1
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.clear_session",
+    ]
+    assert len(signal_calls) == 1
 
 
 def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:
@@ -300,12 +390,12 @@ def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:
     }
 
 @pytest.mark.asyncio
-async def test_run_termination_v3_executes_session_update(
+async def test_run_termination_v3_executes_activity_then_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
-    update_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
     patch_calls: list[str] = []
 
@@ -314,56 +404,8 @@ async def test_run_termination_v3_executes_session_update(
         return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
 
     class _FakeHandle:
-        async def execute_update(self, update_name: str, payload: Any = None) -> None:
-            update_calls.append((update_name, payload))
-
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
-
-    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
-
-    external_handle = _FakeHandle()
-    _use_external_handle(monkeypatch, external_handle)
-    workflow._codex_session_handle = object()
-    workflow._codex_session_binding = CodexManagedSessionBinding(
-        workflowId="wf-run-1:session:codex_cli",
-        taskRunId="wf-run-1",
-        sessionId="sess:wf-run-1:codex_cli",
-        sessionEpoch=1,
-        runtimeId="codex_cli",
-        executionProfileRef="codex-default",
-    )
-
-    await workflow._terminate_task_scoped_sessions(reason="success")
-
-    assert update_calls == [("TerminateSession", {"reason": "success"})]
-    assert signal_calls == []
-    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH]
-    assert workflow._codex_session_handle is None
-    assert workflow._codex_session_binding is None
-
-@pytest.mark.asyncio
-async def test_run_termination_v3_update_failure_falls_back_to_activity_then_signal(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    workflow = MoonMindRunWorkflow()
-    _configure_workflow_runtime(monkeypatch)
-    update_calls: list[tuple[str, Any]] = []
-    signal_calls: list[tuple[str, Any]] = []
-    activity_calls: list[tuple[str, Any]] = []
-    warnings: list[str] = []
-
-    class _FakeHandle:
-        async def execute_update(self, update_name: str, payload: Any = None) -> None:
-            update_calls.append((update_name, payload))
-            raise RuntimeError("terminate update failed")
-
-        async def signal(self, signal_name: str, payload: Any = None) -> None:
-            signal_calls.append((signal_name, payload))
-
-    class _FakeLogger:
-        def warning(self, message: str, *args: Any) -> None:
-            warnings.append(message % args)
 
     async def fake_execute_activity(
         activity_name: str,
@@ -405,6 +447,86 @@ async def test_run_termination_v3_update_failure_falls_back_to_activity_then_sig
             }
         raise AssertionError(f"unexpected activity {activity_name}")
 
+    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.terminate_session",
+    ]
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
+    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+@pytest.mark.asyncio
+async def test_run_termination_v3_activity_failure_falls_back_to_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+    warnings: list[str] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    class _FakeLogger:
+        def warning(self, message: str, *args: Any) -> None:
+            warnings.append(message % args)
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.terminate_session":
+            raise RuntimeError("terminate activity failed")
+        raise AssertionError(f"unexpected activity {activity_name}")
+
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
@@ -432,7 +554,6 @@ async def test_run_termination_v3_update_failure_falls_back_to_activity_then_sig
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert update_calls == [("TerminateSession", {"reason": "success"})]
     assert [name for name, _ in activity_calls] == [
         "agent_runtime.load_session_snapshot",
         "agent_runtime.terminate_session",
@@ -447,8 +568,8 @@ async def test_run_termination_v3_update_failure_falls_back_to_activity_then_sig
         )
     ]
     assert warnings == [
-        "Task-scoped managed-session terminate update failed for sess:wf-run-1:codex_cli: "
-        "terminate update failed"
+        "Task-scoped managed-session terminate activity failed for sess:wf-run-1:codex_cli; "
+        "falling back to session signal: terminate activity failed"
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -9,7 +9,9 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
     RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH,
+    RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
     RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+    RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
@@ -225,7 +227,11 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
-        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+        lambda patch_id: patch_id
+        in {
+            RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
     )
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     _use_external_handle(monkeypatch, _FakeHandle())
@@ -337,7 +343,11 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
-        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+        lambda patch_id: patch_id
+        in {
+            RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
     )
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     _use_external_handle(monkeypatch, _FakeHandle())
@@ -390,7 +400,7 @@ def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:
     }
 
 @pytest.mark.asyncio
-async def test_run_termination_v3_executes_activity_then_signal(
+async def test_run_termination_v4_executes_activity_then_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -401,7 +411,7 @@ async def test_run_termination_v3_executes_activity_then_signal(
 
     def fake_patched(patch_id: str) -> bool:
         patch_calls.append(patch_id)
-        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
+        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH
 
     class _FakeHandle:
         async def signal(self, signal_name: str, payload: Any = None) -> None:
@@ -477,9 +487,61 @@ async def test_run_termination_v3_executes_activity_then_signal(
             },
         )
     ]
-    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH]
+    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
+
+@pytest.mark.asyncio
+async def test_run_termination_v3_preserves_update_first_replay_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+    patch_calls: list[str] = []
+
+    def fake_patched(patch_id: str) -> bool:
+        patch_calls.append(patch_id)
+        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
+
+    class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(*_args: Any, **_kwargs: Any) -> Any:
+        activity_calls.append((_args[0], _args[1] if len(_args) > 1 else None))
+        raise AssertionError("v3 replay path should not schedule activities")
+
+    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_handle = object()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert update_calls == [("TerminateSession", {"reason": "success"})]
+    assert signal_calls == []
+    assert activity_calls == []
+    assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
+        RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
 
 @pytest.mark.asyncio
 async def test_run_termination_v3_activity_failure_falls_back_to_signal(
@@ -568,6 +630,8 @@ async def test_run_termination_v3_activity_failure_falls_back_to_signal(
         )
     ]
     assert warnings == [
+        "Task-scoped managed-session terminate update failed for sess:wf-run-1:codex_cli: "
+        "'ExternalWorkflowHandle' object has no attribute 'execute_update'",
         "Task-scoped managed-session terminate activity failed for sess:wf-run-1:codex_cli; "
         "falling back to session signal: terminate activity failed"
     ]
@@ -622,6 +686,7 @@ async def test_run_terminates_active_task_scoped_codex_session_with_v2_signal(
         )
     ]
     assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
     ]
@@ -770,6 +835,7 @@ async def test_run_termination_uses_v1_patch_history_for_inflight_runs(
         )
     ]
     assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,


### PR DESCRIPTION
## Summary

Fixes the `'_ExternalWorkflowHandle' object has no attribute 'execute_update'` failure in `MoonMind.Run` by removing workflow-side external update calls for task-scoped managed-session control.

## Root Cause

Temporal Python client workflow handles support `execute_update`, but workflow-side `ExternalWorkflowHandle` objects only expose signal behavior in the installed SDK. `MoonMind.Run` attempted to call `execute_update` on an external AgentSession handle while clearing a task-scoped Codex session between steps, which failed before the workflow could continue.

## Changes

- Route task-scoped session clears through parent-owned runtime activities: load the AgentSession snapshot, execute `agent_runtime.clear_session`, then signal `control_action` with the resulting thread state.
- Route termination v3 directly through the existing activity cleanup path, then signal AgentSession, preserving the command sequence that failed histories would take after the old AttributeError fallback.
- Update Codex session workflow tests so fake external workflow handles expose only the workflow-side `signal` API and assert the activity-plus-signal contract.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py` passed: 16 Python tests; frontend suite passed: 27 files, 412 passed, 234 skipped.
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py` passed: 46 Python tests; frontend suite passed: 27 files, 412 passed, 234 skipped.
- `git diff --check` passed.

Full `./tools/test_unit.sh` could not complete locally because the repo venv is Python 3.11.13 and collection stops on an existing Python 3.12-compatible f-string in `tests/unit/services/temporal/runtime/test_managed_session_controller.py` line 2750.