### PR TITLE
Finish removing these specs references to make the project doc-first:

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -189,23 +189,19 @@ Non-negotiable rules:
 
 Rationale: MoonMind is an automation engine; it must learn from real execution.
 
-### XI. Spec-Driven Development Is the Source of Truth
+### XI. Docs-First Development and Traceability
 
-MoonMind development MUST be spec-driven, with clear contracts and traceability.
+MoonMind development MUST be docs-first, with clear contracts and traceability. The durable source of truth is the canonical, long-lived documentation under `docs/` together with this constitution — not the per-feature execution packets under `specs/`.
 
 Non-negotiable rules:
 
-- Any non-trivial change MUST begin with specification artifacts under `specs/<id>-<feature>/`:
-  - `spec.md` (requirements & acceptance scenarios),
-  - `plan.md` (implementation strategy),
-  - `tasks.md` (incremental execution plan).
-- `spec.md` MUST remain technology-agnostic; implementation details belong in `plan.md`.
-- Every `plan.md` MUST include a “Constitution Check” with PASS/FAIL coverage for each principle.
-  - If any principle is violated, the plan MUST document the violation and mitigation in “Complexity Tracking”.
-- Implementation MUST not silently drift from the spec:
-  - if reality changes, update the spec/plan/tasks to match.
+- Durable, desired-state knowledge — architecture, contracts, operator-visible behavior, and target semantics — MUST live in the owning long-lived `docs/` files (and this constitution). These are the canonical surfaces that future readers and agents are expected to trust.
+- Per-feature Spec Kit / MoonSpec artifacts under `specs/<id>-<feature>/` (`spec.md`, `plan.md`, `tasks.md`, `research.md`, contracts) are **optional execution artifacts** — execution helpers and supplemental history. They MUST NOT be treated as canonical long-term architecture or behavior documentation.
+- When a non-trivial change lands, its durable decisions MUST be reflected in the owning `docs/` files; the `specs/` packet (if one was produced) remains supplemental execution evidence, not the system of record.
+- When a feature does use the optional execution workflow, `spec.md` SHOULD remain technology-agnostic with implementation detail in `plan.md`, and `plan.md` SHOULD include a “Constitution Check” with PASS/FAIL coverage for each principle (documenting any violation and mitigation in “Complexity Tracking”).
+- Documentation MUST NOT silently drift from reality: when behavior changes, update the owning long-lived `docs/` first; refresh any in-flight `specs/` execution packet only as supplemental history.
 
-Rationale: Specs are how MoonMind stays maintainable while evolving quickly.
+Rationale: Canonical docs are how MoonMind stays maintainable while evolving quickly. Spec packets are disposable execution scaffolding; the long-lived docs and matrices are what operators and agents must be able to rely on.
 
 ### XII. Canonical Documentation Separates Desired State from Migration Backlog
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -196,10 +196,10 @@ MoonMind development MUST be docs-first, with clear contracts and traceability. 
 Non-negotiable rules:
 
 - Durable, desired-state knowledge — architecture, contracts, operator-visible behavior, and target semantics — MUST live in the owning long-lived `docs/` files (and this constitution). These are the canonical surfaces that future readers and agents are expected to trust.
-- Per-feature Spec Kit / MoonSpec artifacts under `specs/<id>-<feature>/` (`spec.md`, `plan.md`, `tasks.md`, `research.md`, contracts) are **optional execution artifacts** — execution helpers and supplemental history. They MUST NOT be treated as canonical long-term architecture or behavior documentation.
+- Per-feature Spec Kit / MoonSpec artifacts under `specs/<id>-<feature>/` (`spec.md`, `plan.md`, `tasks.md`, `research.md`, `contracts`) are **optional execution artifacts** — execution helpers and supplemental history. They MUST NOT be treated as canonical long-term architecture or behavior documentation.
 - When a non-trivial change lands, its durable decisions MUST be reflected in the owning `docs/` files; the `specs/` packet (if one was produced) remains supplemental execution evidence, not the system of record.
-- When a feature does use the optional execution workflow, `spec.md` SHOULD remain technology-agnostic with implementation detail in `plan.md`, and `plan.md` SHOULD include a “Constitution Check” with PASS/FAIL coverage for each principle (documenting any violation and mitigation in “Complexity Tracking”).
-- Documentation MUST NOT silently drift from reality: when behavior changes, update the owning long-lived `docs/` first; refresh any in-flight `specs/` execution packet only as supplemental history.
+- When a feature does use the optional execution workflow, `spec.md` SHOULD remain technology-agnostic with implementation details in `plan.md`, and `plan.md` MUST include a “Constitution Check” with PASS/FAIL coverage for each principle (documenting any violation and mitigation in “Complexity Tracking”).
+- Documentation MUST NOT silently drift from reality: when behavior changes, update the owning long-lived `docs/` files first; refresh any in-flight `specs/` execution packet only as supplemental history.
 
 Rationale: Canonical docs are how MoonMind stays maintainable while evolving quickly. Spec packets are disposable execution scaffolding; the long-lived docs and matrices are what operators and agents must be able to rely on.
 

