### PR TITLE
[codex] Fix workflows page metrics and scope regression

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -150,7 +150,6 @@ from moonmind.workflows import get_temporal_artifact_service
 router = APIRouter(prefix="/api/executions", tags=["executions"])
 _TEMPORAL_SOURCE = "temporal"
 _ALLOWED_OWNER_TYPES = {"user", "system", "service"}
-_TEMPORAL_LIST_SCOPES = {"workflows", "user", "system", "all"}
 _SUPPORTED_TASK_RUNTIMES = frozenset({
     "codex_cli",
     "gemini_cli",
@@ -162,10 +161,7 @@ _SUPPORTED_TASK_RUNTIMES = frozenset({
     "claude",
 })
 _TEMPORAL_SCOPE_QUERIES = {
-    "workflows": 'WorkflowType="MoonMind.UserWorkflow" AND mm_entry="user_workflow"',
-    "user": '(WorkflowType="MoonMind.UserWorkflow" OR WorkflowType="MoonMind.ManifestIngest")',
-    "system": 'WorkflowType!="MoonMind.UserWorkflow" AND WorkflowType!="MoonMind.ManifestIngest"',
-    "all": "",
+    "default": 'WorkflowType="MoonMind.UserWorkflow" AND mm_entry="user_workflow"',
 }
 _DASHBOARD_STATUS_BY_STATE: dict[MoonMindWorkflowState, str] = {
     MoonMindWorkflowState.SCHEDULED: "queued",
@@ -453,28 +449,19 @@ def _normalize_temporal_list_scope(
     *,
     workflow_type: str | None,
     entry: str | None,
-) -> Literal["workflows", "user", "system", "all"]:
-    """Return the product-facing Temporal list scope.
-
-    The default workflow console view is intentionally not a raw Temporal
-    namespace browser. Recognized broad workflow scopes are accepted for old
-    URLs but fail safe to user-workflow visibility on this ordinary list boundary.
-    """
+) -> Literal["default"]:
+    """Return the product-facing Temporal list scope."""
 
     normalized = str(scope or "").strip().lower()
-    if normalized and normalized not in _TEMPORAL_LIST_SCOPES:
+    if normalized:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
                 "code": "invalid_temporal_list_scope",
-                "message": (
-                    "scope must be one of: "
-                    + ", ".join(sorted(_TEMPORAL_LIST_SCOPES))
-                    + "."
-                ),
+                "message": "scope is no longer supported for workflow execution lists.",
             },
         )
