### PR TITLE
MM-735 Allow selected-step recovery

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -78,6 +78,7 @@ from moonmind.schemas.temporal_models import (
     ExecutionSkillVersionSummaryModel,
     RecoverFromFailedStepRequest,
     RecoverFromFailedStepResponse,
+    RecoverFromSelectedStepRequest,
     TaskInputSnapshotDescriptorModel,
     PollIntegrationRequest,
     RescheduleExecutionRequest,
@@ -5798,6 +5799,8 @@ async def _hydrate_recovery_checkpoint_payload(
 
 def _recovery_not_available_reason(exc: Exception) -> str:
     message = str(exc).lower()
+    if "selected start step" in message:
+        return "selected_step_not_eligible"
     if "does not match" in message:
         return "checkpoint_inconsistent"
     if "plan" in message:
@@ -8968,6 +8971,105 @@ async def recover_execution_from_failed_step(
             detail={
                 "code": "resume_not_available",
                 "message": "Failed-step recovery is not available for this execution.",
+                "reason": "state_not_eligible",
+            },
+        ) from exc
+    await session.commit()
+    return RecoverFromFailedStepResponse.model_validate(result)
+
+@router.post(
+    "/{workflow_id}/recover-from-selected-step",
+    response_model=RecoverFromFailedStepResponse,
+    status_code=status.HTTP_201_CREATED,
+    response_model_exclude_none=True,
+)
+async def recover_execution_from_selected_step(
+    workflow_id: str,
+    payload: dict[str, Any] = Body(default_factory=dict),
+    service: TemporalExecutionService = Depends(_get_service),
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(get_current_user()),
+    _submit_enabled: None = Depends(_ensure_submit_enabled),
+) -> RecoverFromFailedStepResponse:
+    try:
+        request = RecoverFromSelectedStepRequest.model_validate(payload)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_recovery_request",
+                "message": str(exc),
+            },
+        ) from exc
+
+    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
+    canonical = await session.get(TemporalExecutionCanonicalRecord, workflow_id)
+    if canonical is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "execution_not_found",
+                "message": "Source execution was not found or is not visible.",
+            },
+        )
+    if request.source_workflow_id != canonical.workflow_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery source workflow does not match.",
+                "reason": "checkpoint_inconsistent",
+            },
+        )
+    if request.source_run_id != str(canonical.run_id or ""):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery source run does not match.",
+                "reason": "checkpoint_inconsistent",
+            },
+        )
+    checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
+        canonical
+    )
+    if _recovery_evidence_marked_stale(canonical):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery is not available for this execution.",
+                "reason": "stale_recovery_evidence",
+            },
+        )
+    checkpoint_payload = await _hydrate_recovery_checkpoint_payload(
+        session=session,
+        user=user,
+        checkpoint_ref=checkpoint_ref,
+    )
+    try:
+        result = await service.create_failed_step_recovery_execution(
+            canonical,
+            recovery_checkpoint_ref=request.recovery_checkpoint_ref,
+            idempotency_key=request.idempotency_key,
+            checkpoint_payload=checkpoint_payload,
+            selected_start_step_id=request.selected_start_step_id,
+        )
+    except TemporalExecutionRecoveryCheckpointError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery is not available for this execution.",
+                "reason": _recovery_not_available_reason(exc),
+            },
+        ) from exc
+    except TemporalExecutionValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery is not available for this execution.",
                 "reason": "state_not_eligible",
             },
         ) from exc

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9002,16 +9002,9 @@ async def recover_execution_from_selected_step(
             },
         ) from exc
 
-    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
-    canonical = await session.get(TemporalExecutionCanonicalRecord, workflow_id)
-    if canonical is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "execution_not_found",
-                "message": "Source execution was not found or is not visible.",
-            },
-        )
+    canonical = await _get_owned_execution(
+        service=service, workflow_id=workflow_id, user=user
+    )
     if request.source_workflow_id != canonical.workflow_id:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -9033,6 +9026,15 @@ async def recover_execution_from_selected_step(
     checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
         canonical
     )
