### PR TITLE
MM-812 Scan comments before posting

### DIFF
--- a/moonmind/integrations/jira/__init__.py
+++ b/moonmind/integrations/jira/__init__.py
@@ -1,17 +1,7 @@
-"""Trusted Jira integration primitives for managed-agent tools."""
+"""Trusted Jira integration package.
 
-from moonmind.integrations.jira.auth import (
-    ResolvedJiraConnection,
-    resolve_jira_connection,
-)
-from moonmind.integrations.jira.client import JiraClient
-from moonmind.integrations.jira.errors import JiraToolError
-from moonmind.integrations.jira.tool import JiraToolService
+Import concrete Jira primitives from their owning modules to avoid package-level
+cycles between Jira auth helpers and Temporal workflow tooling.
+"""
 
-__all__ = [
-    "JiraClient",
-    "JiraToolError",
-    "JiraToolService",
-    "ResolvedJiraConnection",
-    "resolve_jira_connection",
-]
+__all__: list[str] = []

--- a/moonmind/integrations/jira/tool.py
+++ b/moonmind/integrations/jira/tool.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 
@@ -308,12 +307,7 @@ class JiraToolService:
         if isinstance(request.body, str):
             comment_body = request.body
         else:
-            comment_body = json.dumps(
-                request.body,
-                ensure_ascii=True,
-                sort_keys=True,
-                separators=(",", ":"),
-            )
+            comment_body = "\n".join(self._extract_adf_text(request.body))
         result = scan_outbound_text(
             comment_body,
             location="jira.add_comment.body",
@@ -330,6 +324,21 @@ class JiraToolService:
             status_code=422,
             action="add_comment",
         )
