### PR TITLE
Run Jira Orchestrate for MM-826: Complete remaining behavior for Gate external handoffs on accepted terminal disposition

### DIFF
--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -483,6 +483,8 @@ steps:
       requiredCapabilities:
         - git
   - title: Move Jira issue to Code Review
+    annotations:
+      jiraOrchestrateRole: code-review-handoff
     instructions: |-
       Change Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists.
 

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -493,6 +493,15 @@ def materialize_preserved_steps(
         except (TypeError, ValueError):
             source_execution_ordinal = 1
         row["status"] = str(preserved.get("status") or "succeeded")
+        terminal_disposition = str(
+            preserved.get("terminalDisposition")
+            or preserved.get("terminal_disposition")
+            or ""
+        ).strip()
+        if terminal_disposition:
+            row["terminalDisposition"] = terminal_disposition
+        else:
+            row.pop("terminalDisposition", None)
         row["attempt"] = 0
         row["executionOrdinal"] = 0
         row["summary"] = "Preserved from source run."

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1876,6 +1876,38 @@ class MoonMindRunWorkflow:
             outputs["preservedFrom"] = dict(row.get("preservedFrom") or {})
         return outputs
 
+    def _record_preserved_step_terminal_state(
+        self,
+        logical_step_id: str,
+        node: Mapping[str, Any],
+    ) -> None:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return
+        terminal_disposition = self._coerce_text(
+            row.get("terminalDisposition") or row.get("terminal_disposition"),
+            max_chars=100,
+        )
+        if terminal_disposition:
+            self._step_terminal_dispositions[logical_step_id] = terminal_disposition
+        tool = self._plan_node_tool_mapping(node)
+        tool = tool if isinstance(tool, Mapping) else {}
+        tool_name = str(tool.get("name") or tool.get("id") or "").strip()
+        if (
+            terminal_disposition == "accepted"
+            and self._is_moonspec_verify_step(
+                tool_name=tool_name,
+                node_inputs=self._node_inputs_mapping(node),
+            )
+            and self._normalize_moonspec_verify_verdict(self._moonspec_gate_verdict)
+            is None
+        ):
+            self._moonspec_gate_verdict = "FULLY_IMPLEMENTED"
+            self._publish_context["moonSpecGate"] = {
+                "logicalStepId": logical_step_id,
+                "verdict": "FULLY_IMPLEMENTED",
+            }
+
     def _merge_preserved_dependency_outputs(
         self,
         logical_step_id: str,
@@ -4494,6 +4526,7 @@ class MoonMindRunWorkflow:
             tool_version = str(tool.get("version") or "").strip()
             node_id = str(node.get("id") or "unknown")
             if self._is_preserved_step(node_id):
+                self._record_preserved_step_terminal_state(node_id, node)
                 preserved_outputs = self._preserved_step_outputs(node_id)
                 if preserved_outputs:
                     previous_step_outputs = preserved_outputs
@@ -4515,7 +4548,7 @@ class MoonMindRunWorkflow:
                 self._summary = handoff_block_reason
                 self._mark_remaining_plan_steps_skipped(
                     ordered_nodes=ordered_nodes,
-                    completed_index=index - 1,
+                    completed_index=index - 2,
                     summary=handoff_block_reason,
                 )
                 self._refresh_step_readiness(updated_at=workflow.now())

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -633,6 +633,7 @@ class MoonMindRunWorkflow:
         self._previous_step_checkpoint_refs: dict[str, str] = {}
         self._step_execution_launch_blocks: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
+        self._step_terminal_dispositions: dict[str, str] = {}
         # Side-effect records observed per logical step across attempts, keyed by
         # logical step id. Used to detect already-occurred non-idempotent
         # external effects when a reattempt starts (Section 11, rules 3-4).
@@ -957,13 +958,14 @@ class MoonMindRunWorkflow:
                 (self._step_ledger_row_for(logical_step_id) or {}).get("checks")
                 or []
             ),
-            sideEffects={},
+            sideEffects=self._step_execution_side_effects(logical_step_id),
             dependencyEffects=self._step_dependency_effects.get(
                 logical_step_id,
                 {"invalidatedLogicalStepIds": []},
             ),
             budget=dict(budget or {}),
         )
