### PR TITLE
Fix tool registry snapshot principal dispatch

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4145,6 +4145,7 @@ class MoonMindRunWorkflow:
                         route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(definition)
                         execute_payload = {
                             "registry_snapshot_ref": snapshot.artifact_ref,
+                            "principal": self._principal(),
                             "invocation_payload": {
                                 "id": node_id,
                                 "tool": {

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -548,6 +548,8 @@ async def test_run_execution_stage_rejects_dood_skill_tool_in_run_dispatch(
     }
     assert payload["context"]["workflow_id"] == "wf-1"
     assert payload["context"]["node_id"] == "workload-step"
+    assert payload["principal"] == "owner-1"
+    assert payload["registry_snapshot_ref"] == "art:sha256:456"
     assert tool_calls[0][2]["task_queue"] == "mm.activity.agent_runtime"
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass the workflow principal to legacy skill/tool dispatch when loading registry snapshots from artifacts
- assert the dispatch payload includes both principal and registry snapshot ref

## Verification
- bash -lc '/usr/bin/python3.12 -m pytest tests/unit/workflows/temporal/workflows/test_run_integration.py -q'
- bash -lc '/usr/bin/python3.12 -m pytest tests/unit/workflows/temporal/test_activity_runtime.py::test_skill_execute_loads_registry_snapshot_from_temporal_artifact tests/unit/workflows/temporal/test_activity_runtime.py::test_skill_execute_uses_bound_artifact_service_when_not_passed -q'

Note: full ./tools/test_unit.sh is blocked locally by the existing Python 3.11 venv collecting Python 3.12-only f-string syntax in tests/unit/services/temporal/runtime/test_managed_session_controller.py.