### PR TITLE
MM-603 Implement Skills On Demand command exposure

### DIFF
--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -8,8 +8,10 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.auth_providers import get_current_user
+from api_service.db.base import async_session_maker, get_async_session
 from api_service.db.models import User
 from moonmind.config.settings import settings
 from moonmind.integrations.jira.errors import JiraToolError
@@ -23,6 +25,10 @@ from moonmind.mcp.jules_tool_registry import (
     JulesToolExecutionContext,
     JulesToolRegistry,
 )
+from moonmind.mcp.skills_on_demand_registry import (
+    SkillsOnDemandToolExecutionContext,
+    SkillsOnDemandToolRegistry,
+)
 from moonmind.mcp.tool_registry import (
     QueueToolExecutionContext,
     QueueToolRegistry,
@@ -34,6 +40,7 @@ from moonmind.mcp.tool_registry import (
     ToolListResponse,
     ToolNotFoundError,
 )
+from moonmind.workflows import get_temporal_artifact_service
 from moonmind.workflows.adapters.jules_client import JulesClient, JulesClientError
 
 logger = logging.getLogger(__name__)
@@ -45,6 +52,9 @@ MCP_SERVER_INFO = {"name": "moonmind", "version": "0.1.0"}
 
 _queue_registry = QueueToolRegistry()
 _execution_tool_registry = ExecutableToolDiscoveryRegistry()
+_skills_on_demand_registry = SkillsOnDemandToolRegistry(
+    expose_commands=settings.workflow.skills_on_demand_enabled
+)
 _jira_registry: JiraToolRegistry | None = None
 _jira_service: JiraToolService | None = None
 _jules_registry: JulesToolRegistry | None = None
@@ -135,7 +145,11 @@ def _to_http_exception(exc: Exception) -> HTTPException:
 
 
 def _list_registered_tools() -> list[Any]:
-    tools = _queue_registry.list_tools() + _execution_tool_registry.list_tools()
+    tools = (
+        _queue_registry.list_tools()
+        + _execution_tool_registry.list_tools()
+        + _skills_on_demand_registry.list_tools()
+    )
     if _jira_registry is not None:
         tools = tools + _jira_registry.list_tools()
     if _jules_registry is not None:
@@ -144,7 +158,7 @@ def _list_registered_tools() -> list[Any]:
 
 
 def _list_streamable_callable_tools() -> list[Any]:
-    tools = _queue_registry.list_tools()
+    tools = _queue_registry.list_tools() + _skills_on_demand_registry.list_tools()
     if _jira_registry is not None:
         tools = tools + _jira_registry.list_tools()
     if _jules_registry is not None:
@@ -152,7 +166,11 @@ def _list_streamable_callable_tools() -> list[Any]:
     return tools
 
 
-async def _dispatch_tool_call(payload: ToolCallRequest, user: User) -> Any:
+async def _dispatch_tool_call(
+    payload: ToolCallRequest,
+    user: User,
+    session: AsyncSession | None = None,
+) -> Any:
     if _execution_tool_registry.has_tool(payload.tool):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -182,6 +200,31 @@ async def _dispatch_tool_call(payload: ToolCallRequest, user: User) -> Any:
             tool=payload.tool,
             arguments=payload.arguments,
             context=jules_context,
+        )
+    if payload.tool.startswith("moonmind.skills."):
+        artifact_service = (
+            get_temporal_artifact_service(session)
+            if session is not None and settings.workflow.skills_on_demand_enabled
+            else None
+        )
+        skills_context = SkillsOnDemandToolExecutionContext(
+            enabled=settings.workflow.skills_on_demand_enabled,
+            workspace_root=settings.workflow.repo_root,
+            artifact_service=artifact_service,
+            async_session_maker=async_session_maker,
+            skills_cache_root=settings.workflow.skills_cache_root,
+            skills_workspace_root=settings.workflow.skills_workspace_root,
+            allow_repo_skills=bool(
+                getattr(settings.workflow, "allow_repo_skills", False)
+            ),
+            allow_local_skills=bool(
+                getattr(settings.workflow, "allow_local_skills", False)
+            ),
+        )
+        return await _skills_on_demand_registry.call_tool(
+            tool=payload.tool,
+            arguments=payload.arguments,
+            context=skills_context,
         )
 
     queue_context = QueueToolExecutionContext(
@@ -294,7 +337,11 @@ def _tool_error_payload(detail: Any) -> dict[str, Any]:
     }
 
 
-async def _handle_json_rpc_request(message: Any, user: User) -> dict[str, Any] | None:
+async def _handle_json_rpc_request(
+    message: Any,
+    user: User,
+    session: AsyncSession | None = None,
+) -> dict[str, Any] | None:
     if _is_json_rpc_notification(message) or _is_json_rpc_response(message):
         return None
     if not isinstance(message, dict):
@@ -369,6 +416,7 @@ async def _handle_json_rpc_request(message: Any, user: User) -> dict[str, Any] |
             result = await _dispatch_tool_call(
                 ToolCallRequest(tool=tool_name, arguments=arguments),
                 user,
+                session,
             )
             return _json_rpc_result(request_id, _tool_result_payload(result))
     except HTTPException as exc:
@@ -411,6 +459,7 @@ async def _handle_json_rpc_request(message: Any, user: User) -> dict[str, Any] |
 async def handle_streamable_http_post(
     request: Request,
     user: User = Depends(get_current_user()),
+    session: AsyncSession = Depends(get_async_session),
 ) -> Response:
     """Handle MCP Streamable HTTP JSON-RPC messages at the single MCP endpoint."""
 
