### PR TITLE
MM-805: Add batch-dependabot-resolver recurring workflow skill

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -30,7 +30,7 @@ cap, and a Dependabot-specific summary artifact.
   `github-actions`. Matched against the Dependabot branch ecosystem segment with alias
   normalization (`npm`↔`npm_and_yarn`, `github-actions`↔`github_actions`). Omit to allow all.
 - `titleRegex` (string, optional): Override for the version-bump title matcher.
-  Default `^Bump .+ from \S+ to \S+$` (matches e.g. `Bump anthropic from 0.105.2 to 0.107.1`).
+  Default `^Bump .+ from \S+ to \S+(?: in /.+)?$` (matches e.g. `Bump anthropic from 0.105.2 to 0.107.1` and subdirectory suffixes like `in /frontend`).
 - `includeSecurityUpdates` (boolean, optional): Default `true`. When `false`, PRs labeled
   `security` are skipped.
 - `maxPrs` (number, optional): Safety cap on the number of resolver workflows queued per run.

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: batch-dependabot-resolver
+description: Discover open Dependabot version-bump PRs and enqueue one `pr-resolver` workflow for each.
+---
+
+# Batch Dependabot Resolver Skill
+
+## Purpose
+
+Discover open Dependabot dependency-version PRs in a target repository and enqueue
+one `pr-resolver` workflow per matching PR, so Dependabot bumps can be resolved
+automatically on a daily or weekly recurring schedule. This is a narrower,
+safer-by-default discovery/filter layer over `batch-pr-resolver`: it reuses the
+same child `pr-resolver` payload shape, fork/cross-repo safety, runtime
+inheritance, and `/api/executions` submission path, and adds Dependabot-specific
+matching, a cross-run-stable idempotency key, a dry-run mode, an optional `maxPrs`
+cap, and a Dependabot-specific summary artifact.
+
+## Inputs (skill args)
+
+- `repo` (string, required): Target repository in `owner/repo` form. Falls back to
+  parent task context, `git remote origin`, then env, like `batch-pr-resolver`.
+- `state` (string, optional): PR state filter for discovery. Default `open`. Other
+  states print a warning.
+- `mergeMethod` (string, optional): Merge method passed to `pr-resolver`. Default `squash`.
+- `maxIterations` (number, optional): `pr-resolver` loop cap. Default `3`.
+- `maxAttempts` (number, optional): Queue job `maxAttempts` for each created task. Default `3`.
+- `priority` (number, optional): Queue job priority. Default `0`.
+- `packageManagers` (list, optional): Allowlist of package managers, e.g. `pip`, `npm`,
+  `github-actions`. Matched against the Dependabot branch ecosystem segment with alias
+  normalization (`npm`↔`npm_and_yarn`, `github-actions`↔`github_actions`). Omit to allow all.
+- `titleRegex` (string, optional): Override for the version-bump title matcher.
+  Default `^Bump .+ from \S+ to \S+$` (matches e.g. `Bump anthropic from 0.105.2 to 0.107.1`).
+- `includeSecurityUpdates` (boolean, optional): Default `true`. When `false`, PRs labeled
+  `security` are skipped.
+- `maxPrs` (number, optional): Safety cap on the number of resolver workflows queued per run.
+- `dryRun` (boolean, optional): Default `false`. When `true`, compute and report the resolver
+  workflows that would be submitted without creating any.
+- `runtimeMode` / `runtimeModel` / `runtimeEffort` / `runtimeProviderProfile` (string, optional):
+  Inherited like `batch-pr-resolver` when omitted.
+
+## Workflow
+
+1. Run the helper script:
+
+```bash
+python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py \
+  --repo <owner/repo> \
+  --merge-method squash \
+  --max-iterations 3 \
+  --package-managers pip,npm,github-actions \
+  --max-prs 25 \
+  --runtime-mode <runtime_mode> \
+  --runtime-model <model> \
+  --runtime-effort <effort> \
+  --runtime-provider-profile <profile_id>
+```
+
+   Add `--dry-run` to validate a schedule without creating resolver workflows.
+   Always forward the parent task's explicit runtime selection fields when present so the
+   queued `pr-resolver` tasks reuse the same runtime/model/effort/provider profile.
+
+2. The skill discovers open PRs via
+   `gh pr list --json number,title,author,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,labels`.
+
+3. A PR is **matched** only when ALL of:
+   - it is open and not a fork/cross-repository PR (same head-locality check as `batch-pr-resolver`),
+   - the author is `dependabot[bot]` (also accepts `app/dependabot`),
+   - the head branch starts with `dependabot/`,
+   - the title matches `titleRegex`,
+   - it passes the optional `packageManagers` allowlist,
+   - (when `includeSecurityUpdates=false`) it is not a `security`-labeled PR,
+   - it has a head SHA available for the idempotency key.
+
+   Every non-matching PR is recorded as skipped with a reason: `fork-pr`,
+   `not-dependabot-author`, `non-dependabot-branch`, `title-mismatch`,
+   `package-manager-filtered`, `security-update-excluded`, `missing-head-sha`, or `max-prs-cap`.
+
+4. For each matched PR, submit a `pr-resolver` task with the canonical `batch-pr-resolver`
+   payload (`repository`, `task.inputs = { repo, pr, branch, mergeMethod, maxIterations }`,
+   `task.git.startingBranch/targetBranch`, `task.skill.name = pr-resolver`,
+   `task.publish.mode = none`, inherited runtime) and a stable idempotency key:
+   `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`. Submit via
+   `POST /api/executions` (`MOONMIND_URL` must point at the MoonMind API).
+
+5. Write a summary artifact `batch_dependabot_resolver_result.json` (under the managed
+   session artifact spool when available, otherwise the configured `--artifacts-dir`) listing
+   discovered PRs, matched count, queued / would-queue resolver workflows, skipped PRs with
+   reasons, and submission errors. A deliberate zero-match run also writes
+   `skill_outcome.json` with `status: "no_op"`.
+
+6. Print a short summary to stdout (`matched`, `queued`, `would_queue`, `skipped`, `errors`).
+
+## Idempotency
+
+The idempotency key is `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}` (capped at
+128 chars with a sha256 fallback). The same Dependabot PR at the same commit only ever gets one
+resolver across separate scheduled runs; if Dependabot rebases or updates the PR (new head SHA),
+a fresh resolver is allowed.
+
+## Recurring schedule (daily / weekly)
+
+Target this skill from a `queue_task` recurring schedule rather than `pr-resolver` directly.
+Example `POST /api/recurring-tasks` body:
+
+```json
+{
+  "name": "Daily Dependabot resolver (MoonLadderStudios/MoonMind)",
+  "description": "Resolve open Dependabot version-bump PRs every morning.",
+  "enabled": true,
+  "scheduleType": "cron",
+  "cron": "0 7 * * *",
+  "timezone": "UTC",
+  "scopeType": "personal",
+  "target": {
+    "kind": "queue_task",
+    "job": {
+      "type": "task",
+      "priority": 0,
+      "maxAttempts": 3,
+      "payload": {
+        "repository": "MoonLadderStudios/MoonMind",
+        "requiredCapabilities": ["gh"],
+        "task": {
+          "title": "batch-dependabot-resolver",
+          "instructions": "Discover open Dependabot version-bump PRs and enqueue one pr-resolver workflow for each.",
+          "skill": { "name": "batch-dependabot-resolver", "version": "1.0" },
+          "inputs": {
+            "repo": "MoonLadderStudios/MoonMind",
+            "mergeMethod": "squash",
+            "maxIterations": 3,
+            "packageManagers": ["pip", "npm", "github-actions"],
+            "dryRun": false
+          },
+          "publish": { "mode": "none" }
+        }
+      }
+    }
+  }
+}
+```
+
+Use `"cron": "0 7 * * *"` for daily 07:00 UTC or `"cron": "0 7 * * 1"` for weekly (Mondays).
+MoonMind delegates cron/time handling to Temporal Schedules. Set `"dryRun": true` in `inputs`
+to validate a schedule without creating resolver workflows.
+
+## Safety constraints
+
+- Reject missing `repo` unless it can be inferred from task context / `git remote origin` / env.
+- Use `state=open` by default to avoid dispatching against non-open PRs.
+- Skip fork and cross-repository PRs (cannot reliably check out fork head refs in queued jobs).
+- Match conservatively: author AND branch AND title must all indicate a Dependabot version bump.
+- Require `MOONMIND_URL` to reach the MoonMind API; the legacy direct-DB queue fallback is unsupported.
+- Never queue a PR without a head SHA (no stable idempotency key) — skip it instead.

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 API_EXECUTIONS_ENDPOINT = "/api/executions"
 IDEMPOTENCY_KEY_MAX_LENGTH = 128
-DEFAULT_TITLE_REGEX = r"^Bump .+ from \S+ to \S+$"
+DEFAULT_TITLE_REGEX = r"^Bump .+ from \S+ to \S+(?: in /.+)?$"
 DEPENDABOT_BRANCH_PREFIX = "dependabot/"
 
 # Friendly package-manager names (as an operator would type them) mapped to the