--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -1220,7 +1220,7 @@ Step Executions with Checkpointing supports MoonMind's core principles:
 1. **Orchestrate, Don't Recreate**: agents execute attempts; MoonMind owns orchestration, state, and evidence.
 2. **Own Your Data**: attempt context, outputs, diffs, and checkpoints are operator-controlled artifacts.
 3. **Resilient by Default**: repeated work is explicit, bounded, idempotency-aware, and recoverable.
-4. **Spec-Driven Development**: gates and attempts preserve traceability from requirement to implementation to evidence.
+4. **Docs-First Development and Traceability**: gates and attempts preserve traceability from requirement to implementation to evidence, anchored in long-lived `docs/` rather than disposable spec packets.
 5. **Continuous Improvement**: failed attempts produce structured evidence and improvement signals rather than disappearing into logs.
 
 The key desired-state rule is simple:


### PR DESCRIPTION
Finish removing these specs references to make the project doc-first:

Not **fully** implemented yet, though the **core governance migration is largely in place**.

The main source-of-truth docs now look correct: the constitution has been changed to **“Docs-First Development and Traceability”**, demotes `specs/` to optional execution artifacts, makes owner matrices and `Docs/` durable source-of-truth surfaces, and prohibits treating `specs/` as canonical long-term architecture/behavior docs.  The README now presents **Docs-First Development**, puts portfolio/roadmap/dependency graph and owner matrices before optional `specs/` artifacts, and says PRs must update owning long-lived docs and matrix evidence. 

The roadmap, portfolio, and dependency graph are also updated in the right direction. The roadmap now has **Docs-first execution** instead of spec-first execution, and the modularity guardrail now says phase execution must trace through matrix IDs and long-lived docs-first evidence, with `specs/` as supplemental history.   The portfolio matrix now reframes `PORT-03` around owner-matrix + long-lived docs + implementation + test/runtime evidence and adds `PORT-06` for the docs-first source-of-truth migration.  The dependency graph’s old “spec coverage” blockers have been rewritten as docs-first design/docs coverage blockers. 

The Spec Kit templates were also mostly handled: `spec-template.md`, `plan-template.md`, and `tasks-template.md` now label generated files as optional execution artifacts and require durable decisions to land in owning `Docs/` files and owner matrices.    The main agent docs have also been reframed: `.agents/skills/AGENTS.md` says canonical durable knowledge lives in `Docs/` and owner matrices, and that Spec Kit packets are optional execution helpers, not durable documentation gates.   The agent README similarly says Spec Kit is optional and that canonical durable knowledge is not in `specs/`. 

## What is still not done

There are still active secondary prompt/design surfaces that contradict the new docs-first language. I would not call the effort fully complete until these are cleaned up.

The domain prompt-design docs still explicitly list **“spec-driven development”** as a hard requirement when generating docs. This remains in at least:

`Docs/DndPlugin/DndPromptDesign.md` 
`Docs/Tactics/TacticsPromptDesign.md` 
`Docs/MultiplayerPlugin/MultiplayerPromptDesign.md` 
`Docs/OnlineServicesPlugin/OnlineServicesPromptDesign.md` 

There is also a stale matrix-expansion reference template. It still says expanded matrix rows should “drive spec and milestone planning,” still says evidence should include a “spec/task artifact when present,” and still asks for a follow-up backlog of rows lacking “dedicated specs/tests” plus an optional “spec queue.”    The main `matrix-expansion-design` skill was updated, but it still points to that stale reference template as a resource, so the stale template matters. 

There are also many remaining `spec/task` search hits in active docs. Some are probably acceptable as historical or “when present” evidence references, but the domain prompt docs above are not merely historical; they are reusable active instructions. The generated upstream `.agents/skills/VERSION.md` still says “GitHub Spec Kit - Spec-Driven Development Toolkit,” but I would not treat that as a blocker because it appears to be upstream/generated tool metadata rather than Tactics governance. 

## Verdict

**Core docs-first governance: implemented.**
**Full repo-wide effort as described earlier: not fully implemented.**

I would leave the task open with a smaller follow-up:

```text
Finish docs-first cleanup in active prompt/design surfaces.

Update domain prompt-design docs and matrix-expansion reference templates so they no longer require or prioritize spec-driven development. Replace “spec-driven development” with “docs-first development and traceability,” replace “spec queue” / “dedicated specs/tests” language with optional execution-packet language, and ensure all reusable prompts require owner matrix + long-lived Docs evidence as the durable source of truth.
```

Acceptance for that follow-up should be: no active reusable prompt, skill reference, or governance doc instructs agents to treat specs as required/canonical long-term documentation.