### PR TITLE
[codex] Fix deployment update tool planning

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1426,9 +1426,7 @@ def _build_runtime_planner():
                 ).strip()
                 if not authored_tool_name:
                     raise RuntimeError("task.plan tool name is required")
-                is_legacy_agent_skill_plan_entry = (
-                    not has_authored_tool and authored_tool_type == "skill"
-                )
+                is_legacy_agent_skill_plan_entry = not has_authored_tool
                 tool_type = (
                     "agent_runtime"
                     if is_legacy_agent_skill_plan_entry

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1410,6 +1410,7 @@ def _build_runtime_planner():
             for idx, plan_entry in enumerate(explicit_plan, start=1):
                 if not isinstance(plan_entry, Mapping):
                     raise RuntimeError("task.plan entries must be objects")
+                has_authored_tool = isinstance(plan_entry.get("tool"), Mapping)
                 tool_payload = _coerce_mapping(
                     plan_entry.get("tool")
                 ) or _coerce_mapping(plan_entry.get("skill"))
@@ -1425,10 +1426,19 @@ def _build_runtime_planner():
                 ).strip()
                 if not authored_tool_name:
                     raise RuntimeError("task.plan tool name is required")
-                tool_type = (
-                    "agent_runtime" if authored_tool_type == "skill" else authored_tool_type
+                is_legacy_agent_skill_plan_entry = (
+                    not has_authored_tool and authored_tool_type == "skill"
                 )
-                tool_name = runtime_mode if authored_tool_type == "skill" else authored_tool_name
+                tool_type = (
+                    "agent_runtime"
+                    if is_legacy_agent_skill_plan_entry
+                    else authored_tool_type
+                )
+                tool_name = (
+                    runtime_mode
+                    if is_legacy_agent_skill_plan_entry
+                    else authored_tool_name
+                )
                 tool_version = str(tool_payload.get("version") or "1.0").strip()
                 if not tool_version:
                     raise RuntimeError("task.plan tool version is required")
@@ -1437,7 +1447,7 @@ def _build_runtime_planner():
                     node_inputs = _coerce_mapping(
                         tool_payload.get("inputs") or tool_payload.get("args")
                     )
-                if authored_tool_type == "skill":
+                if is_legacy_agent_skill_plan_entry:
                     node_inputs = {
                         "instructions": f"Execute skill '{authored_tool_name}'",
                         "runtime": dict(runtime_node),

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -577,14 +577,11 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
         {
             "id": "update-moonmind-deployment",
             "tool": {
-                "type": "agent_runtime",
-                "name": "codex_cli",
+                "type": "skill",
+                "name": "deployment.update_compose_stack",
                 "version": "1.0.0",
             },
             "inputs": {
-                "instructions": "Execute skill 'deployment.update_compose_stack'",
-                "runtime": {"mode": "codex_cli"},
-                "selectedSkill": "deployment.update_compose_stack",
                 "stack": "moonmind",
                 "image": {
                     "repository": "ghcr.io/moonladderstudios/moonmind",
@@ -594,6 +591,7 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
             },
         }
     ]
+    assert "selectedSkill" not in plan["nodes"][0]["inputs"]
     assert plan["policy"]["failure_mode"] == "FAIL_FAST"
     registry_snapshot = plan["metadata"]["registry_snapshot"]
     assert registry_snapshot["artifact_ref"] == "art_registry_123"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -597,6 +597,52 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
     assert registry_snapshot["artifact_ref"] == "art_registry_123"
 
 
+def test_runtime_planner_maps_legacy_task_plan_skill_without_type_to_agent_runtime_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={},
+        parameters={
+            "task": {
+                "instructions": "Run a legacy skill plan entry.",
+                "runtime": {"mode": "codex_cli"},
+                "plan": [
+                    {
+                        "id": "implement-story",
+                        "skill": {
+                            "name": "moonspec-implement",
+                            "version": "1.0.0",
+                        },
+                        "inputs": {"story": "MM-573"},
+                    }
+                ],
+            },
+        },
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"] == [
+        {
+            "id": "implement-story",
+            "tool": {
+                "type": "agent_runtime",
+                "name": "codex_cli",
+                "version": "1.0.0",
+            },
+            "inputs": {
+                "instructions": "Execute skill 'moonspec-implement'",
+                "runtime": {"mode": "codex_cli"},
+                "selectedSkill": "moonspec-implement",
+                "story": "MM-573",
+            },
+        }
+    ]
+
+
 def test_runtime_planner_preserves_authored_task_plan_node_metadata():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Preserve explicit deployment update tool plan entries as typed executable tool nodes.
- Keep legacy `task.plan[].skill` fallback behavior for agent-skill plan entries.
- Pin a regression test so `deployment.update_compose_stack` no longer becomes `selectedSkill`.

## Root Cause

`deployment.update_compose_stack` is a typed executable tool, not an agent instruction skill. The runtime planner rewrote explicit legacy `tool.type = "skill"` plan entries into agent-runtime nodes with `selectedSkill`, which sent deployment updates through `agent_skill.resolve` and failed before the update command could run.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k "deployment_update or authored_task_plan_tool_nodes"`
- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_deployment_operations.py -k "deployment_update"`
