### PR TITLE
[codex] Fix story output tool routing

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -140,6 +140,7 @@ from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 from moonmind.workflows.temporal.story_output_tools import (
+    DOCUMENT_UPDATE_TASKS_TOOL_NAME,
     JIRA_STORY_TOOL_NAMES,
     register_story_output_tool_handlers,
 )
@@ -907,7 +908,12 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
     return normalized
 
 _JIRA_AGENT_SKILLS = JIRA_AGENT_SKILLS
-_JIRA_STORY_OUTPUT_TOOLS = JIRA_STORY_TOOL_NAMES
+_STORY_OUTPUT_TASK_TOOLS = frozenset(
+    {
+        *JIRA_STORY_TOOL_NAMES,
+        DOCUMENT_UPDATE_TASKS_TOOL_NAME,
+    }
+)
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
 def _requires_branch_publish_for_story_output(value: Any) -> bool:
@@ -1005,7 +1011,7 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
 def _selected_step_tool_type(step_entry: Mapping[str, Any]) -> str:
-    if _selected_step_tool_name(step_entry).lower() in _JIRA_STORY_OUTPUT_TOOLS:
+    if _selected_step_tool_name(step_entry).lower() in _STORY_OUTPUT_TASK_TOOLS:
         return "skill"
     if _selected_step_type(step_entry) == "tool":
         return "skill"
@@ -1014,8 +1020,8 @@ def _selected_step_tool_type(step_entry: Mapping[str, Any]) -> str:
 def _jira_agent_skill_selected(tool_name: str) -> bool:
     return tool_name.lower() in _JIRA_AGENT_SKILLS
 
-def _jira_story_output_tool_selected(tool_name: str) -> bool:
-    return tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
+def _story_output_task_tool_selected(tool_name: str) -> bool:
+    return tool_name.lower() in _STORY_OUTPUT_TASK_TOOLS
 
 def _task_uses_only_jira_agent_skill(
     *, selected_skill_name: str, raw_steps: Any
@@ -1029,12 +1035,12 @@ def _task_uses_only_jira_agent_skill(
         ]
         return bool(effective_step_tool_names) and all(
             _jira_agent_skill_selected(name)
-            or _jira_story_output_tool_selected(name)
+            or _story_output_task_tool_selected(name)
             for name in effective_step_tool_names
         )
     return _jira_agent_skill_selected(
         selected_skill_name
-    ) or _jira_story_output_tool_selected(selected_skill_name)
+    ) or _story_output_task_tool_selected(selected_skill_name)
 
 def _append_agent_skill_instructions(instructions: str, *, selected_skill: str) -> str:
     selected = selected_skill.strip()
