### PR TITLE
MM-817 Complete reattempt runtime evidence

### DIFF
--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -87,6 +87,12 @@ class AgentRuntimeStepExecutionLaunch(BaseModel):
     runtime_selection: dict[str, Any] = Field(
         default_factory=dict, alias="runtimeSelection"
     )
+    runtime_session_reset: dict[str, Any] | None = Field(
+        None, alias="runtimeSessionReset"
+    )
+    external_provider_continuation: dict[str, Any] | None = Field(
+        None, alias="externalProviderContinuation"
+    )
     skill_source_policy: dict[str, Any] = Field(
         default_factory=dict, alias="skillSourcePolicy"
     )
@@ -113,13 +119,17 @@ class AgentRuntimeStepExecutionLaunch(BaseModel):
 
     @field_validator(
         "runtime_selection",
+        "runtime_session_reset",
+        "external_provider_continuation",
         "skill_source_policy",
         mode="after",
     )
     @classmethod
     def _validate_compact_mappings(
-        cls, value: dict[str, Any], info: ValidationInfo
-    ) -> dict[str, Any]:
+        cls, value: dict[str, Any] | None, info: ValidationInfo
+    ) -> dict[str, Any] | None:
+        if value is None:
+            return None
         field = cls.model_fields[info.field_name]
         field_name = f"stepExecution.{field.alias or info.field_name}"
         compact = validate_compact_temporal_mapping(value, field_name=field_name)

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1457,11 +1457,28 @@ class MoonMindRunWorkflow:
             "agent_runtime"
         ):
             agent_id = str(tool.get("name") or "").strip()
+            agent_kind = self._agent_kind_for_id(agent_id)
             execution["runtimeContextPolicy"] = (
                 "fresh_agent_run"
-                if self._agent_kind_for_id(agent_id) == "managed"
+                if agent_kind == "managed"
                 else "external_provider_continuation"
             )
