### PR TITLE
MM-746 Visualize workflow step DAG in Mission Control

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -86,7 +86,7 @@ The README was reframed (2026-06-09) around three headline value propositions �
 - [x] **3.1** Tracker-native proposal delivery/review — specs 312/313 shipped; `/proposals` remains admin/recovery coverage
 - [ ] **3.2** Automatic RAG context injection per step — Target-aware *prepared file* context is wired (specs 325/349), but retrieval-backed context packs (`rag/context_pack.py`) are still not injected into step execution (tracked with 5.3)
 - [x] **3.3** Context clearing between steps — MM-745
-- [ ] **3.4** Multi-step workflow visualization in Mission Control — Workflow detail subroute tabs shipped (MM-801), but no step-DAG rendering yet
+- [x] **3.4** Multi-step workflow visualization in Mission Control — Workflow detail Steps renders the step ledger as a visible dependency DAG with explicit edge labels (MM-746)
 - [x] **3.5 / 3.6** Preset-driven scheduling; schedules UI overhaul — shipped
 
 ---
@@ -149,7 +149,7 @@ All six items (run digests, fix patterns/error signatures, Mem0 long-term adapte
 - [x] **7.1** Settings migrated to Mission Control — specs 339/341/358/359
 - [ ] **7.2** Artifact browsing UI — API exists (`temporal_artifacts.py`); dashboard browsing of files/logs/patches still partial
 - [ ] **7.5** Side-by-side comparison view — Comparison runs preserve lineage (MM-773), but no side-by-side UI
-- [ ] **7.6** Multi-step / step DAG visualization — Same gap as 3.4
+- [x] **7.6** Multi-step / step DAG visualization — Mission Control workflow detail Steps renders step nodes and dependency edges from the step ledger (MM-746)
 - [ ] **7.7** Remediation panels — Tracked as 13.4
 
 ---

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -436,6 +436,7 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByRole('heading', { name: 'Workflow Steps' }).length).toBeGreaterThan(0);
       expect(screen.getByRole('heading', { name: 'Step DAG' })).toBeTruthy();
       expect(screen.getAllByText('Plan work').length).toBeGreaterThan(0);
+      expect(screen.getByLabelText('start to plan')).toBeTruthy();
       expect(screen.getByLabelText('plan to apply')).toBeTruthy();
       expect(screen.getByLabelText('apply to verify')).toBeTruthy();
       expect(screen.getByLabelText('Step dependency edges')).toBeTruthy();
@@ -443,6 +444,53 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Execution History' })).toBeNull();
+    });
+  });
+
+  it('MM-746 renders an empty step DAG without a fake start edge', async () => {
+    window.history.pushState({}, 'Empty Steps Test', '/workflows/test-123/steps?source=temporal');
+    const emptyStepsSnapshot = { ...latestStepsSnapshot, steps: [] };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Empty step ledger',
+      summary: 'No steps recorded yet',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => emptyStepsSnapshot,
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Step DAG' })).toBeTruthy();
+      expect(screen.getByText('No steps in the ledger yet.')).toBeTruthy();
+      expect(screen.queryByLabelText('start to none')).toBeNull();
+      expect(screen.queryByLabelText('Step dependency edges')).toBeNull();
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -436,6 +436,9 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByRole('heading', { name: 'Workflow Steps' }).length).toBeGreaterThan(0);
       expect(screen.getByRole('heading', { name: 'Step DAG' })).toBeTruthy();
       expect(screen.getAllByText('Plan work').length).toBeGreaterThan(0);
+      expect(screen.getByLabelText('plan to apply')).toBeTruthy();
+      expect(screen.getByLabelText('apply to verify')).toBeTruthy();
+      expect(screen.getByLabelText('Step dependency edges')).toBeTruthy();
       expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('aria-current')).toBe('page');
       expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
@@ -681,6 +684,8 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByText('Verify tests').length).toBeGreaterThan(0);
       expect(screen.getByRole('heading', { name: 'Step DAG' })).toBeTruthy();
       expect(screen.getByText('Depends on: plan')).toBeTruthy();
