### PR TITLE
Gate PR publishing on MoonSpec verification

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -168,6 +168,15 @@ _ALREADY_IMPLEMENTED_UNCERTAINTY_PATTERN = re.compile(
     r"(?:without|no)\s+confirmation)\b",
     re.IGNORECASE,
 )
+_MOONSPEC_GATE_PASSING_VERDICTS = frozenset({"FULLY_IMPLEMENTED"})
+_MOONSPEC_GATE_BLOCKING_VERDICTS = frozenset(
+    {
+        "ADDITIONAL_WORK_NEEDED",
+        "NO_DETERMINATION",
+        "BLOCKED",
+        "FAILED_UNRECOVERABLE",
+    }
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -289,6 +298,9 @@ RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
+)
+RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH = (
+    "run-moonspec-verify-publication-gate-v1"
 )
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
@@ -556,6 +568,8 @@ class MoonMindRunWorkflow:
         self._last_step_id: Optional[str] = None
         self._last_step_summary: Optional[str] = None
         self._plan_blocked_message: Optional[str] = None
+        self._moonspec_gate_verdict: Optional[str] = None
+        self._moonspec_gate_reason: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
         # Bounded, redacted structured failure diagnostic captured at the
         # failure boundary. Surfaced in reports/run_summary.json and reused by
@@ -2249,6 +2263,181 @@ class MoonMindRunWorkflow:
             retry_label = "retry" if retry_count == 1 else "retries"
             return f"Approved after {retry_count} {retry_label}"
         return "Approved by structured review"
