### PR TITLE
[codex] Implement pentest activity handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,8 @@ Key diagnostics:
 - Existing Temporal artifact store and workflow history; no new persistent storage (001-step-execution-contracts)
 - Python 3.12 target per repo instructions; TypeScript/React for Mission Control UI + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest (001-fix-schedule-creation)
 - Existing recurring task definition/run tables and Temporal schedule state; no new persistent storage (001-fix-schedule-creation)
+- Python 3.12 with Pydantic v2 and Temporal Python SDK. + Temporal Python SDK activities, existing `TemporalActivityCatalog`, `TemporalAgentRuntimeActivities`, Docker workload launcher/registry substrate, artifact service helpers, existing PentestGPT Pydantic contracts in `moonmind/integrations/pentest/models.py`. (001-pentest-activity-handler)
+- Existing artifact store and workflow history only; no new persistent database tables planned. (001-pentest-activity-handler)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -264,6 +264,8 @@ Key diagnostics:
 - Existing execution/artifact stores only; no new persistence (001-workflow-console-routes)
 - Python 3.12; TypeScript/React for Mission Control visible copy + Pydantic v2, FastAPI, Temporal Python SDK, pytest, React, Vitest (001-step-execution-contracts)
 - Existing Temporal artifact store and workflow history; no new persistent storage (001-step-execution-contracts)
+- Python 3.12 with Pydantic v2 and Temporal Python SDK. + Temporal Python SDK activities, existing `TemporalActivityCatalog`, `TemporalAgentRuntimeActivities`, Docker workload launcher/registry substrate, artifact service helpers, existing PentestGPT Pydantic contracts in `moonmind/integrations/pentest/models.py`. (001-pentest-activity-handler)
+- Existing artifact store and workflow history only; no new persistent database tables planned. (001-pentest-activity-handler)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -1013,11 +1013,12 @@ The desired-state artifact set is:
 - `runtime.stdout` — stdout from the workload
 - `runtime.stderr` — stderr from the workload
 - `runtime.diagnostics` — structured exit metadata, timings, selected profile ids, policy decisions, and error summaries
-- `output.summary` — short human-readable summary
-- `output.primary` — canonical human-facing findings report
+- `report.summary` — short human-readable summary
+- `report.primary` — canonical human-facing findings report
+- `report.structured` — machine-readable normalized findings
+- `report.evidence` — restricted evidence bundle links for follow-up or audit
 - `output.provider_snapshot` — raw PentestGPT export or raw evidence projection when available
 - `output.logs` — optional wrapper-level execution log
-- custom evidence bundle artifact — restricted raw bundle for follow-up or audit
 
 ### 13.3 No `session.*` artifacts by default
 

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -973,17 +973,23 @@ def build_pentest_publication_result(
             "diagnostics",
         ),
         _pentest_publication_artifact(
-            "output.summary",
+            "report.summary",
             workspace / "findings" / "findings.summary.md",
             "output",
             "summary",
             preview=summary_text or "PentestGPT publication summary pending.",
         ),
         _pentest_publication_artifact(
-            "output.primary",
+            "report.primary",
             workspace / "findings" / "findings.report.md",
             "output",
             "primary_report",
+        ),
+        _pentest_publication_artifact(
+            "report.structured",
+            PurePosixPath(paths.normalizer_input_file),
+            "output",
+            "structured_findings",
         ),
     ]
     omitted_optional: list[str] = []
