### PR TITLE
MM-818 sanitize Step Execution attempts and enforce skill policy

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -50,6 +50,7 @@ from moonmind.schemas.manifest_ingest_models import (
     ManifestStatusSnapshotModel,
 )
 from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
+from moonmind.utils.logging import redact_sensitive_text
 from moonmind.schemas.temporal_models import (
     CancelExecutionRequest,
     ConfigureIntegrationMonitoringRequest,
@@ -4046,6 +4047,12 @@ def _first_text(*values: Any) -> str | None:
     return None
 
 
+def _safe_display_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return redact_sensitive_text(value)
+
+
 def _quality_gate_verdict(checks: list[dict[str, Any]]) -> str | None:
     for check in checks:
         if not isinstance(check, (Mapping, BaseModel)):
@@ -4098,9 +4105,11 @@ def _step_execution_projection_payload(
     source_execution_ordinal = (
         manifest.lineage.source_execution_ordinal if manifest.lineage is not None else None
     )
-    summary = _first_text(
-        _field_value(outputs, "summary"),
-        _field_value(execution, "summary"),
+    summary = _safe_display_text(
+        _first_text(
+            _field_value(outputs, "summary"),
+            _field_value(execution, "summary"),
+        )
     )
     return {
         "manifestArtifactRef": manifest_artifact_ref,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -87,6 +87,7 @@ from moonmind.codex_cloud.settings import build_codex_cloud_gate, CODEX_CLOUD_DI
 from moonmind.workflows.adapters.jules_client import JulesClient
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.schemas.agent_skill_models import (
+    AgentSkillSourceKind,
     ResolvedSkillSet,
     RuntimeMaterializationMode,
 )
@@ -6374,6 +6375,36 @@ class TemporalAgentRuntimeActivities:
             raise TemporalActivityRuntimeError(
                 "selected skill materialization failed before runtime launch: "
                 f"active skill manifest does not include selected skill '{selected_skill}'"
+            )
+
+        selected_entry = next(
+            (
+                entry
+                for entry in resolved_skillset.skills
+                if entry.skill_name == selected_skill
+            ),
+            None,
+        )
+        if selected_entry is None:
+            raise TemporalActivityRuntimeError(
+                "selected skill materialization failed before runtime launch: "
+                f"resolvedSkillsetRef does not include selected skill '{selected_skill}'"
+            )
+        source_kind = selected_entry.provenance.source_kind
+        policy_summary = resolved_skillset.policy_summary
+        if source_kind == AgentSkillSourceKind.REPO and (
+            policy_summary.get("repo_skills_allowed") is not True
+        ):
+            raise TemporalActivityRuntimeError(
+                "selected skill materialization failed before runtime launch: "
+                f"repo skill source for '{selected_skill}' is disabled by skill source policy"
+            )
+        if source_kind == AgentSkillSourceKind.LOCAL and (
+            policy_summary.get("local_skills_allowed") is not True
+        ):
+            raise TemporalActivityRuntimeError(
+                "selected skill materialization failed before runtime launch: "
+                f"local skill source for '{selected_skill}' is disabled by skill source policy"
             )
 
     async def _load_resolved_skillset(self, skillset_ref: str) -> ResolvedSkillSet:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6274,6 +6274,7 @@ class TemporalAgentRuntimeActivities:
                     "selected skill materialization failed before runtime launch: "
                     f"selected skill '{selected_skill}' is not present in resolvedSkillsetRef {skillset_ref}"
                 )
+            self._validate_resolved_skillset_source_policy(resolved_skillset)
             skills_backing_root = (
                 run_root
                 / "runtime"
@@ -6390,22 +6391,31 @@ class TemporalAgentRuntimeActivities:
                 "selected skill materialization failed before runtime launch: "
                 f"resolvedSkillsetRef does not include selected skill '{selected_skill}'"
             )
-        source_kind = selected_entry.provenance.source_kind
-        policy_summary = resolved_skillset.policy_summary
-        if source_kind == AgentSkillSourceKind.REPO and (
-            policy_summary.get("repo_skills_allowed") is not True
-        ):
-            raise TemporalActivityRuntimeError(
-                "selected skill materialization failed before runtime launch: "
-                f"repo skill source for '{selected_skill}' is disabled by skill source policy"
-            )
-        if source_kind == AgentSkillSourceKind.LOCAL and (
-            policy_summary.get("local_skills_allowed") is not True
-        ):
-            raise TemporalActivityRuntimeError(
-                "selected skill materialization failed before runtime launch: "
-                f"local skill source for '{selected_skill}' is disabled by skill source policy"
-            )
+        TemporalAgentRuntimeActivities._validate_resolved_skillset_source_policy(
+            resolved_skillset
+        )
+
+    @staticmethod
+    def _validate_resolved_skillset_source_policy(
+        resolved_skillset: ResolvedSkillSet,
+    ) -> None:
+        policy_summary = resolved_skillset.policy_summary or {}
+        for entry in resolved_skillset.skills:
+            source_kind = entry.provenance.source_kind
+            if source_kind == AgentSkillSourceKind.REPO and (
+                policy_summary.get("repo_skills_allowed") is not True
+            ):
+                raise TemporalActivityRuntimeError(
+                    "selected skill materialization failed before runtime launch: "
+                    f"repo skill source for '{entry.skill_name}' is disabled by skill source policy"
+                )
+            if source_kind == AgentSkillSourceKind.LOCAL and (
+                policy_summary.get("local_skills_allowed") is not True
+            ):
+                raise TemporalActivityRuntimeError(
+                    "selected skill materialization failed before runtime launch: "
+                    f"local skill source for '{entry.skill_name}' is disabled by skill source policy"
+                )
 
     async def _load_resolved_skillset(self, skillset_ref: str) -> ResolvedSkillSet:
         if self._artifact_service is None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7160,6 +7160,85 @@ def test_get_execution_step_executions_returns_bounded_manifest_history() -> Non
     )
 
 
+def test_get_execution_step_executions_sanitizes_failed_attempt_summary() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={
+            "workflowId": "mm:wf-1",
+            "runId": "run-99",
+            "runScope": "latest",
+            "steps": [
+                {
+                    "logicalStepId": "implement",
+                    "order": 1,
+                    "title": "Implement",
+                    "tool": {"type": "skill", "name": "jira-implement", "version": "1"},
+                    "dependsOn": [],
+                    "status": "failed",
+                    "waitingReason": None,
+                    "attentionRequired": True,
+                    "attempt": 1,
+                    "startedAt": "2026-05-19T10:00:00Z",
+                    "updatedAt": "2026-05-19T10:01:00Z",
+                    "summary": "Failed",
+                    "checks": [],
+                    "refs": {
+                        "childWorkflowId": None,
+                        "childRunId": None,
+                        "taskRunId": None,
+                        "latestStepExecutionManifestRef": "art-attempt-1",
+                        "stepExecutionManifestRefs": ["art-attempt-1"],
+                    },
+                    "artifacts": {},
+                    "lastError": None,
+                }
+            ],
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    raw_token = "ghp_123456789012345678901234567890123456"
+    payload = _step_execution_manifest_payload(
+        artifact_ref="art-attempt-1",
+        attempt=1,
+        status="failed",
+    )
+    payload["outputs"] = {
+        "summary": f"failed with token={raw_token}",
+        "diagnosticsRef": "art-diagnostics-1",
+    }
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(
+                SimpleNamespace(artifact_id="art-attempt-1"),
+                json.dumps(payload).encode(),
+            )
+        )
+    )
+    app.dependency_overrides[get_async_session] = _empty_session_override
+
+    with patch(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        return_value=artifact_service,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get(
+                "/api/executions/mm:wf-1/steps/implement/step-executions"
+            )
+
+    assert response.status_code == 200
+    dumped = response.text
+    assert raw_token not in dumped
+    assert "token=[REDACTED]" in dumped
+    assert response.json()["stepExecutions"][0]["outputRefs"] == {
+        "diagnosticsRef": "art-diagnostics-1"
+    }
+
+
 def test_get_execution_step_execution_returns_bounded_detail_refs() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3723,6 +3723,141 @@ async def test_agent_runtime_selected_skill_projection_enforces_local_source_pol
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_selected_skill_projection_rejects_repo_skill_with_missing_policy_summary(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "repo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("repo skill body\n", encoding="utf-8")
+    (workspace / ".agents" / "skills" / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "snapshot_id": "skillset-repo",
+                "skills": [
+                    {
+                        "name": "repo-skill",
+                        "version": "1.0.0",
+                        "source_kind": "repo",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-repo",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="repo-skill",
+                version="1.0.0",
+                content_ref="art-repo-skill-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.REPO,
+                    source_path=".agents/skills/repo-skill",
+                ),
+            )
+        ],
+    )
+    resolved_skillset.policy_summary = None  # type: ignore[assignment]
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="repo skill source for 'repo-skill' is disabled by skill source policy",
+    ):
+        TemporalAgentRuntimeActivities._validate_selected_skill_projection(
+            visible_path=workspace / ".agents" / "skills",
+            selected_skill="repo-skill",
+            resolved_skillset=resolved_skillset,
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_enforces_dependency_source_policy_before_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+    workspace = managed_root / "job-1" / "repo"
+    workspace.mkdir(parents=True)
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-with-repo-dependency",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="pr-resolver",
+                version="1.0.0",
+                content_ref="art-pr-resolver-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            ),
+            ResolvedSkillEntry(
+                skill_name="repo-helper",
+                version="1.0.0",
+                content_ref="art-repo-helper-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.REPO,
+                    source_path=".agents/skills/repo-helper",
+                ),
+            ),
+        ],
+        policy_summary={
+            "repo_skills_allowed": False,
+            "local_skills_allowed": True,
+        },
+    )
+    artifact_service = _StaticArtifactService(
+        {
+            "art-pr-resolver-snapshot": resolved_skillset.model_dump_json().encode(
+                "utf-8"
+            ),
+        }
+    )
+
+    class _UnexpectedMaterializer:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("skill materializer should not be constructed")
+
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "AgentSkillMaterializer",
+        _UnexpectedMaterializer,
+    )
+    activities = TemporalAgentRuntimeActivities(artifact_service=artifact_service)
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="repo skill source for 'repo-helper' is disabled by skill source policy",
+    ):
+        await activities.agent_runtime_prepare_turn_instructions(
+            {
+                "request": {
+                    "agentKind": "managed",
+                    "agentId": "codex",
+                    "correlationId": "corr-1",
+                    "idempotencyKey": "idem-1",
+                    "resolvedSkillsetRef": "art-pr-resolver-snapshot",
+                    "parameters": {
+                        "instructions": "Resolve the PR.",
+                        "metadata": {
+                            "moonmind": {
+                                "selectedSkill": "pr-resolver",
+                            },
+                        },
+                    },
+                },
+                "workspacePath": str(workspace),
+            }
+        )
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_preserves_checked_in_skills_before_projection(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -3607,6 +3608,116 @@ async def test_agent_runtime_selected_skill_projection_rejects_non_mapping_manif
         TemporalAgentRuntimeActivities._validate_selected_skill_projection(
             visible_path=workspace / ".agents" / "skills",
             selected_skill="pr-resolver",
+            resolved_skillset=resolved_skillset,
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_selected_skill_projection_enforces_repo_source_policy(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "repo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("repo skill body\n", encoding="utf-8")
+    (workspace / ".agents" / "skills" / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "snapshot_id": "skillset-repo",
+                "skills": [
+                    {
+                        "name": "repo-skill",
+                        "version": "1.0.0",
+                        "source_kind": "repo",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-repo",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="repo-skill",
+                version="1.0.0",
+                content_ref="art-repo-skill-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.REPO,
+                    source_path=".agents/skills/repo-skill",
+                ),
+            )
+        ],
+        policy_summary={
+            "repo_skills_allowed": False,
+            "local_skills_allowed": True,
+        },
+    )
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="repo skill source for 'repo-skill' is disabled by skill source policy",
+    ):
+        TemporalAgentRuntimeActivities._validate_selected_skill_projection(
+            visible_path=workspace / ".agents" / "skills",
+            selected_skill="repo-skill",
+            resolved_skillset=resolved_skillset,
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_selected_skill_projection_enforces_local_source_policy(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "local-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("local skill body\n", encoding="utf-8")
+    (workspace / ".agents" / "skills" / "_manifest.json").write_text(
+        json.dumps(
+            {
+                "snapshot_id": "skillset-local",
+                "skills": [
+                    {
+                        "name": "local-skill",
+                        "version": "1.0.0",
+                        "source_kind": "local",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-local",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="local-skill",
+                version="1.0.0",
+                content_ref="art-local-skill-body",
+                content_digest="sha256:test",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.LOCAL,
+                    source_path=".agents/skills/local/local-skill",
+                ),
+            )
+        ],
+        policy_summary={
+            "repo_skills_allowed": True,
+            "local_skills_allowed": False,
+        },
+    )
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="local skill source for 'local-skill' is disabled by skill source policy",
+    ):
+        TemporalAgentRuntimeActivities._validate_selected_skill_projection(
+            visible_path=workspace / ".agents" / "skills",
+            selected_skill="local-skill",
             resolved_skillset=resolved_skillset,
         )
 


### PR DESCRIPTION
Jira issue key: MM-818

Summary:
- Redacts Step Execution failed-attempt summary text before API list/detail display payloads are returned.
- Enforces selected repo/local skill provenance against the resolved skill-source policy before agent runtime launch.
- Adds focused API and Temporal activity tests for the new security boundaries.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py::test_get_execution_step_executions_sanitizes_failed_attempt_summary tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_agent_runtime_selected_skill_projection_enforces_repo_source_policy tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_agent_runtime_selected_skill_projection_enforces_local_source_policy

Remaining risks:
- Full unit and integration_ci suites were not rerun in this publication step; focused verification was recorded in var/jira_verify/MM-818-run-jira-implement-for-mm-818-98ccfa01.json.