+
+    def _is_moonspec_verify_step(
+        self,
+        *,
+        tool_name: str,
+        node_inputs: Mapping[str, Any],
+    ) -> bool:
+        normalized_tool = str(tool_name or "").strip().lower()
+        if normalized_tool == "moonspec-verify":
+            return True
+        for key in ("selectedSkill", "skillId", "skill", "targetSkill"):
+            value = node_inputs.get(key)
+            if isinstance(value, str) and value.strip().lower() == "moonspec-verify":
+                return True
+            if isinstance(value, Mapping):
+                nested = value.get("id") or value.get("name")
+                if (
+                    isinstance(nested, str)
+                    and nested.strip().lower() == "moonspec-verify"
+                ):
+                    return True
+        return False
+
+    def _extract_moonspec_verify_verdict(
+        self,
+        outputs: Mapping[str, Any],
+    ) -> str | None:
+        for source in self._moonspec_verify_sources(outputs):
+            for key in (
+                "verdict",
+                "gateVerdict",
+                "gate_verdict",
+                "moonSpecVerdict",
+                "moonspecVerdict",
+                "verificationVerdict",
+                "verification_verdict",
+            ):
+                verdict = self._normalize_moonspec_verify_verdict(source.get(key))
+                if verdict:
+                    return verdict
+        for key in (
+            "operator_summary",
+            "operatorSummary",
+            "summary",
+            "message",
+            "stdout_tail",
+            "stderr_tail",
+            "lastAssistantText",
+            "last_assistant_text",
+        ):
+            verdict = self._extract_moonspec_verify_verdict_from_text(outputs.get(key))
+            if verdict:
+                return verdict
+        return None
+
+    def _moonspec_verify_sources(
+        self,
+        outputs: Mapping[str, Any],
+    ) -> Iterable[Mapping[str, Any]]:
+        for key in (
+            "moonSpecVerify",
+            "moonspecVerify",
+            "moonspec_verify",
+            "verification",
+            "verificationResult",
+            "verification_result",
+            "gate",
+            "review",
+        ):
+            candidate = outputs.get(key)
+            if isinstance(candidate, Mapping):
+                yield candidate
+        yield outputs
+
+    @staticmethod
+    def _normalize_moonspec_verify_verdict(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().upper().replace("-", "_").replace(" ", "_")
+        if normalized == "PASS":
+            normalized = "FULLY_IMPLEMENTED"
+        elif normalized == "FAIL":
+            normalized = "ADDITIONAL_WORK_NEEDED"
+        if (
+            normalized in _MOONSPEC_GATE_PASSING_VERDICTS
+            or normalized in _MOONSPEC_GATE_BLOCKING_VERDICTS
+        ):
+            return normalized
+        return None
+
+    def _extract_moonspec_verify_verdict_from_text(self, value: Any) -> str | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        text = value[:4000]
+        for verdict in (
+            "FULLY_IMPLEMENTED",
+            "ADDITIONAL_WORK_NEEDED",
+            "NO_DETERMINATION",
+            "FAILED_UNRECOVERABLE",
+            "BLOCKED",
+        ):
+            if re.search(rf"\b{re.escape(verdict)}\b", text, re.IGNORECASE):
+                return verdict
+        return None
+
+    def _record_moonspec_verify_gate(
+        self,
+        *,
+        node_id: str,
+        outputs: Mapping[str, Any],
+    ) -> None:
+        verdict = self._extract_moonspec_verify_verdict(outputs)
+        if not verdict:
+            return
+        reason = self._sanitize_operator_summary(
+            self._coerce_text(
+                outputs.get("operator_summary")
+                or outputs.get("operatorSummary")
+                or outputs.get("summary")
+                or outputs.get("message"),
+                max_chars=700,
+            )
+        )
+        diagnostics_ref = self._coerce_text(
+            outputs.get("diagnostics_ref")
+            or outputs.get("diagnosticsRef")
+            or outputs.get("verificationReportRef")
+            or outputs.get("verification_report_ref")
+            or outputs.get("reportRef"),
+            max_chars=400,
+        )
+        self._moonspec_gate_verdict = verdict
+        self._moonspec_gate_reason = reason
+        gate_context: dict[str, Any] = {
+            "logicalStepId": node_id,
+            "verdict": verdict,
+        }
+        if reason:
+            gate_context["summary"] = reason
+        if diagnostics_ref:
+            gate_context["diagnosticsRef"] = diagnostics_ref
+        self._publish_context["moonSpecGate"] = gate_context
+
+    def _blocking_moonspec_gate_reason(self) -> str | None:
+        verdict = self._normalize_moonspec_verify_verdict(self._moonspec_gate_verdict)
+        if verdict is None:
+            return None
+        if verdict in _MOONSPEC_GATE_PASSING_VERDICTS:
+            return None
+        gate_context = self._publish_context.get("moonSpecGate")
+        diagnostics_ref = None
+        if isinstance(gate_context, Mapping):
+            diagnostics_ref = self._coerce_text(
+                gate_context.get("diagnosticsRef"), max_chars=400
+            )
+        parts = [
+            "MoonSpec verification did not approve publication",
+            f"verdict {verdict}",
+        ]
+        if self._moonspec_gate_reason:
+            parts.append(self._moonspec_gate_reason)
+        if diagnostics_ref:
+            parts.append(f"verification report {diagnostics_ref}")
+        reason = ". ".join(part.rstrip(".") for part in parts if part)
+        return f"{reason}." if reason else None
+
+    def _apply_blocking_moonspec_gate_to_publish(self) -> bool:
+        reason = self._blocking_moonspec_gate_reason()
+        if not reason:
+            return False
+        self._plan_blocked_message = reason
+        self._publish_status = "not_required"
+        self._publish_reason = reason
+        self._publish_context["publicationBlockedBy"] = "moonspec_verify"
+        return True
 
     def _review_gate_budget_metadata(
         self,
@@ -4588,6 +4777,19 @@ class MoonMindRunWorkflow:
                 parameters=parameters,
                 execution_result=execution_result,
             )
+            if workflow.patched(RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH):
+                outputs_for_gate = self._get_from_result(execution_result, "outputs")
+                if (
+                    isinstance(outputs_for_gate, Mapping)
+                    and self._is_moonspec_verify_step(
+                        tool_name=tool_name,
+                        node_inputs=node_inputs,
+                    )
+                ):
+                    self._record_moonspec_verify_gate(
+                        node_id=node_id,
+                        outputs=outputs_for_gate,
+                    )
             if self._publish_status == "not_required":
                 require_pull_request_url = False
                 pull_request_url = None
@@ -4751,6 +4953,14 @@ class MoonMindRunWorkflow:
                 self._get_logger().info(
                     "Skipping native PR creation: agent '%s' handles its own PRs.",
                     last_agent_id,
+                )
+            elif (
+                workflow.patched(RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH)
+                and self._apply_blocking_moonspec_gate_to_publish()
+            ):
+                self._get_logger().info(
+                    "Skipping native PR creation: latest MoonSpec verification gate "
+                    "did not approve publication."
                 )
             else:
                 agent_outputs = {}
@@ -6131,6 +6341,7 @@ class MoonMindRunWorkflow:
                 agent_outputs.get("push_branch"),
                 agent_outputs.get("branch"),
                 agent_outputs.get("targetBranch"),
+                self._publish_context.get("branch"),
                 workspace_spec.get("targetBranch"),
                 last_node_inputs.get("targetBranch"),
             )
