### PR TITLE
[codex] Load approved pentest scope artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,8 @@ Key diagnostics:
 - Existing Temporal artifact store and workflow history; no new persistent storage (001-step-execution-contracts)
 - Python 3.12 target per repo instructions; TypeScript/React for Mission Control UI + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, React, TanStack Query, Zod, Vitest, Testing Library, pytest (001-fix-schedule-creation)
 - Existing recurring task definition/run tables and Temporal schedule state; no new persistent storage (001-fix-schedule-creation)
+- Python 3.12 with Pydantic v2 models + Temporal Python SDK activity runtime, FastAPI/MCP executable-tool registry, SQLAlchemy-backed Temporal artifact service, existing Docker workload launcher/registry contracts (001-load-pentest-scope-artifact)
+- Existing Temporal artifact metadata/content store only; no new persistent tables (001-load-pentest-scope-artifact)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -264,6 +264,8 @@ Key diagnostics:
 - Existing execution/artifact stores only; no new persistence (001-workflow-console-routes)
 - Python 3.12; TypeScript/React for Mission Control visible copy + Pydantic v2, FastAPI, Temporal Python SDK, pytest, React, Vitest (001-step-execution-contracts)
 - Existing Temporal artifact store and workflow history; no new persistent storage (001-step-execution-contracts)
