### PR TITLE
A lot of documents are still in a directory like docs/Tasks and have Tasks in the document name. I need all of these documents to change Task to Workf

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -71,8 +71,8 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 **README claim:** *"Break a massive goal into discrete steps with presets, and let MoonMind schedule and sequence them."* / *"Inject the right context into each step and clear it between steps."*
 
 ### What's shipped
-- Task presets system (spec 026/028/055 — `TaskPresetsSystem.md`)
-- Task step templates & step sequencing API (`task_step_templates.py`, `TasksStepSystem.md`)
+- Task presets system (spec 026/028/055 — `WorkflowPresetsSystem.md`)
+- Task step templates & step sequencing API (`task_step_templates.py`, `WorkflowStepSystem.md`)
 - Manifest-based task submission (`manifest.schema.json`, `moonmind/manifest/`)
 - Task proposal queue for automated step generation
 - `proposal_generate` activity implemented
@@ -284,7 +284,7 @@ These are technical debt items that don't map to README claims but improve code 
 
 ### Remaining tasks
 - [x] **H.1** Complete legacy system removal — Code removal is complete (migration `c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining documentation updates are tracked in `docs/MoonMindRoadmap.md`.
-- [x] **H.2** Spec deduplication — Duplicate spec directories were removed with the retired specs tree; canonical desired-state docs remain for Worker Pause ([docs/Temporal/WorkerPauseSystem.md](Temporal/WorkerPauseSystem.md)), Claude gating ([docs/ManagedAgents/ClaudeCodeManagedSessions.md](ManagedAgents/ClaudeCodeManagedSessions.md)), Manifest Phase 0 ([docs/Rag/ManifestIngestDesign.md](Rag/ManifestIngestDesign.md) and [docs/Rag/LlamaIndexManifestSystem.md](Rag/LlamaIndexManifestSystem.md)), Jules events ([docs/ExternalAgents/JulesTemporalExternalEventContract.md](ExternalAgents/JulesTemporalExternalEventContract.md)), and Task Presets ([docs/Tasks/TaskPresetsSystem.md](Tasks/TaskPresetsSystem.md)).
+- [x] **H.2** Spec deduplication — Duplicate spec directories were removed with the retired specs tree; canonical desired-state docs remain for Worker Pause ([docs/Temporal/WorkerPauseSystem.md](Temporal/WorkerPauseSystem.md)), Claude gating ([docs/ManagedAgents/ClaudeCodeManagedSessions.md](ManagedAgents/ClaudeCodeManagedSessions.md)), Manifest Phase 0 ([docs/Rag/ManifestIngestDesign.md](Rag/ManifestIngestDesign.md) and [docs/Rag/LlamaIndexManifestSystem.md](Rag/LlamaIndexManifestSystem.md)), Jules events ([docs/ExternalAgents/JulesTemporalExternalEventContract.md](ExternalAgents/JulesTemporalExternalEventContract.md)), and Task Presets ([docs/Tasks/WorkflowPresetsSystem.md](Tasks/WorkflowPresetsSystem.md)).
 - [x] **H.3** Legacy skill dispatch cleanup — Removed the dead `tool.type == "skill"` dispatch branch from `MoonMind.Run`; current plan execution accepts `agent_runtime` nodes.
 - [x] **H.4** Delete legacy docs identified by the legacy docs review (MM-800) — Removed the legacy docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.).
 

--- a/docs/Observability/LiveLogs.md
+++ b/docs/Observability/LiveLogs.md
@@ -5,7 +5,7 @@ Owners: MoonMind Platform
 Last updated: 2026-04-08
 
 **Replaces or substantially rewrites:**
-- `docs/Temporal/LiveTaskManagement.md`
+- `docs/Temporal/LiveWorkflowManagement.md`
 - `specs/084-live-log-tailing/spec.md`
 
 **Related:**

--- a/docs/Steps/JiraIntegration.md
+++ b/docs/Steps/JiraIntegration.md
@@ -4,7 +4,7 @@ Status: Desired-state architecture
 Owners: MoonMind Engineering
 Last Updated: 2026-05-05
 Canonical for: Jira issue context, Jira issue picker widget, Jira tool execution, Jira credential handling, schema-driven Jira inputs
-Related: `docs/UI/CreatePage.md`, `docs/Tasks/TaskPresetsSystem.md`, `docs/Steps/StepTypes.md`, `docs/Steps/SkillSystem.md`, `docs/Tasks/TaskPublishing.md`, `docs/Tasks/PrMergeAutomation.md`
+Related: `docs/UI/CreatePage.md`, `docs/Tasks/WorkflowPresetsSystem.md`, `docs/Steps/StepTypes.md`, `docs/Steps/SkillSystem.md`, `docs/Tasks/WorkflowPublishing.md`, `docs/Tasks/PrMergeAutomation.md`
 
 ---
 

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -4,7 +4,7 @@ Status: Desired State
 Owners: MoonMind Engineering
 Last Updated: 2026-04-29
 Canonical for: agent skills, Skill steps, skill-set resolution, runtime skill materialization, `.agents/skills` path policy
-Related: `docs/Steps/StepTypes.md`, `docs/Tasks/SkillAndPlanContracts.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/MissionControlArchitecture.md`, `AGENTS.md`
+Related: `docs/Steps/StepTypes.md`, `docs/Tasks/SkillAndPlanContracts.md`, `docs/Tasks/WorkflowArchitecture.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/MissionControlArchitecture.md`, `AGENTS.md`
 
 ---
 

--- a/docs/Steps/SlashCommands.md
+++ b/docs/Steps/SlashCommands.md
@@ -4,7 +4,7 @@ Status: Desired State
 Owners: MoonMind Engineering
 Last Updated: 2026-05-13
 Canonical for: Create Task runtime slash-command pass-through, command hint metadata, runtime command rendering boundaries
-Related: `docs/UI/CreatePage.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Steps/SkillSystem.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/ClaudeCodeManagedSessions.md`
+Related: `docs/UI/CreatePage.md`, `docs/Tasks/WorkflowArchitecture.md`, `docs/Steps/SkillSystem.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/ClaudeCodeManagedSessions.md`
 
 ---
 

--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -4,7 +4,7 @@ Status: Desired State
 Owners: MoonMind Engineering
 Last Updated: 2026-05-16
 Canonical for: semantic step reattempts, checkpointed side-effect policy, gated iteration, failed-step recovery primitive, autonomous story loops
-Related: `docs/Steps/StepTypes.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskRemediation.md`, `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Temporal/RunHistoryAndRerunSemantics.md`, `docs/Temporal/ActivityCatalogAndWorkerTopology.md`, `docs/Artifacts/ArtifactPresentationContract.md`
+Related: `docs/Steps/StepTypes.md`, `docs/Tasks/WorkflowArchitecture.md`, `docs/Tasks/WorkflowRemediation.md`, `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Temporal/RunHistoryAndRerunSemantics.md`, `docs/Temporal/ActivityCatalogAndWorkerTopology.md`, `docs/Artifacts/ArtifactPresentationContract.md`
 
 ---
 
@@ -37,7 +37,7 @@ This document does **not** redefine:
 5. provider-specific runtime launch internals;
 6. full run-history product UI.
 
-Use `docs/Steps/StepTypes.md` for the user-facing step taxonomy. Step Executions are execution-plane records, not authoring steps and not Step Types. Use `docs/Temporal/StepLedgerAndProgressModel.md` for the operator-facing step ledger shape. Use `docs/Tasks/TaskArchitecture.md` and `docs/Temporal/RunHistoryAndRerunSemantics.md` for task create, rerun, and failed-step recovery semantics.
+Use `docs/Steps/StepTypes.md` for the user-facing step taxonomy. Step Executions are execution-plane records, not authoring steps and not Step Types. Use `docs/Temporal/StepLedgerAndProgressModel.md` for the operator-facing step ledger shape. Use `docs/Tasks/WorkflowArchitecture.md` and `docs/Temporal/RunHistoryAndRerunSemantics.md` for task create, rerun, and failed-step recovery semantics.
 
 ---
 

--- a/docs/Steps/StepTypes.md
+++ b/docs/Steps/StepTypes.md
@@ -3,7 +3,7 @@
 Status: Desired-state architecture
 Owners: MoonMind Engineering (Task Platform + UI)
 Last Updated: 2026-05-05
-Related: `docs/Tasks/TaskPresetsSystem.md`, `docs/UI/CreatePage.md`, `docs/Steps/SkillSystem.md`, `docs/Steps/JiraIntegration.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Tools/DockerComposeUpdateSystem.md`
+Related: `docs/Tasks/WorkflowPresetsSystem.md`, `docs/UI/CreatePage.md`, `docs/Steps/SkillSystem.md`, `docs/Steps/JiraIntegration.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Tools/DockerComposeUpdateSystem.md`
 
 ---
 

--- a/docs/Tasks/ImageSystem.md
+++ b/docs/Tasks/ImageSystem.md
@@ -25,7 +25,7 @@ This document is declarative. It defines the target system contract. It is not a
 ## 2. Related docs
 
 - `docs/UI/CreatePage.md`
-- `docs/Tasks/TaskArchitecture.md`
+- `docs/Tasks/WorkflowArchitecture.md`
 - `docs/Temporal/TemporalArchitecture.md`
 - `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
 - `docs/Temporal/ArtifactPresentationContract.md`

--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -3,7 +3,7 @@
 **Status:** Proposed  
 **Owner:** MoonMind Platform  
 **Audience:** backend, workflow authors, API, Mission Control  
-**Related:** `docs/Tasks/TaskDependencies.md`, `docs/Tasks/TaskPublishing.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/TemporalAgentExecution.md`, `docs/ManagedAgents/SkillGithubPrResolver.md`
+**Related:** `docs/Tasks/WorkflowDependencies.md`, `docs/Tasks/WorkflowPublishing.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/TemporalAgentExecution.md`, `docs/ManagedAgents/SkillGithubPrResolver.md`
 
 ---
 

--- a/docs/Tasks/StepReviewGateSystem.md
+++ b/docs/Tasks/StepReviewGateSystem.md
@@ -3,7 +3,7 @@
 Status: **Design Draft**
 Owners: MoonMind Engineering
 Last Updated: 2026-03-18
-Related: `docs/Tasks/SkillAndPlanContracts.md`, `docs/Tasks/TasksStepSystem.md`, `docs/Tasks/TaskArchitecture.md`
+Related: `docs/Tasks/SkillAndPlanContracts.md`, `docs/Tasks/WorkflowStepSystem.md`, `docs/Tasks/WorkflowArchitecture.md`
 
 ---
 

--- a/docs/Tasks/WorkflowArchitecture.md
+++ b/docs/Tasks/WorkflowArchitecture.md
@@ -1,4 +1,4 @@
-# Task Architecture (Control Plane)
+# Workflow Architecture (Control Plane)
 
 Status: Active
 Owners: MoonMind Engineering
@@ -6,11 +6,11 @@ Last updated: 2026-05-06
 
 ## 1. Purpose
 
-This document defines the high-level desired-state control-plane architecture for MoonMind tasks.
+This document defines the high-level desired-state control-plane architecture for MoonMind Workflow Executions.
 
 It maps how the control plane translates user intent from Mission Control — including:
 
-- task objective text
+- Workflow objective text
 - step-authored instructions
 - objective-scoped and step-scoped input attachments
 - runtime and publish choices
@@ -30,23 +30,23 @@ MoonMind uses a Temporal-backed execution model in which Mission Control acts as
 
 The control plane already centers on these product objects:
 
-- `MoonMind.Run` as the standard task execution workflow
+- `MoonMind.Run` as the standard Workflow Execution type
 - first-class artifacts for large or binary inputs and outputs
-- step-authored tasks rather than opaque queue jobs
-- reusable task presets
+- step-authored Workflows rather than opaque queue jobs
+- reusable Workflow presets
 - runtime and provider selection intent
 - durable execution actions such as pause, resume, cancel, approve, and rerun
 
 Desired-state additions clarified by this document:
 
-- image inputs are first-class structured task inputs
+- image inputs are first-class structured Workflow inputs
 - attachment targeting is explicit and durable
 - presets are recursively composable authoring objects resolved entirely in the control plane
-- create, edit, and rerun preserve attachment bindings through an authoritative task input snapshot
-- submitted tasks preserve authored preset metadata and flattened step provenance alongside resolved execution payloads
+- create, edit, and rerun preserve attachment bindings through an authoritative Workflow input snapshot
+- submitted Workflows preserve authored preset metadata and flattened step provenance alongside resolved execution payloads
 - runtime preparation and prompt composition are target-aware rather than attachment-bucket-driven
-- failed-task recovery has two explicit user workflows:
-  - edit the task input and retry the whole task from the beginning
+- failed-Workflow Execution recovery has two explicit user workflows:
+  - edit the Workflow input and retry the whole Workflow from the beginning
   - press **Resume** to retry the last failed step with the work completed before that step preserved
 - failed-step resume depends on durable step ledgers, output refs, and workspace checkpoints rather than log parsing or UI reconstruction
 
@@ -54,14 +54,14 @@ Desired-state additions clarified by this document:
 
 ## 3. Core architectural principles
 
-### 3.1 Task-first control plane
+### 3.1 Workflow-first control plane
 
-The user authors tasks, not workflow internals.
+The user authors Workflows, not workflow internals.
 
 Rules:
 
-- the Create page defines user intent in task terms
-- the control plane translates that task intent into execution-plane contracts
+- the Create page defines user intent in Workflow terms
+- the control plane translates that Workflow intent into execution-plane contracts
 - the execution plane owns lifecycle progression, retries, waiting, and history
 
 ### 3.2 Artifact-first binary handling
@@ -78,7 +78,7 @@ Rules:
 
 - an input attachment must belong to an explicit target
 - the supported target kinds are:
-  - task objective target
+  - Workflow objective target
   - step target
 - target binding must survive create, edit, rerun, prepare, prompt composition, and detail rendering
 
@@ -86,8 +86,8 @@ Rules:
 
 Rules:
 
-- task input reconstruction uses an authoritative snapshot
-- text-only reconstruction is insufficient for attachment-aware tasks
+- Workflow input reconstruction uses an authoritative snapshot
+- text-only reconstruction is insufficient for attachment-aware Workflows
 - silent loss of attachment bindings is a contract violation
 
 ### 3.5 Separation of text from structured inputs
@@ -102,9 +102,9 @@ Rules:
 
 Rules:
 
-- failed-task recovery has two separate workflows, and the user's chosen workflow is explicit
-- **Edit and retry whole task** loads the original task snapshot into the authoring UI, permits edits, and starts execution from the beginning
-- **Resume** does not open an authoring form; it retries the last failed step using the original task input and the durable work completed before that step
+- failed-Workflow Execution recovery has two separate workflows, and the user's chosen workflow is explicit
+- **Edit and retry whole Workflow** loads the original Workflow snapshot into the authoring UI, permits edits, and starts execution from the beginning
+- **Resume** does not open an authoring form; it retries the last failed step using the original Workflow input and the durable work completed before that step
 - Resume must never silently edit instructions, steps, attachments, runtime, publish mode, branch, dependencies, or preset metadata
 - Resume is available only when the platform can identify the failed step and restore the work completed before it from durable evidence
 - if the prior work cannot be restored faithfully, Resume must be unavailable or fail explicitly with an operator-readable reason
@@ -121,9 +121,9 @@ flowchart LR
         UI --> API[Executions API]
         UI --> ART[Artifact API]
         UI --> JIRA[Jira Browser API]
-        API --> SNAP[Authoritative Task Input Snapshot]
+        API --> SNAP[Authoritative Workflow Input Snapshot]
         API --> PROF[Provider Profile + Runtime Defaults]
-        API --> PRESETS[Task Preset APIs]
+        API --> PRESETS[Workflow Preset APIs]
     end
 
     subgraph Execution Plane
@@ -168,9 +168,9 @@ The control plane is responsible for all of the following.
 - finalize artifact creation and reject incomplete uploads
 - submit only structured attachment refs to the execution API
 
-### 5.3 Task contract normalization
+### 5.3 Workflow contract normalization
 
-- normalize the task-shaped payload
+- normalize the Workflow-shaped payload
 - preserve `task.inputAttachments` and `task.steps[].inputAttachments`
 - preserve step identity and order
 - preserve runtime and publish intent
@@ -192,7 +192,7 @@ Rules:
 
 ### 5.5 Snapshot durability
 
-- persist an authoritative task input snapshot for edit and rerun
+- persist an authoritative Workflow input snapshot for edit and rerun
 - reconstruct from that snapshot rather than from lossy derived projections
 - preserve attachment target binding in the snapshot
 - preserve pinned preset bindings, include-tree summary, per-step provenance, detachment state, and final submitted order in the snapshot
@@ -203,19 +203,19 @@ Rules:
 - surface attachment metadata by target in detail, edit, and rerun flows
 - expose enough diagnostics for operators to understand attachment-related failures
 
-### 5.7 Failed-task recovery orchestration
+### 5.7 Failed-Workflow Execution recovery orchestration
 
 The control plane exposes distinct recovery actions instead of treating every recovery path as a generic rerun.
 
 Rules:
 
-- failed task details may expose **Edit task**, **Rerun**, and **Resume** as separate actions when their capability fields are true
-- **Edit task** on a failed execution is the editable full retry path; submitting it creates a new execution from the beginning with a new authoritative task input snapshot
-- **Rerun** is the exact full retry path; it starts from the beginning using the original task input without edits
+- failed Workflow details may expose **Edit Workflow**, **Rerun**, and **Resume** as separate actions when their capability fields are true
+- **Edit Workflow** on a failed execution is the editable full retry path; submitting it creates a new execution from the beginning with a new authoritative Workflow input snapshot
+- **Rerun** is the exact full retry path; it starts from the beginning using the original Workflow input without edits
 - **Resume** is the failed-step recovery path; it starts a linked follow-up execution that imports completed prior progress and retries the last failed step
 - Resume eligibility must be computed by the backend, not inferred by the UI
 - Resume eligibility requires, at minimum:
-  - an authoritative original task input snapshot
+  - an authoritative original Workflow input snapshot
   - a pinned source `workflowId` and `runId`
   - a step ledger that identifies the last failed step
   - durable refs for all completed steps before the failed step
@@ -225,7 +225,7 @@ Rules:
 
 ---
 
-## 6. Canonical task-shaped contract
+## 6. Canonical Workflow-shaped contract
 
 Representative contract:
 
@@ -325,15 +325,15 @@ Rules:
 
 - `task.inputAttachments` is the objective-scoped input target
 - `task.steps[n].inputAttachments` is the step-scoped input target
-- `task.authoredPresets` preserves optional preset binding metadata used to compile the submitted task
+- `task.authoredPresets` preserves optional preset binding metadata used to compile the submitted Workflow
 - `task.steps[n].source` preserves optional source provenance for manual, preset-derived, included, or detached steps
-- these fields are part of the task contract, not incidental UI metadata
+- these fields are part of the Workflow contract, not incidental UI metadata
 - the absence of attachments is valid
 - the presence of attachments must be preserved across create, detail, edit, and rerun
 - `task.git.branch` is the single authored branch field; new create, edit, and rerun payloads do not include `targetBranch`
 - for `publish.mode === "pr"`, `task.git.branch` is the selected repository branch / PR base and the PR head branch is runtime-generated or provider-managed
 - for `publish.mode === "branch"`, `task.git.branch` is the branch to update/push
-- `Publish Mode` remains part of task submission semantics; only its Create page placement changes
+- `Publish Mode` remains part of Workflow submission semantics; only its Create page placement changes
 - the execution-facing payload is resolved before workers consume it; `authoredPresets` and `source` metadata are for reconstruction, audit, diagnostics, and safe rerun semantics
 - `task.recovery.kind === "edited_full_retry"` or `"exact_full_rerun"` means the new execution starts from the beginning
 - `task.resume.kind === "recover_from_failed_step"` means the new execution must restore completed progress from `recoveryCheckpointRef` and start at `failedStepId`
@@ -344,12 +344,12 @@ Rules:
 
 ## 7. Snapshot, full retry, and Resume architecture
 
-The original task input snapshot is the authoritative representation of the authored draft.
+The original Workflow input snapshot is the authoritative representation of the authored draft.
 
 Rules:
 
 - it must preserve:
-  - task objective text
+  - Workflow objective text
   - objective-scoped attachment refs
   - step text
   - step-scoped attachment refs
@@ -363,7 +363,7 @@ Rules:
   - detachment state
   - final submitted order after manual and preset-derived steps are flattened
   - dependency declarations that remain part of the editable contract
-- edit, exact full rerun, edited full retry, and Resume all depend on this snapshot for the original authored task input
+- edit, exact full rerun, edited full retry, and Resume all depend on this snapshot for the original authored Workflow input
 - edit and full retry derive their initial browser state from this snapshot
 - Resume reuses this snapshot without presenting it as an editable authoring surface
 - edit, rerun, full retry, and Resume must not depend on current live preset catalog correctness to reconstruct already submitted work
@@ -372,43 +372,43 @@ Rules:
 
 ### 7.1 Editable full retry
 
-Editable full retry is the workflow used when the user wants to change the overall instructions or any other task input and then retry the task.
+Editable full retry is the workflow used when the user wants to change the overall instructions or any other Workflow input and then retry the Workflow.
 
 Rules:
 
-- the Create page opens in edit-for-rerun mode from the authoritative task input snapshot
+- the Create page opens in edit-for-rerun mode from the authoritative Workflow input snapshot
 - the user may edit instructions, steps, attachments, runtime, publish mode, branch, presets, dependencies, and other authoring fields subject to normal validation
 - submitting the form creates a new execution from the beginning
-- the edited execution gets its own authoritative task input snapshot
+- the edited execution gets its own authoritative Workflow input snapshot
 - the original failed execution, its snapshot, step ledger, artifacts, and checkpoints remain immutable
 - no completed execution progress is imported into the edited full retry
 
 ### 7.2 Exact full rerun
 
-Exact full rerun is the workflow used when the user wants to retry the whole task with the same original task input.
+Exact full rerun is the workflow used when the user wants to retry the whole Workflow with the same original Workflow input.
 
 Rules:
 
-- the original task input snapshot is reused as the execution input
-- the task starts from the beginning
+- the original Workflow input snapshot is reused as the execution input
+- the Workflow starts from the beginning
 - prepare, prompt composition, planning or plan hydration, and all steps run again according to the normal execution path
 - no completed execution progress is imported from the failed source run
 
 ### 7.3 Resume from failed step
 
-Resume is the workflow used when the user presses **Resume** on a failed task to retry the last failed step with the completed work up to that step preserved.
+Resume is the workflow used when the user presses **Resume** on a failed Workflow Execution to retry the last failed step with the completed work up to that step preserved.
 
 Rules:
 
-- Resume is not an edit flow and must not allow task input changes in v1
+- Resume is not an edit flow and must not allow Workflow input changes in v1
 - Resume pins the source execution with both `sourceWorkflowId` and `sourceRunId`
 - Resume identifies the last failed step from the source run's step ledger
 - Resume creates or resolves a `recoveryCheckpointRef` that records the completed steps, their output refs, the prepared input refs, and the workspace or branch state immediately before the failed step
 - the new execution imports completed prior steps as preserved progress rather than re-executing them
 - the failed step is retried as a new attempt in the new execution
 - later steps execute normally after the failed step succeeds
-- the task detail view must show preserved prior steps as reused from the source run, not freshly executed by the resumed run
-- if checkpoint restoration is incomplete, corrupted, unauthorized, or inconsistent with the original task input and plan digest, Resume must fail explicitly before executing the failed step
+- the Workflow detail view must show preserved prior steps as reused from the source run, not freshly executed by the resumed run
+- if checkpoint restoration is incomplete, corrupted, unauthorized, or inconsistent with the original Workflow input and plan digest, Resume must fail explicitly before executing the failed step
 
 Representative recovery checkpoint artifact:
 
@@ -451,13 +451,13 @@ Representative recovery checkpoint artifact:
 
 ## 8. Execution-plane responsibilities
 
-The execution plane consumes the normalized task contract after control-plane preset compilation has produced a resolved execution payload.
+The execution plane consumes the normalized Workflow contract after control-plane preset compilation has produced a resolved execution payload.
 
 Rules:
 
 - workers consume resolved steps and structured input refs
 - workers do not expand presets
-- workers do not read the live preset catalog to recover missing task structure
+- workers do not read the live preset catalog to recover missing Workflow structure
 - workers do not depend on live preset catalog correctness for already submitted work
 
 ### 8.1 Workflow responsibilities
@@ -485,7 +485,7 @@ Prepare owns:
 
 Step execution owns:
 
-- consuming task-level objective context when relevant
+- consuming Workflow-level objective context when relevant
 - consuming only the current step’s step-scoped image context by default
 - avoiding accidental leakage of unrelated step attachments into the wrong step execution
 
@@ -517,7 +517,7 @@ Rules:
 When a new execution starts with `task.resume.kind === "recover_from_failed_step"`, `MoonMind.Run` owns:
 
 - loading and validating the recovery checkpoint
-- verifying the checkpoint source `workflowId`, `runId`, task snapshot, and plan identity
+- verifying the checkpoint source `workflowId`, `runId`, Workflow snapshot, and plan identity
 - materializing the restored workspace state before the failed step
 - marking completed prior steps as preserved from the source run without re-executing them
 - injecting preserved outputs so the failed step and downstream steps observe the same contracts as a continuous run
@@ -542,7 +542,7 @@ Rules:
 - user preview and download are authorized by execution ownership and view permissions
 - worker-side download and materialization use service credentials and execution authorization
 - artifact links are execution-scoped
-- target binding is preserved by task contract and snapshot semantics, not inferred from storage paths alone
+- target binding is preserved by Workflow contract and snapshot semantics, not inferred from storage paths alone
 
 Recommended metadata may include:
 
@@ -564,22 +564,22 @@ The control plane does not dictate provider-native multimodal payloads.
 
 Rules:
 
-- the control plane passes normalized task intent plus artifact refs
+- the control plane passes normalized Workflow intent plus artifact refs
 - text-first runtimes consume generated image context through the canonical `INPUT ATTACHMENTS` contract
-- multimodal runtimes may consume raw image refs through runtime adapters without changing the control-plane task contract
+- multimodal runtimes may consume raw image refs through runtime adapters without changing the control-plane Workflow contract
 - runtime adapters must not invent new attachment targeting rules that the Create page cannot express
 
 ---
 
 ## 11. Invariants
 
-The following invariants define the desired-state task system.
+The following invariants define the desired-state Workflow Execution system.
 
 1. **No binary payloads in Temporal history**
    Image bytes do not belong in execution histories or inline create payload text.
 
 2. **Explicit attachment targets**
-   Every input attachment belongs either to the task objective target or to a declared step target.
+   Every input attachment belongs either to the Workflow objective target or to a declared step target.
 
 3. **No silent attachment loss**
    Create, edit, rerun, and prepare must fail explicitly rather than silently dropping attachments.
@@ -588,13 +588,13 @@ The following invariants define the desired-state task system.
    Instruction fields remain textual authoring surfaces. Images remain structured inputs.
 
 5. **Snapshot-based durability**
-   Attachment-aware edit and rerun require an authoritative task input snapshot.
+   Attachment-aware edit and rerun require an authoritative Workflow input snapshot.
 
 6. **Compile-time preset composition**
    Preset composition is compile-time control-plane behavior. Submitted execution payloads must not require live preset lookup.
 
 7. **Preset provenance durability**
-   Task snapshots preserve pinned bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
+   Workflow snapshots preserve pinned bindings, include-tree summary, per-step provenance, detachment state, and final submitted order.
 
 8. **Server-defined policy**
    Attachment policy is defined by server configuration and enforced by both browser and API.
@@ -615,7 +615,7 @@ The following invariants define the desired-state task system.
    Full rerun, edited full retry, and Resume are distinct intents. The system must not infer Resume from a generic rerun request.
 
 14. **Resume preserves original inputs**
-   Resume uses the original task input snapshot unchanged. Any user edit to instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies requires edited full retry instead.
+   Resume uses the original Workflow input snapshot unchanged. Any user edit to instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies requires edited full retry instead.
 
 15. **Resume requires checkpointed progress**
    Resume may be offered only when completed work before the failed step is recoverable from durable step refs and workspace or branch checkpoints.
@@ -632,12 +632,12 @@ The following invariants define the desired-state task system.
 
 ### 12.1 `MoonMind.Run`
 
-This is the canonical attachment-aware task workflow.
+This is the canonical attachment-aware Workflow type.
 
 Rules:
 
-- attachment-aware task authoring is defined against `MoonMind.Run`
-- create, edit, rerun, and detail flows for attachment-aware tasks are all modeled in task-shaped `MoonMind.Run` terms
+- attachment-aware Workflow authoring is defined against `MoonMind.Run`
+- create, edit, rerun, and detail flows for attachment-aware Workflows are all modeled in Workflow-shaped `MoonMind.Run` terms
 - `MoonMind.Run` is the canonical workflow that produces step ledger state and recovery checkpoints for failed-step recovery
 - `MoonMind.Run` may start from the beginning for full retry or start at a failed step when given a validated recovery checkpoint
 - checkpoint durability remains a parent `MoonMind.Run` responsibility even when an individual step delegates work to `MoonMind.AgentRun`
@@ -653,7 +653,7 @@ Rules:
 
 ### 12.3 Other workflow types
 
-Other workflow types may reuse artifact infrastructure, but they do not redefine the Create-page attachment contract.
+Other Workflow types may reuse artifact infrastructure, but they do not redefine the Create-page attachment contract.
 
 ---
 
@@ -663,13 +663,13 @@ The architecture must support operator understanding without requiring raw histo
 
 Rules:
 
-- task detail should expose attachment metadata by target
+- Workflow detail should expose attachment metadata by target
 - diagnostics should expose manifest and generated context refs where appropriate
 - attachment failures should identify:
   - which target failed
   - whether the failure happened during upload, validation, materialization, or context generation
 - step-aware surfaces should identify the current step’s attachment context separately from unrelated step inputs
-- task detail should identify resumed executions and show preserved prior steps as reused from the source run
+- Workflow detail should identify resumed executions and show preserved prior steps as reused from the source run
 - diagnostics for failed Resume attempts should identify whether the failure happened during checkpoint validation, workspace restoration, preserved-output injection, or failed-step execution
 
 ---
@@ -681,7 +681,7 @@ Use this document to understand the architectural contract.
 Use the related docs for detailed behavior:
 
 - `docs/UI/CreatePage.md` for page sections, field behavior, Jira targeting, edit/rerun UX, and validation copy
-- `docs/UI/TaskDetailsPage.md` for failed-task action presentation, including **Resume**
+- `docs/UI/WorkflowDetailsPage.md` for failed-Workflow Execution action presentation, including **Resume**
 - `docs/Tasks/ImageSystem.md` for image-input upload, artifact storage, materialization, context generation, and preview/download behavior
 - `docs/Tasks/AgentSkillSystem.md` for skill selection and resolution
 - `docs/Temporal/TemporalArchitecture.md` for workflow lifecycle and worker topology
@@ -692,15 +692,15 @@ Use the related docs for detailed behavior:
 
 ## 15. Summary
 
-MoonMind’s control plane is task-first, artifact-first, and target-aware.
+MoonMind’s control plane is Workflow-first, artifact-first, and target-aware.
 
 For image inputs that means:
 
 - the user authors text and image inputs in one draft
 - the control plane uploads and binds images to explicit targets
-- the task contract and authoritative snapshot preserve those bindings
+- the Workflow contract and authoritative snapshot preserve those bindings
 - the execution plane prepares and injects target-aware context
 - detail, edit, and rerun surfaces can round-trip the same authored intent without semantic loss
-- failed-task **Resume** can retry the last failed step only when durable checkpoints can restore the work completed before that step
+- failed-Workflow Execution **Resume** can retry the last failed step only when durable checkpoints can restore the work completed before that step
 
-That is the desired-state task architecture contract.
+That is the desired-state Workflow architecture contract.

--- a/docs/Tasks/WorkflowCancellation.md
+++ b/docs/Tasks/WorkflowCancellation.md
@@ -1,4 +1,4 @@
-# Task Cancellation
+# Workflow Cancellation
 
 Status: Active  
 Owners: MoonMind Engineering  
@@ -6,10 +6,10 @@ Last Updated: 2026-03-24
 
 ## 1. Purpose
 
-This document outlines **Task Cancellation** in MoonMind so that:
+This document outlines **Workflow Cancellation** in MoonMind so that:
 
-* Tasks can be cancelled while **queued** (pending execution).
-* Tasks can be cancelled while **running natively as Temporal Workflows** (via Temporal Cancellation Requests).
+* Workflow Executions can be cancelled while **queued** (pending execution).
+* Workflow Executions can be cancelled while **running natively as Temporal Workflows** (via Temporal Cancellation Requests).
 * Cancellation is exposed through:
   * **Mission Control UI** (thin dashboard over REST)
   * **REST API endpoint(s)** (under `/api/queue`)
@@ -35,10 +35,10 @@ This document outlines **Task Cancellation** in MoonMind so that:
 
 ## 3. Architecture
 
-MoonMind task runs are durably orchestrated by Temporal Workflows (e.g., `MoonMind.Run`). The cancellation flow mirrors standard Temporal patterns.
+MoonMind Workflow runs are durably orchestrated by Temporal Workflows (e.g., `MoonMind.Run`). The cancellation flow mirrors standard Temporal patterns.
 
 * Mission Control UI issues a cancel command to the Control Plane API (`POST /api/queue/jobs/{job_id}/cancel`).
-* If the task is purely queued in the database and hasn't started a workflow, the API marks it `cancelled` in Postgres directly.
+* If the Workflow Execution is purely queued in the database and hasn't started a workflow, the API marks it `cancelled` in Postgres directly.
 * If a Temporal Workflow Execution `MoonMind.Run` is currently active for this run, the API sends a standard **Temporal Cancellation Request** to the workflow via the Temporal Client.
 
 ### 3.1 Temporal Workflow Graceful Cancellation
@@ -88,7 +88,7 @@ Managed agent runs (`MoonMind.AgentRun`) acquire provider profile slots from the
 
 * When a managed `AgentRun` workflow is cancelled (or times out, or fails), it **must** release its provider profile slot.
 * The `ProviderProfileManager` must **not** rely solely on the child workflow's cleanup code to release slots. A defense-in-depth approach is required.
-* Slot recovery must happen within a **reasonable bound** (minutes, not hours) to avoid blocking subsequent task submissions.
+* Slot recovery must happen within a **reasonable bound** (minutes, not hours) to avoid blocking subsequent Workflow Execution submissions.
 
 ### 6.2 Defense-in-Depth Layers
 

--- a/docs/Tasks/WorkflowDependencies.md
+++ b/docs/Tasks/WorkflowDependencies.md
@@ -1,23 +1,23 @@
-# Task Dependencies
+# Workflow Dependencies
 
-Related: `docs/Api/ExecutionsApiContract.md`, `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskCancellation.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/UI/MissionControlArchitecture.md`
+Related: `docs/Api/ExecutionsApiContract.md`, `docs/Tasks/WorkflowArchitecture.md`, `docs/Tasks/WorkflowCancellation.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/UI/MissionControlArchitecture.md`
 
 ---
 
 ## 1. Purpose
 
-This document defines the desired-state contract for **Task Dependencies** in MoonMind.
+This document defines the desired-state contract for **Workflow Dependencies** in MoonMind.
 
-Task dependencies allow one `MoonMind.Run` execution to wait on one or more other `MoonMind.Run` executions before entering its own active work. This supports multi-stage orchestration across separate runs while keeping each execution independently durable, observable, cancelable, rerunnable, and separately inspectable.
+Workflow dependencies allow one `MoonMind.Run` execution to wait on one or more other `MoonMind.Run` executions before entering its own active work. This supports multi-stage orchestration across separate runs while keeping each execution independently durable, observable, cancelable, rerunnable, and separately inspectable.
 
 ---
 
 ## 2. Contract Summary
 
-- A task-shaped create request may declare prerequisite execution IDs in `payload.task.dependsOn`.
+- A Workflow-Execution create request may declare prerequisite execution IDs in `payload.task.dependsOn`.
 - The executions API normalizes this into `initialParameters.task.dependsOn` for `MoonMind.Run`.
 - Each `dependsOn` value is a `workflowId` for an existing `MoonMind.Run` execution.
-- For Temporal-backed task surfaces, `taskId == workflowId`.
+- For Temporal-backed Workflow Execution surfaces, `taskId == workflowId`.
 - `runId` is diagnostic only and is never a valid dependency target.
 - A prerequisite is satisfied only when it reaches terminal MoonMind state `completed`.
 - Any other prerequisite terminal outcome — `failed`, `canceled`, `terminated`, `timed_out`, or runtime unresolvable — keeps the dependent run blocked in `waiting_on_dependencies` until the same prerequisite `workflowId` later reaches `completed`. The dependent never auto-fails on a prerequisite failure. The only way out without prerequisite success is for an operator to cancel the dependent run or bypass the dependency.
@@ -38,9 +38,9 @@ The current contract is intentionally narrow:
 
 ## 3. API Contract
 
-Task dependencies are part of the Temporal-backed create flow through `/api/executions`.
+Workflow dependencies are part of the Temporal-backed create flow through `/api/executions`.
 
-The user-facing request remains task-shaped:
+The user-facing request remains Workflow-Execution-shaped:
 
 ```json
 {
@@ -110,7 +110,7 @@ If `initialParameters.task.dependsOn` is absent or empty, the workflow skips `wa
 
 ### 4.2 Dependency resolution model
 
-The canonical mechanism for inter-run task dependencies is **explicit dependency-resolution signaling**. Dependent runs do not treat direct waiting on external workflow results as the primary dependency contract.
+The canonical mechanism for inter-run Workflow dependencies is **explicit dependency-resolution signaling**. Dependent runs do not treat direct waiting on external workflow results as the primary dependency contract.
 
 When dependencies are present, the workflow must:
 
@@ -381,7 +381,7 @@ The create UX should provide:
 ### 6.2 List and detail surfaces
 
 * `waiting_on_dependencies` maps to dashboard status `waiting`.
-* Task detail shows a **Dependencies** panel with prerequisite links, titles, statuses, and terminal outcomes.
+* Workflow detail shows a **Dependencies** panel with prerequisite links, titles, statuses, and terminal outcomes.
 * When a per-dependency outcome carries `resolution = "waiting_for_successful_rerun"`, the panel must surface a clear "Prerequisite failed; waiting for successful rerun" indicator alongside the failure count and last-failed timestamp.
 * Prerequisite detail shows a **Dependents** panel or equivalent reverse-lookup view.
 * List and quick-view surfaces may show a compact blocked-by summary when useful.
@@ -390,9 +390,9 @@ The create UX should provide:
 
 ## 7. Boundary With Other Ordering Mechanisms
 
-Task dependencies are **inter-workflow** dependencies between separate top-level `MoonMind.Run` executions.
+Workflow dependencies are **inter-workflow** dependencies between separate top-level `MoonMind.Run` executions.
 
-Use task dependencies when the involved runs must remain:
+Use Workflow dependencies when the involved runs must remain:
 
 * independently visible,
 * independently durable,
@@ -400,14 +400,14 @@ Use task dependencies when the involved runs must remain:
 * independently rerunnable,
 * separately inspectable.
 
-Do **not** use task dependencies for:
+Do **not** use Workflow dependencies for:
 
 * plan-node or skill-node ordering inside a single run,
 * direct parent-owned subordinate work that should be awaited inside one orchestration history.
 
 For parent-owned subordinate work that should be directly awaited, use **child workflows**.
 
-Task dependencies block one workflow on the terminal outcome of another workflow. They do not import, merge, or replace the upstream run’s internal plan DAG.
+Workflow dependencies block one workflow on the terminal outcome of another workflow. They do not import, merge, or replace the upstream run’s internal plan DAG.
 
 ---
 

--- a/docs/Tasks/WorkflowDependenciesOperatorGuide.md
+++ b/docs/Tasks/WorkflowDependenciesOperatorGuide.md
@@ -1,10 +1,10 @@
-# Task Dependencies — Operator Guide
+# Workflow Dependencies — Operator Guide
 
-This document describes operational behavior, limits, diagnostics, and remediation for the **Task Dependencies** feature in MoonMind.
+This document describes operational behavior, limits, diagnostics, and remediation for the **Workflow Dependencies** feature in MoonMind.
 
 ---
 
-## 1. What Are Task Dependencies?
+## 1. What Are Workflow Dependencies?
 
 A `MoonMind.Run` execution can declare up to **10 prerequisite `workflowId` values** at create time via `payload.task.dependsOn`. The dependent run:
 
@@ -122,7 +122,7 @@ The following structured log events are emitted during dependency lifecycle:
 
 Under the wait-through-rerun contract, a failed prerequisite does **not** fail the dependent. Instead the dependent stays in `waiting_on_dependencies` with a per-dependency outcome marked `waiting_for_successful_rerun`.
 
-1. Open the dependent's task detail panel (or read `reports/run_summary.json` under `dependencies.outcomes`) and find any per-dependency outcome with `resolution = "waiting_for_successful_rerun"`.
+1. Open the dependent's Workflow detail panel (or read `reports/run_summary.json` under `dependencies.outcomes`) and find any per-dependency outcome with `resolution = "waiting_for_successful_rerun"`.
 2. The `failureCount` and `lastFailedAt` fields tell you how many failure cycles have happened and when the most recent failure occurred.
 3. The `terminalState`, `closeStatus`, and `failureCategory` fields explain the nature of the most recent failure.
 4. **Remediation paths:**
@@ -137,7 +137,7 @@ Workflows that started **before** `dependency-wait-through-rerun-v1` was deploye
 1. Check the `DependencyFailureError` detail in the run summary artifact (`reports/run_summary.json`) under the `dependencies` block.
 2. The `failedDependencyId` field identifies which prerequisite caused the failure.
 3. The `terminalState` and `failureCategory` fields explain the nature of the failure.
-4. **Remediation**: Fix or rerun the failed prerequisite, then rerun the dependent task. Newly created dependent runs use the wait-through-rerun behavior automatically.
+4. **Remediation**: Fix or rerun the failed prerequisite, then rerun the dependent Workflow Execution. Newly created dependent runs use the wait-through-rerun behavior automatically.
 
 ### Reverse Lookup Shows No Dependents
 
@@ -206,18 +206,18 @@ Sent to dependent workflows when a prerequisite reaches terminal state.
 - Automatic transitive dependency expansion
 - Auto-canceling prerequisite runs
 - Auto-rerunning failed prerequisites
-- Auto-creating remediation tasks for failed prerequisites
+- Auto-creating remediation Workflow Executions for failed prerequisites
 - Dependency-based priority or queue-order guarantees
-- Replacing child workflows with task dependencies
+- Replacing child workflows with Workflow dependencies
 - Storing large dependency history in Search Attributes
 
 ---
 
 ## 10. Recommended Remediation When a Prerequisite Fails
 
-1. Identify the failed prerequisite from the dependent run's task detail dependency panel or run summary artifact (look for an outcome with `resolution = "waiting_for_successful_rerun"`).
+1. Identify the failed prerequisite from the dependent run's Workflow detail dependency panel or run summary artifact (look for an outcome with `resolution = "waiting_for_successful_rerun"`).
 2. Diagnose the prerequisite failure (its terminal state, close status, failure category, and message are surfaced on the prerequisite link, and `failureCount` / `lastFailedAt` on the dependent's outcome).
-3. **Rerun the prerequisite task** — keeping the same `workflowId` is automatic when you use the standard rerun action.
+3. **Rerun the prerequisite Workflow Execution** — keeping the same `workflowId` is automatic when you use the standard rerun action.
 4. Once the prerequisite reaches `completed`, the dependent unblocks itself; no action is required on the dependent. Its dependency resolution becomes `satisfied_after_rerun`.
 5. If the prerequisite cannot be recovered:
    - **Bypass the dependency wait** on the dependent if the remaining prerequisites are no longer required, or

--- a/docs/Tasks/WorkflowEditingSystem.md
+++ b/docs/Tasks/WorkflowEditingSystem.md
@@ -1,4 +1,4 @@
-# Task Editing System
+# Workflow Editing System
 
 **Status:** Active
 **Owners:** MoonMind Engineering
@@ -6,15 +6,15 @@
 
 ## 1. Purpose
 
-This document defines the canonical task editing design for the Temporal era of MoonMind.
+This document defines the canonical Workflow editing design for the Temporal era of MoonMind.
 
-The legacy application allowed operators to open a task from the task details page, edit its configuration, and resubmit the task. That behavior was lost during the migration away from queue-job-centric task execution. The Temporal-native design restores that capability without reintroducing queue-era assumptions.
+The legacy application allowed operators to open a Workflow Execution from the Workflow details page, edit its configuration, and resubmit the Workflow Execution. That behavior was lost during the migration away from queue-job-centric Workflow execution. The Temporal-native design restores that capability without reintroducing queue-era assumptions.
 
 The core idea is simple:
 
-- `/tasks/new` remains the single task submission surface.
+- `/tasks/new` remains the single Workflow Execution submission surface.
 - Existing Temporal executions become the editable object.
-- The task details page regains an **Edit** action for executions that support in-place input updates.
+- The Workflow details page regains an **Edit** action for executions that support in-place input updates.
 - Terminal executions, including failed and canceled executions, gain a **Rerun** action that reuses the same prefilled submit experience and allows the operator to edit the draft before submitting it again.
 
 This keeps create, edit, and rerun on one form while making Temporal the source of truth.
@@ -23,8 +23,8 @@ This keeps create, edit, and rerun on one form while making Temporal the source 
 
 This design applies to:
 
-- the shared task submit page at `/tasks/new`
-- Temporal-backed task detail surfaces in Mission Control
+- the shared Workflow Execution submit page at `/tasks/new`
+- Temporal-backed Workflow detail surfaces in Mission Control
 - Temporal-backed list or card surfaces that may expose edit or rerun entry points
 - input reconstruction from Temporal execution details and referenced artifacts
 - submission through Temporal execution updates
@@ -36,13 +36,13 @@ This design does **not** apply to:
 - recurring schedule editing
 - inline edit modals on the detail page
 - direct mutation of previously stored artifacts
-- non-Temporal task execution systems
+- non-Temporal Workflow execution systems
 
 ## 3. Design goals
 
 ### 3.1 Temporal is the source of truth
 
-Task editing must operate on Temporal execution state, capabilities, and inputs. No queue-job payload should be required to support edit or rerun.
+Workflow editing must operate on Temporal execution state, capabilities, and inputs. No queue-job payload should be required to support edit or rerun.
 
 ### 3.2 One submit experience
 
@@ -50,13 +50,13 @@ Create, edit, and rerun should all reuse `/tasks/new` so operators do not learn 
 
 ### 3.3 Preserve create-form ergonomics
 
-Editing should feel like reopening a familiar task form with the same fields, validations, templates, and artifact behavior.
+Editing should feel like reopening a familiar Workflow form with the same fields, validations, templates, and artifact behavior.
 
 ### 3.4 Respect lifecycle correctness
 
 Active executions can be edited only when the backend exposes that capability. Terminal executions cannot be “edited in place”; they can only be rerun.
 
-Failed and canceled terminal executions are first-class rerun candidates. When the backend exposes rerun capability for one of these executions, the operator must be able to reopen its task inputs as an editable draft, change the relevant fields, and submit the updated draft as a new rerun request.
+Failed and canceled terminal executions are first-class rerun candidates. When the backend exposes rerun capability for one of these executions, the operator must be able to reopen its Workflow inputs as an editable draft, change the relevant fields, and submit the updated draft as a new rerun request.
 
 ### 3.5 Preserve auditability
 
@@ -64,7 +64,7 @@ The system must preserve operator-visible lineage between the original execution
 
 ### 3.6 Avoid in-place artifact mutation
 
-Editing a task must never rewrite historical artifacts. New artifacts are created for new input content.
+Editing a Workflow Execution must never rewrite historical artifacts. New artifacts are created for new input content.
 
 ### 3.7 Remove legacy coupling
 
@@ -99,7 +99,7 @@ Any other workflow type is out of scope until explicitly added.
 - **Edit** is for non-terminal executions only.
 - **Rerun** is for terminal executions only.
 - Failed and canceled executions are terminal, but they must be eligible for rerun when `actions.canRerun` is `true`.
-- Rerun mode must allow the operator to edit reconstructed task inputs before submitting the rerun request.
+- Rerun mode must allow the operator to edit reconstructed Workflow inputs before submitting the rerun request.
 - UI availability is determined by backend capability flags, not frontend guesses.
 
 ## 5. Route model
@@ -145,9 +145,9 @@ This ensures rerun remains explicit and cannot be accidentally overridden by edi
 
 ## 6. Entry points
 
-### 6.1 Task detail page
+### 6.1 Workflow detail page
 
-The task details page is the primary place where editing becomes visible again.
+The Workflow details page is the primary place where editing becomes visible again.
 
 The detail page should:
 
@@ -163,7 +163,7 @@ Edit   -> /tasks/new?editExecutionId=<workflowId>
 Rerun  -> /tasks/new?rerunExecutionId=<workflowId>
 ```
 
-### 6.2 Task list or card surfaces
+### 6.2 Workflow list or card surfaces
 
 List and card surfaces may optionally expose the same actions, but the detail page is the canonical entry point that restores the lost edit behavior.
 
@@ -183,9 +183,9 @@ List and card surfaces may optionally expose the same actions, but the detail pa
 
 | Mode | Page title | Primary CTA |
 |---|---|---|
-| Create | New Task | Create Task |
-| Edit | Edit Task | Save Changes |
-| Rerun | Rerun Task | Rerun Task |
+| Create | New Workflow | Create Workflow |
+| Edit | Edit Workflow | Save Changes |
+| Rerun | Rerun Workflow | Rerun Workflow |
 
 ### 7.3 Hidden or constrained controls
 
@@ -215,7 +215,7 @@ The canonical reconstruction entry point is:
 buildTemporalSubmissionDraftFromExecution(execution)
 ```
 
-This helper converts a Temporal execution detail payload into the same draft shape used by normal task creation.
+This helper converts a Temporal execution detail payload into the same draft shape used by normal Workflow Execution creation.
 
 ### 8.2 Draft data sources
 
@@ -239,7 +239,7 @@ The reconstructed draft should prefill, where available:
 - starting branch
 - target branch
 - publish mode
-- task instructions
+- Workflow instructions
 - primary skill
 - explicit steps or workflow options
 - applied template state
@@ -249,7 +249,7 @@ The reconstructed draft should prefill, where available:
 
 Instructions may be stored inline or in artifacts.
 
-The submit page must reconstruct the operator-visible instruction text regardless of storage strategy. Operators should not have to reason about whether the prior task used inline text or artifact-backed content.
+The submit page must reconstruct the operator-visible instruction text regardless of storage strategy. Operators should not have to reason about whether the prior Workflow Execution used inline text or artifact-backed content.
 
 ### 8.5 Fallback behavior
 
@@ -263,7 +263,7 @@ If an execution cannot fully reconstruct a draft:
 
 ### 9.1 Create mode
 
-Create mode continues to use the normal task creation path and is unchanged by this design.
+Create mode continues to use the normal Workflow Execution creation path and is unchanged by this design.
 
 ### 9.2 Edit mode
 
@@ -300,7 +300,7 @@ A helper such as `buildTemporalArtifactEditUpdatePayload(...)` may be used to as
 
 Rerun mode uses the same prefilled form but requests a rerun instead of mutating the original terminal execution.
 
-For failed or canceled executions, rerun mode is the supported way to edit the prior task and submit it again. The original execution remains immutable and terminal; the shared form reconstructs the previous input state, allows the operator to change instructions, runtime options, repository or branch fields, skills, templates, and other supported inputs, and then sends those edited values through `RequestRerun`.
+For failed or canceled executions, rerun mode is the supported way to edit the prior Workflow Execution and submit it again. The original execution remains immutable and terminal; the shared form reconstructs the previous input state, allows the operator to change instructions, runtime options, repository or branch fields, skills, templates, and other supported inputs, and then sends those edited values through `RequestRerun`.
 
 Canonical request:
 
@@ -324,7 +324,7 @@ There is no queue-era fallback path. If Temporal editing or rerun is unsupported
 
 ### 10.1 No historical mutation
 
-Previously stored input artifacts are immutable for the purpose of task editing. An edit must create new artifact references instead of mutating old ones.
+Previously stored input artifacts are immutable for the purpose of Workflow editing. An edit must create new artifact references instead of mutating old ones.
 
 ### 10.2 Preserve lineage
 
@@ -402,7 +402,7 @@ The submit page must block submission when any of the following is true:
 - backend capability flags do not allow the requested action
 - the backend rejects the update because the workflow state changed
 
-Errors should be explicit and operator-readable. The frontend should not pretend a task is editable if Temporal says it is not.
+Errors should be explicit and operator-readable. The frontend should not pretend a Workflow Execution is editable if Temporal says it is not.
 
 ## 14. Observability and audit
 
@@ -421,7 +421,7 @@ Operator-visible detail views should make it possible to understand whether a ch
 This design intentionally does not include:
 
 - a separate edit-only form distinct from `/tasks/new`
-- queue-first task editing UX
+- queue-first Workflow editing UX
 - proposal editing
 - manifest-run editing
 - recurring schedule editing
@@ -430,19 +430,19 @@ This design intentionally does not include:
 
 ## 16. Deprecated legacy references
 
-The following concepts should be removed from canonical docs and primary UI flows when describing Temporal task editing:
+The following concepts should be removed from canonical docs and primary UI flows when describing Temporal Workflow editing:
 
 - `editJobId`
 - `/tasks/queue/new`
 - queue-job update behavior
 - queue resubmit language when the action is actually a Temporal rerun
-- proposal-centric wording for standard task editing
+- proposal-centric wording for standard Workflow editing
 
 ## 17. Completion criteria
 
 This design is considered implemented when all of the following are true:
 
-1. The task detail page once again exposes an **Edit** action for supported Temporal executions.
+1. The Workflow detail page once again exposes an **Edit** action for supported Temporal executions.
 2. `/tasks/new?editExecutionId=<workflowId>` opens with a prefilled draft reconstructed from Temporal execution data and artifacts.
 3. `/tasks/new?rerunExecutionId=<workflowId>` opens the same shared form in rerun mode.
 4. Edit submissions call `UpdateInputs`.
@@ -458,7 +458,7 @@ This design is considered implemented when all of the following are true:
 Implementation sequencing and migration details should be tracked in:
 
 ```text
-docs/Tasks/TaskEditingSystem.md
+docs/Tasks/WorkflowEditingSystem.md
 ```
 
 That plan should remain an execution checklist. This document is the canonical target-state design.

--- a/docs/Tasks/WorkflowFinishSummarySystem.md
+++ b/docs/Tasks/WorkflowFinishSummarySystem.md
@@ -1,9 +1,9 @@
-# Task Finish Summary System
+# Workflow Finish Summary System
 
 Status: Active  
 Owners: MoonMind Engineering  
 Last Updated: 2026-05-17  
-Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskProposalQueue.md`,
+Related: `docs/Tasks/WorkflowArchitecture.md`, `docs/Tasks/WorkflowProposalSystem.md`,
 `docs/Temporal/ErrorTaxonomy.md`, `docs/Temporal/StepLedgerAndProgressModel.md`
 
 ---
@@ -164,7 +164,7 @@ sent to the terminal-state activity.
 
 ### 2.6 Preset Summary Ownership
 
-Task presets do not own generic end-of-run narration. Presets may emit structured
+Workflow presets do not own generic end-of-run narration. Presets may emit structured
 facts that are useful after execution, such as a Jira issue key, pull request
 URL, verification verdict, publish handoff, or outcome data, but those facts are
 inputs to operator surfaces and workflow finalization rather than a replacement

--- a/docs/Tasks/WorkflowPresetsSystem.md
+++ b/docs/Tasks/WorkflowPresetsSystem.md
@@ -1,14 +1,14 @@
-# Task Presets System
+# Workflow Presets System
 
 ## Status
 
 Desired-state architecture.
 
-This document defines MoonMind's task preset system as a declarative, schema-driven composition layer. Presets are reusable step plans that may request typed inputs from the user, expand into one or more executable steps, and preserve provenance so task runs remain understandable after expansion.
+This document defines MoonMind's Workflow preset system as a declarative, schema-driven composition layer. Presets are reusable step plans that may request typed inputs from the user, expand into one or more executable steps, and preserve provenance so Workflow runs remain understandable after expansion.
 
 ## Purpose
 
-Task presets let a user start from a known workflow shape without manually authoring every step. A preset may represent a simple one-step action, a multi-step coding workflow, a Jira-driven orchestration flow, a proposal/remediation flow, or another composed task pattern.
+Workflow presets let a user start from a known workflow shape without manually authoring every step. A preset may represent a simple one-step action, a multi-step coding workflow, a Jira-driven orchestration flow, a proposal/remediation flow, or another composed Workflow pattern.
 
 The preset system must make the Create page easier to use without making the Create page responsible for knowing the details of every preset. Presets describe their own inputs through a machine-readable schema. The Create page renders those inputs automatically from the schema, validates them, and passes the collected values to the shared preset expansion path.
 
@@ -16,7 +16,7 @@ The preset system must make the Create page easier to use without making the Cre
 
 - Presets are first-class step types, not a separate Create page mode.
 - A preset may remain unexpanded while the user configures it.
-- The user may submit a task with unexpanded preset steps; submission expands them automatically after validation.
+- The user may submit a Workflow Execution with unexpanded preset steps; submission expands them automatically after validation.
 - The Create page never hard-codes preset-specific forms such as `if presetId === "jira-orchestrate"`.
 - Each preset declares its expected inputs with an `input_schema` that can drive UI generation, API validation, apply, reapply, and submit-time expansion.
 - Preset input schemas align with the same direction as MoonMind skill input schemas and Agent Skills-style declarative capability metadata.
@@ -25,9 +25,9 @@ The preset system must make the Create page easier to use without making the Cre
 
 ## Non-Goals
 
-- Presets are not a replacement for skills. A skill is a reusable agent capability or instruction bundle. A preset is a reusable task/step composition that may invoke skills, scripts, managed agents, external agents, or other presets.
+- Presets are not a replacement for skills. A skill is a reusable agent capability or instruction bundle. A preset is a reusable Workflow/step composition that may invoke skills, scripts, managed agents, external agents, or other presets.
 - Presets do not require custom React code for each preset. Only reusable field widgets may have custom components.
-- Presets do not require the user to manually expand them before task creation.
+- Presets do not require the user to manually expand them before Workflow Execution creation.
 - Presets do not grant arbitrary execution rights. Expanded steps still pass through the same validation, policy, runtime, and publishing controls as manually authored steps.
 
 ## Core Concepts
@@ -50,7 +50,7 @@ A preset step is a step on the Create page with `type: preset`, a `preset_id`, a
 
 ### Expansion
 
-Expansion transforms a preset step plus validated inputs into concrete child steps. The backend owns expansion so apply, submit, API-driven task creation, and re-run flows share the same behavior.
+Expansion transforms a preset step plus validated inputs into concrete child steps. The backend owns expansion so apply, submit, API-driven Workflow Execution creation, and re-run flows share the same behavior.
 
 ### Provenance
 
@@ -351,10 +351,10 @@ The same path is used by:
 
 - preset apply
 - preset reapply
-- task submission with unexpanded presets
-- API-created tasks
-- task edit and re-run flows that reconstruct preset-originated steps
-- goal-only task submissions that are first mapped to a seeded preset
+- Workflow Execution submission with unexpanded presets
+- API-created Workflow Executions
+- Workflow Execution edit and re-run flows that reconstruct preset-originated steps
+- goal-only Workflow Execution submissions that are first mapped to a seeded preset
 
 Expansion must:
 
@@ -425,31 +425,31 @@ generated story with the current repository state and annotates the story
 breakdown before any Jira mutation occurs:
 
 - fully implemented stories are marked for skip and do not create Jira issues or
-  downstream Jira Orchestrate tasks
+  downstream Jira Orchestrate Workflow Executions
 - partially implemented stories keep their original traceability but add
   `remainingWork`, so Jira tracks only the unmet behavior
 - unverifiable stories are marked for manual review and are not automatically
   converted into implementation work
 
 The deterministic Jira story-output tool consumes only eligible reconciled
-stories, then the downstream Jira Orchestrate task creator consumes only the
+stories, then the downstream Jira Orchestrate Workflow Execution creator consumes only the
 Jira issue mappings that were actually created or reused.
 
 ## Submit-Time Auto-Expansion
 
-The user may click Create Task while one or more preset steps are still unexpanded. The submit path must:
+The user may click Create Workflow while one or more preset steps are still unexpanded. The submit path must:
 
 1. Validate all non-preset step fields.
 2. Validate each preset step's collected inputs.
 3. Expand all unexpanded preset steps through the backend expansion path.
-4. Re-run final task validation on the fully expanded step list.
-5. Submit the task.
+4. Re-run final Workflow Execution validation on the fully expanded step list.
+5. Submit the Workflow Execution.
 
-If a required preset input is missing, Create Task is blocked and the missing field is highlighted. If backend expansion fails, the Create page displays the field-addressable errors and preserves the user's entered values.
+If a required preset input is missing, Create Workflow is blocked and the missing field is highlighted. If backend expansion fails, the Create page displays the field-addressable errors and preserves the user's entered values.
 
 ## Goal-Driven Preset Scheduling
 
-When a task is submitted with a plain `goal` and without already-authored
+When a Workflow Execution is submitted with a plain `goal` and without already-authored
 steps, an explicit plan, a selected tool/skill, or a selected preset, MoonMind
 may map that goal to a seeded preset before normal submit-time expansion. This
 keeps the fast path from requiring manual preset selection while preserving the
@@ -464,7 +464,7 @@ The initial selector is deterministic and conservative:
   preset
 - a general implementation goal maps to MoonSpec Orchestrate
 
-The submitted task records `presetSchedule` metadata with the goal source,
+The submitted Workflow Execution records `presetSchedule` metadata with the goal source,
 selected preset, preset version, and reason. Once the preset is selected, the
 normal backend expansion service owns the executable step list.
 
@@ -564,7 +564,7 @@ Persisted records should support:
 - comparison between original preset inputs and edited generated steps
 - future migrations when preset versions change
 
-Preset versions are immutable once tasks have been created from them. Updating a preset creates a new version or equivalent revision identifier.
+Preset versions are immutable once Workflow Executions have been created from them. Updating a preset creates a new version or equivalent revision identifier.
 
 ## Implementation Requirements
 
@@ -575,7 +575,7 @@ To fully realize this design, MoonMind needs:
 3. A generic schema-form renderer on the Create page.
 4. A reusable widget registry for semantic widgets such as Jira issue picker.
 5. Removal of preset-specific Create page branches.
-6. A shared backend expansion service used by apply, reapply, submit-time auto-expansion, and API-created tasks.
+6. A shared backend expansion service used by apply, reapply, submit-time auto-expansion, and API-created Workflow Executions.
 7. Provenance on expanded steps.
 8. Recursive expansion support with cycle detection.
 9. Field-addressable validation errors.
@@ -603,5 +603,5 @@ The key acceptance test is: a developer can add a new preset manifest with a sup
 - `docs/Steps/StepTypes.md`
 - `docs/Steps/SkillSystem.md`
 - `docs/Steps/JiraIntegration.md`
-- `docs/Tasks/TaskArchitecture.md`
-- `docs/Tasks/TaskEditingSystem.md`
+- `docs/Tasks/WorkflowArchitecture.md`
+- `docs/Tasks/WorkflowEditingSystem.md`

--- a/docs/Tasks/WorkflowProposalSystem.md
+++ b/docs/Tasks/WorkflowProposalSystem.md
@@ -1,9 +1,9 @@
-# Task Proposal System
+# Workflow Proposal System
 
 Status: Active desired state
 Owners: MoonMind Engineering
 Last Updated: 2026-05-06
-Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskFinishSummarySystem.md`, `docs/Api/ExecutionsApiContract.md`, `docs/UI/MissionControlArchitecture.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/ExternalAgents/ExternalAgentIntegrationSystem.md`, `docs/Tasks/AgentSkillSystem.md`, `docs/Tasks/SkillAndPlanContracts.md`
+Related: `docs/Tasks/WorkflowArchitecture.md`, `docs/Tasks/WorkflowFinishSummarySystem.md`, `docs/Api/ExecutionsApiContract.md`, `docs/UI/MissionControlArchitecture.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/ExternalAgents/ExternalAgentIntegrationSystem.md`, `docs/Tasks/AgentSkillSystem.md`, `docs/Tasks/SkillAndPlanContracts.md`
 
 ---
 
@@ -16,7 +16,7 @@ The desired proposal architecture is external-tracker-native:
 1. MoonMind generates candidate follow-up work during the `proposals` stage of a `MoonMind.Run`.
 2. MoonMind validates, normalizes, deduplicates, and stores each proposal as a control-plane delivery record.
 3. MoonMind delivers each proposal to the configured human-review tracker as either a GitHub Issue or Jira issue.
-4. Reviewers triage proposals in GitHub or Jira, not on a dedicated MoonMind task proposal page.
+4. Reviewers triage proposals in GitHub or Jira, not on a dedicated MoonMind Workflow proposal page.
 5. Promotion creates a new `MoonMind.Run` only after a verified human approval action in the configured tracker.
 6. MoonMind comments or transitions the external issue with execution, pull request, error, and final status links.
 
@@ -25,18 +25,18 @@ Each proposal has two representations:
 1. **Executable source of truth:** MoonMind's stored, validated `taskCreateRequest` snapshot or artifact reference.
 2. **Human review artifact:** the GitHub Issue or Jira issue rendered from that snapshot.
 
-The external issue is the review surface, not the executable contract. MoonMind never executes arbitrary edited issue Markdown, Jira ADF, labels, or comments as a task payload. Promotion always uses MoonMind's stored proposal snapshot plus bounded, validated reviewer controls.
+The external issue is the review surface, not the executable contract. MoonMind never executes arbitrary edited issue Markdown, Jira ADF, labels, or comments as a Workflow payload. Promotion always uses MoonMind's stored proposal snapshot plus bounded, validated reviewer controls.
 
 The proposal system is Temporal-native:
 
 1. `MoonMind.Run` executes work.
 2. A dedicated `proposals` stage runs after execution and before finalization.
-3. Generator activities create candidate follow-up tasks from run artifacts and normalized agent results.
+3. Generator activities create candidate follow-up Workflow Executions from run artifacts and normalized agent results.
 4. Submission activities validate candidates, resolve routing policy, persist delivery records, and create or update external issues.
 5. Webhook or sync activities observe approved/rejected/deferred tracker actions.
 6. Promotion creates a new Temporal execution only after human approval.
 
-Canonical agent-skill storage, precedence, and snapshot semantics live in `docs/Tasks/AgentSkillSystem.md`. This document defines how proposals preserve and promote task-facing skill intent.
+Canonical agent-skill storage, precedence, and snapshot semantics live in `docs/Tasks/AgentSkillSystem.md`. This document defines how proposals preserve and promote Workflow-facing skill intent.
 
 ---
 
@@ -44,13 +44,13 @@ Canonical agent-skill storage, precedence, and snapshot semantics live in `docs/
 
 These rules are fixed:
 
-1. `taskCreateRequest` is the canonical promote-to-task payload.
+1. `taskCreateRequest` is the canonical promote-to-Workflow payload.
 2. Proposal creation is not execution; promotion is the only action that starts new work.
 3. Promotion creates a new `MoonMind.Run` execution, not a legacy queue job.
 4. `taskCreateRequest.payload.repository` is the canonical repository target for deduplication and future execution.
 5. Human review is required before any proposal becomes durable running work.
 6. Human review occurs in GitHub Issues or Jira, according to resolved proposal delivery policy.
-7. MoonMind does not provide a dedicated task proposal review page as a primary workflow surface.
+7. MoonMind does not provide a dedicated Workflow proposal review page as a primary workflow surface.
 8. The external issue body is a rendered review artifact, not an executable payload.
 9. Proposal generation is best-effort and must never compromise the correctness of the parent run result.
 10. Proposal payloads must conform to the canonical Temporal submit contract used by `/api/executions`.
@@ -58,7 +58,7 @@ These rules are fixed:
 12. When a proposal depends on agent skill context, that context must be preserved explicitly in the stored `taskCreateRequest` or through documented inheritance semantics.
 13. Proposal promotion must not silently drift to unrelated skill defaults when the original proposal logic depended on explicit skill selection.
 14. Preset-derived metadata in proposals is advisory review and reconstruction metadata, not a runtime dependency.
-15. Proposal promotion validates and submits the reviewed flat task payload; it does not depend on live preset catalog lookup or live preset re-expansion for correctness.
+15. Proposal promotion validates and submits the reviewed flat Workflow payload; it does not depend on live preset catalog lookup or live preset re-expansion for correctness.
 16. Deduplication is repository-aware and deterministic.
 17. Delivery to GitHub or Jira is idempotent. A repeated proposal with the same dedup target updates or links to the existing external issue instead of creating reviewer-facing duplicates.
 18. Tracker credentials and webhook secrets remain inside trusted MoonMind integration boundaries and are never injected into managed agent runtimes.
@@ -69,7 +69,7 @@ These rules are fixed:
 
 ### 3.1 Submit-time contract
 
-Task-shaped submit requests may include:
+Workflow-shaped submit requests may include:
 
 1. `task.proposeTasks`
 2. `task.proposalPolicy`
@@ -81,27 +81,27 @@ These values are part of the durable run contract and must be preserved in `init
 The canonical direction is:
 
 1. Preserve the raw `task.proposalPolicy` object in `initialParameters`.
-2. Resolve global defaults plus per-task overrides inside the proposal stage or inside `proposal.submit`.
+2. Resolve global defaults plus per-Workflow overrides inside the proposal stage or inside `proposal.submit`.
 3. Do not rely on a parallel flattened proposal-policy contract for new work.
 4. Persist enough resolved policy metadata on proposal delivery records to explain why a proposal was delivered to GitHub or Jira.
 
 ### 3.1.1 Canonical submission-path normalization
 
-All new task submission paths must normalize proposal intent into the same canonical nested task payload accepted by `/api/executions` before `MoonMind.Run` starts.
+All new Workflow submission paths must normalize proposal intent into the same canonical nested Workflow payload accepted by `/api/executions` before `MoonMind.Run` starts.
 
-Managed sessions do not define a parallel proposal contract. They are the highest-risk producer because session containers may create additional MoonMind tasks through the internal API path, but the rule also applies to ordinary API submission, proposal promotion, schedules, and any future task-creation surface.
+Managed sessions do not define a parallel proposal contract. They are the highest-risk producer because session containers may create additional MoonMind Workflow Executions through the internal API path, but the rule also applies to ordinary API submission, proposal promotion, schedules, and any future Workflow-creation surface.
 
 Required mapping:
 
 1. session-level or adapter-level proposal opt-in becomes `initialParameters.task.proposeTasks`
 2. session-level or adapter-level proposal routing overrides become `initialParameters.task.proposalPolicy`
-3. task/runtime/repository metadata continues to flow through the canonical task payload instead of a Codex-only side channel
+3. Workflow/runtime/repository metadata continues to flow through the canonical Workflow payload instead of a Codex-only side channel
 
 Non-canonical locations such as root-level `initialParameters.proposeTasks`, turn metadata, session binding metadata, container environment, or adapter-local state are not the durable write contract for new work.
 
 Workflow code may read root-level `initialParameters.proposeTasks` or older policy shapes only for replay and in-flight compatibility. New submission paths must write the nested `task.*` fields so future behavior does not depend on compatibility fallbacks.
 
-For session-capable runtimes, this applies both when a user submits a task targeting a managed-session runtime and when a managed session creates additional MoonMind tasks through the internal API path.
+For session-capable runtimes, this applies both when a user submits a Workflow Execution targeting a managed-session runtime and when a managed session creates additional MoonMind Workflow Executions through the internal API path.
 
 ### 3.2 Run states
 
@@ -134,9 +134,9 @@ The proposal system uses this lifecycle vocabulary consistently across:
 The `proposals` stage runs only when both conditions are true:
 
 1. global proposal generation is enabled by workflow settings
-2. the submitted task enables proposals through `task.proposeTasks`
+2. the submitted Workflow Execution enables proposals through `task.proposeTasks`
 
-This gives operators a real global off switch while still allowing task-level opt-in when the feature is enabled system-wide.
+This gives operators a real global off switch while still allowing Workflow-level opt-in when the feature is enabled system-wide.
 
 For managed-session originated runs, the durable gate is the canonical nested value preserved in `initialParameters.task.proposeTasks`; session-local flags alone must not determine whether the workflow enters `proposals`.
 
@@ -157,7 +157,7 @@ Generators must:
 
 1. treat run inputs and logs as untrusted
 2. use artifact-backed references for large context
-3. avoid side effects such as commits, pushes, issue creation, or task creation
+3. avoid side effects such as commits, pushes, issue creation, or Workflow creation
 4. redact or exclude secrets and unsafe command output
 5. preserve skill selectors only when they materially affect correctness or expected behavior of the follow-up work
 6. preserve reliable preset provenance only when the candidate work is genuinely derived from authored preset metadata or reliable step source metadata
@@ -199,7 +199,7 @@ At minimum it records:
 
 ## 4. Proposal Policy
 
-Proposal routing follows global defaults plus optional per-task overrides.
+Proposal routing follows global defaults plus optional per-Workflow overrides.
 
 `proposalPolicy` controls whether proposals are generated, which repositories receive proposed work, and which external tracker receives reviewer-facing issues. It does not independently redefine agent skill precedence. Skill selection is preserved from the candidate payload or inherited from canonical system semantics, not recomputed by the proposal policy itself.
 
@@ -219,7 +219,7 @@ The canonical global controls are:
 
 Operator-facing configuration remains the source of truth for these defaults.
 
-### 4.2 Per-task policy contract
+### 4.2 Per-Workflow policy contract
 
 `task.proposalPolicy` controls:
 
@@ -268,7 +268,7 @@ Project-targeted proposals keep the triggering repository as `taskCreateRequest.
 
 They are used for follow-up feature work, cleanup, tests, or project-local quality work discovered during the run.
 
-Their external issue is delivered to the tracker associated with the project repository unless the task policy explicitly selects another allowed destination.
+Their external issue is delivered to the tracker associated with the project repository unless the Workflow policy explicitly selects another allowed destination.
 
 ### 4.5 MoonMind-targeted proposals
 
@@ -435,17 +435,17 @@ Large payloads, logs, artifacts, and diagnostics are linked by reference rather 
 
 ### 6.1 Canonical direction
 
-Stored proposals must use the same task-shaped contract accepted by Temporal submission through `/api/executions`.
+Stored proposals must use the same Workflow-shaped contract accepted by Temporal submission through `/api/executions`.
 
 That means:
 
-1. `taskCreateRequest` stores a normal task payload
+1. `taskCreateRequest` stores a normal Workflow payload
 2. `task.runtime.mode` selects the runtime
 3. `task.tool` and `step.tool`, when present, use the canonical Temporal submit shape
 4. `task.tool.type` must be `skill` when a tool selector is provided, representing an executable tool rather than an agent instruction bundle
 5. proposal payloads do not use `tool.type = "agent_runtime"`
 6. `task.skills` and `step.skills` may be included and must follow the canonical Agent Skill System contract defined in `docs/Tasks/AgentSkillSystem.md`
-7. delivery metadata is stored alongside the proposal delivery record, not inside the executable task payload unless it is part of the user's explicit task contract
+7. delivery metadata is stored alongside the proposal delivery record, not inside the executable Workflow payload unless it is part of the user's explicit Workflow contract
 
 ### 6.2 Candidate example
 
@@ -512,19 +512,19 @@ That means:
 
 ### 6.3 Payload rules
 
-1. `taskCreateRequest` must already validate against the canonical task contract.
+1. `taskCreateRequest` must already validate against the canonical Workflow contract.
 2. `taskCreateRequest.payload.repository` determines deduplication and future execution target.
-3. `taskCreateRequest.payload.task.runtime.mode` uses current supported task runtimes: `codex`, `gemini_cli`, `claude`, and optionally `jules`.
+3. `taskCreateRequest.payload.task.runtime.mode` uses current supported Workflow runtimes: `codex`, `gemini_cli`, `claude`, and optionally `jules`.
 4. Candidate payloads must not include secrets, raw credentials, or unsafe log dumps.
-5. Promotion-time overrides must also validate against the same canonical task contract before execution starts.
+5. Promotion-time overrides must also validate against the same canonical Workflow contract before execution starts.
 6. If `task.skills` or `step.skills` are present, they must validate against the canonical agent-skill contract.
 7. Proposals must not embed full agent skill bodies inline when refs or selectors are the correct contract.
 8. Proposals preserve execution intent, not raw runtime materialization state.
 9. Proposal payloads must not store mutable `.agents/skills` directory state, runtime-local materialization outputs, or ephemeral prompt bundles produced only for one adapter session.
-10. Proposal-capable work originating from a managed session must already carry `task.proposeTasks` and any `task.proposalPolicy` in the canonical task payload.
+10. Proposal-capable work originating from a managed session must already carry `task.proposeTasks` and any `task.proposalPolicy` in the canonical Workflow payload.
 11. Proposal generation must not reconstruct proposal intent from session-local metadata.
 12. Proposal payloads may include optional `task.authoredPresets` and `steps[].source` provenance when the metadata is reliable.
-13. Preset provenance fields are reconstruction and review metadata only; they do not change the executable meaning of the flat task payload.
+13. Preset provenance fields are reconstruction and review metadata only; they do not change the executable meaning of the flat Workflow payload.
 14. Proposal payloads must not contain unresolved preset include objects as runtime work.
 15. Preset-derived proposals must be execution-ready flat payloads before storage and promotion.
 
@@ -558,9 +558,9 @@ Canonical keys are:
 
 ### 7.3 Identity rules
 
-1. `workflow_id` is the durable source task identity for workflow-originated proposals.
-2. `temporal_run_id` is diagnostic metadata, not the durable task handle.
-3. Task-oriented Temporal surfaces continue to use `taskId == workflowId`.
+1. `workflow_id` is the durable source Workflow Execution identity for workflow-originated proposals.
+2. `temporal_run_id` is diagnostic metadata, not the durable Workflow Execution handle.
+3. Workflow-oriented Temporal surfaces continue to use `taskId == workflowId`.
 4. Continue-as-new does not change the proposal origin identity; the durable workflow remains the source.
 5. External issue keys are delivery identities, not execution identities.
 6. The MoonMind proposal delivery ID binds the stored proposal snapshot to the external issue.
@@ -608,17 +608,17 @@ Promotion must follow this algorithm:
 4. load the stored proposal snapshot
 5. verify the proposal is still open or approved-but-not-promoted
 6. parse bounded promotion controls such as `priority`, `maxAttempts`, `note`, and `runtimeMode`
-7. apply validated bounded controls to the execution request without replacing the stored task payload
-8. validate the stored payload against the canonical task contract, including verification of any agent-skill selectors and executable step types
+7. apply validated bounded controls to the execution request without replacing the stored Workflow payload
+8. validate the stored payload against the canonical Workflow contract, including verification of any agent-skill selectors and executable step types
 9. preserve explicit skill-selection intent from the stored proposal
 10. preserve `task.authoredPresets` and per-step `source` provenance from the stored proposal
-11. submit the reviewed task through the same Temporal-backed create path used by `/api/executions`
+11. submit the reviewed Workflow Execution through the same Temporal-backed create path used by `/api/executions`
 12. create a new `MoonMind.Run` through `TemporalExecutionService.create_execution()`
 13. store the promoted workflow or execution identifier on the proposal delivery record
 14. update the external issue status to promoted
 15. comment on or transition the external issue with execution metadata
 
-Promotion does not accept a full task payload replacement from the external issue body. If a future proposal refresh, issue-edit ingestion, or preset re-expansion flow exists, it must be an explicit validate-and-confirm action that creates a new stored proposal revision before promotion.
+Promotion does not accept a full Workflow payload replacement from the external issue body. If a future proposal refresh, issue-edit ingestion, or preset re-expansion flow exists, it must be an explicit validate-and-confirm action that creates a new stored proposal revision before promotion.
 
 Promotion is a control-plane-to-Temporal bridge, not a proposal-local mutation only.
 
@@ -642,8 +642,8 @@ MoonMind updates the external issue with the final decision when the provider ac
 
 Proposal promotion preserves agent skill intent from the original execution.
 
-1. When the original task relied only on deployment/default inheritance, proposal payloads may omit redundant explicit skill selectors.
-2. When the original task included explicit non-default skill selection that materially affects execution behavior, proposals should preserve that selection explicitly.
+1. When the original Workflow Execution relied only on deployment/default inheritance, proposal payloads may omit redundant explicit skill selectors.
+2. When the original Workflow Execution included explicit non-default skill selection that materially affects execution behavior, proposals should preserve that selection explicitly.
 3. Operators may override runtime at promotion time.
 4. Agent skill selectors are preserved by default.
 5. Changing the runtime does not automatically erase or rewrite agent skill intent.
@@ -672,7 +672,7 @@ Proposal promotion supports operator runtime selection.
 Rules:
 
 1. the backend-served runtime list is the source of truth
-2. supported task-facing runtime values are `codex`, `gemini_cli`, `claude`, and optionally `jules`
+2. supported Workflow-facing runtime values are `codex`, `gemini_cli`, `claude`, and optionally `jules`
 3. runtime overrides apply to the promoted execution request, not to the stored proposal snapshot
 4. disabled runtimes must fail validation before a workflow is created
 
@@ -708,7 +708,7 @@ Its desired response includes delivery information:
 }
 ```
 
-Internal callers do not need to know whether the reviewer will use GitHub or Jira before submission unless they intentionally provide an allowed per-task delivery override.
+Internal callers do not need to know whether the reviewer will use GitHub or Jira before submission unless they intentionally provide an allowed per-Workflow delivery override.
 
 ### 9.2 Webhook endpoints
 
@@ -782,12 +782,12 @@ The system must show:
 3. external issue links from execution detail
 4. provider, external key, delivery status, and last sync timestamp
 5. whether a proposal was created as a new issue or attached to an existing dedup issue
-6. compact task summary: runtime, repository, publish mode, priority, max attempts, skill context, and preset provenance
+6. compact Workflow summary: runtime, repository, publish mode, priority, max attempts, skill context, and preset provenance
 7. promotion result links after approval
 
 ### 10.3 No dedicated proposal page
 
-MoonMind does not maintain a dedicated human-facing task proposal page for normal proposal triage.
+MoonMind does not maintain a dedicated human-facing Workflow proposal page for normal proposal triage.
 
 The following surfaces are valid:
 
@@ -913,8 +913,8 @@ The desired system satisfies these acceptance criteria:
 
 1. A generated proposal creates or updates exactly one GitHub Issue or Jira issue per provider destination and dedup target.
 2. Reviewers can promote, dismiss, defer, and reprioritize proposals without opening a MoonMind proposal review page.
-3. Promotion executes only from MoonMind's stored validated task snapshot plus bounded reviewer controls.
-4. GitHub or Jira issue links appear in task run details and finish summaries.
+3. Promotion executes only from MoonMind's stored validated Workflow snapshot plus bounded reviewer controls.
+4. GitHub or Jira issue links appear in Workflow run details and finish summaries.
 5. Duplicate proposals comment on or link to an existing external issue instead of creating duplicate reviewer-facing issues.
 6. Security, tests, and run-quality proposals preserve category, tags, origin metadata, priority, and notification behavior.
 7. External delivery failures are retried idempotently and visible in run summaries, delivery records, and operator diagnostics.

--- a/docs/Tasks/WorkflowPublishing.md
+++ b/docs/Tasks/WorkflowPublishing.md
@@ -1,6 +1,6 @@
-# Task Publishing
+# Workflow Publishing
 
-Task publishing controls how agent-produced changes reach the repository after execution. The `publishMode` field on a task determines whether changes are committed only, pushed to a branch, or turned into a pull request.
+Workflow publishing controls how agent-produced changes reach the repository after execution. The `publishMode` field on a Workflow Execution determines whether changes are committed only, pushed to a branch, or turned into a pull request.
 
 ## Publish Modes
 
@@ -12,7 +12,7 @@ Task publishing controls how agent-produced changes reach the repository after e
 
 ### `none`
 
-The agent runs in its workspace but no git operations occur after completion. Useful for read-only tasks (analysis, diagnostics, research) or for tasks with side effects other than a final publish action.
+The agent runs in its workspace but no git operations occur after completion. Useful for read-only Workflow Executions (analysis, diagnostics, research) or for Workflow Executions with side effects other than a final publish action.
 
 ### `branch`
 
@@ -35,13 +35,13 @@ Example:
 
 For PR publication, the authored `branch` is the selected repository branch and PR base. MoonMind creates or obtains a runtime-generated work branch for the PR head, pushes changes there, and creates a pull request back to the authored base branch.
 
-When merge automation is explicitly enabled for a PR-publishing task, successful PR publication starts a parent-owned `MoonMind.MergeAutomation` child workflow. The original `MoonMind.Run` remains in `awaiting_external` while merge automation waits for configured external readiness signals and runs `pr-resolver` with publish mode `none`; downstream dependencies on the original task are satisfied only after merge automation succeeds.
+When merge automation is explicitly enabled for a PR-publishing Workflow Execution, successful PR publication starts a parent-owned `MoonMind.MergeAutomation` child workflow. The original `MoonMind.Run` remains in `awaiting_external` while merge automation waits for configured external readiness signals and runs `pr-resolver` with publish mode `none`; downstream dependencies on the original Workflow Execution are satisfied only after merge automation succeeds.
 
-For Jira-backed PR-publishing tasks, the authored or preset-provided Jira issue key must be preserved as the canonical `jiraIssueKey` in merge automation input. When that key is present, `MoonMind.Run` enables `mergeAutomationConfig.postMergeJira` by default so `MoonMind.MergeAutomation` can complete the same authoritative issue after verified merge success. If operators provide an explicit `postMergeJira.issueKey`, it overrides the canonical key for the post-merge completion step.
+For Jira-backed PR-publishing Workflow Executions, the authored or preset-provided Jira issue key must be preserved as the canonical `jiraIssueKey` in merge automation input. When that key is present, `MoonMind.Run` enables `mergeAutomationConfig.postMergeJira` by default so `MoonMind.MergeAutomation` can complete the same authoritative issue after verified merge success. If operators provide an explicit `postMergeJira.issueKey`, it overrides the canonical key for the post-merge completion step.
 
 The publish path must not infer post-merge completion targets through fuzzy summary search or by transitioning every issue key found in PR metadata. PR metadata is only a strict fallback when stronger configured or captured Jira context is unavailable.
 
-If a Jira-oriented PR-publishing task completes with no repository changes
+If a Jira-oriented PR-publishing Workflow Execution completes with no repository changes
 because the issue is already implemented, `MoonMind.Run` completes that
 authoritative Jira issue through the same trusted Jira transition boundary used
 for post-merge completion. Ambiguous no-change results that do not explicitly
@@ -58,11 +58,11 @@ When `publishMode` is `pr`, the runtime planner auto-generates a work/head branc
 {clean-title-prefix}-{uuid8}
 ```
 
-- **`clean-title-prefix`**: Derived from the task title (or parameter title, or skill name). Lowercased, non-alphanumeric characters replaced with `-`, truncated to 40 characters.
+- **`clean-title-prefix`**: Derived from the Workflow Execution title (or parameter title, or skill name). Lowercased, non-alphanumeric characters replaced with `-`, truncated to 40 characters.
 - **`uuid8`**: First 8 characters of a UUID4 for uniqueness.
 
 **Examples:**
-- Task title "Fix login page" → `fix-login-page-a1b2c3d4`
+- Workflow Execution title "Fix login page" → `fix-login-page-a1b2c3d4`
 - No title available → `e5f6a7b8` (UUID only)
 
 ### Branch Fields
@@ -73,7 +73,7 @@ New authored submissions use one branch field consistently across UI, API, snaps
 | --- | --- | --- |
 | `branch` | Authored branch selection | For `publishMode: pr`, the selected repo branch and PR base. For `publishMode: branch`, the branch to update and push. |
 
-`targetBranch` is not an authored or operator-facing field in new submissions. For PR mode, the head/work branch is runtime-generated or provider-managed and is not part of the create-form contract. `Publish Mode` remains part of the task contract; only its UI placement changed.
+`targetBranch` is not an authored or operator-facing field in new submissions. For PR mode, the head/work branch is runtime-generated or provider-managed and is not part of the create-form contract. `Publish Mode` remains part of the Workflow Execution contract; only its UI placement changed.
 
 ### Legacy Migration
 
@@ -199,7 +199,7 @@ The pull request body should include, when available:
 - Tests run
 - Remaining risks or follow-up work
 
-The publisher must not derive the pull request title or body from arbitrary task-step instructions, workflow control text, Jira transition instructions, or the first step in a multi-step orchestration. In particular, titles such as the following are invalid for implementation pull requests:
+The publisher must not derive the pull request title or body from arbitrary Workflow Execution step instructions, workflow control text, Jira transition instructions, or the first step in a multi-step orchestration. In particular, titles such as the following are invalid for implementation pull requests:
 
 ```text
 Change Jira issue MM-597 to status In Progress before implementation starts.

--- a/docs/Tasks/WorkflowRemediation.md
+++ b/docs/Tasks/WorkflowRemediation.md
@@ -1,39 +1,39 @@
-# Task Remediation
+# Workflow Remediation
 
 **Status:** Desired-state design
 **Owners:** MoonMind Platform + Mission Control
 **Last Updated:** 2026-05-07
-**Related:** `docs/Tasks/TaskDependencies.md`, `docs/Api/ExecutionsApiContract.md`, `docs/Tasks/TaskRunsApi.md`, `docs/Tasks/TaskProposalSystem.md`, `docs/ManagedAgents/LiveLogs.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/SharedManagedAgentAbstractions.md`, `docs/Security/ProviderProfiles.md`, `docs/Security/SecretsSystem.md`, `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/Temporal/ArtifactPresentationContract.md`, `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/RunHistoryAndRerunSemantics.md`, `docs/Temporal/SourceOfTruthAndProjectionModel.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Steps/SkillSystem.md`
+**Related:** `docs/Tasks/WorkflowDependencies.md`, `docs/Api/ExecutionsApiContract.md`, `docs/Tasks/WorkflowRunsApi.md`, `docs/Tasks/WorkflowProposalSystem.md`, `docs/ManagedAgents/LiveLogs.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, `docs/ManagedAgents/SharedManagedAgentAbstractions.md`, `docs/Security/ProviderProfiles.md`, `docs/Security/SecretsSystem.md`, `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/Temporal/ArtifactPresentationContract.md`, `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/RunHistoryAndRerunSemantics.md`, `docs/Temporal/SourceOfTruthAndProjectionModel.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Steps/SkillSystem.md`
 
 ---
 
 ## 1. Purpose
 
-This document defines the desired-state contract for **Task Remediation** in MoonMind.
+This document defines the desired-state contract for **Workflow Remediation** in MoonMind.
 
-Task Remediation is the system that allows one MoonMind task to **troubleshoot, observe, and optionally intervene on another MoonMind task or run**. It is the architectural home for the “self-healing” feature: a task may be created specifically to investigate another task, read its durable evidence, follow its live observability stream when appropriate, and take typed, policy-bound administrative actions when allowed.
+Workflow Remediation is the system that allows one MoonMind Workflow Execution to **troubleshoot, observe, and optionally intervene on another MoonMind Workflow Execution or run**. It is the architectural home for the “self-healing” feature: a Workflow Execution may be created specifically to investigate another Workflow Execution, read its durable evidence, follow its live observability stream when appropriate, and take typed, policy-bound administrative actions when allowed.
 
 In this document:
 
-- a **target execution** is the task being investigated or repaired,
-- a **remediation task** is the follow-up task doing the investigation or repair,
+- a **target execution** is the Workflow Execution being investigated or repaired,
+- a **remediation Workflow Execution** is the follow-up Workflow Execution doing the investigation or repair,
 - **troubleshooting** means evidence collection and diagnosis,
 - **remediation** means diagnosis plus allowed intervention actions,
-- **immediate repair** means a bounded attempt to get the target task unstuck or completed now, using fresh target evidence and allowed actions when a plausible safe fix is available,
+- **immediate repair** means a bounded attempt to get the target Workflow Execution unstuck or completed now, using fresh target evidence and allowed actions when a plausible safe fix is available,
 - **long-term prevention** means a separately reviewable change to MoonMind, a reusable Agent Skill, or associated instructions that reduces the chance of the same failure recurring,
-- **self-healing** means automated or operator-triggered creation of remediation tasks under policy.
+- **self-healing** means automated or operator-triggered creation of remediation Workflow Executions under policy.
 
 The core design goal is:
 
-> MoonMind should let a task investigate another task, attempt a safe immediate repair when one is plausible, and produce a durable prevention fix when a systemic MoonMind or Skill improvement is found **without turning logs into the source of truth and without turning the agent into an unaudited root shell**.
+> MoonMind should let a Workflow Execution investigate another Workflow Execution, attempt a safe immediate repair when one is plausible, and produce a durable prevention fix when a systemic MoonMind or Skill improvement is found **without turning logs into the source of truth and without turning the agent into an unaudited root shell**.
 
 ---
 
 ## 2. Why a separate system is required
 
-Task Remediation must be a first-class concept, separate from ordinary task dependencies.
+Workflow Remediation must be a first-class concept, separate from ordinary Workflow Execution dependencies.
 
-Task dependencies are intentionally narrow. They block one `MoonMind.Run` on the successful terminal completion of another `MoonMind.Run`. They do not import the upstream run’s plan DAG, internal context, logs, or artifacts into the dependent run. They also fail the dependent run when the upstream prerequisite ends in a non-success terminal state. That is the correct contract for orchestration ordering, but it is the wrong contract for troubleshooting and repair.
+Workflow Execution dependencies are intentionally narrow. They block one `MoonMind.Run` on the successful terminal completion of another `MoonMind.Run`. They do not import the upstream run’s plan DAG, internal context, logs, or artifacts into the dependent run. They also fail the dependent run when the upstream prerequisite ends in a non-success terminal state. That is the correct contract for orchestration ordering, but it is the wrong contract for troubleshooting and repair.
 
 Remediation needs the opposite behavior:
 
@@ -48,18 +48,18 @@ Therefore MoonMind needs a dedicated **remediation relationship** and a dedicate
 
 ## 3. Design goals
 
-Task Remediation must satisfy all of the following:
+Workflow Remediation must satisfy all of the following:
 
-1. **Cross-task troubleshooting**
-   - A new task can explicitly target another task/execution.
+1. **Cross-Workflow troubleshooting**
+   - A new Workflow Execution can explicitly target another Workflow Execution.
    - The target relationship is durable, inspectable, and visible in both directions.
 
 2. **Pinned evidence identity**
-   - The remediation task can target a logical execution by `workflowId`.
+   - The remediation Workflow Execution can target a logical execution by `workflowId`.
    - It can also pin a specific run instance by `runId` so it does not silently drift when the target reruns or continues as new.
 
 3. **Artifact-first evidence access**
-   - The remediation task can read:
+   - The remediation Workflow Execution can read:
      - execution detail,
      - latest/current step ledger,
      - selected step artifact refs,
@@ -68,15 +68,15 @@ Task Remediation must satisfy all of the following:
      - continuity and control-boundary artifacts for managed sessions.
 
 4. **Optional live follow**
-   - When the target is active and observability supports it, the remediation task may follow live logs or structured observability events.
+   - When the target is active and observability supports it, the remediation Workflow Execution may follow live logs or structured observability events.
    - Live follow is additive, not authoritative.
 
 5. **Typed administrative actions**
-   - The remediation task may execute allowed administrative actions through a MoonMind-owned action registry.
+   - The remediation Workflow Execution may execute allowed administrative actions through a MoonMind-owned action registry.
    - Actions are explicit, validated, idempotent, and audited.
 
 6. **Privilege separation**
-   - A remediation task may run with stronger permissions than ordinary tasks.
+   - A remediation Workflow Execution may run with stronger permissions than ordinary Workflow Executions.
    - Those permissions are expressed through a named policy/profile, not through implicit raw host access.
 
 7. **Auditability**
@@ -87,12 +87,12 @@ Task Remediation must satisfy all of the following:
 
 9. **Graceful degradation**
    - Historical runs with only merged logs or partial artifact coverage must still be troubleshootable.
-   - Missing evidence should degrade the remediation task, not deadlock it.
+   - Missing evidence should degrade the remediation Workflow Execution, not deadlock it.
 
 10. **Immediate repair plus prevention**
-    - After diagnosis, a remediation task should first attempt the smallest safe repair that can unblock the target task now, such as resuming or retrying the failed step with corrected remediation context when policy, step replayability, and checkpoint evidence allow it.
-    - After the immediate repair succeeds, fails, or is ruled unsafe, the remediation task should look for a long-term fix in MoonMind code, configuration, presets, or Agent Skill instructions.
-    - When a long-term fix is identified and repository write authority is available, the remediation task should create a pull request instead of only writing a diagnosis.
+    - After diagnosis, a remediation Workflow Execution should first attempt the smallest safe repair that can unblock the target Workflow Execution now, such as resuming or retrying the failed step with corrected remediation context when policy, step replayability, and checkpoint evidence allow it.
+    - After the immediate repair succeeds, fails, or is ruled unsafe, the remediation Workflow Execution should look for a long-term fix in MoonMind code, configuration, presets, or Agent Skill instructions.
+    - When a long-term fix is identified and repository write authority is available, the remediation Workflow Execution should create a pull request instead of only writing a diagnosis.
 
 ---
 
@@ -103,34 +103,34 @@ This design does **not** attempt to provide:
 - arbitrary raw shell access on the MoonMind host,
 - unrestricted Docker daemon access from the remediation runtime,
 - arbitrary SQL or direct database row editing by the agent,
-- silent import of another task’s entire workflow history into `initialParameters`,
-- cross-task managed-session reuse,
-- a rule that every failed task automatically spawns an admin healer,
-- a guarantee that every failed task can be resumed, retried, or repaired in place,
+- silent import of another Workflow Execution’s entire workflow history into `initialParameters`,
+- cross-Workflow managed-session reuse,
+- a rule that every failed Workflow Execution automatically spawns an admin healer,
+- a guarantee that every failed Workflow Execution can be resumed, retried, or repaired in place,
 - automatic merge or self-application of MoonMind or Agent Skill prevention changes without review,
 - a guarantee that historical runs always have full structured event history,
 - a bypass around the Secrets System or artifact redaction rules,
 - a claim that Live Logs itself is the source of truth.
 
-MoonMind may still support operator handoff or manual terminal workflows elsewhere. This document only defines the **task-based remediation system**.
+MoonMind may still support operator handoff or manual terminal workflows elsewhere. This document only defines the **Workflow-based remediation system**.
 
 ---
 
 ## 5. Architectural stance
 
-### 5.1 Remediation tasks remain `MoonMind.Run`
+### 5.1 Remediation Workflow Executions remain `MoonMind.Run`
 
-A remediation task should still be represented as a normal top-level `MoonMind.Run` execution with additional nested semantics under `task.remediation`.
+A remediation Workflow Execution should still be represented as a normal top-level `MoonMind.Run` execution with additional nested semantics under `task.remediation`.
 
-This keeps remediation aligned with the existing task-shaped create path, Mission Control task views, proposal promotion, artifacts, step ledger, cancellation, rerun, and summary flows. A new top-level workflow type is not required in v1.
+This keeps remediation aligned with the existing Workflow-shaped create path, Mission Control Workflow views, proposal promotion, artifacts, step ledger, cancellation, rerun, and summary flows. A new top-level workflow type is not required in v1.
 
 ### 5.2 Remediation is a relationship, not a dependency
 
-A remediation task has a **directed link** to a target execution. The link is not a dependency gate. The remediation run starts immediately once created (or once its own schedule starts); it does not wait for the target to complete successfully.
+A remediation Workflow Execution has a **directed link** to a target execution. The link is not a dependency gate. The remediation run starts immediately once created (or once its own schedule starts); it does not wait for the target to complete successfully.
 
 ### 5.3 Control remains separate from observation
 
-Live Logs and observability remain passive observation surfaces. Intervention must occur through a separate MoonMind-owned action surface. A remediation task may use both, but it must not treat the log timeline itself as the control channel.
+Live Logs and observability remain passive observation surfaces. Intervention must occur through a separate MoonMind-owned action surface. A remediation Workflow Execution may use both, but it must not treat the log timeline itself as the control channel.
 
 ### 5.4 Source of truth remains unchanged
 
@@ -142,7 +142,7 @@ For the target execution:
 - evidence remains owned by artifact linkage and managed-run observability,
 - projections remain read models, not a second workflow engine.
 
-Task Remediation is layered on top of those contracts; it does not redefine them.
+Workflow Remediation is layered on top of those contracts; it does not redefine them.
 
 ---
 
@@ -150,10 +150,10 @@ Task Remediation is layered on top of those contracts; it does not redefine them
 
 The following invariants are fixed:
 
-1. **A remediation task is explicitly marked.**
+1. **A remediation Workflow Execution is explicitly marked.**
    The canonical marker is `payload.task.remediation`.
 
-2. **A remediation task targets one logical execution and one pinned run snapshot.**
+2. **A remediation Workflow Execution targets one logical execution and one pinned run snapshot.**
    `target.workflowId` is required. `target.runId` is resolved and persisted at create time even if the user omitted it.
 
 3. **Remediation is non-transitive by default.**
@@ -163,7 +163,7 @@ The following invariants are fixed:
    Large logs, diagnostics, provider snapshots, and evidence bodies remain behind artifact refs or observability APIs.
 
 5. **All evidence access is server-mediated.**
-   Artifact refs are identifiers, not access grants. The remediation task never receives presigned URLs, raw storage keys, or raw local filesystem paths as durable context.
+   Artifact refs are identifiers, not access grants. The remediation Workflow Execution never receives presigned URLs, raw storage keys, or raw local filesystem paths as durable context.
 
 6. **Administrative actions are typed and allowlisted.**
    Remediation never implies “run any command the model suggests.”
@@ -175,16 +175,16 @@ The following invariants are fixed:
    Diagnosis may be parallelized later; mutation may not.
 
 9. **Secrets remain redacted.**
-   Stronger task authority does not override redaction, audit, or secret-reference rules.
+   Stronger Workflow Execution authority does not override redaction, audit, or secret-reference rules.
 
 10. **Nested remediation is off by default.**
-    Automatic remediation of remediation tasks is disabled unless explicitly allowed by policy.
+    Automatic remediation of remediation Workflow Executions is disabled unless explicitly allowed by policy.
 
 11. **Force termination stays high-risk.**
     Even for admin remediation, forced termination is treated as an ops-grade action, not a casual fallback.
 
 12. **Failure to resolve evidence never becomes infinite wait.**
-    The remediation task must degrade, escalate, or fail with a bounded reason.
+    The remediation Workflow Execution must degrade, escalate, or fail with a bounded reason.
 
 ---
 
@@ -192,7 +192,7 @@ The following invariants are fixed:
 
 ### 7.1 Canonical create path
 
-The canonical create path remains the task-shaped submit flow that normalizes into `POST /api/executions`.
+The canonical create path remains the Workflow-shaped submit flow that normalizes into `POST /api/executions`.
 
 Representative request:
 
@@ -268,7 +268,7 @@ Required durable identity of the target execution.
 Pinned target run instance. If omitted, the server resolves the latest/current run at create time and persists the resolved value.
 
 #### `target.stepSelectors[]`
-Optional bounded selectors for steps the remediation task should prioritize. Each selector may include:
+Optional bounded selectors for steps the remediation Workflow Execution should prioritize. Each selector may include:
 - `logicalStepId`
 - `attempt`
 - `taskRunId`
@@ -292,7 +292,7 @@ Allowed values:
 - `approval_gated`
 - `admin_auto`
 
-This field controls whether the task may only diagnose, may plan actions but require approval, or may execute actions automatically within policy.
+This field controls whether the Workflow Execution may only diagnose, may plan actions but require approval, or may execute actions automatically within policy.
 
 #### `evidencePolicy`
 Bounded hints controlling which evidence classes are requested and how much initial log context to include.
@@ -307,7 +307,7 @@ Policy for human approval requirements.
 Policy for lock scope and exclusivity.
 
 #### `trigger`
-Metadata describing how the remediation task was created:
+Metadata describing how the remediation Workflow Execution was created:
 - `manual`
 - `on_failed`
 - `on_attention_required`
@@ -342,7 +342,7 @@ That route is only a control-plane convenience. It must expand into the same can
 
 ### 7.6 Future automatic self-healing policy
 
-Automatic creation is intentionally a later layer. When MoonMind adds automatic self-healing, the triggering task may carry a bounded policy such as:
+Automatic creation is intentionally a later layer. When MoonMind adds automatic self-healing, the triggering Workflow Execution may carry a bounded policy such as:
 
 ```yaml
 task:
@@ -365,7 +365,7 @@ The important rule is that **automatic remediation is policy-driven and bounded*
 
 MoonMind detail routes and compatibility views anchor on the logical execution identity (`workflowId`). However, the latest/current run may change when the target reruns or continues as new. Remediation needs both:
 
-- `workflowId` to identify the logical task,
+- `workflowId` to identify the logical Workflow Execution,
 - `runId` to pin the evidence snapshot that the remediator started from.
 
 ### 8.2 Link directions
@@ -373,16 +373,16 @@ MoonMind detail routes and compatibility views anchor on the logical execution i
 The system must support both of these views:
 
 - **Remediator → Target**
-  - “Which execution is this remediation task investigating?”
+  - “Which execution is this remediation Workflow Execution investigating?”
 - **Target → Remediators**
-  - “Which remediation tasks have investigated or acted on this target?”
+  - “Which remediation Workflow Executions have investigated or acted on this target?”
 
 ### 8.3 Durable linkage requirements
 
 The platform must persist enough data to support:
 
-- forward lookup from remediation task to target execution,
-- reverse lookup from target execution to remediation tasks,
+- forward lookup from remediation Workflow Execution to target execution,
+- reverse lookup from target execution to remediation Workflow Executions,
 - pinned target run identity,
 - current remediation status,
 - current lock holder,
@@ -423,8 +423,8 @@ GET /api/executions/{workflowId}/remediations?direction=outbound
 ```
 
 Where:
-- `inbound` means remediation tasks targeting this execution,
-- `outbound` means executions that this task is remediating.
+- `inbound` means remediation Workflow Executions targeting this execution,
+- `outbound` means executions that this Workflow Execution is remediating.
 
 ---
 
@@ -432,7 +432,7 @@ Where:
 
 ### 9.1 Evidence sources
 
-The remediation task may need data from several MoonMind surfaces:
+The remediation Workflow Execution may need data from several MoonMind surfaces:
 
 1. **Execution detail**
    - title, summary, lifecycle state, current run metadata, progress summary.
@@ -462,14 +462,14 @@ The remediation task may need data from several MoonMind surfaces:
 
 ### 9.2 Remediation Context Builder
 
-MoonMind should introduce a **Remediation Context Builder** activity or service that resolves the target evidence and creates a single MoonMind-owned bundle artifact for the remediation task.
+MoonMind should introduce a **Remediation Context Builder** activity or service that resolves the target evidence and creates a single MoonMind-owned bundle artifact for the remediation Workflow Execution.
 
 Canonical output artifact:
 
 - path: `reports/remediation_context.json`
 - artifact type: `remediation.context`
 
-This artifact is the remediation task’s stable entrypoint. It should contain:
+This artifact is the remediation Workflow Execution’s stable entrypoint. It should contain:
 - target identity,
 - selected steps,
 - observability refs,
@@ -542,7 +542,7 @@ Representative shape:
 
 The context artifact must stay **bounded**. It may include small excerpts or summaries, but not unbounded full log bodies. Full logs and rich diagnostics stay behind refs.
 
-### 9.5 Evidence access surface for remediation tasks
+### 9.5 Evidence access surface for remediation Workflow Executions
 
 The remediation runtime should not scrape Mission Control pages. It should receive a MoonMind-owned tool surface such as:
 
@@ -575,14 +575,14 @@ Live follow is optional and best effort.
 
 Rules:
 
-1. the remediation task may follow only when:
+1. the remediation Workflow Execution may follow only when:
    - the target run is active,
    - the target `taskRunId` supports live follow,
    - policy allows it;
 
-2. the remediation task must persist a resume cursor such as last seen `sequence`;
+2. the remediation Workflow Execution must persist a resume cursor such as last seen `sequence`;
 
-3. disconnects, worker restarts, or task retries must resume from durable cursor state when possible;
+3. disconnects, worker restarts, or Workflow Execution retries must resume from durable cursor state when possible;
 
 4. when structured event history is unavailable, MoonMind may fall back to merged-log retrieval or artifact tailing;
 
@@ -590,19 +590,19 @@ Rules:
 
 ### 9.7 Evidence freshness before action
 
-Before executing a side-effecting action, the remediation task must re-read the target’s current bounded health view. The agent is allowed to start from a pinned snapshot, but it must not act on stale assumptions without a fresh precondition check.
+Before executing a side-effecting action, the remediation Workflow Execution must re-read the target’s current bounded health view. The agent is allowed to start from a pinned snapshot, but it must not act on stale assumptions without a fresh precondition check.
 
 ### 9.8 Immediate repair and prevention workflow
 
 Remediation is a two-track workflow:
 
-1. **Repair the current target if safe.** The remediation task must use the evidence bundle, fresh target health, allowed action list, and lock state to decide whether a bounded immediate repair is plausible. Examples include retrying a failed publish step with clarified remediation context, interrupting a stuck managed turn, clearing a stale session, evicting an orphaned slot lease, or requesting a targeted rerun/resume action. The repair attempt must be the smallest action likely to unblock the target and must not silently broaden into a full rerun or destructive action.
-2. **Verify the target outcome.** After an immediate repair action, the remediation task must call the verification surface and publish the result. Verification should distinguish `repaired`, `still_failed`, `not_attempted`, `unsafe`, `approval_required`, and `escalated` outcomes.
-3. **Prevent recurrence.** Regardless of whether the target was repaired, the remediation task should identify whether the failure points to a reusable MoonMind, preset, prompt, or Agent Skill defect. If it does, the task should prepare the smallest reviewable code, configuration, documentation, or Skill change and create a pull request when repository write authority and policy allow it.
+1. **Repair the current target if safe.** The remediation Workflow Execution must use the evidence bundle, fresh target health, allowed action list, and lock state to decide whether a bounded immediate repair is plausible. Examples include retrying a failed publish step with clarified remediation context, interrupting a stuck managed turn, clearing a stale session, evicting an orphaned slot lease, or requesting a targeted rerun/resume action. The repair attempt must be the smallest action likely to unblock the target and must not silently broaden into a full rerun or destructive action.
+2. **Verify the target outcome.** After an immediate repair action, the remediation Workflow Execution must call the verification surface and publish the result. Verification should distinguish `repaired`, `still_failed`, `not_attempted`, `unsafe`, `approval_required`, and `escalated` outcomes.
+3. **Prevent recurrence.** Regardless of whether the target was repaired, the remediation Workflow Execution should identify whether the failure points to a reusable MoonMind, preset, prompt, or Agent Skill defect. If it does, the Workflow Execution should prepare the smallest reviewable code, configuration, documentation, or Skill change and create a pull request when repository write authority and policy allow it.
 
 Immediate repair is not a substitute for long-term prevention. A successful target repair still requires a recurrence analysis, and a failed or unsafe repair can still produce a prevention pull request.
 
-Corrected-instruction retries are remediation interventions, not ordinary failed-step recovery. If the platform has a distinct Resume-from-failed-step action that preserves the original task input snapshot unchanged, remediation must not overload that action with edited instructions. Any corrected instructions must be recorded as remediation repair context or a follow-up retry override with explicit provenance, not as a mutation of the original task input.
+Corrected-instruction retries are remediation interventions, not ordinary failed-step recovery. If the platform has a distinct Resume-from-failed-step action that preserves the original Workflow input snapshot unchanged, remediation must not overload that action with edited instructions. Any corrected instructions must be recorded as remediation repair context or a follow-up retry override with explicit provenance, not as a mutation of the original Workflow input.
 
 The remediation decision log must record:
 
@@ -611,7 +611,7 @@ The remediation decision log must record:
 - the action request/result and verification refs when attempted,
 - the root-cause category selected for long-term prevention,
 - the prevention branch, commit, and pull request URL when created,
-- the reason no prevention PR was created when the task only reports findings.
+- the reason no prevention PR was created when the Workflow Execution only reports findings.
 
 ---
 
@@ -619,10 +619,10 @@ The remediation decision log must record:
 
 ### 10.1 Authority modes
 
-Task Remediation defines three authority modes:
+Workflow Remediation defines three authority modes:
 
 #### `observe_only`
-The remediation task may:
+The remediation Workflow Execution may:
 - read allowed evidence,
 - produce diagnosis artifacts,
 - suggest actions.
@@ -630,14 +630,14 @@ The remediation task may:
 It may **not** execute side-effecting actions.
 
 #### `approval_gated`
-The remediation task may:
+The remediation Workflow Execution may:
 - read evidence,
 - propose concrete actions,
 - optionally perform dry runs,
 - execute actions only after required approval.
 
 #### `admin_auto`
-The remediation task may:
+The remediation Workflow Execution may:
 - read evidence,
 - plan actions,
 - execute allowed actions automatically within policy,
@@ -645,7 +645,7 @@ The remediation task may:
 
 ### 10.2 Execution principal
 
-A remediation task with elevated authority should execute under a **named admin remediation principal or security profile**, not simply as the ordinary user runtime.
+A remediation Workflow Execution with elevated authority should execute under a **named admin remediation principal or security profile**, not simply as the ordinary user runtime.
 
 Desired-state fields:
 
@@ -665,12 +665,12 @@ Audit must record both:
 The control plane should distinguish:
 
 - permission to view a target execution,
-- permission to create a remediation task,
+- permission to create a remediation Workflow Execution,
 - permission to request an admin remediation profile,
 - permission to approve high-risk actions,
 - permission to inspect remediation audit history.
 
-A user who can view a task should not automatically be able to launch an admin remediator against it.
+A user who can view a Workflow Execution should not automatically be able to launch an admin remediator against it.
 
 ### 10.4 Secret handling
 
@@ -688,7 +688,7 @@ Rules:
 
 Artifacts and logs must remain server-mediated.
 
-A remediation task may receive:
+A remediation Workflow Execution may receive:
 - artifact refs,
 - MoonMind-issued read capability handles,
 - redacted or preview views,
@@ -772,12 +772,12 @@ The registry may later grow, but every new action kind must declare:
 Backed by the ordinary execution signal surface. Use these when the target should stop progressing while evidence is reviewed or operator work occurs.
 
 #### `execution.retry_failed_step_with_remediation_context`
-A targeted immediate-repair action for a failed step when fresh evidence indicates the step may succeed with bounded corrective context. Example: a publish step failed because the task instructions were ambiguous, and remediation can provide clarified publish instructions for that retry.
+A targeted immediate-repair action for a failed step when fresh evidence indicates the step may succeed with bounded corrective context. Example: a publish step failed because the Workflow instructions were ambiguous, and remediation can provide clarified publish instructions for that retry.
 
 This action must:
 - pin the source `workflowId`, source `runId`, failed step identity, and attempt,
 - preserve completed prior-step outputs by refs when resuming a linked follow-up execution,
-- record corrective context separately from the original task input snapshot,
+- record corrective context separately from the original Workflow input snapshot,
 - require step replayability, checkpoint availability, authorization, and policy approval before execution,
 - fail explicitly when checkpoint validation or restoration fails,
 - avoid silent fallback to a full rerun,
@@ -943,7 +943,7 @@ Rules:
 - lock acquisition must be idempotent,
 - stale locks must expire or be recoverable,
 - lock loss must be surfaced explicitly,
-- the remediation task must not silently keep mutating after lock loss.
+- the remediation Workflow Execution must not silently keep mutating after lock loss.
 
 ### 12.4 Action idempotency
 
@@ -953,7 +953,7 @@ The remediation system must not rely solely on the generic execution update idem
 
 ### 12.5 Retry budget and cooldowns
 
-Each remediation task should carry:
+Each remediation Workflow Execution should carry:
 - max actions per target,
 - max attempts per action kind,
 - minimum cooldown between repeated identical actions,
@@ -968,14 +968,14 @@ Example defaults:
 ### 12.6 Nested remediation defaults
 
 Defaults:
-- a remediation task may not automatically spawn another remediation task;
-- a remediation task may not target itself;
-- a remediation task may not target another remediation task unless `allowNestedRemediation` is explicitly enabled by policy;
+- a remediation Workflow Execution may not automatically spawn another remediation Workflow Execution;
+- a remediation Workflow Execution may not target itself;
+- a remediation Workflow Execution may not target another remediation Workflow Execution unless `allowNestedRemediation` is explicitly enabled by policy;
 - automatic self-healing depth defaults to 1.
 
 ### 12.7 Target-change guard
 
-Before acting, the remediation task must compare:
+Before acting, the remediation Workflow Execution must compare:
 - pinned target `runId`,
 - current target `runId`,
 - current target state,
@@ -1032,7 +1032,7 @@ stateDiagram-v2
 
 ### 13.3 Recommended step structure
 
-A remediation task commonly follows these plan nodes:
+A remediation Workflow Execution commonly follows these plan nodes:
 
 1. acquire lock,
 2. build evidence bundle,
@@ -1049,10 +1049,10 @@ This does not need to be a hard-coded universal plan, but the system should make
 ### 13.4 Cancellation semantics
 
 Rules:
-- canceling the remediation task cancels only the remediation task,
+- canceling the remediation Workflow Execution cancels only the remediation Workflow Execution,
 - the target execution is not mutated by cancellation unless a specific action already requested that mutation,
-- canceling the target execution does not automatically cancel the remediation task,
-- the remediation task must still attempt best-effort lock release and final audit artifact publication.
+- canceling the target execution does not automatically cancel the remediation Workflow Execution,
+- the remediation Workflow Execution must still attempt best-effort lock release and final audit artifact publication.
 
 ### 13.5 Rerun semantics
 
@@ -1060,7 +1060,7 @@ The target may change runs while remediation is active.
 
 Rules:
 - the pinned `target.runId` is the diagnosis snapshot anchor,
-- the remediation task may still inspect the current/latest target health before acting,
+- the remediation Workflow Execution may still inspect the current/latest target health before acting,
 - action policies may allow:
   - `request_rerun_same_workflow`,
   - `start_fresh_rerun`,
@@ -1069,7 +1069,7 @@ Rules:
 
 ### 13.6 Continue-As-New safety
 
-If the remediation task continues as new, it must preserve:
+If the remediation Workflow Execution continues as new, it must preserve:
 - target `workflowId`,
 - pinned target `runId`,
 - remediation context artifact ref,
@@ -1085,7 +1085,7 @@ If the remediation task continues as new, it must preserve:
 
 ### 14.1 Required remediation artifacts
 
-At minimum, a remediation task should produce:
+At minimum, a remediation Workflow Execution should produce:
 
 - `reports/remediation_context.json`
   `artifact_type = remediation.context`
@@ -1116,7 +1116,7 @@ These artifacts must obey the normal artifact presentation contract:
 
 ### 14.2 Target-side artifacts
 
-When the remediation task mutates a target-managed session or workload, the target side should also receive the normal continuity/control artifacts appropriate to that subsystem.
+When the remediation Workflow Execution mutates a target-managed session or workload, the target side should also receive the normal continuity/control artifacts appropriate to that subsystem.
 
 Examples:
 - `session.control_event`
@@ -1124,11 +1124,11 @@ Examples:
 - target-side audit annotations
 - new diagnostics or summary artifacts
 
-The remediation task does not replace those subsystem-native artifacts; it adds a parallel remediation audit trail.
+The remediation Workflow Execution does not replace those subsystem-native artifacts; it adds a parallel remediation audit trail.
 
 ### 14.3 Remediation summary block
 
-`reports/run_summary.json` for the remediation task should include a stable `remediation` block.
+`reports/run_summary.json` for the remediation Workflow Execution should include a stable `remediation` block.
 
 Representative shape:
 
@@ -1197,11 +1197,11 @@ Artifacts remain the operator-facing deep evidence; audit rows remain the compac
 
 ### 15.1 Create flow
 
-Mission Control should expose **Create remediation task** from:
-- task detail,
-- failed task banners,
+Mission Control should expose **Create remediation Workflow** from:
+- Workflow detail,
+- failed Workflow banners,
 - attention-required surfaces,
-- stuck task surfaces,
+- stuck Workflow surfaces,
 - provider-slot or session problem surfaces where applicable.
 
 The create UI should let the operator:
@@ -1212,19 +1212,19 @@ The create UI should let the operator:
 - choose or review the action policy,
 - preview which evidence will be attached.
 
-### 15.2 Target task detail
+### 15.2 Target Workflow detail
 
-The target task should show a **Remediation Tasks** panel with:
-- remediation task links,
+The target Workflow should show a **Remediation Workflows** panel with:
+- remediation Workflow links,
 - status,
 - authority mode,
 - last action,
 - resolution,
 - active lock badge.
 
-### 15.3 Remediation task detail
+### 15.3 Remediation Workflow detail
 
-The remediation task detail should show a **Remediation Target** panel with:
+The remediation Workflow detail should show a **Remediation Target** panel with:
 - target execution link,
 - pinned target run id,
 - selected steps,
@@ -1254,7 +1254,7 @@ If live follow is active:
 
 ### 15.6 Operator handoff
 
-When a remediation task is `approval_gated` or encounters a high-risk action:
+When a remediation Workflow Execution is `approval_gated` or encounters a high-risk action:
 - show the proposed action,
 - show preconditions,
 - show expected blast radius,
@@ -1268,7 +1268,7 @@ When a remediation task is `approval_gated` or encounters a high-risk action:
 The system must explicitly handle these cases.
 
 ### 16.1 Target execution not found or not visible
-Fail create-time validation or fail early with a structured remediation error. Do not silently create a task with a null target.
+Fail create-time validation or fail early with a structured remediation error. Do not silently create a Workflow Execution with a null target.
 
 ### 16.2 Target reran after remediation started
 Keep the pinned snapshot. Revalidate current health before acting. Do not silently retarget without recording it.
@@ -1301,7 +1301,7 @@ Treat as `no_op` or `verification_failed` depending on desired action semantics.
 ### 16.10 Forced termination attempted on non-runaway target
 Require approval or reject by policy. Forced termination is not the generic fallback for every failure.
 
-### 16.11 Remediation task itself fails
+### 16.11 Remediation Workflow Execution itself fails
 Publish a final remediation summary and release locks. Automatic remediation of the failed remediator is off by default.
 
 ---
@@ -1311,7 +1311,7 @@ Publish a final remediation summary and release locks. Automatic remediation of 
 A practical v1 should ship with the following constraints:
 
 1. **Manual creation first**
-   - Operators create remediation tasks explicitly from Mission Control.
+   - Operators create remediation Workflow Executions explicitly from Mission Control.
 
 2. **Pinned target run**
    - Always persist `workflowId + runId`.
@@ -1376,19 +1376,19 @@ artifact-first evidence, typed actions, explicit locks, strict audit, and no raw
 This document is complete enough to guide implementation when all of the following are true:
 
 1. `task.remediation` is accepted as the canonical create-time contract.
-2. The system distinguishes remediation from ordinary task dependencies.
+2. The system distinguishes remediation from ordinary Workflow Execution dependencies.
 3. The create path resolves and persists a pinned target `runId`.
 4. A remediation context bundle artifact is generated and linked.
-5. A MoonMind-owned evidence access surface exists for remediation tasks.
+5. A MoonMind-owned evidence access surface exists for remediation Workflow Executions.
 6. A typed action registry exists for side-effecting admin actions.
 7. Privileged remediation uses named policy/profile binding, not implicit host access.
 8. Exclusive mutation locking and a remediation action idempotency ledger are implemented.
-9. Remediation tasks emit the required audit artifacts and summary block.
+9. Remediation Workflow Executions emit the required audit artifacts and summary block.
 10. Mission Control can show forward and reverse remediation links.
 11. The system degrades safely when only partial historical evidence is available.
 12. Automatic self-healing, when later added, is policy-driven and bounded.
-13. Remediation tasks attempt the smallest safe immediate repair when one is plausible.
-14. Remediation tasks create a reviewable long-term MoonMind, preset, prompt, or Agent Skill prevention PR when recurrence analysis identifies an actionable systemic fix and repository write policy allows it.
+13. Remediation Workflow Executions attempt the smallest safe immediate repair when one is plausible.
+14. Remediation Workflow Executions create a reviewable long-term MoonMind, preset, prompt, or Agent Skill prevention PR when recurrence analysis identifies an actionable systemic fix and repository write policy allows it.
 
 ---
 
@@ -1484,4 +1484,4 @@ Keep these rules stable even as implementation evolves:
 9. **Loop prevention is required.**
 10. **Mission Control must make the relationship visible in both directions.**
 11. **Immediate repair and long-term prevention are separate outputs; a remediator may do either or both, but it must record its decision.**
-12. **Corrected-instruction retries must be recorded as remediation context, not as silent mutation of the original task input.**
+12. **Corrected-instruction retries must be recorded as remediation context, not as silent mutation of the original Workflow input.**

--- a/docs/Tasks/WorkflowRunsApi.md
+++ b/docs/Tasks/WorkflowRunsApi.md
@@ -1,4 +1,4 @@
-# Task Runs API
+# Workflow Runs API
 
 Status: Active  
 Owners: MoonMind Engineering  
@@ -6,20 +6,20 @@ Last Updated: 2026-04-04
 
 ## 1. Purpose
 
-Define the REST API surfaces used to create, monitor, and observe MoonMind task runs in the Temporal-first architecture.
+Define the REST API surfaces used to create, monitor, and observe MoonMind Workflow runs in the Temporal-first architecture.
 
 MoonMind now splits this responsibility across:
 
 - **`/api/executions`** for Temporal-backed execution lifecycle operations
 - **`/api/task-runs`** for managed-run observability (logs, diagnostics, live follow)
 
-Mission Control still presents these executions as **tasks** in the product UI, but the active lifecycle API is execution-oriented.
+Mission Control still presents these executions as **Workflows** in the product UI, but the active lifecycle API is execution-oriented.
 
 The public `/api/task-runs` path is intentional: the `task_runs` router itself uses `prefix="/task-runs"` and FastAPI mounts it under the app-level `/api` prefix.
 
 ## 2. API Surface
 
-Task runs are served by two active router families:
+Workflow runs are served by two active router families:
 
 - **`/api/executions`** — Execution lifecycle for Temporal-backed work.
 - **`/api/task-runs`** — Artifact-backed managed-run observability.
@@ -64,7 +64,7 @@ These endpoints expose artifact-backed observability for managed runs. The legac
 
 ## 3. Identity Model
 
-MoonMind currently uses three related identifiers around task runs:
+MoonMind currently uses three related identifiers around Workflow runs:
 
 - **`workflowId`** — the canonical durable execution identifier for `/api/executions`
 - **`taskId`** — the task-oriented product identifier; for Temporal-backed work, `taskId == workflowId`
@@ -108,14 +108,14 @@ The `activity_catalog.py` module defines the full routing contract including per
 
 ## 6. Legacy Queue Posture
 
-The legacy `/api/queue/jobs` lifecycle routes and `/api/queue` worker callback routes are historical migration references only. They are not the active task-run lifecycle API, and the execution router explicitly rejects falling back to the old queue substrate when Temporal submission is disabled.
+The legacy `/api/queue/jobs` lifecycle routes and `/api/queue` worker callback routes are historical migration references only. They are not the active Workflow-run lifecycle API, and the execution router explicitly rejects falling back to the old queue substrate when Temporal submission is disabled.
 
 ## 7. Related Documentation
 
 - [../Api/ExecutionsApiContract.md](../Api/ExecutionsApiContract.md) — Direct execution lifecycle contract
-- [TaskArchitecture.md](TaskArchitecture.md) — Overall task system design
-- [../UI/MissionControlArchitecture.md](../UI/MissionControlArchitecture.md) — Task-oriented UI over execution APIs
-- [TaskProposalSystem.md](TaskProposalSystem.md) — Task proposal generation
-- [TaskCancellation.md](TaskCancellation.md) — Cancellation flow
+- [WorkflowArchitecture.md](WorkflowArchitecture.md) — Overall Workflow system design
+- [../UI/MissionControlArchitecture.md](../UI/MissionControlArchitecture.md) — Workflow-oriented UI over execution APIs
+- [WorkflowProposalSystem.md](WorkflowProposalSystem.md) — Workflow proposal generation
+- [WorkflowCancellation.md](WorkflowCancellation.md) — Cancellation flow
 - [../ManagedAgents/LiveLogs.md](../ManagedAgents/LiveLogs.md) — Managed-run log and observability design
 - [../Temporal/TemporalArchitecture.md](../Temporal/TemporalArchitecture.md) — Temporal infrastructure

--- a/docs/Tasks/WorkflowStatus.md
+++ b/docs/Tasks/WorkflowStatus.md
@@ -1,10 +1,10 @@
-# Task Status Model
+# Workflow Status Model
 
 Status: Archived pointer  
 Owners: MoonMind Engineering  
 Last Updated: 2026-04-04
 
-This file is no longer the canonical source for MoonMind task status design.
+This file is no longer the canonical source for MoonMind Workflow status design.
 
 Use these docs instead:
 
@@ -15,7 +15,7 @@ Use these docs instead:
 Why this file was archived:
 
 - it proposed a separate `1:1 DB ↔ dashboard` status strategy that no longer matches the active exact-vs-compatibility model
-- it did not separate task status from step status
+- it did not separate Workflow status from step status
 - it treated `mm_phase` and related state simplification as the primary direction, which is not the current canonical contract
 
 Retention rule:

--- a/docs/Tasks/WorkflowStepSystem.md
+++ b/docs/Tasks/WorkflowStepSystem.md
@@ -1,4 +1,4 @@
-# Task Steps System
+# Workflow Steps System
 
 Status: Active  
 Owners: MoonMind Engineering  
@@ -6,9 +6,9 @@ Last Updated: 2026-04-04
 
 ## 1. Purpose
 
-This document defines the current MoonMind step-execution model at the task level.
+This document defines the current MoonMind step-execution model at the Workflow Execution level.
 
-It is intentionally task-oriented and high level. The detailed owned contracts live elsewhere:
+It is intentionally Workflow-oriented and high level. The detailed owned contracts live elsewhere:
 
 - `docs/Tasks/SkillAndPlanContracts.md` owns executable plan structure
 - `docs/Temporal/StepLedgerAndProgressModel.md` owns the operator-facing step ledger, status vocabulary, attempts, checks, and refs
@@ -20,12 +20,12 @@ MoonMind no longer models steps as a raw `task.steps` loop inside an `AgentTaskW
 
 The current architecture is:
 
-- `MoonMind.Run` is the root task workflow
+- `MoonMind.Run` is the root Workflow Execution
 - the canonical planned step list comes from the resolved **plan artifact**
 - direct executable steps run as activities
 - true agent-runtime steps run as child `MoonMind.AgentRun` workflows
 
-This preserves one task-oriented operator surface while giving agent steps their own durable lifecycle boundary.
+This preserves one Workflow-oriented operator surface while giving agent steps their own durable lifecycle boundary.
 
 ## 3. Step structure and execution
 
@@ -75,7 +75,7 @@ Because steps are distinct activity or child-workflow executions:
 - step progress is durable across worker restarts
 - failed steps can be retried without rerunning earlier successful expensive steps
 - retry history is represented as step executions scoped to `(workflowId, runId, logicalStepId, attempt)`
-- current task detail shows the latest/current run's steps only by default
+- current Workflow detail shows the latest/current run's steps only by default
 
 ## 5. Observability posture
 
@@ -83,7 +83,7 @@ MoonMind does **not** use terminal-widget output blocks as the canonical step UX
 
 Instead:
 
-- task detail shows a first-class **Steps** section
+- Workflow detail shows a first-class **Steps** section
 - each step row shows exact status, summary, attempt count, blockers, and evidence links
 - expanded rows group **Summary**, **Checks**, **Logs & Diagnostics**, **Artifacts**, and **Metadata**
 - agent-runtime step rows deep-link or embed `/api/task-runs/*` when `taskRunId` is present

--- a/docs/Temporal/ErrorTaxonomy.md
+++ b/docs/Temporal/ErrorTaxonomy.md
@@ -6,7 +6,7 @@ Related:
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](./ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
 - [`docs/Temporal/StepLedgerAndProgressModel.md`](./StepLedgerAndProgressModel.md)
-- [`docs/Tasks/TaskFinishSummarySystem.md`](../Tasks/TaskFinishSummarySystem.md)
+- [`docs/Tasks/WorkflowFinishSummarySystem.md`](../Tasks/WorkflowFinishSummarySystem.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 
 ---
@@ -489,7 +489,7 @@ this taxonomy, the failing `stepId`/`childWorkflowId`, and an optional
 The canonical contract for the diagnostic — including its JSON shape, the
 secret-handling rules, and how it feeds `finishOutcome.reason`, `lastStep`,
 and the terminal-state `errorCategory` — lives in
-[`docs/Tasks/TaskFinishSummarySystem.md`](../Tasks/TaskFinishSummarySystem.md).
+[`docs/Tasks/WorkflowFinishSummarySystem.md`](../Tasks/WorkflowFinishSummarySystem.md).
 The `category` values used there (`user_error`, `integration_error`,
 `execution_error`, `system_error`) are how this taxonomy's
 `ApplicationError.type` values such as `INVALID_INPUT`, `UnsupportedStatus`,

--- a/docs/Temporal/LiveWorkflowManagement.md
+++ b/docs/Temporal/LiveWorkflowManagement.md
@@ -1,4 +1,4 @@
-# Live Task Management
+# Live Workflow Management
 
 > [!WARNING]
 > **DEPRECATED (Phase 6)**: This document describes the legacy terminal-session observability pattern (e.g., `web_ro`, `tmate` embedding). 
@@ -16,9 +16,9 @@ Last Updated: 2026-03-28
 
 ## 1. Purpose
 
-Operators need real-time visibility into running tasks. This document defines two complementary capabilities:
+Operators need real-time visibility into running Workflow Executions. This document defines two complementary capabilities:
 
-1. **Live Log Tailing** — An on-demand, read-only view of the most recent terminal output from a running task, rendered in the Mission Control task detail page (artifact-backed; see [LiveLogs.md](../ManagedAgents/LiveLogs.md)).
+1. **Live Log Tailing** — An on-demand, read-only view of the most recent terminal output from a running Workflow Execution, rendered in the Mission Control Workflow Execution detail page (artifact-backed; see [LiveLogs.md](../ManagedAgents/LiveLogs.md)).
 2. **Live Terminal Handoff** — Interactive operator controls (pause/resume, grants, messages) layered on the same run, without requiring a third-party terminal relay in the managed runtime image.
 
 Implementation detail: the managed launcher runs agents as a plain subprocess with piped streams; live output is not produced by wrapping the agent in an external terminal multiplexer.
@@ -48,7 +48,7 @@ Implementation detail: the managed launcher runs agents as a plain subprocess wi
 Real-time visibility is delivered without an external terminal relay in the default managed path:
 
 1. **Managed runtime** — `ManagedRuntimeLauncher` spawns a direct subprocess; `ManagedRunSupervisor` streams stdout/stderr into run-scoped artifacts. Contracts and UI integration are described in [LiveLogs.md](../ManagedAgents/LiveLogs.md).
-2. **Task-run live sessions** — Historical metadata for operator tooling lived in **`task_run_live_sessions`**. Those `/api/task-runs/{id}/live-session*` routes are migration-era references, not the active managed-run log path. Provider **`none`** applies when no external relay is in use.
+2. **Workflow-run live sessions** — Historical metadata for operator tooling lived in **`task_run_live_sessions`**. Those `/api/task-runs/{id}/live-session*` routes are migration-era references, not the active managed-run log path. Provider **`none`** applies when no external relay is in use.
 3. **Queue worker** — The standalone worker may report live-session state over HTTP when enabled; it does not provision a relay when the configured provider is `none`.
 
 ### 4.1 Session lifecycle (conceptual)
@@ -81,7 +81,7 @@ Runtime images should include `openssh-client` and `ca-certificates` for Git and
 
 ### 5.1 Concept
 
-The Mission Control task detail page includes a collapsible **Live Output** panel. When the operator toggles it open:
+The Mission Control Workflow Execution detail page includes a collapsible **Live Output** panel. When the operator toggles it open:
 
 1. The UI fetches the most recent ~200 lines of terminal output from the running session.
 2. New lines stream in continuously, pushing older lines off the top of the buffer.
@@ -101,7 +101,7 @@ The UI reads recent terminal output from **artifact-backed log APIs** (or equiva
 - **On toggle close**: Disconnect from the stream. No background resource usage.
 - **Background tab**: Disconnect or pause the stream when the tab loses visibility (via `visibilitychange` event).
 - **Terminal workflows**: Show "Session ended" with no stream. If a `transcript.log` artifact exists, offer a download link.
-- **No session available**: Show "Live output is not available for this task" (session in `DISABLED` or `ERROR` state).
+- **No session available**: Show "Live output is not available for this Workflow Execution" (session in `DISABLED` or `ERROR` state).
 
 ### 5.4 Historical API Contract
 
@@ -138,7 +138,7 @@ When passive observation isn't enough, operators can escalate to full interactiv
 ### 6.2 Pause/Resume and Takeover Flow
 
 - **Soft pause (default)**: The agent wrapper honors a `pause_workflow` Temporal Signal at safe checkpoints, prints `== PAUSED FOR OPERATOR ==`, and stops issuing new tool calls. The terminal remains live for RO viewers, and RW operators can use the dedicated pane without racing the agent.
-- **Operator takeover**: Dashboard workflow is pause → grant RW (15-minute TTL by default) → attach via RW pane → perform fixes/tests → enter an operator summary → resume. The summary is appended to task context for traceability.
+- **Operator takeover**: Dashboard workflow is pause → grant RW (15-minute TTL by default) → attach via RW pane → perform fixes/tests → enter an operator summary → resume. The summary is appended to Workflow Execution context for traceability.
 
 ### 6.3 Operator Messages
 
@@ -222,9 +222,9 @@ Pauses and takeovers use standard **Temporal Signals**:
 
 ## 10. Dashboard Integration
 
-### 10.1 Task Detail Page
+### 10.1 Workflow Execution Detail Page
 
-The task detail page (`/tasks/:taskId`) should include two live-session UI elements:
+The Workflow Execution detail page (`/tasks/:taskId`) should include two live-session UI elements:
 
 1. **Live Output Panel** (section 5): Collapsible panel with live log tailing. Toggle on/off. Available when log data exists for the run.
 2. **Live Session Card** (section 6): Shows session status, RO attach instructions, optional web view link, pause/resume signal buttons, RW grant UI, and operator message composer. Available for full handoff workflows.
@@ -243,12 +243,12 @@ The task detail page (`/tasks/:taskId`) should include two live-session UI eleme
 }
 ```
 
-**Desired experience:** operators get artifact-backed log tailing in the task detail UI, optional live handoff controls (RO/RW, pause/resume, operator messages) when session metadata exists, and post-session artifacts such as **`transcript.log`**. Sequencing of UI/backend pieces is tracked in MoonSpec feature artifacts or local planning notes when needed.
+**Desired experience:** operators get artifact-backed log tailing in the Workflow Execution detail UI, optional live handoff controls (RO/RW, pause/resume, operator messages) when session metadata exists, and post-session artifacts such as **`transcript.log`**. Sequencing of UI/backend pieces is tracked in MoonSpec feature artifacts or local planning notes when needed.
 
 ---
 
 ## 11. Open Questions
 
 1. Should optional `web_ro` links (when present) open in a new tab, or should all terminal rendering stay inside first-party log components?
-2. Should log tailing be enabled by default for all running tasks, or only when a live session has been explicitly provisioned?
+2. Should log tailing be enabled by default for all running Workflow Executions, or only when a live session has been explicitly provisioned?
 3. Should completed workflow detail pages show the last captured terminal snapshot as a static artifact?

--- a/docs/Temporal/WorkflowLanguageHardSwitchPlan.md
+++ b/docs/Temporal/WorkflowLanguageHardSwitchPlan.md
@@ -1043,9 +1043,9 @@ merge_automation
 | `docs/UI/MissionControlArchitecture.md` | Rewrite as `docs/UI/WorkflowConsoleArchitecture.md`. |
 | `docs/Temporal/RunHistoryAndRerunSemantics.md` | Rename to `docs/Temporal/WorkflowRunHistoryAndNewRunSemantics.md`. |
 | `docs/Steps/StepExecutionsAndCheckpointing.md` | Rename to `docs/Steps/StepExecutionsAndCheckpointing.md`. |
-| `docs/Tasks/TaskArchitecture.md` | Delete or replace with `docs/Temporal/WorkflowExecutionArchitecture.md`. |
-| `docs/Tasks/TaskPresetsSystem.md` | Rename to `docs/Steps/WorkflowPresetsSystem.md` or fold into Step/Preset docs. |
-| `docs/Tasks/TaskRemediation.md` | Rename to `docs/Temporal/WorkflowRemediation.md` or `docs/Steps/FailedStepRecovery.md`. |
+| `docs/Tasks/WorkflowArchitecture.md` | Delete or replace with `docs/Temporal/WorkflowExecutionArchitecture.md`. |
+| `docs/Tasks/WorkflowPresetsSystem.md` | Rename to `docs/Steps/WorkflowPresetsSystem.md` or fold into Step/Preset docs. |
+| `docs/Tasks/WorkflowRemediation.md` | Rename to `docs/Temporal/WorkflowRemediation.md` or `docs/Steps/FailedStepRecovery.md`. |
 
 ### 16.2 New Primary Docs
 

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -541,12 +541,12 @@ For the Jira example:
 
 ## Related Documents
 
-- `docs/Tasks/TaskPresetsSystem.md`
+- `docs/Tasks/WorkflowPresetsSystem.md`
 - `docs/Steps/StepTypes.md`
 - `docs/Steps/SkillSystem.md`
 - `docs/Steps/JiraIntegration.md`
-- `docs/Tasks/TaskArchitecture.md`
-- `docs/Tasks/TaskPublishing.md`
+- `docs/Tasks/WorkflowArchitecture.md`
+- `docs/Tasks/WorkflowPublishing.md`
 - `docs/Tasks/PrMergeAutomation.md`
 - `docs/UI/MissionControlArchitecture.md`
 - `docs/UI/MissionControlDesignSystem.md`

--- a/docs/UI/TypeScriptSystem.md
+++ b/docs/UI/TypeScriptSystem.md
@@ -3,7 +3,7 @@
 Status: **Active**
 Owners: MoonMind Engineering
 Last Updated: 2026-04-03
-Related: `README.md`, `api_service/static/task_dashboard/`, `docs/Tasks/TaskArchitecture.md`
+Related: `README.md`, `api_service/static/task_dashboard/`, `docs/Tasks/WorkflowArchitecture.md`
 
 **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs (for example `artifacts/`), or other local-only files—not as migration checklists in canonical `docs/`.
 

--- a/docs/UI/WorkflowDetailsPage.md
+++ b/docs/UI/WorkflowDetailsPage.md
@@ -4,7 +4,7 @@
 
 The Workflow Details page is the canonical view for inspecting a single MoonMind Workflow Execution. It presents the Workflow identity, current state, original Workflow configuration, execution history, outputs, errors, and all actions that are available for the Workflow in its current state.
 
-The page is declarative and state-driven. Every visible control is derived from the Workflow Execution status, the Workflow type, and explicit backend capabilities. A failed Workflow presents the user with the complete set of available recovery actions, which may include **Remediate**, **Edit task**, **Rerun**, and **Resume**.
+The page is declarative and state-driven. Every visible control is derived from the Workflow Execution status, the Workflow type, and explicit backend capabilities. A failed Workflow presents the user with the complete set of available recovery actions, which may include **Remediate**, **Edit Workflow**, **Rerun**, and **Resume**.
 
 ## Route
 
@@ -106,7 +106,7 @@ Tasks / Customer Renewal Research
 Customer Renewal Research                     [Failed]
 Research customer renewal risks and summarize next steps.
 
-[Remediate] [Edit task] [Rerun] [Resume] [More]
+[Remediate] [Edit Workflow] [Rerun] [Resume] [More]
 ```
 
 ### Title behavior
@@ -137,14 +137,14 @@ The status badge is not the only indicator of status. The status summary section
 
 The primary action bar appears in the header and remains available near the top of the page. On smaller screens, the same actions may collapse into a sticky bottom action bar or an overflow menu, but the actions remain discoverable.
 
-Actions are additive. Showing one action never hides another valid action. In particular, **Remediate** does not replace **Edit task**, **Rerun**, or **Resume** on failed Workflows.
+Actions are additive. Showing one action never hides another valid action. In particular, **Remediate** does not replace **Edit Workflow**, **Rerun**, or **Resume** on failed Workflows.
 
 ### Failed Workflow actions
 
 For a failed MoonMind Workflow, the primary action bar contains all of the following actions when the corresponding capabilities are true:
 
 ```text
-[Remediate] [Edit task] [Rerun] [Resume]
+[Remediate] [Edit Workflow] [Rerun] [Resume]
 ```
 
 The desired failed-Workflow action state is:
@@ -189,9 +189,9 @@ The button purpose is:
 Investigate and resolve the failure.
 ```
 
-### Edit task button
+### Edit Workflow button
 
-The **Edit task** button is present when either of the following is true:
+The **Edit Workflow** button is present when either of the following is true:
 
 ```ts
 capabilities.canEditForRerun === true
@@ -201,10 +201,10 @@ capabilities.canUpdateInputs === true
 The button label is:
 
 ```text
-Edit task
+Edit Workflow
 ```
 
-For failed Workflows, **Edit task** opens the Create page in edit-for-rerun mode. The page loads the original Workflow setup exactly, including all steps, selected choices, instructions, inputs, attachments, tool selections, model settings, scheduling choices, and advanced configuration.
+For failed Workflows, **Edit Workflow** opens the Create page in edit-for-rerun mode. The page loads the original Workflow setup exactly, including all steps, selected choices, instructions, inputs, attachments, tool selections, model settings, scheduling choices, and advanced configuration.
 
 Failed-Workflow edit destination:
 
@@ -214,7 +214,7 @@ Failed-Workflow edit destination:
 
 Failed-Workflow edit behavior:
 
-- The Create page title is `Edit task`.
+- The Create page title is `Edit Workflow`.
 - The page displays a banner explaining that editing creates a new run.
 - The original failed execution remains unchanged.
 - The user can modify the loaded Workflow configuration.
@@ -227,7 +227,7 @@ Required banner copy:
 You are editing a failed task. Your changes will create a new run. The original failed run will remain unchanged.
 ```
 
-For non-terminal Workflows that support live input updates, **Edit task** opens the Create page in update-inputs mode.
+For non-terminal Workflows that support live input updates, **Edit Workflow** opens the Create page in update-inputs mode.
 
 Running-Workflow edit destination:
 
@@ -237,7 +237,7 @@ Running-Workflow edit destination:
 
 Running-Workflow edit behavior:
 
-- The Create page title is `Edit task`.
+- The Create page title is `Edit Workflow`.
 - The original Workflow Execution may be updated according to product rules.
 - The submit button label is `Save changes`.
 
@@ -375,7 +375,7 @@ Destructive actions are visually separated and require confirmation.
 
 The page follows this desired action matrix.
 
-| Workflow status | Remediate | Edit task | Rerun | Failed step recovery | Cancel | Pause | Lifecycle resume |
+| Workflow status | Remediate | Edit Workflow | Rerun | Failed step recovery | Cancel | Pause | Lifecycle resume |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Pending | No | Yes, if inputs can be updated | No | No | Yes | No | No |
 | Scheduled | No | Yes, if inputs can be updated | No | No | Yes | No | No |
@@ -492,9 +492,9 @@ Status: Failed
 
 ### Exactness requirement for failed-Workflow edit
 
-The configuration shown on the Workflow Details page and the configuration loaded by **Edit task** for a failed Workflow come from the same source of truth.
+The configuration shown on the Workflow Details page and the configuration loaded by **Edit Workflow** for a failed Workflow come from the same source of truth.
 
-When a user selects **Edit task** on a failed Workflow, the edit form contains exactly the same values shown in the Workflow configuration summary unless the backend reports that an option is no longer available.
+When a user selects **Edit Workflow** on a failed Workflow, the edit form contains exactly the same values shown in the Workflow configuration summary unless the backend reports that an option is no longer available.
 
 If an option is no longer available, the edit form displays the prior value, marks it as unavailable, and prompts the user to choose a replacement before submitting.
 
@@ -550,7 +550,7 @@ It contains:
 - Remediation status, when available
 - Resume availability or the disabled reason, when a failed step exists but checkpointed progress cannot be restored
 
-The failure section must not obscure the primary action bar. Users can always see or quickly access **Remediate**, **Edit task**, and **Rerun** on failed Workflows.
+The failure section must not obscure the primary action bar. Users can always see or quickly access **Remediate**, **Edit Workflow**, and **Rerun** on failed Workflows.
 
 Example:
 
@@ -728,7 +728,7 @@ Relationship labels:
 - Recovered from failed step
 - Remediation run
 
-For a failed Workflow, once the user clicks **Rerun**, clicks **Resume**, or submits an edited Workflow from **Edit task**, the new run appears in this section.
+For a failed Workflow, once the user clicks **Rerun**, clicks **Resume**, or submits an edited Workflow from **Edit Workflow**, the new run appears in this section.
 
 ## Metadata section
 
@@ -793,7 +793,7 @@ Task configuration unavailable
 The original task configuration could not be loaded. You can still view status and logs.
 ```
 
-If the Workflow configuration is unavailable, the **Edit task** and **Rerun** actions are hidden unless the backend confirms that a valid submission draft or reconstructable workflow input is available.
+If the Workflow configuration is unavailable, the **Edit Workflow** and **Rerun** actions are hidden unless the backend confirms that a valid submission draft or reconstructable workflow input is available.
 
 ## Accessibility requirements
 
@@ -814,7 +814,7 @@ Button accessible names:
 
 ```text
 Remediate task
-Edit task
+Edit Workflow
 Rerun task
 Cancel task
 Pause task
@@ -850,7 +850,7 @@ On mobile:
 
 ```text
 Remediate
-Edit task
+Edit Workflow
 Rerun
 Resume
 ```
@@ -958,7 +958,7 @@ This task cannot be resumed because the completed work before the failed step is
 A failed Workflow page contains:
 
 - Header with Workflow title and `Failed` status badge.
-- Primary action bar with **Remediate**, **Edit task**, **Rerun**, and **Resume** when backend capabilities allow them.
+- Primary action bar with **Remediate**, **Edit Workflow**, **Rerun**, and **Resume** when backend capabilities allow them.
 - Status summary with failure timestamp and duration.
 - Failure section with failed step, error summary, and technical details.
 - Workflow configuration summary with original steps and choices.
@@ -992,7 +992,7 @@ Desired failed-Workflow action model:
 A running Workflow page contains:
 
 - Header with Workflow title and `Running` status badge.
-- Primary actions for any valid running-state actions, such as **Edit task**, **Pause**, or **Cancel**.
+- Primary actions for any valid running-state actions, such as **Edit Workflow**, **Pause**, or **Cancel**.
 - Live execution progress.
 - Current step.
 - Partial outputs, if available.
@@ -1006,7 +1006,7 @@ A completed Workflow page contains:
 
 - Header with Workflow title and `Completed` status badge.
 - **Rerun** action when supported.
-- Optional **Edit task** action when edit-for-rerun is supported.
+- Optional **Edit Workflow** action when edit-for-rerun is supported.
 - Final outputs.
 - Artifacts.
 - Execution timeline.
@@ -1018,7 +1018,7 @@ A canceled, timed out, or terminated Workflow page contains:
 
 - Header with the corresponding terminal status badge.
 - **Rerun** action when supported.
-- **Edit task** action when edit-for-rerun is supported.
+- **Edit Workflow** action when edit-for-rerun is supported.
 - Remediation action when the backend explicitly marks remediation as available.
 - Status reason.
 - Timeline and logs.
@@ -1033,9 +1033,9 @@ When the user clicks **Remediate**:
 2. The remediation experience receives the current Workflow Execution ID.
 3. The original Workflow details page remains reachable by back navigation.
 
-### Clicking Edit task on a failed Workflow
+### Clicking Edit Workflow on a failed Workflow
 
-When the user clicks **Edit task** on a failed Workflow:
+When the user clicks **Edit Workflow** on a failed Workflow:
 
 1. The user is routed to the Create page in edit-for-rerun mode.
 2. The Create page loads the source Workflow Execution's submission draft.
@@ -1080,15 +1080,15 @@ The Workflow Details page does not reconstruct edit-form state from display-only
 
 The Workflow Details page does not allow destructive actions without confirmation.
 
-The Workflow Details page does not allow Workflow input editing as part of failed-step **Resume**. Editing instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies belongs to **Edit task**.
+The Workflow Details page does not allow Workflow input editing as part of failed-step **Resume**. Editing instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies belongs to **Edit Workflow**.
 
 ## Acceptance criteria
 
 The page is considered correct when all of the following are true:
 
-1. A failed Workflow displays **Remediate**, **Edit task**, **Rerun**, and **Resume** when the backend capabilities allow them.
+1. A failed Workflow displays **Remediate**, **Edit Workflow**, **Rerun**, and **Resume** when the backend capabilities allow them.
 2. **Remediate** opens the remediation flow.
-3. **Edit task** on a failed Workflow opens `/tasks/new?rerunExecutionId=:taskExecutionId&mode=edit`.
+3. **Edit Workflow** on a failed Workflow opens `/tasks/new?rerunExecutionId=:taskExecutionId&mode=edit`.
 4. The edit-for-rerun Create page loads every original step and selected choice exactly.
 5. Submitting an edited failed Workflow creates a new run and does not mutate the failed execution.
 6. **Rerun** creates a new run using the exact original Workflow configuration.

--- a/docs/UI/WorkflowDetailsPage.md
+++ b/docs/UI/WorkflowDetailsPage.md
@@ -1,35 +1,35 @@
-# Task Details Page
+# Workflow Details Page
 
 ## Purpose
 
-The Task Details page is the canonical view for inspecting a single MoonMind task execution. It presents the task identity, current state, original task configuration, execution history, outputs, errors, and all actions that are available for the task in its current state.
+The Workflow Details page is the canonical view for inspecting a single MoonMind Workflow Execution. It presents the Workflow identity, current state, original Workflow configuration, execution history, outputs, errors, and all actions that are available for the Workflow in its current state.
 
-The page is declarative and state-driven. Every visible control is derived from the task execution status, the task type, and explicit backend capabilities. A failed task presents the user with the complete set of available recovery actions, which may include **Remediate**, **Edit task**, **Rerun**, and **Resume**.
+The page is declarative and state-driven. Every visible control is derived from the Workflow Execution status, the Workflow type, and explicit backend capabilities. A failed Workflow presents the user with the complete set of available recovery actions, which may include **Remediate**, **Edit task**, **Rerun**, and **Resume**.
 
 ## Route
 
-The page is available from task lists, task notifications, remediation links, and run history links.
+The page is available from Workflows lists, Workflow notifications, remediation links, and run history links.
 
 ```text
 /tasks/:taskExecutionId
 ```
 
-The page accepts a task execution identifier and loads a single task execution detail record.
+The page accepts a Workflow Execution identifier and loads a single Workflow Execution detail record.
 
 ## Page-level goals
 
 The page enables a user to:
 
-1. Understand what task ran or is running.
-2. See the current task status and relevant timestamps.
-3. Inspect the exact steps, choices, instructions, and configuration used for the task.
+1. Understand what Workflow ran or is running.
+2. See the current Workflow status and relevant timestamps.
+3. Inspect the exact steps, choices, instructions, and configuration used for the Workflow.
 4. View progress, logs, outputs, artifacts, and failure information.
-5. Take the correct next action for the task state.
-6. For failed tasks, choose between remediation, editing the failed task for a new run, rerunning the task exactly as originally submitted, or resuming from the last failed step when prior work can be restored.
+5. Take the correct next action for the Workflow state.
+6. For failed Workflows, choose between remediation, editing the failed Workflow for a new run, rerunning the Workflow exactly as originally submitted, or resuming from the last failed step when prior work can be restored.
 
 ## Source of truth
 
-The page is rendered from a task execution detail model that includes the task execution, original submission draft, current status, derived capabilities, artifacts, logs, and related runs.
+The page is rendered from a Workflow Execution detail model that includes the Workflow Execution, original submission draft, current status, derived capabilities, artifacts, logs, and related runs.
 
 The UI does not infer unavailable actions from status alone. The UI displays actions from explicit capability fields.
 
@@ -75,7 +75,7 @@ The page contains the following major regions:
 1. Header
 2. Primary action bar
 3. Status summary
-4. Task configuration summary
+4. Workflow configuration summary
 5. Execution progress
 6. Failure and remediation panel, when applicable
 7. Outputs and artifacts
@@ -91,12 +91,12 @@ The header is always present.
 
 The header contains:
 
-- A breadcrumb or back link to the task list.
-- The task name or task title.
+- A breadcrumb or back link to the Workflows list.
+- The Workflow name or Workflow title.
 - A status badge.
-- A short task description or prompt summary, when available.
+- A short Workflow description or prompt summary, when available.
 - The primary action bar.
-- A task overflow menu for secondary utility actions.
+- A Workflow overflow menu for secondary utility actions.
 
 Example desired layout:
 
@@ -111,7 +111,7 @@ Research customer renewal risks and summarize next steps.
 
 ### Title behavior
 
-The title displays the user-provided task name when present. If no explicit task name exists, the title displays a generated summary of the task objective. If neither is available, the title displays:
+The title displays the user-provided Workflow name when present. If no explicit Workflow name exists, the title displays a generated summary of the Workflow objective. If neither is available, the title displays:
 
 ```text
 Untitled task
@@ -119,7 +119,7 @@ Untitled task
 
 ### Status badge
 
-The status badge is always visible and uses one of the canonical task statuses:
+The status badge is always visible and uses one of the canonical Workflow statuses:
 
 - Pending
 - Scheduled
@@ -137,17 +137,17 @@ The status badge is not the only indicator of status. The status summary section
 
 The primary action bar appears in the header and remains available near the top of the page. On smaller screens, the same actions may collapse into a sticky bottom action bar or an overflow menu, but the actions remain discoverable.
 
-Actions are additive. Showing one action never hides another valid action. In particular, **Remediate** does not replace **Edit task**, **Rerun**, or **Resume** on failed tasks.
+Actions are additive. Showing one action never hides another valid action. In particular, **Remediate** does not replace **Edit task**, **Rerun**, or **Resume** on failed Workflows.
 
-### Failed task actions
+### Failed Workflow actions
 
-For a failed MoonMind task, the primary action bar contains all of the following actions when the corresponding capabilities are true:
+For a failed MoonMind Workflow, the primary action bar contains all of the following actions when the corresponding capabilities are true:
 
 ```text
 [Remediate] [Edit task] [Rerun] [Resume]
 ```
 
-The desired failed-task action state is:
+The desired failed-Workflow action state is:
 
 ```ts
 capabilities.canRemediate === true
@@ -157,7 +157,7 @@ capabilities.canResumeFromFailedStep === true // only when checkpointed progress
 capabilities.canUpdateInputs === false
 ```
 
-Failed tasks are terminal executions. The user may inspect, remediate, edit for a new run, rerun, or resume from the last failed step, but the original failed execution is not mutated in place.
+Failed Workflows are terminal executions. The user may inspect, remediate, edit for a new run, rerun, or resume from the last failed step, but the original failed execution is not mutated in place.
 
 ### Remediate button
 
@@ -173,7 +173,7 @@ The button label is:
 Remediate
 ```
 
-The button opens the remediation experience for the failed task.
+The button opens the remediation experience for the failed Workflow.
 
 Desired destination:
 
@@ -181,7 +181,7 @@ Desired destination:
 /tasks/:taskExecutionId/remediate
 ```
 
-The button is usually the primary action for failed tasks when remediation is available.
+The button is usually the primary action for failed Workflows when remediation is available.
 
 The button purpose is:
 
@@ -204,21 +204,21 @@ The button label is:
 Edit task
 ```
 
-For failed tasks, **Edit task** opens the create-task page in edit-for-rerun mode. The page loads the original task setup exactly, including all steps, selected choices, instructions, inputs, attachments, tool selections, model settings, scheduling choices, and advanced configuration.
+For failed Workflows, **Edit task** opens the Create page in edit-for-rerun mode. The page loads the original Workflow setup exactly, including all steps, selected choices, instructions, inputs, attachments, tool selections, model settings, scheduling choices, and advanced configuration.
 
-Failed-task edit destination:
+Failed-Workflow edit destination:
 
 ```text
 /tasks/new?rerunExecutionId=:taskExecutionId&mode=edit
 ```
 
-Failed-task edit behavior:
+Failed-Workflow edit behavior:
 
-- The create-task page title is `Edit task`.
+- The Create page title is `Edit task`.
 - The page displays a banner explaining that editing creates a new run.
 - The original failed execution remains unchanged.
-- The user can modify the loaded task configuration.
-- Submitting the form creates a new task run using the edited configuration.
+- The user can modify the loaded Workflow configuration.
+- Submitting the form creates a new Workflow run using the edited configuration.
 - The submit button label is `Run edited task`.
 
 Required banner copy:
@@ -227,18 +227,18 @@ Required banner copy:
 You are editing a failed task. Your changes will create a new run. The original failed run will remain unchanged.
 ```
 
-For non-terminal tasks that support live input updates, **Edit task** opens the create-task page in update-inputs mode.
+For non-terminal Workflows that support live input updates, **Edit task** opens the Create page in update-inputs mode.
 
-Running-task edit destination:
+Running-Workflow edit destination:
 
 ```text
 /tasks/new?editExecutionId=:taskExecutionId
 ```
 
-Running-task edit behavior:
+Running-Workflow edit behavior:
 
-- The create-task page title is `Edit task`.
-- The original task execution may be updated according to product rules.
+- The Create page title is `Edit task`.
+- The original Workflow Execution may be updated according to product rules.
 - The submit button label is `Save changes`.
 
 ### Rerun button
@@ -255,16 +255,16 @@ The button label is:
 Rerun
 ```
 
-For failed tasks, **Rerun** starts a new run using the exact same original task configuration. It does not open an editing form and does not mutate the original failed execution.
+For failed Workflows, **Rerun** starts a new run using the exact same original Workflow configuration. It does not open an editing form and does not mutate the original failed execution.
 
 Rerun behavior:
 
 - Uses the original submission draft or reconstructed original workflow input.
 - Preserves all original steps and choices.
 - Preserves original instructions and artifact references when unchanged.
-- Creates a new task execution.
-- Links the new run back to the original task execution as a rerun.
-- Leaves the original failed task unchanged.
+- Creates a new Workflow Execution.
+- Links the new run back to the original Workflow Execution as a rerun.
+- Leaves the original failed Workflow unchanged.
 
 Optional confirmation copy:
 
@@ -276,11 +276,11 @@ This will run the task again with the exact same steps, choices, and settings.
 [Cancel] [Rerun task]
 ```
 
-After a successful rerun request, the user is taken to the new task execution details page or shown a success toast with a link to the new run.
+After a successful rerun request, the user is taken to the new Workflow Execution details page or shown a success toast with a link to the new run.
 
 ### Resume button
 
-The failed-task **Resume** button is present when:
+The failed-Workflow **Resume** button is present when:
 
 ```ts
 capabilities.canResumeFromFailedStep === true
@@ -298,19 +298,19 @@ The accessible name is:
 Resume from failed step
 ```
 
-The failed-task **Resume** action is separate from the paused-task **Resume** lifecycle action. Failed-task **Resume** retries the last failed step with the completed work before that step restored from durable checkpoints.
+The failed-Workflow **Resume** action is separate from the paused-Workflow **Resume** lifecycle action. Failed-Workflow **Resume** retries the last failed step with the completed work before that step restored from durable checkpoints.
 
 Resume behavior:
 
 - Does not open an editing form.
-- Uses the original task input snapshot unchanged.
+- Uses the original Workflow input snapshot unchanged.
 - Pins the source execution by both `workflowId` and `runId`.
 - Identifies the last failed step from backend progress data.
 - Restores completed prior steps from durable step output refs and workspace, branch, commit, or equivalent checkpoints.
 - Creates a linked follow-up execution.
 - Displays prior completed steps in the new execution as reused from the original run.
 - Starts new execution work at the failed step.
-- Leaves the original failed task unchanged.
+- Leaves the original failed Workflow unchanged.
 
 Optional confirmation copy:
 
@@ -322,7 +322,7 @@ MoonMind will reuse the completed work before the failed step and retry the fail
 [Cancel] [Resume]
 ```
 
-After a successful Resume request, the user is taken to the resumed task execution details page or shown a success toast with a link to the resumed run.
+After a successful Resume request, the user is taken to the resumed Workflow Execution details page or shown a success toast with a link to the resumed run.
 
 ### Cancel button
 
@@ -332,9 +332,9 @@ The **Cancel** button is present when:
 capabilities.canCancel === true
 ```
 
-The button cancels a pending, scheduled, or running task according to task execution rules.
+The button cancels a pending, scheduled, or running Workflow according to Workflow Execution rules.
 
-The original task page remains available after cancellation.
+The original Workflow page remains available after cancellation.
 
 ### Pause and lifecycle Resume buttons
 
@@ -350,11 +350,11 @@ The lifecycle **Resume** button is present when:
 capabilities.canResume === true
 ```
 
-Only one of **Pause** or lifecycle **Resume** is visible at a time. This lifecycle action resumes a paused active task and is not the failed-task **Resume** action described above.
+Only one of **Pause** or lifecycle **Resume** is visible at a time. This lifecycle action resumes a paused active Workflow and is not the failed-Workflow **Resume** action described above.
 
 ### More menu
 
-The overflow menu contains secondary utility actions that are valid for the task.
+The overflow menu contains secondary utility actions that are valid for the Workflow.
 
 Possible menu items:
 
@@ -375,7 +375,7 @@ Destructive actions are visually separated and require confirmation.
 
 The page follows this desired action matrix.
 
-| Task status | Remediate | Edit task | Rerun | Failed step recovery | Cancel | Pause | Lifecycle resume |
+| Workflow status | Remediate | Edit task | Rerun | Failed step recovery | Cancel | Pause | Lifecycle resume |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | Pending | No | Yes, if inputs can be updated | No | No | Yes | No | No |
 | Scheduled | No | Yes, if inputs can be updated | No | No | Yes | No | No |
@@ -387,7 +387,7 @@ The page follows this desired action matrix.
 | Timed out | Optional, if failure can be remediated | Yes, as edit-for-rerun | Yes | Optional, if a failed step and checkpoint are available | No | No | No |
 | Terminated | Optional, if failure can be remediated | Yes, as edit-for-rerun | Yes | Optional, if a failed step and checkpoint are available | No | No | No |
 
-The matrix is descriptive. The final source of truth is the capability object returned with the task detail data.
+The matrix is descriptive. The final source of truth is the capability object returned with the Workflow detail data.
 
 ## Status summary section
 
@@ -433,17 +433,17 @@ Attempts
 1 of 3
 ```
 
-When the task is failed, the failure reason is visible without requiring the user to open logs.
+When the Workflow is failed, the failure reason is visible without requiring the user to open logs.
 
-## Task configuration summary
+## Workflow configuration summary
 
-The task configuration summary is always present when the original task configuration is available.
+The Workflow configuration summary is always present when the original Workflow configuration is available.
 
-It displays the exact user-visible configuration used to create the task.
+It displays the exact user-visible configuration used to create the Workflow.
 
 Required content:
 
-- Task objective
+- Workflow objective
 - Instructions
 - Steps
 - Selected choices
@@ -462,7 +462,7 @@ This section supports two levels of detail:
 
 ### Steps and choices
 
-The page displays every step included in the task, in the original order.
+The page displays every step included in the Workflow, in the original order.
 
 For each step, the page displays:
 
@@ -490,17 +490,17 @@ Choice: Concise executive summary
 Status: Failed
 ```
 
-### Exactness requirement for failed-task edit
+### Exactness requirement for failed-Workflow edit
 
-The configuration shown on the Task Details page and the configuration loaded by **Edit task** for a failed task come from the same source of truth.
+The configuration shown on the Workflow Details page and the configuration loaded by **Edit task** for a failed Workflow come from the same source of truth.
 
-When a user selects **Edit task** on a failed task, the edit form contains exactly the same values shown in the task configuration summary unless the backend reports that an option is no longer available.
+When a user selects **Edit task** on a failed Workflow, the edit form contains exactly the same values shown in the Workflow configuration summary unless the backend reports that an option is no longer available.
 
 If an option is no longer available, the edit form displays the prior value, marks it as unavailable, and prompts the user to choose a replacement before submitting.
 
 ## Execution progress section
 
-The execution progress section is present for tasks with progress data.
+The execution progress section is present for Workflows with progress data.
 
 It contains:
 
@@ -513,9 +513,9 @@ It contains:
 - Step-level outputs or summaries, when available
 - Preserved steps reused from a source run, when viewing a resumed execution
 
-For running tasks, this section updates as new progress is received.
+For running Workflows, this section updates as new progress is received.
 
-For terminal tasks, this section displays the final execution path.
+For terminal Workflows, this section displays the final execution path.
 
 For resumed executions, prior completed steps restored from the source run are displayed as preserved, for example:
 
@@ -550,7 +550,7 @@ It contains:
 - Remediation status, when available
 - Resume availability or the disabled reason, when a failed step exists but checkpointed progress cannot be restored
 
-The failure section must not obscure the primary action bar. Users can always see or quickly access **Remediate**, **Edit task**, and **Rerun** on failed tasks.
+The failure section must not obscure the primary action bar. Users can always see or quickly access **Remediate**, **Edit task**, and **Rerun** on failed Workflows.
 
 Example:
 
@@ -583,7 +583,7 @@ It contains:
 - Remediation recommendation summary
 - Link or button to open remediation
 
-For failed tasks with remediation available, the panel includes a **Remediate** button in addition to the header action.
+For failed Workflows with remediation available, the panel includes a **Remediate** button in addition to the header action.
 
 Panel button label:
 
@@ -612,7 +612,7 @@ It contains:
 - Destination delivery status, when applicable
 - Links to output artifacts
 
-For failed tasks, partial outputs remain visible if they were produced before failure.
+For failed Workflows, partial outputs remain visible if they were produced before failure.
 
 If no outputs exist, the section displays an empty state:
 
@@ -664,30 +664,30 @@ It contains:
 - Copy log line action
 - Download logs action, when supported
 
-For failed tasks, the logs section highlights log lines related to the failure.
+For failed Workflows, the logs section highlights log lines related to the failure.
 
 Default view shows user-relevant logs first. Raw technical logs are available through an expandable advanced view.
 
 ## Events and audit section
 
-The events and audit section contains a chronological timeline of meaningful task events.
+The events and audit section contains a chronological timeline of meaningful Workflow events.
 
 Events may include:
 
-- Task created
-- Task scheduled
-- Task started
+- Workflow created
+- Workflow scheduled
+- Workflow started
 - Step started
 - Step completed
 - Step failed
-- Task paused
-- Task resumed
-- Task canceled
-- Task failed
-- Task completed
+- Workflow paused
+- Workflow resumed
+- Workflow canceled
+- Workflow failed
+- Workflow completed
 - Remediation started
 - Remediation completed
-- Task rerun requested
+- Workflow rerun requested
 - Edited rerun created
 - Failed-step resume requested
 - Resumed run created
@@ -706,9 +706,9 @@ The related runs section is present when related runs exist.
 It contains:
 
 - Original run, when viewing a rerun
-- Reruns created from the current task
-- Edited reruns created from the current task
-- Resumed runs created from the current task
+- Reruns created from the current Workflow
+- Edited reruns created from the current Workflow
+- Resumed runs created from the current Workflow
 - Remediation-generated runs, when applicable
 
 Each related run displays:
@@ -728,7 +728,7 @@ Relationship labels:
 - Recovered from failed step
 - Remediation run
 
-For a failed task, once the user clicks **Rerun**, clicks **Resume**, or submits an edited task from **Edit task**, the new run appears in this section.
+For a failed Workflow, once the user clicks **Rerun**, clicks **Resume**, or submits an edited Workflow from **Edit task**, the new run appears in this section.
 
 ## Metadata section
 
@@ -736,14 +736,14 @@ The metadata section is present for users with permission to view technical deta
 
 It contains:
 
-- Task execution ID
+- Workflow Execution ID
 - Workflow ID
 - Run ID
 - Workflow type
 - Queue name, when applicable
 - Attempt number
-- Parent task, when applicable
-- Source task, when this is a rerun
+- Parent Workflow, when applicable
+- Source Workflow, when this is a rerun
 - Created by
 - Workspace
 - Environment
@@ -767,7 +767,7 @@ The page does not display incomplete action buttons before capabilities are load
 
 ### Not found state
 
-When the task execution does not exist or the user does not have access, the page displays:
+When the Workflow Execution does not exist or the user does not have access, the page displays:
 
 ```text
 Task not found
@@ -783,7 +783,7 @@ Back to tasks
 
 ### Data unavailable state
 
-When the task exists but some details cannot be loaded, the page displays the available task summary and an inline warning for the missing section.
+When the Workflow exists but some details cannot be loaded, the page displays the available Workflow summary and an inline warning for the missing section.
 
 Example:
 
@@ -793,7 +793,7 @@ Task configuration unavailable
 The original task configuration could not be loaded. You can still view status and logs.
 ```
 
-If the task configuration is unavailable, the **Edit task** and **Rerun** actions are hidden unless the backend confirms that a valid submission draft or reconstructable workflow input is available.
+If the Workflow configuration is unavailable, the **Edit task** and **Rerun** actions are hidden unless the backend confirms that a valid submission draft or reconstructable workflow input is available.
 
 ## Accessibility requirements
 
@@ -842,11 +842,11 @@ On mobile:
 - Header stacks vertically.
 - Primary actions remain visible near the top or in a sticky bottom action bar.
 - Secondary actions move into the overflow menu.
-- The failed-task actions remain available and are not hidden behind remediation alone.
+- The failed-Workflow actions remain available and are not hidden behind remediation alone.
 
 ## Copy requirements
 
-### Failed task header actions
+### Failed Workflow header actions
 
 ```text
 Remediate
@@ -855,7 +855,7 @@ Rerun
 Resume
 ```
 
-### Failed task edit banner
+### Failed Workflow edit banner
 
 ```text
 You are editing a failed task. Your changes will create a new run. The original failed run will remain unchanged.
@@ -953,15 +953,15 @@ This task cannot be resumed because the completed work before the failed step is
 
 ## State-specific desired page examples
 
-### Failed task
+### Failed Workflow
 
-A failed task page contains:
+A failed Workflow page contains:
 
-- Header with task title and `Failed` status badge.
+- Header with Workflow title and `Failed` status badge.
 - Primary action bar with **Remediate**, **Edit task**, **Rerun**, and **Resume** when backend capabilities allow them.
 - Status summary with failure timestamp and duration.
 - Failure section with failed step, error summary, and technical details.
-- Task configuration summary with original steps and choices.
+- Workflow configuration summary with original steps and choices.
 - Execution progress showing completed steps and the failed step.
 - Partial outputs, if any.
 - Artifacts, if any.
@@ -969,7 +969,7 @@ A failed task page contains:
 - Related runs, if reruns or remediation runs exist.
 - Metadata and audit events.
 
-Desired failed-task action model:
+Desired failed-Workflow action model:
 
 ```ts
 {
@@ -987,24 +987,24 @@ Desired failed-task action model:
 }
 ```
 
-### Running task
+### Running Workflow
 
-A running task page contains:
+A running Workflow page contains:
 
-- Header with task title and `Running` status badge.
+- Header with Workflow title and `Running` status badge.
 - Primary actions for any valid running-state actions, such as **Edit task**, **Pause**, or **Cancel**.
 - Live execution progress.
 - Current step.
 - Partial outputs, if available.
 - Logs and events.
 
-Running tasks do not show **Remediate** or **Rerun**.
+Running Workflows do not show **Remediate** or **Rerun**.
 
-### Completed task
+### Completed Workflow
 
-A completed task page contains:
+A completed Workflow page contains:
 
-- Header with task title and `Completed` status badge.
+- Header with Workflow title and `Completed` status badge.
 - **Rerun** action when supported.
 - Optional **Edit task** action when edit-for-rerun is supported.
 - Final outputs.
@@ -1012,9 +1012,9 @@ A completed task page contains:
 - Execution timeline.
 - Related runs.
 
-### Canceled, timed out, or terminated task
+### Canceled, timed out, or terminated Workflow
 
-A canceled, timed out, or terminated task page contains:
+A canceled, timed out, or terminated Workflow page contains:
 
 - Header with the corresponding terminal status badge.
 - **Rerun** action when supported.
@@ -1029,25 +1029,25 @@ A canceled, timed out, or terminated task page contains:
 
 When the user clicks **Remediate**:
 
-1. The user is routed to the remediation experience for the current task.
-2. The remediation experience receives the current task execution ID.
-3. The original task details page remains reachable by back navigation.
+1. The user is routed to the remediation experience for the current Workflow.
+2. The remediation experience receives the current Workflow Execution ID.
+3. The original Workflow details page remains reachable by back navigation.
 
-### Clicking Edit task on a failed task
+### Clicking Edit task on a failed Workflow
 
-When the user clicks **Edit task** on a failed task:
+When the user clicks **Edit task** on a failed Workflow:
 
-1. The user is routed to the create-task page in edit-for-rerun mode.
-2. The create-task page loads the source task execution's submission draft.
-3. All original task values are prefilled exactly.
-4. The page displays the failed-task edit banner.
+1. The user is routed to the Create page in edit-for-rerun mode.
+2. The Create page loads the source Workflow Execution's submission draft.
+3. All original Workflow values are prefilled exactly.
+4. The page displays the failed-Workflow edit banner.
 5. The original failed execution is not modified.
 6. Submitting the edited form starts a new run.
 7. The new run is linked to the original execution as an edited rerun.
 
-### Clicking Rerun on a failed task
+### Clicking Rerun on a failed Workflow
 
-When the user clicks **Rerun** on a failed task:
+When the user clicks **Rerun** on a failed Workflow:
 
 1. The user confirms the rerun, if confirmation is enabled.
 2. The system creates a new run using the original submission draft.
@@ -1056,12 +1056,12 @@ When the user clicks **Rerun** on a failed task:
 5. The user receives a success toast or is routed to the new run.
 6. The new run is linked to the original execution as a rerun.
 
-### Clicking Resume on a failed task
+### Clicking Resume on a failed Workflow
 
-When the user clicks **Resume** on a failed task:
+When the user clicks **Resume** on a failed Workflow:
 
 1. The user confirms Resume, if confirmation is enabled.
-2. The backend creates a linked follow-up execution using the original task input snapshot unchanged.
+2. The backend creates a linked follow-up execution using the original Workflow input snapshot unchanged.
 3. The backend pins the source by `workflowId` and `runId`.
 4. The backend restores completed prior work from durable step output refs and workspace, branch, commit, or equivalent checkpoints.
 5. The new execution marks prior completed steps as preserved from the source run.
@@ -1072,28 +1072,28 @@ When the user clicks **Resume** on a failed task:
 
 ## Non-goals
 
-The Task Details page does not mutate terminal executions in place.
+The Workflow Details page does not mutate terminal executions in place.
 
-The Task Details page does not hide valid failed-task actions merely because remediation is available.
+The Workflow Details page does not hide valid failed-Workflow actions merely because remediation is available.
 
-The Task Details page does not reconstruct edit-form state from display-only labels when a canonical submission draft is available.
+The Workflow Details page does not reconstruct edit-form state from display-only labels when a canonical submission draft is available.
 
-The Task Details page does not allow destructive actions without confirmation.
+The Workflow Details page does not allow destructive actions without confirmation.
 
-The Task Details page does not allow task input editing as part of failed-step **Resume**. Editing instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies belongs to **Edit task**.
+The Workflow Details page does not allow Workflow input editing as part of failed-step **Resume**. Editing instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies belongs to **Edit task**.
 
 ## Acceptance criteria
 
 The page is considered correct when all of the following are true:
 
-1. A failed task displays **Remediate**, **Edit task**, **Rerun**, and **Resume** when the backend capabilities allow them.
+1. A failed Workflow displays **Remediate**, **Edit task**, **Rerun**, and **Resume** when the backend capabilities allow them.
 2. **Remediate** opens the remediation flow.
-3. **Edit task** on a failed task opens `/tasks/new?rerunExecutionId=:taskExecutionId&mode=edit`.
-4. The edit-for-rerun create-task page loads every original step and selected choice exactly.
-5. Submitting an edited failed task creates a new run and does not mutate the failed execution.
-6. **Rerun** creates a new run using the exact original task configuration.
+3. **Edit task** on a failed Workflow opens `/tasks/new?rerunExecutionId=:taskExecutionId&mode=edit`.
+4. The edit-for-rerun Create page loads every original step and selected choice exactly.
+5. Submitting an edited failed Workflow creates a new run and does not mutate the failed execution.
+6. **Rerun** creates a new run using the exact original Workflow configuration.
 7. **Resume** creates a linked follow-up execution that reuses completed prior work and starts at the last failed step.
-8. The original failed task remains visible and unchanged after remediation, edit-for-rerun, rerun, or Resume.
+8. The original failed Workflow remains visible and unchanged after remediation, edit-for-rerun, rerun, or Resume.
 9. Remediation availability does not suppress edit, rerun, or Resume availability.
 10. All actions are rendered from explicit capability fields.
 11. Users can inspect failure details, original configuration, outputs, artifacts, logs, related runs, and metadata from the page.

--- a/docs/UI/WorkflowsListPage.md
+++ b/docs/UI/WorkflowsListPage.md
@@ -1,9 +1,9 @@
-# Tasks List Page
+# Workflows List Page
 
 Status: Proposed desired-state contract  
 Owners: MoonMind Engineering  
 Last updated: 2026-05-04  
-Canonical for: Mission Control tasks list route, execution-list controls, table sorting, column filters, filter URL state, and Google Sheets-like list filtering behavior
+Canonical for: Mission Control Workflows list route, execution-list controls, table sorting, column filters, filter URL state, and Google Sheets-like list filtering behavior
 
 **Implementation tracking:** Rollout and backlog notes live in MoonSpec artifacts (`specs/<feature>/`), gitignored handoffs, or other local-only files. This document defines the product and UI contract for the page.
 
@@ -11,9 +11,9 @@ Canonical for: Mission Control tasks list route, execution-list controls, table 
 
 ## 1. Purpose
 
-This document defines the canonical design for the MoonMind **Tasks List** page.
+This document defines the canonical design for the MoonMind **Workflows List** page.
 
-The page helps operators inspect Temporal-backed MoonMind task executions in a task-oriented table. It must support fast scanning, stable pagination, clear status visibility, accessible sorting, and column-level filtering that can replace the current top-of-page filter dropdowns.
+The page helps operators inspect Temporal-backed MoonMind Workflow Executions in a Workflow-oriented table. It must support fast scanning, stable pagination, clear status visibility, accessible sorting, and column-level filtering that can replace the current top-of-page filter dropdowns.
 
 The desired column filtering model is intentionally similar to Google Sheets filters: each column header owns both sorting and a filter popover where users can search values, select or deselect values, include blanks, clear the column filter, and apply or cancel changes.
 
@@ -21,7 +21,7 @@ The desired column filtering model is intentionally similar to Google Sheets fil
 
 ## 2. Related docs and implementation surfaces
 
-Use this document for Tasks List page behavior.
+Use this document for Workflows List page behavior.
 
 Use related docs for system-level contracts:
 
@@ -29,7 +29,7 @@ Use related docs for system-level contracts:
 - `docs/Temporal/VisibilityAndUiQueryModel.md` — Temporal Visibility and UI query model.
 - `docs/UI/MissionControlArchitecture.md` — Mission Control shell and shared frontend architecture.
 - `docs/UI/MissionControlDesignSystem.md` — shared Mission Control visual language.
-- `docs/UI/CreatePage.md` — task authoring surface that creates many rows shown on this page.
+- `docs/UI/CreatePage.md` — Workflow authoring surface that creates many rows shown on this page.
 
 Representative current implementation surfaces:
 
@@ -45,7 +45,7 @@ frontend/src/styles/mission-control.css
 
 ## 3. Route and hosting model
 
-The canonical Tasks List route is:
+The canonical Workflows List route is:
 
 ```text
 /tasks/list
@@ -53,7 +53,7 @@ The canonical Tasks List route is:
 
 Rules:
 
-1. `/tasks/list` is the canonical Tasks List route.
+1. `/tasks/list` is the canonical Workflows List route.
 2. `/tasks` redirects to `/tasks/list`.
 3. `/tasks/tasks-list` is a legacy alias and redirects to `/tasks/list`.
 4. The page is server-hosted by FastAPI and rendered by the shared Mission Control React/Vite frontend.
@@ -66,15 +66,15 @@ Rules:
 
 ## 4. Product stance
 
-The Tasks List page is an operator scanning surface, not a generic Temporal namespace browser.
+The Workflows List page is an operator scanning surface, not a generic Temporal namespace browser.
 
 Core rules:
 
-1. The default view is task-oriented and shows ordinary user-created task executions.
-2. The normal Tasks List page is not a workflow-kind browser. It does not need a `Kind` column.
-3. System workflows are hidden from ordinary Tasks List users. Provider-profile managers, internal monitors, maintenance workflows, and other platform-owned executions belong in an admin diagnostics surface instead of the main task table.
-4. Manifest-ingest workflows belong on the Manifests page or a future user-workflow diagnostics view. They should not force a `Kind`, `Workflow Type`, or `Entry` column into the default task list.
-5. Sorting and filtering are table behaviors and should be expressed on the relevant task columns instead of as detached dropdowns above the table.
+1. The default view is Workflow-oriented and shows ordinary user-created Workflow Executions.
+2. The normal Workflows List page is not a workflow-kind browser. It does not need a `Kind` column.
+3. System workflows are hidden from ordinary Workflows List users. Provider-profile managers, internal monitors, maintenance workflows, and other platform-owned executions belong in an admin diagnostics surface instead of the main Workflow table.
+4. Manifest-ingest workflows belong on the Manifests page or a future user-workflow diagnostics view. They should not force a `Kind`, `Workflow Type`, or `Entry` column into the default Workflows list.
+5. Sorting and filtering are table behaviors and should be expressed on the relevant Workflow columns instead of as detached dropdowns above the table.
 6. The page should make the active query obvious through column filter indicators and active filter chips.
 7. URL state must be shareable and reloadable.
 8. Pagination, sorting, and filtering must be deterministic across refreshes.
@@ -84,7 +84,7 @@ Core rules:
 
 ## 5. Current page behavior
 
-This section describes the current Tasks List page before the proposed column-filter redesign.
+This section describes the current Workflows List page before the proposed column-filter redesign.
 
 ### 5.1 Page shell
 
@@ -95,7 +95,7 @@ The current page renders a single vertical stack with two major surfaces:
 
 The control deck contains:
 
-- page title: `Tasks List`;
+- page title: `Workflows List`;
 - `Live updates` checkbox;
 - polling status copy;
 - disabled-state notice when the Temporal list feature is disabled;
@@ -208,7 +208,7 @@ The current table row model includes these display fields:
 
 | Field | Meaning |
 | --- | --- |
-| `taskId` | Task-oriented execution identifier; linked to detail view. |
+| `taskId` | Workflow-oriented execution identifier; linked to detail view. |
 | `source` | Execution source, currently Temporal for this page. |
 | `workflowType` | Root workflow type when returned. |
 | `repository` | Repository display value, if available. |
@@ -261,7 +261,7 @@ Rules:
 The current mobile layout renders a card list with:
 
 - title link;
-- task ID;
+- Workflow ID;
 - runtime, skill, and workflow type metadata;
 - status pill;
 - field grid for ID, Runtime, Skill, Repository, Scheduled, Created, and Finished;
@@ -272,9 +272,9 @@ The current mobile layout renders a card list with:
 
 Rules:
 
-1. Loading state shows `Loading tasks...`.
+1. Loading state shows `Loading Workflows...`.
 2. API errors render a visible error notice.
-3. Empty first pages show `No tasks found for the current filters.`
+3. Empty first pages show `No Workflows found for the current filters.`
 4. Empty later pages keep the previous-page button enabled.
 5. Pagination uses an opaque `nextPageToken` plus a client-side cursor stack for previous-page navigation.
 6. The results toolbar shows `Page N`, row range, and count when available.
@@ -303,8 +303,8 @@ Rules:
 2. Repository filtering moves from the top text input to the Repository column filter.
 3. Status filtering moves from the top Status dropdown to the Status column filter.
 4. Runtime filtering is added to the Runtime column filter.
-5. Scope, workflow type, and entry controls are removed from the normal Tasks List page instead of being represented by a `Kind` column.
-6. The normal page always queries the user-visible task scope; system workflows are not available from the ordinary task table.
+5. Scope, workflow type, and entry controls are removed from the normal Workflows List page instead of being represented by a `Kind` column.
+6. The normal page always queries the user-visible Workflow scope; system workflows are not available from the ordinary Workflow table.
 7. Active filters are still summarized in a row of chips so users do not have to inspect every header.
 8. Filter chips must be clickable and reopen the corresponding column filter.
 9. `Clear filters` remains available when any filter is active.
@@ -332,26 +332,26 @@ The desired desktop table uses this default column model:
 
 Rules:
 
-1. The normal Tasks List table does not include a `Kind` column.
+1. The normal Workflows List table does not include a `Kind` column.
 2. The normal table does not include `Workflow Type` or `Entry` columns by default.
-3. The default query is the task-run list. In current API terms, this is equivalent to `scope=tasks`, which is `WorkflowType=MoonMind.Run` and `mm_entry=run`.
-4. System workflow rows must not appear in the normal task table, even through column filters or old URL parameters.
+3. The default query is the Workflow-run list. In current API terms, this is equivalent to `scope=tasks`, which is `WorkflowType=MoonMind.Run` and `mm_entry=run`.
+4. System workflow rows must not appear in the normal Workflow table, even through column filters or old URL parameters.
 5. Manifest ingest rows should stay on the Manifests page unless a separate user-workflow diagnostics view is explicitly designed.
 6. The table may hide optional columns by default to preserve width, but optional columns must not reintroduce ordinary access to system workflow browsing.
-7. The mobile filter sheet must expose the same filterable task columns as the desktop table.
+7. The mobile filter sheet must expose the same filterable Workflow columns as the desktop table.
 8. The table must not expose raw Temporal Visibility query syntax to ordinary users.
 
 ### 7.1 Admin diagnostics escape hatch
 
-System and all-workflow browsing is useful for debugging, but it is not part of the normal Tasks List UX.
+System and all-workflow browsing is useful for debugging, but it is not part of the normal Workflows List UX.
 
 Rules:
 
 1. System workflows belong in an admin diagnostics surface such as Settings -> Operations -> Workflow Diagnostics, `/tasks/diagnostics`, or a similarly explicit route.
 2. A diagnostics surface may expose workflow type, entry, owner, namespace, run ID, raw Temporal status, and system workflow filters because its purpose is platform debugging.
 3. Diagnostics access must be permission-gated. Ordinary users cannot widen `/tasks/list` into system workflow visibility by editing URL parameters.
-4. If compatibility routes or query parameters such as `scope=system` are still accepted, the normal Tasks List page must either ignore them safely, redirect authorized admins to diagnostics, or show a recoverable message explaining that system workflows moved to diagnostics.
-5. The product contract for `/tasks/list` remains task-oriented even if the underlying `/api/executions` endpoint can list broader workflow scopes.
+4. If compatibility routes or query parameters such as `scope=system` are still accepted, the normal Workflows List page must either ignore them safely, redirect authorized admins to diagnostics, or show a recoverable message explaining that system workflows moved to diagnostics.
+5. The product contract for `/tasks/list` remains Workflow-oriented even if the underlying `/api/executions` endpoint can list broader workflow scopes.
 
 ---
 
@@ -569,7 +569,7 @@ Rules:
 1. Every active column filter has a chip.
 2. Clicking a chip opens the corresponding column filter popover.
 3. Each chip has a remove action that clears only that column filter.
-4. `Clear filters` clears every column filter and restores the default task-run view.
+4. `Clear filters` clears every column filter and restores the default Workflow-run view.
 5. Chips use product labels, not raw API parameter names.
 6. Chips must remain visible on mobile through a horizontally scrollable row or compact filter summary button.
 
@@ -595,24 +595,24 @@ Existing URLs must continue to fail safe:
 
 | Existing parameter | Desired mapping |
 | --- | --- |
-| `scope=tasks` | Default task-run view. No visible column filter is required. |
-| `scope=user` | Prefer the default task-run view on `/tasks/list`; manifest ingest belongs on the Manifests page or diagnostics. |
-| `scope=system` | Not honored by the normal Tasks List page. Authorized admins may be redirected to diagnostics; ordinary users stay in the default task-run view or see a recoverable message. |
-| `scope=all` | Not honored by the normal Tasks List page. Authorized admins may be redirected to diagnostics; ordinary users stay in the default task-run view or see a recoverable message. |
-| `workflowType=MoonMind.Run` | Default task-run view when paired with `entry=run` or no entry. |
-| `workflowType=MoonMind.ManifestIngest` | Redirect to the Manifests page or show a recoverable message; do not add a `Workflow Type` column to the task table. |
-| `workflowType=<system value>` | Not honored by the normal Tasks List page; use admin diagnostics when authorized. |
+| `scope=tasks` | Default Workflow-run view. No visible column filter is required. |
+| `scope=user` | Prefer the default Workflow-run view on `/tasks/list`; manifest ingest belongs on the Manifests page or diagnostics. |
+| `scope=system` | Not honored by the normal Workflows List page. Authorized admins may be redirected to diagnostics; ordinary users stay in the default Workflow-run view or see a recoverable message. |
+| `scope=all` | Not honored by the normal Workflows List page. Authorized admins may be redirected to diagnostics; ordinary users stay in the default Workflow-run view or see a recoverable message. |
+| `workflowType=MoonMind.Run` | Default Workflow-run view when paired with `entry=run` or no entry. |
+| `workflowType=MoonMind.ManifestIngest` | Redirect to the Manifests page or show a recoverable message; do not add a `Workflow Type` column to the Workflow table. |
+| `workflowType=<system value>` | Not honored by the normal Workflows List page; use admin diagnostics when authorized. |
 | `state=<value>` | Status column include filter for one value. |
-| `entry=run` | Default task-run view. No visible column filter is required. |
+| `entry=run` | Default Workflow-run view. No visible column filter is required. |
 | `entry=manifest` | Redirect to the Manifests page or show a recoverable message. |
 | `repo=<value>` | Repository exact include filter for one value. |
 
 Rules:
 
 1. Existing query parameters remain accepted on load so old shared links do not break.
-2. Compatibility handling must never reveal system workflows in the ordinary Tasks List page.
-3. After the user changes filters in the new UI, the URL should rewrite to the new canonical task-column filter encoding.
-4. Shared old links should either preserve meaning inside the task-focused page, redirect to the more appropriate page, or explain why the old workflow scope moved.
+2. Compatibility handling must never reveal system workflows in the ordinary Workflows List page.
+3. After the user changes filters in the new UI, the URL should rewrite to the new canonical Workflow-column filter encoding.
+4. Shared old links should either preserve meaning inside the Workflow-focused page, redirect to the more appropriate page, or explain why the old workflow scope moved.
 5. Filter changes reset `nextPageToken` and the previous-page cursor stack.
 
 ### 12.2 Canonical filter encoding
@@ -675,7 +675,7 @@ Rules:
 3. Exclude filters are evaluated after field normalization.
 4. Display labels are never sent as canonical filter values when raw values exist.
 5. The API remains the authority for access control; users cannot widen their visibility through filter params.
-6. The normal Tasks List query is always bounded to user-visible task executions. Backend list support for broader workflow scopes must not leak into this page.
+6. The normal Workflows List query is always bounded to user-visible Workflow Executions. Backend list support for broader workflow scopes must not leak into this page.
 
 ### 13.2 Facet query requirements
 
@@ -713,7 +713,7 @@ Rules:
 6. If exact counts are expensive, the response may set `countMode` to an estimated or unknown mode; the UI must label those counts accordingly or omit counts.
 7. Large facets may be paginated and searched server-side.
 8. Facet failure must not break the table; the UI can fall back to values in the currently loaded page with a visible “current page values only” notice.
-9. Facet results must not include system-only workflow values or counts on the normal Tasks List page.
+9. Facet results must not include system-only workflow values or counts on the normal Workflows List page.
 
 ---
 
@@ -765,7 +765,7 @@ Rules:
 5. Card fields may expose small contextual filter actions, such as filtering to a visible runtime or status, but those actions are optional.
 6. Mobile filter changes reset pagination to the first page just like desktop.
 7. Mobile users must not need the removed top dropdowns to reach status, runtime, skill, repository, title, ID, or date filters.
-8. Mobile users cannot reveal system workflows from the ordinary task-card view; diagnostics remains a separate admin surface.
+8. Mobile users cannot reveal system workflows from the ordinary Workflow-card view; diagnostics remains a separate admin surface.
 
 ---
 
@@ -773,12 +773,12 @@ Rules:
 
 Rules:
 
-1. If no rows match active filters on the first page, show `No tasks found for the current filters.`
+1. If no rows match active filters on the first page, show `No Workflows found for the current filters.`
 2. The empty state should include `Clear filters` when filters are active.
 3. If a specific filter is likely too narrow, the empty state may summarize active chips but should not guess which filter is wrong.
 4. If a facet request fails, show an inline warning inside the popover and allow retry.
 5. If the list request rejects a filter parameter, show the API error and preserve the user's filter state so it can be edited.
-6. If an old URL contains unsupported filter combinations, the page should either map it to a valid task-list state, redirect to an appropriate page, or show a recoverable error with `Clear filters`.
+6. If an old URL contains unsupported filter combinations, the page should either map it to a valid Workflows-list state, redirect to an appropriate page, or show a recoverable error with `Clear filters`.
 
 ---
 
@@ -802,9 +802,9 @@ Rules:
 
 The implementation should add or preserve tests for the following behaviors:
 
-1. `/tasks/list` renders the Tasks List page with one control deck and one data slab.
+1. `/tasks/list` renders the Workflows List page with one control deck and one data slab.
 2. Existing `state` and `repo` URLs load into equivalent column filters.
-3. Existing `scope`, `workflowType`, and `entry` URLs fail safe: ordinary users are kept in the task-run view, routed to the appropriate page, or shown a recoverable message without revealing system workflows.
+3. Existing `scope`, `workflowType`, and `entry` URLs fail safe: ordinary users are kept in the Workflow-run view, routed to the appropriate page, or shown a recoverable message without revealing system workflows.
 4. The top Scope, Workflow Type, Status, Entry, and Repository controls are absent once column filters are enabled.
 5. The default desktop table has no `Kind`, `Workflow Type`, or `Entry` column.
 6. Header label activation toggles sort without opening the filter popover.
@@ -816,11 +816,11 @@ The implementation should add or preserve tests for the following behaviors:
 12. Deselecting `canceled` from an all-selected Status checklist applies an exclude filter and creates a chip such as `Status: not canceled`.
 13. Selecting only `Codex CLI` and `Claude Code` applies a Runtime include filter.
 14. Applying any filter resets `nextPageToken` and the previous-page cursor stack.
-15. `Clear filters` clears all column filters and returns to the default task-run view.
+15. `Clear filters` clears all column filters and returns to the default Workflow-run view.
 16. Filter chips can clear individual filters.
 17. Old single-value query params still round-trip to active filters.
-18. Mobile filter sheet exposes the same filterable task columns as desktop.
-19. System/all workflow scopes remain absent from the normal Tasks List and are available only through an admin diagnostics surface when authorized.
+18. Mobile filter sheet exposes the same filterable Workflow columns as desktop.
+19. System/all workflow scopes remain absent from the normal Workflows List and are available only through an admin diagnostics surface when authorized.
 20. Facet failure falls back gracefully or shows a recoverable inline error.
 21. Live polling does not mutate staged filter popover selections.
 22. Empty later pages keep previous-page navigation available.
@@ -840,7 +840,7 @@ The column filter design does not require:
 6. saving named filter views in the first version;
 7. replacing page size or pagination controls;
 8. removing the Live updates toggle;
-9. exposing system workflow browsing through the normal Tasks List page.
+9. exposing system workflow browsing through the normal Workflows List page.
 
 ---
 
@@ -853,11 +853,11 @@ Recommended order:
 1. Preserve the current page behavior and URL compatibility.
 2. Add the reusable column header sort/filter component behind a feature flag.
 3. Add column filter state, chips, and URL mapping while the old top filters still exist.
-4. Add API support for multi-value task filters and facets.
+4. Add API support for multi-value Workflow filters and facets.
 5. Move Status and Repository behavior into column filters.
 6. Remove ordinary Scope, Workflow Type, and Entry controls from `/tasks/list`; keep a compatibility parser that fails safe and sends system/all workflow browsing to admin diagnostics when authorized.
 7. Add Runtime and Skill column filters.
 8. Remove the old top filter controls after parity tests pass.
 9. Keep old URL parameter parsing indefinitely or until a documented compatibility window ends.
 
-Final desired state: the Tasks List page feels like a compact, operational spreadsheet for user-visible task executions, where each task column owns its own sort and filter behavior and the page no longer needs detached filter dropdowns above the table.
+Final desired state: the Workflows List page feels like a compact, operational spreadsheet for user-visible Workflow Executions, where each Workflow column owns its own sort and filter behavior and the page no longer needs detached filter dropdowns above the table.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3493,7 +3493,7 @@ def test_create_task_shaped_execution_preserves_story_output_contract(
             "payload": {
                 "task": {
                     "title": "Break down task proposal design",
-                    "instructions": "Extract stories from docs/Tasks/TaskProposalSystem.md.",
+                    "instructions": "Extract stories from docs/Tasks/WorkflowProposalSystem.md.",
                     "storyOutput": {
                         "mode": "jira",
                         "jira": {
@@ -3536,7 +3536,7 @@ def test_create_task_shaped_execution_defaults_partial_story_output_mode(
             "payload": {
                 "task": {
                     "title": "Break down task proposal design",
-                    "instructions": "Extract stories from docs/Tasks/TaskProposalSystem.md.",
+                    "instructions": "Extract stories from docs/Tasks/WorkflowProposalSystem.md.",
                     "storyOutput": {
                         "jira": {
                             "projectKey": "MM",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1077,7 +1077,7 @@ def test_runtime_planner_routes_jira_issue_creator_as_agent_skill_step():
         inputs={
             "task": {
                 "title": "Break down proposal workflow",
-                "instructions": "Break down docs/Tasks/TaskProposalSystem.md.",
+                "instructions": "Break down docs/Tasks/WorkflowProposalSystem.md.",
                 "runtime": {"mode": "codex_cli"},
                 "publish": {"mode": "pr"},
                 "storyOutput": {


### PR DESCRIPTION
A lot of documents are still in a directory like docs/Tasks and have Tasks in the document name. I need all of these documents to change Task to Workflow as this is the new naming we are standardizing on. Tasks should be referred to as either Workflows or Workflow Runs or other Temporal native terminology. Update all of them accordingly in both filenaming and content.