### PR TITLE
[codex] Fix workflow submission release notes packaging

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -212,6 +212,7 @@ RUN pip install --disable-pip-version-check readmeai~=0.6.3 --no-deps
 COPY moonmind /app/moonmind/
 COPY api_service /app/api_service/
 COPY config /app/config/
+COPY docs/ReleaseNotes /app/docs/ReleaseNotes/
 COPY .agents /app/.agents/
 RUN pip install --disable-pip-version-check --no-deps .
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,7 @@ services:
       - ./model_data:/app/model_data
       - ./api_service:/app/api_service
       - ./moonmind:/app/moonmind:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./.agents:/app/.agents:ro
       - ./deploy/state:/workspace/deployment_state:ro
       - ./keycloak:/app/keycloak:ro # Mount keycloak configs if needed by api, or remove if only for keycloak service
@@ -295,6 +296,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
       - agent_workspaces:/work/agent_jobs
@@ -350,6 +352,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
       - agent_workspaces:/work/agent_jobs
@@ -404,6 +407,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -463,6 +467,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -541,6 +546,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -642,6 +648,7 @@ services:
       - ./deploy/state:/workspace/deployment_state:rw
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -723,6 +730,7 @@ services:
       - ./deploy/state:/workspace/deployment_state:rw
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -783,6 +791,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -835,6 +844,7 @@ services:
       - ./moonmind:/app/moonmind:ro
       - ./tools:/app/tools:ro
       - ./api_service:/app/api_service:ro
+      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./model_data:/app/model_data:ro
       - ./api_service:/app/api_service:ro
       - moonmind_secrets:/app/var/secrets

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -846,7 +846,6 @@ services:
       - ./api_service:/app/api_service:ro
       - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
       - ./model_data:/app/model_data:ro
-      - ./api_service:/app/api_service:ro
       - moonmind_secrets:/app/var/secrets
       - ./init_db:/app/init_db
     command: sh /app/init_db/init_db_entrypoint.sh


### PR DESCRIPTION
## Summary
- Copy `docs/ReleaseNotes` into the runtime Docker image so default MM-730 cutover paths exist in packaged deployments.
- Mount `./docs/ReleaseNotes` into the API and Temporal worker containers for compose-based source-bound deployments.
- Fix workflow submission failures where `POST /api/executions` returned 500 because `TEMPORAL_USER_WORKFLOW_RELEASE_NOTES_PATH` was missing inside `/app`.

## Validation
- `docker compose config --quiet`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_hard_switch_cutover.py`
- Confirmed API and Temporal worker containers became healthy after restart and the user-workflow start contract resolves to `MoonMind.UserWorkflow` on `mm.workflow.user.v2`.