### PR TITLE
MM-802: Update default models to claude-opus-4-8, gpt-5.5, gemini-3.1-pro

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -649,7 +649,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "is_default": True,
             "provider_id": "google",
             "provider_label": "Google",
-            "default_model": None,  # inherits runtime default: gemini-3.1-pro-preview
+            "default_model": None,  # inherits runtime default: gemini-3.1-pro
             "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
             "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
             "volume_ref": get_provider_default("gemini_cli", "volume_ref"),
@@ -664,7 +664,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "is_default": True,
             "provider_id": "openai",
             "provider_label": "OpenAI",
-            "default_model": None,  # inherits runtime default: gpt-5.4
+            "default_model": None,  # inherits runtime default: gpt-5.5
             "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
             "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
             "volume_ref": get_provider_default("codex_cli", "volume_ref"),
@@ -677,7 +677,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "is_default": True,
             "provider_id": "anthropic",
             "provider_label": "Anthropic",
-            "default_model": None,  # inherits runtime default: claude-opus-4-7
+            "default_model": None,  # inherits runtime default: claude-opus-4-8
             "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
             "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
             "volume_ref": get_provider_default("claude_code", "volume_ref"),

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -631,7 +631,7 @@ class WorkflowSettings(BaseSettings):
     )
     codex_environment: Optional[str] = Field(None, alias="CODEX_ENV")
     codex_model: Optional[str] = Field(
-        "gpt-5.3-codex",
+        "gpt-5.5",
         validation_alias=AliasChoices("MOONMIND_CODEX_MODEL", "CODEX_MODEL"),
     )
     codex_effort: Optional[str] = Field(
@@ -1377,7 +1377,7 @@ class WorkflowSettings(BaseSettings):
                 dict.fromkeys((*self.allowed_skills, self.default_skill))
             )
         if not self.codex_model:
-            self.codex_model = "gpt-5.3-codex"
+            self.codex_model = "gpt-5.5"
         if not self.codex_effort:
             self.codex_effort = "high"
         if not self.claude_volume_name:

--- a/moonmind/workflows/tasks/runtime_defaults.py
+++ b/moonmind/workflows/tasks/runtime_defaults.py
@@ -15,9 +15,9 @@ DEFAULT_REPOSITORY = "MoonLadderStudios/MoonMind"
 
 # Canonical runtime ids as primary keys.
 _DEFAULT_RUNTIME_MODELS: dict[str, str] = {
-    "codex_cli": "gpt-5.4",
-    "gemini_cli": "gemini-3.1-pro-preview",
-    "claude_code": "claude-opus-4-7",
+    "codex_cli": "gpt-5.5",
+    "gemini_cli": "gemini-3.1-pro",
+    "claude_code": "claude-opus-4-8",
 }
 _DEFAULT_RUNTIME_EFFORTS: dict[str, str] = {
     "codex_cli": "high",

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -378,7 +378,7 @@ def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
 
     assert config["system"]["supportedTaskRuntimes"] == ["codex_cli", "gemini_cli", "claude_code", "codex_cloud"]
     assert config["system"]["defaultTaskRuntime"] == "claude_code"
-    assert config["system"]["defaultTaskModel"] == "claude-opus-4-7"
+    assert config["system"]["defaultTaskModel"] == "claude-opus-4-8"
 
 def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
     monkeypatch.setattr(settings.workflow, "github_repository", "Octo/Repo")
@@ -713,9 +713,9 @@ def test_build_runtime_config_uses_repo_runtime_model_defaults(monkeypatch) -> N
 
     config = dashboard_view_model.build_runtime_config("/workflows")
 
-    assert config["system"]["defaultTaskModelByRuntime"]["codex_cli"] == "gpt-5.4"
-    assert config["system"]["defaultTaskModelByRuntime"]["gemini_cli"] == "gemini-3.1-pro-preview"
-    assert config["system"]["defaultTaskModelByRuntime"]["claude_code"] == "claude-opus-4-7"
+    assert config["system"]["defaultTaskModelByRuntime"]["codex_cli"] == "gpt-5.5"
+    assert config["system"]["defaultTaskModelByRuntime"]["gemini_cli"] == "gemini-3.1-pro"
+    assert config["system"]["defaultTaskModelByRuntime"]["claude_code"] == "claude-opus-4-8"
 
 def test_normalize_status_maps_temporal_waits_to_awaiting_action() -> None:
     assert dashboard_view_model.normalize_status("temporal", "awaiting_external") == "awaiting_action"

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -61,8 +61,8 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     profile_ids = {p.profile_id for p in profiles}
     assert profile_ids == {"gemini_default", "codex_default", "claude_anthropic"}
     # Standard profiles are seeded with default_model=None so they inherit
-    # the runtime default (codex_cli→gpt-5.4, gemini_cli→gemini-3.1-pro-preview,
-    # claude_code→claude-opus-4-7) rather than storing a duplicate value.
+    # the runtime default (codex_cli→gpt-5.5, gemini_cli→gemini-3.1-pro,
+    # claude_code→claude-opus-4-8) rather than storing a duplicate value.
     defaults = {p.profile_id: p.default_model for p in profiles}
     assert defaults["gemini_default"] is None
     assert defaults["codex_default"] is None

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -576,7 +576,7 @@ class TestWorkflowSettings:
         """Task defaults should provide stable queue execution baselines."""
 
         settings = WorkflowSettings(_env_file=None)
-        assert settings.codex_model == "gpt-5.3-codex"
+        assert settings.codex_model == "gpt-5.5"
         assert settings.codex_effort == "high"
         assert settings.default_task_runtime == "codex_cli"
         assert settings.default_publish_mode == "pr"

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -685,7 +685,7 @@ async def test_start_falls_back_to_runtime_default_model_when_profile_blank() ->
     await adapter.start(request)
 
     profile_payload = captured_payload.get("profile") or {}
-    assert profile_payload.get("defaultModel") == "gpt-5.4"
+    assert profile_payload.get("defaultModel") == "gpt-5.5"
     assert profile_payload.get("defaultEffort") == "high"
 
 async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/workflows/tasks/test_model_resolver.py
+++ b/tests/unit/workflows/tasks/test_model_resolver.py
@@ -131,9 +131,9 @@ class TestResolveEffectiveModelRuntimeDefault:
     @pytest.mark.parametrize(
         "runtime_id,expected_model",
         [
-            ("codex_cli", "gpt-5.4"),
-            ("gemini_cli", "gemini-3.1-pro-preview"),
-            ("claude_code", "claude-opus-4-7"),
+            ("codex_cli", "gpt-5.5"),
+            ("gemini_cli", "gemini-3.1-pro"),
+            ("claude_code", "claude-opus-4-8"),
         ],
     )
     def test_runtime_default_for_each_canonical_id(self, runtime_id, expected_model):
@@ -187,7 +187,7 @@ class TestResolveEffectiveModelNone:
             profile=None,
             requested_model=None,
         )
-        assert model == "gpt-5.4"
+        assert model == "gpt-5.5"
         assert source == "runtime_default"
 
 # ---------------------------------------------------------------------------
@@ -229,5 +229,5 @@ class TestPrecedenceOrder:
             profile=profile,
             requested_model=None,
         )
-        assert model == "gpt-5.4"
+        assert model == "gpt-5.5"
         assert source == "runtime_default"

--- a/tests/unit/workflows/tasks/test_model_resolver.py
+++ b/tests/unit/workflows/tasks/test_model_resolver.py
@@ -137,10 +137,14 @@ class TestResolveEffectiveModelRuntimeDefault:
         ],
     )
     def test_runtime_default_for_each_canonical_id(self, runtime_id, expected_model):
+        # Pass an empty env so the test asserts the in-code runtime default
+        # rather than any ambient MOONMIND_*_MODEL / *_MODEL override that may
+        # be set in the managed-agent container the unit suite runs inside.
         model, source = resolve_effective_model(
             runtime_id=runtime_id,
             profile=None,
             requested_model=None,
+            env={},
         )
         assert model == expected_model
         assert source == "runtime_default"
@@ -186,6 +190,7 @@ class TestResolveEffectiveModelNone:
             runtime_id=None,
             profile=None,
             requested_model=None,
+            env={},
         )
         assert model == "gpt-5.5"
         assert source == "runtime_default"
@@ -228,6 +233,7 @@ class TestPrecedenceOrder:
             runtime_id="codex_cli",
             profile=profile,
             requested_model=None,
+            env={},
         )
         assert model == "gpt-5.5"
         assert source == "runtime_default"