-    return "workflows"
+    return "default"
 
 
 def _is_user_workflow_list_type(workflow_type: str | None) -> bool:

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -41,7 +41,7 @@ describe('Workflows Entrypoint', () => {
 
   const lastExecutionListUrl = () => executionListCalls().at(-1)?.[0];
 
-  it('shows the loading state while the task list request is pending', () => {
+  it('shows the loading state while the workflow list request is pending', () => {
     fetchSpy.mockReturnValue(new Promise(() => {}) as Promise<Response>);
 
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
@@ -49,7 +49,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByText('Loading workflows...')).toBeTruthy();
   });
 
-  it('shows structured API validation detail when the task list request fails', async () => {
+  it('shows structured API validation detail when the workflow list request fails', async () => {
     fetchSpy.mockResolvedValue({
       ok: false,
       statusText: 'Bad Request',
@@ -114,7 +114,7 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks',
+      '/api/executions?source=temporal&pageSize=50',
     );
 
     const scheduledHeaderButton = await screen.findByRole('button', {
@@ -137,72 +137,11 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
-  it('requests and renders operational metrics on the workflow overview', async () => {
+  it('does not query or render operational metrics on the workflow overview', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/executions/metrics?')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            totalRuns: 12,
-            completedRuns: 9,
-            failedRuns: 2,
-            canceledRuns: 1,
-            terminalRuns: 12,
-            successRate: 0.75,
-            duration: {
-              averageSeconds: 125,
-              medianSeconds: 90,
-              observedCount: 8,
-            },
-            cost: {
-              totalEstimateUsd: 1.2345,
-              averageEstimateUsd: 0.1543,
-              observedCount: 8,
-            },
-            sampleSize: 8,
-            countMode: 'exact',
-            refreshedAt: '2026-03-28T00:00:10Z',
-          }),
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          items: [
-            {
-              taskId: 'task-123',
-              source: 'temporal',
-              title: 'Example task',
-              status: 'completed',
-              state: 'completed',
-              rawState: 'completed',
-              createdAt: '2026-03-28T00:00:00Z',
-            },
-          ],
-          count: 12,
-        }),
-      } as Response);
-    });
-
-    renderWithClient(<WorkflowListPage payload={mockPayload} />);
-
-    await screen.findAllByText('Example task');
-    expect(screen.getByLabelText('Operational metrics')).toBeTruthy();
-    expect(screen.getByText('Success Rate')).toBeTruthy();
-    expect(screen.getByText('75%')).toBeTruthy();
-    expect(screen.getByText('Run Duration')).toBeTruthy();
-    expect(screen.getByText('2m 5s')).toBeTruthy();
-    expect(screen.getByText('Cost')).toBeTruthy();
-    expect(screen.getByText('$1.2345')).toBeTruthy();
-    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/metrics?'))).toBe(true);
-  });
-
-  it('does not render placeholder operational metric details while metrics are loading', async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.startsWith('/api/executions/metrics?')) {
-        return new Promise(() => {}) as Promise<Response>;
+        throw new Error('Workflows should not request operational metrics.');
       }
       return Promise.resolve({
         ok: true,
@@ -225,102 +164,9 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    expect(screen.getByLabelText('Operational metrics')).toBeTruthy();
-    expect(screen.queryByText('0 terminal from 0 sampled')).toBeNull();
-    expect(screen.queryByText('0 completed, 0 failed')).toBeNull();
-    expect(screen.queryByText(/^Refreshed /)).toBeNull();
-  });
-
-  it('does not render placeholder operational metric details when metrics fail', async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.startsWith('/api/executions/metrics?')) {
-        return Promise.resolve({
-          ok: false,
-          statusText: 'Service Unavailable',
-          json: async () => ({}),
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          items: [
-            {
-              taskId: 'task-123',
-              source: 'temporal',
-              title: 'Example task',
-              status: 'completed',
-              state: 'completed',
-              rawState: 'completed',
-              createdAt: '2026-03-28T00:00:00Z',
-            },
-          ],
-        }),
-      } as Response);
-    });
-
-    renderWithClient(<WorkflowListPage payload={mockPayload} />);
-
-    await screen.findAllByText('Example task');
-    expect(await screen.findByText('Operational metrics are unavailable.')).toBeTruthy();
-    expect(screen.queryByText('0 terminal from 0 sampled')).toBeNull();
-    expect(screen.queryByText('0 completed, 0 failed')).toBeNull();
-    expect(screen.queryByText(/^Refreshed /)).toBeNull();
-  });
-
-  it('renders negative operational metric durations as unavailable', async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.startsWith('/api/executions/metrics?')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            totalRuns: 1,
-            completedRuns: 1,
-            failedRuns: 0,
-            canceledRuns: 0,
-            terminalRuns: 1,
-            successRate: 1,
-            duration: {
-              averageSeconds: -10,
-              medianSeconds: -5,
-              observedCount: 1,
-            },
-            cost: {
-              totalEstimateUsd: 0,
-              averageEstimateUsd: 0,
-              observedCount: 1,
-            },
-            sampleSize: 1,
-            countMode: 'exact',
-            refreshedAt: '2026-03-28T00:00:10Z',
-          }),
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          items: [
-            {
-              taskId: 'task-123',
-              source: 'temporal',
-              title: 'Example task',
-              status: 'completed',
-              state: 'completed',
-              rawState: 'completed',
-              createdAt: '2026-03-28T00:00:00Z',
-            },
-          ],
-        }),
-      } as Response);
-    });
-
-    renderWithClient(<WorkflowListPage payload={mockPayload} />);
-
-    await screen.findAllByText('Example task');
-    expect(await screen.findByText('Median — across 1 runs')).toBeTruthy();
-    expect(screen.queryByText('-10s')).toBeNull();
-    expect(screen.queryByText('-5s')).toBeNull();
+    expect(screen.queryByLabelText('Operational metrics')).toBeNull();
+    expect(screen.queryByText('Operational metrics are unavailable.')).toBeNull();
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/metrics?'))).toBe(false);
   });
 
   it('surfaces intervention requests in list rows and status filters', async () => {
@@ -380,7 +226,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.queryByRole('dialog', { name: 'Scheduled filter' })).toBeNull();
   });
 