@@ -91,7 +91,10 @@ def _normalize_repo(value: str | None) -> str | None:
 
 
 def _infer_repo_from_remote() -> str | None:
-    remote = _run_command(["git", "remote", "get-url", "origin"]).strip()
+    try:
+        remote = _run_command(["git", "remote", "get-url", "origin"]).strip()
+    except RuntimeError:
+        return None
     if remote.startswith("git@github.com:"):
         body = remote.split(":", 1)[1]
         if body.endswith(".git"):
@@ -186,8 +189,10 @@ def _run_pr_list(repo: str, state: str) -> list[dict[str, Any]]:
             "--state",
             state,
             "--json",
-            "number,title,author,headRefName,headRefOid,"
-            "headRepository,headRepositoryOwner,isCrossRepository,labels",
+            (
+                "number,title,author,headRefName,headRefOid,"
+                + "headRepository,headRepositoryOwner,isCrossRepository,labels"
+            ),
             "--limit",
             "100000",
         ]
@@ -1006,6 +1011,14 @@ async def main(argv: list[str] | None = None) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(asyncio.run(main()))
-    except Exception:
-        print("error: batch-dependabot-resolver failed. See logs for details.", flush=True)
+    except Exception as exc:
+        import sys
+        import traceback
+
+        traceback.print_exc(file=sys.stderr)
+        print(
+            f"error: batch-dependabot-resolver failed: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
         raise SystemExit(1)

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -1,0 +1,1011 @@
+#!/usr/bin/env python3
+"""Discover open Dependabot version-bump PRs and enqueue one `pr-resolver` task each.
+
+This skill is a narrower discovery/filter layer over the `batch-pr-resolver`
+mechanism. It reuses the same `gh pr list` discovery, fork/cross-repo safety,
+child `pr-resolver` queue payload shape, runtime inheritance, and
+`/api/executions` submission path, and adds Dependabot-specific matching
+(author/branch/title/package-manager), a cross-run-stable idempotency key
+(repository + PR number + head SHA), a dry-run mode, an optional `maxPrs`
+safety cap, and a Dependabot-specific summary artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from moonmind.workflows.tasks.runtime_defaults import normalize_runtime_id
+from moonmind.workflows.tasks.task_contract import resolve_publish_mode_for_skill
+
+logger = logging.getLogger(__name__)
+
+API_EXECUTIONS_ENDPOINT = "/api/executions"
+IDEMPOTENCY_KEY_MAX_LENGTH = 128
+DEFAULT_TITLE_REGEX = r"^Bump .+ from \S+ to \S+$"
+DEPENDABOT_BRANCH_PREFIX = "dependabot/"
+
+# Friendly package-manager names (as an operator would type them) mapped to the
+# canonical ecosystem token Dependabot encodes as the second branch segment.
+_PACKAGE_MANAGER_ALIASES = {
+    "npm_and_yarn": "npm",
+    "yarn": "npm",
+    "actions": "github_actions",
+}
+
+
+@dataclass
+class JobSubmission:
+    queue_request: dict[str, Any]
+    pr_number: int | str
+    branch: str
+
+
+@dataclass(frozen=True)
+class RuntimeSelection:
+    mode: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    provider_profile: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Shell + repo resolution (parity with batch-pr-resolver)
+# ---------------------------------------------------------------------------
+
+
+def _run_command(cmd: list[str]) -> str:
+    """Run a command and return trimmed stdout text."""
+
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"required command not found: {cmd[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        message = stderr or (exc.stdout or "").strip() or str(exc)
+        raise RuntimeError(f"command failed: {' '.join(cmd)}: {message}") from exc
+    return (result.stdout or "").strip()
+
+
+def _normalize_repo(value: str | None) -> str | None:
+    if not value:
+        return None
+    candidate = str(value).strip()
+    if not candidate:
+        return None
+    if re.fullmatch(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", candidate):
+        return candidate
+    return None
+
+
+def _infer_repo_from_remote() -> str | None:
+    remote = _run_command(["git", "remote", "get-url", "origin"]).strip()
+    if remote.startswith("git@github.com:"):
+        body = remote.split(":", 1)[1]
+        if body.endswith(".git"):
+            body = body[:-4]
+        if "/" in body:
+            return body
+    match = re.search(
+        r"github\.com[:/](?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)(?:\.git)?$", remote
+    )
+    if match:
+        return match.group("repo")
+    return None
+
+
+def _repo_context_candidates(task_context_path: str | None = None) -> list[Path]:
+    candidates: list[Path] = []
+    if task_context_path:
+        candidates.append(Path(task_context_path))
+    for env_key in ("MOONMIND_TASK_CONTEXT_PATH", "TASK_CONTEXT_PATH"):
+        env_value = str(os.getenv(env_key, "")).strip()
+        if env_value:
+            candidates.append(Path(env_value))
+    candidates.extend(
+        [Path("../artifacts/task_context.json"), Path("artifacts/task_context.json")]
+    )
+    return candidates
+
+
+def _load_parent_repository(task_context_path: str | None = None) -> str | None:
+    seen: set[str] = set()
+    for candidate in _repo_context_candidates(task_context_path):
+        identity = str(candidate.expanduser())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        normalized = _normalize_repo(payload.get("repository"))
+        if normalized:
+            return normalized
+    return None
+
+
+def _resolve_repo(raw_repo: str | None, task_context_path: str | None = None) -> str:
+    if raw_repo is not None:
+        normalized = _normalize_repo(raw_repo)
+        if normalized:
+            return normalized
+        raise RuntimeError("Invalid --repo value; expected owner/repo format.")
+
+    from_context = _load_parent_repository(task_context_path)
+    if from_context:
+        return from_context
+
+    inferred_repo = _infer_repo_from_remote()
+    if inferred_repo:
+        return inferred_repo
+
+    for env_key in ("WORKFLOW_GITHUB_REPOSITORY", "GITHUB_REPOSITORY", "MOONMIND_REPO"):
+        normalized = _normalize_repo(os.getenv(env_key, ""))
+        if normalized:
+            return normalized
+    return ""
+
+
+def _parse_repo_parts(repo: str) -> tuple[str, str]:
+    parts = (repo or "").strip().split("/", 1)
+    if len(parts) != 2:
+        return "", ""
+    return parts[0], parts[1]
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _run_pr_list(repo: str, state: str) -> list[dict[str, Any]]:
+    raw = _run_command(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--json",
+            "number,title,author,headRefName,headRefOid,"
+            "headRepository,headRepositoryOwner,isCrossRepository,labels",
+            "--limit",
+            "100000",
+        ]
+    )
+    parsed = json.loads(raw or "[]")
+    if not isinstance(parsed, list):
+        raise RuntimeError("Unexpected `gh pr list` payload shape.")
+    return parsed
+
+
+def _is_local_head(pr: dict[str, Any], repo: str) -> bool:
+    target_repo = repo.strip().lower()
+    target_owner, target_repo_name = _parse_repo_parts(target_repo)
+
+    is_cross = pr.get("isCrossRepository")
+    if isinstance(is_cross, bool) and is_cross:
+        return False
+
+    head_repo = pr.get("headRepository")
+    if isinstance(head_repo, dict):
+        name_with_owner = str(head_repo.get("nameWithOwner") or "").strip().lower()
+        if name_with_owner:
+            return name_with_owner == target_repo
+
+        head_repo_name = str(head_repo.get("name") or "").strip().lower()
+        if head_repo_name:
+            head_owner = (
+                str(
+                    (
+                        pr.get("headRepositoryOwner")
+                        if isinstance(pr.get("headRepositoryOwner"), dict)
+                        else {}
+                    ).get("login", "")
+                )
+                .strip()
+                .lower()
+            )
+            if head_owner:
+                return head_owner == target_owner and head_repo_name == target_repo_name
+            return False
+
+    owner_obj = pr.get("headRepositoryOwner")
+    if isinstance(owner_obj, dict):
+        head_owner = str(owner_obj.get("login") or "").strip().lower()
+        if head_owner:
+            return head_owner == target_owner
+
+    return False
+
+
+def _extract_branch(pr: dict[str, Any]) -> str:
+    branch = str(pr.get("headRefName") or "").strip()
+    if not branch:
+        raise RuntimeError(f"PR #{pr.get('number')}: missing headRefName")
+    return branch
+
+
+def _extract_head_sha(pr: dict[str, Any]) -> str | None:
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Dependabot matchers
+# ---------------------------------------------------------------------------
+
+
+def _is_dependabot_author(pr: dict[str, Any]) -> bool:
+    author = pr.get("author")
+    if not isinstance(author, dict):
+        return False
+    for key in ("login", "name"):
+        value = str(author.get(key) or "").strip().lower()
+        if not value:
+            continue
+        normalized = value.removeprefix("app/")
+        if normalized.endswith("[bot]"):
+            normalized = normalized[: -len("[bot]")]
+        if normalized.strip() == "dependabot":
+            return True
+    return False
+
+
+def _is_dependabot_branch(branch: str | None) -> bool:
+    return str(branch or "").strip().lower().startswith(DEPENDABOT_BRANCH_PREFIX)
+
+
+def _title_matches(title: str | None, pattern: str) -> bool:
+    try:
+        return re.search(pattern, str(title or "").strip()) is not None
+    except re.error as exc:
+        raise RuntimeError(f"invalid titleRegex {pattern!r}: {exc}") from exc
+
+
+def _branch_package_manager(branch: str | None) -> str | None:
+    parts = str(branch or "").strip().split("/")
+    if len(parts) >= 3 and parts[0].lower() == "dependabot" and parts[1]:
+        return parts[1]
+    return None
+
+
+def _canonical_package_manager(token: str | None) -> str:
+    candidate = str(token or "").strip().lower().replace("-", "_")
+    return _PACKAGE_MANAGER_ALIASES.get(candidate, candidate)
+
+
+def _matches_package_managers(branch: str | None, allowlist: list[str] | None) -> bool:
+    if not allowlist:
+        return True
+    manager = _branch_package_manager(branch)
+    if manager is None:
+        return False
+    allowed = {_canonical_package_manager(item) for item in allowlist if str(item).strip()}
+    if not allowed:
+        return True
+    return _canonical_package_manager(manager) in allowed
+
+
+def _is_security_update(pr: dict[str, Any]) -> bool:
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip().lower()
+        else:
+            name = str(label or "").strip().lower()
+        if name == "security":
+            return True
+    return False
+
+
+def _classify_pr(
+    pr: dict[str, Any],
+    *,
+    repo: str,
+    title_pattern: str,
+    package_managers: list[str] | None,
+    include_security_updates: bool,
+) -> tuple[str | None, str]:
+    """Return (skip_reason_or_None, branch). None reason means the PR matched."""
+
+    branch = _extract_branch(pr)
+    if not _is_local_head(pr, repo=repo):
+        return "fork-pr", branch
+    if not _is_dependabot_author(pr):
+        return "not-dependabot-author", branch
+    if not _is_dependabot_branch(branch):
+        return "non-dependabot-branch", branch
+    if not _title_matches(pr.get("title"), title_pattern):
+        return "title-mismatch", branch
+    if package_managers and not _matches_package_managers(branch, package_managers):
+        return "package-manager-filtered", branch
+    if not include_security_updates and _is_security_update(pr):
+        return "security-update-excluded", branch
+    if not _extract_head_sha(pr):
+        return "missing-head-sha", branch
+    return None, branch
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def _idempotency_key(repo: str, pr_number: int | str, head_sha: str | None) -> str | None:
+    """Stable cross-run idempotency key for an unchanged Dependabot PR.
+
+    A missing head SHA yields ``None`` so the caller skips the PR rather than
+    queuing an unkeyed (duplicate-prone) workflow.
+    """
+
+    head = str(head_sha or "").strip()
+    if not head:
+        return None
+    readable = f"batch-dependabot-resolver:{repo}:pr:{pr_number}:head:{head}"
+    if len(readable) <= IDEMPOTENCY_KEY_MAX_LENGTH:
+        return readable
+    components = {"repo": repo, "pr": str(pr_number), "head": head}
+    canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    fallback = f"batch-dependabot-resolver:pr:{pr_number}:sha256:{digest}"
+    if len(fallback) > IDEMPOTENCY_KEY_MAX_LENGTH:
+        raise RuntimeError("generated idempotency key exceeds storage limit")
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Runtime inheritance (parity with batch-pr-resolver)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_runtime_mode(value: str | None) -> str | None:
+    candidate = str(value or "").strip().lower()
+    return candidate if candidate else None
+
+
+def _runtime_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _runtime_modes_match(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    return normalize_runtime_id(left) == normalize_runtime_id(right)
+
+
+def _load_parent_runtime_selection(
+    task_context_path: str | None = None,
+) -> RuntimeSelection | None:
+    seen: set[str] = set()
+    for candidate in _repo_context_candidates(task_context_path):
+        identity = str(candidate.expanduser())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        runtime_config = (
+            payload.get("runtimeConfig")
+            if isinstance(payload.get("runtimeConfig"), dict)
+            else {}
+        )
+        runtime_node = (
+            payload.get("runtime") if isinstance(payload.get("runtime"), dict) else {}
+        )
+        mode = _normalize_runtime_mode(
+            runtime_config.get("mode")
+            or runtime_node.get("mode")
+            or payload.get("runtime")
+        )
+        if not mode:
+            continue
+
+        model = _runtime_text(runtime_config.get("model") or runtime_node.get("model"))
+        effort = _runtime_text(
+            runtime_config.get("effort") or runtime_node.get("effort")
+        )
+        provider_profile = _runtime_text(
+            runtime_config.get("providerProfile")
+            or runtime_config.get("profileId")
+            or runtime_node.get("providerProfile")
+            or runtime_node.get("profileId")
+        )
+        return RuntimeSelection(
+            mode=mode, model=model, effort=effort, provider_profile=provider_profile
+        )
+    return None
+
+
+def _resolve_runtime_selection(args: argparse.Namespace) -> RuntimeSelection:
+    inherited = _load_parent_runtime_selection(args.task_context_path)
+    configured_default_mode = _normalize_runtime_mode(
+        os.getenv("MOONMIND_DEFAULT_TASK_RUNTIME")
+    )
+    runtime_execution_profile_ref = _runtime_text(
+        os.getenv("MOONMIND_EXECUTION_PROFILE_REF")
+    )
+    runtime_execution_profile_runtime = _runtime_text(
+        os.getenv("MOONMIND_EXECUTION_PROFILE_RUNTIME")
+    )
+    # Resolution order, most to least specific: explicit args, the parent
+    # runtime copied from task_context.json, the caller's own execution profile
+    # (the runtime this skill is currently executing under), and finally the
+    # generic system default.
+    execution_profile_mode = (
+        _normalize_runtime_mode(runtime_execution_profile_runtime)
+        if runtime_execution_profile_ref
+        else None
+    )
+    runtime_mode = (
+        _normalize_runtime_mode(args.runtime_mode)
+        or (inherited.mode if inherited else None)
+        or execution_profile_mode
+        or configured_default_mode
+    )
+    runtime_model = _runtime_text(args.runtime_model)
+    runtime_effort = _runtime_text(args.runtime_effort)
+    runtime_provider_profile = _runtime_text(
+        getattr(args, "runtime_provider_profile", None)
+    )
+    if runtime_model is None and inherited is not None:
+        runtime_model = inherited.model
+    if runtime_effort is None and inherited is not None:
+        runtime_effort = inherited.effort
+    if runtime_provider_profile is None and inherited is not None:
+        runtime_provider_profile = inherited.provider_profile
+    if runtime_provider_profile is None and _runtime_modes_match(
+        runtime_mode, runtime_execution_profile_runtime
+    ):
+        runtime_provider_profile = runtime_execution_profile_ref
+
+    return RuntimeSelection(
+        mode=runtime_mode,
+        model=runtime_model,
+        effort=runtime_effort,
+        provider_profile=runtime_provider_profile,
+    )
+
+
+def _task_workflow_id_from_env() -> str | None:
+    for env_key in (
+        "MOONMIND_TASK_WORKFLOW_ID",
+        "MOONMIND_WORKFLOW_ID",
+        "TEMPORAL_WORKFLOW_ID",
+    ):
+        value = _runtime_text(os.getenv(env_key))
+        if value:
+            return value
+    return None
+
+
+def _task_run_id_from_env() -> str | None:
+    for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
+        value = _runtime_text(os.getenv(env_key))
+        if value:
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Artifacts (parity with batch-pr-resolver)
+# ---------------------------------------------------------------------------
+
+
+def _session_artifact_spool_path() -> Path | None:
+    raw = _runtime_text(os.getenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"))
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path
+
+
+def _default_artifacts_dir_requested(raw_artifacts_dir: str) -> bool:
+    raw = str(raw_artifacts_dir or "").strip()
+    if not raw:
+        return True
+    candidate = Path(raw)
+    return not candidate.is_absolute() and candidate.parts == ("artifacts",)
+
+
+def _artifacts_dir_from_task_context_path(path: Path) -> Path | None:
+    resolved = _resolve_path(path)
+    if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
+        return resolved.parent
+    return None
+
+
+def _resolve_artifacts_dir(
+    raw_artifacts_dir: str,
+    task_context_path: str | None = None,
+) -> Path:
+    raw = str(raw_artifacts_dir or "").strip()
+    if not _default_artifacts_dir_requested(raw):
+        return Path(raw)
+
+    spool_path = _session_artifact_spool_path()
+    if spool_path is not None:
+        return spool_path
+
+    for candidate in _repo_context_candidates(task_context_path):
+        artifacts_dir = _artifacts_dir_from_task_context_path(candidate)
+        if artifacts_dir is not None:
+            return artifacts_dir
+
+    return Path(raw or "artifacts")
+
+
+# ---------------------------------------------------------------------------
+# Child queue request
+# ---------------------------------------------------------------------------
+
+
+def _build_queue_request(
+    repo: str,
+    pr_number: int | str,
+    branch: str,
+    *,
+    head_sha: str | None,
+    runtime: RuntimeSelection,
+    merge_method: str,
+    max_iterations: int,
+    priority: int,
+    max_attempts: int,
+    skill_version: str = "1.0",
+    inherit_runtime_from_caller: bool = False,
+) -> dict[str, Any]:
+    publish_mode = resolve_publish_mode_for_skill("pr-resolver", "none")
+    runtime_payload: dict[str, Any] = {}
+    if runtime.mode:
+        runtime_payload["mode"] = runtime.mode
+    if runtime.model:
+        runtime_payload["model"] = runtime.model
+    if runtime.effort:
+        runtime_payload["effort"] = runtime.effort
+    if runtime.provider_profile:
+        runtime_payload["executionProfileRef"] = runtime.provider_profile
+
+    payload_dict: dict[str, Any] = {
+        "repository": repo,
+        "requiredCapabilities": ["gh"],
+        "task": {
+            "title": branch,
+            "instructions": f"Resolve PR #{pr_number} on branch `{branch}`.",
+            "skill": {
+                "name": "pr-resolver",
+                "version": skill_version,
+            },
+            "inputs": {
+                "repo": repo,
+                "pr": str(pr_number),
+                "branch": branch,
+                "mergeMethod": merge_method,
+                "maxIterations": max_iterations,
+            },
+            "git": {
+                "startingBranch": branch,
+                "targetBranch": branch,
+            },
+            "publish": {"mode": publish_mode},
+        },
+    }
+
+    idempotency_key = _idempotency_key(repo, pr_number, head_sha)
+    if idempotency_key:
+        payload_dict["idempotencyKey"] = idempotency_key
+
+    if inherit_runtime_from_caller:
+        payload_dict["runtimeInheritance"] = "caller"
+    if runtime.mode:
+        payload_dict["targetRuntime"] = runtime.mode
+    if runtime_payload:
+        payload_dict["task"]["runtime"] = runtime_payload
+
+    return {
+        "type": "task",
+        "priority": priority,
+        "maxAttempts": max_attempts,
+        "payload": payload_dict,
+    }
+
+
+def _build_request_records(
+    repo: str,
+    open_prs: list[dict[str, Any]],
+    args: argparse.Namespace,
+    runtime: RuntimeSelection,
+) -> tuple[list[JobSubmission], list[dict[str, Any]], int]:
+    """Partition discovered PRs into queue submissions and skip records.
+
+    Returns (queue_requests, skipped, matched_count) where ``matched_count`` is
+    the number of PRs passing every Dependabot filter *before* the ``maxPrs``
+    cap is applied.
+    """
+
+    skipped: list[dict[str, Any]] = []
+
+    def _get_pr_number(pr_data: dict[str, Any]) -> int:
+        try:
+            return int(pr_data.get("number", 0))
+        except (ValueError, TypeError):
+            return 0
+
+    open_prs_sorted = sorted(open_prs, key=_get_pr_number)
+    inherit_from_caller = _task_workflow_id_from_env() is not None
+    package_managers = list(args.package_managers or [])
+
+    matched: list[tuple[int | str | None, str, str | None]] = []
+    for pr in open_prs_sorted:
+        number = pr.get("number")
+        reason, branch = _classify_pr(
+            pr,
+            repo=repo,
+            title_pattern=args.title_regex,
+            package_managers=package_managers,
+            include_security_updates=args.include_security_updates,
+        )
+        if reason is not None:
+            skipped.append({"pr": number, "branch": branch, "reason": reason})
+            continue
+        matched.append((number, branch, _extract_head_sha(pr)))
+
+    matched_count = len(matched)
+
+    if args.max_prs is not None and matched_count > args.max_prs:
+        for number, branch, _head_sha in matched[args.max_prs :]:
+            skipped.append({"pr": number, "branch": branch, "reason": "max-prs-cap"})
+        matched = matched[: args.max_prs]
+
+    queue_requests: list[JobSubmission] = []
+    for number, branch, head_sha in matched:
+        queue_request = _build_queue_request(
+            repo,
+            number,
+            branch,
+            head_sha=head_sha,
+            runtime=runtime,
+            merge_method=args.merge_method,
+            max_iterations=args.max_iterations,
+            priority=args.priority,
+            max_attempts=args.max_attempts,
+            skill_version=args.skill_version,
+            inherit_runtime_from_caller=inherit_from_caller,
+        )
+        queue_requests.append(
+            JobSubmission(queue_request=queue_request, pr_number=number, branch=branch)
+        )
+
+    return queue_requests, skipped, matched_count
+
+
+# ---------------------------------------------------------------------------
+# Submission
+# ---------------------------------------------------------------------------
+
+
+def _read_worker_token() -> str | None:
+    token = str(os.getenv("MOONMIND_WORKER_TOKEN", "")).strip()
+    if token:
+        return token
+    token_file = str(os.getenv("MOONMIND_WORKER_TOKEN_FILE", "")).strip()
+    if token_file:
+        path = Path(token_file)
+        if path.exists():
+            return path.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+async def _submit_jobs_via_http(
+    queue_requests: list[JobSubmission],
+    *,
+    moonmind_url: str,
+    worker_token: str | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    created: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if worker_token:
+        headers["X-MoonMind-Worker-Token"] = worker_token
+    task_workflow_id = _task_workflow_id_from_env()
+    if task_workflow_id:
+        headers["X-MoonMind-Task-Workflow-Id"] = task_workflow_id
+    task_run_id = _task_run_id_from_env()
+    if task_run_id:
+        headers["X-MoonMind-Task-Run-Identifier"] = task_run_id
+    base = moonmind_url.rstrip("/")
+    async with httpx.AsyncClient(
+        base_url=base, timeout=30.0, headers=headers
+    ) as client:
+        for submission in queue_requests:
+            request = submission.queue_request
+            body = {
+                "type": str(request["type"]),
+                "payload": request["payload"],
+                "priority": int(request.get("priority", 0)),
+                "maxAttempts": int(request.get("maxAttempts", 3)),
+            }
+            try:
+                response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
+                response.raise_for_status()
+                data = response.json()
+                job_id = (
+                    str(
+                        data.get("workflowId")
+                        or data.get("taskId")
+                        or data.get("id")
+                        or ""
+                    )
+                    or "(unknown)"
+                )
+                created.append(
+                    {
+                        "pr": submission.pr_number,
+                        "branch": submission.branch,
+                        "jobId": job_id,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001 - record per-PR submission errors
+                errors.append(
+                    {
+                        "pr": submission.pr_number,
+                        "branch": submission.branch,
+                        "error": str(exc),
+                    }
+                )
+    return created, errors
+
+
+async def _submit_jobs(
+    queue_requests: list[JobSubmission],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    moonmind_url = str(os.getenv("MOONMIND_URL", "")).strip()
+    if moonmind_url:
+        worker_token = _read_worker_token()
+        return await _submit_jobs_via_http(
+            queue_requests,
+            moonmind_url=moonmind_url,
+            worker_token=worker_token,
+        )
+
+    message = (
+        "MOONMIND_URL is not set; batch-dependabot-resolver requires the MoonMind "
+        "Temporal execution API and cannot submit via the removed legacy DB queue."
+    )
+    return [], [
+        {
+            "pr": submission.pr_number,
+            "branch": submission.branch,
+            "error": message,
+        }
+        for submission in queue_requests
+    ]
+
+
+def _would_queue_records(queue_requests: list[JobSubmission]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for submission in queue_requests:
+        payload = submission.queue_request.get("payload", {})
+        records.append(
+            {
+                "pr": submission.pr_number,
+                "branch": submission.branch,
+                "idempotencyKey": payload.get("idempotencyKey"),
+            }
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Artifact writing
+# ---------------------------------------------------------------------------
+
+
+def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
+    """Write the result payload and (when applicable) the no-op outcome file.
+
+    ``skill_outcome.json`` with ``status: "no_op"`` is written only when the run
+    queued zero executions, hit no submission errors, and was not a dry run —
+    i.e. a deliberate "no matching Dependabot PRs" outcome.
+    """
+
+    _write_artifacts(artifacts_dir / "batch_dependabot_resolver_result.json", payload)
+    if (
+        payload.get("created") == 0
+        and not payload.get("errors")
+        and not payload.get("dryRun")
+    ):
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "no_op",
+                "reason": "no_dependabot_prs_matched",
+                "evidence": {
+                    "requested": payload.get("requested"),
+                    "skipped": payload.get("skipped"),
+                },
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _flatten_package_managers(values: list[str] | None) -> list[str]:
+    if not values:
+        return []
+    flattened: list[str] = []
+    for value in values:
+        for token in str(value).split(","):
+            token = token.strip()
+            if token:
+                flattened.append(token)
+    return flattened
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Discover open Dependabot version-bump PRs and submit one pr-resolver "
+            "task for each matching PR."
+        )
+    )
+    parser.add_argument("--repo", default=None, help="Target repo in owner/repo format.")
+    parser.add_argument("--state", default="open", help="PR state filter (default: open).")
+    parser.add_argument("--merge-method", default="squash")
+    parser.add_argument("--max-iterations", type=int, default=3)
+    parser.add_argument("--max-attempts", type=int, default=3)
+    parser.add_argument("--priority", type=int, default=0)
+    parser.add_argument(
+        "--package-managers",
+        action="append",
+        default=None,
+        help="Allowlist of package managers (repeatable or comma-separated).",
+    )
+    parser.add_argument(
+        "--title-regex",
+        default=DEFAULT_TITLE_REGEX,
+        help="Version-bump title matcher (default: Bump <dep> from <old> to <new>).",
+    )
+    parser.add_argument(
+        "--include-security-updates",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include Dependabot security-update PRs (default: true).",
+    )
+    parser.add_argument(
+        "--max-prs",
+        type=int,
+        default=None,
+        help="Optional safety cap on the number of resolver workflows queued.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Compute and report matches without submitting any executions.",
+    )
+    parser.add_argument("--runtime-mode", default=None)
+    parser.add_argument("--runtime-model", default=None)
+    parser.add_argument("--runtime-effort", default=None)
+    parser.add_argument("--runtime-provider-profile", default=None)
+    parser.add_argument("--task-context-path", default=None)
+    parser.add_argument("--skill-version", default="1.0")
+    parser.add_argument("--artifacts-dir", default="artifacts")
+    args = parser.parse_args(argv)
+    args.package_managers = _flatten_package_managers(args.package_managers)
+    return args
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo = _resolve_repo(args.repo, args.task_context_path)
+    if not repo:
+        raise RuntimeError("No repository provided and none could be inferred.")
+    if args.state.strip() != "open":
+        print(f"warning: non-open state requested: {args.state}")
+    runtime = _resolve_runtime_selection(args)
+
+    open_prs = _run_pr_list(repo=repo, state=args.state)
+    queue_requests, skipped, matched_count = _build_request_records(
+        repo, open_prs, args, runtime
+    )
+
+    if args.dry_run:
+        created: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        would_queue = _would_queue_records(queue_requests)
+    else:
+        created, errors = await _submit_jobs(queue_requests)
+        would_queue = []
+
+    payload = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "actor": os.getenv("GITHUB_ACTOR") or os.getenv("USER") or "unknown",
+        "repository": repo,
+        "state": args.state,
+        "dryRun": bool(args.dry_run),
+        "filters": {
+            "titleRegex": args.title_regex,
+            "packageManagers": list(args.package_managers or []),
+            "includeSecurityUpdates": bool(args.include_security_updates),
+            "maxPrs": args.max_prs,
+        },
+        "runtime": {
+            "mode": runtime.mode,
+            "model": runtime.model,
+            "effort": runtime.effort,
+            "executionProfileRef": runtime.provider_profile,
+        },
+        "requested": len(open_prs),
+        "matched": matched_count,
+        "created": len(created),
+        "queued": created,
+        "wouldQueue": would_queue,
+        "skipped": skipped,
+        "errors": errors,
+    }
+    if not args.dry_run and payload["created"] == 0:
+        payload["message"] = "No matching Dependabot PRs were queued."
+
+    artifacts_dir = _resolve_artifacts_dir(args.artifacts_dir, args.task_context_path)
+    _write_run_artifacts(artifacts_dir, payload)
+
+    print(json.dumps(payload, indent=2))
+    print(
+        f"matched={matched_count} queued={payload['created']} "
+        f"would_queue={len(would_queue)} skipped={len(skipped)} "
+        f"errors={len(errors)} repo={repo} dry_run={bool(args.dry_run)}"
+    )
+    if errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except Exception:
+        print("error: batch-dependabot-resolver failed. See logs for details.", flush=True)
+        raise SystemExit(1)

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -90,6 +90,7 @@ class BuiltInSkillLoader(SkillLoader):
             "moonmind-default-reviewer",
             "pr-resolver",
             "batch-pr-resolver",
+            "batch-dependabot-resolver",
             "fix-comments",
             "fix-ci",
             "fix-merge-conflicts",

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -49,7 +49,9 @@ _CONTAINER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"})
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
-_SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver", "batch-pr-resolver"})
+_SELF_MANAGED_PUBLISH_SKILLS = frozenset(
+    {"pr-resolver", "batch-pr-resolver", "batch-dependabot-resolver"}
+)
 _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
     {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}
 )

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -1,0 +1,222 @@
+"""Hermetic end-to-end test for the batch-dependabot-resolver skill.
+
+Drives ``main()`` with ``gh pr list`` (subprocess) and the executions API
+(``httpx.AsyncClient``) mocked, so it requires no compose services and runs
+directly under pytest. Marked ``integration``/``integration_ci`` because it
+exercises the full discovery → Dependabot filter → submit → artifact pipeline
+across module boundaries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import runpy
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _load_module() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[3]
+    return runpy.run_path(
+        str(
+            repo_root
+            / ".agents"
+            / "skills"
+            / "batch-dependabot-resolver"
+            / "bin"
+            / "batch_dependabot_resolver.py"
+        )
+    )
+
+
+def _mixed_pr_set() -> list[dict[str, Any]]:
+    return [
+        {  # genuine Dependabot match
+            "number": 1,
+            "title": "Bump anthropic from 0.105.2 to 0.107.1",
+            "author": {"login": "dependabot[bot]"},
+            "headRefName": "dependabot/pip/anthropic-0.107.1",
+            "headRefOid": "sha-1",
+            "headRepository": {"name": "MoonMind"},
+            "headRepositoryOwner": {"login": "MoonLadderStudios"},
+            "isCrossRepository": False,
+            "labels": [],
+        },
+        {  # fork / cross-repo
+            "number": 2,
+            "title": "Bump requests from 2.0.0 to 2.1.0",
+            "author": {"login": "dependabot[bot]"},
+            "headRefName": "dependabot/pip/requests-2.1.0",
+            "headRefOid": "sha-2",
+            "headRepository": {"name": "MoonMind"},
+            "headRepositoryOwner": {"login": "a-fork-owner"},
+            "isCrossRepository": True,
+            "labels": [],
+        },
+        {  # human PR
+            "number": 3,
+            "title": "Add a feature",
+            "author": {"login": "octocat"},
+            "headRefName": "feature/cool",
+            "headRefOid": "sha-3",
+            "headRepository": {"name": "MoonMind"},
+            "headRepositoryOwner": {"login": "MoonLadderStudios"},
+            "isCrossRepository": False,
+            "labels": [],
+        },
+        {  # Dependabot but non-matching title
+            "number": 4,
+            "title": "Bump the pip group with 2 updates",
+            "author": {"login": "dependabot[bot]"},
+            "headRefName": "dependabot/pip/group-update",
+            "headRefOid": "sha-4",
+            "headRepository": {"name": "MoonMind"},
+            "headRepositoryOwner": {"login": "MoonLadderStudios"},
+            "isCrossRepository": False,
+            "labels": [],
+        },
+        {  # second genuine Dependabot match (npm)
+            "number": 5,
+            "title": "Bump eslint from 8.0.0 to 9.0.0",
+            "author": {"login": "dependabot[bot]"},
+            "headRefName": "dependabot/npm_and_yarn/eslint-9.0.0",
+            "headRefOid": "sha-5",
+            "headRepository": {"name": "MoonMind"},
+            "headRepositoryOwner": {"login": "MoonLadderStudios"},
+            "isCrossRepository": False,
+            "labels": [],
+        },
+    ]
+
+
+class _FakeAsyncClient:
+    submissions: list[dict[str, Any]] = []
+
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        pass
+
+    async def post(self, _path: str, **kwargs: Any) -> Any:
+        body = kwargs.get("json")
+        _FakeAsyncClient.submissions.append(body)
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = MagicMock(
+            return_value={"workflowId": f"mm:wf-{len(_FakeAsyncClient.submissions)}"}
+        )
+        return response
+
+
+def _run_main(
+    module: dict[str, Any], argv: list[str], monkeypatch: Any, tmp_path: Path
+) -> dict[str, Any]:
+    _FakeAsyncClient.submissions = []
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    monkeypatch.delenv("MOONMIND_WORKER_TOKEN", raising=False)
+    monkeypatch.delenv("MOONMIND_WORKER_TOKEN_FILE", raising=False)
+    for env_key in (
+        "MOONMIND_TASK_WORKFLOW_ID",
+        "MOONMIND_WORKFLOW_ID",
+        "TEMPORAL_WORKFLOW_ID",
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+        "MOONMIND_DEFAULT_TASK_RUNTIME",
+        "MOONMIND_EXECUTION_PROFILE_REF",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+
+    completed = subprocess.CompletedProcess(
+        args=["gh"], returncode=0, stdout=json.dumps(_mixed_pr_set()), stderr=""
+    )
+
+    artifacts_dir = tmp_path / "artifacts"
+    full_argv = [*argv, "--artifacts-dir", str(artifacts_dir)]
+
+    import httpx
+
+    with patch.object(subprocess, "run", return_value=completed), patch.object(
+        httpx, "AsyncClient", _FakeAsyncClient
+    ):
+        exit_code = asyncio.run(module["main"](full_argv))
+
+    result_path = artifacts_dir / "batch_dependabot_resolver_result.json"
+    summary = json.loads(result_path.read_text())
+    summary["_exit_code"] = exit_code
+    return summary
+
+
+def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
+    module = _load_module()
+    summary = _run_main(
+        module, ["--repo", "MoonLadderStudios/MoonMind"], monkeypatch, tmp_path
+    )
+
+    # Only PRs 1 and 5 are genuine Dependabot version bumps.
+    assert summary["requested"] == 5
+    assert summary["matched"] == 2
+    assert summary["created"] == 2
+    assert sorted(item["pr"] for item in summary["queued"]) == [1, 5]
+    reasons = {entry["pr"]: entry["reason"] for entry in summary["skipped"]}
+    assert reasons == {2: "fork-pr", 3: "not-dependabot-author", 4: "title-mismatch"}
+    assert summary["_exit_code"] == 0
+
+    # Every discovered PR is accounted for exactly once (INV-1 / SC-004).
+    accounted = (
+        len(summary["queued"])
+        + len(summary["wouldQueue"])
+        + len(summary["skipped"])
+        + len(summary["errors"])
+    )
+    assert accounted == summary["requested"]
+
+    # Each child carries publish.mode=none and a stable idempotency key.
+    for body in _FakeAsyncClient.submissions:
+        assert body["payload"]["task"]["publish"]["mode"] == "none"
+        assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
+        assert body["payload"]["idempotencyKey"].startswith(
+            "batch-dependabot-resolver:MoonLadderStudios/MoonMind:pr:"
+        )
+
+
+def test_end_to_end_dry_run_submits_nothing(monkeypatch: Any, tmp_path: Path) -> None:
+    module = _load_module()
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind", "--dry-run"],
+        monkeypatch,
+        tmp_path,
+    )
+
+    assert summary["dryRun"] is True
+    assert summary["created"] == 0
+    assert summary["queued"] == []
+    assert sorted(item["pr"] for item in summary["wouldQueue"]) == [1, 5]
+    assert _FakeAsyncClient.submissions == []  # nothing submitted
+    assert summary["_exit_code"] == 0
+    # No no-op signal on a dry run even though created==0.
+    assert not (tmp_path / "artifacts" / "skill_outcome.json").exists()
+
+
+def test_end_to_end_package_manager_filter(monkeypatch: Any, tmp_path: Path) -> None:
+    module = _load_module()
+    summary = _run_main(
+        module,
+        ["--repo", "MoonLadderStudios/MoonMind", "--package-managers", "pip"],
+        monkeypatch,
+        tmp_path,
+    )
+    # PR 5 (npm) is filtered out; only PR 1 (pip) is queued.
+    assert [item["pr"] for item in summary["queued"]] == [1]
+    reasons = {entry["pr"]: entry["reason"] for entry in summary["skipped"]}
+    assert reasons[5] == "package-manager-filtered"

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -74,6 +74,25 @@ async def test_built_in_loader_discovers_packaged_agent_skills():
     assert discovered["moonspec-breakdown"].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
     assert discovered["moonspec-breakdown"].provenance.source_path
 
+async def test_built_in_loader_resolves_batch_dependabot_resolver_by_name(tmp_path):
+    """FR-012: batch-dependabot-resolver MUST be resolvable by name through the
+    built-in fallback list so a recurring queue_task schedule can target it.
+
+    Point skills_root at an empty directory so the packaged-folder scan finds
+    nothing; only the built-in fallback name list can supply the skill. This
+    exercises the fallback wiring directly (parity with batch-pr-resolver),
+    rather than incidentally rediscovering the checked-in skill folder.
+    """
+    loader = BuiltInSkillLoader(skills_root=tmp_path)
+    context = SkillResolutionContext(snapshot_id="snap-dependabot")
+
+    results = await loader.load_skills(SkillSelector(include=[]), context)
+
+    resolved_names = {entry.skill_name for entry in results}
+    assert "batch-dependabot-resolver" in resolved_names
+    # Parity: the general-purpose batch resolver is guaranteed by the same path.
+    assert "batch-pr-resolver" in resolved_names
+
 async def test_builtin_loader_ignores_cwd_agents_skills_projection(
     monkeypatch,
     tmp_path,

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    return runpy.run_path(
+        str(
+            repo_root
+            / ".agents"
+            / "skills"
+            / "batch-dependabot-resolver"
+            / "bin"
+            / "batch_dependabot_resolver.py"
+        )
+    )
+
+
+def _dependabot_pr(**overrides: Any) -> dict[str, Any]:
+    pr: dict[str, Any] = {
+        "number": 42,
+        "title": "Bump anthropic from 0.105.2 to 0.107.1",
+        "author": {"login": "dependabot[bot]"},
+        "headRefName": "dependabot/pip/anthropic-0.107.1",
+        "headRefOid": "abc123def456",
+        "headRepository": {"name": "MoonMind"},
+        "headRepositoryOwner": {"login": "MoonLadderStudios"},
+        "isCrossRepository": False,
+        "labels": [],
+    }
+    pr.update(overrides)
+    return pr
+
+
+def _args(**overrides: Any) -> Any:
+    base = {
+        "repo": "MoonLadderStudios/MoonMind",
+        "state": "open",
+        "merge_method": "squash",
+        "max_iterations": 3,
+        "max_attempts": 3,
+        "priority": 0,
+        "package_managers": [],
+        "title_regex": r"^Bump .+ from \S+ to \S+$",
+        "include_security_updates": True,
+        "max_prs": None,
+        "dry_run": False,
+        "runtime_mode": None,
+        "runtime_model": None,
+        "runtime_effort": None,
+        "runtime_provider_profile": None,
+        "task_context_path": None,
+        "skill_version": "1.0",
+        "artifacts_dir": "artifacts",
+    }
+    base.update(overrides)
+    return type("Args", (), base)()
+
+
+# ---------------------------------------------------------------------------
+# Author matching (FR-002, SCN-001, SCN-003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        {"login": "dependabot[bot]"},
+        {"login": "app/dependabot"},
+        {"login": "DEPENDABOT[BOT]"},
+        {"login": "", "name": "dependabot[bot]"},
+    ],
+)
+def test_is_dependabot_author_accepts_bot_spellings(author: dict[str, Any]) -> None:
+    module = _load_module()
+    assert module["_is_dependabot_author"]({"author": author}) is True
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        {"login": "octocat"},
+        {"login": "renovate[bot]"},
+        {},
+        None,
+    ],
+)
+def test_is_dependabot_author_rejects_others(author: Any) -> None:
+    module = _load_module()
+    assert module["_is_dependabot_author"]({"author": author}) is False
+
+
+# ---------------------------------------------------------------------------
+# Branch + title matching (FR-002, SCN-004)
+# ---------------------------------------------------------------------------
+
+
+def test_is_dependabot_branch() -> None:
+    module = _load_module()
+    assert module["_is_dependabot_branch"]("dependabot/pip/anthropic-0.107.1") is True
+    assert module["_is_dependabot_branch"]("feature/manual") is False
+    assert module["_is_dependabot_branch"]("") is False
+
+
+def test_title_matches_default_regex() -> None:
+    module = _load_module()
+    pattern = module["DEFAULT_TITLE_REGEX"]
+    assert module["_title_matches"]("Bump anthropic from 0.105.2 to 0.107.1", pattern)
+    assert not module["_title_matches"]("Bump the pip group with 2 updates", pattern)
+    assert not module["_title_matches"]("Refactor things", pattern)
+
+
+def test_title_matches_invalid_regex_raises() -> None:
+    module = _load_module()
+    with pytest.raises(RuntimeError):
+        module["_title_matches"]("anything", "(")
+
+
+# ---------------------------------------------------------------------------
+# Fork / cross-repo (FR-003, SCN-002) — reuse of batch-pr-resolver behavior
+# ---------------------------------------------------------------------------
+
+
+def test_is_local_head_rejects_cross_repository() -> None:
+    module = _load_module()
+    pr = _dependabot_pr(isCrossRepository=True)
+    assert module["_is_local_head"](pr, "MoonLadderStudios/MoonMind") is False
+
+
+def test_is_local_head_accepts_same_owner() -> None:
+    module = _load_module()
+    assert module["_is_local_head"](_dependabot_pr(), "MoonLadderStudios/MoonMind") is True
+
+
+# ---------------------------------------------------------------------------
+# Package-manager allowlist (FR-008, SCN-007)
+# ---------------------------------------------------------------------------
+
+
+def test_branch_package_manager_extraction() -> None:
+    module = _load_module()
+    assert module["_branch_package_manager"]("dependabot/pip/anthropic-1") == "pip"
+    assert (
+        module["_branch_package_manager"]("dependabot/github_actions/actions/checkout-4")
+        == "github_actions"
+    )
+    assert module["_branch_package_manager"]("feature/manual") is None
+
+
+@pytest.mark.parametrize(
+    "branch,allowlist,expected",
+    [
+        ("dependabot/pip/anthropic-1", ["pip"], True),
+        ("dependabot/npm_and_yarn/eslint-9", ["npm"], True),
+        ("dependabot/github_actions/checkout-4", ["github-actions"], True),
+        ("dependabot/npm_and_yarn/eslint-9", ["pip"], False),
+        ("dependabot/pip/anthropic-1", [], True),
+    ],
+)
+def test_matches_package_managers(
+    branch: str, allowlist: list[str], expected: bool
+) -> None:
+    module = _load_module()
+    assert module["_matches_package_managers"](branch, allowlist) is expected
+
+
+# ---------------------------------------------------------------------------
+# Cross-run idempotency key (FR-006, SCN-005, SC-002, INV-2, INV-5)
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_key_readable_and_stable() -> None:
+    module = _load_module()
+    key = module["_idempotency_key"]
+    k1 = key("MoonLadderStudios/MoonMind", 42, "abc123")
+    k2 = key("MoonLadderStudios/MoonMind", 42, "abc123")
+    assert k1 == "batch-dependabot-resolver:MoonLadderStudios/MoonMind:pr:42:head:abc123"
+    assert k1 == k2  # deterministic across runs
+
+
+def test_idempotency_key_changes_with_head_sha() -> None:
+    module = _load_module()
+    key = module["_idempotency_key"]
+    assert key("o/r", 42, "sha-one") != key("o/r", 42, "sha-two")
+
+
+def test_idempotency_key_missing_head_sha_returns_none() -> None:
+    module = _load_module()
+    assert module["_idempotency_key"]("o/r", 42, None) is None
+    assert module["_idempotency_key"]("o/r", 42, "  ") is None
+
+
+def test_idempotency_key_falls_back_to_hash_when_too_long() -> None:
+    module = _load_module()
+    key = module["_idempotency_key"]
+    long_repo = "owner/" + ("r" * 200)
+    result = key(long_repo, 42, "deadbeef")
+    assert result is not None
+    assert len(result) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
+    assert result.startswith("batch-dependabot-resolver:pr:42:sha256:")
+
+
+# ---------------------------------------------------------------------------
+# Child pr-resolver payload (FR-005, INV-4)
+# ---------------------------------------------------------------------------
+
+
+def test_build_queue_request_child_payload_shape() -> None:
+    module = _load_module()
+    request = module["_build_queue_request"](
+        "MoonLadderStudios/MoonMind",
+        42,
+        "dependabot/pip/anthropic-0.107.1",
+        head_sha="abc123",
+        runtime=module["RuntimeSelection"](mode="codex", model="gpt-5-codex", effort="high"),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+    )
+    payload = request["payload"]
+    task = payload["task"]
+    assert task["skill"] == {"name": "pr-resolver", "version": "1.0"}
+    assert "id" not in task["skill"] and "args" not in task["skill"]
+    assert payload["requiredCapabilities"] == ["gh"]
+    assert task["inputs"] == {
+        "repo": "MoonLadderStudios/MoonMind",
+        "pr": "42",
+        "branch": "dependabot/pip/anthropic-0.107.1",
+        "mergeMethod": "squash",
+        "maxIterations": 3,
+    }
+    assert task["git"]["startingBranch"] == "dependabot/pip/anthropic-0.107.1"
+    assert task["git"]["targetBranch"] == "dependabot/pip/anthropic-0.107.1"
+    assert task["publish"]["mode"] == "none"
+    assert task["runtime"]["mode"] == "codex"
+    assert payload["targetRuntime"] == "codex"
+    assert (
+        payload["idempotencyKey"]
+        == "batch-dependabot-resolver:MoonLadderStudios/MoonMind:pr:42:head:abc123"
+    )
+
+
+def test_build_queue_request_without_head_sha_omits_idempotency_key() -> None:
+    module = _load_module()
+    request = module["_build_queue_request"](
+        "o/r",
+        42,
+        "dependabot/pip/x",
+        head_sha=None,
+        runtime=module["RuntimeSelection"](mode="codex"),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+    )
+    assert "idempotencyKey" not in request["payload"]
+
+
+def test_build_queue_request_runtime_inheritance_opt_in() -> None:
+    module = _load_module()
+    request = module["_build_queue_request"](
+        "o/r",
+        42,
+        "dependabot/pip/x",
+        head_sha="abc",
+        runtime=module["RuntimeSelection"](mode="codex"),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+        inherit_runtime_from_caller=True,
+    )
+    assert request["payload"]["runtimeInheritance"] == "caller"
+
+
+# ---------------------------------------------------------------------------
+# Match / skip partition incl. maxPrs + missing head SHA (FR-004, edge cases)
+# ---------------------------------------------------------------------------
+
+
+def _partition(module: dict[str, Any], prs: list[dict[str, Any]], **arg_overrides: Any):
+    runtime = module["RuntimeSelection"](mode="codex")
+    return module["_build_request_records"](
+        "MoonLadderStudios/MoonMind", prs, _args(**arg_overrides), runtime
+    )
+
+
+def test_partition_matches_only_genuine_dependabot_prs() -> None:
+    module = _load_module()
+    prs = [
+        _dependabot_pr(number=1),  # match
+        _dependabot_pr(number=2, isCrossRepository=True),  # fork-pr
+        _dependabot_pr(number=3, author={"login": "octocat"}),  # not-dependabot-author
+        _dependabot_pr(number=4, headRefName="feature/manual"),  # non-dependabot-branch
+        _dependabot_pr(number=5, title="Bump the pip group with 2 updates"),  # title-mismatch
+        _dependabot_pr(number=6, headRefOid=""),  # missing-head-sha
+    ]
+    queue_requests, skipped, matched_count = _partition(module, prs)
+
+    assert matched_count == 1
+    assert [s.pr_number for s in queue_requests] == [1]
+    reasons = {entry["pr"]: entry["reason"] for entry in skipped}
+    assert reasons == {
+        2: "fork-pr",
+        3: "not-dependabot-author",
+        4: "non-dependabot-branch",
+        5: "title-mismatch",
+        6: "missing-head-sha",
+    }
+
+
+def test_partition_applies_max_prs_cap() -> None:
+    module = _load_module()
+    prs = [_dependabot_pr(number=n, headRefOid=f"sha{n}") for n in (1, 2, 3)]
+    queue_requests, skipped, matched_count = _partition(module, prs, max_prs=2)
+
+    assert matched_count == 3  # pre-cap
+    assert [s.pr_number for s in queue_requests] == [1, 2]
+    assert [(s["pr"], s["reason"]) for s in skipped] == [(3, "max-prs-cap")]
+
+
+def test_partition_package_manager_filter() -> None:
+    module = _load_module()
+    prs = [
+        _dependabot_pr(number=1, headRefName="dependabot/pip/a", headRefOid="s1"),
+        _dependabot_pr(
+            number=2, headRefName="dependabot/npm_and_yarn/b", headRefOid="s2"
+        ),
+    ]
+    queue_requests, skipped, _ = _partition(module, prs, package_managers=["pip"])
+    assert [s.pr_number for s in queue_requests] == [1]
+    assert (skipped[0]["pr"], skipped[0]["reason"]) == (2, "package-manager-filtered")
+
+
+def test_partition_security_update_excluded_when_disabled() -> None:
+    module = _load_module()
+    prs = [
+        _dependabot_pr(number=1, labels=[{"name": "security"}], headRefOid="s1"),
+    ]
+    queue_requests, skipped, _ = _partition(
+        module, prs, include_security_updates=False
+    )
+    assert queue_requests == []
+    assert (skipped[0]["pr"], skipped[0]["reason"]) == (1, "security-update-excluded")
+    # included by default
+    qr2, sk2, _ = _partition(module, prs, include_security_updates=True)
+    assert [s.pr_number for s in qr2] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run + artifacts (FR-007, FR-010, SC-003, SC-004)
+# ---------------------------------------------------------------------------
+
+
+def test_would_queue_records_carry_idempotency_keys() -> None:
+    module = _load_module()
+    prs = [_dependabot_pr(number=7, headRefOid="sha7")]
+    queue_requests, _, _ = _partition(module, prs)
+    records = module["_would_queue_records"](queue_requests)
+    assert records[0]["pr"] == 7
+    assert records[0]["idempotencyKey"].startswith("batch-dependabot-resolver:")
+
+
+def test_write_run_artifacts_emits_no_op_on_zero_match(tmp_path: Path) -> None:
+    module = _load_module()
+    payload = {
+        "dryRun": False,
+        "requested": 3,
+        "created": 0,
+        "queued": [],
+        "wouldQueue": [],
+        "skipped": [{"pr": 1, "branch": "feature/x", "reason": "not-dependabot-author"}],
+        "errors": [],
+    }
+    module["_write_run_artifacts"](tmp_path, payload)
+    assert (tmp_path / "batch_dependabot_resolver_result.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "no_op"
+    assert outcome["reason"] == "no_dependabot_prs_matched"
+
+
+def test_write_run_artifacts_skips_no_op_on_dry_run(tmp_path: Path) -> None:
+    module = _load_module()
+    payload = {
+        "dryRun": True,
+        "requested": 1,
+        "created": 0,
+        "queued": [],
+        "wouldQueue": [{"pr": 1, "branch": "dependabot/pip/x", "idempotencyKey": "k"}],
+        "skipped": [],
+        "errors": [],
+    }
+    module["_write_run_artifacts"](tmp_path, payload)
+    assert (tmp_path / "batch_dependabot_resolver_result.json").exists()
+    assert not (tmp_path / "skill_outcome.json").exists()
+
+
+def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
+    module = _load_module()
+    payload = {
+        "dryRun": False,
+        "requested": 1,
+        "created": 0,
+        "queued": [],
+        "wouldQueue": [],
+        "skipped": [],
+        "errors": [{"pr": 9, "branch": "dependabot/pip/x", "error": "boom"}],
+    }
+    module["_write_run_artifacts"](tmp_path, payload)
+    assert not (tmp_path / "skill_outcome.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Runtime selection inheritance (FR-009)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path) -> None:
+    module = _load_module()
+    task_context = tmp_path / "task_context.json"
+    task_context.write_text(
+        json.dumps(
+            {
+                "runtimeConfig": {
+                    "mode": "claude",
+                    "model": "claude-opus-4-8",
+                    "effort": "high",
+                    "providerProfile": "inherited-profile",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime = module["_resolve_runtime_selection"](
+        _args(task_context_path=str(task_context))
+    )
+    assert runtime.mode == "claude"
+    assert runtime.model == "claude-opus-4-8"
+    assert runtime.effort == "high"
+    assert runtime.provider_profile == "inherited-profile"
+
+
+def test_resolve_runtime_selection_prefers_explicit(tmp_path: Path) -> None:
+    module = _load_module()
+    task_context = tmp_path / "task_context.json"
+    task_context.write_text(
+        json.dumps({"runtimeConfig": {"mode": "codex"}}), encoding="utf-8"
+    )
+    runtime = module["_resolve_runtime_selection"](
+        _args(task_context_path=str(task_context), runtime_mode="gemini")
+    )
+    assert runtime.mode == "gemini"
+
+
+# ---------------------------------------------------------------------------
+# CLI arg flattening
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_flattens_package_managers() -> None:
+    module = _load_module()
+    args = module["_parse_args"](
+        ["--repo", "o/r", "--package-managers", "pip,npm", "--package-managers", "github-actions"]
+    )
+    assert args.package_managers == ["pip", "npm", "github-actions"]
+    assert args.include_security_updates is True
+    assert args.dry_run is False
+
+
+def test_parse_args_no_include_security_updates() -> None:
+    module = _load_module()
+    args = module["_parse_args"](["--repo", "o/r", "--no-include-security-updates"])
+    assert args.include_security_updates is False

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -112,8 +112,24 @@ def test_title_matches_default_regex() -> None:
     module = _load_module()
     pattern = module["DEFAULT_TITLE_REGEX"]
     assert module["_title_matches"]("Bump anthropic from 0.105.2 to 0.107.1", pattern)
+    assert module["_title_matches"](
+        "Bump eslint from 8.0.0 to 9.0.0 in /frontend", pattern
+    )
     assert not module["_title_matches"]("Bump the pip group with 2 updates", pattern)
     assert not module["_title_matches"]("Refactor things", pattern)
+
+
+def test_infer_repo_from_remote_returns_none_when_git_remote_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    def fail_command(_cmd: list[str]) -> str:
+        raise RuntimeError("command failed")
+
+    monkeypatch.setitem(module, "_run_command", fail_command)
+
+    assert module["_infer_repo_from_remote"]() is None
 
 
 def test_title_matches_invalid_regex_raises() -> None:

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -127,7 +127,9 @@ def test_infer_repo_from_remote_returns_none_when_git_remote_unavailable(
     def fail_command(_cmd: list[str]) -> str:
         raise RuntimeError("command failed")
 
-    monkeypatch.setitem(module, "_run_command", fail_command)
+    monkeypatch.setitem(
+        module["_infer_repo_from_remote"].__globals__, "_run_command", fail_command
+    )
 
     assert module["_infer_repo_from_remote"]() is None
 

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -989,6 +989,17 @@ def test_jira_side_effect_skills_reject_repository_publish_modes(
     assert resolve_publish_mode_for_skill(skill_id, "none") == "none"
 
 
+@pytest.mark.parametrize(
+    "skill_id",
+    ["pr-resolver", "batch-pr-resolver", "batch-dependabot-resolver"],
+)
+def test_self_managed_publish_skills_force_none(skill_id: str) -> None:
+    assert resolve_publish_mode_for_skill(skill_id, None) == "none"
+    assert resolve_publish_mode_for_skill(skill_id, "none") == "none"
+    with pytest.raises(TaskContractError):
+        resolve_publish_mode_for_skill(skill_id, "pr")
+
+
 def test_jira_issue_updater_allows_explicit_repository_publish_modes() -> None:
     assert resolve_publish_mode_for_skill("jira-issue-updater", "pr") == "pr"
     assert resolve_publish_mode_for_skill("jira-issue-updater", "branch") == "branch"


### PR DESCRIPTION
## Summary

Adds a new MoonMind agent skill, **`batch-dependabot-resolver`**, that discovers open Dependabot dependency-version PRs in a target GitHub repository and enqueues one `pr-resolver` workflow per matching PR. The skill is designed for daily/weekly recurring execution via MoonMind's existing Temporal-backed recurring schedule system.

It is intentionally a narrower discovery/filter layer over the general-purpose `batch-pr-resolver` (which is left untouched): conservative author ∧ branch ∧ title matching, fork/cross-repo skipping, a canonical child `pr-resolver` payload with `publish.mode: none`, a cross-run-stable idempotency key, `dryRun` support, and a Dependabot-specific summary artifact.

- **Jira issue:** [MM-805](https://moonladder.atlassian.net/browse/MM-805) — Create batch-dependabot-resolver skill - orchestrate
- **Active MoonSpec feature path:** `specs/001-batch-dependabot-resolver`

## Changes

- `.agents/skills/batch-dependabot-resolver/SKILL.md` + `bin/batch_dependabot_resolver.py` — the new skill: PR discovery via `gh pr list`, conservative Dependabot classification, machine-readable skip reasons, child `pr-resolver` payload construction, stable idempotency key `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`, `dryRun`, runtime-selection inheritance, and summary/no-op run artifacts.
- `moonmind/workflows/tasks/task_contract.py` — registers `batch-dependabot-resolver` as a self-managed-publish skill (`publish.mode = none` parity with `batch-pr-resolver`/`pr-resolver`).
- `moonmind/services/skill_resolution.py` — makes the skill resolvable by name.
- Tests: `tests/unit/test_batch_dependabot_resolver.py`, `tests/integration/skills/test_batch_dependabot_resolver_e2e.py`, plus additions to `tests/unit/services/test_skill_resolution.py` and `tests/unit/workflows/tasks/test_task_contract.py`.
- `specs/001-batch-dependabot-resolver/` — MoonSpec feature artifacts (spec, plan, tasks, contracts, quickstart).

## Verification verdict

**FULLY_IMPLEMENTED** (HIGH confidence) — latest post-remediation `moonspec-verify` result. All in-scope FR-001…FR-013, acceptance scenarios SCN-001…SCN-007, and success criteria SC-001…SC-005 verified against production code with passing test evidence.

## Tests run

| Suite | Command | Result |
|-------|---------|--------|
| Unit | `./tools/test_unit.sh tests/unit/test_batch_dependabot_resolver.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/services/test_skill_resolution.py` | **PASS** — 165 passed |
| Integration | `python3 -m pytest tests/integration/skills/test_batch_dependabot_resolver_e2e.py -q` | **PASS** — 3 passed |

## Remaining risks

- **None blocking.** The only observed failure was an out-of-scope, pre-existing frontend timeout flake (`workflow-list.test.tsx`, feature 301-column-filter-popovers). This branch touches **zero** frontend files (`git diff main...HEAD` confirms), so it is not story evidence.
- The skill depends on `gh pr list` metadata and the `/api/executions` submission path; behavior under partial GitHub API responses is handled via machine-readable skip reasons and submission-error reporting in the summary artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-805]: https://moonladder.atlassian.net/browse/MM-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