### PR TITLE
Fix Jira preset brief tool routing

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -167,6 +167,7 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
 )
 from moonmind.workflows.temporal.story_output_tools import (
     JIRA_CHECK_BLOCKERS_TOOL_NAME,
+    JIRA_LOAD_PRESET_BRIEF_TOOL_NAME,
 )
 
 class CmdRes:
@@ -1207,6 +1208,62 @@ def _default_registry_skill_payload(*, name: str, version: str) -> dict[str, Any
                         "decision": {"type": "string", "enum": ["continue", "blocked"]},
                         "blockingIssues": {"type": "array"},
                         "resolvedBlockingIssues": {"type": "array"},
+                        "summary": {"type": "string"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "executor": {
+                "activity_type": "mm.tool.execute",
+                "selector": {"mode": "by_capability"},
+            },
+            "requirements": {"capabilities": ["integration:jira"]},
+            "policies": {
+                "timeouts": {
+                    "start_to_close_seconds": 60,
+                    "schedule_to_close_seconds": 120,
+                },
+                "retries": {"max_attempts": 1},
+            },
+        }
+
+    if name == JIRA_LOAD_PRESET_BRIEF_TOOL_NAME:
+        return {
+            "name": name,
+            "version": version,
+            "description": (
+                "Load a compact Jira preset brief through MoonMind's trusted "
+                "Jira service."
+            ),
+            "inputs": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "issueKey": {"type": "string"},
+                        "issue_key": {"type": "string"},
+                        "jiraIssueKey": {"type": "string"},
+                        "jira_issue_key": {"type": "string"},
+                        "jira": {"type": "object"},
+                        "issue": {"type": "object"},
+                    },
+                    "additionalProperties": True,
+                }
+            },
+            "outputs": {
+                "schema": {
+                    "type": "object",
+                    "required": [
+                        "trustedSource",
+                        "jiraIssueKey",
+                        "jiraPresetBrief",
+                        "summary",
+                    ],
+                    "properties": {
+                        "trustedSource": {"type": "string"},
+                        "jiraIssueKey": {"type": "string"},
+                        "jiraPresetBrief": {"type": "string"},
+                        "jiraStepInstructions": {"type": "string"},
+                        "jiraIssue": {"type": "object"},
                         "summary": {"type": "string"},
                     },
                     "additionalProperties": True,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -39,6 +39,7 @@ from moonmind.workflows.temporal.activity_catalog import (
     AGENT_RUNTIME_FLEET,
     ARTIFACTS_FLEET,
     DEPLOYMENT_FLEET,
+    INTEGRATIONS_FLEET,
     SANDBOX_FLEET,
     build_default_activity_catalog,
 )
@@ -804,6 +805,41 @@ async def test_default_skill_registry_payload_uses_curated_deployment_tool_defin
     route = build_default_activity_catalog().resolve_skill(parsed[0])
     assert route.fleet == DEPLOYMENT_FLEET
     assert route.task_queue == "mm.activity.deployment"
+
+async def test_default_skill_registry_payload_routes_jira_preset_brief_to_integrations():
+    payload = _default_skill_registry_payload(
+        parameters={
+            "task": {
+                "steps": [
+                    {
+                        "tool": {
+                            "type": "skill",
+                            "name": "jira.load_preset_brief",
+                            "version": "1.0",
+                        }
+                    }
+                ]
+            }
+        }
+    )
+
+    skills = payload.get("skills")
+    assert isinstance(skills, list)
+    assert len(skills) == 1
+    definition = skills[0]
+
+    assert definition["name"] == "jira.load_preset_brief"
+    assert definition["requirements"]["capabilities"] == ["integration:jira"]
+    assert definition["policies"]["timeouts"] == {
+        "start_to_close_seconds": 60,
+        "schedule_to_close_seconds": 120,
+    }
+
+    parsed = parse_skill_registry(payload)
+    assert parsed[0].required_capabilities == ("integration:jira",)
+    route = build_default_activity_catalog().resolve_skill(parsed[0])
+    assert route.fleet == INTEGRATIONS_FLEET
+    assert route.task_queue == "mm.activity.integrations"
 
 async def test_curated_pentest_activity_binding_is_registered_on_agent_runtime_fleet():
     bindings = build_activity_bindings(


### PR DESCRIPTION
## Summary
- Route jira.load_preset_brief to the integration:jira activity fleet instead of the sandbox fallback.
- Add a registry/catalog routing regression test for the preset brief tool.

## Verification
- ./tools/test_unit.sh
- Direct integrations-worker load for MM-801 returned COMPLETED with a non-empty preset brief.