-  it('keeps task filters available outside the desktop-only table layout', async () => {
+  it('keeps workflow filters available outside the desktop-only table layout', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -410,7 +256,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&workflowIdContains=task-123&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cloud&titleContains=Example',
+        '/api/executions?source=temporal&pageSize=50&workflowIdContains=task-123&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cloud&titleContains=Example',
       );
     });
   });
@@ -484,7 +330,7 @@ describe('Workflows Entrypoint', () => {
     ]);
   });
 
-  it('keeps workflow-kind browsing controls out of the normal task list', async () => {
+  it('keeps workflow-kind browsing controls out of the normal workflow list', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -493,11 +339,11 @@ describe('Workflows Entrypoint', () => {
     expect(screen.queryByLabelText('Workflow Type')).toBeNull();
     expect(screen.queryByLabelText('Entry')).toBeNull();
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks',
+      '/api/executions?source=temporal&pageSize=50',
     );
   });
 
-  it('normalizes legacy workflow scope URLs to task visibility with recoverable notice', async () => {
+  it('normalizes legacy workflow scope URLs to workflow visibility with recoverable notice', async () => {
     window.history.pushState(
       {},
       'Legacy',
@@ -509,7 +355,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed&repoExact=moon%2Fdemo',
+      '/api/executions?source=temporal&pageSize=50&stateIn=completed&repoExact=moon%2Fdemo',
     );
     expect(screen.getByText(/Workflow scope filters are not available on Workflows/i)).toBeTruthy();
     expect(window.location.search).toBe('?stateIn=completed&repoExact=moon%2Fdemo&limit=50');
@@ -529,7 +375,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&targetRuntimeIn=codex_cli%2Cclaude_code',
+      '/api/executions?source=temporal&pageSize=50&targetRuntimeIn=codex_cli%2Cclaude_code',
     );
     expect(window.location.search).toBe('?targetRuntimeIn=codex_cli%2Cclaude_code&limit=50');
     expect(screen.getByRole('button', { name: 'Runtime filter: Codex CLI +1' })).toBeTruthy();
@@ -547,7 +393,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&targetRuntimeIn=claude_code',
+      '/api/executions?source=temporal&pageSize=50&targetRuntimeIn=claude_code',
     );
     expect(window.location.search).toBe('?targetRuntimeIn=claude_code&limit=50');
     expect(screen.getByRole('button', { name: 'Runtime filter: Claude Code' })).toBeTruthy();
@@ -565,7 +411,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&targetRuntimeIn=codex%2Cclaude',
+      '/api/executions?source=temporal&pageSize=50&targetRuntimeIn=codex%2Cclaude',
     );
     expect(window.location.search).toBe('?targetRuntimeIn=codex%2Cclaude&limit=50');
     expect(screen.getByRole('button', { name: 'Runtime filter: Codex CLI +1' })).toBeTruthy();
@@ -583,7 +429,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&targetRuntimeNotIn=codex%2Cclaude',
+      '/api/executions?source=temporal&pageSize=50&targetRuntimeNotIn=codex%2Cclaude',
     );
     expect(window.location.search).toBe('?targetRuntimeNotIn=codex%2Cclaude&limit=50');
     expect(screen.getByRole('button', { name: 'Runtime filter: not (Codex CLI +1)' })).toBeTruthy();
@@ -733,7 +579,7 @@ describe('Workflows Entrypoint', () => {
 
   });
 
-  it('keeps started time out of the task list presentation', async () => {
+  it('keeps started time out of the workflow list presentation', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -801,7 +647,7 @@ describe('Workflows Entrypoint', () => {
       expect(executionListCalls().length).toBe(baselineCalls + 1);
     });
     expect(lastExecutionListUrl()).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&repoExact=owner%2Frepo',
+      '/api/executions?source=temporal&pageSize=50&repoExact=owner%2Frepo',
     );
     await screen.findAllByText('Example task');
 
@@ -875,7 +721,7 @@ describe('Workflows Entrypoint', () => {
       expect(executionListCalls().length).toBe(baselineCalls + 1);
     });
     expect(lastExecutionListUrl()).toBe(
-      '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed',
+      '/api/executions?source=temporal&pageSize=50&stateIn=completed',
     );
   });
 
@@ -902,7 +748,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=failed',
+        '/api/executions?source=temporal&pageSize=50&stateIn=failed',
       );
     });
   });
