### PR TITLE
MM-813 scan git commits before push

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -213,6 +213,7 @@ All items shipped: per-step runtime/model/effort selection (MM-786/787), cost tr
 ### What's shipped
 - High-security outbound scan contract — deterministic scan boundaries with `OutboundScanDecision` / `OutboundFinding` models (MM-811, `moonmind/security/outbound_scan.py`); per-caller adoption is follow-up scope under 12.4
 - Outbound scan adopted at the Jira comment-posting boundary (MM-812, `moonmind/integrations/jira/tool.py`) — GitHub comment boundaries were *not* changed in MM-812
+- Outbound scan adopted at the managed workspace git-push boundary (MM-813, `moonmind/workflows/temporal/activity_runtime.py`) — high-security mode scans commit metadata and changed content before MoonMind invokes `git push`
 - SecretRef-based settings integration — durable contracts carry secret references, resolved only at launch boundaries (spec `001-secretref-settings-integration`, `docs/Security/SecretsSystem.md`)
 - Claude OAuth guardrails and bootstrap-PTY session controls (specs 192, 245)
 - GitHub token permission scoping (spec 294)
@@ -226,7 +227,7 @@ All items shipped: per-step runtime/model/effort selection (MM-786/787), cost tr
   *Done means:* privileged actions recorded with actor/action/target/decision and exportable, with boundary tests.
 - [ ] **12.3** Secret lifecycle audit surface — Who created/rotated/deleted a secret, which profiles reference it, which launches resolved it (`docs/Security/SecretsSystem.md` §13); contract defined, operator surface missing.
   *Done means:* those questions answerable from Mission Control without exposing secret values.
-- [ ] **12.4** Outbound scan coverage at all publish boundaries — Adopt the MM-811 contract at GitHub PR/issue comments, commits/pushes, artifact publication, and external tool calls under high-security mode (only the Jira comment path is adopted today).
+- [ ] **12.4** Outbound scan coverage at all publish boundaries — Adopt the MM-811 contract at GitHub PR/issue comments, remaining commit/push paths, artifact publication, and external tool calls under high-security mode (Jira comments and managed workspace git pushes are adopted).
   *Done means:* every send/post/push/publish boundary invokes the scan in high-security mode, with block-on-match tests per boundary.
 - [ ] **12.5** Risk-gated action review policy — Classify risky actions before execution and route them through deterministic policy, optional second-model review, or human approval. The current step-review path is a non-blocking placeholder (`moonmind/workflows/temporal/activities/step_review.py`).
   *Done means:* risky actions classified pre-execution; the review decision and its rationale recorded as governance telemetry (12.2).

--- a/docs/Security/SecretsSystem.md
+++ b/docs/Security/SecretsSystem.md
@@ -60,6 +60,8 @@ Effective high-security mode uses deterministic precedence:
 
 When high-security mode is enabled, MoonMind-owned outbound callers should scan text payloads and commit-like payload bundles before send, post, or push side effects. A scan returns a structured allow/block result. Any secret-like or credential-like finding returns a blocked result, and diagnostics identify only the finding category and caller-provided location. Diagnostics, errors, artifacts, logs, and user-visible summaries must not echo the raw detected value.
 
+The managed workspace publish path scans git pushes before invoking `git push`. It resolves the outbound range from the recorded remote branch SHA when available, otherwise from the publish base ref, and builds the scan bundle from commit metadata plus per-file diffs with bounded item sizes. A blocked scan returns file/commit locations such as `git.push.diff:<path>` without printing the detected value.
+
 When high-security mode is disabled, the scan contract returns an allow result and does not silently mutate caller-supplied outbound content.
 
 ---

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -8347,6 +8347,14 @@ class CodexWorker:
             return
 
         scan_env = dict(env) if env is not None else None
+        if base_ref.startswith("origin/"):
+            with suppress(Exception):
+                await self._read_git_text_for_push_scan(
+                    repo_dir=repo_dir,
+                    env=scan_env,
+                    timeout=30,
+                    args=["fetch", "origin", base_ref.removeprefix("origin/")],
+                )
         commit_range = f"{base_ref}..{branch_name}"
         try:
             commit_metadata = await self._read_git_text_for_push_scan(
@@ -8355,8 +8363,10 @@ class CodexWorker:
                 timeout=15,
                 args=[
                     "log",
-                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
-                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    (
+                        "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                        + "subject %s%nbody%n%B%n---END-COMMIT---"
+                    ),
                     commit_range,
                 ],
             )
@@ -8379,25 +8389,30 @@ class CodexWorker:
                 for line in changed_files_text.splitlines()
                 if line.strip()
             ][:_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES]
