### PR TITLE
[codex] Harden managed runtime no-progress handling

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -82,6 +82,41 @@ _PR_RESOLVER_RESULT_PATH_LIST = ", ".join(
 )
 
 
+def managed_run_status_metadata(record: ManagedRunRecord) -> dict[str, Any]:
+    """Return compact status metadata that is safe for workflow history."""
+
+    metadata: dict[str, Any] = {"runtimeId": record.runtime_id}
+    timestamp_fields = {
+        "startedAt": record.started_at,
+        "finishedAt": record.finished_at,
+        "lastHeartbeatAt": record.last_heartbeat_at,
+        "lastLogAt": record.last_log_at,
+    }
+    for key, value in timestamp_fields.items():
+        if value is not None:
+            metadata[key] = value.isoformat()
+
+    scalar_fields = {
+        "pid": record.pid,
+        "exitCode": record.exit_code,
+        "lastLogOffset": record.last_log_offset,
+        "stdoutArtifactRef": record.stdout_artifact_ref,
+        "stderrArtifactRef": record.stderr_artifact_ref,
+        "diagnosticsRef": record.diagnostics_ref,
+        "observabilityEventsRef": record.observability_events_ref,
+        "liveStreamCapable": record.live_stream_capable,
+        "sessionId": record.session_id,
+        "sessionEpoch": record.session_epoch,
+        "containerId": record.container_id,
+        "threadId": record.thread_id,
+        "activeTurnId": record.active_turn_id,
+    }
+    for key, value in scalar_fields.items():
+        if value is not None:
+            metadata[key] = value
+    return metadata
+
+
 def _normalize_pr_resolver_text(value: Any) -> str:
     """Return one normalized resolver status candidate."""
 
@@ -659,6 +694,7 @@ class ManagedAgentAdapter:
                     agentKind="managed",
                     agentId=record.agent_id,
                     status=record.status,
+                    metadata=managed_run_status_metadata(record),
                 )
         return AgentRunStatus(
             runId=run_id,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -69,6 +69,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ManagedProfileLaunchContext,
     build_managed_profile_launch_context,
+    managed_run_status_metadata,
 )
 from moonmind.utils.logging import SecretRedactor, redact_sensitive_payload, redact_sensitive_text
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
@@ -6563,7 +6564,7 @@ class TemporalAgentRuntimeActivities:
             agentKind="managed",
             agentId=record.agent_id or agent_id,
             status=record.status,
-            metadata={"runtimeId": record.runtime_id},
+            metadata=managed_run_status_metadata(record),
         )
         return status
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -149,6 +149,9 @@ PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID = (
     "agent-run-pin-provider-profile-before-slot-request-v1"
 )
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
+AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
+    "agent-run-managed-no-progress-reconciliation-v1"
+)
 MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
     "agent-run-managed-session-start-after-slot-v1"
 )
@@ -667,12 +670,14 @@ class MoonMindAgentRun:
             return {
                 "runtime": runtime_id,
                 "noProgressTimeoutSeconds": 1500,
+                "noProgressGraceSeconds": 600,
                 "stuckAction": "request_intervention",
                 "retryPolicy": "managed_runtime_polling_with_profile_cooldown",
             }
         return {
             "runtime": runtime_id,
             "noProgressTimeoutSeconds": _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS,
+            "noProgressGraceSeconds": 300,
             "stuckAction": "request_intervention",
             "retryPolicy": "managed_runtime_polling_with_profile_cooldown",
         }
@@ -693,6 +698,16 @@ class MoonMindAgentRun:
             "updatedAt",
             "lastUpdatedAt",
             "lastOutputAt",
+            "lastHeartbeatAt",
+            "lastLogAt",
+            "lastLogOffset",
+            "finishedAt",
+            "exitCode",
+            "stdoutArtifactRef",
+            "stderrArtifactRef",
+            "diagnosticsRef",
+            "observabilityEventsRef",
+            "activeTurnId",
         )
         return (
             status_obj.status,
@@ -710,6 +725,10 @@ class MoonMindAgentRun:
             or _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
         )
         return max(1, timeout_seconds // max(1, poll_interval))
+
+    @staticmethod
+    def _no_progress_grace_seconds(policy: Mapping[str, Any]) -> int:
+        return max(0, int(policy.get("noProgressGraceSeconds") or 0))
 
     def _intervention_result(
         self,
@@ -1324,6 +1343,92 @@ class MoonMindAgentRun:
                 == "pr-resolver"
             ),
         )
