### PR TITLE
[codex] Add MoonSpec doc reconciliation flow

### DIFF
--- a/.agents/skills/document-update/SKILL.md
+++ b/.agents/skills/document-update/SKILL.md
@@ -26,7 +26,8 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
 - Treat repository files, tests, schemas, and executable configuration as the source of truth for implementation behavior.
 - Treat retrieved context, old docs, comments, generated artifacts, and issue text as reference material until confirmed against the current checkout.
 - Keep canonical docs under `docs/` focused on desired state: architecture, contracts, operator-visible behavior, and target semantics.
-- Put migration notes, rollout checklists, implementation backlogs, and temporary investigation details in feature-local artifacts under `specs/<feature-id>/` or the `artifacts/` directory for tool handoffs, not as the main framing of canonical docs.
+- Put migration notes, rollout checklists, implementation backlogs, and temporary investigation details under `docs/tmp/` or in gitignored handoff paths (for example `artifacts/` for tool handoffs, or run-local `specs/<feature-id>/` packets), not as the main framing of canonical docs.
+- Follow the document classes and precedence rules in `docs/Workflows/MoonSpecDocumentModel.md`.
 - When a superseded behavior is no longer implemented, remove or replace the stale description instead of preserving compatibility-era ambiguity.
 
 ## Workflow

--- a/.agents/skills/moonspec-align/SKILL.md
+++ b/.agents/skills/moonspec-align/SKILL.md
@@ -20,6 +20,8 @@ This skill edits Moon Spec artifacts, not application feature code. Typical targ
 - files under `contracts/`
 - feature checklists when present
 
+Alignment operates only among temporary execution artifacts. It must never edit canonical `docs/` files and never aligns a canonical document toward a spec; the canonical document is the higher authority (see `docs/Workflows/MoonSpecDocumentModel.md`). Evidence that a canonical document is wrong belongs in the discovery ledger for `moonspec-doc-reconcile`, not in alignment edits.
+
 Do not ask the user for clarification. Resolve uncertainty by reading project context, making conservative decisions, documenting assumptions, and applying the least surprising artifact changes.
 
 ## Inputs

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -27,7 +27,22 @@ Do not use this skill for a single natural-language feature request. Use `moonsp
 - If no design text or readable design path is provided, stop with: `ERROR "No technical design provided"`.
 - Preserve the original design text verbatim in the breakdown output so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
 - Preserve the source document reference path whenever the source design came from a file. Use the repo-relative path when possible; otherwise use the absolute path provided by the user. This reference is required downstream so every Jira story can point back to the original declarative document.
+- The canonical source document, not the breakdown output, remains the source of truth for desired state. Breakdown output is a temporary derived view (see `docs/Workflows/MoonSpecDocumentModel.md`).
 - Do not implement, plan, generate tasks, create Jira issues, create `spec.md`, or create directories under `specs/`.
+
+## Input Classification
+
+Classify the source design before extracting coverage points, using the document classes in `docs/Workflows/MoonSpecDocumentModel.md`:
+
+- `canonical-declarative`: a readable repo path under `docs/` (or `.specify/memory/constitution.md`) describing desired state.
+- `declarative-text`: pasted declarative design text, or a file-backed declarative design outside `docs/`.
+- `imperative-override`: a document whose primary framing is steps, phases, checkboxes, status, or migration sequencing, accepted only with an explicit user override.
+
+A document is declarative when it describes what the system is or should be; it is imperative when its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by their primary framing.
+
+If the input is primarily imperative and the user has not explicitly confirmed imperative input, stop with: `ERROR "Imperative input: provide the underlying declarative design or explicitly confirm imperative input"`. Decomposing a checklist produces stories that mistake process steps for requirements; the underlying declarative document must be written or identified first.
+
+Record the resulting class as `sourceDocumentClass` in the breakdown output.
 
 ## Pre-Breakdown Hooks
 
@@ -165,7 +180,7 @@ Never name any breakdown output `spec.md`. Never write to `specs/` during breakd
 
 The JSON file must be an object with:
 
-- `source`: object containing `title`, `path`, `referencePath`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For pasted designs without a file path, set them to `null` and use a clear title such as `inline user request`.
+- `source`: object containing `title`, `path`, `referencePath`, `sourceDocumentClass`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For pasted designs without a file path, set them to `null` and use a clear title such as `inline user request`. `sourceDocumentClass` must be `canonical-declarative`, `declarative-text`, or `imperative-override` per the Input Classification section.
 - `extractedAt`: ISO-8601 timestamp.
 - `coverageGate`: exactly `PASS - every major design point is owned by at least one story.`
 - `stories`: ordered list of story objects.
@@ -247,6 +262,8 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 ## Key Rules
 
 - One breakdown story candidate equals one future `spec.md`.
+- The canonical source document remains the source of truth for desired state; breakdown output is a temporary derived view and is never cited as authority over its source.
+- Classify the input per `docs/Workflows/MoonSpecDocumentModel.md` and fail fast on imperative inputs without an explicit override.
 - Preserve the original technical or declarative design verbatim in the breakdown output for later specify.
 - Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file.
 - Prefer vertical user or operational outcomes over technical-layer slices.

--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: moonspec-doc-reconcile
+description: Reconcile a canonical declarative document under docs/ with verified implementation discoveries after a FULLY_IMPLEMENTED moonspec-verify verdict. Use when an orchestration run must decide whether implementation discoveries definitely require updating the source design document for function, consistency, or best practices, apply the smallest correct doc update, or escalate a misaligned update as a Jira issue instead of editing.
+---
+
+# MoonSpec Doc Reconcile
+
+Use this skill as the final doc-reconciliation pass of a MoonSpec orchestration run. It decides whether verified implementation discoveries definitely require updating the canonical source document, applies the smallest correct update when they do, and reports a structured outcome either way.
+
+This skill operationalizes the reconciliation expectation in `docs/Workflows/MoonSpecDocumentModel.md` and Constitution XI ("update the owning `docs/` files first").
+
+## Preconditions
+
+- The latest `moonspec-verify` verdict for the active feature is `FULLY_IMPLEMENTED`. If it is not, stop with `NO_UPDATE_REQUIRED` and report that reconciliation only runs after successful verification.
+- A canonical source document exists: `spec.md` records a `**Source Document**` path under `docs/` (or the breakdown `sourceReference.path` points there). If no canonical document exists, stop immediately with `NO_UPDATE_REQUIRED` and the rationale `no canonical source document`.
+
+## Inputs
+
+- Required: canonical source document path(s) from `spec.md` `**Source Document**` or breakdown `sourceReference.path`.
+- Required: the latest `moonspec-verify` report, including its Source Document Drift section.
+- Optional: the discovery ledger at `artifacts/doc-discoveries/<feature>.json` written by `moonspec-implement`.
+- Optional: doc-drift notes from a `story-reconcile-implementation` report.
+- Optional: explicit scope limits from the orchestration step.
+
+Discoveries are the only valid basis for edits. Do not re-derive drift by auditing the whole document; that is `document-update`'s job, not this skill's.
+
+## Update Gate
+
+Edit the canonical document only when at least one discovery **definitely requires** it, meaning the discovery has `definite` severity (or equivalent verified evidence in the verify report) and satisfies at least one of:
+
+1. **Function**: the document as written describes behavior or contracts that are now factually wrong against the verified implementation.
+2. **Consistency**: the implementation correctly resolved an internal contradiction or ambiguity in the document, and the document must record the resolution to stay coherent.
+3. **Best practices**: the implementation deliberately and correctly diverged from a documented approach for a defensible reason validated by verification.
+
+The following never pass the gate:
+
+- `possible`-severity discoveries and unverified suspicions.
+- Stylistic preferences, wording improvements, or speculative future work.
+- Drift in temporary artifacts (`spec.md`, `plan.md`, `tasks.md`); those are disposable and are never reconciled into docs.
+
+When no discovery passes the gate, report `NO_UPDATE_REQUIRED` with a one-line rationale per rejected discovery. A no-op outcome is a correct and common result.
+
+## Editing Rules
+
+Follow the editing doctrine of the `document-update` skill (`.agents/skills/document-update/SKILL.md`):
+
+- Update only the sections the gated discoveries name. Make the smallest coherent edit.
+- Preserve desired-state framing: never downgrade the documented desired state to match buggy or incomplete code.
+- Never insert migration narratives, status checklists, phase plans, or implementation backlogs into canonical docs (Constitution XII).
+- Remove superseded text outright instead of layering compatibility language (Constitution XIII).
+- Preserve the document's voice, heading structure, and terminology where they remain accurate.
+- Cite implementation evidence (file paths, tests) in the reconciliation report, not inside the canonical document.
+
+## Escalation
+
+If a required update would conflict with the constitution, `README.md`, or the declared architecture direction — or the correct desired state is genuinely uncertain — do not edit. Instead:
+
+1. Read `.agents/skills/jira-issue-creator/SKILL.md` and follow its workflow.
+2. Create a Jira issue containing the document path, the contradicted claim, the implementation evidence, and why the update may conflict with project direction.
+3. Report `ESCALATED` with the issue key and URL.
+
+Escalation does not retroactively fail verification or block the surrounding orchestration.
+
+## Boundaries
+
+- Read-only outside `docs/`: never edit source code, tests, `spec.md`, `plan.md`, `tasks.md`, or configuration.
+- Never commit, push, or create pull requests; the orchestration's publication step owns git operations.
+- Never delete or rewrite the discovery ledger; it is run evidence.
+- Respect secret hygiene: redact secret-like content before writing or reporting.
+
+## Output Contract
+
+Write the structured result to the path provided by the orchestration step when one is given (for Jira Orchestrate runs: `artifacts/jira-orchestrate-doc-reconcile.json`), and include it in the response:
+
+```json
+{
+  "action": "updated | no_update_required | escalated",
+  "docPaths": ["docs/Workflows/Example.md"],
+  "gateRationale": "which gate criterion each applied discovery met, or why each discovery was rejected",
+  "evidence": ["file, test, or report references backing the decision"],
+  "jiraIssue": {"key": "MM-000", "url": "https://..."}
+}
+```
+
+`docPaths` lists edited documents for `updated`, the considered documents otherwise. Include `jiraIssue` only for `escalated`.
+
+Also return a short markdown summary suitable for inclusion in a pull request body: outcome, edited paths or rejection rationale, and escalation issue key when present.
+
+## Key Rules
+
+- Run only after `FULLY_IMPLEMENTED` verification.
+- No canonical source document means an immediate `NO_UPDATE_REQUIRED`.
+- Only `definite`, evidence-backed discoveries that meet the function, consistency, or best-practices test justify edits.
+- Smallest correct edit; desired-state framing preserved; no imperative content in canonical docs.
+- Misaligned updates become Jira issues, never silent edits or silent drops.
+- The structured outcome is mandatory in every run, including no-ops.

--- a/.agents/skills/moonspec-implement/SKILL.md
+++ b/.agents/skills/moonspec-implement/SKILL.md
@@ -202,6 +202,28 @@ Rules:
 - Refactor only after tests pass.
 - Preserve unrelated user changes in the worktree.
 
+## Discovery Ledger
+
+When implementation deviates from the canonical source document recorded in `spec.md`, or reveals that the document is wrong, incomplete, or internally inconsistent, append a structured entry to a gitignored handoff at `artifacts/doc-discoveries/<feature>.json` (create the file with a top-level `discoveries` array on first use):
+
+```json
+{
+  "docPath": "docs/Workflows/Example.md",
+  "section": "heading or anchor",
+  "claim": "what the document says",
+  "observed": "what implementation showed",
+  "evidence": "file paths, tests, or command output supporting the observation",
+  "severity": "definite | possible"
+}
+```
+
+Rules:
+
+- Use `definite` only when the document is factually wrong against verified behavior, internally inconsistent, or the implementation deliberately and correctly diverged for a defensible reason.
+- Use `possible` for unconfirmed suspicions; these never authorize doc edits.
+- Write no entry when there is nothing to report. Do not invent discoveries.
+- Discoveries do not authorize editing canonical `docs/` files during implementation. They feed the `moonspec-doc-reconcile` step that runs after verification (see `docs/Workflows/MoonSpecDocumentModel.md`).
+
 ## Completion Validation
 
 Before reporting completion:
@@ -279,4 +301,5 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 - Confirm tests fail for the intended reason before production code.
 - Preserve traceability to the original request and source design mappings.
 - Mark completed tasks `[X]` only after real completion.
+- Record canonical-doc drift in the discovery ledger instead of editing `docs/` files inline.
 - Run or recommend `/speckit.verify` as the final alignment check.

--- a/.agents/skills/moonspec-orchestrate/SKILL.md
+++ b/.agents/skills/moonspec-orchestrate/SKILL.md
@@ -17,6 +17,7 @@ Orchestrate downstream Moon Spec skills instead of reimplementing their detailed
 - `moonspec-align`: analyze and remediate artifact drift before implementation.
 - `moonspec-implement`: implement the task breakdown with TDD.
 - `moonspec-verify`: perform final read-only verification.
+- `moonspec-doc-reconcile`: update the canonical source document when verified discoveries definitely require it.
 
 Do not use older `speckit-*` skill names in orchestration instructions. Slash commands such as `/speckit.plan` may still appear only when referring to the user-facing command names.
 
@@ -37,7 +38,7 @@ Default intent is `runtime`: production code plus tests must be delivered. Use `
 - Single-story requests go through `moonspec-specify`.
 - TDD is the default strategy.
 - Unit tests and integration tests are both expected.