--- a/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from moonmind.workflows.temporal.runtime.strategies import (
     RUNTIME_STRATEGIES,
     GeminiCliStrategy,
@@ -75,8 +77,28 @@ class TestGeminiCliProperties:
 # build_command tests (DOC-REQ-003 validation)
 # ---------------------------------------------------------------------------
 
+_RUNTIME_MODEL_ENV_KEYS = (
+    "MOONMIND_CODEX_MODEL",
+    "CODEX_MODEL",
+    "MOONMIND_GEMINI_MODEL",
+    "GEMINI_MODEL",
+    "MOONMIND_CLAUDE_MODEL",
+    "CLAUDE_MODEL",
+)
+
 class TestGeminiCliBuildCommand:
     """Verify strategy produces identical output to the legacy elif block."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_runtime_model_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Assert in-code runtime defaults, not environment overrides.
+
+        Managed-agent containers (where the unit suite runs) may set
+        ``MOONMIND_GEMINI_MODEL`` etc., which would otherwise mask the in-code
+        defaults these "default tests" intend to assert.
+        """
+        for key in _RUNTIME_MODEL_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
     def test_basic_prompt(self) -> None:
         s = GeminiCliStrategy()
@@ -86,7 +108,7 @@ class TestGeminiCliBuildCommand:
         # When profile.default_model is None, gemini_cli runtime default applies.
         assert cmd == [
             "gemini",
-            "--model", "gemini-3.1-pro-preview",
+            "--model", "gemini-3.1-pro",
             "--yolo", "--prompt", "Fix the bug",
         ]
 
@@ -124,7 +146,7 @@ class TestGeminiCliBuildCommand:
         # No --effort, but runtime default model applies since default_model is None.
         assert cmd == [
             "gemini",
-            "--model", "gemini-3.1-pro-preview",
+            "--model", "gemini-3.1-pro",
             "--yolo", "--prompt", "Think hard",
         ]
 
@@ -156,7 +178,7 @@ class TestGeminiCliBuildCommand:
         # Runtime default model still applies.
         assert cmd == [
             "gemini",
-            "--model", "gemini-3.1-pro-preview",
+            "--model", "gemini-3.1-pro",
             "--yolo", "--prompt", "Think hard",
         ]
 
@@ -166,7 +188,7 @@ class TestGeminiCliBuildCommand:
         request = _make_request()
         cmd = s.build_command(profile, request)
         # No prompt but runtime default model still applies.
-        assert cmd == ["gemini", "--model", "gemini-3.1-pro-preview"]
+        assert cmd == ["gemini", "--model", "gemini-3.1-pro"]
 
     def test_custom_command_template(self) -> None:
         s = GeminiCliStrategy()
@@ -176,7 +198,7 @@ class TestGeminiCliBuildCommand:
         # Runtime default model applies since default_model is None.
         assert cmd == [
             "gemini", "--sandbox",
-            "--model", "gemini-3.1-pro-preview",
+            "--model", "gemini-3.1-pro",
             "--yolo", "--prompt", "Test",
         ]
 

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -118,6 +118,27 @@ class TestClaudeCodeProperties:
     def test_default_auth_mode(self) -> None:
         assert ClaudeCodeStrategy().default_auth_mode == "api_key"
 
+_RUNTIME_MODEL_ENV_KEYS = (
+    "MOONMIND_CODEX_MODEL",
+    "CODEX_MODEL",
+    "MOONMIND_GEMINI_MODEL",
+    "GEMINI_MODEL",
+    "MOONMIND_CLAUDE_MODEL",
+    "CLAUDE_MODEL",
+)
+
+@pytest.fixture
+def _clear_runtime_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Assert in-code runtime defaults, not environment overrides.
+
+    Managed-agent containers (where the unit suite runs) may set
+    ``MOONMIND_CODEX_MODEL`` / ``MOONMIND_GEMINI_MODEL`` etc., which would
+    otherwise mask the in-code defaults these "default tests" intend to assert.
+    """
+    for key in _RUNTIME_MODEL_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+@pytest.mark.usefixtures("_clear_runtime_model_env")
 class TestClaudeCodeBuildCommand:
     def test_basic_prompt(self) -> None:
         s = ClaudeCodeStrategy()
@@ -127,7 +148,7 @@ class TestClaudeCodeBuildCommand:
         # When no profile default_model is set, the claude_code runtime default applies.
         assert cmd == [
             "claude",
-            "--model", "claude-opus-4-7",
+            "--model", "claude-opus-4-8",
             "-p", "--dangerously-skip-permissions", "Refactor this",
         ]
 
@@ -167,7 +188,7 @@ class TestClaudeCodeBuildCommand:
         request = _make_request()
         cmd = s.build_command(profile, request)
         # No instruction_ref but runtime default model still applies.
-        assert cmd == ["claude", "--model", "claude-opus-4-7", "-p", "--dangerously-skip-permissions"]
+        assert cmd == ["claude", "--model", "claude-opus-4-8", "-p", "--dangerously-skip-permissions"]
 
     def test_anthropic_model_env_suppresses_model_flag(self) -> None:
         """When ANTHROPIC_MODEL is in env_overrides (MiniMax profile), --model must be omitted."""
@@ -689,6 +710,7 @@ class TestCodexCliProperties:
 
         assert observed is None
 
+@pytest.mark.usefixtures("_clear_runtime_model_env")
 class TestCodexCliBuildCommand:
     def test_basic_prompt(self) -> None:
         s = CodexCliStrategy()
@@ -698,7 +720,7 @@ class TestCodexCliBuildCommand:
         request = _make_request(instruction_ref="Fix the bug")
         cmd = s.build_command(profile, request)
         # When no profile default_model set, codex_cli runtime default applies.
-        assert cmd == ["codex", "exec", "-m", "gpt-5.4", "Fix the bug"]
+        assert cmd == ["codex", "exec", "-m", "gpt-5.5", "Fix the bug"]
 
     def test_with_model(self) -> None:
         s = CodexCliStrategy()
@@ -744,7 +766,7 @@ class TestCodexCliBuildCommand:
         )
         request = _make_request(instruction_ref="Go")
         cmd = s.build_command(profile, request)
-        assert cmd == ["codex", "exec", "-m", "gpt-5.4", "Go"]
+        assert cmd == ["codex", "exec", "-m", "gpt-5.5", "Go"]
 
     def test_no_prompt(self) -> None:
         s = CodexCliStrategy()
@@ -754,7 +776,7 @@ class TestCodexCliBuildCommand:
         request = _make_request()
         cmd = s.build_command(profile, request)
         # No instruction_ref but runtime default model still applies.
-        assert cmd == ["codex", "exec", "-m", "gpt-5.4"]
+        assert cmd == ["codex", "exec", "-m", "gpt-5.5"]
 
     def test_suppress_default_model_flag_omits_default_m_flag(self) -> None:
         s = CodexCliStrategy()


### PR DESCRIPTION
## Jira issue

[MM-802](https://moonladder.atlassian.net/browse/MM-802) — Update default models

## Summary

Updates the canonical runtime default models (and their default tests) so the per-runtime defaults resolve to the target values:

- **Claude Code** → `claude-opus-4-8`
- **Codex** → `gpt-5.5`
- **Gemini** → `gemini-3.1-pro`

Changes:
- `moonmind/workflows/tasks/runtime_defaults.py`: updated `_DEFAULT_RUNTIME_MODELS` for `claude_code`, `codex_cli`, and `gemini_cli`.
- `moonmind/config/settings.py`: `codex_model` default (field default and post-init fallback) changed from `gpt-5.3-codex` to `gpt-5.5`.
- `api_service/main.py`: updated the provider auto-seed comments documenting the inherited runtime defaults.
- Updated default-value assertions across the unit suite (`test_model_resolver.py`, `test_settings.py`, `test_provider_profile_auto_seed.py`, `test_workflow_console_view_model.py`, `test_managed_agent_adapter.py`).
- Made the runtime-default model resolver tests env-independent by passing an explicit empty `env={}`, so they assert the in-code default rather than any ambient `MOONMIND_*_MODEL` override present in the managed-agent container the unit suite runs in.

## Tests run

`./tools/test_unit.sh` over the affected suites:
- `tests/unit/workflows/tasks/test_model_resolver.py`
- `tests/unit/config/test_settings.py`
- `tests/unit/api_service/test_provider_profile_auto_seed.py`
- `tests/unit/api/routers/test_workflow_console_view_model.py`
- `tests/unit/workflows/adapters/test_managed_agent_adapter.py`

Result: **230 passed** (Python) and **412 passed / 234 skipped** (frontend unit suite), exit code 0.

## Remaining risks

- These are default values only; explicit per-task/profile/env overrides continue to take precedence and are unaffected.
- Other surfaces that already used `gemini-3.1-pro` (e.g. `codex_worker/worker.py`, `google_chat_model`) were already aligned and are out of scope for this change.
- No persistence or in-flight workflow payload shapes change; the update only affects newly resolved defaults.


[MM-802]: https://moonladder.atlassian.net/browse/MM-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