+
+    async def _poll_managed_status(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        adapter: AgentAdapter,
+        uses_codex_session_adapter: bool,
+        use_managed_status_activity: bool,
+    ) -> AgentRunStatusModel:
+        if uses_codex_session_adapter:
+            return await adapter.status(self.run_id)
+        if use_managed_status_activity:
+            status_payload = await self._execute_routed_activity(
+                "agent_runtime.status",
+                AgentRuntimeStatusInput(
+                    runId=str(self.run_id or ""),
+                    agentId=request.agent_id,
+                ),
+                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            )
+            return self._coerce_managed_status_payload(
+                status_payload=status_payload,
+                run_id=str(self.run_id or ""),
+                fallback_agent_id=request.agent_id,
+            )
+
+        # Legacy replay-compatibility path: older histories recorded timer-only
+        # polling for managed runs. Avoid mutable run-store reads here.
+        return AgentRunStatusModel(
+            runId=str(self.run_id or ""),
+            agentKind="managed",
+            agentId=request.agent_id,
+            status=RunStatus.running,
+        )
+
+    async def _reconcile_managed_no_progress(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        adapter: AgentAdapter,
+        uses_codex_session_adapter: bool,
+        use_managed_status_activity: bool,
+        resiliency_policy: Mapping[str, Any],
+        poll_interval: int,
+        initial_status: AgentRunStatusModel,
+        overall_start: datetime,
+        timeout_seconds: int,
+    ) -> AgentRunResult | None:
+        grace_seconds = self._no_progress_grace_seconds(resiliency_policy)
+        if grace_seconds <= 0:
+            return None
+
+        deadline = workflow.now() + timedelta(seconds=grace_seconds)
+        status_obj = initial_status
+        while True:
+            self.run_status = status_obj.status
+            if status_obj.status in _TERMINAL_RUN_STATUSES:
+                return await self._fetch_managed_result(
+                    request=request,
+                    adapter=adapter,
+                    uses_codex_session_adapter=uses_codex_session_adapter,
+                    use_managed_status_activity=use_managed_status_activity,
+                )
+
+            remaining_grace = (deadline - workflow.now()).total_seconds()
+            remaining_overall = timeout_seconds - (
+                workflow.now() - overall_start
+            ).total_seconds()
+            remaining = min(remaining_grace, remaining_overall)
+            if remaining <= 0:
+                return None
+
+            try:
+                await workflow.wait_condition(
+                    lambda: self.completion_event.is_set(),
+                    timeout=timedelta(seconds=min(poll_interval, remaining)),
+                )
+                if self.final_result is not None:
+                    return self.final_result
+            except asyncio.TimeoutError:
+                status_obj = await self._poll_managed_status(
+                    request=request,
+                    adapter=adapter,
+                    uses_codex_session_adapter=uses_codex_session_adapter,
+                    use_managed_status_activity=use_managed_status_activity,
+                )
 
     async def _ensure_manager_and_signal(
         self,
@@ -2737,34 +2842,12 @@ class MoonMindAgentRun:
                                     fallback_agent_id=request.agent_id,
                                 )
                             else:
-                                if uses_codex_session_adapter:
-                                    status_obj = await adapter.status(self.run_id)
-                                elif use_managed_status_activity:
-                                    status_payload = await self._execute_routed_activity(
-                                        "agent_runtime.status",
-                                        AgentRuntimeStatusInput(
-                                            runId=str(self.run_id or ""),
-                                            agentId=request.agent_id,
-                                        ),
-                                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
-
-                                    )
-                                    status_obj = self._coerce_managed_status_payload(
-                                        status_payload=status_payload,
-                                        run_id=str(self.run_id or ""),
-                                        fallback_agent_id=request.agent_id,
-                                    )
-                                else:
-                                    # Legacy replay-compatibility path: older histories
-                                    # recorded timer-only polling for managed runs.
-                                    # Avoid consulting mutable run-store state during
-                                    # replay to keep command sequencing stable.
-                                    status_obj = AgentRunStatusModel(
-                                        runId=str(self.run_id or ""),
-                                        agentKind="managed",
-                                        agentId=request.agent_id,
-                                        status=RunStatus.running,
-                                    )
+                                status_obj = await self._poll_managed_status(
+                                    request=request,
+                                    adapter=adapter,
+                                    uses_codex_session_adapter=uses_codex_session_adapter,
+                                    use_managed_status_activity=use_managed_status_activity,
+                                )
 
                             self.run_status = status_obj.status
                             if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
@@ -2781,6 +2864,31 @@ class MoonMindAgentRun:
                                     poll_interval=poll_interval,
                                 )
                                 if stagnant_poll_count >= max_stagnant_polls:
