### PR TITLE
MM-819 Add Step Execution compatibility boundary coverage

### DIFF
--- a/docs/Steps/StepExecutionsAndCheckpointing.md
+++ b/docs/Steps/StepExecutionsAndCheckpointing.md
@@ -1175,6 +1175,14 @@ This design does not require:
 
 Implementation should be phased.
 
+Payload-affecting Step Execution and checkpoint changes follow a versioned
+cutover rule: canonical writers fail fast for unsupported values, while
+workflow read/replay boundaries must turn degraded, blank, unknown, or future
+values from already-persisted payloads into typed invalid boundary decisions
+instead of crashing workflow tasks. Additive `v1` fields remain optional or
+default-initialized; incompatible payload changes require a new content-type
+version and an explicit cutover before new writers emit that version.
+
 ### Phase 1: Step execution manifests and evidence
 
 1. Add step execution manifest artifact type.

--- a/moonmind/workflows/temporal/step_checkpoints.py
+++ b/moonmind/workflows/temporal/step_checkpoints.py
@@ -6,6 +6,8 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
+from pydantic import ValidationError
+
 from moonmind.schemas.temporal_models import (
     STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
     StepExecutionCheckpointBoundary,
@@ -184,6 +186,56 @@ def validate_step_checkpoint(
     )
 
 
+def validate_step_checkpoint_payload(
+    checkpoint_payload: Mapping[str, Any],
+    *,
+    expected_source: StepExecutionIdentityModel,
+    expected_task_input_snapshot_ref: str,
+    expected_plan_ref: str | None = None,
+    expected_plan_digest: str | None = None,
+    workspace_policy: str | None = None,
+    required_artifact_refs: list[str] | tuple[str, ...] = (),
+    unauthorized_artifact_refs: list[str] | tuple[str, ...] = (),
+    corrupted_artifact_refs: list[str] | tuple[str, ...] = (),
+    expected_workspace: Mapping[str, Any] | None = None,
+    checkpoint_ref: str | None = None,
+) -> StepCheckpointValidationResultModel:
+    """Validate raw workflow-boundary checkpoint payloads without crashing replay.
+
+    Canonical checkpoint writers still use the strict Pydantic models directly.
+    This helper is for replay, Resume, and other workflow boundaries that may read
+    persisted payloads created before a deployment completed.
+    """
+
+    try:
+        checkpoint = StepExecutionCheckpointModel.model_validate(checkpoint_payload)
+        request = StepCheckpointValidationRequestModel(
+            checkpoint=checkpoint,
+            expectedSource=expected_source,
+            expectedTaskInputSnapshotRef=expected_task_input_snapshot_ref,
+            expectedPlanRef=expected_plan_ref,
+            expectedPlanDigest=expected_plan_digest,
+            workspacePolicy=workspace_policy,
+            requiredArtifactRefs=list(required_artifact_refs),
+            unauthorizedArtifactRefs=list(unauthorized_artifact_refs),
+            corruptedArtifactRefs=list(corrupted_artifact_refs),
+            expectedWorkspace=dict(expected_workspace or {}),
+            checkpointRef=checkpoint_ref,
+        )
+    except ValidationError as exc:
+        return StepCheckpointValidationResultModel(
+            valid=False,
+            failureCode="invalid_checkpoint",
+            message=_validation_error_summary(
+                exc,
+                fallback="checkpoint payload rejected at workflow boundary",
+            ),
+            checkpointId=_checkpoint_id_from_payload(checkpoint_payload),
+            checkpointRef=checkpoint_ref,
+        )
+    return validate_step_checkpoint(request)
+
+
 def _invalid(
     request: StepCheckpointValidationRequestModel,
     failure_code: str,
@@ -196,6 +248,27 @@ def _invalid(
         checkpointId=request.checkpoint.checkpoint_id,
         checkpointRef=request.checkpoint_ref,
     )
+
+
+def _checkpoint_id_from_payload(payload: Mapping[str, Any]) -> str:
+    checkpoint_id = str(payload.get("checkpointId") or "").strip()
+    return checkpoint_id or "unknown-checkpoint"
+
+
+def _validation_error_summary(exc: ValidationError, *, fallback: str) -> str:
+    errors = exc.errors(include_input=False)
+    if not errors:
+        return fallback
+    first = errors[0]
+    location = ".".join(
+        str(part) for part in first.get("loc", ()) if part != "__root__"
+    )
+    message = str(first.get("msg") or "").strip()
+    if location and message:
+        return f"{fallback}: {location}: {message}"[:1000]
+    if message:
+        return f"{fallback}: {message}"[:1000]
+    return fallback
 
 
 def _checkpoint_artifact_refs(

--- a/moonmind/workflows/temporal/step_checkpoints.py
+++ b/moonmind/workflows/temporal/step_checkpoints.py
@@ -187,7 +187,7 @@ def validate_step_checkpoint(
 
 
 def validate_step_checkpoint_payload(
-    checkpoint_payload: Mapping[str, Any],
+    checkpoint_payload: Any,
     *,
     expected_source: StepExecutionIdentityModel,
     expected_task_input_snapshot_ref: str,
@@ -206,6 +206,18 @@ def validate_step_checkpoint_payload(
     This helper is for replay, Resume, and other workflow boundaries that may read
     persisted payloads created before a deployment completed.
     """
+
+    if not isinstance(checkpoint_payload, Mapping):
+        return StepCheckpointValidationResultModel(
+            valid=False,
+            failureCode="invalid_checkpoint",
+            message=(
+                "checkpoint payload rejected at workflow boundary: "
+                "payload must be a mapping"
+            ),
+            checkpointId="unknown-checkpoint",
+            checkpointRef=checkpoint_ref,
+        )
 
     try:
         checkpoint = StepExecutionCheckpointModel.model_validate(checkpoint_payload)

--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -16,7 +16,10 @@ from moonmind.schemas.step_execution_models import (
     StepExecutionIdentityModel,
     StepExecutionManifestModel,
 )
-from moonmind.schemas.temporal_models import WorkspacePolicy
+from moonmind.schemas.temporal_models import (
+    StepExecutionManifestModel as BoundaryStepExecutionManifestModel,
+    WorkspacePolicy,
+)
 from moonmind.workflows.temporal.step_checkpoints import (
     checkpoint_kinds_for_workspace_policy,
 )
@@ -526,7 +529,7 @@ def build_step_execution_manifest_payload(
 
 
 def validate_step_execution_manifest_payload(
-    manifest_payload: Mapping[str, Any],
+    manifest_payload: Any,
     *,
     manifest_artifact_ref: str | None = None,
 ) -> dict[str, Any]:
@@ -538,8 +541,42 @@ def validate_step_execution_manifest_payload(
     enum values during a rolling deployment.
     """
 
+    if not isinstance(manifest_payload, Mapping):
+        return {
+            "valid": False,
+            "failureCode": "invalid_step_execution_manifest",
+            "message": (
+                "step execution manifest rejected at workflow boundary: "
+                "payload must be a mapping"
+            ),
+            "manifestArtifactRef": _non_blank_text(manifest_artifact_ref),
+            "stepExecutionId": None,
+            "logicalStepId": None,
+            "executionOrdinal": None,
+        }
+
+    validation_payload = dict(manifest_payload)
+    validation_payload.pop("manifestArtifactRef", None)
+    validation_payload.pop("artifactRef", None)
+    if "stepExecutionId" not in validation_payload:
+        workflow_id = _non_blank_text(validation_payload.get("workflowId"))
+        run_id = _non_blank_text(validation_payload.get("runId"))
+        logical_step_id = _non_blank_text(validation_payload.get("logicalStepId"))
+        execution_ordinal = _positive_int_or_none(
+            validation_payload.get("executionOrdinal")
+        )
+        if workflow_id and run_id and logical_step_id and execution_ordinal is not None:
+            validation_payload["stepExecutionId"] = step_execution_id(
+                workflow_id=workflow_id,
+                run_id=run_id,
+                logical_step_id=logical_step_id,
+                execution_ordinal=execution_ordinal,
+            )
+
     try:
-        manifest = StepExecutionManifestModel.model_validate(manifest_payload)
+        manifest = BoundaryStepExecutionManifestModel.model_validate(
+            validation_payload
+        )
     except ValidationError as exc:
         return {
             "valid": False,
@@ -565,7 +602,11 @@ def validate_step_execution_manifest_payload(
         "valid": True,
         "failureCode": None,
         "message": "step execution manifest validation passed",
-        "manifestArtifactRef": _non_blank_text(manifest_artifact_ref),
+        "manifestArtifactRef": _non_blank_text(
+            manifest_artifact_ref
+            or manifest_payload.get("manifestArtifactRef")
+            or manifest_payload.get("artifactRef")
+        ),
         "stepExecutionId": manifest.step_execution_id,
         "logicalStepId": manifest.logical_step_id,
         "executionOrdinal": manifest.execution_ordinal,

--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -8,6 +8,8 @@ import posixpath
 import re
 from typing import Any, Literal
 
+from pydantic import ValidationError
+
 from moonmind.schemas.step_execution_models import (
     StepExecutionReason,
     StepExecutionStatus,
@@ -521,3 +523,82 @@ def build_step_execution_manifest_payload(
         budget=dict(budget or {}),
     )
     return manifest.model_dump(by_alias=True, mode="json")
+
+
+def validate_step_execution_manifest_payload(
+    manifest_payload: Mapping[str, Any],
+    *,
+    manifest_artifact_ref: str | None = None,
+) -> dict[str, Any]:
+    """Validate raw Step Execution manifests at workflow read/replay boundaries.
+
+    Writers use ``StepExecutionManifestModel`` directly and remain strict. This
+    helper gives boundaries that consume already-persisted manifests a compact
+    invalid result instead of crashing on blank, unknown, or newly introduced
+    enum values during a rolling deployment.
+    """
+
+    try:
+        manifest = StepExecutionManifestModel.model_validate(manifest_payload)
+    except ValidationError as exc:
+        return {
+            "valid": False,
+            "failureCode": "invalid_step_execution_manifest",
+            "message": _validation_error_summary(
+                exc,
+                fallback="step execution manifest rejected at workflow boundary",
+            ),
+            "manifestArtifactRef": _non_blank_text(
+                manifest_artifact_ref
+                or manifest_payload.get("manifestArtifactRef")
+                or manifest_payload.get("artifactRef")
+            ),
+            "stepExecutionId": _non_blank_text(
+                manifest_payload.get("stepExecutionId")
+            ),
+            "logicalStepId": _non_blank_text(manifest_payload.get("logicalStepId")),
+            "executionOrdinal": _positive_int_or_none(
+                manifest_payload.get("executionOrdinal")
+            ),
+        }
+    return {
+        "valid": True,
+        "failureCode": None,
+        "message": "step execution manifest validation passed",
+        "manifestArtifactRef": _non_blank_text(manifest_artifact_ref),
+        "stepExecutionId": manifest.step_execution_id,
+        "logicalStepId": manifest.logical_step_id,
+        "executionOrdinal": manifest.execution_ordinal,
+        "reason": manifest.reason,
+        "status": manifest.status,
+        "terminalDisposition": manifest.terminal_disposition,
+    }
+
+
+def _validation_error_summary(exc: ValidationError, *, fallback: str) -> str:
+    errors = exc.errors(include_input=False)
+    if not errors:
+        return fallback
+    first = errors[0]
+    location = ".".join(
+        str(part) for part in first.get("loc", ()) if part != "__root__"
+    )
+    message = str(first.get("msg") or "").strip()
+    if location and message:
+        return f"{fallback}: {location}: {message}"[:1000]
+    if message:
+        return f"{fallback}: {message}"[:1000]
+    return fallback
+
+
+def _non_blank_text(value: Any) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate or None
+
+
+def _positive_int_or_none(value: Any) -> int | None:
+    try:
+        candidate = int(value)
+    except (TypeError, ValueError):
+        return None
+    return candidate if candidate > 0 else None

--- a/tests/unit/workflows/temporal/test_step_checkpoints.py
+++ b/tests/unit/workflows/temporal/test_step_checkpoints.py
@@ -126,6 +126,24 @@ def test_checkpoint_boundary_accepts_previous_compact_payload_shape() -> None:
     assert result.checkpoint_ref == "artifact-checkpoint"
 
 
+@pytest.mark.parametrize("payload", [None, [], "not-json-object"])
+def test_checkpoint_boundary_rejects_non_mapping_payload_without_crashing(
+    payload: object,
+) -> None:
+    result = validate_step_checkpoint_payload(
+        payload,
+        expected_source=_identity(),
+        expected_task_input_snapshot_ref="artifact-input",
+        checkpoint_ref="artifact-checkpoint",
+    )
+
+    assert result.valid is False
+    assert result.failure_code == "invalid_checkpoint"
+    assert "payload must be a mapping" in result.message
+    assert result.checkpoint_id == "unknown-checkpoint"
+    assert result.checkpoint_ref == "artifact-checkpoint"
+
+
 @pytest.mark.parametrize(
     ("mutator", "field_name"),
     [

--- a/tests/unit/workflows/temporal/test_step_checkpoints.py
+++ b/tests/unit/workflows/temporal/test_step_checkpoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -18,6 +19,7 @@ from moonmind.workflows.temporal.step_checkpoints import (
     build_step_checkpoint_payload,
     checkpoint_kinds_for_workspace_policy,
     validate_step_checkpoint,
+    validate_step_checkpoint_payload,
 )
 
 
@@ -95,6 +97,92 @@ def test_checkpoint_model_rejects_inline_large_or_raw_content() -> None:
     }
     with pytest.raises(ValidationError, match="compact refs"):
         StepExecutionCheckpointModel.model_validate(payload)
+
+
+def test_checkpoint_boundary_accepts_previous_compact_payload_shape() -> None:
+    payload = build_step_checkpoint_payload(
+        identity=_identity(),
+        boundary="before_execution",
+        task_input_snapshot_ref="artifact-input",
+        plan_digest="sha256:plan",
+        workspace=_workspace_patch(),
+        created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+    )
+    payload.pop("contentType")
+    payload.pop("validation")
+
+    result = validate_step_checkpoint_payload(
+        payload,
+        expected_source=_identity(),
+        expected_task_input_snapshot_ref="artifact-input",
+        expected_plan_digest="sha256:plan",
+        workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+        required_artifact_refs=["artifact-patch"],
+        checkpoint_ref="artifact-checkpoint",
+    )
+
+    assert result.valid is True
+    assert result.failure_code is None
+    assert result.checkpoint_ref == "artifact-checkpoint"
+
+
+@pytest.mark.parametrize(
+    ("mutator", "field_name"),
+    [
+        (
+            lambda payload: payload.__setitem__("boundary", "after_future_gate"),
+            "boundary",
+        ),
+        (lambda payload: payload.__setitem__("checkpointKind", ""), "checkpointKind"),
+        (
+            lambda payload: payload["workspace"].__setitem__(
+                "kind",
+                "future_workspace",
+            ),
+            "workspace.kind",
+        ),
+        (
+            lambda payload: payload.__setitem__(
+                "validation",
+                {
+                    "valid": False,
+                    "failureCode": "provider_paused",
+                    "message": "future worker value",
+                    "checkpointId": payload["checkpointId"],
+                },
+            ),
+            "validation.failureCode",
+        ),
+    ],
+)
+def test_checkpoint_boundary_reports_degraded_values_without_crashing(
+    mutator: Callable[[dict[str, object]], None],
+    field_name: str,
+) -> None:
+    payload = build_step_checkpoint_payload(
+        identity=_identity(),
+        boundary="before_execution",
+        task_input_snapshot_ref="artifact-input",
+        plan_digest="sha256:plan",
+        workspace=_workspace_patch(),
+        created_at=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+    )
+    mutator(payload)
+
+    result = validate_step_checkpoint_payload(
+        payload,
+        expected_source=_identity(),
+        expected_task_input_snapshot_ref="artifact-input",
+        expected_plan_digest="sha256:plan",
+        workspace_policy="apply_previous_execution_diff_to_clean_baseline",
+        checkpoint_ref="artifact-checkpoint",
+    )
+
+    assert result.valid is False
+    assert result.failure_code == "invalid_checkpoint"
+    assert field_name in result.message
+    assert result.checkpoint_id == payload["checkpointId"]
+    assert result.checkpoint_ref == "artifact-checkpoint"
 
 
 def test_workspace_checkpoint_model_rejects_unexpected_fields() -> None:

--- a/tests/unit/workflows/temporal/test_step_execution_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_execution_manifest.py
@@ -12,6 +12,9 @@ from moonmind.schemas.temporal_models import (
     build_step_execution_id,
     build_step_execution_idempotency_key,
 )
+from moonmind.workflows.temporal.step_executions import (
+    validate_step_execution_manifest_payload,
+)
 
 
 def _identity() -> dict[str, object]:
@@ -105,6 +108,86 @@ def test_step_execution_manifest_accepts_canonical_payload_and_content_type() ->
     assert manifest.lineage is not None
     assert manifest.lineage.source_execution_ordinal == 1
     assert manifest.model_dump(by_alias=True)["terminalDisposition"] == "accepted"
+
+
+def test_step_execution_manifest_boundary_accepts_previous_compact_payload_shape() -> (
+    None
+):
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "executionScope": "run",
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+        "startedAt": "2026-05-17T12:00:00Z",
+        "updatedAt": "2026-05-17T12:03:00Z",
+        "input": {"taskInputSnapshotRef": "artifact-input"},
+        "context": {"contextBundleRef": "artifact-context"},
+        "workspace": {"policy": "continue_from_previous_execution"},
+        "execution": {"kind": "agent_run"},
+        "outputs": {"summaryRef": "artifact-summary"},
+        "checks": [],
+        "sideEffects": {"external": []},
+        "dependencyEffects": {"invalidatedLogicalStepIds": []},
+        "budget": {"attemptLimit": 3},
+    }
+
+    result = validate_step_execution_manifest_payload(
+        payload,
+        manifest_artifact_ref="artifact-step-execution-2",
+    )
+
+    assert result == {
+        "valid": True,
+        "failureCode": None,
+        "message": "step execution manifest validation passed",
+        "manifestArtifactRef": "artifact-step-execution-2",
+        "stepExecutionId": "workflow-1:run-1:implement-story:execution:2",
+        "logicalStepId": "implement-story",
+        "executionOrdinal": 2,
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("reason", ""),
+        ("status", "paused_by_future_worker"),
+        ("terminalDisposition", "accepted_with_warnings"),
+    ],
+)
+def test_step_execution_manifest_boundary_reports_degraded_values_without_crashing(
+    field: str,
+    value: str,
+) -> None:
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "executionScope": "run",
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+        "startedAt": "2026-05-17T12:00:00Z",
+        "updatedAt": "2026-05-17T12:03:00Z",
+    }
+    payload[field] = value
+
+    result = validate_step_execution_manifest_payload(
+        payload,
+        manifest_artifact_ref="artifact-step-execution-2",
+    )
+
+    assert result["valid"] is False
+    assert result["failureCode"] == "invalid_step_execution_manifest"
+    assert field in result["message"]
+    assert result["manifestArtifactRef"] == "artifact-step-execution-2"
+    assert result["stepExecutionId"] is None
+    assert result["logicalStepId"] == "implement-story"
+    assert result["executionOrdinal"] == 2
 
 
 def test_step_execution_manifest_accepts_compact_evidence_refs() -> None:

--- a/tests/unit/workflows/temporal/test_step_execution_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_execution_manifest.py
@@ -152,6 +152,85 @@ def test_step_execution_manifest_boundary_accepts_previous_compact_payload_shape
     }
 
 
+def test_step_execution_manifest_boundary_accepts_timestamp_optional_v1_payload() -> (
+    None
+):
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "stepExecutionId": "workflow-1:run-1:implement-story:execution:2",
+        "executionScope": "run",
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+        "manifestArtifactRef": "artifact-from-payload",
+        "input": {"taskInputSnapshotRef": "artifact-input"},
+        "context": {"contextBundleRef": "artifact-context"},
+        "workspace": {"policy": "continue_from_previous_execution"},
+        "execution": {"kind": "agent_run"},
+        "outputs": {"summaryRef": "artifact-summary"},
+        "checks": [],
+        "sideEffects": {"external": []},
+        "dependencyEffects": {"invalidatedLogicalStepIds": []},
+        "budget": {"attemptLimit": 3},
+    }
+
+    result = validate_step_execution_manifest_payload(payload)
+
+    assert result["valid"] is True
+    assert result["failureCode"] is None
+    assert result["manifestArtifactRef"] == "artifact-from-payload"
+    assert result["stepExecutionId"] == (
+        "workflow-1:run-1:implement-story:execution:2"
+    )
+    assert result["logicalStepId"] == "implement-story"
+    assert result["executionOrdinal"] == 2
+
+
+@pytest.mark.parametrize("payload", [None, [], "not-json-object"])
+def test_step_execution_manifest_boundary_rejects_non_mapping_payload_without_crashing(
+    payload: object,
+) -> None:
+    result = validate_step_execution_manifest_payload(
+        payload,
+        manifest_artifact_ref="artifact-step-execution-2",
+    )
+
+    assert result == {
+        "valid": False,
+        "failureCode": "invalid_step_execution_manifest",
+        "message": (
+            "step execution manifest rejected at workflow boundary: "
+            "payload must be a mapping"
+        ),
+        "manifestArtifactRef": "artifact-step-execution-2",
+        "stepExecutionId": None,
+        "logicalStepId": None,
+        "executionOrdinal": None,
+    }
+
+
+def test_step_execution_manifest_boundary_uses_payload_artifact_ref_on_success() -> (
+    None
+):
+    payload = {
+        **_identity(),
+        "schemaVersion": "v1",
+        "executionScope": "run",
+        "reason": "quality_gate_failed",
+        "status": "failed",
+        "terminalDisposition": "retryable",
+        "startedAt": "2026-05-17T12:00:00Z",
+        "updatedAt": "2026-05-17T12:03:00Z",
+        "artifactRef": "artifact-from-legacy-field",
+    }
+
+    result = validate_step_execution_manifest_payload(payload)
+
+    assert result["valid"] is True
+    assert result["manifestArtifactRef"] == "artifact-from-legacy-field"
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
Jira issue key: MM-819

Summary:
- Added workflow-boundary validation helpers for raw Step Execution manifest and checkpoint payloads so degraded persisted values return typed invalid results instead of crashing replay/resume boundaries.
- Added compatibility-style tests for previous compact Step Execution/checkpoint payload shapes and explicit degraded unknown/blank/future value coverage.
- Documented the versioned cutover rule and phased rollout ordering for payload-affecting Step Execution/checkpoint contract changes.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_step_checkpoints.py tests/unit/workflows/temporal/test_step_execution_manifest.py`
  - Python targets: 31 passed
  - UI phase: 27 files passed; 417 passed, 234 skipped

Remaining risks:
- Coverage is unit-level workflow-boundary helper coverage; no compose-backed integration suite was run in this publication step.