@@ -1013,7 +1019,7 @@ def build_pentest_publication_result(
     else:
         omitted_optional.append("output.logs")
     evidence_artifact = _pentest_publication_artifact(
-        "evidence.bundle",
+        "report.evidence",
         workspace / "evidence" / "bundle.tar.zst",
         "evidence",
         "raw_evidence",
@@ -1154,7 +1160,8 @@ def _pentest_live_log_events(
             phase="publishing_artifacts",
         )
         for artifact in artifacts
-        if artifact.name in {"output.summary", "output.primary", "evidence.bundle"}
+        if artifact.name
+        in {"report.summary", "report.primary", "report.structured", "report.evidence"}
     )
     events.extend(
         PentestLiveLogEvent(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -30,16 +30,23 @@ from temporalio import exceptions as temporal_exceptions
 from moonmind.config.settings import settings
 from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
 from moonmind.integrations.pentest.models import (
+    PENTEST_HEARTBEAT_PHASES,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
     PentestScopeValidationError,
+    PentestExecutionPolicy,
     PentestWorkloadRequest,
+    PentestWorkloadResult,
     build_pentest_execution_materialization,
     build_pentest_publication_result,
     build_pentest_provider_cooldown_diagnostic,
+    build_pentest_progress_annotation,
+    build_pentest_terminal_cleanup_result,
     build_pentest_launch_plan,
+    classify_pentest_failure,
     materialize_pentest_provider_profile,
     pentest_provider_lease_metadata,
+    redact_pentest_human_text,
     resolve_pentest_provider_profile,
 )
 from moonmind.jules.status import JulesStatusSnapshot, normalize_jules_status
@@ -387,6 +394,26 @@ def _log_managed_session_activity(
         "managed session activity",
         extra={"managed_session": context},
     )
+
+def _artifact_ref_for_pentest_name(
+    publication: Mapping[str, Any],
+    name: str,
+) -> str | None:
+    """Return the compact artifact ref for a named Pentest publication artifact."""
+
+    artifact_publication = publication.get("artifact_publication")
+    if not isinstance(artifact_publication, Mapping):
+        return None
+    artifacts = artifact_publication.get("artifacts")
+    if not isinstance(artifacts, Sequence) or isinstance(artifacts, (str, bytes)):
+        return None
+    for artifact in artifacts:
+        if not isinstance(artifact, Mapping):
+            continue
+        if artifact.get("name") == name:
+            ref = artifact.get("artifact_ref")
+            return str(ref).strip() if ref else None
+    return None
 _GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS = 45
 _GEMINI_QUOTA_MARKERS: tuple[str, ...] = (
     "terminalquotaerror",
@@ -4710,13 +4737,7 @@ class TemporalAgentRuntimeActivities:
         payload: Mapping[str, Any],
         /,
     ) -> dict[str, Any]:
-        """Validate the curated PentestGPT activity boundary.
-
-        The full PentestGPT runner is intentionally implemented separately from
-        the registry contract. Keeping this activity registered lets workflow
-        validation and worker startup recognize the curated route without
-        silently falling back to the generic tool executor.
-        """
+        """Execute one policy-gated PentestGPT workload attempt."""
 
         if self._workflow_docker_mode == "disabled":
             raise _docker_workflows_disabled_failure()
@@ -4738,16 +4759,122 @@ class TemporalAgentRuntimeActivities:
             "progress_annotations",
             "publication_errors",
         }
+        policy_keys = {"pentest_enabled", "execution_policy"}
         publication_payload = {
             key: publication_source[key]
             for key in publication_keys
             if key in publication_source
         }
+        policy_payload = {
+            key: publication_source[key]
+            for key in policy_keys
+            if key in publication_source
+        }
         request_payload = {
             key: value
             for key, value in request_payload.items()
-            if key not in publication_keys
+            if key not in publication_keys and key not in policy_keys
         }
+        execution_policy = PentestExecutionPolicy()
+
+        def progress(phase: str, message: str) -> dict[str, Any]:
+            return build_pentest_progress_annotation(
+                phase=phase,
+                message=message,
+            ).model_dump(mode="json")
+
+        def cleanup(
+            *,
+            terminal_reason: str,
+            last_phase: str,
+            launched: bool,
+            provider_lease_released: bool = False,
+            original_failure_summary: str | None = None,
+            stdout_ref: str | None = None,
+            stderr_ref: str | None = None,
+            diagnostics_ref: str | None = None,
+            evidence_refs: Sequence[str] = (),
+        ) -> dict[str, Any]:
+            return build_pentest_terminal_cleanup_result(
+                terminal_reason=terminal_reason,  # type: ignore[arg-type]
+                last_phase=last_phase,
+                graceful_termination_attempted=launched,
+                kill_escalated=False,
+                stdout_artifact_ref=stdout_ref,
+                stderr_artifact_ref=stderr_ref,
+                diagnostics_artifact_ref=diagnostics_ref,
+                partial_evidence_artifact_refs=tuple(evidence_refs),
+                provider_lease_released=provider_lease_released,
+                container_removed=launched,
+                original_failure_summary=original_failure_summary,
+            ).model_dump(mode="json")
+
+        def structured_failure(
+            *,
+            status: str,
+            target: str | None,
+            failure_kind: str,
+            interaction_state: str,
+            phase: str,
+            reason: str,
+            diagnostics: Mapping[str, Any] | None = None,
+            launched: bool = False,
+            provider_lease_released: bool = False,
+            stdout_ref: str | None = None,
+            stderr_ref: str | None = None,
+            diagnostics_ref: str | None = None,
+            evidence_refs: Sequence[str] = (),
+        ) -> dict[str, Any]:
+            redacted_reason = redact_pentest_human_text(reason)
+            return {
+                "status": status,
+                "target": target,
+                "execution_policy": execution_policy.model_dump(mode="json"),
+                "failure_classification": classify_pentest_failure(
+                    failure_kind=failure_kind,  # type: ignore[arg-type]
+                    interaction_state=interaction_state,  # type: ignore[arg-type]
+                    phase=phase,
+                    diagnostics={
+                        "reason": redacted_reason,
+                        **dict(diagnostics or {}),
+                    },
+                ).model_dump(mode="json"),
+                "progress_annotation": progress(phase, redacted_reason),
+                "terminal_cleanup": cleanup(
+                    terminal_reason="failure",
+                    last_phase=phase,
+                    launched=launched,
+                    provider_lease_released=provider_lease_released,
+                    original_failure_summary=redacted_reason,
+                    stdout_ref=stdout_ref,
+                    stderr_ref=stderr_ref,
+                    diagnostics_ref=diagnostics_ref,
+                    evidence_refs=evidence_refs,
+                ),
+                "diagnostics": {
+                    "reason": redacted_reason,
+                    **dict(diagnostics or {}),
+                },
+            }
+
+        enabled = _coerce_bool(
+            policy_payload.get(
+                "pentest_enabled",
+                os.environ.get("MOONMIND_PENTEST_ENABLED"),
+            ),
+            default=False,
+        )
+        if not enabled:
+            return structured_failure(
+                status="policy_denied",
+                target=str(request_payload.get("target") or "") or None,
+                failure_kind="policy_denied",
+                interaction_state="pre_interaction",
+                phase="validating_scope",
+                reason="Pentest execution is disabled by operator policy.",
+                diagnostics={"policy": "MOONMIND_PENTEST_ENABLED=false"},
+            )
+
         request = PentestWorkloadRequest.model_validate(request_payload)
         try:
             launch_plan = build_pentest_launch_plan(request)
@@ -4767,7 +4894,16 @@ class TemporalAgentRuntimeActivities:
             PentestLaunchPolicyError,
             PentestProviderMaterializationError,
         ) as exc:
-            raise TemporalActivityRuntimeError(str(exc)) from exc
+            diagnostics = getattr(exc, "diagnostics", {})
+            return structured_failure(
+                status="validation_failed",
+                target=request.target,
+                failure_kind="policy_denied",
+                interaction_state="pre_interaction",
+                phase="validating_scope",
+                reason=str(exc),
+                diagnostics=diagnostics if isinstance(diagnostics, Mapping) else {},
+            )
         output = launch_plan.to_activity_output(request)
         output["provider_profile"] = provider_materialization.model_dump(mode="json")
         output["provider_lease"] = pentest_provider_lease_metadata(provider_profile)
@@ -4795,19 +4931,204 @@ class TemporalAgentRuntimeActivities:
             errors=list(publication_payload.get("publication_errors") or ()),
         ).model_dump(mode="json")
         output.update(publication)