+        self._step_terminal_dispositions[logical_step_id] = terminal_disposition
         return await self._write_step_execution_manifest(
             logical_step_id,
             attempt=attempt,
@@ -1627,6 +1629,13 @@ class MoonMindRunWorkflow:
                 outputs[target_key] = value.strip()
         return outputs
 
+    def _step_execution_side_effects(self, logical_step_id: str) -> dict[str, Any]:
+        records = [
+            dict(record)
+            for record in self._step_side_effect_records.get(logical_step_id, ())
+        ]
+        return {"records": records} if records else {}
+
     def _recovery_workspace_checkpoint_ref(
         self,
         workspace: Mapping[str, Any],
@@ -1988,7 +1997,7 @@ class MoonMindRunWorkflow:
         operation: str,
         target: str | None = None,
         idempotency_key: str | None = None,
-        workflow_state_accepted: bool = False,
+        workflow_state_accepted: bool | None = None,
         effect_kind: str = "normal",
         reason: str | None = None,
         approved_workspace_roots: Sequence[str] = (),
@@ -2000,18 +2009,66 @@ class MoonMindRunWorkflow:
         detected and compensated explicitly.
         """
 
+        accepted = (
+            self._step_terminal_dispositions.get(logical_step_id) == "accepted"
+            if workflow_state_accepted is None
+            else workflow_state_accepted
+        )
         record = side_effect_record(
             effect_class=effect_class,  # type: ignore[arg-type]
             operation=operation,
             target=target,
             idempotency_key=idempotency_key,
-            workflow_state_accepted=workflow_state_accepted,
+            workflow_state_accepted=accepted,
             effect_kind=effect_kind,  # type: ignore[arg-type]
             reason=reason,
             approved_workspace_roots=approved_workspace_roots,
         )
         self._step_side_effect_records.setdefault(logical_step_id, []).append(record)
         return record
+
+    def _is_jira_orchestrate_external_handoff_node(
+        self,
+        node: Mapping[str, Any],
+    ) -> bool:
+        node_inputs = self._node_inputs_mapping(node)
+        annotations = node_inputs.get("annotations") or node.get("annotations")
+        if not isinstance(annotations, Mapping):
+            return False
+        role = str(annotations.get("jiraOrchestrateRole") or "").strip().lower()
+        return role in {"pull-request-handoff", "code-review-handoff"}
+
+    def _jira_orchestrate_external_handoff_block_reason(
+        self,
+        node: Mapping[str, Any],
+    ) -> str | None:
+        if not self._is_jira_orchestrate_external_handoff_node(node):
+            return None
+        verdict = self._normalize_moonspec_verify_verdict(self._moonspec_gate_verdict)
+        if verdict in _MOONSPEC_GATE_PASSING_VERDICTS:
+            return None
+        gate_context = self._publish_context.get("moonSpecGate")
+        logical_step_id = None
+        if isinstance(gate_context, Mapping):
+            logical_step_id = self._coerce_text(
+                gate_context.get("logicalStepId"),
+                max_chars=200,
+            )
+        if verdict:
+            parts = [
+                "Jira Orchestrate external handoff requires an accepted MoonSpec "
+                f"verification terminal disposition; latest verdict was {verdict}"
+            ]
+            if logical_step_id:
+                terminal = self._step_terminal_dispositions.get(logical_step_id)
+                if terminal:
+                    parts.append(f"gate step terminal disposition was {terminal}")
+            return ". ".join(parts) + "."
+        return (
+            "Jira Orchestrate external handoff requires an accepted MoonSpec "
+            "verification terminal disposition; no controlling verification gate "
+            "has approved advancement."
+        )
 
     def _orchestrate_reattempt_compensation(
         self,
@@ -4447,6 +4504,23 @@ class MoonMindRunWorkflow:
                 and current_step_row.get("status") == "pending"
             ):
                 continue
+            handoff_block_reason = (
+                self._jira_orchestrate_external_handoff_block_reason(node)
+            )
+            if handoff_block_reason:
+                self._plan_blocked_message = handoff_block_reason
+                self._publish_status = "not_required"
+                self._publish_reason = handoff_block_reason
+                self._publish_context["publicationBlockedBy"] = "moonspec_verify"
+                self._summary = handoff_block_reason
+                self._mark_remaining_plan_steps_skipped(
+                    ordered_nodes=ordered_nodes,
+                    completed_index=index - 1,
+                    summary=handoff_block_reason,
+                )
+                self._refresh_step_readiness(updated_at=workflow.now())
+                self._update_memo()
+                break
             original_node_inputs = dict(node.get("inputs", {}))
             if tool_type == "skill":
                 await load_registry_snapshot()

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -198,6 +198,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             if step["title"] == "Move Jira issue to Code Review"
         )
         assert code_review_step == jira_orchestrate_template.latest_version.steps[-1]
+        assert code_review_step["annotations"] == {
+            "jiraOrchestrateRole": "code-review-handoff"
+        }
         assert "Code Review" in code_review_step["instructions"]
         assert "pull_request_url" in code_review_step["instructions"]
 

--- a/tests/integration/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -90,6 +90,7 @@ def test_failed_step_recovery_preserves_prior_steps_and_unblocks_failed_step() -
             {
                 "logicalStepId": "prepare",
                 "status": "succeeded",
+                "terminalDisposition": "accepted",
                 "sourceExecutionOrdinal": 1,
                 "artifacts": {"outputSummary": "artifact://prepare-summary"},
                 "stateCheckpointRef": "artifact://workspace/prepare",
@@ -101,6 +102,7 @@ def test_failed_step_recovery_preserves_prior_steps_and_unblocks_failed_step() -
 
     assert rows[0]["preservedFrom"]["workflowId"] == "mm:source"
     assert rows[0]["preservedFrom"]["logicalStepId"] == "prepare"
+    assert rows[0]["terminalDisposition"] == "accepted"
     assert rows[0]["artifacts"]["outputSummary"] == "artifact://prepare-summary"
     assert rows[0]["stateCheckpointRef"] == "artifact://workspace/prepare"
     assert rows[1]["status"] == "ready"

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2362,6 +2362,9 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "instructions"
             ]
             assert expanded["steps"][25]["skill"]["id"] == "jira-issue-updater"
+            assert expanded["steps"][25]["annotations"] == {
+                "jiraOrchestrateRole": "code-review-handoff"
+            }
             assert "pull_request_url" in expanded["steps"][25]["instructions"]
             assert "stop without changing Jira" in expanded["steps"][25][
                 "instructions"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2157,6 +2157,84 @@ def test_moonspec_verify_gate_accepts_fully_implemented_publish(
     )
 
 
+def test_jira_orchestrate_external_handoff_requires_passing_moonspec_gate(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    handoff_node = {
+        "id": "code-review",
+        "inputs": {
+            "annotations": {"jiraOrchestrateRole": "code-review-handoff"},
+        },
+    }
+
+    assert (
+        mock_run_workflow._jira_orchestrate_external_handoff_block_reason(
+            handoff_node
+        )
+        == (
+            "Jira Orchestrate external handoff requires an accepted MoonSpec "
+            "verification terminal disposition; no controlling verification gate "
+            "has approved advancement."
+        )
+    )
+
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "ADDITIONAL_WORK_NEEDED"},
+    )
+
+    blocked_reason = (
+        mock_run_workflow._jira_orchestrate_external_handoff_block_reason(
+            handoff_node
+        )
+    )
+    assert blocked_reason is not None
+    assert "latest verdict was ADDITIONAL_WORK_NEEDED" in blocked_reason
+
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-final",
+        outputs={"verdict": "FULLY_IMPLEMENTED"},
+    )
+
+    assert (
+        mock_run_workflow._jira_orchestrate_external_handoff_block_reason(
+            handoff_node
+        )
+        is None
+    )
+
+
+def test_step_side_effect_defaults_to_terminal_disposition_gate(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._step_terminal_dispositions["code-review"] = (
+        "failed_with_remaining_work"
+    )
+
+    blocked = mock_run_workflow._record_step_side_effect(
+        "code-review",
+        effect_class="external_idempotent",
+        operation="jira.transition_issue",
+        target="MM-826",
+        idempotency_key="wf:run:code-review:execution:1:jira-transition:Code Review",
+    )
+
+    assert blocked["workflowStateAccepted"] is False
+    assert blocked["disposition"] == "blocked"
+
+    mock_run_workflow._step_terminal_dispositions["code-review"] = "accepted"
+    accepted = mock_run_workflow._record_step_side_effect(
+        "code-review",
+        effect_class="external_idempotent",
+        operation="jira.transition_issue",
+        target="MM-826",
+        idempotency_key="wf:run:code-review:execution:2:jira-transition:Code Review",
+    )
+
+    assert accepted["workflowStateAccepted"] is True
+    assert accepted["disposition"] == "accepted"
+
+
 def test_native_pr_branch_resolution_prefers_publish_context_branch(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -63,6 +63,14 @@ def test_run_execution_stage_preserves_conditional_registry_patch_marker() -> No
     assert source.index(call_string) < source.index("await load_registry_snapshot()")
 
 
+def test_blocked_external_handoff_skips_current_step_from_call_site() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow._run_execution_stage)
+    block_start = source.index("if handoff_block_reason:")
+    block = source[block_start : source.index("original_node_inputs", block_start)]
+
+    assert "completed_index=index - 2" in block
+
+
 def test_run_workflow_child_task_queue_is_replay_patched(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2199,6 +2207,51 @@ def test_jira_orchestrate_external_handoff_requires_passing_moonspec_gate(
     assert (
         mock_run_workflow._jira_orchestrate_external_handoff_block_reason(
             handoff_node
+        )
+        is None
+    )
+
+
+def test_jira_orchestrate_external_handoff_uses_preserved_verify_gate_state(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "verify-final",
+            "status": "succeeded",
+            "terminalDisposition": "accepted",
+            "preservedFrom": {
+                "workflowId": "mm:source",
+                "runId": "run-source",
+                "logicalStepId": "verify-final",
+                "executionOrdinal": 1,
+            },
+        }
+    ]
+    mock_run_workflow._rebuild_step_ledger_index()
+
+    mock_run_workflow._record_preserved_step_terminal_state(
+        "verify-final",
+        {
+            "id": "verify-final",
+            "tool": {"name": "moonspec-verify"},
+            "inputs": {},
+        },
+    )
+
+    assert mock_run_workflow._step_terminal_dispositions["verify-final"] == "accepted"
+    assert mock_run_workflow._publish_context["moonSpecGate"] == {
+        "logicalStepId": "verify-final",
+        "verdict": "FULLY_IMPLEMENTED",
+    }
+    assert (
+        mock_run_workflow._jira_orchestrate_external_handoff_block_reason(
+            {
+                "id": "code-review",
+                "inputs": {
+                    "annotations": {"jiraOrchestrateRole": "code-review-handoff"},
+                },
+            }
         )
         is None
     )

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -984,6 +984,14 @@ async def test_run_records_terminal_step_execution_manifest_with_result_refs(
         updated_at=now,
         summary="Done",
     )
+    workflow._record_step_side_effect(
+        "run-tests",
+        effect_class="publication",
+        operation="repo.publish_pr",
+        target="PR-1",
+        idempotency_key="wf-run-1:run-1:run-tests:execution:1:publish-pr",
+        workflow_state_accepted=True,
+    )
     await workflow._record_step_execution_manifest_terminal(
         "run-tests",
         updated_at=now,
@@ -1004,6 +1012,21 @@ async def test_run_records_terminal_step_execution_manifest_with_result_refs(
     assert writes[1]["payload"]["outputs"] == {
         "summaryRef": "artifact://summary/attempt-1",
         "stdoutRef": "artifact://stdout/attempt-1",
+    }
+    assert writes[1]["payload"]["sideEffects"] == {
+        "records": [
+            {
+                "class": "publication",
+                "kind": "normal",
+                "operation": "repo.publish_pr",
+                "target": "PR-1",
+                "idempotencyKey": (
+                    "wf-run-1:run-1:run-tests:execution:1:publish-pr"
+                ),
+                "workflowStateAccepted": True,
+                "disposition": "accepted",
+            }
+        ]
     }
 
 


### PR DESCRIPTION
Run Jira Orchestrate for MM-826.

Source story: STORY-007.
Source summary: Complete remaining behavior for Gate external handoffs on accepted terminal disposition.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.