### PR TITLE
[codex] Fix stale Workflows metrics regression

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -454,12 +454,9 @@ def _normalize_temporal_list_scope(
 
     normalized = str(scope or "").strip().lower()
     if normalized:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "invalid_temporal_list_scope",
-                "message": "scope is no longer supported for workflow execution lists.",
-            },
+        logger.info(
+            "Ignoring retired execution list scope=%s on workflow-list boundary",
+            normalized,
         )
     return "default"
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -455,8 +455,8 @@ def _normalize_temporal_list_scope(
     normalized = str(scope or "").strip().lower()
     if normalized:
         logger.info(
-            "Ignoring retired execution list scope=%s on workflow-list boundary",
-            normalized,
+            "Ignoring retired execution list scope=%r on workflow-list boundary",
+            normalized[:64],
         )
     return "default"
 

--- a/api_service/ui_assets.py
+++ b/api_service/ui_assets.py
@@ -170,11 +170,10 @@ def resolve_mission_control_dist_root(entrypoint: str = "mission-control") -> Pa
 
     local_root = local_ui_dist_root()
     bundled_root = bundled_ui_dist_root()
-    candidates = sorted(
-        (local_root, bundled_root),
-        key=_dist_root_manifest_mtime_ns,
-        reverse=True,
-    )
+    # In deployed containers the repository path may be bind-mounted with stale
+    # local build output. Prefer the image-baked bundle unless an operator
+    # explicitly configures VITE_MANIFEST_PATH or MOONMIND_UI_DEV_SERVER_URL.
+    candidates = (bundled_root, local_root)
     for candidate in candidates:
         if _manifest_tree_is_usable(candidate, entrypoint):
             return candidate

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -67,32 +67,6 @@ function cssRuleBlockMatching(css: string, matches: (rule: Rule) => boolean): st
   return block;
 }
 