@@ -953,7 +799,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&titleContains=Example',
+        '/api/executions?source=temporal&pageSize=50&titleContains=Example',
       );
       expect(screen.queryByRole('dialog', { name: 'Title filter' })).toBeNull();
       expect(
@@ -976,7 +822,7 @@ describe('Workflows Entrypoint', () => {
     fireEvent.keyDown(clearButton, { key: 'Enter' });
 
     expect(executionListCalls().length).toBe(baselineCalls);
-    expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50&scope=tasks');
+    expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50');
     expect(screen.getByRole('dialog', { name: 'Title filter' })).toBeTruthy();
   });
 
@@ -1009,7 +855,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateNotIn=canceled',
+        '/api/executions?source=temporal&pageSize=50&stateNotIn=canceled',
       );
     });
     expect(window.location.search).toBe('?stateNotIn=canceled&limit=50');
@@ -1019,7 +865,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks',
+        '/api/executions?source=temporal&pageSize=50',
       );
     });
   });
@@ -1037,7 +883,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed%2Cfailed',
+        '/api/executions?source=temporal&pageSize=50&stateIn=completed%2Cfailed',
       );
     });
     expect(screen.getByRole('button', { name: 'Status filter: completed, failed' })).toBeTruthy();
@@ -1066,7 +912,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateNotIn=completed%2Cfailed%2Cplanning%2Ccanceled',
+        '/api/executions?source=temporal&pageSize=50&stateNotIn=completed%2Cfailed%2Cplanning%2Ccanceled',
       );
     });
     expect(screen.getByRole('button', { name: 'Status filter: not (completed, failed, planning +1)' })).toBeTruthy();
@@ -1078,7 +924,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&nextPageToken=stale-token',
+        '/api/executions?source=temporal&pageSize=50&nextPageToken=stale-token',
       );
     });
     await screen.findAllByText('Example task');
@@ -1087,7 +933,7 @@ describe('Workflows Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
-        '/api/executions?source=temporal&pageSize=100&scope=tasks',
+        '/api/executions?source=temporal&pageSize=100',
       );
     });
     expect(window.location.search).toBe('?limit=100');
@@ -1305,7 +1151,7 @@ describe('Workflows Entrypoint', () => {
     expect(Number(getComputedStyle(firstHeader as HTMLElement).zIndex)).toBeGreaterThan(1);
   });
 