+            execution_ordinal = self._step_execution_for(logical_step_id) or 1
+            if agent_kind == "managed":
+                reset = self._managed_reattempt_session_reset_evidence(
+                    logical_step_id,
+                    agent_id=agent_id,
+                    execution_ordinal=execution_ordinal,
+                )
+                if reset:
+                    execution["runtimeSessionReset"] = reset
+            else:
+                execution["externalProviderContinuation"] = (
+                    self._external_provider_continuation_evidence(
+                        logical_step_id,
+                        execution_ordinal=execution_ordinal,
+                    )
+                )
         if isinstance(refs, Mapping):
             for source_key, target_key in (
                 ("childWorkflowId", "childWorkflowId"),
@@ -1476,6 +1493,90 @@ class MoonMindRunWorkflow:
             if isinstance(diagnostics_ref, str) and diagnostics_ref.strip():
                 execution["diagnosticsRef"] = diagnostics_ref.strip()
         return execution
+
+    def _managed_reattempt_session_reset_evidence(
+        self,
+        logical_step_id: str,
+        *,
+        agent_id: str,
+        execution_ordinal: int,
+    ) -> dict[str, Any] | None:
+        if execution_ordinal <= 1:
+            return None
+        source_execution_ordinal = self._step_execution_source_identity(
+            logical_step_id,
+            attempt=execution_ordinal,
+        )
+        evidence: dict[str, Any] = {
+            "requestedPolicy": "reuse_session_new_epoch",
+            "resolvedPolicy": "fresh_agent_run",
+            "semantics": "new_epoch_cleared_context",
+            "clearContext": True,
+            "newEpoch": True,
+            "runtimeId": agent_id,
+        }
+        if source_execution_ordinal:
+            evidence["sourceExecutionOrdinal"] = source_execution_ordinal
+        previous_checkpoint_ref = self._previous_step_checkpoint_refs.get(
+            logical_step_id
+        )
+        if previous_checkpoint_ref:
+            evidence["availableCheckpointEvidence"] = {
+                "stateCheckpointRef": previous_checkpoint_ref
+            }
+        else:
+            evidence["availableCheckpointEvidence"] = {"available": False}
+        return evidence
+
+    def _external_provider_continuation_evidence(
+        self,
+        logical_step_id: str,
+        *,
+        execution_ordinal: int,
+        context_bundle_ref: str | None = None,
+        prepared_input_refs: Sequence[str] = (),
+    ) -> dict[str, Any]:
+        identity = StepExecutionIdentityModel(
+            workflowId=workflow.info().workflow_id,
+            runId=workflow.info().run_id,
+            logicalStepId=logical_step_id,
+            executionOrdinal=execution_ordinal,
+        )
+        context_refs: dict[str, Any] = {}
+        if context_bundle_ref:
+            context_refs["contextBundleRef"] = context_bundle_ref
+        prepared_refs = [
+            str(ref).strip() for ref in prepared_input_refs if str(ref).strip()
+        ]
+        if not prepared_refs:
+            prepared_refs = list(self._prepared_artifact_refs)
+        if prepared_refs:
+            context_refs["preparedInputRefs"] = prepared_refs
+
+        checkpoint_ref = self._step_checkpoint_refs.get(
+            logical_step_id
+        ) or self._previous_step_checkpoint_refs.get(logical_step_id)
+        checkpoint_evidence: dict[str, Any] = (
+            {"stateCheckpointRef": checkpoint_ref}
+            if checkpoint_ref
+            else {"available": False}
+        )
+        records = [
+            dict(record)
+            for record in self._step_side_effect_records.get(logical_step_id, ())
+        ]
+        return {
+            "attemptIdentity": {
+                "workflowId": identity.workflow_id,
+                "runId": identity.run_id,
+                "logicalStepId": identity.logical_step_id,
+                "executionOrdinal": identity.execution_ordinal,
+                "stepExecutionId": build_step_execution_id(identity),
+            },
+            "contextRefs": context_refs,
+            "knownSideEffects": {"records": records} if records else {"records": []},
+            "checkpointEvidence": checkpoint_evidence,
+        }
 
     def _step_execution_compact_output_refs(
         self,
@@ -8685,6 +8786,39 @@ class MoonMindRunWorkflow:
             skill_source_policy["resolvedSkillsetRef"] = resolved_skillset_ref
         if selected_skill:
             skill_source_policy["selectedSkill"] = selected_skill
+        step_execution_payload: dict[str, Any] = {
+            "schemaVersion": "v1",
+            "workflowId": wf_info.workflow_id,
+            "runId": wf_info.run_id,
+            "logicalStepId": node_id,
+            "executionOrdinal": step_execution_identity.execution_ordinal,
+            "stepExecutionId": build_step_execution_id(step_execution_identity),
+            "reason": attempt_reason,
+            "runtimeContextPolicy": runtime_context_policy,
+            "contextBundleRef": attempt_context.context_bundle_ref,
+            "contextBundleDigest": attempt_context.context_bundle_digest,
+            "preparedInputRefs": list(attempt_context.prepared_input_refs),
+            "resolvedSkillsetRef": resolved_skillset_ref,
+            "runtimeSelection": dict(runtime_selection),
+            "skillSourcePolicy": skill_source_policy,
+        }
+        if agent_kind == "managed":
+            session_reset = self._managed_reattempt_session_reset_evidence(
+                node_id,
+                agent_id=agent_id,
+                execution_ordinal=step_execution_identity.execution_ordinal,
+            )
+            if session_reset:
+                step_execution_payload["runtimeSessionReset"] = session_reset
+        else:
+            step_execution_payload["externalProviderContinuation"] = (
+                self._external_provider_continuation_evidence(
+                    node_id,
+                    execution_ordinal=step_execution_identity.execution_ordinal,
+                    context_bundle_ref=attempt_context.context_bundle_ref,
+                    prepared_input_refs=attempt_context.prepared_input_refs,
+                )
+            )
 
         return AgentExecutionRequest(
             agent_kind=agent_kind,
@@ -8696,22 +8830,7 @@ class MoonMindRunWorkflow:
             or node_inputs.get("instructionRef"),
             runtime_command=node_inputs.get("runtimeCommand")
             or node_inputs.get("runtime_command"),
-            step_execution={
-                "schemaVersion": "v1",
-                "workflowId": wf_info.workflow_id,
-                "runId": wf_info.run_id,
-                "logicalStepId": node_id,
-                "executionOrdinal": step_execution_identity.execution_ordinal,
-                "stepExecutionId": build_step_execution_id(step_execution_identity),
-                "reason": attempt_reason,
-                "runtimeContextPolicy": runtime_context_policy,
-                "contextBundleRef": attempt_context.context_bundle_ref,
-                "contextBundleDigest": attempt_context.context_bundle_digest,
-                "preparedInputRefs": list(attempt_context.prepared_input_refs),
-                "resolvedSkillsetRef": resolved_skillset_ref,
-                "runtimeSelection": dict(runtime_selection),
-                "skillSourcePolicy": skill_source_policy,
-            },
+            step_execution=step_execution_payload,
             resolved_skillset_ref=resolved_skillset_ref,
             input_refs=input_refs,
             workspace_spec=workspace_spec,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -692,7 +692,7 @@ class MoonMindRunWorkflow:
         self._last_publish_repair_node_id: str | None = None
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
-        self._codex_session_cleared_before_step_ids: set[str] = set()
+        self._codex_session_cleared_before_step_attempts: set[tuple[str, int]] = set()
         self._trusted_jira_context: dict[str, Any] | None = None
         self._step_ledger_rows: list[dict[str, Any]] = []
         self._step_ledger_by_id: dict[str, dict[str, Any]] = {}
@@ -6090,7 +6090,9 @@ class MoonMindRunWorkflow:
     ) -> None:
         if not workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH):
             return
-        if logical_step_id in self._codex_session_cleared_before_step_ids:
+        execution_ordinal = self._step_execution_for(logical_step_id) or 1
+        clear_key = (logical_step_id, execution_ordinal)
+        if clear_key in self._codex_session_cleared_before_step_attempts:
             return
         binding = self._codex_session_binding
         if binding is None:
@@ -6103,7 +6105,7 @@ class MoonMindRunWorkflow:
             workflow_id=workflow.info().workflow_id,
             run_id=workflow.info().run_id,
             logical_step_id=logical_step_id,
-            execution_ordinal=self._step_execution_for(logical_step_id) or 1,
+            execution_ordinal=execution_ordinal,
             operation="clear_session",
         )
         if workflow.patched(RUN_TASK_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH):
