### PR TITLE
MM-810 add non-attempt gate budget stop dimension

### DIFF
--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -339,7 +339,14 @@ Representative shape:
   "budget": {
     "executionLimit": 3,
     "executionOrdinalInLoop": 2,
-    "remainingExecutions": 1
+    "remainingExecutions": 1,
+    "additionalStopDimension": {
+      "type": "consecutive_no_progress_attempts",
+      "limit": 2,
+      "consumed": 0,
+      "remaining": 2,
+      "exhausted": false
+    }
   }
 }
 ```
@@ -845,6 +852,10 @@ Budget dimensions may include:
 4. maximum consecutive no-progress attempts;
 5. maximum failed command repeats;
 6. maximum unsafe or policy-denied attempts.
+
+Step Execution manifests for autonomous loops must record the attempt budget and
+at least one additional non-attempt stop dimension with its limit, consumed
+count, remaining count, and exhausted state.
 
 When a budget is exhausted, MoonMind must stop with a deterministic terminal disposition such as `needs_human`, `blocked`, or `failed_with_remaining_work`. It must publish the latest evidence and recommended next action.
 

--- a/moonmind/workflows/skills/tool_plan_contracts.py
+++ b/moonmind/workflows/skills/tool_plan_contracts.py
@@ -785,6 +785,7 @@ class ApprovalPolicyPolicy:
 
     enabled: bool = False
     max_review_attempts: int = 2
+    max_consecutive_no_progress_attempts: int | None = None
     reviewer_model: str = "default"
     review_timeout_seconds: int = 120
     skip_tool_types: tuple[str, ...] = DEFAULT_SKIP_TOOL_TYPES
@@ -799,6 +800,14 @@ class ApprovalPolicyPolicy:
                 "invalid_policy",
                 "approval_policy.max_review_attempts must be >= 0",
             )
+        if (
+            self.max_consecutive_no_progress_attempts is not None
+            and self.max_consecutive_no_progress_attempts < 1
+        ):
+            raise ContractValidationError(
+                "invalid_policy",
+                "approval_policy.max_consecutive_no_progress_attempts must be >= 1",
+            )
         if self.review_timeout_seconds <= 0:
             raise ContractValidationError(
                 "invalid_policy",
@@ -806,13 +815,18 @@ class ApprovalPolicyPolicy:
             )
 
     def to_payload(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "enabled": self.enabled,
             "max_review_attempts": self.max_review_attempts,
             "reviewer_model": self.reviewer_model,
             "review_timeout_seconds": self.review_timeout_seconds,
             "skip_tool_types": list(self.skip_tool_types),
         }
+        if self.max_consecutive_no_progress_attempts is not None:
+            payload["max_consecutive_no_progress_attempts"] = (
+                self.max_consecutive_no_progress_attempts
+            )
+        return payload
 
 @dataclass(frozen=True, slots=True)
 class PlanPolicy:
@@ -1101,6 +1115,16 @@ def parse_plan_definition(payload: Mapping[str, Any]) -> PlanDefinition:
                 int(raw_attempts)
                 if (raw_attempts := approval_policy_raw.get("max_review_attempts")) is not None
                 else 2
+            ),
+            max_consecutive_no_progress_attempts=(
+                int(raw_no_progress_attempts)
+                if (
+                    raw_no_progress_attempts := approval_policy_raw.get(
+                        "max_consecutive_no_progress_attempts"
+                    )
+                )
+                is not None
+                else None
             ),
             reviewer_model=str(
                 approval_policy_raw.get("reviewer_model") or "default"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2585,23 +2585,41 @@ class MoonMindRunWorkflow:
         *,
         max_review_attempts: int,
         review_retry_count: int,
+        max_consecutive_no_progress_attempts: int,
+        consecutive_no_progress_attempts: int,
         verdict: str | None = None,
         recommended_next_action: str | None = None,
     ) -> dict[str, Any]:
         attempts_allowed = max_review_attempts + 1
         attempts_consumed = review_retry_count + 1
         remaining_executions = max(0, attempts_allowed - attempts_consumed)
+        no_progress_exhausted = (
+            consecutive_no_progress_attempts
+            >= max_consecutive_no_progress_attempts
+        )
         metadata: dict[str, Any] = {
             "gate": "approval_policy",
             "maxAttempts": attempts_allowed,
             "attemptsConsumed": attempts_consumed,
             "remainingExecutions": remaining_executions,
+            "additionalStopDimension": {
+                "type": "consecutive_no_progress_attempts",
+                "limit": max_consecutive_no_progress_attempts,
+                "consumed": consecutive_no_progress_attempts,
+                "remaining": max(
+                    0,
+                    max_consecutive_no_progress_attempts
+                    - consecutive_no_progress_attempts,
+                ),
+                "exhausted": no_progress_exhausted,
+            },
             "stopRules": [
                 "structured_gate_verdict_required",
                 "accepted_output_evidence_required",
+                "consecutive_no_progress_attempts_exhaustion_stops_before_publication",
                 "budget_exhaustion_stops_before_publication",
             ],
-            "exhausted": remaining_executions == 0,
+            "exhausted": remaining_executions == 0 or no_progress_exhausted,
         }
         if verdict:
             metadata["gateVerdict"] = str(verdict).strip().upper()
@@ -2615,9 +2633,16 @@ class MoonMindRunWorkflow:
         verdict: Any,
         review_retry_count: int,
         max_review_attempts: int,
+        consecutive_no_progress_attempts: int,
+        max_consecutive_no_progress_attempts: int,
     ) -> bool:
         normalized = str(getattr(verdict, "verdict", "") or "").strip().upper()
         if review_retry_count >= max_review_attempts:
+            return False
+        if (
+            consecutive_no_progress_attempts
+            >= max_consecutive_no_progress_attempts
+        ):
             return False
         if normalized == "ADDITIONAL_WORK_NEEDED":
             return True
@@ -4238,7 +4263,19 @@ class MoonMindRunWorkflow:
                 if review_gate_active
                 else 0
             )
+            max_consecutive_no_progress_attempts = max(1, max_review_attempts + 1)
+            if review_gate_active:
+                raw_no_progress_attempts = getattr(
+                    approval_policy,
+                    "max_consecutive_no_progress_attempts",
+                    None,
+                )
+                if raw_no_progress_attempts is not None:
+                    max_consecutive_no_progress_attempts = int(
+                        raw_no_progress_attempts
+                    )
             review_retry_count = 0
+            consecutive_no_progress_attempts = 0
             previous_review_feedback: str | None = None
             previous_review_issues: tuple[Mapping[str, Any], ...] = ()
             result_status: str | None = None
@@ -4332,6 +4369,12 @@ class MoonMindRunWorkflow:
                             budget=self._review_gate_budget_metadata(
                                 max_review_attempts=max_review_attempts,
                                 review_retry_count=review_retry_count,
+                                max_consecutive_no_progress_attempts=(
+                                    max_consecutive_no_progress_attempts
+                                ),
+                                consecutive_no_progress_attempts=(
+                                    consecutive_no_progress_attempts
+                                ),
                             )
                             if review_gate_active
                             else None,
@@ -4728,6 +4771,7 @@ class MoonMindRunWorkflow:
                 )
 
                 if review_verdict.verdict != "FULLY_IMPLEMENTED":
+                    consecutive_no_progress_attempts += 1
                     failed_review_summary = self._bounded_review_summary(
                         review_verdict.feedback,
                         fallback="Structured gate did not approve advancement",
@@ -4744,6 +4788,12 @@ class MoonMindRunWorkflow:
                         verdict=review_verdict,
                         review_retry_count=review_retry_count,
                         max_review_attempts=max_review_attempts,
+                        consecutive_no_progress_attempts=(
+                            consecutive_no_progress_attempts
+                        ),
+                        max_consecutive_no_progress_attempts=(
+                            max_consecutive_no_progress_attempts
+                        ),
                     ):
                         review_retry_count += 1
                         previous_review_feedback = (
@@ -4773,6 +4823,12 @@ class MoonMindRunWorkflow:
                         budget=self._review_gate_budget_metadata(
                             max_review_attempts=max_review_attempts,
                             review_retry_count=review_retry_count,
+                            max_consecutive_no_progress_attempts=(
+                                max_consecutive_no_progress_attempts
+                            ),
+                            consecutive_no_progress_attempts=(
+                                consecutive_no_progress_attempts
+                            ),
                             verdict=review_verdict.verdict,
                             recommended_next_action=(
                                 review_verdict.recommended_next_action
@@ -4818,6 +4874,12 @@ class MoonMindRunWorkflow:
                         budget=self._review_gate_budget_metadata(
                             max_review_attempts=max_review_attempts,
                             review_retry_count=review_retry_count,
+                            max_consecutive_no_progress_attempts=(
+                                max_consecutive_no_progress_attempts
+                            ),
+                            consecutive_no_progress_attempts=(
+                                consecutive_no_progress_attempts
+                            ),
                             verdict=review_verdict.verdict,
                             recommended_next_action="needs_human",
                         ),
@@ -4874,6 +4936,12 @@ class MoonMindRunWorkflow:
                 budget=self._review_gate_budget_metadata(
                     max_review_attempts=max_review_attempts,
                     review_retry_count=review_retry_count,
+                    max_consecutive_no_progress_attempts=(
+                        max_consecutive_no_progress_attempts
+                    ),
+                    consecutive_no_progress_attempts=(
+                        consecutive_no_progress_attempts
+                    ),
                     verdict="FULLY_IMPLEMENTED",
                     recommended_next_action="advance",
                 )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2650,6 +2650,23 @@ class MoonMindRunWorkflow:
             getattr(verdict, "recoverable_in_current_runtime", False)
         )
 
+    @staticmethod
+    def _review_gate_verdict_made_progress(verdict: Any) -> bool:
+        normalized = str(getattr(verdict, "verdict", "") or "").strip().upper()
+        recommended_next_action = (
+            str(getattr(verdict, "recommended_next_action", "") or "")
+            .strip()
+            .lower()
+        )
+        remaining_work_ref = str(
+            getattr(verdict, "remaining_work_ref", "") or ""
+        ).strip()
+        return (
+            normalized == "ADDITIONAL_WORK_NEEDED"
+            and recommended_next_action == "reattempt_current_step"
+            and bool(remaining_work_ref)
+        )
+
     def _terminal_disposition_for_gate_stop(self, verdict: Any) -> str:
         normalized = str(getattr(verdict, "verdict", "") or "").strip().upper()
         if normalized == "BLOCKED":
@@ -4771,7 +4788,10 @@ class MoonMindRunWorkflow:
                 )
 
                 if review_verdict.verdict != "FULLY_IMPLEMENTED":
-                    consecutive_no_progress_attempts += 1
+                    if self._review_gate_verdict_made_progress(review_verdict):
+                        consecutive_no_progress_attempts = 0
+                    else:
+                        consecutive_no_progress_attempts += 1
                     failed_review_summary = self._bounded_review_summary(
                         review_verdict.feedback,
                         fallback="Structured gate did not approve advancement",

--- a/tests/unit/workflows/skills/test_review_gate_contracts.py
+++ b/tests/unit/workflows/skills/test_review_gate_contracts.py
@@ -25,18 +25,32 @@ class TestApprovalPolicyPolicy:
         p = ApprovalPolicyPolicy()
         assert p.enabled is False
         assert p.max_review_attempts == 2
+        assert p.max_consecutive_no_progress_attempts is None
         assert p.reviewer_model == "default"
         assert p.review_timeout_seconds == 120
         assert p.skip_tool_types == DEFAULT_SKIP_TOOL_TYPES
 
     def test_enabled(self):
-        p = ApprovalPolicyPolicy(enabled=True, max_review_attempts=3)
+        p = ApprovalPolicyPolicy(
+            enabled=True,
+            max_review_attempts=3,
+            max_consecutive_no_progress_attempts=2,
+        )
         assert p.enabled is True
         assert p.max_review_attempts == 3
+        assert p.max_consecutive_no_progress_attempts == 2
 
     def test_negative_max_attempts_rejected(self):
         with pytest.raises(ContractValidationError, match="max_review_attempts"):
             ApprovalPolicyPolicy(max_review_attempts=-1)
+
+    @pytest.mark.parametrize("value", [-1, 0])
+    def test_invalid_no_progress_attempts_rejected(self, value):
+        with pytest.raises(
+            ContractValidationError,
+            match="max_consecutive_no_progress_attempts",
+        ):
+            ApprovalPolicyPolicy(max_consecutive_no_progress_attempts=value)
 
     def test_zero_max_attempts_allowed(self):
         p = ApprovalPolicyPolicy(max_review_attempts=0)
@@ -50,6 +64,7 @@ class TestApprovalPolicyPolicy:
         p = ApprovalPolicyPolicy(enabled=True, skip_tool_types=("agent_runtime",))
         payload = p.to_payload()
         assert payload["enabled"] is True
+        assert "max_consecutive_no_progress_attempts" not in payload
         assert payload["skip_tool_types"] == ["agent_runtime"]
 
 # ── ReviewRequest ─────────────────────────────────────────────────────

--- a/tests/unit/workflows/skills/test_review_gate_policy.py
+++ b/tests/unit/workflows/skills/test_review_gate_policy.py
@@ -75,6 +75,7 @@ class TestParsePlanDefinitionApprovalPolicy:
                 "approval_policy": {
                     "enabled": True,
                     "max_review_attempts": 3,
+                    "max_consecutive_no_progress_attempts": 2,
                     "reviewer_model": "gpt-4",
                     "review_timeout_seconds": 60,
                     "skip_tool_types": ["agent_runtime"],
@@ -85,6 +86,7 @@ class TestParsePlanDefinitionApprovalPolicy:
         rg = plan.policy.approval_policy
         assert rg.enabled is True
         assert rg.max_review_attempts == 3
+        assert rg.max_consecutive_no_progress_attempts == 2
         assert rg.reviewer_model == "gpt-4"
         assert rg.review_timeout_seconds == 60
         assert rg.skip_tool_types == ("agent_runtime",)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1699,15 +1699,168 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
         "maxAttempts": 1,
         "attemptsConsumed": 1,
         "remainingExecutions": 0,
+        "additionalStopDimension": {
+            "type": "consecutive_no_progress_attempts",
+            "limit": 1,
+            "consumed": 1,
+            "remaining": 0,
+            "exhausted": True,
+        },
         "stopRules": [
             "structured_gate_verdict_required",
             "accepted_output_evidence_required",
+            "consecutive_no_progress_attempts_exhaustion_stops_before_publication",
             "budget_exhaustion_stops_before_publication",
         ],
         "exhausted": True,
         "gateVerdict": "ADDITIONAL_WORK_NEEDED",
         "recommendedNextAction": "needs_human",
     }
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_stops_downstream_handoff_when_no_progress_budget_exhausts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    invoked_skills: list[str] = []
+    step_execution_payloads: list[dict[str, Any]] = []
+
+    plan_payload = _approval_policy_plan_payload()
+    plan_payload["policy"]["failure_mode"] = "CONTINUE"
+    plan_payload["policy"]["approval_policy"]["max_review_attempts"] = 2
+    plan_payload["policy"]["approval_policy"][
+        "max_consecutive_no_progress_attempts"
+    ] = 1
+    plan_payload["nodes"] = [
+        {
+            "id": "implement",
+            "tool": {"type": "agent_runtime", "name": "repo.apply_patch", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Apply patch"},
+            "options": {},
+        },
+        {
+            "id": "publish",
+            "tool": {"type": "agent_runtime", "name": "repo.publish", "version": "1.0.0"},
+            "inputs": {"targetRuntime": "codex_cli", "instructions": "Publish"},
+            "options": {},
+        },
+    ]
+    plan_payload["edges"] = [{"from": "implement", "to": "publish"}]
+    registry_payload = _registry_payload()
+    registry_payload["skills"].append(
+        {
+            **registry_payload["skills"][0],
+            "name": "repo.publish",
+        }
+    )
+    artifact_ids = iter(
+        (
+            "art_attempt_1",
+            "art_review_1",
+            "art_attempt_1_terminal",
+        )
+    )
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
+        if activity_type == "artifact.create":
+            return ({"artifact_id": next(artifact_ids)}, {"upload_url": "unused"})
+        if activity_type == "step.review":
+            return {
+                "verdict": "ADDITIONAL_WORK_NEEDED",
+                "confidence": "medium",
+                "feedback": "No material progress.",
+                "issues": [],
+                "remainingWorkRef": "art_remaining_work_1",
+                "recommendedNextAction": "needs_human",
+            }
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        invoked_skills.append(str(kwargs["id"]).rsplit(":agent:", 1)[1])
+        return {
+            "summary": "Patch applied",
+            "metadata": {"outputSummaryRef": "art_summary_1"},
+            "output_refs": [],
+        }
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            artifact_ref = getattr(payload, "artifact_ref", None)
+            if artifact_ref == "art_plan_1":
+                return json.dumps(plan_payload).encode("utf-8")
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(registry_payload).encode("utf-8")
+        if activity_type == "artifact.write_complete":
+            decoded = json.loads(payload.payload.decode("utf-8"))
+            if getattr(payload, "content_type", "") == (
+                "application/vnd.moonmind.step-execution+json;version=1"
+            ):
+                step_execution_payloads.append(decoded)
+            return {"ok": True}
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    assert invoked_skills == ["implement"]
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["status"] == "failed"
+    assert workflow._publish_status == "not_required"
+    assert workflow._publish_reason == (
+        "Structured gate stopped before downstream handoff."
+    )
+    budget = step_execution_payloads[-1]["budget"]
+    assert step_execution_payloads[-1]["terminalDisposition"] == (
+        "failed_with_remaining_work"
+    )
+    assert budget["maxAttempts"] == 3
+    assert budget["attemptsConsumed"] == 1
+    assert budget["remainingExecutions"] == 2
+    assert budget["additionalStopDimension"] == {
+        "type": "consecutive_no_progress_attempts",
+        "limit": 1,
+        "consumed": 1,
+        "remaining": 0,
+        "exhausted": True,
+    }
+    assert budget["exhausted"] is True
+    assert budget["gateVerdict"] == "ADDITIONAL_WORK_NEEDED"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1420,6 +1420,10 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     workflow._owner_id = "owner-1"
     written_review_payloads: list[dict[str, Any]] = []
     skill_inputs: list[dict[str, Any]] = []
+    plan_payload = _approval_policy_plan_payload()
+    plan_payload["policy"]["approval_policy"][
+        "max_consecutive_no_progress_attempts"
+    ] = 1
     review_artifact_ids = iter(("art_review_1", "art_review_2"))
     step_execution_artifact_ids = iter(
         (
@@ -1441,6 +1445,8 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
                         "evidence": "stderr tail",
                     }
                 ],
+                "remainingWorkRef": "art_remaining_work_1",
+                "recommendedNextAction": "reattempt_current_step",
             },
             {
                 "verdict": "PASS",
@@ -1492,7 +1498,7 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
         if activity_type == "artifact.read":
             artifact_ref = getattr(payload, "artifact_ref", None)
             if artifact_ref == "art_plan_1":
-                return json.dumps(_approval_policy_plan_payload()).encode("utf-8")
+                return json.dumps(plan_payload).encode("utf-8")
             if artifact_ref == "artifact://registry/1":
                 return json.dumps(_registry_payload()).encode("utf-8")
         if activity_type == "artifact.write_complete":


### PR DESCRIPTION
Jira issue key: MM-810

Summary:
- Adds an explicit consecutive no-progress stop dimension to approval-policy gate budgets.
- Records limit, consumed, remaining, and exhausted state in Step Execution budget manifests.
- Stops downstream publication/handoff when the non-attempt stop dimension is exhausted and documents the manifest contract.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_step_execution_manifest.py -q
- MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1 pytest tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py -m integration_ci -q --tb=short

Remaining risks:
- Full unit suite was not rerun in this PR publication step; prior verification covered the changed workflow and manifest surfaces.