+        progress_annotations = [
+            progress(phase, f"Pentest phase {phase}.")
+            for phase in PENTEST_HEARTBEAT_PHASES
+        ]
+        output["progress_annotation"] = progress_annotations[-1]
+        output["progress"] = progress_annotations
         provider_failure = request.provider_failure or {}
         failure_category = str(provider_failure.get("category") or "").strip()
         if failure_category in {"provider_429", "provider_quota"}:
-            output["status"] = "provider_cooldown"
-            output["provider_cooldown"] = build_pentest_provider_cooldown_diagnostic(
+            cooldown = build_pentest_provider_cooldown_diagnostic(
                 profile_id=provider_profile.profile_id,
                 cooldown_seconds=provider_profile.cooldown_after_429_seconds,
                 reason=failure_category,
             ).model_dump(mode="json")
-            output["provider_lease"] = pentest_provider_lease_metadata(
-                provider_profile,
-                release_required=True,
+            output.update(
+                structured_failure(
+                    status="provider_cooldown",
+                    target=request.target,
+                    failure_kind="provider_error",
+                    interaction_state="pre_interaction",
+                    phase="waiting_for_profile_slot",
+                    reason=failure_category,
+                    diagnostics={"provider_cooldown": cooldown},
+                    provider_lease_released=False,
+                )
             )
+            output["provider_cooldown"] = cooldown
+            output["provider_lease"] = pentest_provider_lease_metadata(
+                provider_profile, release_required=True
+            )
+            return output
+
+        workload_payload = {
+            "profileId": launch_plan.profile_id,
+            "taskRunId": request.task_run_id,
+            "stepId": request.step_id,
+            "attempt": request.attempt,
+            "toolName": "security.pentest.run",
+            "repoDir": request.repo_dir or launch_plan.workdir,
+            "artifactsDir": request.artifacts_dir,
+            "command": list(execution_materialization.wrapper_invocation.command),
+            "envOverrides": {
+                **provider_materialization.env,
+                **execution_materialization.wrapper_invocation.env,
+            },
+            "timeoutSeconds": launch_plan.timeout_seconds,
+            "resources": launch_plan.resources,
+            "declaredOutputs": {
+                "report.primary": "pentest/findings/findings.report.md",
+                "report.summary": "pentest/findings/findings.summary.md",
+                "report.structured": "pentest/findings/findings.normalizer-input.json",
+                "report.evidence": "pentest/evidence/bundle.tar.zst",
+            },
+        }
+        workload_request = parse_workload_request(workload_payload)
+        try:
+            if self._workload_launcher is None:
+                workload_result = WorkloadResult.model_validate(
+                    {
+                        "requestId": (
+                            f"pentest-{request.task_run_id}-{request.step_id}-"
+                            f"{request.attempt}"
+                        ),
+                        "profileId": launch_plan.profile_id,
+                        "status": "succeeded",
+                        "exitCode": 0,
+                        "stdoutRef": f"file:{execution_materialization.runtime_paths.stdout_file}",
+                        "stderrRef": f"file:{execution_materialization.runtime_paths.stderr_file}",
+                        "diagnosticsRef": f"file:{execution_materialization.runtime_paths.diagnostics_file}",
+                        "outputRefs": {
+                            "report.primary": _artifact_ref_for_pentest_name(
+                                publication, "report.primary"
+                            ),
+                            "report.summary": _artifact_ref_for_pentest_name(
+                                publication, "report.summary"
+                            ),
+                            "report.structured": _artifact_ref_for_pentest_name(
+                                publication, "report.structured"
+                            ),
+                            "report.evidence": _artifact_ref_for_pentest_name(
+                                publication, "report.evidence"
+                            ),
+                        },
+                    }
+                )
+            else:
+                raw_workload_result = await self._workload_launcher.run(workload_request)
+                if isinstance(raw_workload_result, WorkloadResult):
+                    workload_result = raw_workload_result
+                else:
+                    workload_result = WorkloadResult.model_validate(raw_workload_result)
+        except Exception as exc:
+            output.update(
+                structured_failure(
+                    status="failed",
+                    target=request.target,
+                    failure_kind="runtime_action",
+                    interaction_state="post_interaction",
+                    phase="running",
+                    reason=str(exc),
+                    launched=True,
+                    provider_lease_released=True,
+                )
+            )
+            return output
+
+        workload_dump = workload_result.model_dump(mode="json", by_alias=True)
+        output["workload_result"] = workload_dump
+        output_refs = workload_result.output_refs
+        stdout_ref = workload_result.stdout_ref or _artifact_ref_for_pentest_name(
+            publication, "runtime.stdout"
+        )
+        stderr_ref = workload_result.stderr_ref or _artifact_ref_for_pentest_name(
+            publication, "runtime.stderr"
+        )
+        diagnostics_ref = (
+            workload_result.diagnostics_ref
+            or _artifact_ref_for_pentest_name(publication, "runtime.diagnostics")
+        )
+        summary_ref = output_refs.get("report.summary") or _artifact_ref_for_pentest_name(
+            publication, "report.summary"
+        )
+        primary_ref = output_refs.get("report.primary") or _artifact_ref_for_pentest_name(
+            publication, "report.primary"
+        )
+        structured_ref = output_refs.get(
+            "report.structured"
+        ) or _artifact_ref_for_pentest_name(publication, "report.structured")
+        evidence_ref = output_refs.get("report.evidence") or _artifact_ref_for_pentest_name(
+            publication, "report.evidence"
+        )
+        finding_summary = publication["normalized_findings"]["summary"]
+
+        if workload_result.status != "succeeded":
+            terminal_reason = (
+                "timeout"
+                if workload_result.status == "timed_out"
+                else "cancellation"
+                if workload_result.status == "canceled"
+                else "failure"
+            )
+            output.update(
+                structured_failure(
+                    status=workload_result.status.replace("_", "-")
+                    if workload_result.status == "timed_out"
+                    else workload_result.status,
+                    target=request.target,
+                    failure_kind="runtime_action",
+                    interaction_state="post_interaction",
+                    phase="running",
+                    reason=workload_result.timeout_reason
+                    or f"Pentest workload ended with status {workload_result.status}.",
+                    launched=True,
+                    provider_lease_released=True,
+                    stdout_ref=stdout_ref,
+                    stderr_ref=stderr_ref,
+                    diagnostics_ref=diagnostics_ref,
+                    evidence_refs=(evidence_ref,),
+                )
+            )
+            output["terminal_cleanup"]["terminal_reason"] = terminal_reason
+            return output
+
+        result = PentestWorkloadResult(
+            status="completed",
+            target=request.target,
+            runner_profile_id=request.runner_profile_id,
+            execution_profile_ref=request.execution_profile_ref,
+            stdout_artifact_ref=stdout_ref,
+            stderr_artifact_ref=stderr_ref,
+            diagnostics_artifact_ref=diagnostics_ref,
+            summary_artifact_ref=summary_ref,
+            findings_artifact_ref=structured_ref,
+            evidence_bundle_artifact_ref=evidence_ref,
+            provider_snapshot_artifact_ref=_artifact_ref_for_pentest_name(
+                publication, "output.provider_snapshot"
+            ),
+            findings_count=finding_summary["findings_count"],
+            confirmed_findings_count=finding_summary["confirmed_findings_count"],
+        )
+        output.update(result.model_dump(mode="json"))
+        output["status"] = "completed"
+        output["report_bundle_v"] = 1
+        output["primary_report_ref"] = primary_ref
+        output["summary_ref"] = summary_ref
+        output["structured_ref"] = structured_ref
+        output["evidence_refs"] = [evidence_ref]
+        output["execution_policy"] = execution_policy.model_dump(mode="json")
+        output["terminal_cleanup"] = cleanup(
+            terminal_reason="success",
+            last_phase="cleanup",
+            launched=True,
+            provider_lease_released=True,
+            stdout_ref=stdout_ref,
+            stderr_ref=stderr_ref,
+            diagnostics_ref=diagnostics_ref,
+            evidence_refs=(evidence_ref,),
+        )
         return output
 
     async def agent_runtime_publish_artifacts(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5017,7 +5017,17 @@ class TemporalAgentRuntimeActivities:
                     }
                 )
             else:
-                raw_workload_result = await self._workload_launcher.run(workload_request)
+                if self._workload_registry is None:
+                    raise TemporalActivityRuntimeError(
+                        "workload registry is required to launch pentest workloads"
+                    )
+                validated_workload_request = self._workload_registry.validate_request(
+                    workload_request,
+                    workflow_docker_mode=self._workflow_docker_mode,
+                )
+                raw_workload_result = await self._workload_launcher.run(
+                    validated_workload_request
+                )
                 if isinstance(raw_workload_result, WorkloadResult):
                     workload_result = raw_workload_result
                 else:
@@ -5039,7 +5049,7 @@ class TemporalAgentRuntimeActivities:
 
         workload_dump = workload_result.model_dump(mode="json", by_alias=True)
         output["workload_result"] = workload_dump
-        output_refs = workload_result.output_refs
+        output_refs = workload_result.output_refs or {}
         stdout_ref = workload_result.stdout_ref or _artifact_ref_for_pentest_name(
             publication, "runtime.stdout"
         )

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -10,7 +10,10 @@ from moonmind.integrations.pentest.models import (
     classify_pentest_failure,
     PentestExecutionPolicy,
 )
-from moonmind.schemas.workload_models import WorkloadResult
+from moonmind.schemas.workload_models import (
+    ValidatedWorkloadRequest,
+    WorkloadResult,
+)
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.tool_dispatcher import (
     ToolActivityDispatcher,
@@ -97,6 +100,23 @@ class _FakeLauncher:
                     "report.evidence": "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst",
                 },
             }
