### PR TITLE
[codex] fix tool step planning

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1373,12 +1373,24 @@ def _iter_requested_registry_tools(
     return tuple(selected)
 
 def _default_skill_registry_payload(
-    *, parameters: Mapping[str, Any] | None = None
+    *,
+    parameters: Mapping[str, Any] | None = None,
+    inputs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    requested: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for payload in (parameters, inputs):
+        for name, version in _iter_requested_registry_tools(payload):
+            key = (name, version)
+            if key in seen:
+                continue
+            seen.add(key)
+            requested.append(key)
+
     return {
         "skills": [
             _default_registry_skill_payload(name=name, version=version)
-            for name, version in _iter_requested_registry_tools(parameters)
+            for name, version in requested
         ]
     }
 
@@ -1703,7 +1715,10 @@ class TemporalPlanActivities:
                 artifact_locator=_artifact_id_from_ref(registry_snapshot_ref),
             )
         else:
-            registry_payload = _default_skill_registry_payload(parameters=parameters)
+            registry_payload = _default_skill_registry_payload(
+                parameters=parameters,
+                inputs=inputs_payload if isinstance(inputs_payload, Mapping) else None,
+            )
             fallback_ref = await _write_json_artifact(
                 self._artifact_service,
                 principal=principal,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1004,7 +1004,7 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     )
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
-def _selected_step_tool_type(step_entry: Mapping[str, Any], tool_name: str) -> str:
+def _selected_step_tool_type(step_entry: Mapping[str, Any]) -> str:
     if _selected_step_type(step_entry) == "tool":
         return "skill"
     return "agent_runtime"
@@ -1645,7 +1645,7 @@ def _build_runtime_planner():
                     if step_runtime_raw is not None
                     else None
                 )
-                tool_type = _selected_step_tool_type(step_entry, step_tool_name)
+                tool_type = _selected_step_tool_type(step_entry)
                 tool_version = _selected_step_tool_version(step_entry)
                 is_agent_runtime_step = tool_type == "agent_runtime"
                 effective_step_skill_name = (

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1005,6 +1005,8 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
 def _selected_step_tool_type(step_entry: Mapping[str, Any], tool_name: str) -> str:
+    if _selected_step_type(step_entry) == "tool":
+        return "skill"
     return "agent_runtime"
 
 def _jira_agent_skill_selected(tool_name: str) -> bool:
@@ -1645,8 +1647,13 @@ def _build_runtime_planner():
                 )
                 tool_type = _selected_step_tool_type(step_entry, step_tool_name)
                 tool_version = _selected_step_tool_version(step_entry)
-                effective_step_skill_name = step_tool_name or selected_skill_name
-                if step_tool_name:
+                is_agent_runtime_step = tool_type == "agent_runtime"
+                effective_step_skill_name = (
+                    step_tool_name or selected_skill_name
+                    if is_agent_runtime_step
+                    else ""
+                )
+                if step_tool_name and is_agent_runtime_step:
                     step_node_inputs["selectedSkill"] = step_tool_name
                     if (
                         _jira_agent_skill_selected(step_tool_name)
@@ -1679,13 +1686,15 @@ def _build_runtime_planner():
                             story_output_mode=story_output_mode,
                         )
                     )
+                if not is_agent_runtime_step:
+                    step_node_inputs.pop("selectedSkill", None)
 
                 nodes.append({
                     "id": step_id,
                     "tool": {
                         "type": tool_type,
-                        "name": step_runtime,
-                        "version": "1.0",
+                        "name": step_runtime if is_agent_runtime_step else step_tool_name,
+                        "version": "1.0" if is_agent_runtime_step else tool_version,
                     },
                     "inputs": step_node_inputs,
                 })

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -590,6 +590,31 @@ async def test_default_skill_registry_payload_uses_dood_tool_definitions():
         == "mm.tool.execute"
     )
 