+      expect(screen.getByLabelText('plan to apply')).toBeTruthy();
+      expect(screen.getByLabelText('apply to verify')).toBeTruthy();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
     });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4241,26 +4241,103 @@ function StepDagOverview({
 }: {
   snapshot: z.infer<typeof StepLedgerSnapshotSchema>;
 }) {
+  const stepIds = new Set(snapshot.steps.map((step) => step.logicalStepId));
+  const dependencyEdges = snapshot.steps.flatMap((step) =>
+    step.dependsOn.map((sourceId) => ({
+      sourceId,
+      targetId: step.logicalStepId,
+      isKnownSource: stepIds.has(sourceId),
+    })),
+  );
+  const hasDependencies = dependencyEdges.length > 0;
+
   return (
     <section className="step-dag-panel" aria-label="Step DAG visualization">
       <h4>Step DAG</h4>
-      <div className="step-dag-grid">
-        {snapshot.steps.map((step) => (
-          <article key={step.logicalStepId} className="step-dag-node">
-            <div className="step-dag-node-header">
-              <strong>{step.title}</strong>
-              <span {...executionStatusPillProps(step.status)}>
-                {formatStatusLabel(step.status)}
-              </span>
+      <div className="step-dag-canvas">
+        {hasDependencies ? (
+          <svg
+            className="step-dag-edge-layer"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+          >
+            <defs>
+              <marker
+                id="step-dag-arrowhead"
+                viewBox="0 0 10 10"
+                refX="8"
+                refY="5"
+                markerWidth="5"
+                markerHeight="5"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" />
+              </marker>
+            </defs>
+            <path className="step-dag-edge-main" d="M 4 50 H 96" />
+            {snapshot.steps.map((step, index) => {
+              const x =
+                snapshot.steps.length > 1
+                  ? 6 + (index / (snapshot.steps.length - 1)) * 88
+                  : 50;
+              return (
+                <path
+                  key={step.logicalStepId}
+                  className="step-dag-edge-branch"
+                  d={`M ${x} 50 V 82`}
+                />
+              );
+            })}
+          </svg>
+        ) : null}
+        <div className="step-dag-grid" role="list" aria-label="Step dependency nodes">
+          {snapshot.steps.map((step) => (
+            <article key={step.logicalStepId} className="step-dag-node" role="listitem">
+              <div className="step-dag-node-header">
+                <strong>{step.title}</strong>
+                <span {...executionStatusPillProps(step.status)}>
+                  {formatStatusLabel(step.status)}
+                </span>
+              </div>
+              <div className="small">
+                <code>{step.logicalStepId}</code>
+              </div>
+              <div className="small">
+                Depends on: {step.dependsOn.length > 0 ? step.dependsOn.join(', ') : 'start'}
+              </div>
+            </article>
+          ))}
+        </div>
+        <div className="step-dag-edges" aria-label="Step dependency edges">
+          {hasDependencies ? (
+            dependencyEdges.map((edge) => (
+              <div
+                key={`${edge.sourceId}->${edge.targetId}`}
+                className={
+                  edge.isKnownSource
+                    ? 'step-dag-edge-label'
+                    : 'step-dag-edge-label step-dag-edge-label-missing'
+                }
+                aria-label={`${edge.sourceId} to ${edge.targetId}`}
+              >
+                <code>{edge.sourceId}</code>
+                <span aria-hidden="true">-&gt;</span>
+                <code>{edge.targetId}</code>
+              </div>
+            ))
+          ) : (
+            <div
+              className="step-dag-edge-label"
+              aria-label={`start to ${snapshot.steps[0]?.logicalStepId ?? 'none'}`}
+            >
+              <code>start</code>
+              <span aria-hidden="true">-&gt;</span>
+              <code>{snapshot.steps[0]?.logicalStepId ?? 'none'}</code>
             </div>
-            <div className="small">
-              <code>{step.logicalStepId}</code>
-            </div>
-            <div className="small">
-              Depends on: {step.dependsOn.length > 0 ? step.dependsOn.join(', ') : 'start'}
-            </div>
-          </article>
-        ))}
+          )}
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4249,70 +4249,44 @@ function StepDagOverview({
       isKnownSource: stepIds.has(sourceId),
     })),
   );