-            for changed_file in changed_files:
-                file_diff = await self._read_git_text_for_push_scan(
-                    repo_dir=repo_dir,
-                    env=scan_env,
-                    timeout=20,
-                    args=[
-                        "diff",
-                        "--no-ext-diff",
-                        commit_range,
-                        "--",
-                        changed_file,
-                    ],
-                )
-                bundle.append(
-                    OutboundBundleItem(
-                        location=f"git.push.diff:{changed_file}",
-                        content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+            diff_semaphore = asyncio.Semaphore(10)
+
+            async def _diff_item(changed_file: str) -> OutboundBundleItem:
+                async with diff_semaphore:
+                    file_diff = await self._read_git_text_for_push_scan(
+                        repo_dir=repo_dir,
+                        env=scan_env,
+                        timeout=20,
+                        args=[
+                            "diff",
+                            "--no-ext-diff",
+                            commit_range,
+                            "--",
+                            changed_file,
+                        ],
                     )
+                return OutboundBundleItem(
+                    location=f"git.push.diff:{changed_file}",
+                    content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
                 )
+
+            bundle.extend(
+                await asyncio.gather(*(_diff_item(path) for path in changed_files))
+            )
         except Exception as exc:
             safe_detail = moonmind_logging.redact_sensitive_text(str(exc))
             raise RuntimeError(

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -36,6 +36,11 @@ from moonmind.agents.codex_worker.handlers import (
     OutputChunkCallback,
     WorkerExecutionResult,
 )
+from moonmind.security.outbound_scan import (
+    OutboundBundleItem,
+    resolve_high_security_mode,
+    scan_outbound_bundle,
+)
 from moonmind.workflows.tasks.job_types import CANONICAL_TASK_JOB_TYPE, LEGACY_TASK_JOB_TYPES
 from moonmind.workflows.tasks.task_contract import (
     SUPPORTED_EXECUTION_RUNTIMES,
@@ -88,6 +93,10 @@ from moonmind.workflows.skills.workspace_links import (
 from moonmind.workflows.automation.workspace import generate_branch_name
 
 logger = logging.getLogger(__name__)
+
+_PUBLISH_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS = 100_000
+_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS = 200_000
+_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES = 200
 
 _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"})
 _CONTAINER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -6374,6 +6383,12 @@ class CodexWorker:
                 env=prepared.publish_command_env,
                 redaction_values=(commit_message,),
             )
+            await self._scan_publish_git_push(
+                repo_dir=prepared.repo_dir,
+                branch_name=prepared.working_branch,
+                base_ref=f"origin/{publish_base_branch}",
+                env=prepared.publish_command_env,
+            )
             await self._run_stage_command(
                 ["git", "push", "-u", "origin", prepared.working_branch],
                 cwd=prepared.repo_dir,
@@ -8319,6 +8334,118 @@ class CodexWorker:
                 log_path=log_path,
                 env=env,
             )
+
+    async def _scan_publish_git_push(
+        self,
+        *,
+        repo_dir: Path,
+        branch_name: str,
+        base_ref: str,
+        env: Mapping[str, str] | None,
+    ) -> None:
+        if not resolve_high_security_mode():
+            return
+
+        scan_env = dict(env) if env is not None else None
+        commit_range = f"{base_ref}..{branch_name}"
+        try:
+            commit_metadata = await self._read_git_text_for_push_scan(
+                repo_dir=repo_dir,
+                env=scan_env,
+                timeout=15,
+                args=[
+                    "log",
+                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    commit_range,
+                ],
+            )
+            changed_files_text = await self._read_git_text_for_push_scan(
+                repo_dir=repo_dir,
+                env=scan_env,
+                timeout=15,
+                args=["diff", "--name-only", commit_range],
+            )
+            bundle = [
+                OutboundBundleItem(
+                    location=f"git.push.commits:{commit_range}",
+                    content=commit_metadata[
+                        :_PUBLISH_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS
+                    ],
+                )
+            ]
+            changed_files = [
+                line.strip()
+                for line in changed_files_text.splitlines()
+                if line.strip()
+            ][:_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES]
+            for changed_file in changed_files:
+                file_diff = await self._read_git_text_for_push_scan(
+                    repo_dir=repo_dir,
+                    env=scan_env,
+                    timeout=20,
+                    args=[
+                        "diff",
+                        "--no-ext-diff",
+                        commit_range,
+                        "--",
+                        changed_file,
+                    ],
+                )
+                bundle.append(
+                    OutboundBundleItem(
+                        location=f"git.push.diff:{changed_file}",
+                        content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+                    )
+                )
+        except Exception as exc:
+            safe_detail = moonmind_logging.redact_sensitive_text(str(exc))
+            raise RuntimeError(
+                "outbound git push blocked: could not build high security "
+                f"scan payload for {commit_range}: {safe_detail}"
+            ) from exc
+
+        scan_result = scan_outbound_bundle(bundle, high_security_mode=True)
+        if scan_result.allowed:
+            return
+        diagnostics = "; ".join(scan_result.sanitized_diagnostics)
+        raise RuntimeError(
+            "outbound git push blocked by high security scan: " + diagnostics
+        )
+
+    async def _read_git_text_for_push_scan(
+        self,
+        *,
+        repo_dir: Path,
+        env: Mapping[str, str] | None,
+        timeout: int,
+        args: list[str],
+    ) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(repo_dir),
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=dict(env) if env is not None else None,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        if proc.returncode != 0:
+            detail = (
+                stderr_bytes.decode("utf-8", errors="replace").strip()
+                or stdout_bytes.decode("utf-8", errors="replace").strip()
+                or f"git exited with {proc.returncode}"
+            )
+            raise RuntimeError(detail)
+        return stdout_bytes.decode("utf-8", errors="replace")
 
     async def _run_stage_command(
         self,

--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import re
 from pathlib import Path
@@ -285,6 +286,14 @@ class PublishService:
         if not resolve_high_security_mode():
             return
 
+        if base_ref.startswith("origin/"):
+            with contextlib.suppress(Exception):
+                await self._read_git_text_for_scan(
+                    repo_dir=repo_dir,
+                    env=env,
+                    timeout=30,
+                    args=["fetch", "origin", base_ref.removeprefix("origin/")],
+                )
         commit_range = f"{base_ref}..{branch_name}"
         try:
             commit_metadata = await self._read_git_text_for_scan(
@@ -293,8 +302,10 @@ class PublishService:
                 timeout=15,
                 args=[
                     "log",
-                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
-                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    (
+                        "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                        + "subject %s%nbody%n%B%n---END-COMMIT---"
+                    ),
                     commit_range,
                 ],
             )
@@ -317,25 +328,30 @@ class PublishService:
                 for line in changed_files_text.splitlines()
                 if line.strip()
             ][:_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES]
-            for changed_file in changed_files:
-                file_diff = await self._read_git_text_for_scan(
-                    repo_dir=repo_dir,
-                    env=env,
-                    timeout=20,
-                    args=[
-                        "diff",
-                        "--no-ext-diff",
-                        commit_range,
-                        "--",
-                        changed_file,
-                    ],
-                )
-                bundle.append(
-                    OutboundBundleItem(
-                        location=f"git.push.diff:{changed_file}",
-                        content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+            diff_semaphore = asyncio.Semaphore(10)
+
+            async def _diff_item(changed_file: str) -> OutboundBundleItem:
+                async with diff_semaphore:
+                    file_diff = await self._read_git_text_for_scan(
+                        repo_dir=repo_dir,
+                        env=env,
+                        timeout=20,
+                        args=[
+                            "diff",
+                            "--no-ext-diff",
+                            commit_range,
+                            "--",
+                            changed_file,
+                        ],
                     )
+                return OutboundBundleItem(
+                    location=f"git.push.diff:{changed_file}",
+                    content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
                 )
+
+            bundle.extend(
+                await asyncio.gather(*(_diff_item(path) for path in changed_files))
+            )
         except Exception as exc:
             safe_detail = redact_sensitive_text(str(exc))
             raise RuntimeError(

--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Protocol
 from uuid import UUID
 
+from moonmind.security.outbound_scan import (
+    OutboundBundleItem,
+    resolve_high_security_mode,
+    scan_outbound_bundle,
+)
 from moonmind.workflows.adapters.github_service import GitHubService
 from moonmind.utils.cli import verify_cli_is_executable
+from moonmind.utils.logging import redact_sensitive_text
 from moonmind.publish.sanitization import (
     sanitize_metadata_footer_value,
     sanitize_publish_subject,
@@ -26,6 +33,10 @@ CommandRunner = Callable[
     ...,
     Awaitable[CommandResult],
 ]
+
+_PUBLISH_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS = 100_000
+_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS = 200_000
+_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES = 200
 
 class PublishService:
     """Service to publish changes to Git branches or Pull Requests."""
@@ -164,6 +175,12 @@ class PublishService:
             cwd=repo_dir,
             redaction_values=(commit_message,),
         )
+        await self._scan_git_push_before_publish(
+            repo_dir=repo_dir,
+            branch_name=branch_name,
+            base_ref=f"origin/{publish_base_branch or 'main'}",
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
         token = ""
         push_env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
         resolved_github_credential = None
@@ -256,3 +273,114 @@ class PublishService:
             ),
         )
         return f"published PR from {branch_name}"
+
+    async def _scan_git_push_before_publish(
+        self,
+        *,
+        repo_dir: Path,
+        branch_name: str,
+        base_ref: str,
+        env: dict[str, str],
+    ) -> None:
+        if not resolve_high_security_mode():
+            return
+
+        commit_range = f"{base_ref}..{branch_name}"
+        try:
+            commit_metadata = await self._read_git_text_for_scan(
+                repo_dir=repo_dir,
+                env=env,
+                timeout=15,
+                args=[
+                    "log",
+                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    commit_range,
+                ],
+            )
+            changed_files_text = await self._read_git_text_for_scan(
+                repo_dir=repo_dir,
+                env=env,
+                timeout=15,
+                args=["diff", "--name-only", commit_range],
+            )
+            bundle = [
+                OutboundBundleItem(
+                    location=f"git.push.commits:{commit_range}",
+                    content=commit_metadata[
+                        :_PUBLISH_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS
+                    ],
+                )
+            ]
+            changed_files = [
+                line.strip()
+                for line in changed_files_text.splitlines()
+                if line.strip()
+            ][:_PUBLISH_PUSH_SCAN_MAX_CHANGED_FILES]
+            for changed_file in changed_files:
+                file_diff = await self._read_git_text_for_scan(
+                    repo_dir=repo_dir,
+                    env=env,
+                    timeout=20,
+                    args=[
+                        "diff",
+                        "--no-ext-diff",
+                        commit_range,
+                        "--",
+                        changed_file,
+                    ],
+                )
+                bundle.append(
+                    OutboundBundleItem(
+                        location=f"git.push.diff:{changed_file}",
+                        content=file_diff[:_PUBLISH_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+                    )
+                )
+        except Exception as exc:
+            safe_detail = redact_sensitive_text(str(exc))
+            raise RuntimeError(
+                "outbound git push blocked: could not build high security "
+                f"scan payload for {commit_range}: {safe_detail}"
+            ) from exc
+
+        scan_result = scan_outbound_bundle(bundle, high_security_mode=True)
+        if scan_result.allowed:
+            return
+        diagnostics = "; ".join(scan_result.sanitized_diagnostics)
+        raise RuntimeError(
+            "outbound git push blocked by high security scan: " + diagnostics
+        )
+
+    async def _read_git_text_for_scan(
+        self,
+        *,
+        repo_dir: Path,
+        env: dict[str, str],
+        timeout: int,
+        args: list[str],
+    ) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            self._git_binary,
+            "-C",
+            str(repo_dir),
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        if proc.returncode != 0:
+            detail = (
+                stderr_bytes.decode("utf-8", errors="replace").strip()
+                or stdout_bytes.decode("utf-8", errors="replace").strip()
+                or f"git exited with {proc.returncode}"
+            )
+            raise RuntimeError(detail)
+        return stdout_bytes.decode("utf-8", errors="replace")

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -29,6 +29,11 @@ from temporalio import exceptions as temporal_exceptions
 
 from moonmind.config.settings import settings
 from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
+from moonmind.security.outbound_scan import (
+    OutboundBundleItem,
+    resolve_high_security_mode,
+    scan_outbound_bundle,
+)
 from moonmind.integrations.pentest.models import (
     PENTEST_HEARTBEAT_PHASES,
     PentestApprovedScope,
@@ -199,6 +204,10 @@ async def _run_command(cmd, **kwargs):
     return CmdRes(stdout)
 
 logger = getLogger(__name__)
+
+_GIT_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS = 100_000
+_GIT_PUSH_SCAN_MAX_FILE_DIFF_CHARS = 200_000
+_GIT_PUSH_SCAN_MAX_CHANGED_FILES = 200
 
 _PROPOSAL_TELEMETRY_SIGNAL_TAGS = {
     "retry",
@@ -8532,6 +8541,16 @@ class TemporalAgentRuntimeActivities:
                 run_id=run_id,
                 env=auth_command_env,
             )
+            pre_push_scan_result = await self._scan_workspace_push_range(
+                workspace=workspace,
+                run_id=run_id,
+                base_ref=base_ref,
+                branch=current_branch,
+                remote_sha=remote_sha,
+                env=command_env,
+            )
+            if pre_push_scan_result is not None:
+                return pre_push_scan_result
 
             push_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
@@ -8692,6 +8711,17 @@ class TemporalAgentRuntimeActivities:
 
                         retry_metadata["rebase_status"] = "rebased"
                         retry_remote_sha = remote_sha_after_fetch
+                        retry_scan_result = await self._scan_workspace_push_range(
+                            workspace=workspace,
+                            run_id=run_id,
+                            base_ref=base_ref,
+                            branch=current_branch,
+                            remote_sha=retry_remote_sha,
+                            env=command_env,
+                        )
+                        if retry_scan_result is not None:
+                            retry_scan_result.update(retry_metadata)
+                            return retry_scan_result
                         retry_push_proc = await asyncio.create_subprocess_exec(
                             *self._workspace_git_command(
                                 workspace,
@@ -8890,6 +8920,140 @@ class TemporalAgentRuntimeActivities:
             return None
         head_sha = stdout_bytes.decode("utf-8", errors="replace").strip()
         return head_sha or None
+
+    async def _scan_workspace_push_range(
+        self,
+        *,
+        workspace: str,
+        run_id: str,
+        base_ref: str,
+        branch: str,
+        remote_sha: str | None,
+        env: Mapping[str, str],
+    ) -> dict[str, Any] | None:
+        """Block MoonMind-owned pushes when outbound commit content has secrets."""
+
+        if not resolve_high_security_mode():
+            return None
+
+        range_base = str(remote_sha or base_ref or "").strip()
+        branch_name = str(branch or "").strip()
+        if not range_base or not branch_name:
+            return {
+                "push_status": "blocked",
+                "push_branch": branch_name or "(unknown)",
+                "push_error": (
+                    "outbound git push blocked: could not resolve deterministic "
+                    "commit range for high security scan"
+                ),
+                "diagnostic_kind": "outbound_scan_blocked",
+            }
+
+        commit_range = f"{range_base}..{branch_name}"
+        try:
+            commit_metadata = await self._read_workspace_git_text(
+                workspace=workspace,
+                env=env,
+                timeout=15,
+                args=(
+                    "log",
+                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    commit_range,
+                ),
+            )
+            changed_files_text = await self._read_workspace_git_text(
+                workspace=workspace,
+                env=env,
+                timeout=15,
+                args=("diff", "--name-only", commit_range),
+            )
+            changed_files = [
+                line.strip()
+                for line in changed_files_text.splitlines()
+                if line.strip()
+            ][:_GIT_PUSH_SCAN_MAX_CHANGED_FILES]
+            bundle: list[OutboundBundleItem] = [
+                OutboundBundleItem(
+                    location=f"git.push.commits:{commit_range}",
+                    content=commit_metadata[
+                        :_GIT_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS
+                    ],
+                )
+            ]
+            for changed_file in changed_files:
+                file_diff = await self._read_workspace_git_text(
+                    workspace=workspace,
+                    env=env,
+                    timeout=20,
+                    args=("diff", "--no-ext-diff", commit_range, "--", changed_file),
+                )
+                bundle.append(
+                    OutboundBundleItem(
+                        location=f"git.push.diff:{changed_file}",
+                        content=file_diff[:_GIT_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+                    )
+                )
+        except Exception as exc:
+            safe_detail = redact_sensitive_text(str(exc))
+            return {
+                "push_status": "blocked",
+                "push_branch": branch_name,
+                "push_base_ref": base_ref,
+                "push_error": (
+                    "outbound git push blocked: could not build high security "
+                    f"scan payload for {commit_range}: {safe_detail}"
+                ),
+                "diagnostic_kind": "outbound_scan_blocked",
+            }
+
+        scan_result = scan_outbound_bundle(bundle, high_security_mode=True)
+        if scan_result.allowed:
+            return None
+
+        diagnostics = list(scan_result.sanitized_diagnostics)
+        return {
+            "push_status": "blocked",
+            "push_branch": branch_name,
+            "push_base_ref": base_ref,
+            "push_error": (
+                "outbound git push blocked by high security scan: "
+                + "; ".join(diagnostics)
+            ),
+            "diagnostic_kind": "outbound_scan_blocked",
+            "outbound_scan_diagnostics": diagnostics,
+        }
+
+    async def _read_workspace_git_text(
+        self,
+        *,
+        workspace: str,
+        env: Mapping[str, str],
+        timeout: int,
+        args: Sequence[str],
+    ) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            *self._workspace_git_command(workspace, *args),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        if proc.returncode != 0:
+            detail = (
+                stderr_bytes.decode("utf-8", errors="replace").strip()
+                or stdout_bytes.decode("utf-8", errors="replace").strip()
+                or f"git exited with {proc.returncode}"
+            )
+            raise RuntimeError(detail)
+        return stdout_bytes.decode("utf-8", errors="replace")
 
     async def _resolve_workspace_default_branch(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8949,6 +8949,18 @@ class TemporalAgentRuntimeActivities:
                 "diagnostic_kind": "outbound_scan_blocked",
             }
 
+        fetch_ref = branch_name if remote_sha else None
+        if fetch_ref is None and base_ref.startswith("origin/"):
+            fetch_ref = base_ref.removeprefix("origin/")
+        if fetch_ref:
+            with contextlib.suppress(Exception):
+                await self._read_workspace_git_text(
+                    workspace=workspace,
+                    env=env,
+                    timeout=30,
+                    args=("fetch", "origin", fetch_ref),
+                )
+
         commit_range = f"{range_base}..{branch_name}"
         try:
             commit_metadata = await self._read_workspace_git_text(
@@ -8957,8 +8969,10 @@ class TemporalAgentRuntimeActivities:
                 timeout=15,
                 args=(
                     "log",
-                    "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
-                    "subject %s%nbody%n%B%n---END-COMMIT---",
+                    (
+                        "--format=commit %H%nparents %P%nauthor %an <%ae>%n"
+                        + "subject %s%nbody%n%B%n---END-COMMIT---"
+                    ),
                     commit_range,
                 ),
             )
@@ -8981,19 +8995,30 @@ class TemporalAgentRuntimeActivities:
                     ],
                 )
             ]
-            for changed_file in changed_files:
-                file_diff = await self._read_workspace_git_text(
-                    workspace=workspace,
-                    env=env,
-                    timeout=20,
-                    args=("diff", "--no-ext-diff", commit_range, "--", changed_file),
-                )
-                bundle.append(
-                    OutboundBundleItem(
-                        location=f"git.push.diff:{changed_file}",
-                        content=file_diff[:_GIT_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
+            diff_semaphore = asyncio.Semaphore(10)
+
+            async def _diff_item(changed_file: str) -> OutboundBundleItem:
+                async with diff_semaphore:
+                    file_diff = await self._read_workspace_git_text(
+                        workspace=workspace,
+                        env=env,
+                        timeout=20,
+                        args=(
+                            "diff",
+                            "--no-ext-diff",
+                            commit_range,
+                            "--",
+                            changed_file,
+                        ),
                     )
+                return OutboundBundleItem(
+                    location=f"git.push.diff:{changed_file}",
+                    content=file_diff[:_GIT_PUSH_SCAN_MAX_FILE_DIFF_CHARS],
                 )
+
+            bundle.extend(
+                await asyncio.gather(*(_diff_item(path) for path in changed_files))
+            )
         except Exception as exc:
             safe_detail = redact_sensitive_text(str(exc))
             return {
@@ -9036,7 +9061,7 @@ class TemporalAgentRuntimeActivities:
             *self._workspace_git_command(workspace, *args),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=env,
+            env=dict(env) if env is not None else None,
         )
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -96,10 +96,13 @@ async def test_codex_worker_push_scan_blocks_secret_without_printing_raw_value(
         command = list(args)
         assert "push" not in command
         if call_count == 1:
-            return _Proc(b"commit local-sha\nsubject MM-813\n")
+            assert command[-3:] == ["fetch", "origin", "main"]
+            return _Proc(b"")
         if call_count == 2:
-            return _Proc(b"app/config.py\n")
+            return _Proc(b"commit local-sha\nsubject MM-813\n")
         if call_count == 3:
+            return _Proc(b"app/config.py\n")
+        if call_count == 4:
             return _Proc(b"+token=do-not-print-this-value\n")
         raise AssertionError(f"Unexpected scan subprocess: {args!r}")
 

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -73,6 +73,51 @@ def _stub_skill_resolution(monkeypatch):
         _fake_materialize,
     )
 
+
+async def test_codex_worker_push_scan_blocks_secret_without_printing_raw_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(settings.security, "high_security_mode", True)
+    worker = CodexWorker.__new__(CodexWorker)
+    call_count = 0
+
+    class _Proc:
+        def __init__(self, stdout: bytes):
+            self.returncode = 0
+            self._stdout = stdout
+
+        async def communicate(self):
+            return self._stdout, b""
+
+    async def _mock_exec(*args, **kwargs):
+        nonlocal call_count
+        del kwargs
+        call_count += 1
+        command = list(args)
+        assert "push" not in command
+        if call_count == 1:
+            return _Proc(b"commit local-sha\nsubject MM-813\n")
+        if call_count == 2:
+            return _Proc(b"app/config.py\n")
+        if call_count == 3:
+            return _Proc(b"+token=do-not-print-this-value\n")
+        raise AssertionError(f"Unexpected scan subprocess: {args!r}")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _mock_exec)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await worker._scan_publish_git_push(
+            repo_dir=tmp_path,
+            branch_name="feature/scan-block",
+            base_ref="origin/main",
+            env={},
+        )
+
+    message = str(exc_info.value)
+    assert "git.push.diff:app/config.py" in message
+    assert "do-not-print-this-value" not in message
+
+
 class FakeQueueClient:
     """In-memory queue client stub for worker tests."""
 

--- a/tests/unit/publish/test_publish_service_github_auth.py
+++ b/tests/unit/publish/test_publish_service_github_auth.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
 
+from moonmind.config.settings import settings
 from moonmind.publish.service import PublishService
 
 pytestmark = pytest.mark.asyncio
@@ -40,6 +42,60 @@ async def test_publish_branch_push_uses_resolved_token_env(monkeypatch, tmp_path
     assert env["GH_TOKEN"] == "publish-token"
     assert env["GIT_TERMINAL_PROMPT"] == "0"
     assert "publish-token" in push_call["redaction_values"]
+
+
+async def test_publish_branch_blocks_high_security_scan_before_push(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setattr(settings.security, "high_security_mode", True)
+    calls: list[dict[str, object]] = []
+    scan_call_count = 0
+
+    async def _run(command, **kwargs):
+        calls.append({"command": command, **kwargs})
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M file.py\n")
+        return SimpleNamespace(stdout="")
+
+    async def _mock_exec(*args, **kwargs):
+        nonlocal scan_call_count
+        del kwargs
+        scan_call_count += 1
+        proc = AsyncMock()
+        if scan_call_count == 1:
+            proc.communicate = AsyncMock(
+                return_value=(b"commit local-sha\nsubject MM-813\n", b"")
+            )
+            proc.returncode = 0
+        elif scan_call_count == 2:
+            proc.communicate = AsyncMock(return_value=(b"app/config.py\n", b""))
+            proc.returncode = 0
+        elif scan_call_count == 3:
+            proc.communicate = AsyncMock(
+                return_value=(b"+api_key=do-not-print-this-value\n", b"")
+            )
+            proc.returncode = 0
+        else:
+            raise AssertionError(f"Unexpected scan subprocess: {args!r}")
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+        with pytest.raises(RuntimeError) as exc_info:
+            await PublishService().publish(
+                job_id=uuid4(),
+                instruction="MM-813 make change",
+                publish_mode="branch",
+                publish_base_branch="main",
+                runtime_mode="codex",
+                repo_dir=tmp_path,
+                run_command=_run,
+                repo=None,
+            )
+
+    message = str(exc_info.value)
+    assert "git.push.diff:app/config.py" in message
+    assert "do-not-print-this-value" not in message
+    assert not any(call["command"][:2] == ["git", "push"] for call in calls)
 
 
 async def test_publish_pr_uses_rest_service_without_ambient_gh(monkeypatch, tmp_path: Path):

--- a/tests/unit/publish/test_publish_service_github_auth.py
+++ b/tests/unit/publish/test_publish_service_github_auth.py
@@ -61,16 +61,22 @@ async def test_publish_branch_blocks_high_security_scan_before_push(
         nonlocal scan_call_count
         del kwargs
         scan_call_count += 1
+        command = list(args)
+        assert "push" not in command
         proc = AsyncMock()
         if scan_call_count == 1:
+            assert command[-3:] == ["fetch", "origin", "main"]
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+        elif scan_call_count == 2:
             proc.communicate = AsyncMock(
                 return_value=(b"commit local-sha\nsubject MM-813\n", b"")
             )
             proc.returncode = 0
-        elif scan_call_count == 2:
+        elif scan_call_count == 3:
             proc.communicate = AsyncMock(return_value=(b"app/config.py\n", b""))
             proc.returncode = 0
-        elif scan_call_count == 3:
+        elif scan_call_count == 4:
             proc.communicate = AsyncMock(
                 return_value=(b"+api_key=do-not-print-this-value\n", b"")
             )

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -695,6 +695,126 @@ class TestPushWorkspaceBranch:
         assert "push_error" not in result
 
     @pytest.mark.asyncio
+    async def test_push_blocks_high_security_scan_before_git_push(self, monkeypatch):
+        monkeypatch.setattr(settings.security, "high_security_mode", True)
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            del kwargs
+            call_count += 1
+            recorded_calls.append(args)
+            command = list(args)
+            assert "push" not in command
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse --abbrev-ref HEAD
+                proc.communicate = AsyncMock(return_value=(b"feature/scan-block\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # remote branch sha before scan/push
+                proc.communicate = AsyncMock(return_value=(b"remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # commit metadata
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"commit local-sha\nsubject MM-813 scanned push\n",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif call_count == 6:  # changed file list
+                proc.communicate = AsyncMock(return_value=(b"app/config.py\n", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # per-file changed content
+                proc.communicate = AsyncMock(
+                    return_value=(b"+password=do-not-print-this-value\n", b"")
+                )
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "blocked"
+        assert result["diagnostic_kind"] == "outbound_scan_blocked"
+        assert "git.push.diff:app/config.py" in result["push_error"]
+        assert "do-not-print-this-value" not in result["push_error"]
+        assert not any("push" in call for call in recorded_calls)
+
+    @pytest.mark.asyncio
+    async def test_push_allows_clean_high_security_scan(self, monkeypatch):
+        monkeypatch.setattr(settings.security, "high_security_mode", True)
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            del kwargs
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse --abbrev-ref HEAD
+                proc.communicate = AsyncMock(return_value=(b"feature/scan-allow\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # remote branch sha before scan/push
+                proc.communicate = AsyncMock(return_value=(b"remote-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # commit metadata
+                proc.communicate = AsyncMock(
+                    return_value=(
+                        b"commit local-sha\nsubject MM-813 clean scanned push\n",
+                        b"",
+                    )
+                )
+                proc.returncode = 0
+            elif call_count == 6:  # changed file list
+                proc.communicate = AsyncMock(return_value=(b"app/service.py\n", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # per-file changed content
+                proc.communicate = AsyncMock(
+                    return_value=(b"+return 'ordinary value'\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 8:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 9:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"pushed-head-sha\n", b""))
+                proc.returncode = 0
+            elif call_count == 10:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/scan-allow"
+        assert result["push_head_sha"] == "pushed-head-sha"
+        assert any("push" in call for call in recorded_calls)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("raw_ref", [b"origin/\n", b"origin/HEAD\n", b"HEAD\n"])
     async def test_resolve_workspace_default_branch_rejects_non_branch_refs(
         self,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -722,7 +722,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 4:  # remote branch sha before scan/push
                 proc.communicate = AsyncMock(return_value=(b"remote-sha\n", b""))
                 proc.returncode = 0
-            elif call_count == 5:  # commit metadata
+            elif call_count == 5:  # fetch remote branch object before scan
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # commit metadata
                 proc.communicate = AsyncMock(
                     return_value=(
                         b"commit local-sha\nsubject MM-813 scanned push\n",
@@ -730,10 +733,10 @@ class TestPushWorkspaceBranch:
                     )
                 )
                 proc.returncode = 0
-            elif call_count == 6:  # changed file list
+            elif call_count == 7:  # changed file list
                 proc.communicate = AsyncMock(return_value=(b"app/config.py\n", b""))
                 proc.returncode = 0
-            elif call_count == 7:  # per-file changed content
+            elif call_count == 8:  # per-file changed content
                 proc.communicate = AsyncMock(
                     return_value=(b"+password=do-not-print-this-value\n", b"")
                 )
@@ -777,7 +780,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 4:  # remote branch sha before scan/push
                 proc.communicate = AsyncMock(return_value=(b"remote-sha\n", b""))
                 proc.returncode = 0
-            elif call_count == 5:  # commit metadata
+            elif call_count == 5:  # fetch remote branch object before scan
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # commit metadata
                 proc.communicate = AsyncMock(
                     return_value=(
                         b"commit local-sha\nsubject MM-813 clean scanned push\n",
@@ -785,21 +791,21 @@ class TestPushWorkspaceBranch:
                     )
                 )
                 proc.returncode = 0
-            elif call_count == 6:  # changed file list
+            elif call_count == 7:  # changed file list
                 proc.communicate = AsyncMock(return_value=(b"app/service.py\n", b""))
                 proc.returncode = 0
-            elif call_count == 7:  # per-file changed content
+            elif call_count == 8:  # per-file changed content
                 proc.communicate = AsyncMock(
                     return_value=(b"+return 'ordinary value'\n", b"")
                 )
                 proc.returncode = 0
-            elif call_count == 8:  # push
+            elif call_count == 9:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 9:  # rev-parse HEAD
+            elif call_count == 10:  # rev-parse HEAD
                 proc.communicate = AsyncMock(return_value=(b"pushed-head-sha\n", b""))
                 proc.returncode = 0
-            elif call_count == 10:  # rev-list --count
+            elif call_count == 11:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"1\n", b""))
                 proc.returncode = 0
             else:


### PR DESCRIPTION
Jira issue key: MM-813

Summary:
- Adds high-security outbound scanning before MoonMind-controlled git push paths in the Codex worker, publish service, and Temporal runtime push activity.
- Builds scan payloads from outbound commit metadata, changed file lists, and changed content while keeping blocked diagnostics sanitized.
- Updates security roadmap/docs to reflect git push scan adoption.

Tests run:
- ./tools/test_unit.sh tests/unit/agents/codex_worker/test_worker.py tests/unit/publish/test_publish_service_github_auth.py tests/unit/services/temporal/test_fetch_result_push.py
- Python: 266 passed, 1 warning.
- Frontend phase: 27 files passed; 417 passed, 234 skipped.

Remaining risks:
- Full repository unit suite beyond the focused Python targets and automatic frontend phase was not separately rerun.
- Integration tests were not run in this PR-publication step.