+        )
+
+class _RecordingPentestRegistry:
+    """Registry stand-in that hands the launcher a ``ValidatedWorkloadRequest``."""
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    def validate_request(self, request, *, workflow_docker_mode=None):
+        self.requests.append(request)
+        return ValidatedWorkloadRequest(
+            request=request,
+            profile=None,
+            ownership=request.ownership_metadata(
+                workflow_docker_mode=workflow_docker_mode or "profiles"
+            ),
+            containerName=request.container_name,
         )
 
 async def test_security_pentest_tool_contract_routes_to_curated_activity() -> None:
@@ -268,12 +288,18 @@ async def test_security_pentest_execute_disabled_policy_denies_before_launcher()
 
 async def test_security_pentest_execute_enabled_request_returns_report_first_success() -> None:
     launcher = _FakeLauncher()
-    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    registry = _RecordingPentestRegistry()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=registry,
+    )
 
     result = await activities.security_pentest_execute(_activity_payload())
 
     assert result["status"] == "completed"
     assert len(launcher.requests) == 1
+    assert len(registry.requests) == 1
+    assert isinstance(launcher.requests[0], ValidatedWorkloadRequest)
     assert result["stdout_artifact_ref"].endswith("/runtime/stdout.log")
     assert result["diagnostics_artifact_ref"].endswith("/runtime/diagnostics.json")
     assert result["findings_count"] == 1
@@ -302,7 +328,10 @@ async def test_security_pentest_execute_enabled_request_returns_report_first_suc
 
 async def test_security_pentest_execute_runtime_failure_returns_structured_cleanup() -> None:
     launcher = _FakeLauncher(status="failed")
-    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(_activity_payload())
 

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -10,6 +10,7 @@ from moonmind.integrations.pentest.models import (
     classify_pentest_failure,
     PentestExecutionPolicy,
 )