+async def test_default_skill_registry_payload_includes_input_sourced_tool_steps():
+    payload = _default_skill_registry_payload(
+        parameters={"task": {"tool": {"name": "auto", "version": "1.0"}}},
+        inputs={
+            "task": {
+                "steps": [
+                    {
+                        "type": "tool",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-579"},
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    skills = payload.get("skills")
+    assert isinstance(skills, list)
+    assert [(item["name"], item["version"]) for item in skills] == [
+        ("jira.get_issue", "1.0.0")
+    ]
+
 async def test_default_skill_registry_payload_uses_curated_pentest_tool_definition():
     payload = _default_skill_registry_payload(
         parameters={
@@ -1192,6 +1217,88 @@ async def test_plan_generate_accepts_auto_placeholder_without_registry_entries(
 
             assert plan_payload["nodes"][0]["tool"]["type"] == "agent_runtime"
             assert registry_payload == {"skills": []}
+
+async def test_plan_generate_fallback_registry_includes_input_artifact_tool_steps(
+    tmp_path: Path,
+):
+    from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            inputs_artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="application/json",
+            )
+            await service.write_complete(
+                artifact_id=inputs_artifact.artifact_id,
+                principal="user-1",
+                payload=(
+                    json.dumps(
+                        {
+                            "task": {
+                                "instructions": "Fetch the Jira issue.",
+                                "runtime": {"mode": "codex_cli"},
+                                "steps": [
+                                    {
+                                        "id": "fetch-issue",
+                                        "type": "tool",
+                                        "instructions": "Fetch MM-579.",
+                                        "tool": {
+                                            "id": "jira.get_issue",
+                                            "version": "1.0.0",
+                                            "inputs": {"issueKey": "MM-579"},
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    )
+                    + "\n"
+                ).encode("utf-8"),
+                content_type="application/json",
+            )
+
+            planner = TemporalPlanActivities(
+                artifact_service=service,
+                planner=_build_runtime_planner(),
+            )
+            result = await planner.plan_generate(
+                principal="user-1",
+                inputs_ref=inputs_artifact.artifact_id,
+                parameters={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                    "task": {
+                        "tool": {"type": "skill", "name": "auto", "version": "1.0"}
+                    },
+                },
+            )
+
+            _artifact, plan_payload_raw = await service.read(
+                artifact_id=result.plan_ref.artifact_id,
+                principal="user-1",
+            )
+            plan_payload = json.loads(plan_payload_raw.decode("utf-8"))
+            registry_ref = plan_payload["metadata"]["registry_snapshot"]["artifact_ref"]
+            _registry_artifact, registry_payload_raw = await service.read(
+                artifact_id=registry_ref,
+                principal="user-1",
+            )
+            registry_payload = json.loads(registry_payload_raw.decode("utf-8"))
+
+            assert plan_payload["nodes"][0]["tool"] == {
+                "type": "skill",
+                "name": "jira.get_issue",
+                "version": "1.0.0",
+            }
+            assert [
+                (item["name"], item["version"])
+                for item in registry_payload["skills"]
+            ] == [("jira.get_issue", "1.0.0")]
 
 async def test_default_registry_payload_uses_extended_timeouts_for_pr_resolver():
     payload = _default_registry_skill_payload(name="pr-resolver", version="1.0")

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -396,11 +396,11 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
-        "version": "1.0",
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
     }
-    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
+    assert "selectedSkill" not in plan["nodes"][0]["inputs"]
     assert plan["nodes"][0]["inputs"]["type"] == "tool"
     assert plan["nodes"][0]["inputs"]["issueKey"] == "MM-559"
     assert plan["nodes"][0]["inputs"]["source"] == {
@@ -517,9 +517,9 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
     ]
     assert plan["edges"] == [{"from": "fetch-issue", "to": "implement-story"}]
     assert plan["nodes"][0]["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
-        "version": "1.0",
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
     }
     assert plan["nodes"][1]["tool"] == {
         "type": "agent_runtime",
@@ -682,13 +682,11 @@ def test_runtime_planner_maps_deployment_update_step_to_typed_tool_node():
     )
 
     assert plan["nodes"][0]["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
-        "version": "1.0",
+        "type": "skill",
+        "name": "deployment.update_compose_stack",
+        "version": "1.0.0",
     }
-    assert plan["nodes"][0]["inputs"]["selectedSkill"] == (
-        "deployment.update_compose_stack"
-    )
+    assert "selectedSkill" not in plan["nodes"][0]["inputs"]
     assert plan["nodes"][0]["inputs"]["image"]["reference"] == "latest"
 
 
@@ -945,8 +943,12 @@ def test_runtime_planner_materializes_tool_steps_without_source_lookup(
         snapshot=snapshot,
     )
 
-    assert plan["nodes"][0]["tool"]["name"] == "codex_cli"
-    assert plan["nodes"][0]["inputs"]["selectedSkill"] == "jira.get_issue"
+    assert plan["nodes"][0]["tool"] == {
+        "type": "skill",
+        "name": "jira.get_issue",
+        "version": "1.0.0",
+    }
+    assert "selectedSkill" not in plan["nodes"][0]["inputs"]
     if source is None:
         assert "source" not in plan["nodes"][0]["inputs"]
     else:


### PR DESCRIPTION
## Summary
- Keep preset-authored `type: "tool"` steps on the executable tool dispatcher path instead of converting them to agent-runtime steps.
- Prevent typed tool steps from carrying `selectedSkill`, which is reserved for agent skill selection.
- Update runtime planner tests for tool/skill step separation.

## Root Cause
The runtime planner converted every expanded preset step into `agent_runtime`. For Jira preset tool steps such as `jira.load_preset_brief`, that made the tool id look like an agent `selectedSkill`, causing `agent_skill.resolve` to fail before the trusted Jira tool could run.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Live worker planner check confirmed `jira.load_preset_brief` now plans as an executable tool node with no `selectedSkill`.
