### PR TITLE
MM-816 Orchestrate idempotent observable reattempt compensation

### DIFF
--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -430,12 +430,19 @@ def plan_reattempt_compensation(
         accounted.append(effect_summary)
 
     requires_compensation = bool(accounted)
+    # Compensation is only complete when every planned compensation was actually
+    # accepted. A blocked compensation leaves the prior non-idempotent effect
+    # uncompensated, so the count-based check (always true, since compensations
+    # and accounted grow in lockstep) would wrongly report completion.
+    compensation_complete = all(
+        record.get("disposition") == "accepted" for record in compensations
+    )
     # A reattempt is only safe to advance once every already-occurred
     # non-idempotent effect is accounted for: either compensated here, already
     # compensated on an earlier reattempt, or explicitly permitted by policy.
     reattempt_allowed = (
         not requires_compensation
-        or len(compensations) == len(accounted)
+        or compensation_complete
         or policy_permits_non_idempotent_reattempt
     )
     plan: dict[str, Any] = {
@@ -445,7 +452,7 @@ def plan_reattempt_compensation(
         "outstandingEffects": accounted,
         "alreadyCompensated": skipped,
         "compensations": compensations,
-        "compensationComplete": len(compensations) == len(accounted),
+        "compensationComplete": compensation_complete,
         "policyPermitsNonIdempotentReattempt": bool(
             policy_permits_non_idempotent_reattempt
         ),

--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -44,6 +44,15 @@ _GATED_SIDE_EFFECT_CLASSES = {
     "publication",
     "provider_account",
 }
+# Side-effect classes whose effects cannot safely repeat. When one of these
+# already occurred on a prior attempt, a later attempt must account for it
+# explicitly (Section 11, rule 3) rather than pretending the step can reset.
+_NON_IDEMPOTENT_SIDE_EFFECT_CLASSES = {
+    "external_non_idempotent",
+    "publication",
+    "provider_account",
+}
+_COMPENSATION_OPERATION_PREFIX = "compensate"
 _GATED_OPERATION_PREFIXES = (
     "jira.transition",
     "repo.merge",
@@ -309,6 +318,142 @@ def side_effect_record(
     elif reason:
         record["reason"] = _sanitize_diagnostic_text(reason)
     return record
+
+
+def _side_effect_already_occurred(record: Mapping[str, Any]) -> bool:
+    """Return whether a recorded side effect is a non-idempotent effect that ran."""
+
+    if record.get("kind", "normal") not in (None, "normal"):
+        # cleanup/compensation records are reconciliation, not original effects.
+        return False
+    if record.get("class") not in _NON_IDEMPOTENT_SIDE_EFFECT_CLASSES:
+        return False
+    # Only effects that were actually allowed to run need to be reconciled. A
+    # blocked or discarded effect never mutated external state.
+    return record.get("disposition") == "accepted"
+
+
+def compensation_subject_key(record: Mapping[str, Any]) -> str:
+    """Return a stable identity for the prior effect a compensation reconciles.
+
+    Used to dedupe compensation across successive reattempts so an
+    already-occurred non-idempotent effect is compensated at most once.
+    """
+
+    existing_key = str(record.get("idempotencyKey") or "").strip()
+    if existing_key:
+        return existing_key
+    effect_class = str(record.get("class") or "").strip()
+    operation = str(record.get("operation") or "").strip()
+    target = str(record.get("target") or "").strip()
+    return f"{effect_class}:{operation}:{target}"
+
+
+def already_occurred_non_idempotent_effects(
+    records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Filter recorded side effects to non-idempotent effects that already ran."""
+
+    return [
+        dict(record)
+        for record in records
+        if isinstance(record, Mapping) and _side_effect_already_occurred(record)
+    ]
+
+
+def plan_reattempt_compensation(
+    *,
+    workflow_id: str,
+    run_id: str,
+    logical_step_id: str,
+    execution_ordinal: int,
+    prior_side_effect_records: Sequence[Mapping[str, Any]] = (),
+    already_compensated_subjects: Sequence[str] = (),
+    policy_permits_non_idempotent_reattempt: bool = False,
+) -> dict[str, Any]:
+    """Plan explicit, idempotent, observable compensation for a reattempt.
+
+    Implements Section 11 rules 3 and 4: when a non-idempotent external effect
+    already occurred on a prior attempt, a later attempt must account for it
+    explicitly with compensation that is explicit, idempotent, and observable —
+    not merely reset the step.
+
+    The plan is deterministic: each outstanding effect maps to exactly one
+    compensation side-effect record whose idempotency key derives from the new
+    attempt identity, and effects already compensated on an earlier reattempt
+    are skipped so the same external mutation is never compensated twice.
+    """
+
+    already_compensated = {
+        str(subject).strip()
+        for subject in already_compensated_subjects
+        if str(subject).strip()
+    }
+    outstanding = already_occurred_non_idempotent_effects(prior_side_effect_records)
+    compensations: list[dict[str, Any]] = []
+    accounted: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for effect in outstanding:
+        subject = compensation_subject_key(effect)
+        effect_summary = {
+            "class": effect.get("class"),
+            "operation": effect.get("operation"),
+            "target": effect.get("target"),
+            "idempotencyKey": effect.get("idempotencyKey"),
+            "subject": subject,
+        }
+        if subject in already_compensated:
+            skipped.append(effect_summary)
+            continue
+        operation = str(effect.get("operation") or "").strip()
+        compensation_operation = f"{_COMPENSATION_OPERATION_PREFIX}:{operation or 'unknown'}"
+        compensation_key = step_execution_operation_idempotency_key(
+            workflow_id=workflow_id,
+            run_id=run_id,
+            logical_step_id=logical_step_id,
+            execution_ordinal=execution_ordinal,
+            operation=compensation_operation,
+        )
+        record = side_effect_record(
+            effect_class="external_idempotent",
+            operation=compensation_operation,
+            target=effect.get("target"),
+            idempotency_key=compensation_key,
+            effect_kind="compensation",
+            # Compensation is the authorized reconciliation action that makes a
+            # reattempt safe; it must be allowed to run rather than gated.
+            workflow_state_accepted=True,
+            reason=f"compensate_prior_{effect.get('class')}",
+        )
+        record["compensates"] = effect_summary
+        compensations.append(record)
+        accounted.append(effect_summary)
+
+    requires_compensation = bool(accounted)
+    # A reattempt is only safe to advance once every already-occurred
+    # non-idempotent effect is accounted for: either compensated here, already
+    # compensated on an earlier reattempt, or explicitly permitted by policy.
+    reattempt_allowed = (
+        not requires_compensation
+        or len(compensations) == len(accounted)
+        or policy_permits_non_idempotent_reattempt
+    )
+    plan: dict[str, Any] = {
+        "logicalStepId": logical_step_id,
+        "reattemptExecutionOrdinal": execution_ordinal,
+        "requiresCompensation": requires_compensation,
+        "outstandingEffects": accounted,
+        "alreadyCompensated": skipped,
+        "compensations": compensations,
+        "compensationComplete": len(compensations) == len(accounted),
+        "policyPermitsNonIdempotentReattempt": bool(
+            policy_permits_non_idempotent_reattempt
+        ),
+        "reattemptAllowed": bool(reattempt_allowed),
+    }
+    if not reattempt_allowed:
+        plan["reason"] = "uncompensated_non_idempotent_effects"
+    return plan
 
 
 def build_step_execution_manifest_payload(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -106,6 +106,8 @@ from moonmind.workflows.temporal.step_executions import (
     build_step_execution_manifest_payload,
     git_effect_metadata,
     logical_step_success_allowed,
+    plan_reattempt_compensation,
+    side_effect_record,
     step_execution_operation_idempotency_key,
     workspace_policy_metadata,
 )
@@ -623,6 +625,15 @@ class MoonMindRunWorkflow:
         self._previous_step_checkpoint_refs: dict[str, str] = {}
         self._step_execution_launch_blocks: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
+        # Side-effect records observed per logical step across attempts, keyed by
+        # logical step id. Used to detect already-occurred non-idempotent
+        # external effects when a reattempt starts (Section 11, rules 3-4).
+        self._step_side_effect_records: dict[str, list[dict[str, Any]]] = {}
+        # Subjects (prior-effect identities) already compensated, so a given
+        # non-idempotent effect is reconciled at most once across reattempts.
+        self._step_compensated_subjects: dict[str, set[str]] = {}
+        # Observable compensation plan for the latest reattempt of each step.
+        self._step_reattempt_compensations: dict[str, dict[str, Any]] = {}
 
         # State tracking
         self._paused: bool = False
@@ -1842,6 +1853,106 @@ class MoonMindRunWorkflow:
             self._mark_real_work_started(now=updated_at)
         self._sync_progress_snapshot(updated_at=updated_at)
 
+    def _record_step_side_effect(
+        self,
+        logical_step_id: str,
+        *,
+        effect_class: str,
+        operation: str,
+        target: str | None = None,
+        idempotency_key: str | None = None,
+        workflow_state_accepted: bool = False,
+        effect_kind: str = "normal",
+        reason: str | None = None,
+        approved_workspace_roots: Sequence[str] = (),
+    ) -> dict[str, Any]:
+        """Classify and record one side effect for the current step attempt.
+
+        Records accumulate per logical step so that, when a later attempt
+        starts, already-occurred non-idempotent external effects can be
+        detected and compensated explicitly.
+        """
+
+        record = side_effect_record(
+            effect_class=effect_class,  # type: ignore[arg-type]
+            operation=operation,
+            target=target,
+            idempotency_key=idempotency_key,
+            workflow_state_accepted=workflow_state_accepted,
+            effect_kind=effect_kind,  # type: ignore[arg-type]
+            reason=reason,
+            approved_workspace_roots=approved_workspace_roots,
+        )
+        self._step_side_effect_records.setdefault(logical_step_id, []).append(record)
+        return record
+
+    def _orchestrate_reattempt_compensation(
+        self,
+        logical_step_id: str,
+        *,
+        execution_ordinal: int,
+        updated_at: datetime,
+        policy_permits_non_idempotent_reattempt: bool = False,
+    ) -> dict[str, Any] | None:
+        """Plan and record idempotent, observable compensation for a reattempt.
+
+        On any reattempt (``execution_ordinal > 1``) this inspects the side
+        effects recorded on prior attempts of the same logical step. For each
+        already-occurred non-idempotent external effect it derives an explicit
+        compensation side-effect record with a deterministic idempotency key,
+        records it as a side effect of the new attempt, and stores an
+        observable plan projection. Compensation subjects are deduped across
+        reattempts so a given external mutation is compensated at most once.
+
+        Returns the compensation plan, or ``None`` when there is no prior
+        attempt to reconcile.
+        """
+
+        if execution_ordinal is None or execution_ordinal <= 1:
+            return None
+        prior_records = list(self._step_side_effect_records.get(logical_step_id, ()))
+        already_compensated = self._step_compensated_subjects.setdefault(
+            logical_step_id, set()
+        )
+        plan = plan_reattempt_compensation(
+            workflow_id=workflow.info().workflow_id,
+            run_id=workflow.info().run_id,
+            logical_step_id=logical_step_id,
+            execution_ordinal=execution_ordinal,
+            prior_side_effect_records=prior_records,
+            already_compensated_subjects=sorted(already_compensated),
+            policy_permits_non_idempotent_reattempt=(
+                policy_permits_non_idempotent_reattempt
+            ),
+        )
+        # Record each compensation as a side effect of the new attempt and mark
+        # its subject compensated so successive reattempts do not repeat it.
+        for compensation in plan.get("compensations", ()):
+            self._step_side_effect_records.setdefault(logical_step_id, []).append(
+                dict(compensation)
+            )
+        for effect in plan.get("outstandingEffects", ()):
+            subject = str(effect.get("subject") or "").strip()
+            if subject:
+                already_compensated.add(subject)
+        if plan.get("requiresCompensation"):
+            self._step_reattempt_compensations[logical_step_id] = plan
+            self._get_logger().info(
+                "Orchestrated reattempt compensation for %s execution %d: "
+                "%d effect(s) accounted for",
+                logical_step_id,
+                execution_ordinal,
+                len(plan.get("outstandingEffects", ())),
+                extra={
+                    "event": "step_reattempt_compensation",
+                    "logical_step_id": logical_step_id,
+                    "execution_ordinal": execution_ordinal,
+                    "compensation_count": len(plan.get("compensations", ())),
+                    "reattempt_allowed": plan.get("reattemptAllowed"),
+                },
+            )
+        return plan
+
     async def _record_step_execution_manifest_started(
         self,
         logical_step_id: str,
@@ -1870,6 +1981,16 @@ class MoonMindRunWorkflow:
             attempt=attempt,
             source_execution_ordinal=source_execution_ordinal,
         )
+        compensation_plan = self._orchestrate_reattempt_compensation(
+            logical_step_id,
+            execution_ordinal=attempt,
+            updated_at=updated_at,
+        )
+        side_effects_payload: dict[str, Any] = {}
+        side_effect_records: list[Mapping[str, Any]] = []
+        if compensation_plan and compensation_plan.get("requiresCompensation"):
+            side_effects_payload["reattemptCompensation"] = compensation_plan
+            side_effect_records = list(compensation_plan.get("compensations", ()))
         launch_blocked = self._workspace_policy_launch_blocked(workspace)
         manifest_payload = build_step_execution_manifest_payload(
             workflow_id=workflow.info().workflow_id,
@@ -1891,6 +2012,8 @@ class MoonMindRunWorkflow:
                 **self._step_execution_compact_execution_refs(logical_step_id),
                 **(execution or {}),
             },
+            side_effects=side_effects_payload,
+            side_effect_records=side_effect_records,
             budget=budget,
         )
         if launch_blocked:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1931,10 +1931,16 @@ class MoonMindRunWorkflow:
             self._step_side_effect_records.setdefault(logical_step_id, []).append(
                 dict(compensation)
             )
-        for effect in plan.get("outstandingEffects", ()):
-            subject = str(effect.get("subject") or "").strip()
-            if subject:
-                already_compensated.add(subject)
+            # Only treat a subject as compensated once its compensation was
+            # actually accepted. A blocked compensation never reconciled the
+            # prior effect, so it must remain eligible for a later reattempt
+            # rather than being silently skipped.
+            if compensation.get("disposition") == "accepted":
+                subject = str(
+                    (compensation.get("compensates") or {}).get("subject") or ""
+                ).strip()
+                if subject:
+                    already_compensated.add(subject)
         if plan.get("requiresCompensation"):
             self._step_reattempt_compensations[logical_step_id] = plan
             self._get_logger().info(

--- a/tests/unit/workflows/temporal/test_step_executions.py
+++ b/tests/unit/workflows/temporal/test_step_executions.py
@@ -4,9 +4,12 @@ from datetime import UTC, datetime
 
 from moonmind.schemas.step_execution_models import STEP_EXECUTION_CONTENT_TYPE
 from moonmind.workflows.temporal.step_executions import (
+    already_occurred_non_idempotent_effects,
     build_step_execution_manifest_payload,
+    compensation_subject_key,
     git_effect_metadata,
     logical_step_success_allowed,
+    plan_reattempt_compensation,
     side_effect_record,
     step_execution_id,
     step_execution_operation_idempotency_key,
@@ -199,6 +202,124 @@ def test_side_effect_records_sanitize_diagnostics_and_gate_workspace_writes() ->
     assert approved_workspace["target"].endswith(
         "/moonmind/workflows/temporal/run.py"
     )
+
+
+def _occurred_non_idempotent_effect(
+    *,
+    effect_class: str = "external_non_idempotent",
+    operation: str = "jira.transition_issue",
+    target: str = "MM-705",
+    idempotency_key: str = "wf-1:run-1:implement:execution:1:jira-transition",
+) -> dict[str, object]:
+    return side_effect_record(
+        effect_class=effect_class,  # type: ignore[arg-type]
+        operation=operation,
+        target=target,
+        idempotency_key=idempotency_key,
+        workflow_state_accepted=True,
+    )
+
+
+def test_already_occurred_filters_to_accepted_non_idempotent_effects() -> None:
+    occurred = _occurred_non_idempotent_effect()
+    blocked = side_effect_record(
+        effect_class="external_non_idempotent",
+        operation="jira.transition_issue",
+        target="MM-705",
+        idempotency_key="wf-1:run-1:implement:execution:1:jira-transition",
+        workflow_state_accepted=False,
+    )
+    idempotent = side_effect_record(
+        effect_class="external_idempotent",
+        operation="jira.add_comment",
+        target="MM-705",
+        idempotency_key="wf-1:run-1:implement:execution:1:comment",
+        workflow_state_accepted=True,
+    )
+    workspace = side_effect_record(
+        effect_class="workspace_mutation",
+        operation="workspace.write",
+        target="/work/repo/file.py",
+    )
+
+    accounted = already_occurred_non_idempotent_effects(
+        [occurred, blocked, idempotent, workspace]
+    )
+
+    assert len(accounted) == 1
+    assert accounted[0]["operation"] == "jira.transition_issue"
+
+
+def test_plan_reattempt_compensation_is_explicit_idempotent_and_observable() -> None:
+    occurred = _occurred_non_idempotent_effect()
+
+    plan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=2,
+        prior_side_effect_records=[occurred],
+    )
+
+    assert plan["requiresCompensation"] is True
+    assert plan["compensationComplete"] is True
+    assert plan["reattemptAllowed"] is True
+    assert len(plan["compensations"]) == 1
+    compensation = plan["compensations"][0]
+    # Explicit: classified as a compensation that reconciles the prior effect.
+    assert compensation["kind"] == "compensation"
+    assert compensation["operation"] == "compensate:jira.transition_issue"
+    assert compensation["disposition"] == "accepted"
+    assert compensation["compensates"]["operation"] == "jira.transition_issue"
+    # Idempotent: deterministic key derived from the new attempt identity.
+    assert (
+        compensation["idempotencyKey"]
+        == "wf-1:run-1:implement:execution:2:compensate:jira.transition_issue"
+    )
+
+    # Deterministic: replanning the same reattempt yields identical records.
+    replan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=2,
+        prior_side_effect_records=[occurred],
+    )
+    assert replan == plan
+
+
+def test_plan_reattempt_compensation_dedupes_already_compensated_subjects() -> None:
+    occurred = _occurred_non_idempotent_effect()
+    subject = compensation_subject_key(occurred)
+
+    plan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=3,
+        prior_side_effect_records=[occurred],
+        already_compensated_subjects=[subject],
+    )
+
+    assert plan["requiresCompensation"] is False
+    assert plan["compensations"] == []
+    assert plan["alreadyCompensated"][0]["subject"] == subject
+    assert plan["reattemptAllowed"] is True
+
+
+def test_plan_reattempt_compensation_noop_without_prior_effects() -> None:
+    plan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=2,
+        prior_side_effect_records=[],
+    )
+
+    assert plan["requiresCompensation"] is False
+    assert plan["compensations"] == []
+    assert plan["reattemptAllowed"] is True
+    assert "reason" not in plan
 
 
 def test_manifest_payload_embeds_policy_git_effect_and_side_effect_records() -> None:

--- a/tests/unit/workflows/temporal/test_step_executions.py
+++ b/tests/unit/workflows/temporal/test_step_executions.py
@@ -307,6 +307,67 @@ def test_plan_reattempt_compensation_dedupes_already_compensated_subjects() -> N
     assert plan["reattemptAllowed"] is True
 
 
+def _patch_blocked_compensation(monkeypatch) -> None:
+    """Force planned compensations to be recorded with a blocked disposition."""
+
+    from moonmind.workflows.temporal import step_executions as step_executions_module
+
+    real_side_effect_record = step_executions_module.side_effect_record
+
+    def _blocked_compensation(*args: object, **kwargs: object) -> dict[str, object]:
+        record = real_side_effect_record(*args, **kwargs)  # type: ignore[arg-type]
+        record["disposition"] = "blocked"
+        return record
+
+    monkeypatch.setattr(
+        step_executions_module, "side_effect_record", _blocked_compensation
+    )
+
+
+def test_plan_reattempt_compensation_blocks_when_compensation_not_accepted(
+    monkeypatch,
+) -> None:
+    occurred = _occurred_non_idempotent_effect()
+    _patch_blocked_compensation(monkeypatch)
+
+    plan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=2,
+        prior_side_effect_records=[occurred],
+    )
+
+    assert plan["requiresCompensation"] is True
+    assert plan["compensations"][0]["disposition"] == "blocked"
+    # A blocked compensation leaves the prior effect uncompensated: completion
+    # must be false and the reattempt must not be allowed to advance.
+    assert plan["compensationComplete"] is False
+    assert plan["reattemptAllowed"] is False
+    assert plan["reason"] == "uncompensated_non_idempotent_effects"
+
+
+def test_plan_reattempt_compensation_policy_override_allows_blocked_compensation(
+    monkeypatch,
+) -> None:
+    occurred = _occurred_non_idempotent_effect()
+    _patch_blocked_compensation(monkeypatch)
+
+    plan = plan_reattempt_compensation(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=2,
+        prior_side_effect_records=[occurred],
+        policy_permits_non_idempotent_reattempt=True,
+    )
+
+    # Completion still reflects the blocked compensation, but explicit policy
+    # permission lets the reattempt advance.
+    assert plan["compensationComplete"] is False
+    assert plan["reattemptAllowed"] is True
+
+
 def test_plan_reattempt_compensation_noop_without_prior_effects() -> None:
     plan = plan_reattempt_compensation(
         workflow_id="wf-1",

--- a/tests/unit/workflows/temporal/workflows/test_run_reattempt_compensation.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_reattempt_compensation.py
@@ -1,0 +1,143 @@
+"""Workflow-boundary coverage for MM-816 reattempt compensation orchestration.
+
+Exercises explicit, idempotent, observable cleanup/compensation orchestration
+for already-occurred non-idempotent external effects during reattempts, as
+behavior of ``MoonMindRunWorkflow`` -- not only as a manifest record shape.
+
+Traceability: MM-816 (source issue MM-705).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-816",
+        run_id="run-816",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["user-1"]},
+    )
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        isEnabledFor=lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "logger", logger)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
+
+
+def test_first_attempt_has_no_compensation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    wf = MoonMindRunWorkflow()
+
+    plan = wf._orchestrate_reattempt_compensation(
+        "implement",
+        execution_ordinal=1,
+        updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    )
+
+    assert plan is None
+    assert wf._step_reattempt_compensations == {}
+
+
+def test_reattempt_orchestrates_observable_compensation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    wf = MoonMindRunWorkflow()
+
+    # Attempt 1 performed an already-gate-approved non-idempotent Jira
+    # transition against the MM-705 source issue.
+    wf._record_step_side_effect(
+        "implement",
+        effect_class="external_non_idempotent",
+        operation="jira.transition_issue",
+        target="MM-705",
+        idempotency_key="wf-816:run-816:implement:execution:1:jira-transition",
+        workflow_state_accepted=True,
+    )
+
+    plan = wf._orchestrate_reattempt_compensation(
+        "implement",
+        execution_ordinal=2,
+        updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    )
+
+    assert plan is not None
+    assert plan["requiresCompensation"] is True
+    assert plan["reattemptAllowed"] is True
+    assert len(plan["compensations"]) == 1
+    compensation = plan["compensations"][0]
+    assert compensation["kind"] == "compensation"
+    assert (
+        compensation["idempotencyKey"]
+        == "wf-816:run-816:implement:execution:2:compensate:jira.transition_issue"
+    )
+
+    # Observable as workflow state, not only inside a manifest payload.
+    assert "implement" in wf._step_reattempt_compensations
+    assert wf._step_reattempt_compensations["implement"]["reattemptExecutionOrdinal"] == 2
+    # The compensation was recorded as a side effect of the new attempt.
+    recorded_kinds = [
+        record.get("kind")
+        for record in wf._step_side_effect_records["implement"]
+    ]
+    assert "compensation" in recorded_kinds
+
+
+def test_compensation_is_idempotent_across_successive_reattempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    wf = MoonMindRunWorkflow()
+
+    wf._record_step_side_effect(
+        "implement",
+        effect_class="publication",
+        operation="repo.merge_pr",
+        target="PR-705",
+        idempotency_key="wf-816:run-816:implement:execution:1:publish-pr",
+        workflow_state_accepted=True,
+    )
+
+    first = wf._orchestrate_reattempt_compensation(
+        "implement",
+        execution_ordinal=2,
+        updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    )
+    assert first is not None
+    assert len(first["compensations"]) == 1
+
+    # A later reattempt must not compensate the same external mutation again.
+    second = wf._orchestrate_reattempt_compensation(
+        "implement",
+        execution_ordinal=3,
+        updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    )
+
+    assert second is not None
+    assert second["requiresCompensation"] is False
+    assert second["compensations"] == []
+    assert second["alreadyCompensated"][0]["operation"] == "repo.merge_pr"
+
+    # Exactly one compensation side effect was recorded across both reattempts.
+    compensation_records = [
+        record
+        for record in wf._step_side_effect_records["implement"]
+        if record.get("kind") == "compensation"
+    ]
+    assert len(compensation_records) == 1


### PR DESCRIPTION
## Jira issue
[MM-816](https://moonladder.atlassian.net/browse/MM-816) — Orchestrate explicit, idempotent, observable cleanup/compensation for already-occurred non-idempotent external effects during reattempts.

## Summary of implementation
The contract-level scope (side-effect classification, deterministic idempotency keys, and gating of non-idempotent/publication effects) was already in place. This change adds the remaining **runtime behavior**: explicit, idempotent, observable cleanup/compensation **orchestration** for already-occurred non-idempotent external effects on a subsequent attempt.

- `moonmind/workflows/temporal/step_executions.py`: add `plan_reattempt_compensation()`, `already_occurred_non_idempotent_effects()`, and `compensation_subject_key()`. The planner detects accepted non-idempotent external effects from a prior attempt and derives one compensation side-effect record per effect with a deterministic `{stepExecutionId}:compensate:{operation}` idempotency key from the new attempt identity, deduping by subject so a given external mutation is compensated at most once across successive reattempts (Section 11, rules 3–4).
- `moonmind/workflows/temporal/workflows/run.py`: record side effects per logical step across attempts; on each reattempt, `_orchestrate_reattempt_compensation()` (wired into the reattempt manifest path, attempt > 1) records compensations as side effects of the new attempt, stores the plan in workflow state (`_step_reattempt_compensations`), logs a `step_reattempt_compensation` event, and embeds the plan in the manifest payload's `sideEffects` — observable workflow behavior, not only a manifest record shape.

## Tests run
- `tests/unit/workflows/temporal/workflows/test_run_reattempt_compensation.py` (workflow boundary) — new
- `tests/unit/workflows/temporal/test_step_executions.py` (planner helpers) — extended
- `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` (regression)
- `tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py` (regression)

Result: 15 + 48 Python tests passed; full frontend suite 417 passed / 234 skipped; no regressions.

## Remaining risks
- The compensation orchestration runs on the reattempt manifest path (attempt > 1); first-attempt runs are unaffected. In-flight workflows started before this change will only gain compensation behavior on attempts initiated after the worker rolls out — first reattempts already in progress under the old code are not retroactively compensated.
- Compensation derivation depends on prior attempts having correctly classified and recorded their non-idempotent external effects; effects never recorded as side effects cannot be detected for compensation.
- Compensation records are deduped by subject key; an external mutation whose subject cannot be derived stably could in principle be compensated more than once. Covered by the dedup tests but worth monitoring as new side-effect operations are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-816]: https://moonladder.atlassian.net/browse/MM-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