### PR TITLE
[codex] Fix Jira story handoff previous outputs

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1650,6 +1650,8 @@ async def create_jira_issues_from_stories(
     previous_outputs = _mapping(
         (_context or {}).get("previousOutputs")
         or (_context or {}).get("previous_outputs")
+        or inputs.get("previousOutputs")
+        or inputs.get("previous_outputs")
     )
     story_output = _mapping(inputs.get("storyOutput") or inputs.get("story_output"))
     previous_story_output = _mapping(

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -607,6 +607,63 @@ async def test_create_jira_issues_reads_story_artifact_ref_from_previous_outputs
     assert service.requests[0].summary == "Create previous-output artifact Jira story"
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_reads_previous_outputs_from_tool_inputs():
+    service = _FakeJiraService()
+    breakdown = {
+        "source": {"referencePath": "docs/Designs/RuntimeTypes.md"},
+        "stories": [
+            {
+                "id": "STORY-001",
+                "summary": "Create input previous-output Jira story",
+                "description": "As an operator, I can reuse an input handoff.",
+                "sourceReference": {"path": "docs/Designs/RuntimeTypes.md"},
+            }
+        ],
+    }
+    fetch_calls: list[tuple[str, str, str]] = []
+    artifact_reads: list[str] = []
+
+    async def artifact_reader(ref: str) -> bytes:
+        artifact_reads.append(ref)
+        return json.dumps(breakdown).encode("utf-8")
+
+    async def fetcher(repo: str, ref: str, path: str) -> str:
+        fetch_calls.append((repo, ref, path))
+        raise AssertionError("repo fetch should not run when input artifact exists")
+
+    result = await create_jira_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "breakdown-branch",
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "handoff": "artifact",
+                "requiresStoryBreakdownArtifactRef": True,
+                "fallback": "fail",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "none",
+                },
+            },
+            "previousOutputs": {
+                "storyOutput": {
+                    "storyBreakdownArtifactRef": "art_input_story_breakdown",
+                }
+            },
+        },
+        jira_service_factory=lambda: service,
+        story_fetcher=fetcher,
+        artifact_reader=artifact_reader,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert artifact_reads == ["art_input_story_breakdown"]
+    assert fetch_calls == []
+    assert service.requests[0].summary == "Create input previous-output Jira story"
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_explains_protected_branch_handoff_failure():
     async def fetcher(_repo: str, _ref: str, _path: str) -> str:
         raise RuntimeError("404 Not Found")


### PR DESCRIPTION
## Summary
- Allow Jira story creation to read `previousOutputs` from tool invocation inputs as well as dispatcher context.
- Add regression coverage for artifact-backed story breakdown refs nested under input `previousOutputs.storyOutput`.

## Root Cause
The failed workflow published a durable `storyBreakdownArtifactRef`, but the next deterministic Jira tool received it under `inputs.previousOutputs`. `create_jira_issues_from_stories()` only looked for previous outputs in dispatcher context, so it missed the valid artifact ref and failed before Jira issue creation.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
- `./tools/test_unit.sh` Python suite: 5818 passed, 6 skipped, 1 xpassed
- `npm run ui:test -- frontend/src/entrypoints/workflow-list.test.tsx`: 45 passed

Note: full `./tools/test_unit.sh` frontend phase had one timeout in `workflow-list.test.tsx`; the same file passed on immediate targeted rerun.