### PR TITLE
[codex] Fix Jira orchestration handoff mappings

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -920,11 +920,16 @@ def _issue_mappings_from_inputs(
     context: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     jira_payload = _mapping(inputs.get("jira"))
-    previous_outputs = _mapping(
+    input_previous_outputs = _mapping(
+        inputs.get("previousOutputs")
+        or inputs.get("previous_outputs")
+    )
+    context_previous_outputs = _mapping(
         (context or {}).get("previousOutputs")
         or (context or {}).get("previous_outputs")
     )
-    previous_jira_payload = _mapping(previous_outputs.get("jira"))
+    input_previous_jira_payload = _mapping(input_previous_outputs.get("jira"))
+    context_previous_jira_payload = _mapping(context_previous_outputs.get("jira"))
     candidates = (
         jira_payload.get("issueMappings")
         or jira_payload.get("issue_mappings")
@@ -932,12 +937,18 @@ def _issue_mappings_from_inputs(
         or inputs.get("issue_mappings")
         or jira_payload.get("createdIssues")
         or inputs.get("createdIssues")
-        or previous_jira_payload.get("issueMappings")
-        or previous_jira_payload.get("issue_mappings")
-        or previous_jira_payload.get("createdIssues")
-        or previous_outputs.get("issueMappings")
-        or previous_outputs.get("issue_mappings")
-        or previous_outputs.get("createdIssues")
+        or input_previous_jira_payload.get("issueMappings")
+        or input_previous_jira_payload.get("issue_mappings")
+        or input_previous_jira_payload.get("createdIssues")
+        or input_previous_outputs.get("issueMappings")
+        or input_previous_outputs.get("issue_mappings")
+        or input_previous_outputs.get("createdIssues")
+        or context_previous_jira_payload.get("issueMappings")
+        or context_previous_jira_payload.get("issue_mappings")
+        or context_previous_jira_payload.get("createdIssues")
+        or context_previous_outputs.get("issueMappings")
+        or context_previous_outputs.get("issue_mappings")
+        or context_previous_outputs.get("createdIssues")
         or []
     )
     mappings = [dict(item) for item in _list(candidates) if isinstance(item, Mapping)]

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1666,6 +1666,45 @@ async def test_create_jira_orchestrate_tasks_uses_previous_step_mappings_and_own
     assert "Source Jira issue: MM-404." in task["instructions"]
 
 @pytest.mark.asyncio
+async def test_create_jira_orchestrate_tasks_uses_input_previous_outputs_mappings():
+    creator = _FakeExecutionCreator()
+
+    result = await create_jira_orchestrate_tasks_from_issue_mappings(
+        {
+            "jiraOrchestration": {
+                "task": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
+                },
+                "traceability": {"sourceIssueKey": "MM-705"},
+            },
+            "previousOutputs": {
+                "jira": {
+                    "issueMappings": [
+                        {
+                            "storyId": "STORY-003",
+                            "storyIndex": 1,
+                            "summary": "Remaining work",
+                            "issueKey": "MM-810",
+                        }
+                    ]
+                }
+            },
+        },
+        execution_creator=creator,
+    )
+
+    orchestration = result.outputs["jiraOrchestration"]
+    assert orchestration["status"] == "completed"
+    assert orchestration["storyCount"] == 1
+    assert orchestration["createdTaskCount"] == 1
+    assert orchestration["tasks"][0]["jiraIssueKey"] == "MM-810"
+    assert creator.requests[0]["initial_parameters"]["task"]["inputs"][
+        "jira_issue_key"
+    ] == "MM-810"
+
+@pytest.mark.asyncio
 async def test_create_jira_orchestrate_tasks_handles_one_and_zero_story_results():
     one_creator = _FakeExecutionCreator()
 


### PR DESCRIPTION
## Summary

Fixes the Jira breakdown orchestration handoff so downstream Jira Orchestrate task creation can consume issue mappings passed in the workflow step input payload.

## Root Cause

`story.create_jira_issues` returned `jira.issueMappings`, but the next step received that result under `inputs.previousOutputs.jira.issueMappings`. The downstream task helper only checked direct Jira inputs and `context.previousOutputs`, so it treated the run as having zero issue mappings and returned `no_downstream_tasks`.

## Changes

- Read Jira issue mappings from `inputs.previousOutputs` and `inputs.previous_outputs` in addition to the existing direct and context shapes.
- Added a regression test that exercises the public Jira Orchestrate task creation path with the workflow-passed previous-output shape.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_story_output_tools.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`