+                                    if (
+                                        request.agent_kind == "managed"
+                                        and workflow.patched(
+                                            AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID
+                                        )
+                                    ):
+                                        reconciled_result = (
+                                            await self._reconcile_managed_no_progress(
+                                                request=request,
+                                                adapter=adapter,
+                                                uses_codex_session_adapter=uses_codex_session_adapter,
+                                                use_managed_status_activity=(
+                                                    use_managed_status_activity
+                                                ),
+                                                resiliency_policy=resiliency_policy,
+                                                poll_interval=poll_interval,
+                                                initial_status=status_obj,
+                                                overall_start=overall_start,
+                                                timeout_seconds=timeout_seconds,
+                                            )
+                                        )
+                                        if reconciled_result is not None:
+                                            self.final_result = reconciled_result
+                                            break
+
                                     self.run_status = "intervention_requested"
                                     self.final_result = self._intervention_result(
                                         summary=(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -698,7 +698,6 @@ class MoonMindAgentRun:
             "updatedAt",
             "lastUpdatedAt",
             "lastOutputAt",
-            "lastHeartbeatAt",
             "lastLogAt",
             "lastLogOffset",
             "finishedAt",
@@ -1416,19 +1415,22 @@ class MoonMindAgentRun:
                 return None
 
             try:
-                await workflow.wait_condition(
+                completed = await workflow.wait_condition(
                     lambda: self.completion_event.is_set(),
                     timeout=timedelta(seconds=min(poll_interval, remaining)),
                 )
-                if self.final_result is not None:
-                    return self.final_result
-            except asyncio.TimeoutError:
-                status_obj = await self._poll_managed_status(
-                    request=request,
-                    adapter=adapter,
-                    uses_codex_session_adapter=uses_codex_session_adapter,
-                    use_managed_status_activity=use_managed_status_activity,
-                )
+            except (asyncio.TimeoutError, TimeoutError):
+                completed = False
+
+            if completed or self.completion_event.is_set():
+                return self.final_result
+
+            status_obj = await self._poll_managed_status(
+                request=request,
+                adapter=adapter,
+                uses_codex_session_adapter=uses_codex_session_adapter,
+                use_managed_status_activity=use_managed_status_activity,
+            )
 
     async def _ensure_manager_and_signal(
         self,
@@ -2822,117 +2824,87 @@ class MoonMindAgentRun:
 
                         try:
                             # Add bounded wait
-                            await workflow.wait_condition(
+                            completed = await workflow.wait_condition(
                                 lambda: self.completion_event.is_set(),
                                 timeout=timedelta(seconds=min(poll_interval, remaining_timeout))
                             )
+                        except (asyncio.TimeoutError, TimeoutError):
+                            completed = False
+
+                        if completed or self.completion_event.is_set():
                             break  # Callback received
-                        except asyncio.TimeoutError:
-                            if request.agent_kind == "external":
-                                # Poll via Temporal activity (determinism-safe).
-                                act_name = f"integration.{self._external_agent_id}.status"
-                                status_dict = await self._execute_routed_activity(
-                                    act_name,
-                                    ExternalAgentRunInput(runId=str(self.run_id or "")),
-                                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
-                                )
-                                status_obj = self._coerce_external_status_payload(
-                                    status_payload=status_dict,
-                                    fallback_agent_id=request.agent_id,
-                                )
+                        if request.agent_kind == "external":
+                            # Poll via Temporal activity (determinism-safe).
+                            act_name = f"integration.{self._external_agent_id}.status"
+                            status_dict = await self._execute_routed_activity(
+                                act_name,
+                                ExternalAgentRunInput(runId=str(self.run_id or "")),
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+
+                            )
+                            status_obj = self._coerce_external_status_payload(
+                                status_payload=status_dict,
+                                fallback_agent_id=request.agent_id,
+                            )
+                        else:
+                            status_obj = await self._poll_managed_status(
+                                request=request,
+                                adapter=adapter,
+                                uses_codex_session_adapter=uses_codex_session_adapter,
+                                use_managed_status_activity=use_managed_status_activity,
+                            )
+
+                        self.run_status = status_obj.status
+                        if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
+                            progress_signature = self._status_progress_signature(
+                                status_obj
+                            )
+                            if progress_signature == last_progress_signature:
+                                stagnant_poll_count += 1
                             else:
-                                status_obj = await self._poll_managed_status(
-                                    request=request,
-                                    adapter=adapter,
-                                    uses_codex_session_adapter=uses_codex_session_adapter,
-                                    use_managed_status_activity=use_managed_status_activity,
-                                )
-
-                            self.run_status = status_obj.status
-                            if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
-                                progress_signature = self._status_progress_signature(
-                                    status_obj
-                                )
-                                if progress_signature == last_progress_signature:
-                                    stagnant_poll_count += 1
-                                else:
-                                    last_progress_signature = progress_signature
-                                    stagnant_poll_count = 0
-                                max_stagnant_polls = self._max_no_progress_polls(
-                                    policy=resiliency_policy,
-                                    poll_interval=poll_interval,
-                                )
-                                if stagnant_poll_count >= max_stagnant_polls:
-                                    if (
-                                        request.agent_kind == "managed"
-                                        and workflow.patched(
-                                            AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID
-                                        )
-                                    ):
-                                        reconciled_result = (
-                                            await self._reconcile_managed_no_progress(
-                                                request=request,
-                                                adapter=adapter,
-                                                uses_codex_session_adapter=uses_codex_session_adapter,
-                                                use_managed_status_activity=(
-                                                    use_managed_status_activity
-                                                ),
-                                                resiliency_policy=resiliency_policy,
-                                                poll_interval=poll_interval,
-                                                initial_status=status_obj,
-                                                overall_start=overall_start,
-                                                timeout_seconds=timeout_seconds,
-                                            )
-                                        )
-                                        if reconciled_result is not None:
-                                            self.final_result = reconciled_result
-                                            break
-
-                                    self.run_status = "intervention_requested"
-                                    self.final_result = self._intervention_result(
-                                        summary=(
-                                            "Agent run made no observable progress "
-                                            f"for {resiliency_policy.get('noProgressTimeoutSeconds', _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS)}s; "
-                                            "human intervention is required before retrying."
-                                        ),
-                                        request=request,
-                                        metadata={
-                                            "reason": "stuck_no_progress",
-                                            "resiliencyPolicy": dict(resiliency_policy),
-                                            "lastStatus": status_obj.model_dump(
-                                                mode="json",
-                                                by_alias=True,
+                                last_progress_signature = progress_signature
+                                stagnant_poll_count = 0
+                            max_stagnant_polls = self._max_no_progress_polls(
+                                policy=resiliency_policy,
+                                poll_interval=poll_interval,
+                            )
+                            if stagnant_poll_count >= max_stagnant_polls:
+                                if (
+                                    request.agent_kind == "managed"
+                                    and workflow.patched(
+                                        AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID
+                                    )
+                                ):
+                                    reconciled_result = (
+                                        await self._reconcile_managed_no_progress(
+                                            request=request,
+                                            adapter=adapter,
+                                            uses_codex_session_adapter=uses_codex_session_adapter,
+                                            use_managed_status_activity=(
+                                                use_managed_status_activity
                                             ),
-                                        },
+                                            resiliency_policy=resiliency_policy,
+                                            poll_interval=poll_interval,
+                                            initial_status=status_obj,
+                                            overall_start=overall_start,
+                                            timeout_seconds=timeout_seconds,
+                                        )
                                     )
-                                    await self._signal_parent_child_state_changed(
-                                        parent_info,
-                                        "intervention_requested",
-                                        (
-                                            "Agent run made no observable progress "
-                                            "and needs human review."
-                                        ),
-                                    )
-                                    break
+                                    if reconciled_result is not None:
+                                        self.final_result = reconciled_result
+                                        break
 
-                            if (
-                                workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID)
-                                and status_obj.status == RunStatus.awaiting_feedback
-                                and not (
-                                    request.agent_kind == "external"
-                                    and self._external_agent_id == "jules"
-                                )
-                            ):
                                 self.run_status = "intervention_requested"
                                 self.final_result = self._intervention_result(
                                     summary=(
-                                        "Agent requested human feedback; "
-                                        "operator intervention is required."
+                                        "Agent run made no observable progress "
+                                        f"for {resiliency_policy.get('noProgressTimeoutSeconds', _DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS)}s; "
+                                        "human intervention is required before retrying."
                                     ),
                                     request=request,
                                     metadata={
-                                        "reason": "agent_requested_feedback",
+                                        "reason": "stuck_no_progress",
                                         "resiliencyPolicy": dict(resiliency_policy),
                                         "lastStatus": status_obj.model_dump(
                                             mode="json",
@@ -2943,113 +2915,147 @@ class MoonMindAgentRun:
                                 await self._signal_parent_child_state_changed(
                                     parent_info,
                                     "intervention_requested",
-                                    "Agent requested human feedback.",
+                                    (
+                                        "Agent run made no observable progress "
+                                        "and needs human review."
+                                    ),
                                 )
                                 break
 
-                            # --- Jules auto-answer sub-flow (spec 094) ---
-                            # Only react when Jules explicitly signals
-                            # awaiting_user_feedback (normalized to
-                            # awaiting_feedback).  Probing during "running"
-                            # caused every progress message to be treated as
-                            # a question and spammed with auto-answers.
-                            if (
-                                getattr(status_obj, "status", None)
-                                == RunStatus.awaiting_feedback
-                                and request.agent_kind == "external"
+                        if (
+                            workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID)
+                            and status_obj.status == RunStatus.awaiting_feedback
+                            and not (
+                                request.agent_kind == "external"
                                 and self._external_agent_id == "jules"
-                            ):
-                                # Probe for an unanswered question first (cheap GET).
-                                activities_result = await self._execute_routed_activity(
-                                    "integration.jules.list_activities",
-                                    {"session_id": self.run_id},
+                            )
+                        ):
+                            self.run_status = "intervention_requested"
+                            self.final_result = self._intervention_result(
+                                summary=(
+                                    "Agent requested human feedback; "
+                                    "operator intervention is required."
+                                ),
+                                request=request,
+                                metadata={
+                                    "reason": "agent_requested_feedback",
+                                    "resiliencyPolicy": dict(resiliency_policy),
+                                    "lastStatus": status_obj.model_dump(
+                                        mode="json",
+                                        by_alias=True,
+                                    ),
+                                },
+                            )
+                            await self._signal_parent_child_state_changed(
+                                parent_info,
+                                "intervention_requested",
+                                "Agent requested human feedback.",
+                            )
+                            break
+
+                        # --- Jules auto-answer sub-flow (spec 094) ---
+                        # Only react when Jules explicitly signals
+                        # awaiting_user_feedback (normalized to
+                        # awaiting_feedback).  Probing during "running"
+                        # caused every progress message to be treated as
+                        # a question and spammed with auto-answers.
+                        if (
+                            getattr(status_obj, "status", None)
+                            == RunStatus.awaiting_feedback
+                            and request.agent_kind == "external"
+                            and self._external_agent_id == "jules"
+                        ):
+                            # Probe for an unanswered question first (cheap GET).
+                            activities_result = await self._execute_routed_activity(
+                                "integration.jules.list_activities",
+                                {"session_id": self.run_id},
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                            act_id = activities_result.get("activityId") if isinstance(activities_result, dict) else None
+                            question = activities_result.get("latestAgentQuestion") if isinstance(activities_result, dict) else None
+
+                            if question and act_id and act_id not in self._answered_activity_ids:
+                                # New question detected — read config via activity (determinism-safe)
+                                auto_answer_config = await self._execute_routed_activity(
+                                    "integration.jules.get_auto_answer_config",
+                                    [],
                                     cancellation_type=ActivityCancellationType.TRY_CANCEL,
                                 )
+                                aa_enabled = auto_answer_config.get("enabled", True) if isinstance(auto_answer_config, dict) else True
+                                aa_max = auto_answer_config.get("max_answers", 3) if isinstance(auto_answer_config, dict) else 3
 
-                                act_id = activities_result.get("activityId") if isinstance(activities_result, dict) else None
-                                question = activities_result.get("latestAgentQuestion") if isinstance(activities_result, dict) else None
-
-                                if question and act_id and act_id not in self._answered_activity_ids:
-                                    # New question detected — read config via activity (determinism-safe)
-                                    auto_answer_config = await self._execute_routed_activity(
-                                        "integration.jules.get_auto_answer_config",
-                                        [],
-                                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                if not aa_enabled or self._auto_answer_count >= aa_max:
+                                    # Opt-out or max cycles exhausted → escalate
+                                    self.run_status = "intervention_requested"
+                                    auto_answer_reason = (
+                                        "jules_auto_answer_disabled"
+                                        if not aa_enabled
+                                        else "jules_auto_answer_exhausted"
                                     )
-                                    aa_enabled = auto_answer_config.get("enabled", True) if isinstance(auto_answer_config, dict) else True
-                                    aa_max = auto_answer_config.get("max_answers", 3) if isinstance(auto_answer_config, dict) else 3
-
-                                    if not aa_enabled or self._auto_answer_count >= aa_max:
-                                        # Opt-out or max cycles exhausted → escalate
-                                        self.run_status = "intervention_requested"
-                                        auto_answer_reason = (
-                                            "jules_auto_answer_disabled"
-                                            if not aa_enabled
-                                            else "jules_auto_answer_exhausted"
-                                        )
-                                        self.final_result = self._intervention_result(
-                                            summary=(
-                                                "Jules requested human feedback; "
-                                                "operator intervention is required."
+                                    self.final_result = self._intervention_result(
+                                        summary=(
+                                            "Jules requested human feedback; "
+                                            "operator intervention is required."
+                                        ),
+                                        request=request,
+                                        metadata={
+                                            "reason": "agent_requested_feedback",
+                                            "julesAutoAnswerReason": auto_answer_reason,
+                                            "julesAutoAnswerCount": self._auto_answer_count,
+                                            "julesAutoAnswerMax": aa_max,
+                                            "resiliencyPolicy": dict(resiliency_policy),
+                                            "lastStatus": status_obj.model_dump(
+                                                mode="json",
+                                                by_alias=True,
                                             ),
-                                            request=request,
-                                            metadata={
-                                                "reason": "agent_requested_feedback",
-                                                "julesAutoAnswerReason": auto_answer_reason,
-                                                "julesAutoAnswerCount": self._auto_answer_count,
-                                                "julesAutoAnswerMax": aa_max,
-                                                "resiliencyPolicy": dict(resiliency_policy),
-                                                "lastStatus": status_obj.model_dump(
-                                                    mode="json",
-                                                    by_alias=True,
-                                                ),
-                                            },
-                                        )
-                                        self._get_logger().warning(
-                                            "Jules auto-answer %s for session %s (count=%d, max=%d)",
-                                            "disabled" if not aa_enabled else "exhausted",
-                                            self.run_id,
-                                            self._auto_answer_count,
-                                            aa_max,
-                                        )
-                                        await self._signal_parent_child_state_changed(
-                                            parent_info,
-                                            "intervention_requested",
-                                            "Jules requested human feedback.",
-                                        )
-                                        break
-
-                                    # Dispatch question-answer cycle
-                                    task_context = request.agent_id or ""
-                                    answer_result = await self._execute_routed_activity(
-                                        "integration.jules.answer_question",
-                                        {
-                                            "session_id": self.run_id,
-                                            "question": question,
-                                            "task_context": task_context,
                                         },
-                                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
                                     )
-                                    if isinstance(answer_result, dict) and answer_result.get("answered"):
-                                        self._answered_activity_ids.add(act_id)
-                                        self._auto_answer_count += 1
-                                        self._get_logger().info(
-                                            "Jules auto-answer #%d sent for session %s (activity %s)",
-                                            self._auto_answer_count,
-                                            self.run_id,
-                                            act_id,
-                                        )
-                                    else:
-                                        self._get_logger().warning(
-                                            "Jules auto-answer failed for session %s: %s",
-                                            self.run_id,
-                                            answer_result.get("error") if isinstance(answer_result, dict) else "unknown",
-                                        )
+                                    self._get_logger().warning(
+                                        "Jules auto-answer %s for session %s (count=%d, max=%d)",
+                                        "disabled" if not aa_enabled else "exhausted",
+                                        self.run_id,
+                                        self._auto_answer_count,
+                                        aa_max,
+                                    )
+                                    await self._signal_parent_child_state_changed(
+                                        parent_info,
+                                        "intervention_requested",
+                                        "Jules requested human feedback.",
+                                    )
+                                    break
 
-                            # --- end auto-answer sub-flow ---
+                                # Dispatch question-answer cycle
+                                task_context = request.agent_id or ""
+                                answer_result = await self._execute_routed_activity(
+                                    "integration.jules.answer_question",
+                                    {
+                                        "session_id": self.run_id,
+                                        "question": question,
+                                        "task_context": task_context,
+                                    },
+                                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                )
+                                if isinstance(answer_result, dict) and answer_result.get("answered"):
+                                    self._answered_activity_ids.add(act_id)
+                                    self._auto_answer_count += 1
+                                    self._get_logger().info(
+                                        "Jules auto-answer #%d sent for session %s (activity %s)",
+                                        self._auto_answer_count,
+                                        self.run_id,
+                                        act_id,
+                                    )
+                                else:
+                                    self._get_logger().warning(
+                                        "Jules auto-answer failed for session %s: %s",
+                                        self.run_id,
+                                        answer_result.get("error") if isinstance(answer_result, dict) else "unknown",
+                                    )
 
-                            if status_obj.status in _TERMINAL_RUN_STATUSES:
-                                break
+                        # --- end auto-answer sub-flow ---
+
+                        if status_obj.status in _TERMINAL_RUN_STATUSES:
+                            break
 
                 elapsed = (workflow.now() - overall_start).total_seconds()
 

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -114,6 +114,11 @@ _COMMON_AGENT_RUN_ACTIVITIES = [
     mock_provider_profile_reset_manager,
 ]
 
+_managed_launch_requests: list[dict] = []
+_managed_status_mode = "default"
+_managed_status_poll_count = 0
+_managed_fetch_result_count = 0
+
 @_activity.defn(name="agent_runtime.launch")
 async def mock_agent_runtime_launch(request: dict) -> dict:
     """Simulate launching a managed agent container."""
@@ -138,6 +143,25 @@ async def mock_agent_runtime_build_launch_context(request: dict) -> dict:
 @_activity.defn(name="agent_runtime.status")
 async def mock_agent_runtime_status(request: dict) -> dict:
     """Simulate polling the agent's execution status."""
+    global _managed_status_poll_count
+    _managed_status_poll_count += 1
+    if _managed_status_mode == "silent_then_completed":
+        status = "completed" if _managed_status_poll_count >= 3 else "running"
+        metadata: dict[str, Any] = {"runtimeId": "claude_code"}
+        if status == "completed":
+            metadata["finishedAt"] = datetime.now(tz=UTC).isoformat()
+            metadata["exitCode"] = 0
+        return {
+            "runId": request.get("runId")
+            or request.get("run_id")
+            or "test-managed-run",
+            "agentKind": "managed",
+            "agentId": request.get("agentId")
+            or request.get("agent_id")
+            or "claude_code",
+            "status": status,
+            "metadata": metadata,
+        }
     return {
         "status": "running",
         "container_id": request.get("container_id", "test-container-001"),
@@ -146,6 +170,16 @@ async def mock_agent_runtime_status(request: dict) -> dict:
 @_activity.defn(name="agent_runtime.fetch_result")
 async def mock_agent_runtime_fetch_result(request: dict) -> dict:
     """Simulate fetching the agent's final result."""
+    global _managed_fetch_result_count
+    _managed_fetch_result_count += 1
+    if _managed_status_mode == "silent_then_completed":
+        return {
+            "summary": "Managed run completed during no-progress grace.",
+            "metadata": {
+                "normalizedStatus": "completed",
+                "fetchRunId": request.get("runId") or request.get("run_id"),
+            },
+        }
     return {
         "summary": "Completed via test mock",
         "artifacts": [],
@@ -158,8 +192,6 @@ _COMMON_AGENT_RUN_ACTIVITIES.extend([
     mock_agent_runtime_status,
     mock_agent_runtime_fetch_result,
 ])
-
-_managed_launch_requests: list[dict] = []
 
 @pytest.mark.integration_ci
 async def test_workload_auth_volume_guardrails_reject_inheritance_and_allow_declared_exception(
@@ -1089,6 +1121,106 @@ async def test_agent_run_escalates_external_no_progress_to_parent_intervention(
         for change in parent_state["state_changes"]
     )
     assert "codex_cloud_fetch_result" not in _external_activity_calls
+
+@pytest.mark.asyncio
+async def test_agent_run_reconciles_managed_completion_during_no_progress_grace(
+    monkeypatch,
+):
+    global _managed_status_mode, _managed_status_poll_count, _managed_fetch_result_count
+    _managed_launch_requests.clear()
+    _managed_status_mode = "silent_then_completed"
+    _managed_status_poll_count = 0
+    _managed_fetch_result_count = 0
+
+    def test_policy(request: AgentExecutionRequest) -> dict[str, Any]:
+        return {
+            "runtime": request.agent_id,
+            "noProgressTimeoutSeconds": 1,
+            "noProgressGraceSeconds": 5,
+            "stuckAction": "request_intervention",
+            "retryPolicy": "test_managed_grace_reconciliation",
+        }
+
+    monkeypatch.setattr(
+        MoonMindAgentRun,
+        "_resiliency_policy_for_request",
+        staticmethod(test_policy),
+    )
+
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with (
+                Worker(
+                    env.client,
+                    task_queue="agent-run-task-queue",
+                    workflows=[
+                        MoonMindAgentRun,
+                        MockProviderProfileManager,
+                        TestAgentRunParent,
+                    ],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.artifacts",
+                    activities=[
+                        mock_provider_profile_list,
+                        mock_provider_profile_ensure_manager,
+                        mock_provider_profile_reset_manager,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.agent_runtime",
+                    activities=[
+                        mock_agent_runtime_build_launch_context,
+                        mock_agent_runtime_launch,
+                        mock_agent_runtime_status,
+                        mock_agent_runtime_fetch_result,
+                        mock_publish_artifacts,
+                        mock_cancel,
+                    ],
+                ),
+            ):
+                manager_id = "provider-profile-manager:claude_code"
+                await env.client.start_workflow(
+                    MockProviderProfileManager.run,
+                    {"runtime_id": "claude_code"},
+                    id=manager_id,
+                    task_queue="agent-run-task-queue",
+                )
+
+                parent_handle = await env.client.start_workflow(
+                    TestAgentRunParent.run,
+                    AgentExecutionRequest(
+                        agent_kind="managed",
+                        agent_id="claude_code",
+                        execution_profile_ref="default-managed",
+                        correlation_id="managed-grace:corr",
+                        idempotency_key="managed-grace:idem",
+                    ),
+                    id="test-parent-managed-no-progress-grace",
+                    task_queue="agent-run-task-queue",
+                )
+
+                result = await asyncio.wait_for(parent_handle.result(), timeout=15)
+                parent_state = await parent_handle.query(TestAgentRunParent.get_state)
+
+        assert isinstance(result, AgentRunResult)
+        assert result.failure_class is None
+        assert result.provider_error_code is None
+        assert result.summary == "Managed run completed during no-progress grace."
+        assert result.metadata["resiliencyPolicy"]["retryPolicy"] == (
+            "test_managed_grace_reconciliation"
+        )
+        assert _managed_status_poll_count >= 3
+        assert _managed_fetch_result_count == 1
+        assert not any(
+            change["state"] == "intervention_requested"
+            for change in parent_state["state_changes"]
+        )
+    finally:
+        _managed_status_mode = "default"
 
 @pytest.mark.asyncio
 async def test_agent_run_external_agent_workflow():

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -636,7 +636,22 @@ def _session_record(session_id: str, *, status: str) -> dict[str, Any]:
 async def test_status_running_record_returns_typed_model(tmp_path: Path) -> None:
     """T1.1 — running record yields typed AgentRunStatus."""
     store = _make_store(tmp_path)
-    _save_record(store, run_id="run-1", status="running", runtime_id="codex_cli")
+    now = datetime.now(tz=UTC)
+    store.save(
+        ManagedRunRecord(
+            runId="run-1",
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="running",
+            startedAt=now,
+            lastHeartbeatAt=now + timedelta(seconds=30),
+            lastLogAt=now + timedelta(seconds=20),
+            lastLogOffset=128,
+            stdoutArtifactRef="run-1/stdout.log",
+            diagnosticsRef="run-1/diagnostics.json",
+            activeTurnId="turn-1",
+        )
+    )
 
     activities = TemporalAgentRuntimeActivities(run_store=store)
     result = await activities.agent_runtime_status({"run_id": "run-1", "agent_id": "codex_cli"})
@@ -644,6 +659,13 @@ async def test_status_running_record_returns_typed_model(tmp_path: Path) -> None
     assert isinstance(result, AgentRunStatus), f"Expected AgentRunStatus, got {type(result)}"
     assert result.status == "running"
     assert result.agent_kind == "managed"
+    assert result.metadata["runtimeId"] == "codex_cli"
+    assert result.metadata["lastHeartbeatAt"] == (now + timedelta(seconds=30)).isoformat()
+    assert result.metadata["lastLogAt"] == (now + timedelta(seconds=20)).isoformat()
+    assert result.metadata["lastLogOffset"] == 128
+    assert result.metadata["stdoutArtifactRef"] == "run-1/stdout.log"
+    assert result.metadata["diagnosticsRef"] == "run-1/diagnostics.json"
+    assert result.metadata["activeTurnId"] == "turn-1"
 
 async def test_status_completed_record_returns_typed_model(tmp_path: Path) -> None:
     """T1.2 — completed record yields typed AgentRunStatus with correct status."""

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -113,6 +113,52 @@ def test_status_progress_signature_tracks_metadata_progress_keys() -> None:
         MoonMindAgentRun._status_progress_signature(second)
     )
 
+def test_status_progress_signature_ignores_heartbeat_only_changes() -> None:
+    first = AgentRunStatus(
+        runId="run-1",
+        agentKind="managed",
+        agentId="claude_code",
+        status="running",
+        metadata={
+            "runtimeId": "claude_code",
+            "lastHeartbeatAt": "2026-06-09T20:00:00Z",
+        },
+    )
+    second = AgentRunStatus(
+        runId="run-1",
+        agentKind="managed",
+        agentId="claude_code",
+        status="running",
+        metadata={
+            "runtimeId": "claude_code",
+            "lastHeartbeatAt": "2026-06-09T20:00:30Z",
+        },
+    )
+
+    assert MoonMindAgentRun._status_progress_signature(first) == (
+        MoonMindAgentRun._status_progress_signature(second)
+    )
+
+def test_status_progress_signature_tracks_log_output_progress() -> None:
+    first = AgentRunStatus(
+        runId="run-1",
+        agentKind="managed",
+        agentId="claude_code",
+        status="running",
+        metadata={"lastLogOffset": 128},
+    )
+    second = AgentRunStatus(
+        runId="run-1",
+        agentKind="managed",
+        agentId="claude_code",
+        status="running",
+        metadata={"lastLogOffset": 256},
+    )
+
+    assert MoonMindAgentRun._status_progress_signature(first) != (
+        MoonMindAgentRun._status_progress_signature(second)
+    )
+
 def test_intervention_result_uses_terminal_operator_review_metadata() -> None:
     workflow_instance = MoonMindAgentRun()
     workflow_instance.run_id = "run-1"


### PR DESCRIPTION
## Summary

This PR hardens managed-runtime no-progress handling so silent but still-running providers are less likely to be reported as failed before their terminal output lands.

Changes include:
- Add compact managed-run status metadata such as heartbeat/log timestamps, terminal timestamps, exit code, and artifact refs.
- Treat those metadata fields as managed-runtime progress signals in `MoonMind.AgentRun`.
- Add a patch-gated managed no-progress reconciliation path that waits briefly and fetches the result when a run becomes terminal during the grace window.
- Add regression coverage for a silent managed run completing during no-progress grace, plus status metadata activity coverage.

## Root Cause

A Claude Code resolver run stayed quiet longer than the no-progress threshold, so the workflow published `intervention_requested` even though the managed process later exited successfully and produced its final stdout.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_status_running_record_returns_typed_model`
- `./tools/test_unit.sh --python-only tests/integration/services/temporal/workflows/test_agent_run.py::test_agent_run_reconciles_managed_completion_during_no_progress_grace`
- `./tools/test_unit.sh --python-only tests/integration/services/temporal/workflows/test_agent_run.py::test_agent_run_escalates_external_no_progress_to_parent_intervention tests/integration/services/temporal/workflows/test_agent_run.py::test_agent_run_escalates_external_feedback_request_to_parent_intervention`
- `PYTHONPYCACHEPREFIX=/tmp/moonmind_pycache .venv/bin/python -m py_compile ...touched files...`
- `./tools/test_unit.sh` passed: Python `5813 passed, 6 skipped, 1 xpassed`; frontend `27 passed`, `416 passed | 234 skipped`.