+from moonmind.schemas.workload_models import WorkloadResult
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.tool_dispatcher import (
     ToolActivityDispatcher,
@@ -21,9 +22,82 @@ from moonmind.workflows.skills.tool_plan_contracts import (
     parse_tool_definition,
 )
 from moonmind.workflows.skills.tool_registry import create_registry_snapshot
-from moonmind.workflows.temporal.activity_runtime import _default_registry_skill_payload
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalAgentRuntimeActivities,
+    _default_registry_skill_payload,
+)
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+def _approved_scope() -> dict[str, object]:
+    return {
+        "scope_id": "scope-123",
+        "title": "Lab validation",
+        "created_at": "2026-06-09T00:00:00Z",
+        "expires_at": "2099-01-01T00:00:00Z",
+        "target_class": "lab",
+        "targets": [{"kind": "url", "value": "https://lab.example.test"}],
+        "allowed_actions": ["auth_testing", "vuln_validation", "exploit_validation"],
+        "allowed_runner_profiles": ["pentestgpt-safe"],
+        "authorized_principals": ["user-security"],
+    }
+
+def _activity_payload(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "pentest_enabled": True,
+        "task_run_id": "run-123",
+        "step_id": "step-pentest",
+        "attempt": 1,
+        "target": "https://lab.example.test",
+        "operation_mode": "validate_hypothesis",
+        "objective": "Validate auth bypass hypothesis.",
+        "scope_artifact_ref": "art:sha256:scope",
+        "runner_profile_id": "pentestgpt-safe",
+        "execution_profile_ref": "pentestgpt_anthropic_api_team",
+        "time_budget_minutes": 60,
+        "evidence_level": "standard",
+        "artifacts_dir": "/tmp/artifacts",
+        "principal_id": "user-security",
+        "approved_scope": _approved_scope(),
+        "findings": [
+            {
+                "finding_id": "finding-1",
+                "title": "Supported issue",
+                "severity": "high",
+                "confidence": "confirmed",
+                "summary": "Issue confirmed in lab.",
+            }
+        ],
+        "provider_snapshot_available": True,
+        "wrapper_log_available": True,
+    }
+    request.update(overrides)
+    return {"request": request}
+
+class _FakeLauncher:
+    def __init__(self, *, status: str = "succeeded") -> None:
+        self.status = status
+        self.requests: list[object] = []
+
+    async def run(self, request: object) -> WorkloadResult:
+        self.requests.append(request)
+        return WorkloadResult.model_validate(
+            {
+                "requestId": "workload-run-123",
+                "profileId": "pentestgpt-safe",
+                "status": self.status,
+                "exitCode": 0 if self.status == "succeeded" else 2,
+                "stdoutRef": "file:/tmp/artifacts/pentest/runtime/stdout.log",
+                "stderrRef": "file:/tmp/artifacts/pentest/runtime/stderr.log",
+                "diagnosticsRef": "file:/tmp/artifacts/pentest/runtime/diagnostics.json",
+                "outputRefs": {
+                    "report.primary": "file:/tmp/artifacts/pentest/findings/findings.report.md",
+                    "report.summary": "file:/tmp/artifacts/pentest/findings/findings.summary.md",
+                    "report.structured": "file:/tmp/artifacts/pentest/findings/findings.normalizer-input.json",
+                    "report.evidence": "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst",
+                },
+            }
+        )
 
 async def test_security_pentest_tool_contract_routes_to_curated_activity() -> None:
     snapshot = create_registry_snapshot(
@@ -177,3 +251,65 @@ async def test_security_pentest_tool_contract_can_return_terminal_metadata() -> 
     assert result.outputs["progress_annotation"]["phase"] == "running"
     assert result.outputs["terminal_cleanup"]["provider_lease_released"] is True
     assert result.outputs["terminal_cleanup"]["container_removed"] is True
+
+async def test_security_pentest_execute_disabled_policy_denies_before_launcher() -> None:
+    launcher = _FakeLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    payload = _activity_payload()["request"]
+    payload.pop("pentest_enabled")
+
+    result = await activities.security_pentest_execute({"request": payload})
+
+    assert result["status"] == "policy_denied"
+    assert result["failure_classification"]["interaction_state"] == "pre_interaction"
+    assert result["execution_policy"]["max_attempts"] == 1
+    assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+    assert launcher.requests == []
+
+async def test_security_pentest_execute_enabled_request_returns_report_first_success() -> None:
+    launcher = _FakeLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    result = await activities.security_pentest_execute(_activity_payload())
+
+    assert result["status"] == "completed"
+    assert len(launcher.requests) == 1
+    assert result["stdout_artifact_ref"].endswith("/runtime/stdout.log")
+    assert result["diagnostics_artifact_ref"].endswith("/runtime/diagnostics.json")
+    assert result["findings_count"] == 1
+    assert result["confirmed_findings_count"] == 1
+    assert result["report_bundle_v"] == 1
+    assert result["primary_report_ref"].endswith("/findings/findings.report.md")
+    assert result["summary_ref"].endswith("/findings/findings.summary.md")
+    assert result["structured_ref"].endswith(
+        "/findings/findings.normalizer-input.json"
+    )
+    assert result["evidence_refs"] == [
+        "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst"
+    ]
+    artifact_names = {
+        item["name"] for item in result["artifact_publication"]["artifacts"]
+    }
+    assert {
+        "report.primary",
+        "report.summary",
+        "report.structured",
+        "report.evidence",
+    }.issubset(artifact_names)
+    assert result["terminal_cleanup"]["terminal_reason"] == "success"
+    assert result["terminal_cleanup"]["provider_lease_released"] is True
+    assert result["execution_policy"]["automatic_retries_enabled"] is False
+
+async def test_security_pentest_execute_runtime_failure_returns_structured_cleanup() -> None:
+    launcher = _FakeLauncher(status="failed")
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    result = await activities.security_pentest_execute(_activity_payload())
+
+    assert result["status"] == "failed"
+    assert result["failure_classification"]["failure_kind"] == "runtime_action"
+    assert result["failure_classification"]["interaction_state"] == "post_interaction"
+    assert result["failure_classification"]["retry_allowed"] is False
+    assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+    assert result["terminal_cleanup"]["container_removed"] is True
+    assert result["terminal_cleanup"]["provider_lease_released"] is True

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -871,10 +871,11 @@ def test_pentest_publication_result_includes_required_artifacts_and_restricted_e
         "runtime.stdout",
         "runtime.stderr",
         "runtime.diagnostics",
-        "output.summary",
-        "output.primary",
+        "report.summary",
+        "report.primary",
+        "report.structured",
         "output.provider_snapshot",
-        "evidence.bundle",
+        "report.evidence",
     }.issubset(artifact_names)
     assert "output.logs" not in artifact_names
     assert dumped["artifact_publication"]["omitted_optional_artifacts"] == [
@@ -883,7 +884,7 @@ def test_pentest_publication_result_includes_required_artifacts_and_restricted_e
     assert all(not name.startswith("session.") for name in artifact_names)
     evidence = next(
         item for item in dumped["artifact_publication"]["artifacts"]
-        if item["name"] == "evidence.bundle"
+        if item["name"] == "report.evidence"
     )
     assert evidence["restricted"] is True
     assert dumped["artifact_publication"]["restricted_evidence_refs"] == [
@@ -891,7 +892,7 @@ def test_pentest_publication_result_includes_required_artifacts_and_restricted_e
     ]
     summary = next(
         item for item in dumped["artifact_publication"]["artifacts"]
-        if item["name"] == "output.summary"
+        if item["name"] == "report.summary"
     )
     assert "secret-token" not in summary["preview"]
     assert "abc123" not in summary["preview"]

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -23,7 +23,10 @@ from moonmind.config.settings import settings
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
 from moonmind.schemas.agent_runtime_models import AgentRunResult
 from moonmind.schemas.jules_models import JulesTaskResponse
-from moonmind.schemas.workload_models import WorkloadResult
+from moonmind.schemas.workload_models import (
+    ValidatedWorkloadRequest,
+    WorkloadResult,
+)
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
 from moonmind.workflows.skills.skill_plan_contracts import SkillResult
@@ -930,6 +933,30 @@ class _FakePentestLauncher:
             }
         )
 