-- The original request or source design preserved in `spec.md` `**Input**` is the final alignment source.
+- The original request or source design preserved in `spec.md` `**Input**` is the final alignment source, interpreted against the canonical source document per `docs/Workflows/MoonSpecDocumentModel.md`. When a derived artifact conflicts with its canonical source document, the canonical document wins unless verified evidence shows the document itself is wrong — then the conflict goes to doc reconciliation, never silent override.
 - `moonspec-align` replaces the old multi-step analyze remediation sequence.
 - Do not synthesize user approvals, scripted user responses, or pretend an analyze report exists.
 - Resume from existing artifacts when they pass gates; do not regenerate by default.
@@ -96,6 +97,9 @@ Use these gates before advancing:
   - `moonspec-verify` produced a concrete report for the active `spec.md`.
   - Verdict is not `NO_DETERMINATION`.
   - Completion is claimed only when verdict is `FULLY_IMPLEMENTED`.
+- Doc Reconcile gate:
+  - `moonspec-doc-reconcile` has run after a `FULLY_IMPLEMENTED` verdict when `spec.md` records a canonical source document.
+  - Its result is exactly one of `UPDATED`, `NO_UPDATE_REQUIRED`, or `ESCALATED`, with rationale.
 
 If a gate fails, stop or run the appropriate upstream skill. Do not continue on a claimed success without artifacts or evidence.
 
@@ -151,6 +155,15 @@ This replaces the old manual analyze remediation flow. Do not provide scripted "
 4. Run at most two verification-remediation cycles unless the user explicitly asks to keep going.
 5. If verdict is `NO_DETERMINATION`, stop and report the exact missing evidence, commands, or context.
 
+### 7. Reconcile Declarative Docs
+
+Run only when the final verdict is `FULLY_IMPLEMENTED` and `spec.md` records a canonical source document under `docs/`:
+
+1. Run `moonspec-doc-reconcile` with the canonical document path(s), the latest verification report (including its Source Document Drift section), and `artifacts/doc-discoveries/<feature>.json` when present.
+2. Accept exactly one outcome: `UPDATED` (canonical doc edited), `NO_UPDATE_REQUIRED` (gate not met), or `ESCALATED` (Jira issue created for a misaligned update).
+3. `ESCALATED` does not retroactively fail verification; report the issue key alongside the outcome.
+4. Skip this stage with outcome `NO_UPDATE_REQUIRED` when no canonical source document exists.
+
 ## Multi-Spec Designs
 
 Multi-spec orchestration is out of scope for this skill. A higher-level workflow must split, order, and select stories before invoking MoonSpec Orchestrate for each individual story.
@@ -178,6 +191,7 @@ Stages:
 - Align: PASS/FAIL/SKIPPED
 - Implement: PASS/FAIL/SKIPPED
 - Verify: FULLY_IMPLEMENTED/ADDITIONAL_WORK_NEEDED/NO_DETERMINATION/SKIPPED
+- Doc Reconcile: UPDATED/NO_UPDATE_REQUIRED/ESCALATED/SKIPPED
 
 Changed files:
 - [paths]
@@ -203,3 +217,4 @@ Mention source design coverage and `DOC-REQ-*`/`DESIGN-REQ-*` status when presen
 - Enforce one story per spec.
 - Keep TDD, unit tests, integration tests, and `/speckit.verify` in the pipeline.
 - Treat verification as the final authority for completion.
+- Run doc reconciliation after a `FULLY_IMPLEMENTED` verdict when a canonical source document exists; never let derived artifacts silently override canonical docs.

--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -28,6 +28,7 @@ Do not use this skill to create a spec from a request. Use `moonspec-specify` or
 - If the spec is missing, contains multiple user stories, or has unresolved story-critical clarifications after research, stop with an error.
 - Use absolute paths in reports.
 - Treat `spec.md` as the desired behavior contract. Do not remove a requirement from the story because similar behavior already exists in the codebase.
