### PR TITLE
Run Jira Orchestrate for MM-829: Complete remaining behavior for Add memory proposal and promotion manifests

### DIFF
--- a/docs/tmp/JiraOrchestrateMM829Submission.md
+++ b/docs/tmp/JiraOrchestrateMM829Submission.md
@@ -1,0 +1,16 @@
+# Jira Orchestrate MM-829 Submission
+
+Date: 2026-06-12
+
+Submitted the seeded Jira Orchestrate workflow for `MM-829`.
+
+- Source story: `STORY-010`
+- Source summary: Complete remaining behavior for Add memory proposal and promotion manifests
+- Source Jira issue: unknown
+- Source design document: `docs/Steps/StepExecutionsAndCheckpointing.md`
+- Created workflow ID: `mm:e9856430-52f7-4a1c-b83e-5dc01f5ee28a`
+- Run ID: `019eb8fb-b90a-7e99-810d-bebf021aac6e`
+- Initial observed state: `queued` / `awaiting_slot`
+- Follow-up detail check: Jira Orchestrate run visible through `/api/executions/mm:e9856430-52f7-4a1c-b83e-5dc01f5ee28a`, awaiting a Codex provider profile slot.
+
+This note is a temporary run handoff, not canonical design documentation.


### PR DESCRIPTION
Run Jira Orchestrate for MM-829.

Source story: STORY-010.
Source summary: Complete remaining behavior for Add memory proposal and promotion manifests.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.