### PR TITLE
[codex] Fix workflow child queue routing

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -968,10 +968,10 @@ async def ensure_provider_profile_managers_started():
     from sqlalchemy import select
     from api_service.db.models import ManagedAgentProviderProfile
     from moonmind.workflows.temporal.client import TemporalClientAdapter
+    from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         WORKFLOW_NAME,
         ProviderProfileManagerInput,
-        WORKFLOW_TASK_QUEUE,
         workflow_id_for_runtime,
     )
     from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -1000,7 +1000,7 @@ async def ensure_provider_profile_managers_started():
                     WORKFLOW_NAME,
                     ProviderProfileManagerInput(runtime_id=runtime_id),
                     id=workflow_id,
-                    task_queue=WORKFLOW_TASK_QUEUE,
+                    task_queue=get_workflow_task_queue(),
                 )
                 logger.info(f"Started ProviderProfileManager for runtime: {runtime_id}")
             except WorkflowAlreadyStartedError:

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -971,6 +971,7 @@ async def ensure_provider_profile_managers_started():
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         WORKFLOW_NAME,
         ProviderProfileManagerInput,
+        WORKFLOW_TASK_QUEUE,
         workflow_id_for_runtime,
     )
     from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -999,7 +1000,7 @@ async def ensure_provider_profile_managers_started():
                     WORKFLOW_NAME,
                     ProviderProfileManagerInput(runtime_id=runtime_id),
                     id=workflow_id,
-                    task_queue="mm.workflow",
+                    task_queue=WORKFLOW_TASK_QUEUE,
                 )
                 logger.info(f"Started ProviderProfileManager for runtime: {runtime_id}")
             except WorkflowAlreadyStartedError:

--- a/api_service/services/oauth_session_service.py
+++ b/api_service/services/oauth_session_service.py
@@ -14,10 +14,10 @@ async def start_oauth_session_workflow(session_model: Any) -> None:
     ``oauth-session:<session_id>``.  The workflow manages volume
     provisioning, status transitions, and session expiry.
     """
+    from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
     from moonmind.workflows.temporal.client import TemporalClientAdapter
     from moonmind.workflows.temporal.workflows.oauth_session import (
         WORKFLOW_NAME,
-        WORKFLOW_TASK_QUEUE,
     )
 
     session_id: str = session_model.session_id
@@ -40,7 +40,7 @@ async def start_oauth_session_workflow(session_model: Any) -> None:
                 "profile_settings": session_model.metadata_json or {},
             },
             id=workflow_id,
-            task_queue=WORKFLOW_TASK_QUEUE,
+            task_queue=get_workflow_task_queue(),
         )
         logger.info("Started OAuth session workflow %s", workflow_id)
     except Exception as exc:

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -125,6 +125,7 @@ async def sync_provider_profile_manager(
         from moonmind.workflows.temporal.workflows.provider_profile_manager import (
             ProviderProfileManagerInput,
             WORKFLOW_NAME,
+            WORKFLOW_TASK_QUEUE,
             workflow_id_for_runtime,
         )
         from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -140,7 +141,7 @@ async def sync_provider_profile_manager(
                     runtime_id=runtime_id
                 ),
                 id=workflow_id,
-                task_queue="mm.workflow",
+                task_queue=WORKFLOW_TASK_QUEUE,
             )
             logger.info("Started ProviderProfileManager for runtime=%s", runtime_id)
         except WorkflowAlreadyStartedError:

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -122,10 +122,10 @@ async def sync_provider_profile_manager(
 
     try:
         from moonmind.workflows.temporal.client import TemporalClientAdapter
+        from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
         from moonmind.workflows.temporal.workflows.provider_profile_manager import (
             ProviderProfileManagerInput,
             WORKFLOW_NAME,
-            WORKFLOW_TASK_QUEUE,
             workflow_id_for_runtime,
         )
         from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -141,7 +141,7 @@ async def sync_provider_profile_manager(
                     runtime_id=runtime_id
                 ),
                 id=workflow_id,
-                task_queue=WORKFLOW_TASK_QUEUE,
+                task_queue=get_workflow_task_queue(),
             )
             logger.info("Started ProviderProfileManager for runtime=%s", runtime_id)
         except WorkflowAlreadyStartedError:

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -26,7 +26,7 @@ INTEGRATIONS_FLEET = "integrations"
 AGENT_RUNTIME_FLEET = "agent_runtime"
 DEPLOYMENT_FLEET = "deployment"
 
-WORKFLOW_TASK_QUEUE = "mm.workflow"
+WORKFLOW_TASK_QUEUE = resolve_user_workflow_start_contract(settings.temporal).task_queue
 ARTIFACTS_TASK_QUEUE = "mm.activity.artifacts"
 LLM_TASK_QUEUE = "mm.activity.llm"
 SANDBOX_TASK_QUEUE = "mm.activity.sandbox"

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -26,13 +26,22 @@ INTEGRATIONS_FLEET = "integrations"
 AGENT_RUNTIME_FLEET = "agent_runtime"
 DEPLOYMENT_FLEET = "deployment"
 
-WORKFLOW_TASK_QUEUE = resolve_user_workflow_start_contract(settings.temporal).task_queue
+WORKFLOW_TASK_QUEUE = "mm.workflow"
 ARTIFACTS_TASK_QUEUE = "mm.activity.artifacts"
 LLM_TASK_QUEUE = "mm.activity.llm"
 SANDBOX_TASK_QUEUE = "mm.activity.sandbox"
 INTEGRATIONS_TASK_QUEUE = "mm.activity.integrations"
 AGENT_RUNTIME_TASK_QUEUE = "mm.activity.agent_runtime"
 DEPLOYMENT_TASK_QUEUE = "mm.activity.deployment"
+
+def get_workflow_task_queue(
+    temporal_settings: TemporalSettings | None = None,
+) -> str:
+    """Resolve the currently configured workflow-fleet task queue lazily."""
+
+    return resolve_user_workflow_start_contract(
+        temporal_settings or settings.temporal
+    ).task_queue
 
 class TemporalActivityCatalogError(ValueError):
     """Raised when Temporal activity routing metadata is invalid."""
@@ -295,7 +304,7 @@ def build_default_activity_catalog(
     """Return the canonical Temporal activity catalog for MoonMind."""
 
     cfg = temporal_settings or settings.temporal
-    workflow_task_queue = resolve_user_workflow_start_contract(cfg).task_queue
+    workflow_task_queue = get_workflow_task_queue(cfg)
     
     # See docs/Temporal/ErrorTaxonomy.md
     NON_RETRYABLE_ERRORS = ("INVALID_INPUT", "ProfileResolutionError", "UnsupportedStatus")
@@ -1282,6 +1291,7 @@ __all__ = [
     "WORKFLOW_FLEET",
     "WORKFLOW_TASK_QUEUE",
     "build_default_activity_catalog",
+    "get_workflow_task_queue",
     "manifest_ingest_activity_routes",
     "skill_policy_as_route",
 ]

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2850,9 +2850,9 @@ class TemporalArtifactActivities:
         from temporalio.exceptions import WorkflowAlreadyStartedError
 
         from moonmind.workflows.temporal.client import TemporalClientAdapter
+        from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
         from moonmind.workflows.temporal.workflows.provider_profile_manager import (
             WORKFLOW_NAME as PROVIDER_PROFILE_MANAGER_WF,
-            WORKFLOW_TASK_QUEUE as PROVIDER_PROFILE_MANAGER_QUEUE,
             workflow_id_for_runtime,
         )
 
@@ -2865,7 +2865,7 @@ class TemporalArtifactActivities:
                 PROVIDER_PROFILE_MANAGER_WF,
                 {"runtime_id": runtime_id},
                 id=workflow_id,
-                task_queue=PROVIDER_PROFILE_MANAGER_QUEUE,
+                task_queue=get_workflow_task_queue(),
             )
             logger.info(
                 "provider_profile.ensure_manager started manager for runtime=%s",
@@ -2894,9 +2894,9 @@ class TemporalArtifactActivities:
         from temporalio.service import RPCError
 
         from moonmind.workflows.temporal.client import TemporalClientAdapter
+        from moonmind.workflows.temporal.activity_catalog import get_workflow_task_queue
         from moonmind.workflows.temporal.workflows.provider_profile_manager import (
             WORKFLOW_NAME as PROVIDER_PROFILE_MANAGER_WF,
-            WORKFLOW_TASK_QUEUE as PROVIDER_PROFILE_MANAGER_QUEUE,
             workflow_id_for_runtime,
         )
 
@@ -2923,7 +2923,7 @@ class TemporalArtifactActivities:
             PROVIDER_PROFILE_MANAGER_WF,
             {"runtime_id": runtime_id},
             id=workflow_id,
-            task_queue=PROVIDER_PROFILE_MANAGER_QUEUE,
+            task_queue=get_workflow_task_queue(),
         )
         logger.info(
             "provider_profile.reset_manager started fresh manager for runtime=%s",

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -51,6 +51,7 @@ with workflow.unsafe.imports_passed_through():
         WORKFLOW_TASK_QUEUE,
         build_default_activity_catalog,
     )
+    from moonmind.config.settings import settings
     from moonmind.workflows.temporal.runtime.store import ManagedRunStore
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
@@ -154,6 +155,9 @@ AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
 )
 MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
     "agent-run-managed-session-start-after-slot-v1"
+)
+AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
+    "agent-run-workflow-child-task-queue-v2"
 )
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
@@ -332,6 +336,12 @@ async def external_adapter_execution_style(agent_id: str) -> str:
 
 @workflow.defn(name="MoonMind.AgentRun")
 class MoonMindAgentRun:
+    @staticmethod
+    def _workflow_child_task_queue() -> str:
+        if workflow.patched(AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH):
+            return settings.temporal.user_workflow_v2_task_queue
+        return WORKFLOW_TASK_QUEUE
+
     def _get_logger(self) -> logging.LoggerAdapter | logging.Logger:
         try:
             info = workflow.info()
@@ -1178,7 +1188,7 @@ class MoonMindAgentRun:
             "MoonMind.AgentSession",
             session_input,
             id=session_workflow_id,
-            task_queue=WORKFLOW_TASK_QUEUE,
+            task_queue=self._workflow_child_task_queue(),
             parent_close_policy=workflow.ParentClosePolicy.ABANDON,
             search_attributes=self._workflow_scoped_session_visibility(binding=binding),
             static_summary="Workflow-scoped managed runtime session",

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -13,6 +13,7 @@ from temporalio.exceptions import CancelledError
 from temporalio.workflow import ActivityCancellationType, ChildWorkflowCancellationType
 
 with workflow.unsafe.imports_passed_through():
+    from moonmind.config.settings import settings
     from moonmind.schemas.temporal_models import (
         MergeAutomationStartInput,
         ReadinessBlockerModel,
@@ -54,10 +55,19 @@ ALLOWED_DISPOSITIONS = SUCCESS_DISPOSITIONS | NON_SUCCESS_DISPOSITIONS | {
     DISPOSITION_REENTER_GATE
 }
 MAX_PUBLISHED_ARTIFACT_REFS = 20
+MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
+    "merge-automation-workflow-child-task-queue-v2"
+)
 
 @workflow.defn(name=WORKFLOW_NAME)
 class MoonMindMergeAutomationWorkflow:
     """Wait for PR readiness, run pr-resolver as a child, and return a parent outcome."""
+
+    @staticmethod
+    def _workflow_child_task_queue() -> str:
+        if workflow.patched(MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH):
+            return settings.temporal.user_workflow_v2_task_queue
+        return WORKFLOW_TASK_QUEUE
 
     def __init__(self) -> None:
         self._status = STATE_WAITING
@@ -630,7 +640,7 @@ class MoonMindMergeAutomationWorkflow:
                 self._resolver_child_workflow_ids.append(resolver_workflow_id)
                 child_kwargs: dict[str, Any] = {
                     "id": resolver_workflow_id,
-                    "task_queue": WORKFLOW_TASK_QUEUE,
+                    "task_queue": self._workflow_child_task_queue(),
                     "search_attributes": self._resolver_search_attributes(),
                     "cancellation_type": ChildWorkflowCancellationType.TRY_CANCEL,
                     "static_summary": "Resolving pull request for merge automation",

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -22,9 +22,9 @@ from temporalio import exceptions, workflow
 
 with workflow.unsafe.imports_passed_through():
     from temporalio.common import RetryPolicy
+    from moonmind.workflows.temporal.activity_catalog import WORKFLOW_TASK_QUEUE
 
 WORKFLOW_NAME = "MoonMind.OAuthSession"
-WORKFLOW_TASK_QUEUE = "mm.workflow"
 ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"
 RUNNER_ACTIVITY_TASK_QUEUE = "mm.activity.agent_runtime"
 

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -22,7 +22,6 @@ from temporalio import exceptions, workflow
 
 with workflow.unsafe.imports_passed_through():
     from temporalio.common import RetryPolicy
-    from moonmind.workflows.temporal.activity_catalog import WORKFLOW_TASK_QUEUE
 
 WORKFLOW_NAME = "MoonMind.OAuthSession"
 ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -25,7 +25,6 @@ from temporalio import exceptions, workflow
 with workflow.unsafe.imports_passed_through():
     from temporalio.common import RetryPolicy
     from moonmind.billing.costs import pricing_from_profile_metadata
-    from moonmind.workflows.temporal.activity_catalog import WORKFLOW_TASK_QUEUE
 
 WORKFLOW_NAME = "MoonMind.ProviderProfileManager"
 ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -25,9 +25,9 @@ from temporalio import exceptions, workflow
 with workflow.unsafe.imports_passed_through():
     from temporalio.common import RetryPolicy
     from moonmind.billing.costs import pricing_from_profile_metadata
+    from moonmind.workflows.temporal.activity_catalog import WORKFLOW_TASK_QUEUE
 
 WORKFLOW_NAME = "MoonMind.ProviderProfileManager"
-WORKFLOW_TASK_QUEUE = "mm.workflow"
 ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"
 WORKFLOW_ID_PREFIX = "provider-profile-manager"
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -272,6 +272,7 @@ RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH = (
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
+RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = "run-workflow-child-task-queue-v2"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 # Replay-stable patch id for unified wait-through-rerun dependency behavior.
 # Under this patch, a non-success prerequisite terminal outcome (failed,
@@ -344,6 +345,11 @@ class MoonMindRunWorkflow:
         if workflow.patched(RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH):
             return workflow_id_for_runtime(runtime_id)
         return _legacy_manager_workflow_id(runtime_id)
+
+    def _workflow_child_task_queue(self) -> str:
+        if workflow.patched(RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH):
+            return settings.temporal.user_workflow_v2_task_queue
+        return WORKFLOW_TASK_QUEUE
 
     def _get_logger(self) -> logging.LoggerAdapter | logging.Logger:
         try:
@@ -3203,7 +3209,7 @@ class MoonMindRunWorkflow:
                 "MoonMind.AgentRun",
                 repair_request,
                 id=child_workflow_id,
-                task_queue=WORKFLOW_TASK_QUEUE,
+                task_queue=self._workflow_child_task_queue(),
             )
         finally:
             self._active_agent_child_workflow_id = None
@@ -4674,7 +4680,7 @@ class MoonMindRunWorkflow:
                                     "MoonMind.AgentRun",
                                     request,
                                     id=child_workflow_id,
-                                    task_queue=WORKFLOW_TASK_QUEUE,
+                                    task_queue=self._workflow_child_task_queue(),
                                 )
                             finally:
                                 self._active_agent_child_workflow_id = None
@@ -5942,7 +5948,7 @@ class MoonMindRunWorkflow:
                     "MoonMind.AgentRun",
                     request,
                     id=child_workflow_id,
-                    task_queue=WORKFLOW_TASK_QUEUE,
+                    task_queue=self._workflow_child_task_queue(),
                 )
             finally:
                 self._active_agent_child_workflow_id = None
@@ -6066,7 +6072,7 @@ class MoonMindRunWorkflow:
                             "MoonMind.AgentRun",
                             agent_request,
                             id=child_workflow_id,
-                            task_queue=WORKFLOW_TASK_QUEUE,
+                            task_queue=self._workflow_child_task_queue(),
                         )
                         current_result = self._map_agent_run_result(child_result)
                     except Exception as exc:
@@ -6272,7 +6278,7 @@ class MoonMindRunWorkflow:
             "MoonMind.AgentSession",
             session_input,
             id=session_workflow_id,
-            task_queue=WORKFLOW_TASK_QUEUE,
+            task_queue=self._workflow_child_task_queue(),
             search_attributes=self._workflow_scoped_session_visibility(
                 binding=initial_binding
             ),
@@ -8471,7 +8477,7 @@ class MoonMindRunWorkflow:
                 "MoonMind.MergeAutomation",
                 payload,
                 id=workflow_id,
-                task_queue=WORKFLOW_TASK_QUEUE,
+                task_queue=self._workflow_child_task_queue(),
                 cancellation_type=ChildWorkflowCancellationType.TRY_CANCEL,
                 static_summary="Waiting for pull request merge readiness",
                 static_details=f"Merge automation for {pull_request_url}",

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -8,9 +8,9 @@ from temporalio import activity
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
+from moonmind.workflows.temporal.activity_catalog import WORKFLOW_TASK_QUEUE
 from moonmind.workflows.temporal.workflows.oauth_session import (
     MoonMindOAuthSessionWorkflow,
-    WORKFLOW_TASK_QUEUE,
     ACTIVITY_TASK_QUEUE,
     RUNNER_ACTIVITY_TASK_QUEUE,
 )

--- a/tests/unit/workflows/temporal/test_hard_switch_cutover.py
+++ b/tests/unit/workflows/temporal/test_hard_switch_cutover.py
@@ -9,7 +9,9 @@ from moonmind.config.settings import settings
 from moonmind.workflows.temporal import hard_switch_cutover
 from moonmind.workflows.temporal.activity_catalog import (
     WORKFLOW_FLEET,
+    WORKFLOW_TASK_QUEUE,
     build_default_activity_catalog,
+    get_workflow_task_queue,
 )
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.hard_switch_cutover import (
@@ -135,6 +137,15 @@ def test_renamed_contract_routes_new_starts_to_distinct_queue(tmp_path: Path) ->
     assert contract.workflow_type == RENAMED_USER_WORKFLOW_TYPE
     assert contract.task_queue == "mm.workflow.user.v2"
     assert contract.contract_mode == "renamed_contract"
+
+
+def test_workflow_task_queue_constant_stays_replay_stable_while_start_queue_is_lazy(
+    tmp_path: Path,
+) -> None:
+    temporal_settings = _renamed_contract_settings(tmp_path)
+
+    assert WORKFLOW_TASK_QUEUE == "mm.workflow"
+    assert get_workflow_task_queue(temporal_settings) == "mm.workflow.user.v2"
 
 
 def test_renamed_contract_resolution_caches_cutover_file_validation(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
@@ -2,7 +2,14 @@
 
 import inspect
 
-from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+import pytest
+
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import (
+    AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    MoonMindAgentRun,
+)
+
 
 def test_managed_launch_binding_uses_temporal_patch_guard() -> None:
     source = inspect.getsource(MoonMindAgentRun.run)
@@ -11,3 +18,22 @@ def test_managed_launch_binding_uses_temporal_patch_guard() -> None:
     assert "task_workflow_id = parent_info.workflow_id" in source
     assert "task_workflow_id = wf_id" in source
     assert "task_workflow_id=task_workflow_id" in source
+
+
+def test_agent_run_workflow_child_task_queue_is_replay_patched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temporal_settings = agent_run_module.settings.temporal.model_copy(
+        update={"user_workflow_v2_task_queue": "mm.workflow.custom.v2"}
+    )
+    monkeypatch.setattr(agent_run_module.settings, "temporal", temporal_settings)
+
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    )
+    assert MoonMindAgentRun._workflow_child_task_queue() == "mm.workflow.custom.v2"
+
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch_id: False)
+    assert MoonMindAgentRun._workflow_child_task_queue() == "mm.workflow"

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -10,6 +10,7 @@ from temporalio.workflow import ChildWorkflowCancellationType
 
 from moonmind.workflows.temporal.workflows import merge_automation as merge_automation_module
 from moonmind.workflows.temporal.workflows.merge_automation import (
+    MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
     MoonMindMergeAutomationWorkflow,
 )
 from moonmind.workflows.temporal.workflows.merge_gate import (
@@ -89,6 +90,34 @@ def test_merge_automation_extracts_artifact_id_from_ref_shapes() -> None:
         )
         == "art-attr-camel"
     )
+
+
+def test_merge_automation_workflow_child_task_queue_is_replay_patched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temporal_settings = merge_automation_module.settings.temporal.model_copy(
+        update={"user_workflow_v2_task_queue": "mm.workflow.custom.v2"}
+    )
+    monkeypatch.setattr(merge_automation_module.settings, "temporal", temporal_settings)
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        == MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    )
+    assert (
+        MoonMindMergeAutomationWorkflow._workflow_child_task_queue()
+        == "mm.workflow.custom.v2"
+    )
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    assert MoonMindMergeAutomationWorkflow._workflow_child_task_queue() == "mm.workflow"
+
 
 def test_merge_automation_summary_payload_bounds_published_artifact_refs() -> None:
     workflow = MoonMindMergeAutomationWorkflow()

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -17,6 +17,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH,
+    RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
@@ -60,6 +61,31 @@ def test_run_execution_stage_preserves_conditional_registry_patch_marker() -> No
         call_string
     )
     assert source.index(call_string) < source.index("await load_registry_snapshot()")
+
+
+def test_run_workflow_child_task_queue_is_replay_patched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temporal_settings = run_workflow_module.settings.temporal.model_copy(
+        update={"user_workflow_v2_task_queue": "mm.workflow.custom.v2"}
+    )
+    monkeypatch.setattr(run_workflow_module.settings, "temporal", temporal_settings)
+    workflow = MoonMindRunWorkflow()
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    )
+    assert workflow._workflow_child_task_queue() == "mm.workflow.custom.v2"
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    assert workflow._workflow_child_task_queue() == "mm.workflow"
+
 
 @pytest.fixture
 def mock_run_workflow(monkeypatch: pytest.MonkeyPatch) -> MoonMindRunWorkflow:


### PR DESCRIPTION
## Summary

Fix workflow child/static workflow routing after the hard-switch queue cutover.

## Root Cause

The workflow fleet now polls `mm.workflow.user.v2`, but some child/static workflow starts still used hardcoded `mm.workflow`. That stranded `MoonMind.AgentRun`, `MoonMind.ProviderProfileManager`, and OAuth-session starts whenever no worker was polling the legacy queue.

## Changes

- Resolve the shared workflow task queue through the hard-switch start contract.
- Reuse the provider-profile manager queue constant in API startup/sync paths instead of hardcoding `mm.workflow`.
- Route ProviderProfileManager and OAuthSession workflow constants through the shared workflow queue contract.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_hard_switch_cutover.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