+- `plan.md` and its design artifacts are imperative, temporary execution artifacts (see `docs/Workflows/MoonSpecDocumentModel.md`). Never copy their content into canonical `docs/` files.
 
 ## Pre-Plan Hooks
 

--- a/.agents/skills/moonspec-specify/SKILL.md
+++ b/.agents/skills/moonspec-specify/SKILL.md
@@ -20,6 +20,7 @@ Do not use this skill to split a broad design into multiple specs; use `/speckit
 ## Inputs
 
 - Treat the user's request text as the feature description.
+- `spec.md` is a temporary execution artifact derived from the request or its canonical source document. It is never the source of truth for desired state (see `docs/Workflows/MoonSpecDocumentModel.md`).
 - Do not ask the user to repeat the request unless it is empty or no independently testable story can be derived.
 - If the feature description is empty, stop with: `ERROR "No feature description provided"`.
 - Preserve the original feature description verbatim in the generated spec's `**Input**` field. Do not summarize or normalize it; `/speckit.verify` relies on this source request.
@@ -46,6 +47,8 @@ For source-backed requests:
 4. Assign stable IDs: `DESIGN-REQ-001`, `DESIGN-REQ-002`, and so on.
 5. If the source artifact contains multiple independent stories, do not collapse them into one spec. Ask the user to choose one story, or direct them to `/speckit.breakdown` when the goal is to extract stories from a broader technical or declarative design.
 6. If a source requirement is intentionally out of scope for the selected story, keep it in the source mapping as out of scope with a short rationale. Do not silently drop it.
+7. Record the canonical source document path and its document class (per `docs/Workflows/MoonSpecDocumentModel.md`) in a `**Source Document**` line directly below `**Input**` in `spec.md`.
+8. If drafting reveals a conflict between the feature request and the canonical source document, surface it as a `[NEEDS CLARIFICATION]` marker or an explicitly flagged conflict in the spec. Do not silently resolve the conflict toward either side; the canonical document wins by default, and evidence that the document itself is wrong must flow to doc reconciliation, not be buried in the spec.
 
 Complete source reading, requirement extraction, and single-story selection before creating the feature directory.
 
@@ -200,6 +203,7 @@ After writing the initial spec, create `SPECIFY_FEATURE_DIRECTORY/checklists/req
 - [ ] Independent Test describes how the story can be validated end-to-end
 - [ ] Acceptance scenarios are concrete enough to derive unit and integration tests
 - [ ] No in-scope source design requirements are unmapped from functional requirements
+- [ ] Spec does not contradict its canonical source document, or contradictions are explicitly flagged
 - [ ] Edge cases are identified
 - [ ] Scope is clearly bounded
 - [ ] Dependencies and assumptions identified

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -19,6 +19,9 @@ The generated task list must:
 - Include red-first confirmation tasks.
 - Preserve traceability to the original request or source design preserved in `spec.md`.
 - Include final `/speckit.verify` work after implementation and tests pass.
+- Include a final doc-reconciliation task (`moonspec-doc-reconcile`) after `/speckit.verify` when `spec.md` records a canonical source document under `docs/`.
+
+`tasks.md` is an imperative, temporary execution artifact (see `docs/Workflows/MoonSpecDocumentModel.md`). Never copy its content into canonical `docs/` files.
 
 ## Inputs
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -17,6 +17,7 @@ This skill answers:
 - Is the single story in `spec.md` fully implemented?
 - Do unit tests and integration tests provide credible evidence?
 - Which requirements, scenarios, source design mappings, or constitution rules remain partial, missing, conflicting, or unverified?
+- Did verified implementation evidence contradict claims in the canonical source document, indicating doc drift that reconciliation must handle?
 
 ## Inputs
 