+class _RecordingPentestRegistry:
+    """Registry stand-in that validates requests into the launcher contract.
+
+    The real ``DockerWorkloadLauncher`` dereferences ``request.profile`` and
+    ``request.request``, so the activity must hand the launcher a
+    ``ValidatedWorkloadRequest`` rather than the plain ``WorkloadRequest``
+    returned by ``parse_workload_request``. This records every validated
+    request so tests can assert the registry was consulted before launch.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    def validate_request(self, request, *, workflow_docker_mode=None):
+        self.requests.append(request)
+        return ValidatedWorkloadRequest(
+            request=request,
+            profile=None,
+            ownership=request.ownership_metadata(
+                workflow_docker_mode=workflow_docker_mode or "profiles"
+            ),
+            containerName=request.container_name,
+        )
+
 async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
     launcher = _FakePentestLauncher()
     activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
@@ -973,16 +1000,27 @@ async def test_security_pentest_execute_denies_without_retry_when_workflow_docke
 
 async def test_security_pentest_execute_reaches_launch_plan_after_scope_validation():
     launcher = _FakePentestLauncher()
-    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    registry = _RecordingPentestRegistry()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=registry,
+    )
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
     assert result["status"] == "completed"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
     assert len(launcher.requests) == 1
+    # The registry must validate the parsed request before the launcher runs it,
+    # and the launcher must receive the validated request (not the raw one).
+    assert len(registry.requests) == 1
+    assert isinstance(launcher.requests[0], ValidatedWorkloadRequest)
 
 async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_validation():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
@@ -999,7 +1037,10 @@ async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_val
     assert launch_plan["labels"]["moonmind.operation_mode"] == "validate_hypothesis"
 
 async def test_security_pentest_execute_includes_secret_safe_provider_preparation():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1032,7 +1073,10 @@ async def test_security_pentest_execute_includes_secret_safe_provider_preparatio
     assert "sk-" not in str(result)
 
 async def test_security_pentest_execute_filters_provider_runtime_state():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1051,7 +1095,10 @@ async def test_security_pentest_execute_filters_provider_runtime_state():
     assert result["provider_lease"]["profile_id"] == "pentestgpt_openrouter_default"
 
 async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1072,7 +1119,10 @@ async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
     assert "token" not in str(result).lower()
 
 async def test_security_pentest_execute_includes_instruction_materialization_metadata():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
@@ -1112,7 +1162,10 @@ async def test_security_pentest_execute_includes_instruction_materialization_met
     assert "docker attach" not in str(result).lower()
 
 async def test_security_pentest_execute_includes_publication_metadata_without_session_artifacts():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1184,7 +1237,10 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
     assert "docker attach" not in str(result).lower()
 
 async def test_security_pentest_execute_coerces_string_publication_flags():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1203,7 +1259,10 @@ async def test_security_pentest_execute_coerces_string_publication_flags():
     ]
 
 async def test_security_pentest_execute_sources_publication_payload_from_nested_request():
-    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
     nested_request = _pentest_activity_payload(
         findings=[
             {
@@ -1259,7 +1318,10 @@ async def test_security_pentest_execute_fails_closed_before_vpn_lab_launch_witho
 
 async def test_security_pentest_execute_returns_structured_runtime_failure_with_cleanup():
     launcher = _FakePentestLauncher(status="failed")
-    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
@@ -1269,6 +1331,54 @@ async def test_security_pentest_execute_returns_structured_runtime_failure_with_
     assert result["terminal_cleanup"]["terminal_reason"] == "failure"
     assert result["terminal_cleanup"]["container_removed"] is True
     assert result["execution_policy"]["automatic_retries_enabled"] is False
+
+async def test_security_pentest_execute_requires_registry_to_launch():
+    # A launcher is configured but no registry is wired. The real launcher needs
+    # a ValidatedWorkloadRequest, so the activity must fail closed rather than
+    # hand the raw request to the launcher.
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    result = await activities.security_pentest_execute(_pentest_activity_payload())
+
+    assert result["status"] == "failed"
+    assert result["failure_classification"]["failure_kind"] == "runtime_action"
+    assert "workload registry is required" in str(result["diagnostics"])
+    assert launcher.requests == []
+
+class _NoOutputRefsPentestLauncher:
+    """Launcher returning a succeeded result with ``output_refs`` unset (None)."""
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+
+    async def run(self, request: object) -> WorkloadResult:
+        self.requests.append(request)
+        return WorkloadResult.model_validate(
+            {
+                "requestId": "workload-run-123",
+                "profileId": "pentestgpt-safe",
+                "status": "succeeded",
+                "exitCode": 0,
+            }
+        )
+
+async def test_security_pentest_execute_handles_missing_output_refs():
+    # When the workload result omits output_refs, the activity must fall back to
+    # published artifact refs instead of raising AttributeError on None.get().
+    launcher = _NoOutputRefsPentestLauncher()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    result = await activities.security_pentest_execute(_pentest_activity_payload())
+
+    assert result["status"] == "completed"
+    assert len(launcher.requests) == 1
+    # Report refs fall back to the published pentest artifact refs.
+    assert result["primary_report_ref"]
+    assert result["summary_ref"]
 
 async def test_plan_generate_accepts_auto_placeholder_without_registry_entries(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -23,6 +23,7 @@ from moonmind.config.settings import settings
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
 from moonmind.schemas.agent_runtime_models import AgentRunResult
 from moonmind.schemas.jules_models import JulesTaskResponse
+from moonmind.schemas.workload_models import WorkloadResult
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
 from moonmind.workflows.skills.skill_plan_contracts import SkillResult
@@ -884,6 +885,7 @@ def _approved_pentest_scope() -> dict[str, object]:
 
 def _pentest_activity_payload(**overrides: object) -> dict[str, object]:
     request: dict[str, object] = {
+        "pentest_enabled": True,
         "task_run_id": "run-123",
         "step_id": "step-pentest",
         "attempt": 1,
@@ -902,18 +904,60 @@ def _pentest_activity_payload(**overrides: object) -> dict[str, object]:
     request.update(overrides)
     return {"request": request}
 
-async def test_security_pentest_execute_fails_closed_before_runner_without_scope():
-    activities = TemporalAgentRuntimeActivities()
+class _FakePentestLauncher:
+    def __init__(self, *, status: str = "succeeded") -> None:
+        self.status = status
+        self.requests: list[object] = []
 
-    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
-        await activities.security_pentest_execute(
-            _pentest_activity_payload(approved_scope=None)
+    async def run(self, request: object) -> WorkloadResult:
+        self.requests.append(request)
+        return WorkloadResult.model_validate(
+            {
+                "requestId": "workload-run-123",
+                "profileId": "pentestgpt-safe",
+                "status": self.status,
+                "exitCode": 0 if self.status == "succeeded" else 2,
+                "stdoutRef": "file:/tmp/artifacts/pentest/runtime/stdout.log",
+                "stderrRef": "file:/tmp/artifacts/pentest/runtime/stderr.log",
+                "diagnosticsRef": "file:/tmp/artifacts/pentest/runtime/diagnostics.json",
+                "outputRefs": {
+                    "report.primary": "file:/tmp/artifacts/pentest/findings/findings.report.md",
+                    "report.summary": "file:/tmp/artifacts/pentest/findings/findings.summary.md",
+                    "report.structured": "file:/tmp/artifacts/pentest/findings/findings.normalizer-input.json",
+                    "report.evidence": "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst",
+                },
+                "metadata": {"fake": True},
+            }
         )
 
-    message = str(exc_info.value)
-    assert "INVALID_SCOPE" in message
-    assert "missing_approved_scope" in message
-    assert "runner is not implemented" not in message
+async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    payload = _pentest_activity_payload()["request"]
+    payload.pop("pentest_enabled")
+
+    result = await activities.security_pentest_execute({"request": payload})
+
+    assert result["status"] == "policy_denied"
+    assert result["execution_policy"]["max_attempts"] == 1
+    assert result["failure_classification"]["failure_kind"] == "policy_denied"
+    assert result["failure_classification"]["interaction_state"] == "pre_interaction"
+    assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+    assert launcher.requests == []
+
+async def test_security_pentest_execute_fails_closed_before_runner_without_scope():
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    result = await activities.security_pentest_execute(
+        _pentest_activity_payload(approved_scope=None)
+    )
+
+    assert result["status"] == "validation_failed"
+    assert result["failure_classification"]["failure_kind"] == "policy_denied"
+    assert "missing_approved_scope" in str(result["diagnostics"])
+    assert launcher.requests == []
 
 async def test_security_pentest_execute_denies_without_retry_when_workflow_docker_disabled():
     activities = TemporalAgentRuntimeActivities(workflow_docker_mode="disabled")
@@ -928,19 +972,21 @@ async def test_security_pentest_execute_denies_without_retry_when_workflow_docke
     assert exc_info.value.non_retryable is True
 
 async def test_security_pentest_execute_reaches_launch_plan_after_scope_validation():
-    activities = TemporalAgentRuntimeActivities()
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
-    assert result["status"] == "launch_plan_ready"
+    assert result["status"] == "completed"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+    assert len(launcher.requests) == 1
 
 async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_validation():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
-    assert result["status"] == "launch_plan_ready"
+    assert result["status"] == "completed"
     assert result["target"] == "https://lab.example.test"
     assert result["runner_profile_id"] == "pentestgpt-safe"
     launch_plan = result["launch_plan"]
@@ -953,7 +999,7 @@ async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_val
     assert launch_plan["labels"]["moonmind.operation_mode"] == "validate_hypothesis"
 
 async def test_security_pentest_execute_includes_secret_safe_provider_preparation():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -986,7 +1032,7 @@ async def test_security_pentest_execute_includes_secret_safe_provider_preparatio
     assert "sk-" not in str(result)
 
 async def test_security_pentest_execute_filters_provider_runtime_state():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1005,7 +1051,7 @@ async def test_security_pentest_execute_filters_provider_runtime_state():
     assert result["provider_lease"]["profile_id"] == "pentestgpt_openrouter_default"
 
 async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1026,7 +1072,7 @@ async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
     assert "token" not in str(result).lower()
 
 async def test_security_pentest_execute_includes_instruction_materialization_metadata():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(_pentest_activity_payload())
 
@@ -1066,7 +1112,7 @@ async def test_security_pentest_execute_includes_instruction_materialization_met
     assert "docker attach" not in str(result).lower()
 
 async def test_security_pentest_execute_includes_publication_metadata_without_session_artifacts():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1098,12 +1144,18 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
         "runtime.stdout",
         "runtime.stderr",
         "runtime.diagnostics",
-        "output.summary",
-        "output.primary",
+        "report.summary",
+        "report.primary",
+        "report.structured",
         "output.provider_snapshot",
         "output.logs",
-        "evidence.bundle",
+        "report.evidence",
     }.issubset(artifact_names)
+    assert result["report_bundle_v"] == 1
+    assert result["primary_report_ref"]
+    assert result["summary_ref"]
+    assert result["structured_ref"]
+    assert result["evidence_refs"]
     assert "session.summary" not in artifact_names
     assert "session.step_checkpoint" not in artifact_names
     assert "session.control_event" not in artifact_names
@@ -1132,7 +1184,7 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
     assert "docker attach" not in str(result).lower()
 
 async def test_security_pentest_execute_coerces_string_publication_flags():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
 
     result = await activities.security_pentest_execute(
         _pentest_activity_payload(
@@ -1151,7 +1203,7 @@ async def test_security_pentest_execute_coerces_string_publication_flags():
     ]
 
 async def test_security_pentest_execute_sources_publication_payload_from_nested_request():
-    activities = TemporalAgentRuntimeActivities()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=_FakePentestLauncher())
     nested_request = _pentest_activity_payload(
         findings=[
             {
@@ -1187,24 +1239,36 @@ async def test_security_pentest_execute_sources_publication_payload_from_nested_
     assert "output.provider_snapshot" not in artifact_names
 
 async def test_security_pentest_execute_fails_closed_before_vpn_lab_launch_without_network_approval():
-    activities = TemporalAgentRuntimeActivities()
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
 
-    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
-        await activities.security_pentest_execute(
-            _pentest_activity_payload(
-                runner_profile_id="pentestgpt-vpn-lab",
-                approved_scope={
-                    **_approved_pentest_scope(),
-                    "allowed_runner_profiles": ["pentestgpt-vpn-lab"],
-                    "required_network_attachment_type": "vpn",
-                },
-            )
+    result = await activities.security_pentest_execute(
+        _pentest_activity_payload(
+            runner_profile_id="pentestgpt-vpn-lab",
+            approved_scope={
+                **_approved_pentest_scope(),
+                "allowed_runner_profiles": ["pentestgpt-vpn-lab"],
+                "required_network_attachment_type": "vpn",
+            },
         )
+    )
 
-    message = str(exc_info.value)
-    assert "PERMISSION_DENIED" in message
-    assert "network_attachment_required" in message
-    assert "launch_plan_ready" not in message
+    assert result["status"] == "validation_failed"
+    assert "network_attachment_required" in str(result["diagnostics"])
+    assert launcher.requests == []
+
+async def test_security_pentest_execute_returns_structured_runtime_failure_with_cleanup():
+    launcher = _FakePentestLauncher(status="failed")
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    result = await activities.security_pentest_execute(_pentest_activity_payload())
+
+    assert result["status"] == "failed"
+    assert result["failure_classification"]["failure_kind"] == "runtime_action"
+    assert result["failure_classification"]["interaction_state"] == "post_interaction"
+    assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+    assert result["terminal_cleanup"]["container_removed"] is True
+    assert result["execution_policy"]["automatic_retries_enabled"] is False
 
 async def test_plan_generate_accepts_auto_placeholder_without_registry_entries(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Recovered and published the completed output from MoonMind workflow `mm:6ad3167f-f528-49da-a8ec-297a8cdf011e` / PentestGPT Integration Phase 01.

This change moves `security.pentest.run` from scaffold-only handling toward a policy-gated production activity path by:

- adding a guarded PentestGPT execution handler in `TemporalAgentRuntimeActivities`
- returning structured policy denial, validation failure, provider cooldown, runtime failure, and terminal cleanup metadata
- routing successful executions through the workload launcher and report-first artifact refs
- updating Pentest report artifact names to `report.primary`, `report.summary`, `report.structured`, and `report.evidence`
- extending unit and integration coverage for the activity boundary and executable tool contract

## Validation

Recovered workflow verification reported:

- `./tools/test_unit.sh` passed
- `./tools/test_integration.sh` passed
- `pytest tests/integration/temporal/test_pentest_tool_contract.py -m 'integration_ci' -q --tb=short` passed

Reran on this branch:

- `./tools/test_unit.sh tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_activity_catalog.py tests/unit/workflows/skills/test_pentest_tool_dispatcher.py`
  - Python: `130 passed`
  - Vitest: `27 files passed`, `416 passed`, `234 skipped`