+    if not checkpoint_ref:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Selected-step recovery requires a valid checkpoint reference.",
+                "reason": "checkpoint_missing",
+            },
+        )
     if _recovery_evidence_marked_stale(canonical):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -9050,7 +9052,7 @@ async def recover_execution_from_selected_step(
     try:
         result = await service.create_failed_step_recovery_execution(
             canonical,
-            recovery_checkpoint_ref=request.recovery_checkpoint_ref,
+            recovery_checkpoint_ref=checkpoint_ref,
             idempotency_key=request.idempotency_key,
             checkpoint_payload=checkpoint_payload,
             selected_start_step_id=request.selected_start_step_id,

--- a/artifacts.root-mm735/context/rag-context-b18f044954a4.json
+++ b/artifacts.root-mm735/context/rag-context-b18f044954a4.json
@@ -1,0 +1,121 @@
+{
+  "context_text": "### Retrieved Context\n1. api_service/ui_assets.py (score: 1.000, trust: canonical)\n    line 94: except json.JSONDecodeError:\n2. docs/ManagedAgents/ClaudeCodeMiniMax.md (score: 1.000, trust: canonical)\n    line 1: # Claude Code via MiniMax\n3. docs/ManagedAgents/DockerSidecarRuntime.md (score: 1.000, trust: canonical)\n    line 10: - [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)\n4. moonmind/security/outbound_scan.py (score: 1.000, trust: canonical)\n    line 17: \"\"\"Allow/block decision returned before an external side effect.\"\"\"\n5. api_service/docker/README.md (score: 1.000, trust: canonical)\n    line 9: - `CODEX_CLI_VERSION`\n6. api_service/auth_providers.py (score: 1.000, trust: canonical)\n    line 35: raise HTTPException(status_code=500, detail=\"Invalid DEFAULT_USER_ID\") from exc\n7. docs/Rag/WorkflowRag.md (score: 1.000, trust: canonical)\n    line 18: MoonMind’s managed-agent architecture is **managed-session first**. A managed session is the runtime-owned work session, but MoonMind remains the owner of durable context assembly, artifact publication, and orchestration. Workflow RAG is therefore **not** primarily a chat-style “agent remembers to search” feature. Its primary job is to let MoonMind assemble relevant document and code context, publish that context as durable artifacts and refs, and deliver it into managed sessions at the right step boundaries.\n8. docs/Development/PreCommitWorkflow.md (score: 1.000, trust: canonical)\n    line 5: MoonMind uses `pre-commit` as a fast local quality gate for Python formatting and lint cleanup before longer test runs.",
+  "items": [
+    {
+      "score": 1.0,
+      "source": "api_service/ui_assets.py",
+      "text": "line 94: except json.JSONDecodeError:",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 94,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/ClaudeCodeMiniMax.md",
+      "text": "line 1: # Claude Code via MiniMax",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 1,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/ManagedAgents/DockerSidecarRuntime.md",
+      "text": "line 10: - [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 10,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "moonmind/security/outbound_scan.py",
+      "text": "line 17: \"\"\"Allow/block decision returned before an external side effect.\"\"\"",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 17,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/docker/README.md",
+      "text": "line 9: - `CODEX_CLI_VERSION`",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 9,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "api_service/auth_providers.py",
+      "text": "line 35: raise HTTPException(status_code=500, detail=\"Invalid DEFAULT_USER_ID\") from exc",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 35,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Rag/WorkflowRag.md",
+      "text": "line 18: MoonMind’s managed-agent architecture is **managed-session first**. A managed session is the runtime-owned work session, but MoonMind remains the owner of durable context assembly, artifact publication, and orchestration. Workflow RAG is therefore **not** primarily a chat-style “agent remembers to search” feature. Its primary job is to let MoonMind assemble relevant document and code context, publish that context as durable artifacts and refs, and deliver it into managed sessions at the right step boundaries.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 18,
+        "mode": "local_fallback"
+      }
+    },
+    {
+      "score": 1.0,
+      "source": "docs/Development/PreCommitWorkflow.md",
+      "text": "line 5: MoonMind uses `pre-commit` as a fast local quality gate for Python formatting and lint cleanup before longer test runs.",
+      "offset_start": null,
+      "offset_end": null,
+      "trust_class": "canonical",
+      "chunk_hash": null,
+      "payload": {
+        "line": 5,
+        "mode": "local_fallback"
+      }
+    }
+  ],
+  "filters": {
+    "mode": "local_fallback"
+  },
+  "budgets": {},
+  "usage": {
+    "matches": 8
+  },
+  "transport": "local_fallback",
+  "retrieved_at": "2026-06-10T08:34:29Z",
+  "telemetry_id": "local-fallback",
+  "initiation_mode": "automatic",
+  "truncated": false
+}

--- a/docs/Workflows/WorkflowRunsApi.md
+++ b/docs/Workflows/WorkflowRunsApi.md
@@ -48,6 +48,8 @@ These routes extend the main lifecycle surface for specific execution types:
 | `POST` | `/api/executions/{workflowId}/integration/poll` | Record integration poll results |
 | `POST` | `/api/executions/{workflowId}/reschedule` | Change the scheduled time of a scheduled execution |
 | `POST` | `/api/executions/{workflowId}/rerun` | Create a fresh execution with the original parameters and a new `workflowId` |
+| `POST` | `/api/executions/{workflowId}/recover-from-failed-step` | Create a linked recovery execution that resumes from the last failed step using durable checkpoint evidence |
+| `POST` | `/api/executions/{workflowId}/recover-from-selected-step` | Create a linked recovery execution that resumes from an operator-selected eligible step using pinned source `workflowId`/`runId` and checkpoint evidence |
 
 ### 2.3 Managed-Run Observability (`/api/task-runs`)
 
@@ -88,6 +90,14 @@ These routes are artifact-first:
 - `diagnostics` exposes the persisted supervision payload for postmortem inspection.
 
 Full log bodies and diagnostics come from managed-run artifact storage and spool files, not from workflow history or raw Temporal event history.
+
+## 4.1 Recovery Behavior
+
+Failed `MoonMind.Run` executions may expose failed-step recovery when the source run has an original task input snapshot, recovery checkpoint ref, plan identity, workspace checkpoint evidence, and completed prior-step output refs.
+
+The default `recover-from-failed-step` route preserves the original task input and starts new execution at the recorded failed step. The `recover-from-selected-step` route is for intentional earlier recovery: the request must include the source `workflowId`, source `runId`, and `selectedStartStepId`. The service validates those values against the canonical source execution and checkpoint payload before creating the follow-up execution. Steps before the selected start step are preserved from checkpoint evidence; the selected step and downstream steps execute again.
+
+Recovery routes do not accept edited task instructions, attachments, runtime/model settings, dependency changes, or publish changes. Operators must use edit/rerun flows for those behaviors.
 
 ## 5. Request Model Posture
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2389,9 +2389,147 @@ describe('Workflow Detail Entrypoint', () => {
       expect(calls.some((call) => call.url.includes('/recover-from-failed-step'))).toBe(true);
     });
     const resumeCall = calls.find((call) => call.url.includes('/recover-from-failed-step'));
-    expect(JSON.parse(String(resumeCall?.init?.body || '{}')).resumeCheckpointRef).toBe(
+    expect(JSON.parse(String(resumeCall?.init?.body || '{}')).recoveryCheckpointRef).toBe(
       'artifact://checkpoint/source',
     );
+    confirmSpy.mockRestore();
+  });
+
+  it('submits selected-step recovery with pinned source identity', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const actionPayload: BootPayload = {
+      ...mockPayload,
+      initialData: {
+        dashboardConfig: {
+          features: {
+            temporalDashboard: {
+              actionsEnabled: true,
+              temporalTaskEditing: true,
+            },
+          },
+        },
+      },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Failed workflow',
+      summary: 'Execution summary',
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      stepsHref: '/api/executions/test-123/steps',
+      actions: {
+        canResume: false,
+        canResumeFromFailedStep: true,
+      },
+      resume: {
+        available: true,
+        checkpointRef: 'artifact://checkpoint/source',
+        failedStepId: 'implement',
+        sourceRunId: '01-run',
+      },
+      relatedRuns: [],
+    };
+    const stepLedger = {
+      workflowId: 'test-123',
+      runId: '01-run',
+      runScope: 'latest',
+      steps: [
+        {
+          logicalStepId: 'plan',
+          order: 1,
+          title: 'Plan',
+          status: 'succeeded',
+          executionOrdinal: 1,
+          updatedAt: '2026-03-28T00:00:01Z',
+          refs: {},
+          artifacts: { outputSummary: 'artifact://summary/plan' },
+          recoveryPreservation: {
+            eligible: true,
+            reason: 'complete',
+            message: 'Step has recoverable output refs and state checkpoint evidence.',
+          },
+        },
+        {
+          logicalStepId: 'implement',
+          order: 2,
+          title: 'Implement',
+          status: 'failed',
+          executionOrdinal: 1,
+          updatedAt: '2026-03-28T00:00:02Z',
+          refs: {},
+          artifacts: {},
+          recoveryPreservation: {
+            eligible: false,
+            reason: 'not_completed',
+            message: 'Step is not completed and cannot be preserved for Resume.',
+          },
+        },
+        {
+          logicalStepId: 'publish',
+          order: 3,
+          title: 'Publish',
+          status: 'pending',
+          executionOrdinal: 0,
+          updatedAt: '2026-03-28T00:00:03Z',
+          refs: {},
+          artifacts: {},
+          recoveryPreservation: {
+            eligible: false,
+            reason: 'not_completed',
+            message: 'Step is not completed and cannot be preserved for Resume.',
+          },
+        },
+      ],
+    };
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push(init === undefined ? { url } : { url, init });
+      if (url.includes('/recover-from-selected-step')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ accepted: true }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({ ok: true, json: async () => stepLedger } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
+
+    const select = await screen.findByLabelText('Recovery start step');
+    fireEvent.change(select, { target: { value: 'plan' } });
+    expect(
+      (screen.getByRole('option', { name: /Publish - after failed step/ }) as HTMLOptionElement).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Recover from selected step' }));
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.url.includes('/recover-from-selected-step'))).toBe(true);
+    });
+    const selectedCall = calls.find((call) => call.url.includes('/recover-from-selected-step'));
+    const body = JSON.parse(String(selectedCall?.init?.body || '{}'));
+    expect(body).toMatchObject({
+      sourceWorkflowId: 'test-123',
+      sourceRunId: '01-run',
+      selectedStartStepId: 'plan',
+      recoveryCheckpointRef: 'artifact://checkpoint/source',
+    });
     confirmSpy.mockRestore();
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -966,6 +966,14 @@ const StepLedgerArtifactsSchema = z
     stepExecutionManifestRefs: [],
   });
 