+
+    def _extract_adf_text(self, node: Any) -> list[str]:
+        if isinstance(node, dict):
+            if node.get("type") == "text" and isinstance(node.get("text"), str):
+                return [node["text"]]
+            text: list[str] = []
+            for value in node.values():
+                text.extend(self._extract_adf_text(value))
+            return text
+        if isinstance(node, list):
+            text: list[str] = []
+            for item in node:
+                text.extend(self._extract_adf_text(item))
+            return text
+        return []
 
     async def list_create_issue_types(
         self, request: ListCreateIssueTypesRequest

--- a/moonmind/integrations/jira/tool.py
+++ b/moonmind/integrations/jira/tool.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
 from moonmind.config.settings import AtlassianSettings, settings
 from moonmind.integrations.jira.adf import ensure_adf_document
-from moonmind.integrations.jira.auth import resolve_jira_connection
-from moonmind.integrations.jira.client import JiraClient
 from moonmind.integrations.jira.errors import JiraToolError
 from moonmind.integrations.jira.models import (
     ALL_JIRA_ACTIONS,
@@ -27,6 +26,7 @@ from moonmind.integrations.jira.models import (
     VerifyConnectionRequest,
     normalize_action_name,
 )
+from moonmind.security import scan_outbound_text
 
 _JQL_ORDER_BY_RE = re.compile(r"\border\s+by\b", re.IGNORECASE)
 
@@ -37,8 +37,10 @@ class JiraToolService:
         self,
         *,
         atlassian_settings: AtlassianSettings | None = None,
+        high_security_mode: bool | None = None,
     ) -> None:
         self._settings = atlassian_settings or settings.atlassian
+        self._high_security_mode = high_security_mode
 
     def discoverable_actions(self) -> set[str]:
         configured = self._allowed_actions()
@@ -289,6 +291,7 @@ class JiraToolService:
         self._ensure_enabled()
         self._ensure_action_allowed("add_comment")
         self._ensure_project_allowed(self._project_from_issue_key(request.issue_key))
+        self._scan_comment_body_before_side_effect(request)
         body = ensure_adf_document(request.body)
         return await self._request_json(
             method="POST",
@@ -296,6 +299,36 @@ class JiraToolService:
             action="add_comment",
             json_body={"body": body},
             context={"issueKey": request.issue_key},
+        )
+
+    def _scan_comment_body_before_side_effect(
+        self,
+        request: AddCommentRequest,
+    ) -> None:
+        if isinstance(request.body, str):
+            comment_body = request.body
+        else:
+            comment_body = json.dumps(
+                request.body,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        result = scan_outbound_text(
+            comment_body,
+            location="jira.add_comment.body",
+            high_security_mode=self._high_security_mode,
+        )
+        if result.allowed:
+            return
+        diagnostics = "; ".join(result.sanitized_diagnostics) or (
+            "Blocked outbound content at jira.add_comment.body"
+        )
+        raise JiraToolError(
+            f"Outbound comment blocked by high security scan: {diagnostics}",
+            code="outbound_scan_blocked",
+            status_code=422,
+            action="add_comment",
         )
 
     async def list_create_issue_types(
@@ -383,6 +416,9 @@ class JiraToolService:
         json_body: Any = None,
         context: dict[str, Any] | None = None,
     ) -> Any:
+        from moonmind.integrations.jira.auth import resolve_jira_connection
+        from moonmind.integrations.jira.client import JiraClient
+
         connection = await resolve_jira_connection(self._settings)
         client = JiraClient(connection=connection)
         try:

--- a/tests/unit/integrations/test_jira_tool_service.py
+++ b/tests/unit/integrations/test_jira_tool_service.py
@@ -392,6 +392,65 @@ async def test_add_comment_scans_structured_body_before_provider_submission() ->
     assert raw_secret not in str(exc_info.value)
     assert service.calls == []
 
+async def test_add_comment_scans_consolidated_adf_text_nodes() -> None:
+    raw_secret = "split-structured-comment-secret"
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"id": "must-not-post"}],
+        high_security_mode=True,
+    )
+
+    with pytest.raises(JiraToolError) as exc_info:
+        await service.add_comment(
+            AddCommentRequest(
+                issueKey="ENG-123",
+                body={
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {"type": "text", "text": "password="},
+                                {"type": "text", "text": raw_secret},
+                            ],
+                        }
+                    ],
+                },
+            )
+        )
+
+    assert exc_info.value.code == "outbound_scan_blocked"
+    assert raw_secret not in str(exc_info.value)
+    assert service.calls == []
+
+async def test_add_comment_ignores_adf_metadata_during_outbound_scan() -> None:
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"id": "20001"}],
+        high_security_mode=True,
+    )
+
+    result = await service.add_comment(
+        AddCommentRequest(
+            issueKey="ENG-123",
+            body={
+                "type": "doc",
+                "version": 1,
+                "attrs": {"localId": "password=metadata-only"},
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Ready to publish"}],
+                    }
+                ],
+            },
+        )
+    )
+
+    assert result == {"id": "20001"}
+    assert len(service.calls) == 1
+
 async def test_search_issues_preserves_order_by_after_project_scoping() -> None:
     service = _StubJiraToolService(
         atlassian_settings=_build_settings(),

--- a/tests/unit/integrations/test_jira_tool_service.py
+++ b/tests/unit/integrations/test_jira_tool_service.py
@@ -30,8 +30,12 @@ class _StubJiraToolService(JiraToolService):
         *,
         atlassian_settings: AtlassianSettings,
         responses: list[Any] | None = None,
+        high_security_mode: bool | None = None,
     ) -> None:
-        super().__init__(atlassian_settings=atlassian_settings)
+        super().__init__(
+            atlassian_settings=atlassian_settings,
+            high_security_mode=high_security_mode,
+        )
         self.calls: list[dict[str, Any]] = []
         self._responses = list(responses or [])
 
@@ -288,6 +292,81 @@ async def test_add_comment_converts_plain_text_to_adf() -> None:
     body = service.calls[0]["json_body"]["body"]
     assert body["type"] == "doc"
     assert body["content"][0]["content"][1] == {"type": "hardBreak"}