+- Python 3.12 with Pydantic v2 models + Temporal Python SDK activity runtime, FastAPI/MCP executable-tool registry, SQLAlchemy-backed Temporal artifact service, existing Docker workload launcher/registry contracts (001-load-pentest-scope-artifact)
+- Existing Temporal artifact metadata/content store only; no new persistent tables (001-load-pentest-scope-artifact)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -1937,7 +1937,7 @@ def validate_authorized_scope_for_request(
         )
 
     ambiguity_markers = {
-        str(scope.metadata.get(key) or "").strip().lower()
+        str((scope.metadata or {}).get(key) or "").strip().lower()
         for key in (
             "idempotency_safety",
             "prior_interaction_state",

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -378,7 +378,7 @@ class PentestWorkloadRequest(PentestBaseModel):
     target: str = Field(..., min_length=1)
     operation_mode: PentestOperationMode
     objective: str | None = None
-    scope_artifact_ref: str = Field(..., min_length=1)
+    scope_artifact_ref: str | None = None
     runner_profile_id: str = Field(..., min_length=1)
     execution_profile_ref: str | None = None
     provider_selector: PentestProviderSelector | None = None
@@ -392,10 +392,13 @@ class PentestWorkloadRequest(PentestBaseModel):
     network_attachment_ref: str | None = None
     principal_id: str | None = None
     approved_scope: PentestApprovedScope | None = None
+    scope_artifact_loaded: bool = False
+    trusted_internal_execution: bool = False
     provider_failure: dict[str, Any] | None = None
 
     @field_validator(
         "objective",
+        "scope_artifact_ref",
         "execution_profile_ref",
         "repo_dir",
         "network_attachment_ref",
@@ -1870,6 +1873,17 @@ def validate_authorized_scope_for_request(
 
     checked_at = now or datetime.now(UTC)
     scope = request.approved_scope
+    if (
+        scope is not None
+        and not request.trusted_internal_execution
+        and not request.scope_artifact_loaded
+    ):
+        _raise_scope_error(
+            request,
+            scope,
+            "INVALID_SCOPE",
+            "inline_scope_requires_trusted_internal_execution",
+        )
     if scope is None:
         _raise_scope_error(request, None, "INVALID_SCOPE", "missing_approved_scope")
 
@@ -1882,31 +1896,31 @@ def validate_authorized_scope_for_request(
         _raise_scope_error(request, scope, "INVALID_SCOPE", "scope_expired")
 
     if not any(_target_matches_scope(request.target, item) for item in scope.targets):
-        _raise_scope_error(request, scope, "INVALID_SCOPE", "target_outside_scope")
+        _raise_scope_error(request, scope, "UNAPPROVED_TARGET", "target_outside_scope")
 
     if request.runner_profile_id not in set(scope.allowed_runner_profiles):
         _raise_scope_error(
-            request, scope, "PERMISSION_DENIED", "runner_profile_not_allowed"
+            request, scope, "UNSUPPORTED_PROFILE", "runner_profile_not_allowed"
         )
 
     allowed_actions = frozenset(scope.allowed_actions)
     mode_actions = _MODE_ACTIONS[request.operation_mode]
     if not mode_actions.issubset(allowed_actions):
         _raise_scope_error(
-            request, scope, "INVALID_SCOPE", "operation_mode_not_allowed"
+            request, scope, "UNSUPPORTED_PROFILE", "operation_mode_not_allowed"
         )
     if mode_actions & frozenset(scope.prohibited_actions):
         _raise_scope_error(
-            request, scope, "INVALID_SCOPE", "operation_mode_prohibited"
+            request, scope, "UNSUPPORTED_PROFILE", "operation_mode_prohibited"
         )
 
     if scope.required_network_attachment_type and not request.network_attachment_ref:
         _raise_scope_error(
-            request, scope, "PERMISSION_DENIED", "network_attachment_required"
+            request, scope, "UNSUPPORTED_PROFILE", "network_attachment_required"
         )
     if not scope.required_network_attachment_type and request.network_attachment_ref:
         _raise_scope_error(
-            request, scope, "PERMISSION_DENIED", "network_attachment_not_allowed"
+            request, scope, "UNSUPPORTED_PROFILE", "network_attachment_not_allowed"
         )
 
     if (
@@ -1920,6 +1934,24 @@ def validate_authorized_scope_for_request(
     if scope.requires_manual_approval and not scope.approval_recorded:
         _raise_scope_error(
             request, scope, "UNAPPROVED_TARGET", "manual_approval_required"
+        )
+
+    ambiguity_markers = {
+        str(scope.metadata.get(key) or "").strip().lower()
+        for key in (
+            "idempotency_safety",
+            "prior_interaction_state",
+            "policy_clarity",
+            "approval_clarity",
+            "network_authorization",
+        )
+    }
+    if ambiguity_markers & {"ambiguous", "unknown", "unclear"}:
+        _raise_scope_error(
+            request,
+            scope,
+            "NON_IDEMPOTENT_OPERATION",
+            "idempotency_safety_ambiguous",
         )
 
 def _normalize_target(value: str) -> str:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -30,6 +30,7 @@ from temporalio import exceptions as temporal_exceptions
 from moonmind.config.settings import settings
 from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
 from moonmind.integrations.pentest.models import (
+    PentestApprovedScope,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
     PentestScopeValidationError,
@@ -149,6 +150,7 @@ from moonmind.workflows.temporal.artifacts import (
     ArtifactRef,
     ArtifactUploadDescriptor,
     ExecutionRef,
+    TemporalArtifactError,
     TemporalArtifactService,
     build_artifact_ref,
 )
@@ -4236,6 +4238,68 @@ class TemporalAgentRuntimeActivities:
         self._client_adapter = client_adapter
         self._supervision_tasks: set[asyncio.Task] = set()
 
+    @staticmethod
+    def _pentest_scope_artifact_id(scope_artifact_ref: object) -> str:
+        if isinstance(scope_artifact_ref, Mapping):
+            artifact_id = str(scope_artifact_ref.get("artifact_id") or "").strip()
+        else:
+            artifact_id = str(scope_artifact_ref or "").strip()
+        if not artifact_id:
+            raise PentestScopeValidationError(
+                error_code="INVALID_SCOPE",
+                reasons=("scope_artifact_ref_required",),
+                diagnostics={"scope_artifact_ref": None},
+            )
+        return artifact_id
+
+    async def _load_pentest_approved_scope(
+        self,
+        request_payload: Mapping[str, Any],
+    ) -> PentestApprovedScope:
+        if self._artifact_service is None:
+            raise PentestScopeValidationError(
+                error_code="INVALID_SCOPE",
+                reasons=("scope_artifact_service_unavailable",),
+                diagnostics={"scope_artifact_ref": request_payload.get("scope_artifact_ref")},
+            )
+        artifact_id = self._pentest_scope_artifact_id(
+            request_payload.get("scope_artifact_ref")
+        )
+        principal = str(
+            request_payload.get("principal_id")
+            or request_payload.get("task_run_id")
+            or "workflow"
+        ).strip()
+        try:
+            _artifact, payload = await self._artifact_service.read(
+                artifact_id=artifact_id,
+                principal=principal,
+            )
+        except TemporalArtifactError as exc:
+            raise PentestScopeValidationError(
+                error_code="INVALID_SCOPE",
+                reasons=("scope_artifact_unreadable",),
+                diagnostics={"scope_artifact_ref": artifact_id},
+            ) from exc
+        try:
+            decoded = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PentestScopeValidationError(
+                error_code="INVALID_SCOPE",
+                reasons=("scope_artifact_malformed",),
+                diagnostics={"scope_artifact_ref": artifact_id},
+            ) from exc
+        try:
+            return PentestApprovedScope.model_validate(decoded)
+        except ValidationError as exc:
+            raise PentestScopeValidationError(
+                error_code="INVALID_SCOPE",
+                reasons=("scope_artifact_invalid",),
+                diagnostics={
+                    "scope_artifact_ref": artifact_id,
+                    "error_count": exc.error_count(),
+                },
+            ) from exc
     async def execution_notify_completion(
         self,
         request: Any = None,
@@ -4748,8 +4812,36 @@ class TemporalAgentRuntimeActivities:
             for key, value in request_payload.items()
             if key not in publication_keys
         }
-        request = PentestWorkloadRequest.model_validate(request_payload)
         try:
+            trusted_internal_execution = _coerce_bool(
+                request_payload.get("trusted_internal_execution"),
+                default=False,
+            )
+            if trusted_internal_execution:
+                request_payload["trusted_internal_execution"] = True
+                if not request_payload.get("scope_artifact_ref"):
+                    request_payload["scope_artifact_ref"] = (
+                        "trusted-internal-inline-scope"
+                    )
+            else:
+                if request_payload.get("approved_scope") is not None:
+                    raise PentestScopeValidationError(
+                        error_code="INVALID_SCOPE",
+                        reasons=("inline_scope_requires_trusted_internal_execution",),
+                        diagnostics={
+                            "scope_artifact_ref": request_payload.get(
+                                "scope_artifact_ref"
+                            ),
+                        },
+                    )
+                approved_scope = await self._load_pentest_approved_scope(
+                    request_payload
+                )
+                request_payload["approved_scope"] = approved_scope.model_dump(
+                    mode="json"
+                )
+                request_payload["scope_artifact_loaded"] = True
+            request = PentestWorkloadRequest.model_validate(request_payload)
             launch_plan = build_pentest_launch_plan(request)
             provider_profile = resolve_pentest_provider_profile(
                 execution_profile_ref=request.execution_profile_ref,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4240,7 +4240,9 @@ class TemporalAgentRuntimeActivities:
 
     @staticmethod
     def _pentest_scope_artifact_id(scope_artifact_ref: object) -> str:
-        if isinstance(scope_artifact_ref, Mapping):
+        if isinstance(scope_artifact_ref, ArtifactRef):
+            artifact_id = str(scope_artifact_ref.artifact_id or "").strip()
+        elif isinstance(scope_artifact_ref, Mapping):
             artifact_id = str(scope_artifact_ref.get("artifact_id") or "").strip()
         else:
             artifact_id = str(scope_artifact_ref or "").strip()
@@ -4774,7 +4776,43 @@ class TemporalAgentRuntimeActivities:
         payload: Mapping[str, Any],
         /,
     ) -> dict[str, Any]:
-        """Validate the curated PentestGPT activity boundary.
+        """Registry-dispatched PentestGPT activity boundary (untrusted input).
+
+        This is the entrypoint bound to the ``security.pentest.execute``
+        activity type, so its payload may originate from a caller-supplied
+        plan. The trusted/internal decision is therefore derived from the
+        entrypoint (here, always untrusted) rather than from request inputs:
+        an inline ``approved_scope`` is rejected and the scope is always loaded
+        from the artifact store. Trusted internal callers must use
+        :meth:`_security_pentest_execute_trusted_internal` instead.
+        """
+
+        return await self._run_security_pentest(payload, trusted_internal=False)
+
+    async def _security_pentest_execute_trusted_internal(
+        self,
+        payload: Mapping[str, Any],
+        /,
+    ) -> dict[str, Any]:
+        """Internal entrypoint that may honor an inline ``approved_scope``.
+
+        This method is intentionally **not** registered in
+        ``_ACTIVITY_HANDLER_ATTRS``, so it cannot be reached through
+        registry/plan dispatch. The trusted decision comes from the fact that
+        only trusted workflow-internal code can call this entrypoint, never
+        from a ``trusted_internal_execution`` flag in the request payload.
+        """
+
+        return await self._run_security_pentest(payload, trusted_internal=True)
+
+    async def _run_security_pentest(
+        self,
+        payload: Mapping[str, Any],
+        /,
+        *,
+        trusted_internal: bool,
+    ) -> dict[str, Any]:
+        """Shared PentestGPT activity body.
 
         The full PentestGPT runner is intentionally implemented separately from
         the registry contract. Keeping this activity registered lets workflow
@@ -4813,17 +4851,18 @@ class TemporalAgentRuntimeActivities:
             if key not in publication_keys
         }
         try:
-            trusted_internal_execution = _coerce_bool(
-                request_payload.get("trusted_internal_execution"),
-                default=False,
-            )
-            if trusted_internal_execution:
+            if trusted_internal:
                 request_payload["trusted_internal_execution"] = True
                 if not request_payload.get("scope_artifact_ref"):
                     request_payload["scope_artifact_ref"] = (
                         "trusted-internal-inline-scope"
                     )
             else:
+                # Untrusted callers can never assert trusted-internal execution
+                # or supply their own inline scope, regardless of what the
+                # request payload claims. Drop any caller-supplied trust flag
+                # and require an artifact-backed approved scope.
+                request_payload.pop("trusted_internal_execution", None)
                 if request_payload.get("approved_scope") is not None:
                     raise PentestScopeValidationError(
                         error_code="INVALID_SCOPE",

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
 import pytest
 
 from moonmind.integrations.pentest.models import (
@@ -21,9 +25,78 @@ from moonmind.workflows.skills.tool_plan_contracts import (
     parse_tool_definition,
 )
 from moonmind.workflows.skills.tool_registry import create_registry_snapshot
-from moonmind.workflows.temporal.activity_runtime import _default_registry_skill_payload
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalActivityRuntimeError,
+    TemporalAgentRuntimeActivities,
+    _default_registry_skill_payload,
+)
+from moonmind.workflows.temporal.artifacts import TemporalArtifactNotFoundError
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+def _approved_scope_payload(**overrides: object) -> dict[str, object]:
+    now = datetime.now(timezone.utc)
+    payload: dict[str, object] = {
+        "scope_id": "scope-123",
+        "title": "Lab validation",
+        "owner_user_id": "user-security",
+        "created_at": (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        "target_class": "lab",
+        "targets": [{"kind": "url", "value": "https://lab.example.test"}],
+        "allowed_actions": [
+            "auth_testing",
+            "vuln_validation",
+            "exploit_validation",
+        ],
+        "prohibited_actions": [],
+        "requires_manual_approval": False,
+        "approval_recorded": False,
+        "allowed_runner_profiles": ["pentestgpt-safe"],
+        "required_network_attachment_type": None,
+        "authorized_principals": ["user-security"],
+        "metadata": {"jira": "MM-470"},
+    }
+    payload.update(overrides)
+    return payload
+
+def _pentest_execute_payload(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "task_run_id": "run-123",
+        "step_id": "step-pentest",
+        "attempt": 1,
+        "target": "https://lab.example.test",
+        "operation_mode": "validate_hypothesis",
+        "scope_artifact_ref": "art_scope_valid",
+        "runner_profile_id": "pentestgpt-safe",
+        "execution_profile_ref": "pentestgpt_anthropic_api_team",
+        "time_budget_minutes": 60,
+        "evidence_level": "standard",
+        "artifacts_dir": "/tmp/artifacts",
+        "principal_id": "user-security",
+    }
+    request.update(overrides)
+    return {"request": request}
+
+class _FakeArtifactService:
+    def __init__(self, artifacts: dict[str, bytes]) -> None:
+        self.artifacts = artifacts
+        self.read_count = 0
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool = False,
+    ) -> tuple[object, bytes]:
+        self.read_count += 1
+        if artifact_id not in self.artifacts:
+            raise TemporalArtifactNotFoundError(artifact_id)
+        return SimpleNamespace(artifact_id=artifact_id), self.artifacts[artifact_id]
+
+def _scope_bytes(**overrides: object) -> bytes:
+    return json.dumps(_approved_scope_payload(**overrides)).encode("utf-8")
 
 async def test_security_pentest_tool_contract_routes_to_curated_activity() -> None:
     snapshot = create_registry_snapshot(
@@ -95,6 +168,118 @@ async def test_security_pentest_tool_contract_routes_to_curated_activity() -> No
     ]
     assert result.outputs["summary_artifact_ref"] == "art:sha256:summary"
     assert result.outputs["confirmed_findings_count"] == 1
+
+async def test_security_pentest_execute_accepts_valid_artifact_backed_scope() -> None:
+    artifact_service = _FakeArtifactService({"art_scope_valid": _scope_bytes()})
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    result = await activities.security_pentest_execute(_pentest_execute_payload())
+
+    assert artifact_service.read_count == 1
+    assert result["status"] == "launch_plan_ready"
+    assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+
+@pytest.mark.parametrize(
+    ("artifact_payload", "request_overrides", "error_code", "reason"),
+    [
+        (
+            None,
+            {"scope_artifact_ref": "art_scope_missing"},
+            "INVALID_SCOPE",
+            "scope_artifact_unreadable",
+        ),
+        (
+            b"{bad-json",
+            {"scope_artifact_ref": "art_scope_valid"},
+            "INVALID_SCOPE",
+            "scope_artifact_malformed",
+        ),
+        (_scope_bytes(expires_at="2020-01-01T00:00:00Z"), {}, "INVALID_SCOPE", "scope_expired"),
+        (
+            _scope_bytes(),
+            {"principal_id": "user-other"},
+            "PERMISSION_DENIED",
+            "principal_not_authorized",
+        ),
+        (
+            _scope_bytes(targets=[{"kind": "url", "value": "https://other.example.test"}]),
+            {},
+            "UNAPPROVED_TARGET",
+            "target_outside_scope",
+        ),
+        (
+            _scope_bytes(allowed_runner_profiles=["pentestgpt-vpn-lab"]),
+            {},
+            "UNSUPPORTED_PROFILE",
+            "runner_profile_not_allowed",
+        ),
+        (
+            _scope_bytes(allowed_actions=["auth_testing"]),
+            {},
+            "UNSUPPORTED_PROFILE",
+            "operation_mode_not_allowed",
+        ),
+        (
+            _scope_bytes(metadata={"idempotency_safety": "ambiguous"}),
+            {},
+            "NON_IDEMPOTENT_OPERATION",
+            "idempotency_safety_ambiguous",
+        ),
+    ],
+)
+async def test_security_pentest_execute_fails_closed_before_provider_or_workload_side_effects(
+    artifact_payload: bytes | None,
+    request_overrides: dict[str, object],
+    error_code: str,
+    reason: str,
+) -> None:
+    artifacts = {} if artifact_payload is None else {"art_scope_valid": artifact_payload}
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakeArtifactService(artifacts)
+    )
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_execute_payload(**request_overrides)
+        )
+
+    message = str(exc_info.value)
+    assert error_code in message
+    assert reason in message
+    assert "provider_profile" not in message
+    assert "provider_lease" not in message
+    assert "launch_plan_ready" not in message
+
+async def test_security_pentest_execute_rejects_ordinary_inline_scope() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_execute_payload(
+                scope_artifact_ref="",
+                approved_scope=_approved_scope_payload(),
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "INVALID_SCOPE" in message
+    assert (
+        "inline_scope_requires_trusted_internal_execution" in message
+        or "scope_artifact_ref" in message
+    )
+
+async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.security_pentest_execute(
+        _pentest_execute_payload(
+            scope_artifact_ref=None,
+            approved_scope=_approved_scope_payload(),
+            trusted_internal_execution=True,
+        )
+    )
+
+    assert result["status"] == "launch_plan_ready"
 
 async def test_security_pentest_tool_contract_can_return_terminal_metadata() -> None:
     snapshot = create_registry_snapshot(

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -271,7 +271,7 @@ async def test_security_pentest_execute_rejects_ordinary_inline_scope() -> None:
 async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -> None:
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_execute_payload(
             scope_artifact_ref=None,
             approved_scope=_approved_scope_payload(),
@@ -280,6 +280,28 @@ async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -
     )
 
     assert result["status"] == "launch_plan_ready"
+
+
+async def test_security_pentest_execute_rejects_caller_supplied_trust_flag() -> None:
+    """The registry-dispatched activity must not honor request-supplied trust."""
+
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_execute_payload(
+                scope_artifact_ref=None,
+                approved_scope=_approved_scope_payload(),
+                trusted_internal_execution=True,
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "INVALID_SCOPE" in message
+    assert (
+        "inline_scope_requires_trusted_internal_execution" in message
+        or "scope_artifact_ref" in message
+    )
 
 async def test_security_pentest_tool_contract_can_return_terminal_metadata() -> None:
     snapshot = create_registry_snapshot(

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from moonmind.integrations.pentest.models import (
     PENTEST_TOOL_NAME,
     PENTEST_HEARTBEAT_PHASES,
+    PentestApprovedScope,
     PentestExecutionPolicy,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
@@ -55,6 +56,16 @@ def _valid_request_payload() -> dict[str, object]:
         "principal_id": "user-security",
     }
 
+def _request_with_scope(
+    *,
+    request_overrides: dict[str, object] | None = None,
+    scope_overrides: dict[str, object] | None = None,
+) -> PentestWorkloadRequest:
+    payload = _valid_request_payload()
+    payload["approved_scope"] = _approved_scope_payload(**(scope_overrides or {}))
+    payload.update(request_overrides or {})
+    return PentestWorkloadRequest.model_validate(payload)
+
 def _approved_scope_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
         "scope_id": "scope-123",
@@ -89,6 +100,32 @@ def test_pentest_workload_request_accepts_canonical_payload() -> None:
     assert request.time_budget_minutes == 60
     assert request.evidence_level == "standard"
     assert request.principal_id == "user-security"
+
+def test_pentest_workload_request_rejects_ordinary_inline_scope() -> None:
+    request = _request_with_scope()
+
+    with pytest.raises(PentestScopeValidationError) as exc_info:
+        validate_authorized_scope_for_request(
+            request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+        )
+
+    assert exc_info.value.error_code == "INVALID_SCOPE"
+    assert "inline_scope_requires_trusted_internal_execution" in exc_info.value.reasons
+
+def test_pentest_workload_request_allows_trusted_internal_inline_scope() -> None:
+    payload = _valid_request_payload()
+    payload.pop("scope_artifact_ref")
+    payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
+    request = PentestWorkloadRequest.model_validate(payload)
+
+    validate_authorized_scope_for_request(
+        request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+    )
+
+    assert request.approved_scope == PentestApprovedScope.model_validate(
+        _approved_scope_payload()
+    )
 
 def test_pentest_workload_request_defaults_and_provider_selector() -> None:
     payload = _valid_request_payload()
@@ -134,6 +171,7 @@ def test_pentest_workload_request_rejects_invalid_values(
 def test_pentest_scope_validation_accepts_authorized_scope() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     validate_authorized_scope_for_request(
@@ -153,37 +191,37 @@ def test_pentest_scope_validation_accepts_authorized_scope() -> None:
         (
             {},
             {"targets": [{"kind": "url", "value": "https://other.example.test"}]},
-            "INVALID_SCOPE",
+            "UNAPPROVED_TARGET",
             "target_outside_scope",
         ),
         (
             {},
             {"allowed_runner_profiles": ["pentestgpt-vpn-lab"]},
-            "PERMISSION_DENIED",
+            "UNSUPPORTED_PROFILE",
             "runner_profile_not_allowed",
         ),
         (
             {},
             {"allowed_actions": ["auth_testing", "vuln_validation"]},
-            "INVALID_SCOPE",
+            "UNSUPPORTED_PROFILE",
             "operation_mode_not_allowed",
         ),
         (
             {},
             {"prohibited_actions": ["exploit_validation"]},
-            "INVALID_SCOPE",
+            "UNSUPPORTED_PROFILE",
             "operation_mode_prohibited",
         ),
         (
             {"network_attachment_ref": None},
             {"required_network_attachment_type": "vpn"},
-            "PERMISSION_DENIED",
+            "UNSUPPORTED_PROFILE",
             "network_attachment_required",
         ),
         (
             {"network_attachment_ref": "net:vpn:unexpected"},
             {"required_network_attachment_type": None},
-            "PERMISSION_DENIED",
+            "UNSUPPORTED_PROFILE",
             "network_attachment_not_allowed",
         ),
         (
@@ -208,6 +246,7 @@ def test_pentest_scope_validation_fails_closed(
 ) -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload(**scope_overrides)
+    payload["trusted_internal_execution"] = True
     payload.update(mutate_request)
     request = PentestWorkloadRequest.model_validate(payload)
 
@@ -219,6 +258,20 @@ def test_pentest_scope_validation_fails_closed(
     assert exc_info.value.error_code == error_code
     assert reason in exc_info.value.reasons
     assert exc_info.value.diagnostics["target"] == "https://lab.example.test"
+
+def test_pentest_scope_validation_ambiguous_idempotency_fails_closed() -> None:
+    request = _request_with_scope(
+        request_overrides={"trusted_internal_execution": True},
+        scope_overrides={"metadata": {"idempotency_safety": "ambiguous"}},
+    )
+
+    with pytest.raises(PentestScopeValidationError) as exc_info:
+        validate_authorized_scope_for_request(
+            request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
+        )
+
+    assert exc_info.value.error_code == "NON_IDEMPOTENT_OPERATION"
+    assert "idempotency_safety_ambiguous" in exc_info.value.reasons
 
 @pytest.mark.parametrize(
     ("mode", "actions"),
@@ -247,6 +300,7 @@ def test_pentest_scope_validation_handles_explicit_operation_modes(
     payload = _valid_request_payload()
     payload["operation_mode"] = mode
     payload["approved_scope"] = _approved_scope_payload(allowed_actions=actions)
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     validate_authorized_scope_for_request(
@@ -258,6 +312,7 @@ def test_pentest_scope_validation_rejects_naive_expiry() -> None:
     payload["approved_scope"] = _approved_scope_payload(
         expires_at=datetime(2026, 4, 23, 0, 0, 0)
     )
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     with pytest.raises(PentestScopeValidationError) as exc_info:
@@ -274,6 +329,7 @@ def test_pentest_scope_validation_allows_host_inside_cidr_scope() -> None:
     payload["approved_scope"] = _approved_scope_payload(
         targets=[{"kind": "cidr", "value": "10.0.0.0/24"}]
     )
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     validate_authorized_scope_for_request(
@@ -382,6 +438,7 @@ def test_pentest_vpn_lab_profile_requires_approved_network_attachment() -> None:
         {
             "runner_profile_id": "pentestgpt-vpn-lab",
             "network_attachment_ref": "net:vpn:lab-1",
+            "trusted_internal_execution": True,
             "approved_scope": _approved_scope_payload(
                 allowed_runner_profiles=["pentestgpt-vpn-lab"],
                 required_network_attachment_type="vpn",
@@ -408,6 +465,7 @@ def test_pentest_vpn_lab_profile_fails_without_network_attachment() -> None:
     payload.update(
         {
             "runner_profile_id": "pentestgpt-vpn-lab",
+            "trusted_internal_execution": True,
             "approved_scope": _approved_scope_payload(
                 allowed_runner_profiles=["pentestgpt-vpn-lab"],
                 required_network_attachment_type="vpn",
@@ -421,7 +479,7 @@ def test_pentest_vpn_lab_profile_fails_without_network_attachment() -> None:
             request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
         )
 
-    assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert exc_info.value.error_code == "UNSUPPORTED_PROFILE"
     assert "network_attachment_required" in exc_info.value.reasons
 
 def test_pentest_launch_plan_rejects_unknown_profiles_and_container_overrides() -> None:
@@ -433,6 +491,7 @@ def test_pentest_launch_plan_rejects_unknown_profiles_and_container_overrides() 
 
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     payload["image"] = "attacker/image:1.0"
 
     with pytest.raises(ValidationError):
@@ -441,6 +500,7 @@ def test_pentest_launch_plan_rejects_unknown_profiles_and_container_overrides() 
 def test_pentest_launch_plan_uses_deterministic_metadata_and_cleanup_selector() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     plan = build_pentest_launch_plan(
@@ -753,6 +813,7 @@ def test_pentest_instruction_materialization_uses_required_sections_and_paths() 
     payload["approved_scope"] = _approved_scope_payload(
         prohibited_actions=["exploit_validation"]
     )
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     materialization = build_pentest_execution_materialization(request)
@@ -807,6 +868,7 @@ def test_pentest_workload_request_rejects_unsafe_artifacts_dir(
 def test_pentest_wrapper_invocation_is_path_only_noninteractive_and_telemetry_off() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     materialization = build_pentest_execution_materialization(request)
@@ -841,6 +903,7 @@ def test_pentest_wrapper_invocation_is_path_only_noninteractive_and_telemetry_of
 def test_pentest_publication_result_includes_required_artifacts_and_restricted_evidence() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     publication = build_pentest_publication_result(
@@ -905,6 +968,7 @@ def test_pentest_publication_result_includes_required_artifacts_and_restricted_e
 def test_pentest_finding_set_counts_and_confidence_are_conservative() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     publication = build_pentest_publication_result(
@@ -943,6 +1007,7 @@ def test_pentest_finding_set_counts_and_confidence_are_conservative() -> None:
 def test_pentest_publication_falls_back_for_blank_finding_summary() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     publication = build_pentest_publication_result(
@@ -964,6 +1029,7 @@ def test_pentest_publication_falls_back_for_blank_finding_summary() -> None:
 def test_pentest_publication_handles_zero_findings_live_logs_and_progress() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
+    payload["trusted_internal_execution"] = True
     request = PentestWorkloadRequest.model_validate(payload)
 
     publication = build_pentest_publication_result(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -898,9 +898,49 @@ def _pentest_activity_payload(**overrides: object) -> dict[str, object]:
         "artifacts_dir": "/tmp/artifacts",
         "principal_id": "user-security",
         "approved_scope": _approved_pentest_scope(),
+        "trusted_internal_execution": True,
     }
     request.update(overrides)
     return {"request": request}
+
+def _pentest_artifact_activity_payload(**overrides: object) -> dict[str, object]:
+    request: dict[str, object] = {
+        "task_run_id": "run-123",
+        "step_id": "step-pentest",
+        "attempt": 1,
+        "target": "https://lab.example.test",
+        "operation_mode": "validate_hypothesis",
+        "objective": "Validate auth bypass hypothesis.",
+        "scope_artifact_ref": "art_scope_valid",
+        "runner_profile_id": "pentestgpt-safe",
+        "execution_profile_ref": "pentestgpt_anthropic_api_team",
+        "time_budget_minutes": 60,
+        "evidence_level": "standard",
+        "artifacts_dir": "/tmp/artifacts",
+        "principal_id": "user-security",
+    }
+    request.update(overrides)
+    return {"request": request}
+
+class _FakePentestArtifactService:
+    def __init__(self, artifacts: dict[str, bytes]) -> None:
+        self.artifacts = artifacts
+        self.reads: list[tuple[str, str]] = []
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool = False,
+    ) -> tuple[object, bytes]:
+        self.reads.append((artifact_id, principal))
+        if artifact_id not in self.artifacts:
+            raise TemporalArtifactNotFoundError(artifact_id)
+        return SimpleNamespace(artifact_id=artifact_id), self.artifacts[artifact_id]
+
+def _scope_artifact_bytes(**overrides: object) -> bytes:
+    return json.dumps(_approved_pentest_scope() | overrides).encode("utf-8")
 
 async def test_security_pentest_execute_fails_closed_before_runner_without_scope():
     activities = TemporalAgentRuntimeActivities()
@@ -914,6 +954,142 @@ async def test_security_pentest_execute_fails_closed_before_runner_without_scope
     assert "INVALID_SCOPE" in message
     assert "missing_approved_scope" in message
     assert "runner is not implemented" not in message
+
+async def test_security_pentest_execute_loads_scope_artifact_before_launch_plan():
+    artifact_service = _FakePentestArtifactService(
+        {"art_scope_valid": _scope_artifact_bytes()}
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    result = await activities.security_pentest_execute(
+        _pentest_artifact_activity_payload()
+    )
+
+    assert artifact_service.reads == [("art_scope_valid", "user-security")]
+    assert result["status"] == "launch_plan_ready"
+    assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+
+@pytest.mark.parametrize(
+    ("artifact_id", "artifact_payload", "message"),
+    [
+        ("art_scope_missing", None, "scope_artifact_unreadable"),
+        ("art_scope_malformed", b"{not-json", "scope_artifact_malformed"),
+        (
+            "art_scope_structurally_invalid",
+            json.dumps({"scope_id": "scope-123"}).encode("utf-8"),
+            "scope_artifact_invalid",
+        ),
+    ],
+)
+async def test_security_pentest_execute_maps_unreadable_scope_artifacts(
+    artifact_id: str,
+    artifact_payload: bytes | None,
+    message: str,
+):
+    artifacts = {} if artifact_payload is None else {artifact_id: artifact_payload}
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakePentestArtifactService(artifacts)
+    )
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_artifact_activity_payload(scope_artifact_ref=artifact_id)
+        )
+
+    assert "INVALID_SCOPE" in str(exc_info.value)
+    assert message in str(exc_info.value)
+
+async def test_security_pentest_execute_rejects_ordinary_inline_scope_without_artifact():
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_activity_payload(
+                scope_artifact_ref="",
+                approved_scope=_approved_pentest_scope(),
+                trusted_internal_execution=False,
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "INVALID_SCOPE" in message
+    assert (
+        "scope_artifact_ref" in message
+        or "inline_scope_requires_trusted_internal_execution" in message
+    )
+
+async def test_security_pentest_execute_allows_trusted_internal_inline_scope():
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.security_pentest_execute(
+        _pentest_activity_payload(
+            scope_artifact_ref=None,
+            trusted_internal_execution=True,
+        )
+    )
+
+    assert result["status"] == "launch_plan_ready"
+    assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+
+@pytest.mark.parametrize(
+    ("scope_overrides", "request_overrides", "error_code", "reason"),
+    [
+        ({"expires_at": "2020-01-01T00:00:00Z"}, {}, "INVALID_SCOPE", "scope_expired"),
+        ({}, {"principal_id": "user-other"}, "PERMISSION_DENIED", "principal_not_authorized"),
+        (
+            {"targets": [{"kind": "url", "value": "https://other.example.test"}]},
+            {},
+            "UNAPPROVED_TARGET",
+            "target_outside_scope",
+        ),
+        (
+            {"allowed_runner_profiles": ["pentestgpt-vpn-lab"]},
+            {},
+            "UNSUPPORTED_PROFILE",
+            "runner_profile_not_allowed",
+        ),
+        (
+            {"allowed_actions": ["auth_testing"]},
+            {},
+            "UNSUPPORTED_PROFILE",
+            "operation_mode_not_allowed",
+        ),
+        (
+            {"required_network_attachment_type": "vpn"},
+            {},
+            "UNSUPPORTED_PROFILE",
+            "network_attachment_required",
+        ),
+        (
+            {"metadata": {"idempotency_safety": "ambiguous"}},
+            {},
+            "NON_IDEMPOTENT_OPERATION",
+            "idempotency_safety_ambiguous",
+        ),
+    ],
+)
+async def test_security_pentest_execute_returns_validation_failure_before_side_effects(
+    scope_overrides: dict[str, object],
+    request_overrides: dict[str, object],
+    error_code: str,
+    reason: str,
+):
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakePentestArtifactService(
+            {"art_scope_valid": _scope_artifact_bytes(**scope_overrides)}
+        )
+    )
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_artifact_activity_payload(**request_overrides)
+        )
+
+    message = str(exc_info.value)
+    assert error_code in message
+    assert reason in message
+    assert "provider_profile" not in message
+    assert "launch_plan_ready" not in message
 
 async def test_security_pentest_execute_denies_without_retry_when_workflow_docker_disabled():
     activities = TemporalAgentRuntimeActivities(workflow_docker_mode="disabled")
@@ -1202,7 +1378,7 @@ async def test_security_pentest_execute_fails_closed_before_vpn_lab_launch_witho
         )
 
     message = str(exc_info.value)
-    assert "PERMISSION_DENIED" in message
+    assert "UNSUPPORTED_PROFILE" in message
     assert "network_attachment_required" in message
     assert "launch_plan_ready" not in message
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -946,7 +946,7 @@ async def test_security_pentest_execute_fails_closed_before_runner_without_scope
     activities = TemporalAgentRuntimeActivities()
 
     with pytest.raises(TemporalActivityRuntimeError) as exc_info:
-        await activities.security_pentest_execute(
+        await activities._security_pentest_execute_trusted_internal(
             _pentest_activity_payload(approved_scope=None)
         )
 
@@ -1021,7 +1021,7 @@ async def test_security_pentest_execute_rejects_ordinary_inline_scope_without_ar
 async def test_security_pentest_execute_allows_trusted_internal_inline_scope():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             scope_artifact_ref=None,
             trusted_internal_execution=True,
@@ -1030,6 +1030,27 @@ async def test_security_pentest_execute_allows_trusted_internal_inline_scope():
 
     assert result["status"] == "launch_plan_ready"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+
+
+async def test_security_pentest_execute_ignores_caller_supplied_trust_flag():
+    """A registry-dispatched submission cannot self-authorize an inline scope."""
+
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(TemporalActivityRuntimeError) as exc_info:
+        await activities.security_pentest_execute(
+            _pentest_activity_payload(
+                scope_artifact_ref=None,
+                trusted_internal_execution=True,
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "INVALID_SCOPE" in message
+    assert (
+        "inline_scope_requires_trusted_internal_execution" in message
+        or "scope_artifact_ref" in message
+    )
 
 @pytest.mark.parametrize(
     ("scope_overrides", "request_overrides", "error_code", "reason"),
@@ -1106,7 +1127,9 @@ async def test_security_pentest_execute_denies_without_retry_when_workflow_docke
 async def test_security_pentest_execute_reaches_launch_plan_after_scope_validation():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(_pentest_activity_payload())
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
 
     assert result["status"] == "launch_plan_ready"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
@@ -1114,7 +1137,9 @@ async def test_security_pentest_execute_reaches_launch_plan_after_scope_validati
 async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_validation():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(_pentest_activity_payload())
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
 
     assert result["status"] == "launch_plan_ready"
     assert result["target"] == "https://lab.example.test"
@@ -1131,7 +1156,7 @@ async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_val
 async def test_security_pentest_execute_includes_secret_safe_provider_preparation():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             execution_profile_ref="pentestgpt_anthropic_api_team",
         )
@@ -1164,7 +1189,7 @@ async def test_security_pentest_execute_includes_secret_safe_provider_preparatio
 async def test_security_pentest_execute_filters_provider_runtime_state():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             execution_profile_ref=None,
             provider_selector={"tags_any": ["api-key"]},
@@ -1183,7 +1208,7 @@ async def test_security_pentest_execute_filters_provider_runtime_state():
 async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             execution_profile_ref="pentestgpt_openrouter_default",
             provider_failure={"category": "provider_429"},
@@ -1204,7 +1229,9 @@ async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
 async def test_security_pentest_execute_includes_instruction_materialization_metadata():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(_pentest_activity_payload())
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
 
     bundle = result["instruction_bundle"]
     paths = result["runtime_paths"]
@@ -1244,7 +1271,7 @@ async def test_security_pentest_execute_includes_instruction_materialization_met
 async def test_security_pentest_execute_includes_publication_metadata_without_session_artifacts():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             summary_text="Pentest finished with password=hunter2",
             findings=[
@@ -1310,7 +1337,7 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
 async def test_security_pentest_execute_coerces_string_publication_flags():
     activities = TemporalAgentRuntimeActivities()
 
-    result = await activities.security_pentest_execute(
+    result = await activities._security_pentest_execute_trusted_internal(
         _pentest_activity_payload(
             provider_snapshot_available="false",
             wrapper_log_available="0",
@@ -1354,7 +1381,7 @@ async def test_security_pentest_execute_sources_publication_payload_from_nested_
         "provider_snapshot_available": True,
     }
 
-    result = await activities.security_pentest_execute(payload)
+    result = await activities._security_pentest_execute_trusted_internal(payload)
 
     publication = result["artifact_publication"]
     artifact_names = {item["name"] for item in publication["artifacts"]}
@@ -1366,7 +1393,7 @@ async def test_security_pentest_execute_fails_closed_before_vpn_lab_launch_witho
     activities = TemporalAgentRuntimeActivities()
 
     with pytest.raises(TemporalActivityRuntimeError) as exc_info:
-        await activities.security_pentest_execute(
+        await activities._security_pentest_execute_trusted_internal(
             _pentest_activity_payload(
                 runner_profile_id="pentestgpt-vpn-lab",
                 approved_scope={


### PR DESCRIPTION
## Summary

Recovered and published the completed output from MoonMind workflow `mm:a805e946-e5c4-4369-8ed0-452ce389a384` / PentestGPT Integration Phase 02.

This change implements the approved-scope artifact loading story by extending the PentestGPT activity path and contracts around validated scope inputs, report-first outputs, and workflow/tool boundary coverage.

Key changes:

- expands PentestGPT model coverage for approved scope artifact handling
- updates `TemporalAgentRuntimeActivities.security_pentest_execute` for scope-aware execution payloads
- extends executable tool contract and activity runtime tests
- records the phase technology/storage notes in the agent instruction files

## Validation

Recovered workflow verification reported:

- `./tools/test_unit.sh tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_runtime.py` passed
- `./tools/test_integration.sh tests/integration/temporal/test_pentest_tool_contract.py` passed, selecting the full `integration_ci` suite
- `./tools/test_unit.sh` passed

Reran on this branch:

- `./tools/test_unit.sh tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_runtime.py`
  - Python: `135 passed`
  - Vitest: `27 files passed`, `416 passed`, `234 skipped`