@@ -123,6 +124,7 @@ Read:
 - `.specify/memory/constitution.md`: `MUST` constraints and quality gates.
 - `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `checklists/` when present and relevant.
 - `specs/breakdown.md` when source design coverage or cross-spec dependencies matter.
+- The canonical source document named by `spec.md` `**Source Document**` when present, plus `artifacts/doc-discoveries/<feature>.json` when it exists, so source-document drift can be assessed.
 
 Do not use copied source requirement text in `spec.md` as evidence that behavior exists.
 
@@ -199,6 +201,7 @@ Rules:
 - Separate missing implementation from missing validation when both matter.
 - Treat violated constitution `MUST` rules as blocking failures.
 - Treat original request misalignment as blocking even if later tasks are complete.
+- Source-document drift alone does not block `FULLY_IMPLEMENTED` when the implementation is correct per the agreed story scope; record it in the Source Document Drift section as structured input for `moonspec-doc-reconcile`. Drift becomes blocking only when it reveals the implementation itself contradicts agreed scope.
 
 ## Verdict
 
@@ -253,6 +256,12 @@ Use this structure:
 
 - [Pass/fail summary against the verbatim original request]
 
+## Source Document Drift
+
+| Doc Claim | Observed Behavior | Evidence | Severity |
+|-----------|-------------------|----------|----------|
+| [docs/ path + claim] | [verified behavior] | [file/test/reference] | definite/possible |
+
 ## Gaps
 
 - [Blocking gaps first]
@@ -300,7 +309,7 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 ## Key Rules
 
 - Verification is read-only except ignored disposable test artifacts.
-- The original request in `spec.md` is the source of truth for final alignment.
+- The original request as preserved in `spec.md`, interpreted against the canonical source document per `docs/Workflows/MoonSpecDocumentModel.md`, is the alignment baseline. The canonical document — not the spec — remains the source of truth for desired state.
 - Moon Spec uses one story per spec.
 - `spec.md` plus `.specify/memory/constitution.md` define governing requirements.
 - `plan.md` and `tasks.md` are useful context but never proof of implementation.

--- a/.agents/skills/story-reconcile-implementation/SKILL.md
+++ b/.agents/skills/story-reconcile-implementation/SKILL.md
@@ -123,6 +123,7 @@ The markdown report must include:
 - Remaining work for partially implemented stories.
 - Skipped fully implemented stories.
 - Unverifiable stories and the exact missing evidence or ambiguity.
+- Doc-drift notes: when repository evidence shows the canonical source document itself is stale, wrong, or internally inconsistent (not just a story), record the document path, the contradicted claim, and the evidence. These notes are informational input for doc reconciliation; they do not change Jira actions.
 - Confirmation that Jira issue creation should consume the reconciled JSON, not the original unreconciled story list.
 
 ## Key Rules

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -196,7 +196,7 @@ MoonMind development MUST be docs-first, with clear contracts and traceability. 
 Non-negotiable rules:
 
 - Durable, desired-state knowledge — architecture, contracts, operator-visible behavior, and target semantics — MUST live in the owning long-lived `docs/` files (and this constitution). These are the canonical surfaces that future readers and agents are expected to trust.
-- Per-feature Spec Kit / MoonSpec artifacts under `specs/<id>-<feature>/` (`spec.md`, `plan.md`, `tasks.md`, `research.md`, `contracts`) are **optional execution artifacts** — execution helpers and supplemental history. They MUST NOT be treated as canonical long-term architecture or behavior documentation.
+- Per-feature Spec Kit / MoonSpec artifacts under `specs/<id>-<feature>/` (`spec.md`, `plan.md`, `tasks.md`, `research.md`, `contracts`) are **temporary, run-local execution artifacts**. The `specs/` tree is gitignored: packets are disposable execution scaffolding, not version-controlled history, and MUST NOT be treated as canonical long-term architecture or behavior documentation.
 - When a non-trivial change lands, its durable decisions MUST be reflected in the owning `docs/` files; the `specs/` packet (if one was produced) remains supplemental execution evidence, not the system of record.
 - When a feature does use the optional execution workflow, `spec.md` SHOULD remain technology-agnostic with implementation details in `plan.md`, and `plan.md` MUST include a “Constitution Check” with PASS/FAIL coverage for each principle (documenting any violation and mitigation in “Complexity Tracking”).
 - Documentation MUST NOT silently drift from reality: when behavior changes, update the owning long-lived `docs/` files first; refresh any in-flight `specs/` execution packet only as supplemental history.
@@ -210,12 +210,12 @@ MoonMind MUST keep long-lived documentation readable as **what the system is for
 Non-negotiable rules:
 
 - Documentation under `docs/` MUST focus on **declarative, desired-state** descriptions: architecture, contracts, operator-visible behavior, and target semantics (including Temporal-native orchestration where that is the product direction).
-- **Migration narratives, phased implementation plans, rollout sequencing, and implementation backlogs** MUST be recorded in **MoonSpec feature artifacts** under `specs/<feature>/` (for example `plan.md`, `tasks.md`, `research.md`, and contracts) or in **local-only / gitignored handoff paths** (for example `artifacts/` for ephemeral tool outputs), not embedded as the primary framing of canonical docs.
-- Canonical docs MUST NOT link to or require disposable migration-only trees under `docs/`; time-bound work belongs in `specs/<feature>/`, `artifacts/`, or other explicitly local handoffs.
+- **Migration narratives, phased implementation plans, rollout sequencing, and implementation backlogs** MUST be recorded under **`docs/tmp/`** or in **local-only / gitignored handoff paths** (for example `artifacts/` for ephemeral tool outputs, or run-local `specs/<feature>/` packets), not embedded as the primary framing of canonical docs.
+- Canonical docs MUST NOT depend on disposable migration-only material to be readable; time-bound work belongs in `docs/tmp/`, `artifacts/`, run-local `specs/<feature>/` packets, or other explicitly local handoffs.
 - When a migration or implementation effort completes, **delete or archive** the corresponding scratch material rather than leaving obsolete plan sections in canonical files.
-- Canonical docs that still have open migration work SHOULD **point** to the relevant `specs/<feature>/` artifacts (or equivalent) instead of duplicating volatile checklists inline.
+- Canonical docs that still have open migration work SHOULD **point** to the relevant `docs/tmp/` plan or tracking issue instead of duplicating volatile checklists inline; they MUST NOT cite gitignored paths as required reading.
 
-Rationale: Canonical docs stay stable references for operators and implementers; time-bound work belongs in feature specs or disposable local artifacts.
+Rationale: Canonical docs stay stable references for operators and implementers; time-bound work belongs in `docs/tmp/` or disposable local artifacts.
 
 ### XIII. Pre-Release Velocity: Delete, Don't Deprecate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ When writing code that interacts with skills:
 - **Canonical docs** (`docs/`): describe **declarative desired state** — architecture, contracts, operator-visible behavior, target semantics. Avoid making phased migration or implementation checklists the main story in these files.
 - **Migration, rollout, and MoonSpec execution notes** belong under **`docs/tmp/`** or in **local-only / gitignored paths** (e.g. `artifacts/` for tool handoffs), not as the primary framing of canonical docs. `specs/` is no longer a version-controlled source of guidance.
 - Align with **Constitution principle XII** in `.specify/memory/constitution.md`.
+- Document classes, declarative-vs-imperative classification, and precedence rules are defined in `docs/Workflows/MoonSpecDocumentModel.md`.
 
 ## Testing Instructions
 

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -63,6 +63,9 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:
       id: moonspec-breakdown

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -63,6 +63,9 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:
       id: moonspec-breakdown
@@ -116,6 +119,7 @@ steps:
       Create one Jira Orchestrate task for each Jira issue created from the trusted Jira story output.
 
       Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream tasks.
+      Each downstream task must carry the story's sourceReference.path as its source_design_path input so the downstream Jira Orchestrate doc-reconciliation step knows the canonical source document.
       Do not create downstream tasks for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
       Each downstream task must run Jira Orchestrate on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
       Create task dependencies with dependsOn so each later generated task waits for the immediately earlier generated task workflow ID.

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -49,6 +49,9 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:
       id: moonspec-breakdown

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -430,6 +430,26 @@ steps:
     skill:
       id: moonspec-verify
       args: {}
+  - title: Reconcile declarative docs
+    annotations:
+      jiraOrchestrateRole: doc-reconciliation
+    instructions: |-
+      /clear
+
+      Run moonspec-doc-reconcile for {{ inputs.jira_issue_key }} only when the controlling post-remediation verdict is FULLY_IMPLEMENTED. If the latest verdict is not FULLY_IMPLEMENTED, make no changes and report that doc reconciliation is skipped because publication is already blocked.
+
+      Use the canonical source document recorded in spec.md (Source Document){% if inputs.source_design_path %} or the provided source design path {{ inputs.source_design_path }}{% endif %}. If no canonical source document under docs/ exists, write the structured no_update_required outcome and continue.
+
+      Consume the latest moonspec-verify report, including its Source Document Drift section, plus artifacts/doc-discoveries/<feature>.json when present. Apply the moonspec-doc-reconcile update gate strictly: edit canonical docs only for definite, evidence-backed discoveries showing the document is functionally wrong, internally inconsistent, or correctly diverged from for verified best-practice reasons. Otherwise report no_update_required; a no-op outcome is a correct result.
+
+      If a required update conflicts with the constitution, README, or architecture direction, do not edit the document; create the Jira escalation issue per the skill and continue. Escalation does not block pull request creation.
+
+      Write the structured outcome to artifacts/jira-orchestrate-doc-reconcile.json with keys action, docPaths, gateRationale, evidence, and jiraIssue when escalated. Do not commit, push, or create a pull request from this step; any canonical doc edits remain in the working tree so the pull request step publishes them together with the implementation.
+    skill:
+      id: moonspec-doc-reconcile
+      args: {}
+      requiredCapabilities:
+        - git
   - title: Create pull request
     annotations:
       jiraOrchestrateRole: pull-request-handoff
@@ -452,6 +472,9 @@ steps:
       - verification verdict
       - tests run
       - remaining risks
+      - the doc reconciliation outcome from artifacts/jira-orchestrate-doc-reconcile.json when present: updated canonical doc paths, the no-update rationale, or the escalation Jira issue key
+
+      Canonical doc edits produced by the doc reconciliation step are intentional changes for this issue and must be committed in the same pull request.
 
       After creation and non-draft verification, record the confirmed pull request URL in the step result and in a local handoff artifact at artifacts/jira-orchestrate-pr.json with keys jira_issue_key and pull_request_url. Do not continue unless the pull_request_url is a GitHub pull request URL for the current work branch and the pull request is confirmed non-draft.
     skill:

--- a/api_service/data/presets/moonspec-orchestrate.yaml
+++ b/api_service/data/presets/moonspec-orchestrate.yaml
@@ -90,3 +90,13 @@ steps:
     skill:
       id: moonspec-verify
       args: {}
+  - title: Reconcile declarative docs
+    instructions: |-
+      Run moonspec-doc-reconcile only when the final moonspec-verify verdict is FULLY_IMPLEMENTED and spec.md records a canonical source document under docs/{% if inputs.source_design_path %} (source design path: {{ inputs.source_design_path }}){% endif %}.
+      If no canonical source document exists, report no_update_required and finish.
+      Consume the latest verification report, including its Source Document Drift section, plus artifacts/doc-discoveries/<feature>.json when present.
+      Apply the update gate strictly: edit canonical docs only for definite, evidence-backed discoveries showing the document is functionally wrong, internally inconsistent, or correctly diverged from for verified best-practice reasons. A no-op outcome is a correct result.
+      Report exactly one outcome: updated, no_update_required, or escalated. Escalation creates a Jira issue per the skill and does not retroactively fail verification.
+    skill:
+      id: moonspec-doc-reconcile
+      args: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
       - ./model_data:/app/model_data
       - ./api_service:/app/api_service
       - ./moonmind:/app/moonmind:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./.agents:/app/.agents:ro
       - ./deploy/state:/workspace/deployment_state:ro
       - ./keycloak:/app/keycloak:ro # Mount keycloak configs if needed by api, or remove if only for keycloak service
@@ -296,7 +296,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
       - agent_workspaces:/work/agent_jobs
@@ -352,7 +352,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
       - agent_workspaces:/work/agent_jobs
@@ -407,7 +407,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -467,7 +467,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -546,7 +546,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -648,7 +648,7 @@ services:
       - ./deploy/state:/workspace/deployment_state:rw
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -730,7 +730,7 @@ services:
       - ./deploy/state:/workspace/deployment_state:rw
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - ./.agents:/app/.agents:ro
       - moonmind_secrets:/app/var/secrets
@@ -791,7 +791,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./services:/app/services:ro
       - moonmind_secrets:/app/var/secrets
     entrypoint:
@@ -844,7 +844,7 @@ services:
       - ./moonmind:/app/moonmind:ro
       - ./tools:/app/tools:ro
       - ./api_service:/app/api_service:ro
-      - ./docs/ReleaseNotes:/app/docs/ReleaseNotes:ro
+      - ./docs:/app/docs:ro
       - ./model_data:/app/model_data:ro
       - moonmind_secrets:/app/var/secrets
       - ./init_db:/app/init_db

--- a/docs/Workflows/MoonSpecDocumentModel.md
+++ b/docs/Workflows/MoonSpecDocumentModel.md
@@ -1,0 +1,50 @@
+# MoonSpec Document Model
+
+This document defines the document classes MoonSpec workflows operate on, the precedence rules between them, and the reconciliation expectation that keeps canonical documentation aligned with verified implementation. MoonSpec skills and presets reference this document instead of restating its rules.
+
+## Document Classes
+
+### Canonical declarative documents
+
+- **Location**: long-lived files under `docs/`, plus `.specify/memory/constitution.md`.
+- **Content**: desired state — architecture, contracts, operator-visible behavior, and target semantics.
+- **Lifecycle**: version-controlled and durable. These are the primary source of truth for what the system is and how it should behave.
+- **Constraints**: canonical documents must stay declarative. Migration narratives, phased rollout sequencing, status checklists, and implementation backlogs must not become their primary framing (Constitution XII).
+
+### Temporary execution artifacts
+
+- **Location**: `specs/`, `artifacts/`, and `artifacts/story-breakdowns/` (all gitignored).
+- **Content**: derived, run-scoped working material — `spec.md`, `plan.md`, `tasks.md`, `research.md`, `contracts/`, story breakdown JSON/markdown, discovery ledgers, and tool handoffs.
+- **Lifecycle**: disposable. They exist to execute one run of work and are never cited as authority for desired state. A spec is a temporary derived view of its canonical source, not a replacement for it.
+
+### Imperative working documents
+
+- **Location**: `docs/tmp/` or gitignored handoff paths.
+- **Content**: checklists, status trackers, migration and rollout plans, cleanup sequences — anything whose primary framing is steps, phases, checkboxes, or status.
+- **Lifecycle**: time-bound. Delete or archive them when the work completes (Constitution XII).
+
+## Classification Rule
+
+A document is **declarative** when it describes what the system is or should be. A document is **imperative** when its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by their primary framing.
+
+MoonSpec breakdown and specification workflows require declarative input. An imperative document is not a valid substitute for a declarative design: decomposing a checklist produces stories that mistake process steps for requirements. When only an imperative document exists, the underlying declarative document must be written or identified first.
+
+## Precedence Rule
+
+When a derived artifact (`spec.md`, `stories.json`, `plan.md`, `tasks.md`) conflicts with its canonical source document:
+
+1. The canonical document wins by default.
+2. If implementation or verification evidence shows the canonical document itself is wrong, incomplete, or internally inconsistent, the canonical document must be updated through doc reconciliation — or the conflict escalated — rather than silently overridden in the derived artifact.
+3. Derived artifacts never resolve such conflicts on their own authority.
+
+## Reconciliation Expectation
+
+Implementation runs that discover canonical-document drift end with a doc-reconciliation pass (see the `moonspec-doc-reconcile` skill). This operationalizes Constitution XI: when a non-trivial change lands, its durable decisions are reflected in the owning `docs/` files.
+
+Reconciliation updates a canonical document only when discoveries **definitely require** it:
+
+- **Function**: the document describes behavior or contracts that are now factually wrong against the verified implementation.
+- **Consistency**: the implementation correctly resolved an internal contradiction or ambiguity in the document, and the document must record the resolution.
+- **Best practices**: the implementation deliberately and correctly diverged from a documented approach for a defensible, verification-backed reason.
+
+Stylistic preferences, speculative improvements, and unverified observations never qualify. Reconciliation preserves desired-state framing: it never downgrades a canonical document to match buggy or incomplete code, and it never inserts imperative content into canonical files. Updates that would conflict with the constitution, README, or architecture direction are escalated as Jira issues instead of applied.

--- a/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
+++ b/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
@@ -1,0 +1,153 @@
+# MoonSpec Docs-First Alignment Plan
+
+Status: proposal (2026-06-11). Execution plan — lives in `docs/tmp/` per Constitution XII.
+
+## Goals
+
+1. Align MoonSpec skills and presets around canonical `docs/` documents as the primary source of truth; all generated spec artifacts are temporary, derived views.
+2. Strongly separate **declarative docs** (desired state) from **imperative artifacts** (checklists, status trackers, migration plans) in MoonSpec skill doctrine.
+3. Add a final orchestrate step that updates the declarative doc when implementation discoveries definitely require it (best practices, function, or consistency).
+
+## Current-state findings
+
+- `specs/` and `artifacts/` are gitignored — spec packets are already physically temporary, but no moonspec skill says so. `moonspec-verify` even calls `spec.md` "the source of truth for final alignment," inverting the intended hierarchy.
+- No moonspec skill mentions `docs/`, "canonical," or "declarative vs imperative." The doctrine exists only in Constitution XI/XII, CLAUDE.md, and the `document-update` skill.
+- `jira-breakdown-orchestrate` labels its input "Declarative Design Path or Text" but nothing validates the input is declarative; an imperative migration checklist would be decomposed into stories as if its steps were requirements.
+- `jira-orchestrate` ends at verify → PR → Code Review with no doc reconciliation. Discoveries made during implementation never flow back to the source doc.
+- Stale guidance conflict: Constitution XII and `document-update` (line 29) still route migration notes to `specs/<feature>/`, while CLAUDE.md declares `specs/` deprecated in favor of `docs/tmp/` and gitignored handoffs.
+- `jira-orchestrate` already accepts `source_design_path`, but `story.create_jira_orchestrate_tasks` does not populate it from story `sourceReference.path` — the canonical doc path is not guaranteed to reach downstream tasks.
+
+## Decisions (confirmed)
+
+- Doc updates land in the **same PR** as the implementation (step inserted before "Create pull request").
+- A **new thin skill** `moonspec-doc-reconcile` owns the reconciliation gate; it borrows editing doctrine from `document-update`.
+- The plan **includes** fixing the stale `specs/` references in the constitution and `document-update`.
+
+---
+
+## Phase 1 — Doctrine foundation
+
+### 1.1 New canonical doc: `docs/Workflows/MoonSpecDocumentModel.md`
+
+Declarative description of the MoonSpec document model (no migration framing):
+
+- **Document classes**:
+  - *Canonical declarative docs* (`docs/`, constitution): desired state — architecture, contracts, operator-visible behavior, target semantics. Long-lived, version-controlled, the primary source of truth.
+  - *Temporary execution artifacts* (`specs/`, `artifacts/`, `artifacts/story-breakdowns/`): derived, run-scoped, gitignored, disposable. Never cited as authority for desired state.
+  - *Imperative working documents* (`docs/tmp/`, gitignored handoffs): checklists, status trackers, migration/rollout plans. Time-bound; deleted or archived on completion.
+- **Precedence rule**: when a derived artifact (spec.md, stories.json, tasks.md) conflicts with its canonical source doc, the source doc wins unless implementation evidence shows the doc itself is wrong — in which case the doc must be updated or the conflict escalated, never silently overridden in the derived artifact.
+- **Classification rule**: a document is declarative if it describes what the system is/should be; it is imperative if its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by primary framing.
+- **Reconciliation expectation**: implementation runs that discover canonical-doc drift end with a doc-reconciliation pass (operationalizes Constitution XI "update the owning docs/ files first").
+
+All skill changes below reference this doc by path instead of duplicating doctrine prose.
+
+### 1.2 Reconcile stale `specs/` guidance
+
+- **Constitution XI/XII**: amend to state that `specs/<feature>/` packets are gitignored, run-local, temporary artifacts (not "supplemental history" in version control), and that migration narratives/rollout checklists belong in `docs/tmp/` or gitignored handoff paths. Keep the desired-state rules unchanged.
+- **`document-update` SKILL.md**: replace the `specs/<feature-id>/` boundary (line 29) with `docs/tmp/` + `artifacts/`; add a pointer to `MoonSpecDocumentModel.md`.
+- **CLAUDE.md**: already consistent; add a pointer to the new doctrine doc in the documentation section.
+
+## Phase 2 — Skill text updates
+
+All edits per Constitution XIII: replace language outright, no compatibility phrasing.
+
+### 2.1 `moonspec-breakdown`
+
+- **Input classification**: before extracting coverage points, classify the source as declarative or imperative per `MoonSpecDocumentModel.md`. If the input is primarily an imperative checklist/migration/status document, **fail fast** with a clear error directing the user to either supply the underlying declarative doc or explicitly confirm imperative input (constitution prefers fail-fast over hidden fallback).
+- **Canonical anchoring**: when the input is a path under `docs/`, record it as the canonical source of truth; add `sourceDocumentClass` (`canonical-declarative` | `declarative-text` | `imperative-override`) to `stories.json` `source`.
+- **Key rules**: add "Breakdown output is a temporary derived view of the canonical document. The canonical document remains the source of truth for desired state."
+
+### 2.2 `moonspec-specify`
+
+- State explicitly: `spec.md` is a temporary execution artifact derived from the request/source doc; it is never the source of truth for desired state.
+- For source-backed requests, record the canonical doc path and class in the spec header alongside `**Input**`.
+- Precedence: if spec drafting reveals a conflict between the request and the canonical doc, surface it as `[NEEDS CLARIFICATION]` or a flagged conflict — do not silently resolve toward either side.
+- Quality checklist: add "Spec does not contradict its canonical source document, or contradictions are explicitly flagged."
+
+### 2.3 `moonspec-plan` / `moonspec-tasks`
+
+- One-line doctrine note each: `plan.md` / `tasks.md` are imperative, temporary execution artifacts; their content must never be copied into canonical `docs/` files.
+- `moonspec-tasks`: the generated breakdown must include a final doc-reconciliation task (after `/speckit.verify`) when the spec is source-backed by a canonical doc.
+
+### 2.4 `moonspec-implement`
+
+- **Discovery ledger** (new requirement): when implementation deviates from the canonical source doc, or reveals the doc is wrong, incomplete, or internally inconsistent, append a structured entry to a gitignored handoff (`artifacts/doc-discoveries/<feature>.json`): `{docPath, section, claim, observed, evidence, severity: definite|possible}`. No entry when there is nothing to report.
+- Discoveries do not authorize doc edits during implementation; they feed `moonspec-doc-reconcile`.
+
+### 2.5 `moonspec-verify`
+
+- Replace "the original request in `spec.md` is the source of truth" with: the original request as preserved in `spec.md`, **interpreted against the canonical source document**, is the alignment baseline.
+- New report section **Source Document Drift**: claims in the canonical doc contradicted by verified implementation evidence. Doc drift alone does not block `FULLY_IMPLEMENTED` when the implementation is correct per agreed scope; it is structured input for reconciliation. Remains read-only.
+
+### 2.6 `moonspec-align`
+
+- Clarify scope: alignment operates only among temporary artifacts (spec/plan/tasks). It must never edit canonical `docs/` files and never "aligns" a canonical doc toward a spec.
+
+### 2.7 `moonspec-orchestrate` (skill)
+
+- Add stage 7 **Reconcile Declarative Docs** (after Verify, only on `FULLY_IMPLEMENTED`, only when a canonical source doc exists): run `moonspec-doc-reconcile`.
+- Add a Doc Reconcile gate (`UPDATED` / `NO_UPDATE_REQUIRED` / `ESCALATED`) and a `Doc Reconcile:` line in the final report.
+- Core rules: add the precedence rule and a pointer to `MoonSpecDocumentModel.md`.
+
+### 2.8 `story-reconcile-implementation`
+
+- When repository evidence shows the canonical source doc itself is stale (not just the story), record it in the markdown report as a doc-drift note. No behavior change to Jira actions.
+
+## Phase 3 — New skill: `moonspec-doc-reconcile`
+
+`.agents/skills/moonspec-doc-reconcile/SKILL.md`. Thin, gate-focused; delegates editing doctrine to `document-update` conventions.
+
+- **Inputs** (required): canonical source doc path(s) from `spec.md`/breakdown `sourceReference`; latest `moonspec-verify` report (Source Document Drift section); `artifacts/doc-discoveries/<feature>.json` when present. If no canonical doc exists, exit `NO_UPDATE_REQUIRED` immediately.
+- **Strict update gate** — edit only when a discovery **definitely requires** it, meaning at least one of:
+  1. *Function*: the doc as written describes behavior/contracts that are now factually wrong against the verified implementation.
+  2. *Consistency*: the implementation correctly resolved an internal contradiction or ambiguity in the doc, and the doc must record the resolution.
+  3. *Best practices*: the implementation deliberately and correctly diverged from a documented approach for a defensible reason validated by verification.
+  `possible`-severity discoveries, stylistic preferences, and speculative improvements do not pass the gate.
+- **Editing rules** (inherited from `document-update`): preserve desired-state framing; never downgrade the doc to match buggy/incomplete code; never insert migration narratives, checklists, or status language into canonical docs (Constitution XII); remove superseded text outright (Constitution XIII).
+- **Escalation**: if a required update conflicts with the constitution, README, or architecture direction, do not edit — create a Jira issue via `jira-issue-creator` (same fallback pattern as `document-update`).
+- **Output contract** (structured, for orchestrate gating): `{action: updated | no_update_required | escalated, docPaths, gateRationale, evidence, jiraIssue?}` plus a short markdown summary for the PR body.
+- **Boundaries**: read-only outside `docs/`; never edits spec/plan/tasks; never commits (the PR step owns git).
+
+## Phase 4 — Preset updates
+
+Implementation note (deviation from the original draft): preset `version` labels stay at `1.0.0`. `sync_seed_templates` refreshes the same version row in place when YAML steps change, and `_downstream_task_payload` pins `taskTemplate.version: "1.0.0"` for breakdown-created child runs — bumping would have made those child runs expand the stale old-version steps.
+
+### 4.1 `jira-orchestrate.yaml` (primary target)
+
+- Insert step **Reconcile declarative docs** between "Verify remediation 6 of 6" and "Create pull request":
+  - `annotations.jiraOrchestrateRole: doc-reconciliation`
+  - Instructions: run only when the controlling verdict is `FULLY_IMPLEMENTED`; consume the verify report + discovery ledger; apply the `moonspec-doc-reconcile` gate; on `escalated`, create the Jira issue and continue (escalation does not block the PR); record the structured result at `artifacts/jira-orchestrate-doc-reconcile.json`.
+  - `skill.id: moonspec-doc-reconcile`, `requiredCapabilities: [git]`.
+- "Create pull request" step: require the PR body to include the doc reconciliation outcome (updated paths, no-update rationale, or escalation issue key); doc edits ride the same commit/PR.
+
+### 4.2 `moonspec-orchestrate.yaml`
+
+- Add the same step after "Verify completion" with parallel instructions (no Jira/PR mechanics; report outcome in the final summary).
+
+### 4.3 `jira-breakdown-orchestrate.yaml` (primary target)
+
+- **Step 1 (Break down declarative design)**: add input-classification language — resolve the path, confirm the document is declarative per `MoonSpecDocumentModel.md`, fail fast on imperative inputs, record the canonical doc as primary source of truth and breakdown output as temporary.
+- **Step 4 (Create dependent Jira Orchestrate tasks)**: require each downstream task to carry the story's `sourceReference.path` as the Jira Orchestrate `source_design_path` so the doc-reconcile step knows its canonical doc.
+- Apply the same step-1 language to `jira-breakdown.yaml` and `jira-breakdown-implement.yaml` for consistency.
+
+### 4.4 Code touchpoint
+
+- `story.create_jira_orchestrate_tasks` handler: populate `source_design_path` on created tasks from story `sourceReference.path`. Add/extend tests at the activity/tool boundary per repo testing rules.
+
+## Phase 5 — Tests and verification
+
+- Update preset assertions: `tests/unit/api/test_presets_service.py`, `tests/integration/test_startup_preset_seeding.py` (step counts/titles change), `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` if it enumerates steps.
+- Skill resolution: confirm `moonspec-doc-reconcile` is picked up (`tests/unit/services/test_skill_resolution.py`); add coverage if skills are enumerated by name anywhere.
+- Run `tools/check_terminology.sh` (new skill/preset wording must comply with the Task→Workflow rename).
+- Final: `./tools/test_unit.sh`, then `./tools/test_integration.sh` for preset seeding.
+
+## Compatibility and risks
+
+- **In-flight runs**: presets expand at submission, so running workflows keep their old step lists — inserting a step is safe for in-flight runs. No skill payload shape changes; `stories.json` gains additive fields only.
+- **Doc-edit quality risk**: mitigated by the strict gate (definite-severity evidence only), inherited desired-state rules, escalation path, and human PR review (doc changes are visible in the same PR diff).
+- **Imperative-input fail-fast** may break existing habits of feeding migration plans into breakdown; the error message must name the override and the preferred alternative (write/point to the declarative doc first).
+- **Constitution amendment** (Phase 1.2) is the only change touching governance text; keep it minimal and aligned with the already-ratified XIII delete-don't-deprecate posture.
+
+## Suggested execution order
+
+Phase 1 (doctrine + guidance reconciliation) → Phase 2 (skill text) → Phase 3 (new skill) → Phase 4 (presets + handler) → Phase 5 (tests). Phases 1–3 are mergeable independently; Phase 4 should land with Phase 5 in one change.

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1022,11 +1022,15 @@ def _downstream_task_payload(
     source_brief_ref = _string(
         traceability.get("sourceBriefRef") or traceability.get("source_brief_ref")
     )
+    source_design_path = _string(
+        mapping.get("sourceDesignPath") or mapping.get("source_design_path")
+    )
     instructions = (
         f"Run {preset_label} for {issue_key}.\n\n"
         f"Source story: {story_id or summary}.\n"
         f"Source summary: {summary}.\n"
         f"Source Jira issue: {source_issue_key or 'unknown'}.\n"
+        f"Source design document: {source_design_path or 'not provided'}.\n"
         f"Original brief reference: {source_brief_ref or 'not provided'}.\n\n"
         f"Use the existing {preset_label} workflow for this Jira issue. "
         "Do not run implementation inline inside the breakdown task."
@@ -1056,7 +1060,7 @@ def _downstream_task_payload(
         "instructions": instructions,
         "inputs": {
             "jira_issue_key": issue_key,
-            "source_design_path": "",
+            "source_design_path": source_design_path,
             "constraints": (
                 f"Preserve source issue {source_issue_key} traceability."
                 if source_issue_key
@@ -1546,11 +1550,16 @@ def _issue_mapping(
     issue: Mapping[str, Any],
     index: int,
     summary: str,
+    fallback_source_path: str = "",
 ) -> dict[str, Any]:
     mapping = dict(issue)
     mapping["storyId"] = _story_id(story, index=index)
     mapping["storyIndex"] = index
     mapping["summary"] = summary
+    source_reference = _story_source_reference(
+        story, fallback_path=fallback_source_path
+    )
+    mapping["sourceDesignPath"] = _string(source_reference.get("path"))
     return mapping
 
 async def _create_dependency_links(
@@ -2020,6 +2029,7 @@ async def create_jira_issues_from_stories(
                         issue=existing_issue,
                         index=index,
                         summary=summary,
+                        fallback_source_path=breakdown_source_path,
                     )
                 )
                 continue
@@ -2067,6 +2077,7 @@ async def create_jira_issues_from_stories(
                     issue=issue_result,
                     index=index,
                     summary=summary,
+                    fallback_source_path=breakdown_source_path,
                 )
             )
     except Exception as exc:

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -55,6 +55,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "moonspec-align",
             "moonspec-implement",
             "moonspec-verify",
+            "moonspec-doc-reconcile",
         ]
         seeded_step_titles = [step["title"] for step in template.latest_version.steps]
         assert "Classify request and resume point" not in seeded_step_titles
@@ -124,9 +125,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "moonspec-implement" in jira_orchestrate_steps
         assert "moonspec-verify" in jira_orchestrate_steps
         assert jira_orchestrate_steps[-1] == "jira-issue-updater"
-        assert len(jira_orchestrate_steps) == 25
+        assert len(jira_orchestrate_steps) == 26
         assert jira_orchestrate_steps.count("moonspec-implement") == 7
         assert jira_orchestrate_steps.count("moonspec-verify") == 7
+        assert jira_orchestrate_steps.count("moonspec-doc-reconcile") == 1
         blocker_step = jira_orchestrate_template.latest_version.steps[1]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
         assert blocker_step["type"] == "tool"
@@ -157,12 +159,33 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         assert remediation_verify_step["skill"]["id"] == "moonspec-verify"
         assert "controlling verification gate" in remediation_verify_step["instructions"]
+        doc_reconcile_step = next(
+            step
+            for step in jira_orchestrate_template.latest_version.steps
+            if step["title"] == "Reconcile declarative docs"
+        )
+        assert doc_reconcile_step["skill"]["id"] == "moonspec-doc-reconcile"
+        assert doc_reconcile_step["annotations"] == {
+            "jiraOrchestrateRole": "doc-reconciliation"
+        }
+        assert "FULLY_IMPLEMENTED" in doc_reconcile_step["instructions"]
+        assert "artifacts/jira-orchestrate-doc-reconcile.json" in doc_reconcile_step[
+            "instructions"
+        ]
+        doc_reconcile_index = jira_orchestrate_template.latest_version.steps.index(
+            doc_reconcile_step
+        )
         pr_step = next(
             step
             for step in jira_orchestrate_template.latest_version.steps
             if step["title"] == "Create pull request"
         )
+        assert (
+            jira_orchestrate_template.latest_version.steps.index(pr_step)
+            == doc_reconcile_index + 1
+        )
         assert "pull request" in pr_step["instructions"]
+        assert "doc reconciliation outcome" in pr_step["instructions"]
         assert "post-remediation moonspec-verify" in pr_step["instructions"]
         assert "parent workflow must use the pull request URL" in pr_step["instructions"]
         assert "explicit PR-publication step" in pr_step["instructions"]

--- a/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
+++ b/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+_SKILLS_DIR = Path(__file__).resolve().parents[3] / ".agents" / "skills"
+
+
+def test_moonspec_doc_reconcile_skill_defines_gate_and_output_contract() -> None:
+    text = (_SKILLS_DIR / "moonspec-doc-reconcile" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "name: moonspec-doc-reconcile" in text
+    assert "FULLY_IMPLEMENTED" in text
+    assert "## Update Gate" in text
+    assert "definitely requires" in text
+    assert "**Function**" in text
+    assert "**Consistency**" in text
+    assert "**Best practices**" in text
+    assert "no_update_required" in text
+    assert "escalated" in text
+    assert "docs/Workflows/MoonSpecDocumentModel.md" in text
+    assert "Never commit, push, or create pull requests" in text
+
+
+def test_moonspec_implement_skill_defines_discovery_ledger() -> None:
+    text = (_SKILLS_DIR / "moonspec-implement" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Discovery Ledger" in text
+    assert "artifacts/doc-discoveries/<feature>.json" in text
+    assert '"severity": "definite | possible"' in text
+    assert "moonspec-doc-reconcile" in text
+
+
+def test_moonspec_verify_skill_reports_source_document_drift() -> None:
+    text = (_SKILLS_DIR / "moonspec-verify" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "## Source Document Drift" in text
+    assert "moonspec-doc-reconcile" in text
+    assert "does not block `FULLY_IMPLEMENTED`" in text
+
+
+def test_moonspec_breakdown_skill_classifies_input_documents() -> None:
+    text = (_SKILLS_DIR / "moonspec-breakdown" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Input Classification" in text
+    assert "canonical-declarative" in text
+    assert "imperative-override" in text
+    assert "sourceDocumentClass" in text
+    assert "docs/Workflows/MoonSpecDocumentModel.md" in text

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2246,6 +2246,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "moonspec-implement",
                 "moonspec-verify",
                 *(["moonspec-implement", "moonspec-verify"] * 6),
+                "moonspec-doc-reconcile",
                 "auto",
                 "jira-issue-updater",
             ]
@@ -2265,7 +2266,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 context={},
             )
 
-            assert len(expanded["steps"]) == 25
+            assert len(expanded["steps"]) == 26
             assert expanded["steps"][0]["skill"]["id"] == "jira-issue-updater"
             assert "MM-328" in expanded["steps"][0]["instructions"]
             assert "In Progress" in expanded["steps"][0]["instructions"]
@@ -2314,38 +2315,58 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "controlling verification gate" in expanded["steps"][22][
                 "instructions"
             ]
-            assert expanded["steps"][23]["title"] == "Create pull request"
+            assert expanded["steps"][23]["title"] == "Reconcile declarative docs"
             assert expanded["steps"][23]["annotations"] == {
+                "jiraOrchestrateRole": "doc-reconciliation"
+            }
+            assert expanded["steps"][23]["skill"]["id"] == "moonspec-doc-reconcile"
+            assert "FULLY_IMPLEMENTED" in expanded["steps"][23]["instructions"]
+            assert "no_update_required" in expanded["steps"][23]["instructions"]
+            assert "Source Document Drift" in expanded["steps"][23]["instructions"]
+            assert "artifacts/jira-orchestrate-doc-reconcile.json" in expanded[
+                "steps"
+            ][23]["instructions"]
+            assert "Escalation does not block pull request creation" in expanded[
+                "steps"
+            ][23]["instructions"]
+            assert "Do not commit, push, or create a pull request" in expanded[
+                "steps"
+            ][23]["instructions"]
+            assert expanded["steps"][24]["title"] == "Create pull request"
+            assert expanded["steps"][24]["annotations"] == {
                 "jiraOrchestrateRole": "pull-request-handoff"
             }
-            assert "post-remediation moonspec-verify" in expanded["steps"][23][
+            assert "post-remediation moonspec-verify" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "pull request title must include MM-328" in expanded["steps"][23][
+            assert "pull request title must include MM-328" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "parent workflow must use the pull request URL" in expanded["steps"][23][
+            assert "parent workflow must use the pull request URL" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "explicit PR-publication step" in expanded["steps"][23][
+            assert "explicit PR-publication step" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "controlling instruction for this step only" in expanded["steps"][23][
+            assert "controlling instruction for this step only" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "merge automation" in expanded["steps"][23]["instructions"]
-            assert "non-draft pull request" in expanded["steps"][23]["instructions"]
-            assert "isDraft value is false" in expanded["steps"][23]["instructions"]
-            assert "confirmed non-draft" in expanded["steps"][23]["instructions"]
-            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][23][
+            assert "merge automation" in expanded["steps"][24]["instructions"]
+            assert "non-draft pull request" in expanded["steps"][24]["instructions"]
+            assert "isDraft value is false" in expanded["steps"][24]["instructions"]
+            assert "confirmed non-draft" in expanded["steps"][24]["instructions"]
+            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][24][
                 "instructions"
             ]
-            assert expanded["steps"][24]["skill"]["id"] == "jira-issue-updater"
-            assert "pull_request_url" in expanded["steps"][24]["instructions"]
-            assert "stop without changing Jira" in expanded["steps"][24][
+            assert "doc reconciliation outcome" in expanded["steps"][24][
                 "instructions"
             ]
-            assert "Code Review" in expanded["steps"][24]["instructions"]
+            assert expanded["steps"][25]["skill"]["id"] == "jira-issue-updater"
+            assert "pull_request_url" in expanded["steps"][25]["instructions"]
+            assert "stop without changing Jira" in expanded["steps"][25][
+                "instructions"
+            ]
+            assert "Code Review" in expanded["steps"][25]["instructions"]
             assert all(
                 step["title"] != "Return Jira orchestration report"
                 for step in expanded["steps"]
@@ -2610,13 +2631,15 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 "moonspec-align",
                 "moonspec-implement",
                 "moonspec-verify",
+                "moonspec-doc-reconcile",
             ]
             step_titles = [step["title"] for step in template.latest_version.steps]
             assert (
                 "Return orchestration report and defer publish actions"
                 not in step_titles
             )
-            assert step_titles[-1] == "Verify completion"
+            assert step_titles[-2] == "Verify completion"
+            assert step_titles[-1] == "Reconcile declarative docs"
             template_payload = await service.get_template(
                 slug="moonspec-orchestrate",
                 scope="global",
@@ -2641,7 +2664,7 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 context={},
             )
 
-            assert len(expanded["steps"]) == 6
+            assert len(expanded["steps"]) == 7
             assert (
                 expanded["appliedTemplate"]["inputs"]["orchestration_mode"]
                 == "runtime"
@@ -2650,8 +2673,11 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
             assert "runtime implementation workflow" in expanded["steps"][0][
                 "instructions"
             ]
-            assert expanded["steps"][-1]["title"] == "Verify completion"
-            assert "moonspec-verify" == expanded["steps"][-1]["skill"]["id"]
+            assert expanded["steps"][-2]["title"] == "Verify completion"
+            assert "moonspec-verify" == expanded["steps"][-2]["skill"]["id"]
+            assert expanded["steps"][-1]["title"] == "Reconcile declarative docs"
+            assert "moonspec-doc-reconcile" == expanded["steps"][-1]["skill"]["id"]
+            assert "no_update_required" in expanded["steps"][-1]["instructions"]
             assert all(
                 step["title"] != "Return orchestration report and defer publish actions"
                 for step in expanded["steps"]

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1194,6 +1194,58 @@ async def test_create_jira_issues_linear_blocker_chain_creates_adjacent_links():
     assert [item["status"] for item in jira["linkResults"]] == ["created", "created"]
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_issue_mappings_carry_source_design_path():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {"projectKey": "MM", "issueTypeId": "10001"},
+            },
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "First",
+                    "sourceReference": {"path": "docs/Designs/RuntimeTypes.md"},
+                },
+                {
+                    "id": "STORY-002",
+                    "summary": "No reference",
+                },
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    mappings = result.outputs["jira"]["issueMappings"]
+    assert mappings[0]["sourceDesignPath"] == "docs/Designs/RuntimeTypes.md"
+    assert mappings[1]["sourceDesignPath"] == ""
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_issue_mappings_use_breakdown_source_fallback():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {"projectKey": "MM", "issueTypeId": "10001"},
+            },
+            "storyBreakdown": {
+                "source": {"referencePath": "docs/Designs/RuntimeTypes.md"},
+                "stories": [
+                    {"id": "STORY-001", "summary": "First"},
+                ],
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    mappings = result.outputs["jira"]["issueMappings"]
+    assert mappings[0]["sourceDesignPath"] == "docs/Designs/RuntimeTypes.md"
+
+@pytest.mark.asyncio
 async def test_check_jira_blockers_blocks_on_single_outward_unresolved_blocks_link():
     service = _FakeJiraService()
     service.issue_responses["MM-2"] = {
@@ -1703,6 +1755,47 @@ async def test_create_jira_orchestrate_tasks_uses_input_previous_outputs_mapping
     assert creator.requests[0]["initial_parameters"]["workflow"]["inputs"][
         "jira_issue_key"
     ] == "MM-810"
+
+@pytest.mark.asyncio
+async def test_create_jira_orchestrate_tasks_propagates_source_design_path():
+    creator = _FakeExecutionCreator()
+
+    result = await create_jira_orchestrate_tasks_from_issue_mappings(
+        {
+            "jira": {
+                "issueMappings": [
+                    {
+                        "storyId": "STORY-001",
+                        "storyIndex": 1,
+                        "summary": "First",
+                        "issueKey": "MM-501",
+                        "sourceDesignPath": "docs/Designs/RuntimeTypes.md",
+                    },
+                    {
+                        "storyId": "STORY-002",
+                        "storyIndex": 2,
+                        "summary": "Legacy mapping without source path",
+                        "issueKey": "MM-502",
+                    },
+                ]
+            },
+            "traceability": {"sourceIssueKey": "MM-404"},
+        },
+        execution_creator=creator,
+    )
+
+    assert result.outputs["jiraOrchestration"]["status"] == "completed"
+    first_task = creator.requests[0]["initial_parameters"]["workflow"]
+    assert first_task["inputs"]["source_design_path"] == (
+        "docs/Designs/RuntimeTypes.md"
+    )
+    assert (
+        "Source design document: docs/Designs/RuntimeTypes.md"
+        in first_task["instructions"]
+    )
+    second_task = creator.requests[1]["initial_parameters"]["workflow"]
+    assert second_task["inputs"]["source_design_path"] == ""
+    assert "Source design document: not provided" in second_task["instructions"]
 
 @pytest.mark.asyncio
 async def test_create_jira_orchestrate_tasks_handles_one_and_zero_story_results():

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1785,8 +1785,8 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
             )
 
     task = expanded_parameters["task"]
-    assert expanded_parameters["stepCount"] == 25
-    assert len(task["steps"]) == 25
+    assert expanded_parameters["stepCount"] == 26
+    assert len(task["steps"]) == 26
     assert task["steps"][0]["title"] == "Move Jira issue to In Progress"
     assert task["steps"][0]["skill"]["id"] == "jira-issue-updater"
     assert "MM-501" in task["steps"][0]["instructions"]
@@ -1796,10 +1796,12 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert task["steps"][11]["skill"]["id"] == "moonspec-implement"
     assert task["steps"][22]["title"] == "Verify remediation 6 of 6"
     assert task["steps"][22]["skill"]["id"] == "moonspec-verify"
-    assert task["steps"][23]["title"] == "Create pull request"
-    assert task["steps"][24]["title"] == "Move Jira issue to Code Review"
+    assert task["steps"][23]["title"] == "Reconcile declarative docs"
+    assert task["steps"][23]["skill"]["id"] == "moonspec-doc-reconcile"
+    assert task["steps"][24]["title"] == "Create pull request"
+    assert task["steps"][25]["title"] == "Move Jira issue to Code Review"
     assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
-    assert len(task["appliedStepTemplates"][0]["stepIds"]) == 25
+    assert len(task["appliedStepTemplates"][0]["stepIds"]) == 26
     assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
     assert task["authoredPresets"][0]["presetVersion"] == "1.0.0"
     assert "authoredPresets" not in task["appliedStepTemplates"][0]


### PR DESCRIPTION
## Summary

Adds a MoonSpec document model and a final doc-reconciliation step so verified implementation discoveries can update canonical docs when the evidence gate is met.

## Changes

- Adds the `moonspec-doc-reconcile` skill and doctrine for canonical declarative docs, temporary execution artifacts, imperative working docs, and precedence rules.
- Updates MoonSpec skills and presets to classify declarative inputs, preserve canonical source-document paths, and include doc-reconciliation outcomes in orchestration and PR handoff steps.
- Propagates `source_design_path` through Jira story-output task creation and covers the behavior with unit tests.
- Mounts `docs/` into service containers that need access to canonical workflow docs.

## Validation

- `./tools/check_terminology.sh`
- `./tools/test_unit.sh tests/unit/agents/test_moonspec_doc_reconcile_skill.py tests/unit/api/test_presets_service.py tests/unit/workflows/temporal/test_story_output_tools.py` (Python: 126 passed; frontend phase: 27 files passed, 422 passed, 234 skipped)
- `./tools/test_unit.sh` full suite was started after the targeted run but stopped locally after prolonged slow progress; GitHub CI is running the required suites on this PR.