-  const hasDependencies = dependencyEdges.length > 0;
+  const rootEdges = snapshot.steps
+    .filter((step) => step.dependsOn.length === 0)
+    .map((step) => ({
+      sourceId: 'start',
+      targetId: step.logicalStepId,
+      isKnownSource: true,
+    }));
+  const displayEdges = [...rootEdges, ...dependencyEdges];
 
   return (
     <section className="step-dag-panel" aria-label="Step DAG visualization">
       <h4>Step DAG</h4>
       <div className="step-dag-canvas">
-        {hasDependencies ? (
-          <svg
-            className="step-dag-edge-layer"
-            aria-hidden="true"
-            focusable="false"
-            viewBox="0 0 100 100"
-            preserveAspectRatio="none"
-          >
-            <defs>
-              <marker
-                id="step-dag-arrowhead"
-                viewBox="0 0 10 10"
-                refX="8"
-                refY="5"
-                markerWidth="5"
-                markerHeight="5"
-                orient="auto-start-reverse"
-              >
-                <path d="M 0 0 L 10 5 L 0 10 z" />
-              </marker>
-            </defs>
-            <path className="step-dag-edge-main" d="M 4 50 H 96" />
-            {snapshot.steps.map((step, index) => {
-              const x =
-                snapshot.steps.length > 1
-                  ? 6 + (index / (snapshot.steps.length - 1)) * 88
-                  : 50;
-              return (
-                <path
-                  key={step.logicalStepId}
-                  className="step-dag-edge-branch"
-                  d={`M ${x} 50 V 82`}
-                />
-              );
-            })}
-          </svg>
-        ) : null}
-        <div className="step-dag-grid" role="list" aria-label="Step dependency nodes">
-          {snapshot.steps.map((step) => (
-            <article key={step.logicalStepId} className="step-dag-node" role="listitem">
-              <div className="step-dag-node-header">
-                <strong>{step.title}</strong>
-                <span {...executionStatusPillProps(step.status)}>
-                  {formatStatusLabel(step.status)}
-                </span>
-              </div>
-              <div className="small">
-                <code>{step.logicalStepId}</code>
-              </div>
-              <div className="small">
-                Depends on: {step.dependsOn.length > 0 ? step.dependsOn.join(', ') : 'start'}
-              </div>
-            </article>
-          ))}
-        </div>
-        <div className="step-dag-edges" aria-label="Step dependency edges">
-          {hasDependencies ? (
-            dependencyEdges.map((edge) => (
+        {snapshot.steps.length > 0 ? (
+          <div className="step-dag-grid" role="list" aria-label="Step dependency nodes">
+            {snapshot.steps.map((step) => (
+              <article key={step.logicalStepId} className="step-dag-node" role="listitem">
+                <div className="step-dag-node-header">
+                  <strong>{step.title}</strong>
+                  <span {...executionStatusPillProps(step.status)}>
+                    {formatStatusLabel(step.status)}
+                  </span>
+                </div>
+                <div className="small">
+                  <code>{step.logicalStepId}</code>
+                </div>
+                <div className="small">
+                  Depends on: {step.dependsOn.length > 0 ? step.dependsOn.join(', ') : 'start'}
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="small step-dag-empty">No steps in the ledger yet.</p>
+        )}
+        {displayEdges.length > 0 ? (
+          <div className="step-dag-edges" aria-label="Step dependency edges">
+            {displayEdges.map((edge) => (
               <div
                 key={`${edge.sourceId}->${edge.targetId}`}
                 className={
@@ -4326,18 +4300,9 @@ function StepDagOverview({
                 <span aria-hidden="true">-&gt;</span>
                 <code>{edge.targetId}</code>
               </div>
-            ))
-          ) : (
-            <div
-              className="step-dag-edge-label"
-              aria-label={`start to ${snapshot.steps[0]?.logicalStepId ?? 'none'}`}
-            >
-              <code>start</code>
-              <span aria-hidden="true">-&gt;</span>
-              <code>{snapshot.steps[0]?.logicalStepId ?? 'none'}</code>
-            </div>
-          )}
-        </div>
+            ))}
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3015,37 +3015,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   gap: 0.75rem;
 }
 
-.step-dag-edge-layer {
-  position: absolute;
-  inset: 0.25rem 0.4rem 3.2rem;
-  z-index: 0;
-  overflow: visible;
-  pointer-events: none;
-  color: rgb(71 85 105);
-}
-
-.dark .step-dag-edge-layer {
-  color: rgb(148 163 184);
-}
-
-.step-dag-edge-layer marker path {
-  fill: currentColor;
-}
-
-.step-dag-edge-main,
-.step-dag-edge-branch {
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-width: 1.35;
-  marker-end: url("#step-dag-arrowhead");
-}
-
-.step-dag-edge-branch {
-  opacity: 0.72;
-  stroke-dasharray: 2.5 2.5;
-}
-
 .step-dag-grid {
   position: relative;
   z-index: 1;
@@ -3117,10 +3086,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 @media (max-width: 720px) {
-  .step-dag-edge-layer {
-    display: none;
-  }
-
   .step-dag-edge-label {
     white-space: normal;
   }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3009,7 +3009,46 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-weight: 700;
 }
 
+.step-dag-canvas {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.step-dag-edge-layer {
+  position: absolute;
+  inset: 0.25rem 0.4rem 3.2rem;
+  z-index: 0;
+  overflow: visible;
+  pointer-events: none;
+  color: rgb(71 85 105);
+}
+
+.dark .step-dag-edge-layer {
+  color: rgb(148 163 184);
+}
+
+.step-dag-edge-layer marker path {
+  fill: currentColor;
+}
+
+.step-dag-edge-main,
+.step-dag-edge-branch {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.35;
+  marker-end: url("#step-dag-arrowhead");
+}
+
+.step-dag-edge-branch {
+  opacity: 0.72;
+  stroke-dasharray: 2.5 2.5;
+}
+
 .step-dag-grid {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 0.75rem;
@@ -3022,30 +3061,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   border-radius: 0.75rem;
   padding: 0.85rem;
   background: white;
+  box-shadow: 0 16px 32px rgb(15 23 42 / 0.08);
 }
 
 .dark .step-dag-node {
   border-color: rgb(51 65 85);
   background: rgb(15 23 42);
-}
-
-.step-dag-node::after {
-  content: "";
-  position: absolute;
-  right: -0.55rem;
-  top: 50%;
-  width: 0.55rem;
-  border-top: 2px solid rgb(148 163 184);
-}
-
-.step-dag-node:last-child::after {
-  display: none;
-}
-
-@media (max-width: 720px) {
-  .step-dag-node::after {
-    display: none;
-  }
 }
 
 .step-dag-node-header {
@@ -3054,6 +3075,55 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+}
+
+.step-dag-edges {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.step-dag-edge-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  border: 1px solid rgb(203 213 225);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  background: rgb(255 255 255 / 0.88);
+  color: rgb(51 65 85);
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.dark .step-dag-edge-label {
+  border-color: rgb(51 65 85);
+  background: rgb(15 23 42 / 0.9);
+  color: rgb(203 213 225);
+}
+
+.step-dag-edge-label-missing {
+  border-color: rgb(245 158 11 / 0.55);
+  color: rgb(146 64 14);
+}
+
+.dark .step-dag-edge-label-missing {
+  border-color: rgb(251 191 36 / 0.45);
+  color: rgb(252 211 77);
+}
+
+@media (max-width: 720px) {
+  .step-dag-edge-layer {
+    display: none;
+  }
+
+  .step-dag-edge-label {
+    white-space: normal;
+  }
 }
 
 .step-tl-row {


### PR DESCRIPTION
Jira issue key: MM-746

Summary:
- Renders workflow detail Steps as a visible dependency DAG backed by the step ledger.
- Adds explicit dependency edge labels and accessible edge/node labels for step relationships.
- Updates roadmap items 3.4 and 7.6 to reflect the shipped Mission Control DAG visualization.

Tests run:
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx (112 passed)

Remaining risks:
- Full unit suite was not run in this handoff step; verification was limited to the focused workflow detail frontend test.