-  it('keeps the task list surfaces to one control deck and one data slab', async () => {
+  it('keeps the workflow list surfaces to one control deck and one data slab', async () => {
     renderWithClient(
       <section className="panel" aria-live="polite">
         <WorkflowListPage payload={mockPayload} />
@@ -1378,7 +1224,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
-        '/api/executions?source=temporal&pageSize=50&scope=tasks&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cli',
+        '/api/executions?source=temporal&pageSize=50&stateIn=completed&repoExact=owner%2Frepo&targetRuntimeIn=codex_cli',
       );
     });
 

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -8,7 +8,6 @@ import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
 
 const POLL_MS_DEFAULT = 5000;
-const METRICS_SAMPLE_SIZE = 500;
 
 type ListDashboardConfig = {
   pollIntervalsMs?: { list?: number };
@@ -140,34 +139,6 @@ const ExecutionListResponseSchema = z.object({
 
 type ExecutionRow = z.infer<typeof ExecutionRowSchema>;
 
-const ExecutionMetricsResponseSchema = z.object({
-  totalRuns: z.number().optional(),
-  completedRuns: z.number().optional(),
-  failedRuns: z.number().optional(),
-  canceledRuns: z.number().optional(),
-  terminalRuns: z.number().optional(),
-  successRate: z.number().nullable().optional(),
-  duration: z
-    .object({
-      averageSeconds: z.number().nullable().optional(),
-      medianSeconds: z.number().nullable().optional(),
-      observedCount: z.number().optional(),
-    })
-    .optional(),
-  cost: z
-    .object({
-      totalEstimateUsd: z.number().optional(),
-      averageEstimateUsd: z.number().nullable().optional(),
-      observedCount: z.number().optional(),
-    })
-    .optional(),
-  sampleSize: z.number().optional(),
-  countMode: z.string().optional(),
-  refreshedAt: z.string().optional(),
-});
-
-type ExecutionMetricsResponse = z.infer<typeof ExecutionMetricsResponseSchema>;
-
 function rowWorkflowId(row: ExecutionRow): string {
   return row.workflowId || row.taskId || '';
 }
@@ -217,7 +188,7 @@ function hasUnsupportedWorkflowScopeState(params: URLSearchParams): boolean {
   const workflowType = (params.get('workflowType') || '').trim();
   const entry = (params.get('entry') || '').trim().toLowerCase();
   return Boolean(
-    (scope && scope !== 'tasks') ||
+    scope ||
       (workflowType && workflowType !== TASK_WORKFLOW_TYPE) ||
       (entry && entry !== TASK_ENTRY),
   );
@@ -247,35 +218,6 @@ function displayTemporalCount(count: number | null | undefined, countMode: strin
     return '';
   }
   return countMode && countMode !== 'exact' ? `${count} (${countMode})` : String(count);
-}
-
-function formatPercent(value: number | null | undefined): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
-  return new Intl.NumberFormat('en-US', {
-    style: 'percent',
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatDuration(seconds: number | null | undefined): string {
-  if (typeof seconds !== 'number' || Number.isNaN(seconds) || seconds < 0) return '—';
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-
-  const roundedSeconds = Math.round(seconds);
-  const hours = Math.floor(roundedSeconds / 3600);
-  const minutes = Math.floor((roundedSeconds % 3600) / 60);
-  const remainingSeconds = roundedSeconds % 60;
-  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
-}
-
-function formatUsd(value: number | null | undefined): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) return '—';
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: value >= 10 ? 2 : 4,
-  }).format(value);
 }
 
 function sortRows(rows: ExecutionRow[], field: string, direction: 'asc' | 'desc'): ExecutionRow[] {
@@ -354,7 +296,7 @@ async function taskListErrorMessage(response: Response): Promise<string> {
     // Fall back to status text below when the body is empty or not JSON.
   }
   const statusText = sanitizeApiErrorMessage(response.statusText || '');
-  return statusText ? `Failed to fetch: ${statusText}` : 'Failed to fetch tasks.';
+  return statusText ? `Failed to fetch: ${statusText}` : 'Failed to fetch workflows.';
 }
 
 function emptyValueFilter(): ValueFilter {
@@ -720,27 +662,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     listCursor,
   ] as const;
 
-  const metricsQuery = useQuery({
-    queryKey: ['workflow-list', 'operational-metrics', filters] as const,
-    enabled: listEnabled && filterValidationErrors.length === 0,
-    queryFn: async (): Promise<ExecutionMetricsResponse> => {
-      const params = new URLSearchParams();
-      params.set('source', 'temporal');
-      params.set('scope', 'tasks');
-      params.set('sampleSize', String(METRICS_SAMPLE_SIZE));
-      appendFilterParams(params, filters);
-      const response = await fetch(`${payload.apiBase}/executions/metrics?${params}`, {
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch operational metrics: ${response.statusText}`);
-      }
-      return ExecutionMetricsResponseSchema.parse(await response.json());
-    },
-    refetchInterval: liveUpdates && listEnabled && !openFilter ? listPollMs : false,
-    retry: false,
-  });
-
   const { data, isLoading, isError, error } = useQuery({
     queryKey,
     enabled: listEnabled && filterValidationErrors.length === 0,
@@ -748,7 +669,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       const params = new URLSearchParams();
       params.set('source', 'temporal');
       params.set('pageSize', String(pageSize));
-      params.set('scope', 'tasks');
       if (listCursor) params.set('nextPageToken', listCursor);
       appendFilterParams(params, filters);
       const response = await fetch(`${payload.apiBase}/executions?${params}`);
@@ -773,7 +693,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       params.set('source', 'temporal');
       params.set('facet', openFacet as string);
       params.set('pageSize', '50');
-      params.set('scope', 'tasks');
       appendFilterParams(params, filters);
       const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
       if (!response.ok) {
@@ -973,10 +892,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     [filters],
   );
   const hasActiveFilters = activeFilters.length > 0;
-  const metrics = metricsQuery.data;
-  const metricsRefreshedAt = metrics?.refreshedAt
-    ? formatWhen(metrics.refreshedAt)
-    : '—';
   const toggleFilter = useCallback((field: FilterField) => {
     setOpenFilter((current) => (current === field ? null : field));
   }, []);
@@ -1510,7 +1425,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
           <div
             id="workflow-list-mobile-filter-panel"
             className={`workflow-list-mobile-filter-controls${mobileFiltersOpen ? ' is-open' : ''}`}
-            aria-label="Mobile task filters"
+            aria-label="Mobile workflow filters"
           >
             {TABLE_COLUMNS.map(([field]) =>
               isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
@@ -1526,43 +1441,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
         <header className="workflow-list-results-header">
           <h2 className="page-title" id="workflow-list-title">Workflows</h2>
         </header>
-        <section className="workflow-list-metrics" aria-label="Operational metrics">
-          {metricsQuery.isError ? (
-            <div className="notice warning workflow-list-metrics-notice">
-              Operational metrics are unavailable.
-            </div>
-          ) : null}
-          {!metricsQuery.isLoading && !metricsQuery.isError && metrics ? (
-            <>
-              <dl className="workflow-list-metrics-grid">
-                <div className="workflow-list-metric-tile">
-                  <dt>Runs</dt>
-                  <dd>{String(metrics.totalRuns ?? 0)}</dd>
-                  <p>{metrics.terminalRuns ?? 0} terminal from {metrics.sampleSize ?? 0} sampled</p>
-                </div>
-                <div className="workflow-list-metric-tile">
-                  <dt>Success Rate</dt>
-                  <dd>{formatPercent(metrics.successRate)}</dd>
-                  <p>{metrics.completedRuns ?? 0} completed, {metrics.failedRuns ?? 0} failed</p>
-                </div>
-                <div className="workflow-list-metric-tile">
-                  <dt>Run Duration</dt>
-                  <dd>{formatDuration(metrics.duration?.averageSeconds)}</dd>
-                  <p>Median {formatDuration(metrics.duration?.medianSeconds)} across {metrics.duration?.observedCount ?? 0} runs</p>
-                </div>
-                <div className="workflow-list-metric-tile">
-                  <dt>Cost</dt>
-                  <dd>{formatUsd(metrics.cost?.totalEstimateUsd)}</dd>
-                  <p>Average {formatUsd(metrics.cost?.averageEstimateUsd)} across {metrics.cost?.observedCount ?? 0} runs</p>
-                </div>
-              </dl>
-              <p className="small workflow-list-metrics-refreshed">
-                Refreshed {metricsRefreshedAt}
-                {metrics.countMode && metrics.countMode !== 'exact' ? ' · count estimate' : ''}
-              </p>
-            </>
-          ) : null}
-        </section>
         {isLoading ? (
           <p className="loading workflow-list-empty-message">Loading workflows...</p>
         ) : isError ? (

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1460,53 +1460,6 @@ tbody tr:hover {
   letter-spacing: 0.01em;
 }
 
-.workflow-list-metrics {
-  display: grid;
-  gap: 0.75rem;
-  padding: 1rem;
-  border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
-}
-
-.workflow-list-metrics-grid {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  margin: 0;
-}
-
-.workflow-list-metric-tile {
-  min-width: 0;
-  border: 1px solid rgb(var(--mm-border) / 0.36);
-  border-radius: 8px;
-  background: rgb(var(--mm-surface) / 0.82);
-  padding: 0.85rem;
-}
-
-.workflow-list-metric-tile dt {
-  color: rgb(var(--mm-muted) / 0.94);
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-
-.workflow-list-metric-tile dd {
-  margin: 0.35rem 0 0;
-  color: rgb(var(--mm-foreground) / 0.98);
-  font-size: 1.45rem;
-  font-weight: 800;
-  line-height: 1.1;
-  font-variant-numeric: tabular-nums;
-}
-
-.workflow-list-metric-tile p,
-.workflow-list-metrics-refreshed {
-  margin: 0.35rem 0 0;
-  color: rgb(var(--mm-muted) / 0.94);
-}
-
-.workflow-list-metrics-notice {
-  margin: 0;
-}
-
 .workflow-list-empty-message {
   margin: 0;
   padding: 1rem;
@@ -2016,15 +1969,6 @@ tr[data-proposal-id].proposal-consuming td {
     padding: 0 0 0.75rem;
     border-bottom: 0;
     background: transparent;
-  }
-
-  .workflow-list-metrics {
-    padding: 0 0 1rem;
-    border-bottom: 0;
-  }
-
-  .workflow-list-metrics-grid {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .workflow-list-data-slab .workflow-list-results-footer {

--- a/tests/integration/temporal/test_workflow_execution_terminology.py
+++ b/tests/integration/temporal/test_workflow_execution_terminology.py
@@ -47,7 +47,7 @@ def test_temporal_user_workflow_query_excludes_legacy_run_entry() -> None:
     with TestClient(app) as test_client:
         response = test_client.get(
             "/api/executions",
-            params={"source": "temporal", "scope": "workflows"},
+            params={"source": "temporal"},
         )
 
     assert response.status_code == 200

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -630,7 +630,6 @@ def test_list_executions_temporal_query_includes_target_runtime_filter() -> None
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "targetRuntime": "codex_cli",
             },
         )
@@ -671,7 +670,6 @@ def test_list_executions_temporal_query_includes_canonical_state_filters() -> No
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "stateIn": "completed,failed",
             },
         )
@@ -722,7 +720,6 @@ def test_list_executions_temporal_query_anchors_non_terminal_state_to_running_st
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "stateIn": "waiting_on_dependencies",
             },
         )
@@ -760,7 +757,6 @@ def test_list_executions_temporal_query_mixes_terminal_and_non_terminal_state_fi
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "stateIn": "waiting_on_dependencies,canceled",
             },
         )
@@ -797,7 +793,6 @@ def test_list_executions_temporal_query_supports_repeated_canonical_filters() ->
             "/api/executions",
             params=[
                 ("source", "temporal"),
-                ("scope", "workflows"),
                 ("targetRuntimeIn", "codex_cli"),
                 ("targetRuntimeIn", "claude_code"),
                 ("targetRuntimeIn", ""),
@@ -836,7 +831,6 @@ def test_list_executions_temporal_query_ignores_empty_canonical_state_for_legacy
             "/api/executions",
             params=[
                 ("source", "temporal"),
-                ("scope", "workflows"),
                 ("state", "completed"),
                 ("stateIn", ""),
             ],
@@ -865,7 +859,6 @@ def test_list_executions_temporal_query_rejects_contradictory_canonical_filters(
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "stateIn": "completed",
                 "stateNotIn": "canceled",
             },
@@ -903,7 +896,6 @@ def test_list_executions_temporal_query_includes_canonical_runtime_skill_and_rep
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "targetRuntimeIn": "codex_cli,claude_code",
                 "targetSkillIn": "moonspec-implement",
                 "repoIn": "Moon/Mind",
@@ -943,7 +935,6 @@ def test_list_executions_temporal_query_prefers_canonical_filters_over_legacy_ex
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "state": "executing",
                 "stateIn": "completed",
                 "repo": "legacy/repo",
@@ -990,7 +981,6 @@ def test_list_executions_temporal_query_includes_canonical_date_bounds() -> None
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "scheduledFrom": "2026-05-01",
                 "scheduledTo": "2026-05-05",
                 "createdFrom": "2026-05-02",
@@ -1038,7 +1028,6 @@ def test_list_executions_temporal_query_includes_blank_date_filter_semantics() -
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "scheduledFrom": "2026-05-01",
                 "scheduledBlank": "include",
                 "finishedBlank": "include",
@@ -1075,7 +1064,6 @@ def test_list_executions_temporal_query_supports_sort_and_text_filters() -> None
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "repoContains": "Moon",
                 "workflowIdContains": "wf-",
                 "titleContains": "release",
@@ -1119,7 +1107,6 @@ def test_list_executions_temporal_query_uses_workflow_id_text_filter() -> None:
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "workflows",
                 "workflowIdContains": "wf-",
                 "sort": "workflowId",
             },
@@ -1177,7 +1164,7 @@ def test_list_executions_temporal_query_rejects_invalid_filter_bounds() -> None:
     assert "sort must be one of" in invalid_sort.json()["detail"]["message"]
     temporal_client.count_workflows.assert_not_called()
 
-def test_execution_facets_exclude_requested_facet_filter_and_keep_task_scope() -> None:
+def test_execution_facets_exclude_requested_facet_filter_and_keep_workflow_scope() -> None:
     app = FastAPI()
     app.include_router(router)
     mock_service = AsyncMock()
@@ -1337,7 +1324,7 @@ def test_execution_metrics_counts_workflows_concurrently() -> None:
     assert max_active_calls > 1
 
 
-def test_execution_status_facet_counts_static_status_values_with_task_scope() -> None:
+def test_execution_status_facet_counts_static_status_values_with_workflow_scope() -> None:
     app = FastAPI()
     app.include_router(router)
     mock_service = AsyncMock()

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -152,7 +152,7 @@ def test_list_executions_source_temporal_bypasses_db_and_queries_temporal(
         _assert_no_banned_execution_keys(item)
 
 
-def test_list_executions_source_temporal_defaults_to_task_scope(client) -> None:
+def test_list_executions_source_temporal_defaults_to_workflow_scope(client) -> None:
     test_client, _service, _user, _mock_session = client
 
     executions_module.get_temporal_client_adapter.cache_clear()
@@ -210,7 +210,7 @@ def test_list_executions_source_temporal_default_scope_excludes_legacy_run_entry
         assert 'mm_entry="run"' not in query
 
 
-def test_list_executions_source_temporal_scope_all_fails_safe_to_task_query(
+def test_list_executions_source_temporal_default_scope_uses_workflow_query(
     client,
 ) -> None:
     test_client, _service, _user, _mock_session = client
@@ -232,7 +232,7 @@ def test_list_executions_source_temporal_scope_all_fails_safe_to_task_query(
 
         response = test_client.get(
             "/api/executions",
-            params={"source": "temporal", "scope": "all"},
+            params={"source": "temporal"},
         )
 
         assert response.status_code == 200
@@ -332,7 +332,23 @@ def test_execution_metrics_source_temporal_returns_operational_aggregates(
     assert 'mm_repo="MoonLadderStudios/MoonMind"' in mock_client.list_workflows.call_args.kwargs["query"]
 
 
-def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_task_list(
+def test_list_executions_source_temporal_rejects_retired_broad_scopes(
+    client,
+) -> None:
+    test_client, _service, _user, _mock_session = client
+
+    response = test_client.get(
+        "/api/executions",
+        params={"source": "temporal", "scope": "system"},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_temporal_list_scope"
+    assert detail["message"] == "scope is no longer supported for workflow execution lists."
+
+
+def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_workflow_list(
     client,
 ) -> None:
     test_client, _service, _user, _mock_session = client
@@ -356,7 +372,6 @@ def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_task_
             "/api/executions",
             params={
                 "source": "temporal",
-                "scope": "system",
                 "workflowType": "MoonMind.ProviderProfileManager",
                 "entry": "manifest",
             },
@@ -380,7 +395,9 @@ def test_list_executions_source_temporal_rejects_unknown_scope(client) -> None:
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"]["code"] == "invalid_temporal_list_scope"
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_temporal_list_scope"
+    assert detail["message"] == "scope is no longer supported for workflow execution lists."
 
 
 def test_execution_router_exposes_recover_route_without_recovery_alias() -> None:


### PR DESCRIPTION
## Summary
- remove the Workflows page operational metrics query and metrics panel
- stop the Workflows page from sending any execution list scope parameter
- reject retired execution list scope parameters with a current workflow-list error instead of advertising old categories

## Root cause
The Workflows page was querying /api/executions/metrics and sending a list scope value that did not match the backend's supported values. That surfaced the metrics warning and scope validation message at the top of the page.

## Validation
- npm run ui:test -- frontend/src/entrypoints/workflow-list.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/test_executions_temporal.py tests/unit/api/routers/test_executions.py tests/integration/temporal/test_workflow_execution_terminology.py