+
+async def test_add_comment_scans_clean_body_before_provider_submission() -> None:
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"id": "20001"}],
+        high_security_mode=True,
+    )
+
+    result = await service.add_comment(
+        AddCommentRequest(
+            issueKey="ENG-123",
+            body="Clean publication body",
+        )
+    )
+
+    assert result == {"id": "20001"}
+    assert len(service.calls) == 1
+    assert service.calls[0]["path"] == "/issue/ENG-123/comment"
+
+async def test_add_comment_blocks_secret_body_before_provider_submission() -> None:
+    raw_secret = "unit-test-comment-secret"
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"id": "must-not-post"}],
+        high_security_mode=True,
+    )
+
+    with pytest.raises(JiraToolError) as exc_info:
+        await service.add_comment(
+            AddCommentRequest(
+                issueKey="ENG-123",
+                body=f"Please post password={raw_secret}",
+            )
+        )
+
+    error = exc_info.value
+    assert error.code == "outbound_scan_blocked"
+    assert error.action == "add_comment"
+    assert "jira.add_comment.body" in str(error)
+    assert raw_secret not in str(error)
+    assert service.calls == []
+
+async def test_add_comment_scans_structured_body_before_provider_submission() -> None:
+    raw_secret = "structured-comment-secret"
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"id": "must-not-post"}],
+        high_security_mode=True,
+    )
+
+    with pytest.raises(JiraToolError) as exc_info:
+        await service.add_comment(
+            AddCommentRequest(
+                issueKey="ENG-123",
+                body={
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": f"credential={raw_secret}",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
+        )
+
+    assert exc_info.value.code == "outbound_scan_blocked"
+    assert raw_secret not in str(exc_info.value)
+    assert service.calls == []
 
 async def test_search_issues_preserves_order_by_after_project_scoping() -> None:
     service = _StubJiraToolService(

--- a/tests/unit/integrations/test_jira_tool_service.py
+++ b/tests/unit/integrations/test_jira_tool_service.py
@@ -20,7 +20,9 @@ from moonmind.integrations.jira.models import (
     TransitionIssueRequest,
     VerifyConnectionRequest,
 )
+from moonmind.integrations.jira import tool as jira_tool_module
 from moonmind.integrations.jira.tool import JiraToolService
+from moonmind.security.outbound_scan import OutboundScanResult
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -293,12 +295,33 @@ async def test_add_comment_converts_plain_text_to_adf() -> None:
     assert body["type"] == "doc"
     assert body["content"][0]["content"][1] == {"type": "hardBreak"}
 
-async def test_add_comment_scans_clean_body_before_provider_submission() -> None:
+async def test_add_comment_scans_clean_body_before_provider_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
     service = _StubJiraToolService(
         atlassian_settings=_build_settings(),
         responses=[{"id": "20001"}],
         high_security_mode=True,
     )
+    original_request_json = service._request_json
+
+    async def recording_request_json(**kwargs: Any) -> Any:
+        events.append("request")
+        return await original_request_json(**kwargs)
+
+    def recording_scan_outbound_text(*args: Any, **kwargs: Any) -> OutboundScanResult:
+        events.append("scan")
+        return OutboundScanResult(
+            allowed=True,
+            decision="allow",
+            highSecurityMode=True,
+            findings=[],
+            sanitizedDiagnostics=[],
+        )
+
+    service._request_json = recording_request_json  # type: ignore[method-assign]
+    monkeypatch.setattr(jira_tool_module, "scan_outbound_text", recording_scan_outbound_text)
 
     result = await service.add_comment(
         AddCommentRequest(
@@ -308,6 +331,7 @@ async def test_add_comment_scans_clean_body_before_provider_submission() -> None
     )
 
     assert result == {"id": "20001"}
+    assert events == ["scan", "request"]
     assert len(service.calls) == 1
     assert service.calls[0]["path"] == "/issue/ENG-123/comment"
 


### PR DESCRIPTION
Jira issue key: MM-812

Active MoonSpec feature path: `specs/001-scan-comments-before-posting`

Verification verdict: `FULLY_IMPLEMENTED`

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/integrations/test_jira_tool_service.py`
- `./tools/test_integration.sh`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Remaining risks:
- GitHub comment-posting boundaries were not changed in this story because the implemented in-scope MoonMind-owned provider comment side effect is the Jira `add_comment` path.
- The branch includes deliberate fake secret-like unit-test fixtures to verify outbound scan blocking and redaction; no raw credentials were identified in the PR body or branch diff.
