### PR TITLE
MM-738 support OAuth tmate session transport

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -64,6 +64,7 @@ _FINALIZE_SUPERSEDING_STATUSES = (
     OAuthSessionStatus.REGISTERING_PROFILE,
     OAuthSessionStatus.SUCCEEDED,
 )
+_SUPPORTED_SESSION_TRANSPORTS = {"none", "moonmind_pty_ws", "tmate"}
 _oauth_terminal_pty_adapter_factory = create_docker_exec_pty_adapter
 
 def _make_terminal_output_sender(websocket: WebSocket):
@@ -75,6 +76,20 @@ def _make_terminal_output_sender(websocket: WebSocket):
             await websocket.send_text(text)
 
     return _send_terminal_output
+
+def _resolve_session_transport(runtime_id: str, requested_transport: str | None) -> str:
+    default_transport = _oauth_default(runtime_id, "session_transport") or "none"
+    raw_transport = requested_transport if requested_transport is not None else default_transport
+    session_transport = str(raw_transport).strip() or "none"
+    if session_transport not in _SUPPORTED_SESSION_TRANSPORTS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Unsupported OAuth session transport. "
+                "Expected one of: moonmind_pty_ws, none, tmate."
+            ),
+        )
+    return session_transport
 
 async def _close_for_pty_io_error(
     websocket: WebSocket,
@@ -308,6 +323,10 @@ async def create_oauth_session(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="volume_mount_path is required for OAuth sessions.",
         )
+    session_transport = _resolve_session_transport(
+        request.runtime_id,
+        request.session_transport,
+    )
 
     await _expire_stale_active_sessions(db, profile_id=request.profile_id)
 
@@ -349,7 +368,7 @@ async def create_oauth_session(
         profile_id=request.profile_id,
         volume_ref=volume_ref,
         volume_mount_path=volume_mount_path,
-        session_transport=_oauth_default(request.runtime_id, "session_transport") or "none",
+        session_transport=session_transport,
         account_label=request.account_label,
         status=OAuthSessionStatus.PENDING,
         requested_by_user_id=str(current_user.id),

--- a/api_service/api/schemas_oauth_sessions.py
+++ b/api_service/api/schemas_oauth_sessions.py
@@ -22,6 +22,7 @@ class CreateOAuthSessionRequest(BaseModel):
     profile_id: str
     volume_ref: Optional[str] = None
     volume_mount_path: Optional[str] = None
+    session_transport: Optional[str] = None
     provider_id: Optional[str] = None
     provider_label: Optional[str] = None
     account_label: str

--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -242,8 +242,15 @@ OAuth session state should be transport-neutral:
 Runtime provider registry entries may use `session_transport = "none"` while the
 interactive PTY bridge is unavailable or intentionally disabled. When the bridge
 is enabled, the transport identifier should be a MoonMind-owned value such as
-`moonmind_pty_ws`; provider profile and workflow semantics should not depend on
-the old `tmate` URL model.
+`moonmind_pty_ws`.
+
+MoonMind also supports an explicit `tmate` session transport for OAuth sessions
+that need an external terminal handoff. Tmate transport is requested per OAuth
+session, starts the same short-lived auth runner container, creates a tmate
+session inside that container, and stores the safe web/SSH connection refs on
+the OAuth session row through `terminal_session_id` and `terminal_bridge_id`.
+Provider profile and workflow semantics still depend on the OAuth session row,
+auth volume, and finalization endpoint rather than on the tmate URL itself.
 
 ### 5.4 Provider terminal finalization workflow
 

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -581,6 +581,36 @@ describe('ProviderProfilesManager form controls', () => {
     expect(await screen.findByText('OAuth: Pending')).toBeTruthy();
   });
 
+  it('shows a Tmate OAuth modal instead of opening the xterm terminal', async () => {
+    vi.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session_id: 'oas_settings_tmate',
+        runtime_id: 'codex_cli',
+        profile_id: 'codex-oauth',
+        status: 'awaiting_user',
+        terminal_session_id: 'https://tmate.io/t/oas_settings_tmate',
+        terminal_bridge_id: 'ssh tmate.io/t/oas_settings_tmate',
+        session_transport: 'tmate',
+      }),
+    } as Response);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    renderProviderProfilesManager([codexOauthProfile]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'OAuth codex-oauth' }));
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Tmate OAuth session',
+    });
+    expect(dialog.textContent).toContain('https://tmate.io/t/oas_settings_tmate');
+    expect(dialog.textContent).toContain('ssh tmate.io/t/oas_settings_tmate');
+    expect(screen.getByRole('link', { name: 'Open Tmate' }).getAttribute('href')).toBe(
+      'https://tmate.io/t/oas_settings_tmate',
+    );
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
   it('supports OAuth finalize without offering reconnect after success', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch')
       .mockResolvedValueOnce({

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -15,6 +15,7 @@ import {
 import { renderWithClient } from '../../utils/test-utils';
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -610,6 +611,58 @@ describe('ProviderProfilesManager form controls', () => {
     );
     expect(openSpy).not.toHaveBeenCalled();
   });
+
+  it('updates the Tmate OAuth modal when terminal refs arrive from polling', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          session_id: 'oas_settings_tmate_poll',
+          runtime_id: 'codex_cli',
+          profile_id: 'codex-oauth',
+          status: 'awaiting_user',
+          terminal_session_id: null,
+          terminal_bridge_id: null,
+          session_transport: 'tmate',
+        }),
+      } as Response)
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          session_id: 'oas_settings_tmate_poll',
+          runtime_id: 'codex_cli',
+          profile_id: 'codex-oauth',
+          status: 'awaiting_user',
+          terminal_session_id: 'https://tmate.io/t/oas_settings_tmate_poll',
+          terminal_bridge_id: 'ssh tmate.io/t/oas_settings_tmate_poll',
+          session_transport: 'tmate',
+        }),
+      } as Response);
+    vi.spyOn(window, 'open').mockReturnValue(null);
+
+    renderProviderProfilesManager([codexOauthProfile]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'OAuth codex-oauth' }));
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Tmate OAuth session',
+    });
+    expect(dialog.textContent).not.toContain('https://tmate.io/t/oas_settings_tmate_poll');
+
+    await waitFor(
+      () => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          '/api/v1/oauth-sessions/oas_settings_tmate_poll',
+          expect.objectContaining({ headers: { Accept: 'application/json' } }),
+        );
+        expect(screen.getByRole('link', { name: 'Open Tmate' }).getAttribute('href')).toBe(
+          'https://tmate.io/t/oas_settings_tmate_poll',
+        );
+      },
+      { timeout: 7000 },
+    );
+    expect(dialog.textContent).toContain('ssh tmate.io/t/oas_settings_tmate_poll');
+  }, 10000);
 
   it('supports OAuth finalize without offering reconnect after success', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch')

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -128,7 +128,7 @@ interface OAuthSessionResponse {
 
 interface OAuthSessionState {
   sessionId: string;
-  profileId?: string | undefined;
+  profileId: string;
   status: OAuthSessionStatus;
   sessionTransport?: string | null | undefined;
   terminalSessionId?: string | null | undefined;
@@ -138,6 +138,33 @@ interface OAuthSessionState {
 
 export const PROVIDER_PROFILE_QUERY_KEY = ['provider-profiles'] as const;
 const PROVIDER_PROFILE_REFRESH_STORAGE_KEY = 'moonmind:provider-profile-updated';
+
+function oauthSessionStateFromResponse(
+  session: OAuthSessionResponse,
+  fallbackProfileId?: string,
+): OAuthSessionState {
+  return {
+    sessionId: session.session_id,
+    profileId: session.profile_id || fallbackProfileId || '',
+    status: session.status,
+    sessionTransport: session.session_transport,
+    terminalSessionId: session.terminal_session_id,
+    terminalBridgeId: session.terminal_bridge_id,
+    failureReason: session.failure_reason,
+  };
+}
+
+function oauthSessionStatesEqual(left: OAuthSessionState, right: OAuthSessionState): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.profileId === right.profileId &&
+    left.status === right.status &&
+    left.sessionTransport === right.sessionTransport &&
+    left.terminalSessionId === right.terminalSessionId &&
+    left.terminalBridgeId === right.terminalBridgeId &&
+    left.failureReason === right.failureReason
+  );
+}
 
 export function defaultFormState(): ProviderProfileFormState {
   return {
@@ -582,6 +609,23 @@ export function ProviderProfilesManager({
     });
   };
 
+  const applyOAuthSessionResponse = (session: OAuthSessionResponse, fallbackProfileId?: string) => {
+    const sessionState = oauthSessionStateFromResponse(session, fallbackProfileId);
+    setOauthSessions((current) => ({
+      ...current,
+      [sessionState.profileId]: sessionState,
+    }));
+    if (sessionState.sessionTransport === 'tmate') {
+      setTmateOAuthSession(sessionState);
+    } else {
+      window.open(
+        `/oauth-terminal?session_id=${encodeURIComponent(sessionState.sessionId)}`,
+        '_blank',
+        'noopener,noreferrer',
+      );
+    }
+  };
+
   useEffect(() => {
     claudeEnrollmentProfileIdRef.current = claudeEnrollment?.profile.profile_id ?? null;
   }, [claudeEnrollment?.profile.profile_id]);
@@ -909,35 +953,7 @@ export function ProviderProfilesManager({
       return response.json() as Promise<OAuthSessionResponse>;
     },
     onSuccess: (session) => {
-      setOauthSessions((current) => ({
-        ...current,
-        [session.profile_id]: {
-          sessionId: session.session_id,
-          profileId: session.profile_id,
-          status: session.status,
-          sessionTransport: session.session_transport,
-          terminalSessionId: session.terminal_session_id,
-          terminalBridgeId: session.terminal_bridge_id,
-          failureReason: session.failure_reason,
-        },
-      }));
-      if (session.session_transport === 'tmate') {
-        setTmateOAuthSession({
-          sessionId: session.session_id,
-          profileId: session.profile_id,
-          status: session.status,
-          sessionTransport: session.session_transport,
-          terminalSessionId: session.terminal_session_id,
-          terminalBridgeId: session.terminal_bridge_id,
-          failureReason: session.failure_reason,
-        });
-      } else {
-        window.open(
-          `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
-          '_blank',
-          'noopener,noreferrer',
-        );
-      }
+      applyOAuthSessionResponse(session);
       onNotice({
         level: 'ok',
         text: `OAuth session "${session.session_id}" started for "${session.profile_id}".`,
@@ -967,7 +983,12 @@ export function ProviderProfilesManager({
     onSuccess: ({ profileId }) => {
       setOauthSessions((current) => ({
         ...current,
-        [profileId]: { ...current[profileId], sessionId: current[profileId]?.sessionId ?? '', status: 'cancelled' },
+        [profileId]: {
+          ...current[profileId],
+          sessionId: current[profileId]?.sessionId ?? '',
+          profileId,
+          status: 'cancelled',
+        },
       }));
       onNotice({ level: 'ok', text: `OAuth session for "${profileId}" cancelled.` });
     },
@@ -995,7 +1016,7 @@ export function ProviderProfilesManager({
     onSuccess: ({ profileId, sessionId }) => {
       setOauthSessions((current) => ({
         ...current,
-        [profileId]: { sessionId, status: 'succeeded' },
+        [profileId]: { ...current[profileId], sessionId, profileId, status: 'succeeded' },
       }));
       setTmateOAuthSession((current) =>
         current?.sessionId === sessionId ? { ...current, status: 'succeeded' } : current,
@@ -1026,35 +1047,7 @@ export function ProviderProfilesManager({
       return { profileId, session };
     },
     onSuccess: ({ profileId, session }) => {
-      setOauthSessions((current) => ({
-        ...current,
-        [profileId]: {
-          sessionId: session.session_id,
-          profileId: session.profile_id,
-          status: session.status,
-          sessionTransport: session.session_transport,
-          terminalSessionId: session.terminal_session_id,
-          terminalBridgeId: session.terminal_bridge_id,
-          failureReason: session.failure_reason,
-        },
-      }));
-      if (session.session_transport === 'tmate') {
-        setTmateOAuthSession({
-          sessionId: session.session_id,
-          profileId: session.profile_id,
-          status: session.status,
-          sessionTransport: session.session_transport,
-          terminalSessionId: session.terminal_session_id,
-          terminalBridgeId: session.terminal_bridge_id,
-          failureReason: session.failure_reason,
-        });
-      } else {
-        window.open(
-          `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
-          '_blank',
-          'noopener,noreferrer',
-        );
-      }
+      applyOAuthSessionResponse(session, profileId);
       onNotice({ level: 'ok', text: `OAuth session for "${profileId}" retried.` });
     },
     onError: (error: Error) => {
@@ -1131,26 +1124,31 @@ export function ProviderProfilesManager({
         let hasChanges = false;
         for (const { profileId, session } of appliedUpdates) {
           const existing = current[profileId];
-          if (
-            existing &&
-            existing.sessionId === session.session_id &&
-            existing.status === session.status &&
-            existing.failureReason === session.failure_reason
-          ) {
+          const sessionState = oauthSessionStateFromResponse(session, profileId);
+          if (existing && oauthSessionStatesEqual(existing, sessionState)) {
             continue;
           }
-          next[profileId] = {
-            sessionId: session.session_id,
-            profileId,
-            status: session.status,
-            sessionTransport: session.session_transport,
-            terminalSessionId: session.terminal_session_id,
-            terminalBridgeId: session.terminal_bridge_id,
-            failureReason: session.failure_reason,
-          };
+          next[profileId] = sessionState;
           hasChanges = true;
         }
         return hasChanges ? next : current;
+      });
+
+      setTmateOAuthSession((current) => {
+        if (!current) {
+          return current;
+        }
+        const matchingUpdate = appliedUpdates.find(
+          ({ session }) => session.session_id === current.sessionId,
+        );
+        if (!matchingUpdate) {
+          return current;
+        }
+        const sessionState = oauthSessionStateFromResponse(
+          matchingUpdate.session,
+          matchingUpdate.profileId,
+        );
+        return oauthSessionStatesEqual(current, sessionState) ? current : sessionState;
       });
 
       if (appliedUpdates.some(({ session }) => session.status === 'succeeded')) {
@@ -1664,7 +1662,7 @@ export function ProviderProfilesManager({
                   className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
                   onClick={() => {
                     finalizeOAuthMutation.mutate({
-                      profileId: tmateOAuthSession.profileId ?? '',
+                      profileId: tmateOAuthSession.profileId,
                       sessionId: tmateOAuthSession.sessionId,
                     });
                   }}

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -120,13 +120,19 @@ interface OAuthSessionResponse {
   runtime_id: string;
   profile_id: string;
   status: OAuthSessionStatus;
+  terminal_session_id?: string | null;
+  terminal_bridge_id?: string | null;
   session_transport?: string | null;
   failure_reason?: string | null;
 }
 
 interface OAuthSessionState {
   sessionId: string;
+  profileId?: string | undefined;
   status: OAuthSessionStatus;
+  sessionTransport?: string | null | undefined;
+  terminalSessionId?: string | null | undefined;
+  terminalBridgeId?: string | null | undefined;
   failureReason?: string | null | undefined;
 }
 
@@ -556,6 +562,7 @@ export function ProviderProfilesManager({
   const [form, setForm] = useState<ProviderProfileFormState>(() => defaultFormState());
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
   const [oauthSessions, setOauthSessions] = useState<Record<string, OAuthSessionState>>({});
+  const [tmateOAuthSession, setTmateOAuthSession] = useState<OAuthSessionState | null>(null);
   const [claudeEnrollment, setClaudeEnrollment] = useState<ClaudeEnrollmentState | null>(null);
   const claudeEnrollmentDrawerRef = useRef<HTMLDivElement | null>(null);
   const claudeEnrollmentProfileIdRef = useRef<string | null>(null);
@@ -906,15 +913,31 @@ export function ProviderProfilesManager({
         ...current,
         [session.profile_id]: {
           sessionId: session.session_id,
+          profileId: session.profile_id,
           status: session.status,
+          sessionTransport: session.session_transport,
+          terminalSessionId: session.terminal_session_id,
+          terminalBridgeId: session.terminal_bridge_id,
           failureReason: session.failure_reason,
         },
       }));
-      window.open(
-        `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
-        '_blank',
-        'noopener,noreferrer',
-      );
+      if (session.session_transport === 'tmate') {
+        setTmateOAuthSession({
+          sessionId: session.session_id,
+          profileId: session.profile_id,
+          status: session.status,
+          sessionTransport: session.session_transport,
+          terminalSessionId: session.terminal_session_id,
+          terminalBridgeId: session.terminal_bridge_id,
+          failureReason: session.failure_reason,
+        });
+      } else {
+        window.open(
+          `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
+          '_blank',
+          'noopener,noreferrer',
+        );
+      }
       onNotice({
         level: 'ok',
         text: `OAuth session "${session.session_id}" started for "${session.profile_id}".`,
@@ -974,6 +997,9 @@ export function ProviderProfilesManager({
         ...current,
         [profileId]: { sessionId, status: 'succeeded' },
       }));
+      setTmateOAuthSession((current) =>
+        current?.sessionId === sessionId ? { ...current, status: 'succeeded' } : current,
+      );
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
       onNotice({ level: 'ok', text: `OAuth session for "${profileId}" finalized.` });
     },
@@ -1004,15 +1030,31 @@ export function ProviderProfilesManager({
         ...current,
         [profileId]: {
           sessionId: session.session_id,
+          profileId: session.profile_id,
           status: session.status,
+          sessionTransport: session.session_transport,
+          terminalSessionId: session.terminal_session_id,
+          terminalBridgeId: session.terminal_bridge_id,
           failureReason: session.failure_reason,
         },
       }));
-      window.open(
-        `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
-        '_blank',
-        'noopener,noreferrer',
-      );
+      if (session.session_transport === 'tmate') {
+        setTmateOAuthSession({
+          sessionId: session.session_id,
+          profileId: session.profile_id,
+          status: session.status,
+          sessionTransport: session.session_transport,
+          terminalSessionId: session.terminal_session_id,
+          terminalBridgeId: session.terminal_bridge_id,
+          failureReason: session.failure_reason,
+        });
+      } else {
+        window.open(
+          `/oauth-terminal?session_id=${encodeURIComponent(session.session_id)}`,
+          '_blank',
+          'noopener,noreferrer',
+        );
+      }
       onNotice({ level: 'ok', text: `OAuth session for "${profileId}" retried.` });
     },
     onError: (error: Error) => {
@@ -1099,7 +1141,11 @@ export function ProviderProfilesManager({
           }
           next[profileId] = {
             sessionId: session.session_id,
+            profileId,
             status: session.status,
+            sessionTransport: session.session_transport,
+            terminalSessionId: session.terminal_session_id,
+            terminalBridgeId: session.terminal_bridge_id,
             failureReason: session.failure_reason,
           };
           hasChanges = true;
@@ -1541,6 +1587,96 @@ export function ProviderProfilesManager({
           </tbody>
         </table>
       </div>
+
+      {tmateOAuthSession ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              setTmateOAuthSession(null);
+            }
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tmate-oauth-session-title"
+            className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-5 shadow-2xl outline-none dark:border-slate-800 dark:bg-slate-900"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h4
+                  id="tmate-oauth-session-title"
+                  className="text-base font-semibold text-slate-900 dark:text-white"
+                >
+                  Tmate OAuth session
+                </h4>
+                <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                  Complete provider login in the Tmate terminal, then finalize this OAuth session.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:border-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
+                onClick={() => setTmateOAuthSession(null)}
+              >
+                Close
+              </button>
+            </div>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div>
+                <dt className="font-medium text-slate-700 dark:text-slate-300">Session</dt>
+                <dd className="mt-1 font-mono text-xs text-slate-600 dark:text-slate-400">
+                  {tmateOAuthSession.sessionId}
+                </dd>
+              </div>
+              {tmateOAuthSession.terminalSessionId ? (
+                <div>
+                  <dt className="font-medium text-slate-700 dark:text-slate-300">Web terminal</dt>
+                  <dd className="mt-1 break-all font-mono text-xs text-slate-600 dark:text-slate-400">
+                    {tmateOAuthSession.terminalSessionId}
+                  </dd>
+                </div>
+              ) : null}
+              {tmateOAuthSession.terminalBridgeId ? (
+                <div>
+                  <dt className="font-medium text-slate-700 dark:text-slate-300">SSH terminal</dt>
+                  <dd className="mt-1 break-all font-mono text-xs text-slate-600 dark:text-slate-400">
+                    {tmateOAuthSession.terminalBridgeId}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+            <div className="mt-5 flex flex-wrap gap-2">
+              {tmateOAuthSession.terminalSessionId ? (
+                <a
+                  className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+                  href={tmateOAuthSession.terminalSessionId}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Open Tmate
+                </a>
+              ) : null}
+              {canFinalizeOAuthStatus(tmateOAuthSession.status) ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
+                  onClick={() => {
+                    finalizeOAuthMutation.mutate({
+                      profileId: tmateOAuthSession.profileId ?? '',
+                      sessionId: tmateOAuthSession.sessionId,
+                    });
+                  }}
+                  disabled={finalizeOAuthMutation.isPending}
+                >
+                  Finalize Provider Profile
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {claudeEnrollment ? (
         <div

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3753,6 +3753,8 @@ export interface components {
             volume_ref?: string | null;
             /** Volume Mount Path */
             volume_mount_path?: string | null;
+            /** Session Transport */
+            session_transport?: string | null;
             /** Provider Id */
             provider_id?: string | null;
             /** Provider Label */

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -85,6 +85,7 @@ async def oauth_session_start_auth_runner(
     runtime_id = request.get("runtime_id", "")
     volume_ref = request.get("volume_ref", "")
     volume_mount_path = request.get("volume_mount_path", "")
+    session_transport = str(request.get("session_transport") or "moonmind_pty_ws").strip()
     session_ttl = int(request.get("session_ttl", 1800))
 
     if not session_id:
@@ -95,6 +96,27 @@ async def oauth_session_start_auth_runner(
         raise ValueError("volume_mount_path is required")
     session_ttl = max(60, min(session_ttl, 86400))
     bootstrap_command = get_provider_bootstrap_command(runtime_id)
+
+    if session_transport == "tmate":
+        from moonmind.workflows.temporal.runtime.terminal_bridge import start_tmate_auth_runner_container
+
+        bridge_info = await start_tmate_auth_runner_container(
+            session_id=session_id,
+            runtime_id=runtime_id,
+            volume_ref=volume_ref,
+            volume_mount_path=volume_mount_path,
+            session_ttl=session_ttl,
+            bootstrap_command=bootstrap_command,
+        )
+        bridge_info.setdefault(
+            "expires_at",
+            (datetime.now(timezone.utc) + timedelta(seconds=session_ttl)).isoformat(),
+        )
+        bridge_info.setdefault("session_transport", "tmate")
+        return bridge_info
+
+    if session_transport != "moonmind_pty_ws":
+        raise ValueError(f"Unsupported OAuth session transport: {session_transport}")
 
     from moonmind.workflows.temporal.runtime.terminal_bridge import start_terminal_bridge_container
     

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -20,6 +20,7 @@ _SECRET_ASSIGNMENT_PATTERN = re.compile(
 )
 _DEFAULT_OAUTH_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind:latest"
 _DEFAULT_OAUTH_RUNNER_USER = "1000:1000"
+_TMATE_SOCKET = "/tmp/moonmind-oauth-tmate.sock"
 
 class TerminalBridgeFrameError(ValueError):
     """Raised when a browser terminal frame is unsupported or unsafe."""
@@ -122,6 +123,11 @@ def _runner_environment_args(runtime_id: str, volume_mount_path: str) -> list[st
             ]
         )
     return args
+
+def _docker_command_error(stderr: bytes, returncode: int) -> RuntimeError:
+    error_output = _redact_startup_output(stderr)
+    detail = f": {error_output}" if error_output else ""
+    return RuntimeError(f"Failed to start auth container with exit code {returncode}{detail}")
 
 class DockerExecPtyAdapter:
     """Docker exec PTY adapter for the OAuth auth-runner container."""
@@ -337,15 +343,116 @@ async def start_terminal_bridge_container(
         raise TimeoutError("Timed out while starting auth container")
 
     if proc.returncode != 0:
-        error_output = _redact_startup_output(stderr)
-        detail = f": {error_output}" if error_output else ""
-        raise RuntimeError(
-            f"Failed to start auth container with exit code {proc.returncode}{detail}"
-        )
+        raise _docker_command_error(stderr, proc.returncode)
 
     return {
         "container_name": container_name,
         "terminal_session_id": f"term_{session_id}",
         "terminal_bridge_id": f"br_{session_id}",
         "session_transport": "moonmind_pty_ws",
+    }
+
+async def start_tmate_auth_runner_container(
+    session_id: str,
+    runtime_id: str,
+    volume_ref: str,
+    volume_mount_path: str,
+    session_ttl: int,
+    bootstrap_command: tuple[str, ...] | list[str],
+) -> dict[str, Any]:
+    """Start a Tmate-backed OAuth auth runner and return safe connection refs."""
+    command = tuple(str(part).strip() for part in bootstrap_command)
+    if not command or any(not part for part in command):
+        raise ValueError("provider bootstrap command is not configured")
+
+    container_name = f"moonmind_auth_{session_id}"
+    runner_image = os.environ.get(
+        "MOONMIND_OAUTH_RUNNER_IMAGE",
+        _DEFAULT_OAUTH_RUNNER_IMAGE,
+    )
+    executable = shlex.quote(command[0])
+    idle_command = (
+        "command -v tmate >/dev/null 2>&1 "
+        "|| { echo 'OAuth runner image does not contain tmate' >&2; exit 127; }; "
+        f"command -v {executable} >/dev/null 2>&1 "
+        f"|| {{ echo 'OAuth runner image does not contain {executable}' >&2; exit 127; }}; "
+        f"sleep {int(session_ttl)}"
+    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "run", "-d", "--init", "-i", "-t", "--rm",
+            "--name", container_name,
+            "--label", "moonmind.oauth_session=true",
+            "--label", f"moonmind.oauth_session_id={session_id}",
+            "--label", f"moonmind.runtime_id={runtime_id}",
+            "--label", "moonmind.oauth_session_transport=tmate",
+            "--user", _oauth_runner_user(),
+            *_runner_environment_args(runtime_id, volume_mount_path),
+            "-v", f"{volume_ref}:{volume_mount_path}",
+            runner_image,
+            "/bin/sh",
+            "-lc",
+            idle_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "Docker CLI is not available on this worker. "
+            "Ensure Docker is installed and 'docker' is on the PATH before using Tmate OAuth sessions."
+        ) from exc
+
+    try:
+        _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise TimeoutError("Timed out while starting Tmate auth container")
+
+    if proc.returncode != 0:
+        raise _docker_command_error(stderr, proc.returncode)
+
+    bootstrap_shell = " ".join(shlex.quote(part) for part in command)
+    tmate_start_command = (
+        f"tmate -S {shlex.quote(_TMATE_SOCKET)} new-session -d {shlex.quote(bootstrap_shell)} && "
+        f"tmate -S {shlex.quote(_TMATE_SOCKET)} wait tmate-ready && "
+        f"tmate -S {shlex.quote(_TMATE_SOCKET)} display -p '#{{tmate_web}}' && "
+        f"tmate -S {shlex.quote(_TMATE_SOCKET)} display -p '#{{tmate_ssh}}'"
+    )
+    try:
+        exec_proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "exec",
+            container_name,
+            "/bin/sh",
+            "-lc",
+            tmate_start_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "Docker CLI is not available on this worker. "
+            "Ensure Docker is installed and 'docker' is on the PATH before using Tmate OAuth sessions."
+        ) from exc
+
+    try:
+        stdout, stderr = await asyncio.wait_for(exec_proc.communicate(), timeout=45)
+    except asyncio.TimeoutError:
+        raise TimeoutError("Timed out while starting Tmate OAuth session")
+
+    if exec_proc.returncode != 0:
+        raise _docker_command_error(stderr, exec_proc.returncode)
+
+    refs = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
+    web_url = refs[0] if refs else ""
+    ssh_command = refs[1] if len(refs) > 1 else ""
+    if not web_url:
+        raise RuntimeError("Tmate did not return a web connection URL")
+
+    return {
+        "container_name": container_name,
+        "terminal_session_id": web_url,
+        "terminal_bridge_id": ssh_command,
+        "session_transport": "tmate",
     }

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -129,6 +129,33 @@ def _docker_command_error(stderr: bytes, returncode: int) -> RuntimeError:
     detail = f": {error_output}" if error_output else ""
     return RuntimeError(f"Failed to start auth container with exit code {returncode}{detail}")
 
+
+async def _create_docker_subprocess(*args: str) -> asyncio.subprocess.Process:
+    try:
+        return await asyncio.create_subprocess_exec(
+            "docker",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "Docker CLI is not available on this worker. "
+            "Ensure Docker is installed and 'docker' is on the PATH before using OAuth terminal sessions."
+        ) from exc
+
+
+async def _stop_docker_container(container_name: str) -> None:
+    try:
+        proc = await _create_docker_subprocess("stop", container_name)
+        await asyncio.wait_for(proc.communicate(), timeout=15)
+    except Exception:
+        logger.warning(
+            "Failed to stop OAuth auth runner container after startup failure",
+            exc_info=True,
+        )
+
+
 class DockerExecPtyAdapter:
     """Docker exec PTY adapter for the OAuth auth-runner container."""
 
@@ -310,30 +337,20 @@ async def start_terminal_bridge_container(
         f"|| {{ echo 'OAuth runner image does not contain {executable}' >&2; exit 127; }}; "
         f"sleep {int(session_ttl)}"
     )
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "run", "-d", "--init", "-i", "-t", "--rm",
-            "--name", container_name,
-            "--label", "moonmind.oauth_session=true",
-            "--label", f"moonmind.oauth_session_id={session_id}",
-            "--label", f"moonmind.runtime_id={runtime_id}",
-            "--user", _oauth_runner_user(),
-            *_runner_environment_args(runtime_id, volume_mount_path),
-            "-v", f"{volume_ref}:{volume_mount_path}",
-            runner_image,
-            "/bin/sh",
-            "-lc",
-            idle_command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        logger.error("Failed to start auth container: docker CLI not found on PATH")
-        raise RuntimeError(
-            "Docker CLI is not available on this worker. "
-            "Ensure Docker is installed and 'docker' is on the PATH, "
-            "or configure a different terminal bridge backend."
-        ) from exc
+    proc = await _create_docker_subprocess(
+        "run", "-d", "--init", "-i", "-t", "--rm",
+        "--name", container_name,
+        "--label", "moonmind.oauth_session=true",
+        "--label", f"moonmind.oauth_session_id={session_id}",
+        "--label", f"moonmind.runtime_id={runtime_id}",
+        "--user", _oauth_runner_user(),
+        *_runner_environment_args(runtime_id, volume_mount_path),
+        "-v", f"{volume_ref}:{volume_mount_path}",
+        runner_image,
+        "/bin/sh",
+        "-lc",
+        idle_command,
+    )
 
     try:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
@@ -378,29 +395,21 @@ async def start_tmate_auth_runner_container(
         f"|| {{ echo 'OAuth runner image does not contain {executable}' >&2; exit 127; }}; "
         f"sleep {int(session_ttl)}"
     )
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "run", "-d", "--init", "-i", "-t", "--rm",
-            "--name", container_name,
-            "--label", "moonmind.oauth_session=true",
-            "--label", f"moonmind.oauth_session_id={session_id}",
-            "--label", f"moonmind.runtime_id={runtime_id}",
-            "--label", "moonmind.oauth_session_transport=tmate",
-            "--user", _oauth_runner_user(),
-            *_runner_environment_args(runtime_id, volume_mount_path),
-            "-v", f"{volume_ref}:{volume_mount_path}",
-            runner_image,
-            "/bin/sh",
-            "-lc",
-            idle_command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        raise RuntimeError(
-            "Docker CLI is not available on this worker. "
-            "Ensure Docker is installed and 'docker' is on the PATH before using Tmate OAuth sessions."
-        ) from exc
+    proc = await _create_docker_subprocess(
+        "run", "-d", "--init", "-i", "-t", "--rm",
+        "--name", container_name,
+        "--label", "moonmind.oauth_session=true",
+        "--label", f"moonmind.oauth_session_id={session_id}",
+        "--label", f"moonmind.runtime_id={runtime_id}",
+        "--label", "moonmind.oauth_session_transport=tmate",
+        "--user", _oauth_runner_user(),
+        *_runner_environment_args(runtime_id, volume_mount_path),
+        "-v", f"{volume_ref}:{volume_mount_path}",
+        runner_image,
+        "/bin/sh",
+        "-lc",
+        idle_command,
+    )
 
     try:
         _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
@@ -419,35 +428,29 @@ async def start_tmate_auth_runner_container(
         f"tmate -S {shlex.quote(_TMATE_SOCKET)} display -p '#{{tmate_web}}' && "
         f"tmate -S {shlex.quote(_TMATE_SOCKET)} display -p '#{{tmate_ssh}}'"
     )
-    try:
-        exec_proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "exec",
-            container_name,
-            "/bin/sh",
-            "-lc",
-            tmate_start_command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        raise RuntimeError(
-            "Docker CLI is not available on this worker. "
-            "Ensure Docker is installed and 'docker' is on the PATH before using Tmate OAuth sessions."
-        ) from exc
+    exec_proc = await _create_docker_subprocess(
+        "exec",
+        container_name,
+        "/bin/sh",
+        "-lc",
+        tmate_start_command,
+    )
 
     try:
         stdout, stderr = await asyncio.wait_for(exec_proc.communicate(), timeout=45)
     except asyncio.TimeoutError:
+        await _stop_docker_container(container_name)
         raise TimeoutError("Timed out while starting Tmate OAuth session")
 
     if exec_proc.returncode != 0:
+        await _stop_docker_container(container_name)
         raise _docker_command_error(stderr, exec_proc.returncode)
 
     refs = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
     web_url = refs[0] if refs else ""
     ssh_command = refs[1] if len(refs) > 1 else ""
     if not web_url:
+        await _stop_docker_container(container_name)
         raise RuntimeError("Tmate did not return a web connection URL")
 
     return {

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -211,6 +211,7 @@ class MoonMindOAuthSessionWorkflow:
                         "runtime_id": runtime_id,
                         "volume_ref": volume_ref,
                         "volume_mount_path": volume_mount_path,
+                        "session_transport": session_transport,
                         "session_ttl": session_ttl,
                     },
                     task_queue=RUNNER_ACTIVITY_TASK_QUEUE,

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -372,6 +372,7 @@ async def test_oauth_session_workflow_missing_transport_uses_legacy_bridge_defau
             "runtime_id": "codex_cli",
             "volume_ref": "vol_123",
             "volume_mount_path": "/mnt/auth",
+            "session_transport": "moonmind_pty_ws",
             "session_ttl": 1800,
         }
     ]
@@ -441,6 +442,7 @@ async def test_oauth_session_workflow_success_starts_and_stops_runner() -> None:
             "runtime_id": "codex_cli",
             "volume_ref": "vol_123",
             "volume_mount_path": "/mnt/auth",
+            "session_transport": "moonmind_pty_ws",
             "session_ttl": 1800,
         }
     ]
@@ -452,6 +454,73 @@ async def test_oauth_session_workflow_success_starts_and_stops_runner() -> None:
             "container_name": "mocked_container",
         }
     ]
+
+async def test_oauth_session_workflow_routes_tmate_transport_to_runner() -> None:
+    """Tmate OAuth sessions carry the requested transport through the boundary."""
+    start_payloads: list[dict] = []
+    terminal_payloads: list[dict] = []
+
+    @activity.defn(name="oauth_session.start_auth_runner")
+    async def record_start_auth_runner(request: dict) -> dict:
+        start_payloads.append(request)
+        return {
+            "container_name": "mocked_tmate_container",
+            "terminal_session_id": "https://tmate.io/t/sess_runner_tmate",
+            "terminal_bridge_id": "ssh tmate.io/t/sess_runner_tmate",
+            "session_transport": "tmate",
+        }
+
+    @activity.defn(name="oauth_session.update_terminal_session")
+    async def record_update_terminal_session(request: dict) -> dict:
+        terminal_payloads.append(request)
+        return {}
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with _oauth_workers(
+            env,
+            activity_activities=[
+                record_update_terminal_session,
+                mock_update_status,
+                mock_register_profile,
+                mock_mark_failed,
+            ],
+            runner_activities=[
+                mock_ensure_volume,
+                record_start_auth_runner,
+                mock_verify_cli_fingerprint,
+                mock_stop_auth_runner,
+            ],
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindOAuthSessionWorkflow.run,
+                {
+                    "session_id": "sess_runner_tmate",
+                    "runtime_id": "codex_cli",
+                    "volume_ref": "vol_123",
+                    "volume_mount_path": "/mnt/auth",
+                    "session_transport": "tmate",
+                },
+                id="oauth-session:sess_runner_tmate",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+            await handle.signal(MoonMindOAuthSessionWorkflow.finalize)
+            result = await handle.result()
+
+    assert result["status"] == "succeeded"
+    assert start_payloads == [
+        {
+            "session_id": "sess_runner_tmate",
+            "runtime_id": "codex_cli",
+            "volume_ref": "vol_123",
+            "volume_mount_path": "/mnt/auth",
+            "session_transport": "tmate",
+            "session_ttl": 1800,
+        }
+    ]
+    assert terminal_payloads[0]["terminal_session_id"] == "https://tmate.io/t/sess_runner_tmate"
+    assert terminal_payloads[0]["terminal_bridge_id"] == "ssh tmate.io/t/sess_runner_tmate"
+    assert terminal_payloads[0]["session_transport"] == "tmate"
 
 async def test_oauth_session_workflow_rejects_codex_oauth_input_without_refs() -> None:
     """Codex OAuth sessions route missing refs through the failure activity path."""

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -244,6 +244,47 @@ async def test_create_oauth_session_returns_terminal_transport_refs(
     assert body["session_transport"] == "moonmind_pty_ws"
 
 @pytest.mark.asyncio
+async def test_create_oauth_session_accepts_explicit_tmate_transport(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = {}
+
+    async def _capture_start(session_model):
+        captured["session_transport"] = session_model.session_transport
+        session_model.terminal_session_id = "https://tmate.io/t/oas_tmate"
+        session_model.terminal_bridge_id = "ssh tmate.io/t/oas_tmate"
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _capture_start,
+    )
+
+    payload = _oauth_payload("codex-cli-tmate")
+    payload["session_transport"] = "tmate"
+    async with client_app as client:
+        response = await client.post("/api/v1/oauth-sessions", json=payload)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["session_transport"] == "tmate"
+    assert body["terminal_session_id"] == "https://tmate.io/t/oas_tmate"
+    assert body["terminal_bridge_id"] == "ssh tmate.io/t/oas_tmate"
+    assert captured["session_transport"] == "tmate"
+
+@pytest.mark.asyncio
+async def test_create_oauth_session_rejects_unknown_transport(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = _oauth_payload("codex-cli-bad-transport")
+    payload["session_transport"] = "legacy-shell"
+
+    async with client_app as client:
+        response = await client.post("/api/v1/oauth-sessions", json=payload)
+
+    assert response.status_code == 422
+    assert "Unsupported OAuth session transport" in response.text
+
+@pytest.mark.asyncio
 async def test_reconnect_oauth_session_preserves_terminal_transport(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -395,6 +395,43 @@ async def test_start_auth_runner_resolves_claude_bootstrap_command(
     assert observed["volume_mount_path"] == "/home/app/.claude"
 
 @pytest.mark.asyncio
+async def test_start_auth_runner_routes_tmate_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    async def fake_start_tmate_auth_runner_container(**kwargs):
+        observed.update(kwargs)
+        return {
+            "container_name": "moonmind_auth_oas_tmate_activityrunner",
+            "terminal_session_id": "https://tmate.io/t/oas_tmate_activityrunner",
+            "terminal_bridge_id": "ssh tmate.io/t/oas_tmate_activityrunner",
+            "session_transport": "tmate",
+        }
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.terminal_bridge.start_tmate_auth_runner_container",
+        fake_start_tmate_auth_runner_container,
+    )
+
+    result = await oauth_session_start_auth_runner(
+        {
+            "session_id": "oas_tmate_activityrunner",
+            "runtime_id": "codex_cli",
+            "volume_ref": "codex_auth_volume",
+            "volume_mount_path": "/home/app/.codex",
+            "session_transport": "tmate",
+            "session_ttl": 120,
+        }
+    )
+
+    assert result["session_transport"] == "tmate"
+    assert result["terminal_session_id"] == "https://tmate.io/t/oas_tmate_activityrunner"
+    assert observed["bootstrap_command"] == ("codex", "login", "--device-auth")
+    assert observed["volume_ref"] == "codex_auth_volume"
+    assert observed["volume_mount_path"] == "/home/app/.codex"
+
+@pytest.mark.asyncio
 async def test_start_auth_runner_rejects_missing_provider_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_terminal_bridge.py
+++ b/tests/unit/services/temporal/runtime/test_terminal_bridge.py
@@ -10,6 +10,7 @@ from moonmind.workflows.temporal.runtime.terminal_bridge import (
     TerminalBridgeConnection,
     TerminalBridgeFrameError,
     start_terminal_bridge_container,
+    start_tmate_auth_runner_container,
 )
 
 def test_terminal_bridge_handles_resize_input_output_and_heartbeat() -> None:
@@ -169,13 +170,19 @@ async def test_terminal_bridge_streams_output_to_async_callback() -> None:
     assert bridge.output_event_count == 2
 
 class _FakeProcess:
-    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+    def __init__(
+        self,
+        returncode: int = 0,
+        stderr: bytes = b"",
+        stdout: bytes = b"container-id\n",
+    ) -> None:
         self.returncode = returncode
         self._stderr = stderr
+        self._stdout = stdout
         self.killed = False
 
     async def communicate(self) -> tuple[bytes, bytes]:
-        return b"container-id\n", self._stderr
+        return self._stdout, self._stderr
 
     def kill(self) -> None:
         self.killed = True
@@ -218,6 +225,52 @@ async def test_start_terminal_bridge_container_uses_provider_bootstrap_command(
     assert "sleep 1800" in observed[-1]
     assert observed[-1].count("codex") == 2
     assert observed[-1] != "codex login --device-auth"
+
+@pytest.mark.asyncio
+async def test_start_tmate_auth_runner_container_returns_connection_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        calls.append(tuple(str(arg) for arg in args))
+        if args[:2] == ("docker", "exec"):
+            return _FakeProcess(
+                stdout=(
+                    b"https://tmate.io/t/oas_terminal_tmate\n"
+                    b"ssh tmate.io/t/oas_terminal_tmate\n"
+                )
+            )
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        terminal_bridge.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await start_tmate_auth_runner_container(
+        session_id="oas_terminal_tmate",
+        runtime_id="codex_cli",
+        volume_ref="codex_auth_volume",
+        volume_mount_path="/home/app/.codex",
+        session_ttl=1800,
+        bootstrap_command=("codex", "login", "--device-auth"),
+    )
+
+    assert result == {
+        "container_name": "moonmind_auth_oas_terminal_tmate",
+        "terminal_session_id": "https://tmate.io/t/oas_terminal_tmate",
+        "terminal_bridge_id": "ssh tmate.io/t/oas_terminal_tmate",
+        "session_transport": "tmate",
+    }
+    assert len(calls) == 2
+    assert calls[0][:3] == ("docker", "run", "-d")
+    assert "moonmind.oauth_session_transport=tmate" in calls[0]
+    assert "command -v tmate" in calls[0][-1]
+    assert calls[1][:4] == ("docker", "exec", "moonmind_auth_oas_terminal_tmate", "/bin/sh")
+    assert "tmate -S" in calls[1][-1]
+    assert "codex login --device-auth" in calls[1][-1]
 
 @pytest.mark.asyncio
 async def test_start_terminal_bridge_container_uses_claude_home_environment(

--- a/tests/unit/services/temporal/runtime/test_terminal_bridge.py
+++ b/tests/unit/services/temporal/runtime/test_terminal_bridge.py
@@ -273,6 +273,36 @@ async def test_start_tmate_auth_runner_container_returns_connection_refs(
     assert "codex login --device-auth" in calls[1][-1]
 
 @pytest.mark.asyncio
+async def test_start_tmate_auth_runner_container_stops_container_when_tmate_start_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        calls.append(tuple(str(arg) for arg in args))
+        if args[:2] == ("docker", "exec"):
+            return _FakeProcess(returncode=1, stderr=b"tmate failed")
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        terminal_bridge.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    with pytest.raises(RuntimeError, match="tmate failed"):
+        await start_tmate_auth_runner_container(
+            session_id="oas_terminal_tmate_failed",
+            runtime_id="codex_cli",
+            volume_ref="codex_auth_volume",
+            volume_mount_path="/home/app/.codex",
+            session_ttl=1800,
+            bootstrap_command=("codex", "login", "--device-auth"),
+        )
+
+    assert calls[-1] == ("docker", "stop", "moonmind_auth_oas_terminal_tmate_failed")
+
+@pytest.mark.asyncio
 async def test_start_terminal_bridge_container_uses_claude_home_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Jira issue key: MM-738

## Summary
- Adds explicit OAuth session transport resolution so OAuth sessions can request `tmate`, `moonmind_pty_ws`, or `none` with fail-fast validation for unsupported values.
- Carries the resolved transport through session creation, workflow/activity payloads, terminal bridge metadata, and Settings UI start/reconnect flows.
- Documents the explicit `tmate` OAuth session transport while preserving provider-profile semantics around the OAuth session row, auth volume, and finalize endpoint.
- Adds unit and Temporal boundary coverage for transport validation, workflow payloads, terminal bridge behavior, and Settings UI request payloads.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining risks
- Hermetic compose-backed integration suite was not run in this PR-publication step; full unit and frontend suites passed locally.
- Live external tmate/provider OAuth behavior still depends on deployment/runtime availability and should be verified in an environment with the configured auth runner transport.