+const StepLedgerRecoveryPreservationSchema = z
+  .object({
+    eligible: z.boolean(),
+    reason: z.string(),
+    message: z.string().nullable().optional(),
+  })
+  .passthrough();
+
 const StepLedgerWorkloadSchema = z
   .object({
     taskRunId: z.string().nullable().optional(),
@@ -1020,6 +1028,7 @@ const StepLedgerRowSchema = z
       .optional(),
     workload: StepLedgerWorkloadSchema.nullable().optional(),
     stateCheckpointRef: z.string().nullable().optional(),
+    recoveryPreservation: StepLedgerRecoveryPreservationSchema.nullable().optional(),
     lastError: z.unknown().nullable().optional(),
   })
   .passthrough();
@@ -4557,6 +4566,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const [remediationMode, setRemediationMode] = useState('snapshot_then_follow');
   const [remediationAuthority, setRemediationAuthority] = useState('approval_gated');
   const [remediationActionPolicy, setRemediationActionPolicy] = useState('admin_healer_default');
+  const [selectedRecoveryStepId, setSelectedRecoveryStepId] = useState('');
 
   const detailQuery = useQuery({
     queryKey: ['workflow-detail', encodedTaskId, sourceTemporal],
@@ -4624,6 +4634,44 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     refetchInterval: liveUpdates && execution?.stepsHref && !isTerminalExecution ? detailPoll : false,
   });
   const latestRunId = stepsQuery.data?.runId || runId;