@@ -6139,6 +6350,7 @@ class MoonMindRunWorkflow:
                 agent_outputs.get("push_base_branch"),
                 agent_outputs.get("baseBranch"),
                 agent_outputs.get("base_branch"),
+                self._publish_context.get("baseRef"),
                 workspace_spec.get("startingBranch"),
                 last_node_inputs.get("startingBranch"),
                 "main",
@@ -6148,6 +6360,7 @@ class MoonMindRunWorkflow:
                 agent_outputs.get("push_branch"),
                 agent_outputs.get("branch"),
                 agent_outputs.get("targetBranch"),
+                self._publish_context.get("branch"),
                 workspace_spec.get("targetBranch"),
                 parameters.get("targetBranch"),
                 last_node_inputs.get("targetBranch"),
@@ -6157,6 +6370,7 @@ class MoonMindRunWorkflow:
             base_candidates = (
                 agent_outputs.get("baseBranch"),
                 agent_outputs.get("base_branch"),
+                self._publish_context.get("baseRef"),
                 workspace_spec.get("startingBranch"),
                 workspace_spec.get("branch"),
                 last_node_inputs.get("startingBranch"),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -177,6 +177,16 @@ _MOONSPEC_GATE_BLOCKING_VERDICTS = frozenset(
         "FAILED_UNRECOVERABLE",
     }
 )
+_MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
+    r"\b("
+    r"FULLY_IMPLEMENTED|"
+    r"ADDITIONAL_WORK_NEEDED|"
+    r"NO_DETERMINATION|"
+    r"FAILED_UNRECOVERABLE|"
+    r"BLOCKED"
+    r")\b",
+    re.IGNORECASE,
+)
 
 class RunWorkflowInput(TypedDict, total=False):
     """Input payload for the MoonMind.Run workflow."""
@@ -2357,16 +2367,10 @@ class MoonMindRunWorkflow:
         if not isinstance(value, str) or not value.strip():
             return None
         text = value[:4000]
