### PR TITLE
Run Jira Orchestrate for MM-822: Complete remaining behavior for Add checkpoint model and activity substrate

### DIFF
--- a/docs/tmp/JiraOrchestrateMM822Submission.md
+++ b/docs/tmp/JiraOrchestrateMM822Submission.md
@@ -1,0 +1,16 @@
+# Jira Orchestrate MM-822 Submission
+
+Date: 2026-06-11
+
+Submitted the seeded Jira Orchestrate workflow for `MM-822`.
+
+- Source story: `STORY-003`
+- Source summary: Complete remaining behavior for Add checkpoint model and activity substrate
+- Source Jira issue: unknown
+- Source design document: `docs/Steps/StepExecutionsAndCheckpointing.md`
+- Created workflow ID: `mm:bba3289f-e103-412c-82ed-dc6964a92425`
+- Run ID: `019eb8f0-3685-7f40-bdde-ed8995afa1f5`
+- Initial observed state: `queued` / `awaiting_slot`
+- Follow-up detail check: 26-step Jira Orchestrate run visible through `/api/executions/mm:bba3289f-e103-412c-82ed-dc6964a92425`, awaiting the first Jira transition step.
+
+This note is a temporary run handoff, not canonical design documentation.


### PR DESCRIPTION
Run Jira Orchestrate for MM-822.

Source story: STORY-003.
Source summary: Complete remaining behavior for Add checkpoint model and activity substrate.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.