+  const selectedRecoveryOptions = useMemo(() => {
+    const failedStepId = execution?.resume?.failedStepId || '';
+    const rows = stepsQuery.data?.steps || [];
+    if (!failedStepId || rows.length === 0) {
+      return [];
+    }
+    const failedRow = rows.find((row) => row.logicalStepId === failedStepId);
+    const failedOrder = failedRow?.order ?? Number.POSITIVE_INFINITY;
+    return rows.map((row) => {
+      const preservation = row.recoveryPreservation;
+      const isFailedStep = row.logicalStepId === failedStepId;
+      const eligible = isFailedStep || Boolean(preservation?.eligible);
+      let reason = '';
+      if (!eligible) {
+        if (row.order > failedOrder) {
+          reason = 'after failed step';
+        } else if (preservation?.message) {
+          reason = preservation.message;
+        } else if (preservation?.reason) {
+          reason = formatStatusLabel(preservation.reason);
+        } else {
+          reason = 'checkpoint evidence missing';
+        }
+      }
+      return {
+        logicalStepId: row.logicalStepId,
+        title: row.title,
+        eligible,
+        reason,
+        isFailedStep,
+      };
+    });
+  }, [execution?.resume?.failedStepId, stepsQuery.data?.steps]);
+  const selectedRecoveryStep =
+    selectedRecoveryOptions.find((option) => option.logicalStepId === selectedRecoveryStepId) ||
+    selectedRecoveryOptions.find((option) => option.isFailedStep) ||
+    selectedRecoveryOptions.find((option) => option.eligible) ||
+    null;
 
   const artifactsQuery = useQuery({
     queryKey: ['workflow-detail-artifacts', namespace, workflowId, latestRunId],
@@ -4821,7 +4869,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           body: JSON.stringify({
             idempotencyKey: `resume-${workflowId}-${latestRunId || runId || 'latest'}`,
             ...(execution?.resume?.checkpointRef
-              ? { resumeCheckpointRef: execution.resume.checkpointRef }
+              ? { recoveryCheckpointRef: execution.resume.checkpointRef }
               : {}),
             operatorMetadata: { requestedFrom: 'workflow-detail' },
           }),
@@ -4835,6 +4883,43 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     },
     onSuccess: () => {
       setActionNotice('Resumed from failed step.');
+      invalidate();
+    },
+    onError: (error: Error) => setActionError(error.message),
+  });
+
+  const selectedStepRecoveryMutation = useMutation({
+    mutationFn: async () => {
+      const selectedStepId = selectedRecoveryStep?.logicalStepId || '';
+      const sourceRunId = execution?.resume?.sourceRunId || latestRunId || runId || '';
+      if (!selectedStepId || !sourceRunId) {
+        throw new Error('Selected-step recovery requires a source run and start step.');
+      }
+      const response = await fetch(
+        `${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/recover-from-selected-step`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({
+            idempotencyKey: `selected-step-recovery-${workflowId}-${sourceRunId}-${selectedStepId}`,
+            sourceWorkflowId: workflowId,
+            sourceRunId,
+            selectedStartStepId: selectedStepId,
+            ...(execution?.resume?.checkpointRef
+              ? { recoveryCheckpointRef: execution.resume.checkpointRef }
+              : {}),
+            operatorMetadata: { requestedFrom: 'workflow-detail', mode: 'selected-step' },
+          }),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      setActionNotice('Recovery started from selected step.');
       invalidate();
     },
     onError: (error: Error) => setActionError(error.message),
@@ -4932,6 +5017,13 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     failedStepResumeMutation.mutate();
   };
 
+  const onRecoverFromSelectedStep = () => {
+    setActionError(null);
+    const label = selectedRecoveryStep?.title || selectedRecoveryStep?.logicalStepId || 'the selected step';
+    if (!window.confirm(`Recover from ${label} using checkpoint evidence from the source run?`)) return;
+    selectedStepRecoveryMutation.mutate();
+  };
+
   const onApprove = () => {
     setActionError(null);
     signalMutation.mutate({ signalName: 'Approve', payload: {} });
@@ -4973,6 +5065,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     signalMutation.isPending ||
     cancelMutation.isPending ||
     failedStepResumeMutation.isPending ||
+    selectedStepRecoveryMutation.isPending ||
     createRemediationMutation.isPending ||
     remediationApprovalMutation.isPending;
   const editHref = workflowId
@@ -5787,6 +5880,39 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                   </button>
                 ) : null}
               </div>
+              {taskEditingOn && actions.canResumeFromFailedStep && selectedRecoveryOptions.length > 0 ? (
+                <div className="stack">
+                  <label className="field-label" htmlFor="selected-recovery-step">
+                    Recovery start step
+                  </label>
+                  <select
+                    id="selected-recovery-step"
+                    value={selectedRecoveryStep?.logicalStepId || ''}
+                    disabled={busy}
+                    onChange={(event) => setSelectedRecoveryStepId(event.target.value)}
+                  >
+                    {selectedRecoveryOptions.map((option) => (
+                      <option
+                        key={option.logicalStepId}
+                        value={option.logicalStepId}
+                        disabled={!option.eligible}
+                      >
+                        {option.title || option.logicalStepId}
+                        {option.isFailedStep ? ' (failed step)' : ''}
+                        {!option.eligible && option.reason ? ` - ${option.reason}` : ''}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    className="secondary"
+                    disabled={busy || !selectedRecoveryStep?.eligible}
+                    onClick={onRecoverFromSelectedStep}
+                  >
+                    Recover from selected step
+                  </button>
+                </div>
+              ) : null}
               {editTaskUnavailableReason ? (
                 <p className="small">
                   Edit workflow unavailable: {formatStatusLabel(editTaskUnavailableReason)}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1670,6 +1670,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/executions/{workflow_id}/recover-from-selected-step": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Recover Execution From Selected Step */
+        post: operations["recover_execution_from_selected_step_api_executions__workflow_id__recover_from_selected_step_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/integrations/callbacks": {
         parameters: {
             query?: never;
@@ -6298,9 +6315,9 @@ export interface components {
             /**
              * Relationship
              * @default Recovered from failed step
-             * @constant
+             * @enum {string}
              */
-            relationship: "Recovered from failed step";
+            relationship: "Recovered from failed step" | "Recovered from selected step";
             /** Recoverycheckpointref */
             recoveryCheckpointRef: string;
         };
@@ -12106,6 +12123,43 @@ export interface operations {
         };
     };
     recover_execution_from_failed_step_api_executions__workflow_id__recover_from_failed_step_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoverFromFailedStepResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    recover_execution_from_selected_step_api_executions__workflow_id__recover_from_selected_step_post: {
         parameters: {
             query?: never;
             header?: never;

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1025,6 +1025,17 @@ class RecoverFromFailedStepRequest(BaseModel):
             )
         return value
 
+
+class RecoverFromSelectedStepRequest(RecoverFromFailedStepRequest):
+    """Request payload for creating a selected-step recovery follow-up execution."""
+
+    source_workflow_id: str = Field(..., alias="sourceWorkflowId", min_length=1)
+    source_run_id: str = Field(..., alias="sourceRunId", min_length=1)
+    selected_start_step_id: str = Field(
+        ..., alias="selectedStartStepId", min_length=1
+    )
+
+
 class RecoveryCheckpointSourceModel(BaseModel):
     """Source identity embedded in failed-step Recovery checkpoint evidence."""
 
@@ -1156,6 +1167,13 @@ class RecoverySourceModel(BaseModel):
     source_plan_digest: Optional[str] = Field(None, alias="sourcePlanDigest")
     failed_step_id: str = Field(..., alias="failedStepId", min_length=1)
     failed_step_execution: int = Field(..., alias="failedStepExecution", ge=1)
+    recovery_mode: Literal["last_failed_step", "selected_step"] = Field(
+        "last_failed_step", alias="recoveryMode"
+    )
+    selected_start_step_id: Optional[str] = Field(None, alias="selectedStartStepId")
+    selected_start_step_execution: Optional[int] = Field(
+        None, alias="selectedStartStepExecution", ge=1
+    )
     recovery_checkpoint_ref: str = Field(..., alias="recoveryCheckpointRef", min_length=1)
     recovery_workspace: dict[str, Any] = Field(
         default_factory=dict, alias="recoveryWorkspace"
@@ -1182,9 +1200,9 @@ class RecoverFromFailedStepResponse(BaseModel):
     )
     source: ResumeExecutionRefModel = Field(..., alias="source")
     execution: ResumeExecutionRefModel = Field(..., alias="execution")
-    relationship: Literal["Recovered from failed step"] = Field(
-        "Recovered from failed step", alias="relationship"
-    )
+    relationship: Literal[
+        "Recovered from failed step", "Recovered from selected step"
+    ] = Field("Recovered from failed step", alias="relationship")
     recovery_checkpoint_ref: str = Field(..., alias="recoveryCheckpointRef")
 
 class SignalExecutionRequest(BaseModel):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2955,6 +2955,10 @@ class TemporalExecutionService:
                     raise TemporalExecutionRecoveryCheckpointError(
                         "Selected start step is not compatible with recovery checkpoint evidence."
                     )
+                if selected_preserved.order >= checkpoint.failed_step.order:
+                    raise TemporalExecutionRecoveryCheckpointError(
+                        "Selected start step must precede the failed step."
+                    )
                 failed_step_id = selected_preserved.logical_step_id
                 failed_step_execution = selected_preserved.source_execution_ordinal
                 preserved_steps = [

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2848,6 +2848,7 @@ class TemporalExecutionService:
         recovery_checkpoint_ref: str | None,
         idempotency_key: str,
         checkpoint_payload: Mapping[str, Any] | None = None,
+        selected_start_step_id: str | None = None,
     ) -> dict[str, Any]:
         """Create a linked follow-up execution for failed-step recovery."""
 
@@ -2927,17 +2928,45 @@ class TemporalExecutionService:
                 raise TemporalExecutionRecoveryCheckpointError(
                     "Recovery checkpoint plan identity does not match source execution."
                 )
-        failed_step_id = checkpoint.failed_step.logical_step_id
-        failed_step_execution = checkpoint.failed_step.execution_ordinal
-        if not failed_step_id:
+        checkpoint_failed_step_id = checkpoint.failed_step.logical_step_id
+        checkpoint_failed_step_execution = checkpoint.failed_step.execution_ordinal
+        if not checkpoint_failed_step_id:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Recovery failed step id is required."
             )
+        selected_step_id = str(selected_start_step_id or "").strip()
+        recovery_mode = "selected_step" if selected_step_id else "last_failed_step"
+        failed_step_id = checkpoint_failed_step_id
+        failed_step_execution = checkpoint_failed_step_execution
+        preserved_steps = list(checkpoint.preserved_steps)
+        if selected_step_id:
+            if selected_step_id == checkpoint_failed_step_id:
+                recovery_mode = "last_failed_step"
+            else:
+                selected_preserved = next(
+                    (
+                        step
+                        for step in checkpoint.preserved_steps
+                        if step.logical_step_id == selected_step_id
+                    ),
+                    None,
+                )
+                if selected_preserved is None:
+                    raise TemporalExecutionRecoveryCheckpointError(
+                        "Selected start step is not compatible with recovery checkpoint evidence."
+                    )
+                failed_step_id = selected_preserved.logical_step_id
+                failed_step_execution = selected_preserved.source_execution_ordinal
+                preserved_steps = [
+                    step
+                    for step in checkpoint.preserved_steps
+                    if step.order < selected_preserved.order
+                ]
 
         params = dict(record.parameters or {})
         for key in TASK_RUN_ID_PARAM_KEYS:
             params.pop(key, None)
-        params["recoverySource"] = RecoverySourceModel(
+        recovery_source_payload = RecoverySourceModel(
             sourceWorkflowId=record.workflow_id,
             sourceRunId=source_run_id,
             sourceTaskInputSnapshotRef=source_snapshot_ref,
@@ -2945,10 +2974,22 @@ class TemporalExecutionService:
             sourcePlanDigest=checkpoint.plan_digest,
             failedStepId=failed_step_id,
             failedStepExecution=failed_step_execution,
+            recoveryMode=recovery_mode,
+            selectedStartStepId=(
+                failed_step_id if recovery_mode == "selected_step" else None
+            ),
+            selectedStartStepExecution=(
+                failed_step_execution if recovery_mode == "selected_step" else None
+            ),
             recoveryCheckpointRef=checkpoint_ref,
             recoveryWorkspace=checkpoint.recovery_workspace,
-            preservedSteps=checkpoint.preserved_steps,
+            preservedSteps=preserved_steps,
         ).model_dump(by_alias=True, mode="json")
+        if recovery_mode == "last_failed_step":
+            recovery_source_payload.pop("recoveryMode", None)
+            recovery_source_payload.pop("selectedStartStepId", None)
+            recovery_source_payload.pop("selectedStartStepExecution", None)
+        params["recoverySource"] = recovery_source_payload
 
         task_payload = params.get("task")
         task_params = dict(task_payload) if isinstance(task_payload, Mapping) else {}
@@ -2966,6 +3007,10 @@ class TemporalExecutionService:
             "recoveryCheckpointRef": checkpoint_ref,
             "taskInputSnapshotRef": source_snapshot_ref,
         }
+        if recovery_mode == "selected_step":
+            recover_ref["recoveryMode"] = recovery_mode
+            recover_ref["selectedStartStepId"] = failed_step_id
+            recover_ref["selectedStartStepExecution"] = failed_step_execution
         plan_ref = checkpoint.plan_ref or source_plan_ref
         if plan_ref:
             recover_ref["planRef"] = plan_ref
@@ -2995,7 +3040,11 @@ class TemporalExecutionService:
             ),
             repository=repository,
             integration=None,
-            summary=f"Recovered from failed step of {record.workflow_id}.",
+            summary=(
+                f"Recovered from selected step of {record.workflow_id}."
+                if recovery_mode == "selected_step"
+                else f"Recovered from failed step of {record.workflow_id}."
+            ),
         )
         return {
             "accepted": True,
@@ -3009,7 +3058,11 @@ class TemporalExecutionService:
                 "runId": created.run_id,
                 "detailHref": f"/workflows/{created.workflow_id}",
             },
-            "relationship": "Recovered from failed step",
+            "relationship": (
+                "Recovered from selected step"
+                if recovery_mode == "selected_step"
+                else "Recovered from failed step"
+            ),
             "recoveryCheckpointRef": checkpoint_ref,
         }
 

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -1462,3 +1462,11 @@ def test_recover_from_failed_step_route_contract_is_registered() -> None:
     assert route["responses"]["201"]["description"]
     request_schema = route["requestBody"]["content"]["application/json"]["schema"]
     assert request_schema["type"] == "object"
+
+
+def test_recover_from_selected_step_route_contract_is_registered() -> None:
+    schema = app.openapi()
+    route = schema["paths"]["/api/executions/{workflow_id}/recover-from-selected-step"]["post"]
+    assert route["responses"]["201"]["description"]
+    request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+    assert request_schema["type"] == "object"

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -9662,8 +9662,12 @@ def test_selected_step_recovery_requires_checkpoint_ref_before_hydration(
     mock_service.describe_execution.return_value = canonical
 
     artifact_service = SimpleNamespace(read=AsyncMock())
+
+    def session_override() -> SimpleNamespace:
+        return SimpleNamespace()
+
     app.dependency_overrides[_get_service] = lambda: mock_service
-    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace()
+    app.dependency_overrides[get_async_session] = session_override
     _override_user_dependencies(app, is_superuser=True)
     monkeypatch.setattr(
         "api_service.api.routers.executions.get_temporal_artifact_service",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -9558,6 +9558,134 @@ def test_failed_step_recovery_hydrates_checkpoint_artifact(
     assert call_kwargs["recovery_checkpoint_ref"] is None
 
 
+def test_selected_step_recovery_pins_source_and_selected_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.memo = {
+        **canonical.memo,
+        "recovery_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+    }
+    mock_service.describe_execution.return_value = canonical
+    mock_service.create_failed_step_recovery_execution.return_value = {
+        "accepted": True,
+        "applied": "created_resumed_execution",
+        "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
+        "execution": {
+            "workflowId": "mm:selected",
+            "runId": "run-selected",
+            "detailHref": "/workflows/mm:selected",
+        },
+        "relationship": "Recovered from selected step",
+        "recoveryCheckpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
+    }
+    checkpoint_payload = {
+        "schemaVersion": "v1",
+        "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
+        "taskInputSnapshotRef": "artifact://snapshot/source",
+        "planDigest": "sha256:resume-plan",
+        "failedStep": {
+            "logicalStepId": "implement",
+            "order": 2,
+            "attempt": 1,
+        },
+        "preservedSteps": [
+            {
+                "logicalStepId": "plan",
+                "order": 1,
+                "status": "succeeded",
+                "sourceExecutionOrdinal": 1,
+                "artifacts": {"outputSummary": "artifact://completed/plan"},
+                "stateCheckpointRef": "artifact://workspace/before-plan",
+            }
+        ],
+        "recoveryWorkspace": {"checkpointRef": "artifact://workspace/source"},
+    }
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(SimpleNamespace(), json.dumps(checkpoint_payload).encode())
+        )
+    )
+
+    class Session:
+        async def get(self, model, key):
+            return canonical
+
+        async def commit(self):
+            return None
+
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: Session()
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-selected-step",
+            json={
+                "idempotencyKey": "recover-selected-1",
+                "sourceWorkflowId": canonical.workflow_id,
+                "sourceRunId": canonical.run_id,
+                "selectedStartStepId": "plan",
+            },
+        )
+
+    assert response.status_code == 201
+    call_kwargs = mock_service.create_failed_step_recovery_execution.await_args.kwargs
+    assert call_kwargs["checkpoint_payload"] == checkpoint_payload
+    assert call_kwargs["selected_start_step_id"] == "plan"
+
+
+def test_selected_step_recovery_rejects_source_run_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.memo = {
+        **canonical.memo,
+        "recovery_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+    }
+    mock_service.describe_execution.return_value = canonical
+
+    class Session:
+        async def get(self, model, key):
+            return canonical
+
+    artifact_service = SimpleNamespace(read=AsyncMock())
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: Session()
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-selected-step",
+            json={
+                "idempotencyKey": "recover-selected-1",
+                "sourceWorkflowId": canonical.workflow_id,
+                "sourceRunId": "stale-run",
+                "selectedStartStepId": "plan",
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["reason"] == "checkpoint_inconsistent"
+    artifact_service.read.assert_not_awaited()
+    mock_service.create_failed_step_recovery_execution.assert_not_awaited()
+
+
 def test_failed_step_recovery_reports_checkpoint_authorization_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -9640,7 +9640,51 @@ def test_selected_step_recovery_pins_source_and_selected_step(
     assert response.status_code == 201
     call_kwargs = mock_service.create_failed_step_recovery_execution.await_args.kwargs
     assert call_kwargs["checkpoint_payload"] == checkpoint_payload
+    assert (
+        call_kwargs["recovery_checkpoint_ref"]
+        == "artifact://resume-checkpoints/source/checkpoint-v1"
+    )
     assert call_kwargs["selected_start_step_id"] == "plan"
+
+
+def test_selected_step_recovery_requires_checkpoint_ref_before_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.memo = {
+        key: value
+        for key, value in dict(canonical.memo).items()
+        if key not in {"recovery_checkpoint_ref", "recoveryCheckpointRef"}
+    }
+    mock_service.describe_execution.return_value = canonical
+
+    artifact_service = SimpleNamespace(read=AsyncMock())
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace()
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-selected-step",
+            json={
+                "idempotencyKey": "recover-selected-1",
+                "sourceWorkflowId": canonical.workflow_id,
+                "sourceRunId": canonical.run_id,
+                "selectedStartStepId": "plan",
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["reason"] == "checkpoint_missing"
+    artifact_service.read.assert_not_awaited()
+    mock_service.create_failed_step_recovery_execution.assert_not_awaited()
 
 
 def test_selected_step_recovery_rejects_source_run_mismatch(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2735,6 +2735,127 @@ async def test_failed_step_recovery_accepts_legacy_checkpoint_memo_key(
 
 
 @pytest.mark.asyncio
+async def test_selected_step_recovery_starts_from_preserved_step(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="recover source",
+            input_artifact_ref="artifact://input/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "taskRunId": "old-task-run",
+                "task": {"title": "recovery source", "instructions": "Original"},
+            },
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "recovery_checkpoint_ref": "artifact://checkpoint/source",
+        }
+        await session.commit()
+
+        checkpoint_payload = _valid_recovery_checkpoint_payload(
+            workflow_id=created.workflow_id,
+            run_id=created.run_id,
+            snapshot_ref="artifact://snapshot/source",
+        )
+        checkpoint_payload["preservedSteps"] = [
+            checkpoint_payload["preservedSteps"][0],
+            {
+                "logicalStepId": "design",
+                "order": 2,
+                "status": "succeeded",
+                "sourceExecutionOrdinal": 1,
+                "artifacts": {"outputSummary": "artifact://summary/design"},
+                "stateCheckpointRef": "artifact://workspace/before-design",
+            },
+        ]
+        checkpoint_payload["failedStep"] = {
+            "logicalStepId": "implement",
+            "order": 3,
+            "executionOrdinal": 1,
+            "title": "Implement",
+        }
+
+        result = await service.create_failed_step_recovery_execution(
+            created,
+            recovery_checkpoint_ref=None,
+            idempotency_key="recover-selected",
+            checkpoint_payload=checkpoint_payload,
+            selected_start_step_id="design",
+        )
+
+        resumed = await service.describe_execution(result["execution"]["workflowId"])
+        assert result["relationship"] == "Recovered from selected step"
+        assert resumed.parameters["recoverySource"]["recoveryMode"] == "selected_step"
+        assert resumed.parameters["recoverySource"]["failedStepId"] == "design"
+        assert resumed.parameters["recoverySource"]["selectedStartStepId"] == "design"
+        assert [
+            step["logicalStepId"]
+            for step in resumed.parameters["recoverySource"]["preservedSteps"]
+        ] == ["plan"]
+        assert resumed.parameters["task"]["resume"]["failedStepId"] == "design"
+        assert resumed.parameters["task"]["resume"]["recoveryMode"] == "selected_step"
+        assert resumed.parameters["task"]["resume"]["selectedStartStepId"] == "design"
+
+
+@pytest.mark.asyncio
+async def test_selected_step_recovery_rejects_step_without_checkpoint_evidence(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="recover source",
+            input_artifact_ref="artifact://input/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "recovery_checkpoint_ref": "artifact://checkpoint/source",
+        }
+        await session.commit()
+
+        with pytest.raises(
+            TemporalExecutionRecoveryCheckpointError,
+            match="Selected start step",
+        ):
+            await service.create_failed_step_recovery_execution(
+                created,
+                recovery_checkpoint_ref=None,
+                idempotency_key="recover-selected",
+                checkpoint_payload=_valid_recovery_checkpoint_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                    snapshot_ref="artifact://snapshot/source",
+                ),
+                selected_start_step_id="missing-step",
+            )
+
+
+@pytest.mark.asyncio
 async def test_failed_step_recovery_requires_hydrated_checkpoint_payload(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2856,6 +2856,63 @@ async def test_selected_step_recovery_rejects_step_without_checkpoint_evidence(
 
 
 @pytest.mark.asyncio
+async def test_selected_step_recovery_rejects_step_after_failed_step(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title="recover source",
+            input_artifact_ref="artifact://input/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.FAILED
+        created.close_status = TemporalExecutionCloseStatus.FAILED
+        created.memo = {
+            **created.memo,
+            "task_input_snapshot_ref": "artifact://snapshot/source",
+            "recovery_checkpoint_ref": "artifact://checkpoint/source",
+        }
+        await session.commit()
+
+        checkpoint_payload = _valid_recovery_checkpoint_payload(
+            workflow_id=created.workflow_id,
+            run_id=created.run_id,
+            snapshot_ref="artifact://snapshot/source",
+        )
+        checkpoint_payload["preservedSteps"].append(
+            {
+                "logicalStepId": "notify",
+                "order": 4,
+                "status": "succeeded",
+                "sourceExecutionOrdinal": 1,
+                "artifacts": {"outputSummary": "artifact://summary/notify"},
+                "stateCheckpointRef": "artifact://workspace/before-notify",
+            }
+        )
+
+        with pytest.raises(
+            TemporalExecutionRecoveryCheckpointError,
+            match="must precede the failed step",
+        ):
+            await service.create_failed_step_recovery_execution(
+                created,
+                recovery_checkpoint_ref=None,
+                idempotency_key="recover-selected",
+                checkpoint_payload=checkpoint_payload,
+                selected_start_step_id="notify",
+            )
+
+
+@pytest.mark.asyncio
 async def test_failed_step_recovery_requires_hydrated_checkpoint_payload(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
Jira issue key: MM-735

Summary:
- Adds selected-step recovery request/response contracts and API handling alongside the existing last-failed-step resume path.
- Extends Temporal recovery payload creation so a chosen eligible step pins source workflow/run identity, checkpoint evidence, preserved prior steps, and selected-step audit details.
- Updates Mission Control task detail UI to present eligible/ineligible recovery step choices and distinguish selected-step recovery from last-failed-step recovery.
- Documents the selected-step recovery API behavior and updates generated frontend API types.

Tests run:
- ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/contract/test_temporal_execution_api.py --ui-args frontend/src/entrypoints/workflow-detail.test.tsx
  - 377 Python tests passed
  - 113 frontend tests passed

Remaining risks:
- Full ./tools/test_unit.sh was not run in this PR-publication step; targeted backend/frontend coverage for the changed recovery surfaces passed.
- Integration behavior depends on existing durable checkpoint/output evidence shape from completed task runs.