@@ -1555,7 +1561,7 @@ def _build_runtime_planner():
                         ).strip().lower()
                         break
             should_prepare_story_breakdown = should_prepare_story_breakdown or bool(
-                step_tool_names & (_JIRA_STORY_OUTPUT_TOOLS | _MOONSPEC_BREAKDOWN_TOOLS)
+                step_tool_names & (_STORY_OUTPUT_TASK_TOOLS | _MOONSPEC_BREAKDOWN_TOOLS)
             )
         elif selected_skill_name:
             creates_story_breakdown_artifact = (
@@ -1666,7 +1672,7 @@ def _build_runtime_planner():
                 tool_version = _selected_step_tool_version(step_entry)
                 is_agent_runtime_step = tool_type == "agent_runtime"
                 is_story_output_tool = (
-                    step_tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
+                    step_tool_name.lower() in _STORY_OUTPUT_TASK_TOOLS
                 )
                 effective_step_skill_name = (
                     step_tool_name or selected_skill_name
@@ -1772,7 +1778,7 @@ def _build_runtime_planner():
         else:
             node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
             selected_skill_lower = selected_skill_name.lower()
-            is_story_output_tool = selected_skill_lower in _JIRA_STORY_OUTPUT_TOOLS
+            is_story_output_tool = selected_skill_lower in _STORY_OUTPUT_TASK_TOOLS
             if selected_skill_lower in _MOONSPEC_BREAKDOWN_TOOLS:
                 if (
                     story_output_mode == "jira"

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1005,12 +1005,17 @@ def _selected_step_tool_version(step_entry: Mapping[str, Any]) -> str:
     return str(step_tool.get("version") or "1.0").strip() or "1.0"
 
 def _selected_step_tool_type(step_entry: Mapping[str, Any]) -> str:
+    if _selected_step_tool_name(step_entry).lower() in _JIRA_STORY_OUTPUT_TOOLS:
+        return "skill"
     if _selected_step_type(step_entry) == "tool":
         return "skill"
     return "agent_runtime"
 
 def _jira_agent_skill_selected(tool_name: str) -> bool:
     return tool_name.lower() in _JIRA_AGENT_SKILLS
+
+def _jira_story_output_tool_selected(tool_name: str) -> bool:
+    return tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
 
 def _task_uses_only_jira_agent_skill(
     *, selected_skill_name: str, raw_steps: Any
@@ -1023,9 +1028,13 @@ def _task_uses_only_jira_agent_skill(
             for step in raw_steps
         ]
         return bool(effective_step_tool_names) and all(
-            _jira_agent_skill_selected(name) for name in effective_step_tool_names
+            _jira_agent_skill_selected(name)
+            or _jira_story_output_tool_selected(name)
+            for name in effective_step_tool_names
         )
-    return _jira_agent_skill_selected(selected_skill_name)
+    return _jira_agent_skill_selected(
+        selected_skill_name
+    ) or _jira_story_output_tool_selected(selected_skill_name)
 
 def _append_agent_skill_instructions(instructions: str, *, selected_skill: str) -> str:
     selected = selected_skill.strip()
@@ -1656,6 +1665,9 @@ def _build_runtime_planner():
                 tool_type = _selected_step_tool_type(step_entry)
                 tool_version = _selected_step_tool_version(step_entry)
                 is_agent_runtime_step = tool_type == "agent_runtime"
+                is_story_output_tool = (
+                    step_tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
+                )
                 effective_step_skill_name = (
                     step_tool_name or selected_skill_name
                     if is_agent_runtime_step
@@ -1696,6 +1708,8 @@ def _build_runtime_planner():
                     )
                 if not is_agent_runtime_step:
                     step_node_inputs.pop("selectedSkill", None)
+                if is_story_output_tool:
+                    step_node_inputs["publishMode"] = "none"
 
                 nodes.append({
                     "id": step_id,
@@ -1757,7 +1771,9 @@ def _build_runtime_planner():
                 prev_step_id = step_id
         else:
             node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
-            if selected_skill_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
+            selected_skill_lower = selected_skill_name.lower()
+            is_story_output_tool = selected_skill_lower in _JIRA_STORY_OUTPUT_TOOLS
+            if selected_skill_lower in _MOONSPEC_BREAKDOWN_TOOLS:
                 if (
                     story_output_mode == "jira"
                     and _requires_branch_publish_for_story_output(
@@ -1779,14 +1795,24 @@ def _build_runtime_planner():
                 str(node_inputs.get("instructions") or ""),
                 selected_skill=selected_skill_name,
             )
-            node_tool_type = "agent_runtime"
-            node_tool_name = runtime_mode
+            node_tool_type = "skill" if is_story_output_tool else "agent_runtime"
+            node_tool_name = (
+                selected_skill_name if is_story_output_tool else runtime_mode
+            )
+            node_tool_version = (
+                _selected_step_tool_version({"tool": selected_skill_payload})
+                if is_story_output_tool
+                else "1.0"
+            )
+            if is_story_output_tool:
+                node_inputs.pop("selectedSkill", None)
+                node_inputs["publishMode"] = "none"
             nodes.append({
                 "id": node_id,
                 "tool": {
                     "type": node_tool_type,
                     "name": node_tool_name,
-                    "version": "1.0",
+                    "version": node_tool_version,
                 },
                 "inputs": node_inputs,
             })
@@ -1834,9 +1860,13 @@ def _build_runtime_planner():
             publish_tool = str(
                 publish_node.get("tool", {}).get("name") or ""
             ).strip().lower()
+            publish_tool_type = str(
+                publish_node.get("tool", {}).get("type") or ""
+            ).strip().lower()
             publish_selected_skill = _plan_node_selected_skill(publish_node)
             if (
-                publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
+                publish_tool_type == "agent_runtime"
+                and publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
                 and (
                     not _jira_agent_skill_selected(publish_selected_skill)
                     or publish_selected_skill.lower() in _MOONSPEC_BREAKDOWN_TOOLS

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1544,6 +1544,100 @@ def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
     }
 
 
+def test_runtime_planner_routes_document_update_task_creator_as_tool_step():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Document Update Orchestrate",
+                "instructions": "Discover docs and create update tasks.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {
+                        "id": "discover",
+                        "instructions": "Discover documents.",
+                    },
+                    {
+                        "id": "create-update-tasks",
+                        "tool": {
+                            "type": "skill",
+                            "name": "story.create_document_update_tasks",
+                        },
+                        "instructions": "Create document update tasks.",
+                        "documentUpdateOrchestration": {
+                            "task": {
+                                "repository": "MoonLadderStudios/MoonMind",
+                                "runtime": {"mode": "codex_cli"},
+                                "publish": {"mode": "none"},
+                            },
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    create_tasks = plan["nodes"][1]
+
+    assert create_tasks["tool"] == {
+        "type": "skill",
+        "name": "story.create_document_update_tasks",
+        "version": "1.0",
+    }
+    assert "selectedSkill" not in create_tasks["inputs"]
+    assert create_tasks["inputs"]["publishMode"] == "none"
+
+
+def test_runtime_planner_routes_single_document_update_task_creator_as_tool_step():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Create document update tasks",
+                "instructions": "Create document update tasks from known paths.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "tool": {
+                    "type": "skill",
+                    "name": "story.create_document_update_tasks",
+                },
+                "documentUpdateOrchestration": {
+                    "task": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "runtime": {"mode": "codex_cli"},
+                        "publish": {"mode": "none"},
+                    },
+                },
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+
+    assert node["tool"] == {
+        "type": "skill",
+        "name": "story.create_document_update_tasks",
+        "version": "1.0",
+    }
+    assert "selectedSkill" not in node["inputs"]
+    assert node["inputs"]["publishMode"] == "none"
+
+
 def test_runtime_planner_dedupes_repeated_identical_preset_steps():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1196,11 +1196,12 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     )
     assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
     assert jira["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
+        "type": "skill",
+        "name": "story.create_jira_issues",
         "version": "1.0",
     }
-    assert jira["inputs"]["selectedSkill"] == "story.create_jira_issues"
+    assert "selectedSkill" not in jira["inputs"]
+    assert jira["inputs"]["publishMode"] == "none"
     assert jira["inputs"]["storyOutput"]["jira"]["dependencyMode"] == (
         "linear_blocker_chain"
     )
@@ -1351,10 +1352,12 @@ def test_runtime_planner_preserves_authored_branch_for_jira_story_import():
     node = plan["nodes"][0]
 
     assert node["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
+        "type": "skill",
+        "name": "story.create_jira_issues",
         "version": "1.0",
     }
+    assert "selectedSkill" not in node["inputs"]
+    assert node["inputs"]["publishMode"] == "none"
     assert node["inputs"]["branch"] == "feature/authored-breakdown"
     assert node["inputs"]["storyBreakdownPath"] == (
         "artifacts/story-breakdowns/import/stories.json"
@@ -1445,11 +1448,12 @@ def test_runtime_planner_routes_jira_orchestrate_task_creator_as_skill_step():
         == breakdown["inputs"]["storyBreakdownPath"]
     )
     assert orchestrate["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
+        "type": "skill",
+        "name": "story.create_jira_orchestrate_tasks",
         "version": "1.0",
     }
-    assert orchestrate["inputs"]["selectedSkill"] == "story.create_jira_orchestrate_tasks"
+    assert "selectedSkill" not in orchestrate["inputs"]
+    assert orchestrate["inputs"]["publishMode"] == "none"
     assert orchestrate["inputs"]["jiraOrchestration"]["traceability"] == {
         "sourceIssueKey": "MM-404"
     }
@@ -1525,11 +1529,12 @@ def test_runtime_planner_routes_jira_implement_task_creator_as_skill_step():
     implement = plan["nodes"][3]
 
     assert implement["tool"] == {
-        "type": "agent_runtime",
-        "name": "codex_cli",
+        "type": "skill",
+        "name": "story.create_jira_implement_tasks",
         "version": "1.0",
     }
-    assert implement["inputs"]["selectedSkill"] == "story.create_jira_implement_tasks"
+    assert "selectedSkill" not in implement["inputs"]
+    assert implement["inputs"]["publishMode"] == "none"
     assert implement["inputs"]["jiraOrchestration"]["task"]["publish"] == {
         "mode": "pr",
         "mergeAutomation": {"enabled": True},


### PR DESCRIPTION
## Summary

Fixes story-output tools such as `story.create_jira_issues` being routed as agent-runtime skill steps. These deterministic tools now stay on the tool execution path, omit `selectedSkill`, and use `publishMode: none`.

## Root Cause

The runtime planner treated legacy `tool.type: skill` story-output tool markers as agent skills. That caused `MoonMind.Run` to resolve `story.create_jira_issues` through the agent skill catalog, where it does not exist.

## Validation

- `python3.12 -m pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/test_story_output_tools.py -q --tb=short`

Note: `./tools/test_unit.sh` currently stops during collection because the local `.venv` uses Python 3.11 and an existing test requires Python 3.12 f-string parsing.