-function mockExecutionMetricsResponse() {
-  return {
-    totalRuns: 42,
-    completedRuns: 28,
-    failedRuns: 7,
-    canceledRuns: 2,
-    terminalRuns: 37,
-    successRate: 0.7568,
-    duration: {
-      averageSeconds: 3661,
-      medianSeconds: 91,
-      minSeconds: 12,
-      maxSeconds: 7200,
-      observedCount: 35,
-    },
-    cost: {
-      totalEstimateUsd: 12.3456,
-      averageEstimateUsd: 0.3527,
-      observedCount: 35,
-    },
-    sampleSize: 42,
-    countMode: 'exact',
-    refreshedAt: '2026-06-10T12:00:00Z',
-  };
-}
-
 vi.mock('@xterm/xterm', () => {
   class MockTerminal {
     cols = 80;
@@ -158,12 +132,6 @@ describe('Mission Control shared entry', () => {
           json: async () => [],
         } as Response);
       }
-      if (url === '/api/executions/metrics?scope=tasks&sampleSize=500') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => mockExecutionMetricsResponse(),
-        } as Response);
-      }
       return Promise.resolve({
         ok: false,
         status: 404,
@@ -191,15 +159,10 @@ describe('Mission Control shared entry', () => {
 
     renderWithClient(<MissionControlApp payload={payload} />);
 
-    expect(await screen.findByRole('heading', { name: 'Operational Metrics' }, { timeout: 10000 })).toBeTruthy();
-    expect(await screen.findByLabelText('Operational metrics')).toBeTruthy();
-    await waitFor(() => {
-      expect(
-        fetchSpy.mock.calls.some(
-          ([url]) => String(url) === '/api/executions/metrics?scope=tasks&sampleSize=500',
-        ),
-      ).toBe(true);
-    });
+    expect(await screen.findByRole('heading', { name: 'Workflows' }, { timeout: 10000 })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open workflows' }).getAttribute('href')).toBe('/workflows');
+    expect(screen.queryByLabelText('Operational metrics')).toBeNull();
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/metrics'))).toBe(false);
     expect(await screen.findByText(/First-Run Setup:/i)).toBeTruthy();
     await waitFor(() => {
       expect(document.querySelector('.panel--data-wide')).toBeTruthy();
@@ -207,101 +170,20 @@ describe('Mission Control shared entry', () => {
     });
   });
 
-  it('renders operational metrics on the workflows home dashboard', async () => {
+  it('does not render operational metrics on the workflows home dashboard', async () => {
     renderWithClient(<MissionControlApp payload={{ page: 'workflows-home', apiBase: '/api' }} />);
 
-    expect(await screen.findByRole('heading', { name: 'Operational Metrics' })).toBeTruthy();
-    expect(await screen.findByText('42')).toBeTruthy();
-    expect(await screen.findByText('75.7%')).toBeTruthy();
-    expect(await screen.findByText('1h 1m')).toBeTruthy();
-    expect(await screen.findByText('$12.35')).toBeTruthy();
-    expect(screen.getByText('Median 1m 31s across 35 runs')).toBeTruthy();
-    expect(screen.getByText('Average $0.3527 across 35 runs')).toBeTruthy();
-  });
-
-  it('does not render placeholder operational metric details while home metrics are loading', async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === '/api/executions/metrics?scope=tasks&sampleSize=500') {
-        return new Promise(() => {}) as Promise<Response>;
-      }
-      if (url === '/api/v1/secrets') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ items: [] }),
-        } as Response);
-      }
-      if (url === '/api/v1/provider-profiles') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [],
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        text: async () => 'Unhandled fetch',
-      } as Response);
-    });
-
-    renderWithClient(<MissionControlApp payload={{ page: 'workflows-home', apiBase: '/api' }} />);
-
-    expect(await screen.findByText('Loading operational metrics...')).toBeTruthy();
-    expect(screen.queryByText('0 terminal from 0 sampled')).toBeNull();
-    expect(screen.queryByText('0 completed, 0 failed')).toBeNull();
-    expect(screen.queryByText(/^Refreshed /)).toBeNull();
-  });
-
-  it('renders negative home metric durations as unavailable', async () => {
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === '/api/executions/metrics?scope=tasks&sampleSize=500') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            ...mockExecutionMetricsResponse(),
-            duration: {
-              averageSeconds: -3661,
-              medianSeconds: -91,
-              minSeconds: -91,
-              maxSeconds: -1,
-              observedCount: 35,
-            },
-          }),
-        } as Response);
-      }
-      if (url === '/api/v1/secrets') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ items: [] }),
-        } as Response);
-      }
-      if (url === '/api/v1/provider-profiles') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => [],
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        text: async () => 'Unhandled fetch',
-      } as Response);
-    });
-
-    renderWithClient(<MissionControlApp payload={{ page: 'workflows-home', apiBase: '/api' }} />);
-
-    expect(await screen.findByText('Median — across 35 runs')).toBeTruthy();
-    expect(screen.queryByText('-1h 1m')).toBeNull();
-    expect(screen.queryByText('-1m 31s')).toBeNull();
+    expect(await screen.findByRole('heading', { name: 'Workflows' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open workflows' }).getAttribute('href')).toBe('/workflows');
+    expect(screen.queryByLabelText('Operational metrics')).toBeNull();
+    expect(screen.queryByText('Operational metrics are unavailable.')).toBeNull();
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).startsWith('/api/executions/metrics'))).toBe(false);
   });
 
   it('uses the constrained shell by default for non-table pages', async () => {
     renderWithClient(<MissionControlApp payload={{ page: 'workflows-home', apiBase: '/api' }} />);
 
-    expect(await screen.findByRole('heading', { name: 'Operational Metrics' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflows' })).toBeTruthy();
     expect(document.querySelector('.panel--data-wide')).toBeNull();
     expect(document.querySelector('.dashboard-shell-constrained--data-wide')).toBeNull();
     expect(document.querySelector('.dashboard-shell-constrained')).toBeTruthy();

--- a/frontend/src/entrypoints/workflows-home.tsx
+++ b/frontend/src/entrypoints/workflows-home.tsx
@@ -1,155 +1,20 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { BootPayload } from '../boot/parseBootPayload';
-import type { components } from '../generated/openapi';
 
-type ExecutionMetrics = components['schemas']['ExecutionMetricsResponse'];
-
-const METRICS_SAMPLE_SIZE = 500;
-
-function formatPercent(value: number | null | undefined): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return '—';
-  }
-  return new Intl.NumberFormat('en-US', {
-    style: 'percent',
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatDuration(seconds: number | null | undefined): string {
-  if (typeof seconds !== 'number' || Number.isNaN(seconds) || seconds < 0) {
-    return '—';
-  }
-  if (seconds < 60) {
-    return `${Math.round(seconds)}s`;
-  }
-
-  const roundedSeconds = Math.round(seconds);
-  const hours = Math.floor(roundedSeconds / 3600);
-  const minutes = Math.floor((roundedSeconds % 3600) / 60);
-  const remainingSeconds = roundedSeconds % 60;
-
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
-}
-
-function formatUsd(value: number | null | undefined): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return '—';
-  }
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: value >= 10 ? 2 : 4,
-  }).format(value);
-}
-
-function buildMetricsUrl(apiBase: string): string {
-  const params = new URLSearchParams({
-    scope: 'tasks',
-    sampleSize: String(METRICS_SAMPLE_SIZE),
-  });
-  return `${apiBase}/executions/metrics?${params.toString()}`;
-}
-
-function MetricTile({
-  label,
-  value,
-  detail,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-}) {
-  return (
-    <div className="card min-h-32">
-      <dt className="text-sm font-semibold text-slate-500 dark:text-slate-400">{label}</dt>
-      <dd className="mt-3 text-3xl font-semibold tabular-nums text-slate-950 dark:text-slate-50">
-        {value}
-      </dd>
-      <dd className="mt-2 text-sm text-slate-500 dark:text-slate-400">{detail}</dd>
-    </div>
-  );
-}
-
-export function WorkflowsHomePage({ payload }: { payload: BootPayload }) {
-  const apiBase = payload.apiBase || '/api';
-  const metricsQuery = useQuery({
-    queryKey: ['workflow-home', 'execution-metrics', apiBase],
-    queryFn: async (): Promise<ExecutionMetrics> => {
-      const response = await fetch(buildMetricsUrl(apiBase), { credentials: 'include' });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch operational metrics: ${response.statusText}`);
-      }
-      return (await response.json()) as ExecutionMetrics;
-    },
-  });
-
-  const metrics = metricsQuery.data;
-  const duration = metrics?.duration;
-  const cost = metrics?.cost;
-  const refreshedAt = metrics?.refreshedAt
-    ? new Intl.DateTimeFormat(undefined, {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      }).format(new Date(metrics.refreshedAt))
-    : '—';
-
+export function WorkflowsHomePage({ payload: _payload }: { payload: BootPayload }) {
   return (
     <main className="space-y-6" aria-label="Mission Control dashboard">
       <header>
         <p className="eyebrow">Mission Control</p>
-        <h1>Operational Metrics</h1>
+        <h1>Workflows</h1>
         <p className="subhead">
-          Run duration, success rate, and cost across recent task executions.
+          Review workflow executions, inspect status, and open run evidence from the workflow list.
         </p>
       </header>
 
-      <section aria-label="Operational metrics" className="space-y-4">
-        {metricsQuery.isLoading ? (
-          <p className="text-sm text-slate-500 dark:text-slate-400">Loading operational metrics...</p>
-        ) : null}
-
-        {metricsQuery.isError ? (
-          <p className="text-sm text-rose-600 dark:text-rose-300">
-            Operational metrics are unavailable.
-          </p>
-        ) : null}
-
-        {!metricsQuery.isLoading && !metricsQuery.isError && metrics ? (
-          <>
-            <dl className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-              <MetricTile
-                label="Runs"
-                value={String(metrics.totalRuns ?? '—')}
-                detail={`${metrics.terminalRuns ?? 0} terminal from ${metrics.sampleSize ?? 0} sampled`}
-              />
-              <MetricTile
-                label="Success Rate"
-                value={formatPercent(metrics.successRate)}
-                detail={`${metrics.completedRuns ?? 0} completed, ${metrics.failedRuns ?? 0} failed`}
-              />
-              <MetricTile
-                label="Run Duration"
-                value={formatDuration(duration?.averageSeconds)}
-                detail={`Median ${formatDuration(duration?.medianSeconds)} across ${duration?.observedCount ?? 0} runs`}
-              />
-              <MetricTile
-                label="Cost"
-                value={formatUsd(cost?.totalEstimateUsd)}
-                detail={`Average ${formatUsd(cost?.averageEstimateUsd)} across ${cost?.observedCount ?? 0} runs`}
-              />
-            </dl>
-
-            <p className="text-xs text-slate-500 dark:text-slate-400">
-              Refreshed {refreshedAt}
-              {metrics.countMode === 'estimated_or_unknown' ? ' · count estimate' : ''}
-            </p>
-          </>
-        ) : null}
+      <section className="space-y-4" aria-label="Workflow navigation">
+        <a href="/workflows" className="button">
+          Open workflows
+        </a>
       </section>
     </main>
   );

--- a/tests/api_service/test_ui_assets_strict.py
+++ b/tests/api_service/test_ui_assets_strict.py
@@ -254,7 +254,64 @@ def test_ui_assets_prefers_newer_usable_bundled_dist_over_older_local_dist(
     assert 'href="/static/workflow_console/dist/assets/mission-control.css"' in html
     assert resolve_mission_control_dist_root() == bundled_dist_root
 
-def test_resolve_mission_control_dist_root_returns_after_newest_usable_candidate(
+def test_ui_assets_prefers_bundled_dist_over_newer_local_dist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_dist_root = tmp_path / "local-dist"
+    local_manifest_dir = local_dist_root / ".vite"
+    local_assets_dir = local_dist_root / "assets"
+    local_manifest_dir.mkdir(parents=True)
+    local_assets_dir.mkdir()
+    (local_manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "entrypoints/mission-control.tsx": {
+                    "file": "assets/local-mission-control.js",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (local_assets_dir / "local-mission-control.js").write_text(
+        "console.log('newer local dist');", encoding="utf-8"
+    )
+
+    bundled_dist_root = tmp_path / "bundled-dist"
+    bundled_manifest_dir = bundled_dist_root / ".vite"
+    bundled_assets_dir = bundled_dist_root / "assets"
+    bundled_manifest_dir.mkdir(parents=True)
+    bundled_assets_dir.mkdir()
+    (bundled_manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "entrypoints/mission-control.tsx": {
+                    "file": "assets/bundled-mission-control.js",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (bundled_assets_dir / "bundled-mission-control.js").write_text(
+        "console.log('bundled dist');", encoding="utf-8"
+    )
+
+    older = 1_700_000_000
+    newer = older + 300
+    os.utime(bundled_manifest_dir / "manifest.json", (older, older))
+    os.utime(local_manifest_dir / "manifest.json", (newer, newer))
+
+    monkeypatch.delenv("VITE_MANIFEST_PATH", raising=False)
+    monkeypatch.delenv("MOONMIND_LENIENT_UI_ASSETS", raising=False)
+    monkeypatch.setenv("MOONMIND_BUNDLED_UI_DIST_ROOT", str(bundled_dist_root))
+    monkeypatch.setattr(ui_assets_module, "local_ui_dist_root", lambda: local_dist_root)
+
+    html = ui_assets("mission-control")
+
+    assert 'src="/static/workflow_console/dist/assets/bundled-mission-control.js"' in html
+    assert "local-mission-control.js" not in html
+    assert resolve_mission_control_dist_root() == bundled_dist_root
+
+def test_resolve_mission_control_dist_root_returns_after_bundled_usable_candidate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     local_dist_root = tmp_path / "local-dist"

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Iterator
@@ -428,6 +429,26 @@ def test_list_executions_source_temporal_ignores_unknown_scope(client) -> None:
     query = mock_client.count_workflows.await_args.kwargs["query"]
     assert 'WorkflowType="MoonMind.UserWorkflow"' in query
     assert 'mm_entry="user_workflow"' in query
+
+
+def test_normalize_temporal_list_scope_logs_retired_scope_safely(caplog) -> None:
+    retired_scope = " System\nInjected" + ("x" * 100)
+
+    with caplog.at_level(logging.INFO, logger=executions_module.logger.name):
+        scope = executions_module._normalize_temporal_list_scope(
+            retired_scope,
+            workflow_type=None,
+            entry=None,
+        )
+
+    assert scope == "default"
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    logged_scope = caplog.records[0].args[0]
+    assert logged_scope == retired_scope.strip().lower()[:64]
+    assert len(logged_scope) == 64
+    assert "system\\ninjected" in message
+    assert "system\ninjected" not in message
 
 
 def test_execution_router_exposes_recover_route_without_recovery_alias() -> None:

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -332,20 +332,35 @@ def test_execution_metrics_source_temporal_returns_operational_aggregates(
     assert 'mm_repo="MoonLadderStudios/MoonMind"' in mock_client.list_workflows.call_args.kwargs["query"]
 
 
-def test_list_executions_source_temporal_rejects_retired_broad_scopes(
+def test_list_executions_source_temporal_ignores_retired_scope_values(
     client,
 ) -> None:
     test_client, _service, _user, _mock_session = client
 
-    response = test_client.get(
-        "/api/executions",
-        params={"source": "temporal", "scope": "system"},
-    )
+    executions_module.get_temporal_client_adapter.cache_clear()
 
-    assert response.status_code == 422
-    detail = response.json()["detail"]
-    assert detail["code"] == "invalid_temporal_list_scope"
-    assert detail["message"] == "scope is no longer supported for workflow execution lists."
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = []
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=0))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "scope": "system"},
+        )
+
+    assert response.status_code == 200
+    query = mock_client.count_workflows.await_args.kwargs["query"]
+    assert 'WorkflowType="MoonMind.UserWorkflow"' in query
+    assert 'mm_entry="user_workflow"' in query
 
 
 def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_workflow_list(
@@ -386,18 +401,33 @@ def test_list_executions_source_temporal_ignores_workflow_kind_filters_for_workf
         assert mock_client.list_workflows.call_args.kwargs["query"] == expected_query
 
 
-def test_list_executions_source_temporal_rejects_unknown_scope(client) -> None:
+def test_list_executions_source_temporal_ignores_unknown_scope(client) -> None:
     test_client, _service, _user, _mock_session = client
 
-    response = test_client.get(
-        "/api/executions",
-        params={"source": "temporal", "scope": "surprise"},
-    )
+    executions_module.get_temporal_client_adapter.cache_clear()
 
-    assert response.status_code == 422
-    detail = response.json()["detail"]
-    assert detail["code"] == "invalid_temporal_list_scope"
-    assert detail["message"] == "scope is no longer supported for workflow execution lists."
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = []
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = MagicMock(return_value=mock_iterator)
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=0))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "scope": "surprise"},
+        )
+
+    assert response.status_code == 200
+    query = mock_client.count_workflows.await_args.kwargs["query"]
+    assert 'WorkflowType="MoonMind.UserWorkflow"' in query
+    assert 'mm_entry="user_workflow"' in query
 
 
 def test_execution_router_exposes_recover_route_without_recovery_alias() -> None:


### PR DESCRIPTION
## Summary
- remove the remaining workflows-home operational metrics query and panel from the shared Mission Control bundle
- ignore retired execution list scope query params instead of surfacing a scope validation error
- prefer the image-baked Mission Control UI bundle over stale repo-local dist output unless an explicit dev/config manifest is set

## Root cause
PR #2418 fixed the workflow-list source, but stale or alternate shared Mission Control bundles could still call /api/executions/metrics with scope=tasks. The backend then rejected that stale scope and the old frontend rendered both the operational metrics warning and the scope error.

## Validation
- npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx frontend/src/entrypoints/workflow-list.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/test_executions_temporal.py tests/api_service/test_ui_assets_strict.py
- npm run ui:build
- grep verified built workflows-home/workflow-list/mission-control chunks do not contain the removed metrics/scope strings