@@ -446,7 +495,8 @@ async def handle_streamable_http_post(
         responses = [
             response
             for response in [
-                await _handle_json_rpc_request(message, user) for message in payload
+                await _handle_json_rpc_request(message, user, session)
+                for message in payload
             ]
             if response is not None
         ]
@@ -454,7 +504,7 @@ async def handle_streamable_http_post(
             return Response(status_code=status.HTTP_202_ACCEPTED)
         return JSONResponse(responses)
 
-    response = await _handle_json_rpc_request(payload, user)
+    response = await _handle_json_rpc_request(payload, user, session)
     if response is None:
         return Response(status_code=status.HTTP_202_ACCEPTED)
     return JSONResponse(response)
@@ -495,11 +545,16 @@ async def list_tools(
 async def call_tool(
     payload: ToolCallRequest,
     user: User = Depends(get_current_user()),
+    session: AsyncSession = Depends(get_async_session),
 ) -> ToolCallResponse:
     """Dispatch one MCP tool invocation."""
 
     try:
-        result = await _dispatch_tool_call(payload, user)
+        result = await _dispatch_tool_call(
+            payload,
+            user,
+            session,
+        )
     except HTTPException:
         raise
     except JiraToolError as exc:

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -64,7 +64,7 @@ from moonmind.workflows.temporal.runtime.self_heal import (
 )
 from moonmind.workflows.adapters.github_service import GitHubService
 from moonmind.config.settings import settings
-from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
+from moonmind.services.skills_on_demand import skills_on_demand_runtime_instruction
 from moonmind.jules.runtime import JULES_RUNTIME_DISABLED_MESSAGE
 from moonmind.jules.runtime import (
     build_runtime_gate_state as build_jules_runtime_gate_state,
@@ -11286,11 +11286,11 @@ class CodexWorker:
                 "- .agents/skills is a compatibility alias only when MoonMind can "
                 "create it without masking repo-authored skill source."
             )
-            disabled_instruction = skills_on_demand_disabled_instruction(
+            on_demand_instruction = skills_on_demand_runtime_instruction(
                 enabled=settings.workflow.skills_on_demand_enabled
             )
-            if disabled_instruction:
-                instruction += f"\n{disabled_instruction}"
+            if on_demand_instruction:
+                instruction += f"\n{on_demand_instruction}"
             instruction += (
                 f"\n\nRUNTIME ADAPTER: {runtime_mode}"
                 "\n\nSKILL USAGE:\n"

--- a/moonmind/mcp/__init__.py
+++ b/moonmind/mcp/__init__.py
@@ -8,6 +8,10 @@ from moonmind.mcp.jules_tool_registry import (
     JulesToolExecutionContext,
     JulesToolRegistry,
 )
+from moonmind.mcp.skills_on_demand_registry import (
+    SkillsOnDemandToolExecutionContext,
+    SkillsOnDemandToolRegistry,
+)
 from moonmind.mcp.tool_registry import (
     QueueToolExecutionContext,
     QueueToolRegistry,
@@ -28,6 +32,8 @@ __all__ = [
     "JulesToolRegistry",
     "QueueToolExecutionContext",
     "QueueToolRegistry",
+    "SkillsOnDemandToolExecutionContext",
+    "SkillsOnDemandToolRegistry",
     "ResourceListResponse",
     "ResourceMetadata",
     "ToolArgumentsValidationError",

--- a/moonmind/mcp/skills_on_demand_registry.py
+++ b/moonmind/mcp/skills_on_demand_registry.py
@@ -9,7 +9,6 @@ from typing import Any, Awaitable, Callable, Mapping
 from pydantic import BaseModel, ValidationError
 
 from moonmind.schemas.agent_skill_models import (
-    ResolvedSkillSet,
     RuntimeMaterializationMode,
     SkillSelector,
     SkillSelectorEntry,
@@ -268,17 +267,15 @@ class SkillsOnDemandToolRegistry:
         request: SkillsOnDemandRequest,
         context: SkillsOnDemandToolExecutionContext,
     ) -> SkillsOnDemandRequest:
-        if request.active_snapshot is not None:
-            return request
         if not request.current_snapshot_ref:
-            return request
+            return request.model_copy(update={"active_snapshot": None})
         try:
             active_snapshot = await load_resolved_skillset(
                 context.artifact_service,
                 request.current_snapshot_ref,
             )
         except Exception:
-            return request
+            return request.model_copy(update={"active_snapshot": None})
         return request.model_copy(
             update={
                 "active_snapshot": active_snapshot,

--- a/moonmind/mcp/skills_on_demand_registry.py
+++ b/moonmind/mcp/skills_on_demand_registry.py
@@ -1,0 +1,298 @@
+"""Skills On Demand MCP command registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Awaitable, Callable, Mapping
+
+from pydantic import BaseModel, ValidationError
+
+from moonmind.schemas.agent_skill_models import (
+    ResolvedSkillSet,
+    RuntimeMaterializationMode,
+    SkillSelector,
+    SkillSelectorEntry,
+    SkillsOnDemandQueryRequest,
+    SkillsOnDemandRequest,
+)
+from moonmind.services.skill_materialization import AgentSkillMaterializer
+from moonmind.services.skill_resolution import AgentSkillResolver, SkillResolutionContext
+from moonmind.services.skills_on_demand import SkillsOnDemandService
+from moonmind.mcp.tool_registry import (
+    ToolArgumentsValidationError,
+    ToolMetadata,
+    ToolNotFoundError,
+    _ToolDefinition,
+)
+from moonmind.workflows.agent_skills.agent_skills_activities import AgentSkillsActivities
+from moonmind.workflows.skills.run_projection import load_resolved_skillset
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsOnDemandToolExecutionContext:
+    """Dependencies for MoonMind-owned Skills On Demand MCP commands."""
+
+    enabled: bool
+    workspace_root: str
+    artifact_service: Any | None = None
+    async_session_maker: Any | None = None
+    skills_cache_root: str | None = None
+    skills_workspace_root: str | None = None
+    allow_repo_skills: bool = False
+    allow_local_skills: bool = False
+
+
+SkillsOnDemandToolHandler = Callable[
+    [BaseModel, SkillsOnDemandToolExecutionContext], Awaitable[Any]
+]
+
+
+class SkillsOnDemandToolRegistry:
+    """Registry for managed-runtime Skills On Demand control commands."""
+
+    def __init__(self, *, expose_commands: bool = False) -> None:
+        self._expose_commands = expose_commands
+        self._tools: dict[str, _ToolDefinition] = {}
+        self._register_default_tools()
+
+    def list_tools(self) -> list[ToolMetadata]:
+        if not self._expose_commands:
+            return []
+        output: list[ToolMetadata] = []
+        for definition in sorted(self._tools.values(), key=lambda item: item.name):
+            output.append(
+                ToolMetadata(
+                    name=definition.name,
+                    description=definition.description,
+                    input_schema=definition.argument_model.model_json_schema(
+                        by_alias=True
+                    ),
+                )
+            )
+        return output
+
+    async def call_tool(
+        self,
+        *,
+        tool: str,
+        arguments: Mapping[str, Any] | None,
+        context: SkillsOnDemandToolExecutionContext,
+    ) -> Any:
+        definition = self._tools.get(tool)
+        if definition is None:
+            raise ToolNotFoundError(tool)
+
+        payload = dict(arguments or {})
+        try:
+            parsed_args = definition.argument_model.model_validate(payload)
+        except ValidationError as exc:
+            raise ToolArgumentsValidationError(tool, detail=str(exc)) from exc
+
+        result = await definition.handler(parsed_args, context)
+        return result.model_dump(mode="json")
+
+    def _register_default_tools(self) -> None:
+        self._register(
+            "moonmind.skills.query",
+            "Query metadata for policy-eligible MoonMind agent Skills.",
+            SkillsOnDemandQueryRequest,
+            self._handle_query,
+        )
+        self._register(
+            "moonmind.skills.request",
+            "Request activation of additional MoonMind agent Skills.",
+            SkillsOnDemandRequest,
+            self._handle_request,
+        )
+
+    def _register(
+        self,
+        name: str,
+        description: str,
+        argument_model: type[BaseModel],
+        handler: SkillsOnDemandToolHandler,
+    ) -> None:
+        self._tools[name] = _ToolDefinition(
+            name=name,
+            description=description,
+            argument_model=argument_model,
+            handler=handler,
+        )
+
+    async def _handle_query(
+        self,
+        args: BaseModel,
+        context: SkillsOnDemandToolExecutionContext,
+    ) -> Any:
+        if not isinstance(args, SkillsOnDemandQueryRequest):
+            raise ToolArgumentsValidationError(
+                "moonmind.skills.query", detail="Invalid payload type"
+            )
+
+        catalog_entries = []
+        if context.enabled:
+            resolver_context = SkillResolutionContext(
+                snapshot_id=args.current_snapshot_ref
+                or f"skillquery_mcp_{datetime.now(UTC).timestamp():.0f}",
+                workspace_root=context.workspace_root,
+                allow_repo_skills=context.allow_repo_skills,
+                allow_local_skills=context.allow_local_skills,
+                async_session_maker=context.async_session_maker,
+            )
+            catalog_entries = await AgentSkillResolver().query_catalog(
+                SkillSelector(),
+                resolver_context,
+            )
+
+        return await SkillsOnDemandService(
+            enabled=context.enabled,
+            catalog_entries=catalog_entries,
+            allow_repo_skills=context.allow_repo_skills,
+            allow_local_skills=context.allow_local_skills,
+        ).query(args)
+
+    async def _handle_request(
+        self,
+        args: BaseModel,
+        context: SkillsOnDemandToolExecutionContext,
+    ) -> Any:
+        if not isinstance(args, SkillsOnDemandRequest):
+            raise ToolArgumentsValidationError(
+                "moonmind.skills.request", detail="Invalid payload type"
+            )
+
+        request = await self._with_loaded_active_snapshot(args, context)
+        service = SkillsOnDemandService(enabled=context.enabled)
+        initial_result = await service.request(request)
+        if (
+            initial_result.status != "denied"
+            or initial_result.code != "enabled_mode_not_implemented"
+        ):
+            return initial_result
+
+        active_snapshot = request.active_snapshot
+        if active_snapshot is None:
+            return initial_result
+
+        requested = service.normalized_requested_skills(request)
+        active_versions = {
+            skill.skill_name: skill.version for skill in active_snapshot.skills
+        }
+        addition_selector = SkillSelector(
+            include=[
+                SkillSelectorEntry(name=name, version=version)
+                for name, version in requested
+                if name not in active_versions
+                or (version is not None and active_versions[name] != version)
+            ]
+        )
+        snapshot_id = f"skillset_mcp_{active_snapshot.snapshot_id}_derived"
+        resolver_context = SkillResolutionContext(
+            snapshot_id=snapshot_id,
+            deployment_id=active_snapshot.deployment_id,
+            workspace_root=context.workspace_root,
+            allow_repo_skills=context.allow_repo_skills,
+            allow_local_skills=context.allow_local_skills,
+            async_session_maker=context.async_session_maker,
+        )
+
+        activities = AgentSkillsActivities(
+            artifact_service=context.artifact_service,
+            async_session_maker=context.async_session_maker,
+        )
+        try:
+            resolved_additions = await AgentSkillResolver().resolve(
+                addition_selector,
+                resolver_context,
+                base_entries=list(active_snapshot.skills),
+            )
+            derived_set = activities._build_on_demand_derived_skillset(
+                active_snapshot=active_snapshot,
+                resolved_additions=resolved_additions,
+                request=request,
+                snapshot_id=snapshot_id,
+            )
+            if context.artifact_service is not None:
+                activity_info = _McpActivityInfo()
+                derived_set = await activities._persist_file_backed_skill_content(
+                    resolved_set=derived_set,
+                    activity_info=activity_info,
+                )
+                derived_set = await activities._persist_resolved_skillset_manifest(
+                    resolved_set=derived_set,
+                    snapshot_id=derived_set.snapshot_id,
+                    activity_info=activity_info,
+                )
+            materialization = await AgentSkillMaterializer(
+                workspace_root=context.workspace_root,
+                artifact_service=context.artifact_service,
+                backing_root=context.skills_cache_root,
+                source_preservation_root=context.skills_workspace_root,
+            ).materialize(
+                derived_set,
+                request.runtime_id or "managed-runtime",
+                RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+            )
+            if materialization.metadata.get("runtimeRefreshFailed"):
+                message = (
+                    materialization.metadata.get("runtimeRefreshMessage")
+                    or "Skills On Demand runtime refresh failed."
+                )
+                return service.denied_request_result(
+                    request,
+                    code="runtime_refresh_failed",
+                    message=str(message).split("\n", 1)[0],
+                )
+        except ValueError as exc:
+            return service.denied_request_result(
+                request,
+                code=activities._skills_on_demand_resolution_code(str(exc)),
+                message=str(exc).split("\n", 1)[0],
+            )
+        except RuntimeError as exc:
+            return service.denied_request_result(
+                request,
+                code=activities._skills_on_demand_runtime_code(str(exc)),
+                message=str(exc).split("\n", 1)[0],
+            )
+
+        return await service.request(
+            request,
+            resolved_skillset=derived_set,
+            materialization=materialization,
+        )
+
+    async def _with_loaded_active_snapshot(
+        self,
+        request: SkillsOnDemandRequest,
+        context: SkillsOnDemandToolExecutionContext,
+    ) -> SkillsOnDemandRequest:
+        if request.active_snapshot is not None:
+            return request
+        if not request.current_snapshot_ref:
+            return request
+        try:
+            active_snapshot = await load_resolved_skillset(
+                context.artifact_service,
+                request.current_snapshot_ref,
+            )
+        except Exception:
+            return request
+        return request.model_copy(
+            update={
+                "active_snapshot": active_snapshot,
+                "current_snapshot_ref": active_snapshot.snapshot_id,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _McpActivityInfo:
+    namespace: str = "default"
+    workflow_id: str = "mcp.skills_on_demand"
+    workflow_run_id: str = "mcp"
+    activity_id: str = "mcp.skills_on_demand"
+
+
+__all__ = ["SkillsOnDemandToolExecutionContext", "SkillsOnDemandToolRegistry"]

--- a/moonmind/services/skills_on_demand.py
+++ b/moonmind/services/skills_on_demand.py
@@ -35,6 +35,14 @@ SKILLS_ON_DEMAND_DISABLED_INSTRUCTION = (
     "- Skills On Demand is disabled for this run. Use only the active Skills "
     "already available under the active skill path provided by MoonMind."
 )
+SKILLS_ON_DEMAND_ENABLED_INSTRUCTION = (
+    "- Skills On Demand is enabled. You may ask MoonMind for additional Skill "
+    "metadata with `moonmind.skills.query` or request additional Skills with "
+    "`moonmind.skills.request`. MoonMind must approve and resolve any requested "
+    "Skill before it becomes active. Continue reading active Skill bodies from "
+    "the active skill path, and do not copy full Skill bodies into responses "
+    "unless specifically needed."
+)
 
 
 class SkillsOnDemandService:
@@ -550,3 +558,11 @@ def skills_on_demand_disabled_instruction(*, enabled: bool) -> str:
     """Return runtime guidance when on-demand Skill commands cannot be hidden."""
 
     return "" if enabled else SKILLS_ON_DEMAND_DISABLED_INSTRUCTION
+
+
+def skills_on_demand_runtime_instruction(*, enabled: bool) -> str:
+    """Return runtime guidance for the current Skills On Demand feature state."""
+
+    if enabled:
+        return SKILLS_ON_DEMAND_ENABLED_INSTRUCTION
+    return SKILLS_ON_DEMAND_DISABLED_INSTRUCTION

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -226,7 +226,7 @@ class AgentSkillsActivities:
             catalog_entries=catalog_entries,
         )
         result = await service.query(request)
-        return self._with_activity_audit_context(result)
+        return await self._with_persisted_activity_audit_context(result)
 
     @activity.defn(name="agent_skill.request_on_demand")
     async def request_on_demand(
@@ -243,12 +243,12 @@ class AgentSkillsActivities:
             initial_result.status != "denied"
             or initial_result.code != "enabled_mode_not_implemented"
         ):
-            return self._with_activity_audit_context(initial_result)
+            return await self._with_persisted_activity_audit_context(initial_result)
 
         requested = service.normalized_requested_skills(request)
         active_snapshot = request.active_snapshot
         if active_snapshot is None:
-            return self._with_activity_audit_context(initial_result)
+            return await self._with_persisted_activity_audit_context(initial_result)
 
         try:
             info = activity.info()
@@ -301,7 +301,7 @@ class AgentSkillsActivities:
                     materialization.metadata.get("runtimeRefreshMessage")
                     or "Skills On Demand runtime refresh failed."
                 )
-                return self._with_activity_audit_context(
+                return await self._with_persisted_activity_audit_context(
                     service.denied_request_result(
                         request,
                         code="runtime_refresh_failed",
@@ -315,7 +315,7 @@ class AgentSkillsActivities:
                     activity_info=info,
                 )
         except ValueError as exc:
-            return self._with_activity_audit_context(
+            return await self._with_persisted_activity_audit_context(
                 service.denied_request_result(
                     request,
                     code=self._skills_on_demand_resolution_code(str(exc)),
@@ -323,7 +323,7 @@ class AgentSkillsActivities:
                 )
             )
         except RuntimeError as exc:
-            return self._with_activity_audit_context(
+            return await self._with_persisted_activity_audit_context(
                 service.denied_request_result(
                     request,
                     code=self._skills_on_demand_runtime_code(str(exc)),
@@ -336,7 +336,72 @@ class AgentSkillsActivities:
             resolved_skillset=derived_set,
             materialization=materialization,
         )
-        return self._with_activity_audit_context(result)
+        return await self._with_persisted_activity_audit_context(result)
+
+    async def _with_persisted_activity_audit_context(self, result):
+        enriched_result = self._with_activity_audit_context(result)
+        if self._artifact_service is None or not getattr(
+            enriched_result, "audit_events", None
+        ):
+            return enriched_result
+        try:
+            info = activity.info()
+        except Exception:
+            return enriched_result
+
+        from moonmind.workflows.temporal.artifacts import ExecutionRef
+        from moonmind.core.artifacts import (
+            TemporalArtifactRedactionLevel,
+            TemporalArtifactRetentionClass,
+        )
+
+        events = [
+            event.model_dump(mode="json") for event in enriched_result.audit_events
+        ]
+        payload = {
+            "producer": "agent_skill.skills_on_demand",
+            "workflow_id": getattr(info, "workflow_id", None),
+            "run_id": getattr(info, "workflow_run_id", None),
+            "activity_id": getattr(info, "activity_id", None),
+            "status": getattr(enriched_result, "status", None),
+            "code": getattr(enriched_result, "code", None),
+            "events": events,
+        }
+        link = ExecutionRef(
+            namespace=info.namespace,
+            workflow_id=info.workflow_id,
+            run_id=info.workflow_run_id,
+            link_type="audit.skills_on_demand",
+        )
+        artifact, _ = await self._artifact_service.create(
+            principal="agent_workflow",
+            content_type="application/json",
+            metadata_json={
+                "producer": "agent_skill.skills_on_demand",
+                "eventTypes": sorted(
+                    {
+                        str(event.get("event_type"))
+                        for event in events
+                        if event.get("event_type")
+                    }
+                ),
+                "status": getattr(enriched_result, "status", None),
+                "code": getattr(enriched_result, "code", None),
+            },
+            link=link,
+            retention_class=TemporalArtifactRetentionClass.LONG,
+            redaction_level=TemporalArtifactRedactionLevel.NONE,
+        )
+        await self._artifact_service.write_complete(
+            artifact_id=artifact.artifact_id,
+            principal="agent_workflow",
+            payload=json.dumps(payload, sort_keys=True, indent=2).encode("utf-8"),
+            content_type="application/json",
+        )
+        metadata = dict(getattr(enriched_result, "metadata", {}) or {})
+        metadata["audit_ref"] = artifact.artifact_id
+        metadata["audit_event_count"] = len(events)
+        return enriched_result.model_copy(update={"metadata": metadata})
 
     def _with_activity_audit_context(self, result):
         if not getattr(result, "audit_events", None):

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -29,7 +29,7 @@ from moonmind.schemas.agent_skill_models import (
     RuntimeMaterializationMode,
 )
 from moonmind.services.skill_materialization import AgentSkillMaterializer
-from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
+from moonmind.services.skills_on_demand import skills_on_demand_runtime_instruction
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.temporal.artifacts import TemporalArtifactError
 
@@ -244,11 +244,11 @@ def build_skill_activation_summary(
         f"- Read `{skill_doc}` first and follow that active snapshot.\n"
         "- Do not discover skills from repo-local or local-only source folders during execution.\n"
     )
-    disabled_instruction = skills_on_demand_disabled_instruction(
+    on_demand_instruction = skills_on_demand_runtime_instruction(
         enabled=skills_on_demand_enabled
     )
-    if disabled_instruction:
-        block = block + f"{disabled_instruction}\n"
+    if on_demand_instruction:
+        block = block + f"{on_demand_instruction}\n"
     if not alias_available:
         block = block + (
             "- The repository also contains `.agents/skills`; that directory "

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, ValidationError
 from temporalio import exceptions as temporal_exceptions
 
 from moonmind.config.settings import settings
-from moonmind.services.skills_on_demand import skills_on_demand_disabled_instruction
+from moonmind.services.skills_on_demand import skills_on_demand_runtime_instruction
 from moonmind.integrations.pentest.models import (
     PENTEST_HEARTBEAT_PHASES,
     PentestApprovedScope,
@@ -6436,7 +6436,7 @@ class TemporalAgentRuntimeActivities:
             parameters=parameters,
             skill_materialization_metadata=skill_materialization_metadata,
         )
-        prepared = cls._append_skills_on_demand_disabled_notice(
+        prepared = cls._append_skills_on_demand_notice(
             prepared,
             parameters=parameters,
         )
@@ -6630,7 +6630,7 @@ class TemporalAgentRuntimeActivities:
         return instructions.rstrip() + "\n\n" + "\n".join(lines)
 
     @staticmethod
-    def _append_skills_on_demand_disabled_notice(
+    def _append_skills_on_demand_notice(
         instructions: str,
         *,
         parameters: Mapping[str, Any] | None,
@@ -6638,12 +6638,12 @@ class TemporalAgentRuntimeActivities:
         selected_skill = selected_agent_skill(parameters)
         if not selected_skill or selected_skill == _AUTO_SKILL_SENTINEL:
             return instructions
-        disabled_instruction = skills_on_demand_disabled_instruction(
+        on_demand_instruction = skills_on_demand_runtime_instruction(
             enabled=settings.workflow.skills_on_demand_enabled
         )
-        if not disabled_instruction or disabled_instruction in instructions:
+        if not on_demand_instruction or on_demand_instruction in instructions:
             return instructions
-        return instructions.rstrip() + "\n\n" + disabled_instruction
+        return instructions.rstrip() + "\n\n" + on_demand_instruction
 
     @staticmethod
     def _append_managed_step_boundary(instructions: str) -> str:
@@ -6695,11 +6695,11 @@ class TemporalAgentRuntimeActivities:
             f"- Read `{skill_doc}` first and follow that active snapshot.\n"
             "- Do not discover skills from repo-local or local-only source folders during execution.\n\n"
         )
-        disabled_instruction = skills_on_demand_disabled_instruction(
+        on_demand_instruction = skills_on_demand_runtime_instruction(
             enabled=settings.workflow.skills_on_demand_enabled
         )
-        if disabled_instruction:
-            block = block.rstrip() + f"\n{disabled_instruction}\n\n"
+        if on_demand_instruction:
+            block = block.rstrip() + f"\n{on_demand_instruction}\n\n"
         if not alias_available:
             block = block.rstrip() + (
                 "\n- The repository also contains `.agents/skills`; that directory "

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -13,6 +13,7 @@ from api_service.api.routers import mcp_tools as mcp_tools_router
 from api_service.auth_providers import get_current_user
 from moonmind.integrations.jira.errors import JiraToolError
 from moonmind.mcp.jira_tool_registry import JiraToolRegistry
+from moonmind.mcp.skills_on_demand_registry import SkillsOnDemandToolRegistry
 from moonmind.mcp.tool_registry import QueueToolRegistry, ResourceListResponse
 
 pytestmark = [pytest.mark.asyncio]
@@ -38,10 +39,18 @@ def router_app(
     app.include_router(mcp_tools_router.router, prefix="/api")
     app.dependency_overrides[CURRENT_USER_DEP] = lambda: SimpleNamespace(id=None)
     monkeypatch.setattr(mcp_tools_router, "_queue_registry", QueueToolRegistry())
+    monkeypatch.setattr(
+        mcp_tools_router,
+        "_skills_on_demand_registry",
+        SkillsOnDemandToolRegistry(expose_commands=False),
+    )
     monkeypatch.setattr(mcp_tools_router, "_jira_registry", None)
     monkeypatch.setattr(mcp_tools_router, "_jira_service", None)
     monkeypatch.setattr(mcp_tools_router, "_jules_registry", None)
     monkeypatch.setattr(mcp_tools_router, "_jules_client", None)
+    app.dependency_overrides[mcp_tools_router.get_async_session] = (
+        lambda: SimpleNamespace()
+    )
     return app
 
 
@@ -69,6 +78,62 @@ async def test_list_tools_includes_enabled_jira_tools(
     assert response.status_code == 200
     names = {tool["name"] for tool in response.json()["tools"]}
     assert {"jira.get_issue", "jira.verify_connection"}.issubset(names)
+
+
+async def test_list_tools_includes_skills_on_demand_commands_when_enabled(
+    router_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mcp_tools_router.settings.workflow,
+        "skills_on_demand_enabled",
+        True,
+    )
+    monkeypatch.setattr(
+        mcp_tools_router,
+        "_skills_on_demand_registry",
+        SkillsOnDemandToolRegistry(expose_commands=True),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=router_app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/mcp/tools")
+
+    assert response.status_code == 200
+    names = {tool["name"] for tool in response.json()["tools"]}
+    assert "moonmind.skills.query" in names
+    assert "moonmind.skills.request" in names
+
+
+async def test_call_skills_on_demand_query_denies_when_disabled(
+    router_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mcp_tools_router.settings.workflow,
+        "skills_on_demand_enabled",
+        False,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=router_app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/mcp/tools/call",
+            json={
+                "tool": "moonmind.skills.query",
+                "arguments": {"query": "jira"},
+            },
+        )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] == "denied"
+    assert result["code"] == "feature_disabled"
+    assert result["results"] == []
 
 
 async def test_streamable_http_initialize_returns_mcp_capabilities(
@@ -278,7 +343,8 @@ async def test_streamable_http_tools_call_preserves_string_result_text(
     router_app: FastAPI,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def dispatch_tool(payload: Any, user: Any) -> str:
+    async def dispatch_tool(payload: Any, user: Any, session: Any = None) -> str:
+        del payload, user, session
         return "success"
 
     monkeypatch.setattr(mcp_tools_router, "_dispatch_tool_call", dispatch_tool)

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -20,6 +20,11 @@ pytestmark = [pytest.mark.asyncio]
 
 CURRENT_USER_DEP = get_current_user()
 
+
+def _empty_async_session() -> SimpleNamespace:
+    return SimpleNamespace()
+
+
 class _FakeJiraService:
     def __init__(self) -> None:
         self.calls: list[tuple[str, Any]] = []
@@ -48,9 +53,7 @@ def router_app(
     monkeypatch.setattr(mcp_tools_router, "_jira_service", None)
     monkeypatch.setattr(mcp_tools_router, "_jules_registry", None)
     monkeypatch.setattr(mcp_tools_router, "_jules_client", None)
-    app.dependency_overrides[mcp_tools_router.get_async_session] = (
-        lambda: SimpleNamespace()
-    )
+    app.dependency_overrides[mcp_tools_router.get_async_session] = _empty_async_session
     return app
 
 

--- a/tests/unit/mcp/test_skills_on_demand_registry.py
+++ b/tests/unit/mcp/test_skills_on_demand_registry.py
@@ -27,12 +27,12 @@ def _entry(name: str) -> ResolvedSkillEntry:
     )
 
 
-def _snapshot() -> ResolvedSkillSet:
+def _snapshot(*, skills: list[ResolvedSkillEntry] | None = None) -> ResolvedSkillSet:
     return ResolvedSkillSet(
         snapshot_id="skillset-active",
         manifest_ref="manifest-active",
         resolved_at=datetime.now(UTC),
-        skills=[_entry("jira-issue-updater")],
+        skills=skills or [_entry("jira-issue-updater")],
     )
 
 
@@ -45,7 +45,7 @@ class _StaticArtifactService:
         allow_restricted_raw: bool,
     ) -> tuple[object, bytes]:
         del principal, allow_restricted_raw
-        assert artifact_id == "manifest-active"
+        assert artifact_id in {"manifest-active", "skillset-active"}
         return object(), json.dumps(_snapshot().model_dump(mode="json")).encode("utf-8")
 
 
@@ -120,6 +120,7 @@ async def test_enabled_request_already_active_returns_no_change() -> None:
         context=SkillsOnDemandToolExecutionContext(
             enabled=True,
             workspace_root="/tmp/repo",
+            artifact_service=_StaticArtifactService(),
         ),
     )
 
@@ -148,3 +149,30 @@ async def test_enabled_request_loads_active_snapshot_from_manifest_ref() -> None
     assert result["status"] == "no_change"
     assert result["active_snapshot_id"] == "skillset-active"
     assert result["parent_snapshot_ref"] == "skillset-active"
+
+
+async def test_enabled_request_rejects_caller_supplied_active_snapshot() -> None:
+    registry = SkillsOnDemandToolRegistry(expose_commands=True)
+    caller_snapshot = _snapshot(skills=[_entry("unsafe-client-skill")])
+
+    with patch(
+        "moonmind.mcp.skills_on_demand_registry.AgentSkillResolver.resolve",
+        new=AsyncMock(side_effect=ValueError("requested Skill was not found")),
+    ):
+        result = await registry.call_tool(
+            tool="moonmind.skills.request",
+            arguments={
+                "current_snapshot_ref": "skillset-active",
+                "requested_skills": [{"name": "unsafe-client-skill"}],
+                "active_snapshot": caller_snapshot.model_dump(mode="json"),
+            },
+            context=SkillsOnDemandToolExecutionContext(
+                enabled=True,
+                workspace_root="/tmp/repo",
+                artifact_service=_StaticArtifactService(),
+            ),
+        )
+
+    assert result["status"] == "denied"
+    assert result["code"] == "skill_not_found"
+    assert result["active_snapshot_id"] == "skillset-active"

--- a/tests/unit/mcp/test_skills_on_demand_registry.py
+++ b/tests/unit/mcp/test_skills_on_demand_registry.py
@@ -1,0 +1,150 @@
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from moonmind.mcp.skills_on_demand_registry import (
+    SkillsOnDemandToolExecutionContext,
+    SkillsOnDemandToolRegistry,
+)
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _entry(name: str) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name=name,
+        version="1.0.0",
+        content_ref="hidden-content-ref",
+        provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN),
+    )
+
+
+def _snapshot() -> ResolvedSkillSet:
+    return ResolvedSkillSet(
+        snapshot_id="skillset-active",
+        manifest_ref="manifest-active",
+        resolved_at=datetime.now(UTC),
+        skills=[_entry("jira-issue-updater")],
+    )
+
+
+class _StaticArtifactService:
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ) -> tuple[object, bytes]:
+        del principal, allow_restricted_raw
+        assert artifact_id == "manifest-active"
+        return object(), json.dumps(_snapshot().model_dump(mode="json")).encode("utf-8")
+
+
+async def test_skills_on_demand_commands_hidden_but_direct_call_denies_when_disabled() -> None:
+    registry = SkillsOnDemandToolRegistry(expose_commands=False)
+
+    assert registry.list_tools() == []
+
+    result = await registry.call_tool(
+        tool="moonmind.skills.query",
+        arguments={"query": "jira"},
+        context=SkillsOnDemandToolExecutionContext(
+            enabled=False,
+            workspace_root="/tmp/repo",
+        ),
+    )
+
+    assert result["status"] == "denied"
+    assert result["code"] == "feature_disabled"
+    assert result["results"] == []
+
+
+async def test_enabled_query_returns_metadata_without_skill_body_refs() -> None:
+    registry = SkillsOnDemandToolRegistry(expose_commands=True)
+
+    with patch(
+        "moonmind.mcp.skills_on_demand_registry.AgentSkillResolver.query_catalog",
+        new=AsyncMock(return_value=[_entry("jira-issue-updater")]),
+    ):
+        result = await registry.call_tool(
+            tool="moonmind.skills.query",
+            arguments={
+                "query": "jira",
+                "current_snapshot_ref": "skillset-active",
+                "active_snapshot": _snapshot().model_dump(mode="json"),
+            },
+            context=SkillsOnDemandToolExecutionContext(
+                enabled=True,
+                workspace_root="/tmp/repo",
+            ),
+        )
+
+    assert result["status"] == "ok"
+    assert result["results"] == [
+        {
+            "name": "jira-issue-updater",
+            "title": None,
+            "description": None,
+            "latest_version": "1.0.0",
+            "source_kind": "built_in",
+            "supported_runtimes": [],
+            "eligible": True,
+            "in_current_snapshot": True,
+            "eligibility_summary": "Eligible for this runtime and deployment policy.",
+        }
+    ]
+    assert "hidden-content-ref" not in str(result)
+    assert result["audit_events"][0]["event_type"] == "skills_on_demand.query"
+    assert result["audit_events"][0]["query_hash"]
+
+
+async def test_enabled_request_already_active_returns_no_change() -> None:
+    registry = SkillsOnDemandToolRegistry(expose_commands=True)
+
+    result = await registry.call_tool(
+        tool="moonmind.skills.request",
+        arguments={
+            "current_snapshot_ref": "skillset-active",
+            "requested_skills": [{"name": "jira-issue-updater"}],
+            "active_snapshot": _snapshot().model_dump(mode="json"),
+        },
+        context=SkillsOnDemandToolExecutionContext(
+            enabled=True,
+            workspace_root="/tmp/repo",
+        ),
+    )
+
+    assert result["status"] == "no_change"
+    assert result["code"] == "already_active"
+    assert result["active_snapshot_id"] == "skillset-active"
+    assert result["snapshot_id"] is None
+
+
+async def test_enabled_request_loads_active_snapshot_from_manifest_ref() -> None:
+    registry = SkillsOnDemandToolRegistry(expose_commands=True)
+
+    result = await registry.call_tool(
+        tool="moonmind.skills.request",
+        arguments={
+            "current_snapshot_ref": "manifest-active",
+            "requested_skills": [{"name": "jira-issue-updater"}],
+        },
+        context=SkillsOnDemandToolExecutionContext(
+            enabled=True,
+            workspace_root="/tmp/repo",
+            artifact_service=_StaticArtifactService(),
+        ),
+    )
+
+    assert result["status"] == "no_change"
+    assert result["active_snapshot_id"] == "skillset-active"
+    assert result["parent_snapshot_ref"] == "skillset-active"

--- a/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
+++ b/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
@@ -742,12 +742,14 @@ async def test_enabled_activity_request_does_not_persist_manifest_on_materializa
     class FakeArtifactService:
         def __init__(self) -> None:
             self.created: list[dict] = []
+            self.writes: list[dict] = []
 
         async def create(self, **kwargs):
             self.created.append(kwargs)
             return SimpleNamespace(artifact_id=f"artifact-{len(self.created)}"), None
 
-        async def write_complete(self, **_kwargs) -> None:
+        async def write_complete(self, **kwargs) -> None:
+            self.writes.append(kwargs)
             return None
 
     artifact_service = FakeArtifactService()
@@ -777,4 +779,11 @@ async def test_enabled_activity_request_does_not_persist_manifest_on_materializa
 
     assert result.status == "denied"
     assert result.code == "materialization_failed"
-    assert artifact_service.created == []
+    assert result.metadata["audit_ref"] == "artifact-1"
+    assert result.metadata["audit_event_count"] == 1
+    assert len(artifact_service.created) == 1
+    assert artifact_service.created[0]["metadata_json"]["producer"] == (
+        "agent_skill.skills_on_demand"
+    )
+    assert artifact_service.writes[0]["artifact_id"] == "artifact-1"
+    assert b"skills_on_demand.request" in artifact_service.writes[0]["payload"]

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -363,6 +363,21 @@ def test_activation_summary_includes_required_fields() -> None:
     assert "/work/agent_jobs/workspaces/r1/runtime/skills_active/snap-1/pr-resolver/SKILL.md" in summary
 
 
+def test_activation_summary_exposes_on_demand_commands_when_enabled() -> None:
+    summary = build_skill_activation_summary(
+        parameters={"selectedSkill": "pr-resolver"},
+        materialization_metadata={
+            "visiblePath": "/work/skills/snap",
+            "canonicalAliasAvailable": True,
+        },
+        skills_on_demand_enabled=True,
+    )
+
+    assert "Skills On Demand is enabled." in summary
+    assert "moonmind.skills.query" in summary
+    assert "moonmind.skills.request" in summary
+
+
 def test_activation_summary_warns_when_alias_unavailable() -> None:
     summary = build_skill_activation_summary(
         parameters={"selectedSkill": "pr-resolver"},

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3500,6 +3500,48 @@ async def test_agent_runtime_prepare_turn_instructions_warns_skills_on_demand_di
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_exposes_on_demand_commands_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        activity_runtime_module.settings.workflow,
+        "skills_on_demand_enabled",
+        True,
+    )
+    workspace = tmp_path / "agent_jobs" / "job-1" / "repo"
+    workspace.mkdir(parents=True)
+
+    activities = TemporalAgentRuntimeActivities()
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Use the active skill.",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "moonspec-implement",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+            "includePreparedRequestMetadata": True,
+            "skipSkillMaterialization": True,
+        }
+    )
+
+    instructions = result["instructions"]
+    assert "Skills On Demand is enabled." in instructions
+    assert "moonmind.skills.query" in instructions
+    assert "moonmind.skills.request" in instructions
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_fails_before_launch_when_projection_missing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Jira issue key: MM-603

Summary:
- Exposes Skills On Demand managed-runtime MCP commands as `moonmind.skills.query` and `moonmind.skills.request` when the feature flag is enabled, while keeping them hidden when disabled.
- Adds the Skills On Demand MCP registry and routes command execution through the existing artifact, skill resolution, materialization, and audit paths.
- Updates managed-runtime turn preparation and projection behavior so enabled runtimes receive guidance for querying/requesting additional skill metadata, and disabled runtimes do not see command names.
- Adds API, MCP registry, skill workflow, projection, and Temporal activity boundary coverage.

Tests run:
- `python -m py_compile api_service/api/routers/mcp_tools.py moonmind/mcp/skills_on_demand_registry.py moonmind/mcp/__init__.py tests/unit/mcp/test_skills_on_demand_registry.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/mcp/test_skills_on_demand_registry.py tests/unit/api/test_mcp_tools_router.py tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/workflows/skills/test_run_projection.py tests/unit/workflows/temporal/test_activity_runtime.py::test_prepare_managed_codex_turn_text_hides_on_demand_command_names_when_disabled tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_agent_runtime_prepare_turn_instructions_exposes_on_demand_commands_when_enabled` -> 69 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` -> Python 5869 passed, 6 skipped, 1 xpassed, 16 subtests passed; Vitest 27 files passed, 417 passed, 234 skipped
- `pytest tests/integration/temporal/test_skills_on_demand_disabled.py tests/integration/temporal/test_skills_on_demand_request_activation.py -q --tb=short` -> 7 passed

Remaining risks:
- Command-line git push was unavailable in this managed workspace because the MoonMind git credential helper auth socket was missing; the branch ref was updated through the authenticated GitHub connector instead.
- Broader compose-backed `integration_ci` was not rerun in this publication step; focused Skills On Demand integration coverage passed.