### PR TITLE
MM-817: Clean-context session-reset semantics and external-agent reattempt evidence

### DIFF
--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -7290,6 +7290,10 @@ export interface components {
             preservedFrom?: components["schemas"]["PreservedStepProvenanceModel"] | null;
             /** Statecheckpointref */
             stateCheckpointRef?: string | null;
+            /** Workspacecheckpointref */
+            workspaceCheckpointRef?: string | null;
+            /** Stepcheckpointref */
+            stepCheckpointRef?: string | null;
             recoveryPreservation?: components["schemas"]["StepLedgerResumePreservationModel"] | null;
             workload?: components["schemas"]["StepLedgerWorkloadModel"] | null;
             /** Lasterror */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1059,6 +1059,10 @@ class RecoveryCheckpointPreservedStepModel(BaseModel):
     source_execution_ordinal: int = Field(..., alias="sourceExecutionOrdinal", ge=1)
     artifacts: dict[str, Any] = Field(default_factory=dict, alias="artifacts")
     state_checkpoint_ref: Optional[str] = Field(None, alias="stateCheckpointRef")
+    workspace_checkpoint_ref: Optional[str] = Field(
+        None, alias="workspaceCheckpointRef"
+    )
+    step_checkpoint_ref: Optional[str] = Field(None, alias="stepCheckpointRef")
 
     @field_validator("artifacts", mode="before")
     @classmethod
@@ -1070,6 +1074,14 @@ class RecoveryCheckpointPreservedStepModel(BaseModel):
     @field_validator("state_checkpoint_ref", mode="before")
     @classmethod
     def _normalize_state_checkpoint_ref(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator("workspace_checkpoint_ref", "step_checkpoint_ref", mode="before")
+    @classmethod
+    def _normalize_optional_checkpoint_ref(cls, value: Any) -> str | None:
         if value is None:
             return None
         candidate = str(value).strip()
@@ -1741,6 +1753,8 @@ class StepLedgerRowModel(BaseModel):
         None, alias="preservedFrom"
     )
     state_checkpoint_ref: str | None = Field(None, alias="stateCheckpointRef")
+    workspace_checkpoint_ref: str | None = Field(None, alias="workspaceCheckpointRef")
+    step_checkpoint_ref: str | None = Field(None, alias="stepCheckpointRef")
     resume_preservation: StepLedgerResumePreservationModel | None = Field(
         None, alias="recoveryPreservation"
     )

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -472,6 +472,16 @@ def materialize_preserved_steps(
             or preserved.get("state_checkpoint_ref")
             or ""
         ).strip()
+        workspace_checkpoint_ref = str(
+            preserved.get("workspaceCheckpointRef")
+            or preserved.get("workspace_checkpoint_ref")
+            or ""
+        ).strip()
+        step_checkpoint_ref = str(
+            preserved.get("stepCheckpointRef")
+            or preserved.get("step_checkpoint_ref")
+            or ""
+        ).strip()
         if not state_checkpoint_ref:
             raise ValueError(
                 f"preserved step {logical_step_id} requires a state checkpoint ref"
@@ -490,6 +500,14 @@ def materialize_preserved_steps(
         row["attentionRequired"] = False
         row["artifacts"] = artifacts
         row["stateCheckpointRef"] = state_checkpoint_ref
+        if workspace_checkpoint_ref:
+            row["workspaceCheckpointRef"] = workspace_checkpoint_ref
+        else:
+            row.pop("workspaceCheckpointRef", None)
+        if step_checkpoint_ref:
+            row["stepCheckpointRef"] = step_checkpoint_ref
+        else:
+            row.pop("stepCheckpointRef", None)
         row["recoveryPreservation"] = _recovery_preservation(
             eligible=True,
             reason="complete",
@@ -515,6 +533,8 @@ def mark_step_checkpoint_evidence(
     *,
     updated_at: datetime,
     state_checkpoint_ref: str | None = None,
+    workspace_checkpoint_ref: str | None = None,
+    step_checkpoint_ref: str | None = None,
 ) -> dict[str, Any]:
     """Attach checkpoint evidence and preservation eligibility to a step row."""
 
@@ -523,6 +543,10 @@ def mark_step_checkpoint_evidence(
             continue
         if state_checkpoint_ref is not None:
             row["stateCheckpointRef"] = state_checkpoint_ref
+        if workspace_checkpoint_ref is not None:
+            row["workspaceCheckpointRef"] = workspace_checkpoint_ref
+        if step_checkpoint_ref is not None:
+            row["stepCheckpointRef"] = step_checkpoint_ref
         existing_checkpoint = str(row.get("stateCheckpointRef") or "").strip()
         status = str(row.get("status") or "").strip()
         if status not in {"succeeded", "skipped"}:
@@ -604,6 +628,8 @@ def clear_step_checkpoint_evidence(
         if row.get("logicalStepId") != logical_step_id:
             continue
         row.pop("stateCheckpointRef", None)
+        row.pop("workspaceCheckpointRef", None)
+        row.pop("stepCheckpointRef", None)
         row.pop("recoveryPreservation", None)
         row["updatedAt"] = updated_at.isoformat()
         return row

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -296,6 +296,9 @@ RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
 RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH = (
     "run-task-scoped-session-clear-between-steps-v1"
 )
+RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH = (
+    "run-task-scoped-session-clear-per-execution-v2"
+)
 RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH = (
     "run-task-scoped-session-clear-activity-signal-v1"
 )
@@ -6070,8 +6073,11 @@ class MoonMindRunWorkflow:
         # epoch before the attempt (reuse_session_new_epoch / clear_session
         # semantics per docs/Steps/StepExecutionsAndCheckpointing.md §16.1).
         execution_ordinal = self._step_execution_for(logical_step_id) or 1
-        step_execution_key = f"{logical_step_id}:{execution_ordinal}"
-        if step_execution_key in self._codex_session_cleared_before_step_executions:
+        if workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH):
+            clear_dedupe_key = f"{logical_step_id}:{execution_ordinal}"
+        else:
+            clear_dedupe_key = logical_step_id
+        if clear_dedupe_key in self._codex_session_cleared_before_step_executions:
             return
         binding = self._codex_session_binding
         if binding is None:
@@ -6133,7 +6139,7 @@ class MoonMindRunWorkflow:
                     reason=reason,
                     request_id=request_id,
                 )
-        self._codex_session_cleared_before_step_executions.add(step_execution_key)
+        self._codex_session_cleared_before_step_executions.add(clear_dedupe_key)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
         binding = self._codex_session_binding

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -692,7 +692,7 @@ class MoonMindRunWorkflow:
         self._last_publish_repair_node_id: str | None = None
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
-        self._codex_session_cleared_before_step_ids: set[str] = set()
+        self._codex_session_cleared_before_step_executions: set[str] = set()
         self._trusted_jira_context: dict[str, Any] | None = None
         self._step_ledger_rows: list[dict[str, Any]] = []
         self._step_ledger_by_id: dict[str, dict[str, Any]] = {}
@@ -1453,15 +1453,17 @@ class MoonMindRunWorkflow:
         artifacts = row.get("artifacts")
         execution: dict[str, Any] = {}
         tool = row.get("tool")
+        runtime_context_policy: str | None = None
         if isinstance(tool, Mapping) and str(tool.get("type") or "").strip() == (
             "agent_runtime"
         ):
             agent_id = str(tool.get("name") or "").strip()
-            execution["runtimeContextPolicy"] = (
+            runtime_context_policy = (
                 "fresh_agent_run"
                 if self._agent_kind_for_id(agent_id) == "managed"
                 else "external_provider_continuation"
             )
+            execution["runtimeContextPolicy"] = runtime_context_policy
         if isinstance(refs, Mapping):
             for source_key, target_key in (
                 ("childWorkflowId", "childWorkflowId"),
@@ -1475,7 +1477,78 @@ class MoonMindRunWorkflow:
             diagnostics_ref = artifacts.get("runtimeDiagnostics")
             if isinstance(diagnostics_ref, str) and diagnostics_ref.strip():
                 execution["diagnosticsRef"] = diagnostics_ref.strip()
+        if runtime_context_policy == "external_provider_continuation":
+            # External/coordinated agents have weaker runtime control: MoonMind
+            # cannot reset their state, so it still records attempt identity and
+            # context refs (above) together with the known side effects and any
+            # available checkpoint evidence, so the continuation attempt remains
+            # auditable (docs/Steps/StepExecutionsAndCheckpointing.md §16.1).
+            known_side_effects = self._external_continuation_known_side_effects(
+                logical_step_id
+            )
+            if known_side_effects:
+                execution["knownSideEffects"] = known_side_effects
+            checkpoint_evidence = self._external_continuation_checkpoint_evidence(row)
+            if checkpoint_evidence:
+                execution["availableCheckpointEvidence"] = checkpoint_evidence
         return execution
+
+    def _external_continuation_known_side_effects(
+        self,
+        logical_step_id: str,
+    ) -> list[dict[str, Any]]:
+        """Compact projection of side effects recorded across a step's attempts.
+
+        External or coordinated agents may have weaker runtime control, so
+        MoonMind records the side effects it observed rather than assuming the
+        step can be silently reset. Records accumulate per logical step, so this
+        surfaces evidence from prior attempts when an external continuation
+        reattempt is launched.
+        """
+        records = self._step_side_effect_records.get(logical_step_id, ())
+        projected: list[dict[str, Any]] = []
+        for record in records:
+            if not isinstance(record, Mapping):
+                continue
+            compact: dict[str, Any] = {}
+            for key in (
+                "class",
+                "kind",
+                "operation",
+                "target",
+                "idempotencyKey",
+                "disposition",
+            ):
+                value = record.get(key)
+                if isinstance(value, str) and value.strip():
+                    compact[key] = value.strip()
+            accepted = record.get("workflowStateAccepted")
+            if isinstance(accepted, bool):
+                compact["workflowStateAccepted"] = accepted
+            if compact:
+                projected.append(compact)
+        return projected
+
+    def _external_continuation_checkpoint_evidence(
+        self,
+        row: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Available checkpoint evidence for an external continuation attempt.
+
+        MoonMind records whatever durable checkpoint refs exist ("where
+        available") without assuming direct workspace restoration is possible
+        for an external/coordinated runtime.
+        """
+        evidence: dict[str, Any] = {}
+        for source_key, target_key in (
+            ("stateCheckpointRef", "stateCheckpointRef"),
+            ("workspaceCheckpointRef", "workspaceCheckpointRef"),
+            ("stepCheckpointRef", "stepCheckpointRef"),
+        ):
+            value = row.get(source_key)
+            if isinstance(value, str) and value.strip():
+                evidence[target_key] = value.strip()
+        return evidence
 
     def _step_execution_compact_output_refs(
         self,
@@ -5989,7 +6062,16 @@ class MoonMindRunWorkflow:
     ) -> None:
         if not workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH):
             return
-        if logical_step_id in self._codex_session_cleared_before_step_ids:
+        # Dedup by Step Execution identity (logical step + attempt ordinal), not
+        # by logical step alone. A same-attempt retry of an already-cleared
+        # execution must not re-clear, but a genuine reattempt
+        # (execution_ordinal > 1) is a clean-context reattempt: for managed
+        # sessions it resolves to fresh_agent_run plus a session reset to a new
+        # epoch before the attempt (reuse_session_new_epoch / clear_session
+        # semantics per docs/Steps/StepExecutionsAndCheckpointing.md §16.1).
+        execution_ordinal = self._step_execution_for(logical_step_id) or 1
+        step_execution_key = f"{logical_step_id}:{execution_ordinal}"
+        if step_execution_key in self._codex_session_cleared_before_step_executions:
             return
         binding = self._codex_session_binding
         if binding is None:
@@ -6002,7 +6084,7 @@ class MoonMindRunWorkflow:
             workflow_id=workflow.info().workflow_id,
             run_id=workflow.info().run_id,
             logical_step_id=logical_step_id,
-            execution_ordinal=self._step_execution_for(logical_step_id) or 1,
+            execution_ordinal=execution_ordinal,
             operation="clear_session",
         )
         if workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH):
@@ -6051,7 +6133,7 @@ class MoonMindRunWorkflow:
                     reason=reason,
                     request_id=request_id,
                 )
-        self._codex_session_cleared_before_step_ids.add(logical_step_id)
+        self._codex_session_cleared_before_step_executions.add(step_execution_key)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
         binding = self._codex_session_binding

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -385,10 +385,14 @@ def test_mark_step_checkpoint_evidence_marks_completed_step_eligible() -> None:
         "implement",
         updated_at=updated_at,
         state_checkpoint_ref="artifact://checkpoint/implement/1",
+        workspace_checkpoint_ref="artifact://workspace/implement/1",
+        step_checkpoint_ref="artifact://step/implement/1",
     )
 
     row = StepLedgerRowModel.model_validate(rows[0])
     assert row.state_checkpoint_ref == "artifact://checkpoint/implement/1"
+    assert row.workspace_checkpoint_ref == "artifact://workspace/implement/1"
+    assert row.step_checkpoint_ref == "artifact://step/implement/1"
     assert row.resume_preservation is not None
     assert row.resume_preservation.eligible is True
     assert row.resume_preservation.reason == "complete"

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -11,6 +11,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_DEFER_TASK_SCOPED_SESSION_UNTIL_SLOT_PATCH,
     RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
     RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+    RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
@@ -230,6 +231,7 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
         lambda patch_id: patch_id
         in {
             RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
             RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
         },
     )
@@ -346,6 +348,7 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
         lambda patch_id: patch_id
         in {
             RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
             RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
         },
     )
@@ -442,6 +445,7 @@ async def test_run_clears_task_scoped_session_again_for_managed_reattempt(
         lambda patch_id: patch_id
         in {
             RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
             RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
         },
     )
@@ -490,6 +494,99 @@ async def test_run_clears_task_scoped_session_again_for_managed_reattempt(
         "wf-run-1:run-1:step-2:execution:1:clear_session",
         "wf-run-1:run-1:step-2:execution:2:clear_session",
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_logical_step_clear_dedupe_without_per_execution_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Histories that predate per-execution clear dedupe keep the old command path."""
+
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    activity_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.clear_session":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread:sess:wf-run-1:codex_cli:2",
+                },
+                "status": "ready",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
+    )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    workflow._step_ledger_rows = [{"logicalStepId": "step-2", "attempt": 1}]
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+    workflow._step_ledger_rows = [{"logicalStepId": "step-2", "attempt": 2}]
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    clear_calls = [
+        name for name, _ in activity_calls if name == "agent_runtime.clear_session"
+    ]
+    assert len(clear_calls) == 1
+    assert len(signal_calls) == 1
+    assert workflow._codex_session_cleared_before_step_executions == {"step-2"}
 
 
 def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -285,7 +285,7 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
     ]
     assert workflow._codex_session_binding is not None
     assert workflow._codex_session_binding.session_epoch == 2
-    assert "step-2" in workflow._codex_session_cleared_before_step_ids
+    assert "step-2:1" in workflow._codex_session_cleared_before_step_executions
 
 
 @pytest.mark.asyncio
@@ -374,6 +374,122 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
         "agent_runtime.clear_session",
     ]
     assert len(signal_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_clears_task_scoped_session_again_for_managed_reattempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed clean-context reattempt (execution_ordinal > 1) resolves to a
+    session reset to a new epoch, distinct from the prior attempt's reset, while
+    a same-attempt retry of the reattempt is still deduped."""
+
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    activity_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
+    # Current attempt ordinal, surfaced through the step ledger row.
+    current_epoch = {"value": 1}
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": current_epoch["value"],
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": f"thread:sess:wf-run-1:codex_cli:{current_epoch['value']}",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.clear_session":
+            next_epoch = current_epoch["value"] + 1
+            current_epoch["value"] = next_epoch
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": next_epoch,
+                    "containerId": "container-1",
+                    "threadId": f"thread:sess:wf-run-1:codex_cli:{next_epoch}",
+                },
+                "status": "ready",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
+    )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    # First attempt (execution_ordinal == 1): one reset, epoch advances to 2.
+    workflow._step_ledger_rows = [{"logicalStepId": "step-2", "attempt": 1}]
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+    assert workflow._codex_session_binding is not None
+    assert workflow._codex_session_binding.session_epoch == 2
+    assert "step-2:1" in workflow._codex_session_cleared_before_step_executions
+
+    # Clean-context reattempt (execution_ordinal == 2): a *new* reset fires and
+    # the session advances to a fresh epoch, even though the same logical step
+    # was already cleared on attempt 1.
+    workflow._step_ledger_rows = [{"logicalStepId": "step-2", "attempt": 2}]
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+    assert workflow._codex_session_binding.session_epoch == 3
+    assert "step-2:2" in workflow._codex_session_cleared_before_step_executions
+
+    # A same-attempt retry of the reattempt is deduped (no third reset).
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    clear_calls = [name for name, _ in activity_calls if name == "agent_runtime.clear_session"]
+    assert len(clear_calls) == 2
+    request_ids = [payload.get("requestId") for name, payload in signal_calls]
+    assert request_ids == [
+        "wf-run-1:run-1:step-2:execution:1:clear_session",
+        "wf-run-1:run-1:step-2:execution:2:clear_session",
+    ]
 
 
 def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -838,6 +838,10 @@ async def test_external_continuation_manifest_records_side_effects_and_checkpoin
     workflow._step_ledger_rows[0]["stateCheckpointRef"] = (
         "artifact://checkpoints/external-step"
     )
+    workflow._step_ledger_rows[0]["workspaceCheckpointRef"] = (
+        "artifact://checkpoints/workspace"
+    )
+    workflow._step_ledger_rows[0]["stepCheckpointRef"] = "artifact://checkpoints/step"
     # A known, already-occurred external side effect from this attempt.
     workflow._record_step_side_effect(
         "delegate-external",
@@ -874,6 +878,8 @@ async def test_external_continuation_manifest_records_side_effects_and_checkpoin
     # Available checkpoint evidence is recorded under the continuation path.
     assert execution["availableCheckpointEvidence"] == {
         "stateCheckpointRef": "artifact://checkpoints/external-step",
+        "workspaceCheckpointRef": "artifact://checkpoints/workspace",
+        "stepCheckpointRef": "artifact://checkpoints/step",
     }
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -784,6 +784,100 @@ async def test_step_execution_manifest_merges_explicit_execution_with_refs(
 
 
 @pytest.mark.asyncio
+async def test_external_continuation_manifest_records_side_effects_and_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under external_provider_continuation MoonMind still records attempt
+    identity, context refs, known side effects, and available checkpoint
+    evidence for the attempt even though it cannot reset the external runtime."""
+
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    writes: list[dict[str, Any]] = []
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append({"name": name, "payload": payload})
+        return f"artifact-attempt-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "delegate-external",
+                "tool": {"type": "agent_runtime", "name": "jules", "version": ""},
+                "inputs": {"title": "Delegate external agent"},
+            }
+        ],
+        dependency_map={"delegate-external": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "delegate-external",
+        updated_at=now,
+        summary="Launching external runtime",
+    )
+    workflow._record_step_result_evidence(
+        "delegate-external",
+        execution_result={
+            "status": "RUNNING",
+            "outputs": {
+                "childWorkflowId": "wf-child-external",
+                "childRunId": "run-child-external",
+            },
+        },
+        updated_at=now,
+    )
+    # Durable checkpoint evidence recorded on the step ledger row.
+    workflow._step_ledger_rows[0]["stateCheckpointRef"] = (
+        "artifact://checkpoints/external-step"
+    )
+    # A known, already-occurred external side effect from this attempt.
+    workflow._record_step_side_effect(
+        "delegate-external",
+        effect_class="external_idempotent",
+        operation="open_pull_request",
+        target="github_pr",
+        idempotency_key="pr-key-1",
+        workflow_state_accepted=True,
+    )
+
+    await workflow._record_step_execution_manifest_started(
+        "delegate-external",
+        updated_at=now,
+        reason="initial_execution",
+    )
+
+    execution = writes[0]["payload"]["execution"]
+    assert execution["runtimeContextPolicy"] == "external_provider_continuation"
+    # Attempt identity / context refs are still recorded.
+    assert execution["childWorkflowId"] == "wf-child-external"
+    assert execution["childRunId"] == "run-child-external"
+    # Known side effects are recorded under the continuation path.
+    assert execution["knownSideEffects"] == [
+        {
+            "class": "external_idempotent",
+            "kind": "normal",
+            "operation": "open_pull_request",
+            "target": "github_pr",
+            "idempotencyKey": "pr-key-1",
+            "disposition": "accepted",
+            "workflowStateAccepted": True,
+        }
+    ]
+    # Available checkpoint evidence is recorded under the continuation path.
+    assert execution["availableCheckpointEvidence"] == {
+        "stateCheckpointRef": "artifact://checkpoints/external-step",
+    }
+
+
+@pytest.mark.asyncio
 async def test_run_records_terminal_step_execution_manifest_with_result_refs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Jira issue

[MM-817](https://moonladder.atlassian.net/browse/MM-817) — Complete and test clean-context session-reset semantics and external-agent evidence recording for reattempts.

## Summary of implementation

Completes the two "remaining work" items from MM-817 against the existing MoonMind.Run orchestration foundation (RuntimeContextPolicy literal, MoonMind.Run-owned Step Execution identity/checkpoint/evidence/advancement, agent-cannot-mutate-ledger).

**1. Per-reattempt clean-context session reset (managed sessions → `fresh_agent_run` + new epoch).**
The task-scoped session clear was previously deduped by logical step id alone, so a genuine reattempt (`execution_ordinal > 1`) of a step never re-cleared the session. Dedup is now keyed by Step Execution identity (`logical_step_id:execution_ordinal`):
- A same-attempt retry of an already-cleared execution still does **not** re-clear (no double reset).
- A clean-context reattempt (`execution_ordinal > 1`) now resolves to a fresh session reset / new epoch before the attempt, per `docs/Steps/StepExecutionsAndCheckpointing.md` §16.1.

State field renamed `_codex_session_cleared_before_step_ids` → `_codex_session_cleared_before_step_executions` to reflect the identity it now tracks.

**2. External-provider continuation evidence recording.**
Under `external_provider_continuation`, MoonMind cannot reset external/coordinated agent state, so it now records — alongside the existing attempt identity and context refs — the **known side effects** observed across the step's attempts and any **available checkpoint evidence** refs, keeping the continuation attempt auditable. Two helpers added: `_external_continuation_known_side_effects` (compact per-step side-effect projection) and `_external_continuation_checkpoint_evidence` (durable checkpoint refs where available).

## Tests run

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` → **48 passed**.
  - New coverage ties a managed reattempt (`execution_ordinal > 1`) to a session reset / new epoch, retains the existing assertion that a same-step same-attempt retry does not re-clear, and asserts `external_provider_continuation` manifests record known side effects and available checkpoint evidence.
- Frontend Vitest suite executed by the same runner: **417 passed / 234 skipped**, no failures.

## Remaining risks

- Workflow-payload-shape change: the manifest now carries additional `knownSideEffects` / `availableCheckpointEvidence` keys and the session-clear dedup key changed. Both are additive/internal to in-workflow state; existing manifest consumers ignore unknown keys. Session-clear behavior is gated behind the existing `RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH` workflow patch, so in-flight runs follow their pinned behavior.
- The heavier Temporal time-skipping boundary suites (excluded from required CI per repo policy) were not run in this environment; the targeted unit boundary tests above exercise the changed code paths.
- Side-effect / checkpoint evidence projection depends on records already present in per-step state; if upstream stages do not populate those records the fields are simply omitted (best-effort, non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-817]: https://moonladder.atlassian.net/browse/MM-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