@@ -6152,7 +6154,7 @@ class MoonMindRunWorkflow:
                     reason=reason,
                     request_id=request_id,
                 )
-        self._codex_session_cleared_before_step_ids.add(logical_step_id)
+        self._codex_session_cleared_before_step_attempts.add(clear_key)
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
         binding = self._codex_session_binding

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -830,6 +830,148 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "prohibited",
         )
 
+    def test_managed_reattempt_records_session_reset_launch_evidence(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+        now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+        wf._initialize_step_ledger(
+            ordered_nodes=[
+                {
+                    "id": "implement",
+                    "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                    "inputs": {"title": "Implement"},
+                }
+            ],
+            dependency_map={"implement": []},
+            updated_at=now,
+        )
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=False,
+        ):
+            wf._mark_step_running("implement", updated_at=now, summary="Attempt 1")
+            wf._record_step_result_evidence(
+                "implement",
+                execution_result={
+                    "status": "FAILED",
+                    "outputs": {
+                        "latestCheckpointRef": "artifact://checkpoint/attempt-1"
+                    },
+                },
+                updated_at=now,
+            )
+            wf._mark_step_terminal(
+                "implement",
+                status="failed",
+                updated_at=now,
+                summary="Attempt 1 failed",
+            )
+            wf._mark_step_running("implement", updated_at=now, summary="Attempt 2")
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=False,
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "instructions": "Retry in a clean context.",
+                    "runtime": {"mode": "codex_cli"},
+                },
+                node_id="implement",
+                tool_name="codex_cli",
+                attempt_reason="runtime_recovered",
+            )
+
+        step_execution = request.step_execution
+        assert step_execution is not None
+        self.assertEqual(step_execution.runtime_context_policy, "fresh_agent_run")
+        self.assertEqual(step_execution.execution_ordinal, 2)
+        self.assertEqual(
+            step_execution.runtime_session_reset,
+            {
+                "requestedPolicy": "reuse_session_new_epoch",
+                "resolvedPolicy": "fresh_agent_run",
+                "semantics": "new_epoch_cleared_context",
+                "clearContext": True,
+                "newEpoch": True,
+                "runtimeId": "codex_cli",
+                "sourceExecutionOrdinal": {
+                    "workflowId": "test-wf-id",
+                    "runId": "test-run-id",
+                    "logicalStepId": "implement",
+                    "executionOrdinal": 1,
+                },
+                "availableCheckpointEvidence": {
+                    "stateCheckpointRef": "artifact://checkpoint/attempt-1"
+                },
+            },
+        )
+
+    def test_external_request_records_continuation_evidence(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+        wf._prepared_artifact_refs = ["prepared-context://steps/delegate/input"]
+        wf._step_side_effect_records["delegate"] = [
+            {
+                "effectClass": "external_provider",
+                "operation": "provider_run_started",
+                "target": "jules",
+                "disposition": "occurred",
+            }
+        ]
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "instructions": "Continue delegated work.",
+                    "runtime": {"mode": "jules"},
+                },
+                node_id="delegate",
+                tool_name="jules",
+            )
+
+        step_execution = request.step_execution
+        assert step_execution is not None
+        continuation = step_execution.external_provider_continuation
+        assert continuation is not None
+        self.assertEqual(
+            continuation["attemptIdentity"],
+            {
+                "workflowId": "test-wf-id",
+                "runId": "test-run-id",
+                "logicalStepId": "delegate",
+                "executionOrdinal": 1,
+                "stepExecutionId": "test-wf-id:test-run-id:delegate:execution:1",
+            },
+        )
+        self.assertEqual(
+            continuation["contextRefs"]["contextBundleRef"],
+            step_execution.context_bundle_ref,
+        )
+        self.assertEqual(
+            continuation["knownSideEffects"]["records"][0]["operation"],
+            "provider_run_started",
+        )
+        self.assertEqual(continuation["checkpointEvidence"], {"available": False})
+
     def test_build_agent_execution_request_propagates_story_output_handoff(self) -> None:
         from unittest.mock import patch
 

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -178,6 +179,7 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    now = datetime(2026, 6, 10, 12, 0, tzinfo=UTC)
     activity_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
 