-        for verdict in (
-            "FULLY_IMPLEMENTED",
-            "ADDITIONAL_WORK_NEEDED",
-            "NO_DETERMINATION",
-            "FAILED_UNRECOVERABLE",
-            "BLOCKED",
-        ):
-            if re.search(rf"\b{re.escape(verdict)}\b", text, re.IGNORECASE):
-                return verdict
-        return None
+        match = _MOONSPEC_GATE_VERDICT_TEXT_PATTERN.search(text)
+        if not match:
+            return None
+        return self._normalize_moonspec_verify_verdict(match.group(1))
 
     def _record_moonspec_verify_gate(
         self,
@@ -2377,23 +2381,31 @@ class MoonMindRunWorkflow:
         verdict = self._extract_moonspec_verify_verdict(outputs)
         if not verdict:
             return
-        reason = self._sanitize_operator_summary(
-            self._coerce_text(
-                outputs.get("operator_summary")
-                or outputs.get("operatorSummary")
-                or outputs.get("summary")
-                or outputs.get("message"),
-                max_chars=700,
+        reason = None
+        for source in self._moonspec_verify_sources(outputs):
+            reason = self._sanitize_operator_summary(
+                self._coerce_text(
+                    source.get("operator_summary")
+                    or source.get("operatorSummary")
+                    or source.get("summary")
+                    or source.get("message"),
+                    max_chars=700,
+                )
             )
-        )
-        diagnostics_ref = self._coerce_text(
-            outputs.get("diagnostics_ref")
-            or outputs.get("diagnosticsRef")
-            or outputs.get("verificationReportRef")
-            or outputs.get("verification_report_ref")
-            or outputs.get("reportRef"),
-            max_chars=400,
-        )
+            if reason:
+                break
+        diagnostics_ref = None
+        for source in self._moonspec_verify_sources(outputs):
+            diagnostics_ref = self._coerce_text(
+                source.get("diagnostics_ref")
+                or source.get("diagnosticsRef")
+                or source.get("verificationReportRef")
+                or source.get("verification_report_ref")
+                or source.get("reportRef"),
+                max_chars=400,
+            )
+            if diagnostics_ref:
+                break
         self._moonspec_gate_verdict = verdict
         self._moonspec_gate_reason = reason
         gate_context: dict[str, Any] = {
@@ -4885,6 +4897,13 @@ class MoonMindRunWorkflow:
         if self._cancel_requested:
             return
 
+        if (
+            workflow.patched(RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH)
+            and self._apply_blocking_moonspec_gate_to_publish()
+        ):
+            require_pull_request_url = False
+            pull_request_url = None
+
         if require_pull_request_url and pull_request_url is None:
             repair_candidate_outputs: Mapping[str, Any] = {}
             if execution_result is not None:
@@ -6339,9 +6358,9 @@ class MoonMindRunWorkflow:
         if workflow.patched(NATIVE_PR_BRANCH_DEFAULTS_PATCH):
             head_candidates = (
                 agent_outputs.get("push_branch"),
+                self._publish_context.get("branch"),
                 agent_outputs.get("branch"),
                 agent_outputs.get("targetBranch"),
-                self._publish_context.get("branch"),
                 workspace_spec.get("targetBranch"),
                 last_node_inputs.get("targetBranch"),
             )
@@ -6358,9 +6377,9 @@ class MoonMindRunWorkflow:
         else:
             head_candidates = (
                 agent_outputs.get("push_branch"),
+                self._publish_context.get("branch"),
                 agent_outputs.get("branch"),
                 agent_outputs.get("targetBranch"),
-                self._publish_context.get("branch"),
                 workspace_spec.get("targetBranch"),
                 parameters.get("targetBranch"),
                 last_node_inputs.get("targetBranch"),

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2825,7 +2825,10 @@ async def test_run_execution_stage_moonspec_verify_blocks_native_pr_creation(
         **_kwargs: object,
     ) -> object:
         return {
-            "summary": "Verdict: ADDITIONAL_WORK_NEEDED",
+            "summary": (
+                "Opened https://github.com/MoonLadderStudios/MoonMind/pull/999. "
+                "Verdict: ADDITIONAL_WORK_NEEDED"
+            ),
             "metadata": {
                 "verdict": "ADDITIONAL_WORK_NEEDED",
                 "operator_summary": "Overview route still renders full detail sections.",
@@ -2899,6 +2902,7 @@ async def test_run_execution_stage_moonspec_verify_blocks_native_pr_creation(
     )
 
     assert not create_pr_called
+    assert workflow._pull_request_url is None
     assert workflow._publish_status == "not_required"
     assert workflow._publish_context["publicationBlockedBy"] == "moonspec_verify"
     assert status == "failed"

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2730,6 +2730,183 @@ async def test_run_execution_stage_jira_implement_not_required_skips_native_pr(
 
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_moonspec_verify_blocks_native_pr_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+        if activity_type == "agent_skill.resolve":
+            return {
+                "manifestRef": "art_skill_snapshot_1",
+                "skills": [{"name": "moonspec-verify"}],
+            }
+
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            )
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "auto",
+                                "version": "1.0.0",
+                                "description": "Auto",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "MoonSpec Verify",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "tpl:jira-orchestrate:1.0.0:13:verify",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                                "version": "1.0.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "codex"},
+                                "selectedSkill": "moonspec-verify",
+                                "targetBranch": "generated-target",
+                                "instructions": "Run MoonSpec verify.",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Verdict: ADDITIONAL_WORK_NEEDED",
+            "metadata": {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "operator_summary": "Overview route still renders full detail sections.",
+                "diagnostics_ref": "art_verify_report",
+                "push_status": "pushed",
+                "branch": "804-workflow-detail-tabs",
+                "baseRef": "origin/main",
+            },
+            "output_refs": [],
+        }
+
+    async def fake_bind_task_scoped_session(
+        self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _immediate_wait_condition,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_task_scoped_session",
+        fake_bind_task_scoped_session,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+            run_workflow_module.NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+            run_workflow_module.RUN_MOONSPEC_VERIFY_PUBLICATION_GATE_PATCH,
+        },
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    status, message, publish_failure = workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert not create_pr_called
+    assert workflow._publish_status == "not_required"
+    assert workflow._publish_context["publicationBlockedBy"] == "moonspec_verify"
+    assert status == "failed"
+    assert publish_failure is True
+    assert "MoonSpec verification did not approve publication" in message
+
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2007,6 +2007,7 @@ def test_record_execution_context_scrubs_operator_summary_and_ignores_negative_c
     assert "ghp_" not in mock_run_workflow._operator_summary
     assert "commitCount" not in mock_run_workflow._publish_context
 
+
 def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
@@ -2019,6 +2020,74 @@ def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(
     assert status == "failed"
     assert message == "publishMode 'pr' requested but no PR was created"
     assert publish_failure is True
+
+
+def test_moonspec_verify_gate_blocks_pr_publish_completion(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="tpl:jira-orchestrate:1.0.0:13:verify",
+        outputs={
+            "verdict": "ADDITIONAL_WORK_NEEDED",
+            "operator_summary": "Overview route still renders full detail sections.",
+            "diagnostics_ref": "art_verify_report",
+        },
+    )
+
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == "failed"
+    assert publish_failure is True
+    assert "MoonSpec verification did not approve publication" in message
+    assert "ADDITIONAL_WORK_NEEDED" in message
+    assert "art_verify_report" in message
+    assert mock_run_workflow._publish_status == "not_required"
+    assert mock_run_workflow._publish_context["publicationBlockedBy"] == (
+        "moonspec_verify"
+    )
+
+
+def test_moonspec_verify_gate_accepts_fully_implemented_publish(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="tpl:jira-orchestrate:1.0.0:13:verify",
+        outputs={"verdict": "FULLY_IMPLEMENTED"},
+    )
+
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is False
+    assert mock_run_workflow._publish_context["moonSpecGate"]["verdict"] == (
+        "FULLY_IMPLEMENTED"
+    )
+
+
+def test_native_pr_branch_resolution_prefers_publish_context_branch(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    mock_run_workflow._publish_context["branch"] = "804-workflow-detail-tabs"
+    mock_run_workflow._publish_context["baseRef"] = "origin/main"
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={"targetBranch": "generated-target"},
+        agent_outputs={},
+        workspace_spec={
+            "targetBranch": "change-jira-issue-mm-804-to-status-in-pr-c31f93a5",
+            "startingBranch": "main",
+        },
+        last_node_inputs={
+            "targetBranch": "change-jira-issue-mm-804-to-status-in-pr-c31f93a5"
+        },
+        publish_payload={},
+    )
+
+    assert head_branch == "804-workflow-detail-tabs"
+    assert base_branch == "origin/main"
+
 
 def test_publish_repair_feedback_names_branch_and_managed_publish_contract(
     mock_run_workflow: MoonMindRunWorkflow,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2050,6 +2050,35 @@ def test_moonspec_verify_gate_blocks_pr_publish_completion(
     )
 
 
+def test_moonspec_verify_text_verdict_uses_first_matching_occurrence(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    verdict = mock_run_workflow._extract_moonspec_verify_verdict_from_text(
+        "Current verdict: ADDITIONAL_WORK_NEEDED. Prior run was FULLY_IMPLEMENTED."
+    )
+
+    assert verdict == "ADDITIONAL_WORK_NEEDED"
+
+
+def test_moonspec_verify_gate_records_nested_summary_and_report(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="tpl:jira-orchestrate:1.0.0:13:verify",
+        outputs={
+            "verification": {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "operator_summary": "Nested verifier summary.",
+                "diagnostics_ref": "art_nested_verify_report",
+            }
+        },
+    )
+
+    gate_context = mock_run_workflow._publish_context["moonSpecGate"]
+    assert gate_context["summary"] == "Nested verifier summary."
+    assert gate_context["diagnosticsRef"] == "art_nested_verify_report"
+
+
 def test_moonspec_verify_gate_accepts_fully_implemented_publish(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
@@ -2074,7 +2103,7 @@ def test_native_pr_branch_resolution_prefers_publish_context_branch(
 
     head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
         parameters={"targetBranch": "generated-target"},
-        agent_outputs={},
+        agent_outputs={"targetBranch": "generated-target"},
         workspace_spec={
             "targetBranch": "change-jira-issue-mm-804-to-status-in-pr-c31f93a5",
             "startingBranch": "main",


### PR DESCRIPTION
## Summary
- record the latest MoonSpec verify verdict in MoonMind run publication context
- block native PR creation and PR publish completion when MoonSpec verify reports additional work or another non-passing verdict
- prefer the actual published branch/base recorded in publish context when resolving native PR branches

## Verification
- `git diff --check`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_run_artifacts.py -k 'moonspec_verify_gate or native_pr_branch_resolution or moonspec_verify_blocks_native_pr_creation'`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