@@ -243,6 +245,17 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
         runtimeId="codex_cli",
         executionProfileRef="codex-default",
     )
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "step-2",
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+            }
+        ],
+        dependency_map={"step-2": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("step-2", updated_at=now)
 
     await workflow._maybe_clear_task_scoped_session_before_step(
         request=_managed_request("codex"),
@@ -285,15 +298,16 @@ async def test_run_clears_existing_task_scoped_codex_session_before_next_step(
     ]
     assert workflow._codex_session_binding is not None
     assert workflow._codex_session_binding.session_epoch == 2
-    assert "step-2" in workflow._codex_session_cleared_before_step_ids
+    assert ("step-2", 1) in workflow._codex_session_cleared_before_step_attempts
 
 
 @pytest.mark.asyncio
-async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
+async def test_run_clears_task_scoped_session_once_per_step_execution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    now = datetime(2026, 6, 10, 12, 0, tzinfo=UTC)
     activity_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
 
@@ -308,30 +322,38 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
     ) -> dict[str, Any]:
         activity_calls.append((activity_name, payload))
         if activity_name == "agent_runtime.load_session_snapshot":
+            session_epoch = len(
+                [
+                    name
+                    for name, _payload in activity_calls
+                    if name == "agent_runtime.clear_session"
+                ]
+            ) + 1
             return {
                 "binding": {
                     "workflowId": "wf-run-1:session:codex_cli",
                     "taskRunId": "wf-run-1",
                     "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 1,
+                    "sessionEpoch": session_epoch,
                     "runtimeId": "codex_cli",
                     "executionProfileRef": "codex-default",
                 },
                 "status": "active",
                 "containerId": "container-1",
-                "threadId": "thread-1",
+                "threadId": f"thread-{session_epoch}",
                 "activeTurnId": None,
                 "lastControlAction": None,
                 "lastControlReason": None,
                 "terminationRequested": False,
             }
         if activity_name == "agent_runtime.clear_session":
+            session_epoch = int(payload["sessionEpoch"]) + 1
             return {
                 "sessionState": {
                     "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 2,
+                    "sessionEpoch": session_epoch,
                     "containerId": "container-1",
-                    "threadId": "thread:sess:wf-run-1:codex_cli:2",
+                    "threadId": f"thread:sess:wf-run-1:codex_cli:{session_epoch}",
                 },
                 "status": "ready",
                 "imageRef": "codex:latest",
@@ -359,11 +381,33 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
         runtimeId="codex_cli",
         executionProfileRef="codex-default",
     )
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "step-2",
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+            }
+        ],
+        dependency_map={"step-2": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("step-2", updated_at=now)
 
     await workflow._maybe_clear_task_scoped_session_before_step(
         request=_managed_request("codex"),
         logical_step_id="step-2",
     )
+    await workflow._maybe_clear_task_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+    workflow._mark_step_terminal(
+        "step-2",
+        status="failed",
+        updated_at=now,
+        summary="Attempt 1 failed",
+    )
+    workflow._mark_step_running("step-2", updated_at=now)
     await workflow._maybe_clear_task_scoped_session_before_step(
         request=_managed_request("codex"),
         logical_step_id="step-2",
@@ -372,8 +416,21 @@ async def test_run_does_not_clear_task_scoped_session_twice_for_same_step_retry(
     assert [name for name, _ in activity_calls] == [
         "agent_runtime.load_session_snapshot",
         "agent_runtime.clear_session",
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.clear_session",
     ]
-    assert len(signal_calls) == 1
+    assert [
+        payload["requestId"]
+        for signal_name, payload in signal_calls
+        if signal_name == "control_action"
+    ] == [
+        "wf-run-1:run-1:step-2:execution:1:clear_session",
+        "wf-run-1:run-1:step-2:execution:2:clear_session",
+    ]
+    assert workflow._codex_session_cleared_before_step_attempts == {
+        ("step-2", 1),
+        ("step-2", 2),
+    }
 
 
 def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -688,6 +688,21 @@ async def test_run_records_step_execution_manifest_ref_when_work_begins(
     assert writes[1]["payload"]["reason"] == "runtime_recovered"
     assert writes[1]["payload"]["execution"] == {
         "runtimeContextPolicy": "fresh_agent_run",
+        "runtimeSessionReset": {
+            "requestedPolicy": "reuse_session_new_epoch",
+            "resolvedPolicy": "fresh_agent_run",
+            "semantics": "new_epoch_cleared_context",
+            "clearContext": True,
+            "newEpoch": True,
+            "runtimeId": "codex",
+            "sourceExecutionOrdinal": {
+                "workflowId": "wf-run-1",
+                "runId": "run-1",
+                "logicalStepId": "delegate-agent",
+                "executionOrdinal": 1,
+            },
+            "availableCheckpointEvidence": {"available": False},
+        },
         "childWorkflowId": "wf-child-1",
         "childRunId": "run-child-1",
     }
@@ -776,6 +791,18 @@ async def test_step_execution_manifest_merges_explicit_execution_with_refs(
 
     assert writes[0]["payload"]["execution"] == {
         "runtimeContextPolicy": "external_provider_continuation",
+        "externalProviderContinuation": {
+            "attemptIdentity": {
+                "workflowId": "wf-run-1",
+                "runId": "run-1",
+                "logicalStepId": "delegate-external",
+                "executionOrdinal": 1,
+                "stepExecutionId": "wf-run-1:run-1:delegate-external:execution:1",
+            },
+            "contextRefs": {},
+            "knownSideEffects": {"records": []},
+            "checkpointEvidence": {"available": False},
+        },
         "childWorkflowId": "wf-child-explicit",
         "childRunId": "run-child-from-ledger",
         "diagnosticsRef": "artifact://diagnostics/external",


### PR DESCRIPTION
Jira issue key: MM-817

Summary:
- Records managed clean-context reattempt session reset evidence on step execution manifests and agent launch payloads.
- Resolves managed reattempt evidence to fresh_agent_run with reuse_session_new_epoch/new epoch/cleared context semantics.
- Records external_provider_continuation evidence with attempt identity, context refs, known side effects, and checkpoint evidence.
- Extends workflow/unit coverage for managed reattempt reset evidence and external continuation evidence.

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py

Remaining risks:
- Full compose-backed integration suite was not run in this PR publication step.
- Existing in-flight Temporal histories may need operator cutover review if they depend on the previous compact stepExecution shape.