### PR TITLE
Run Jira Orchestrate for MM-824: Complete remaining behavior for Validate and apply checkpoint-backed workspace policies

### DIFF
--- a/docs/tmp/JiraOrchestrateMM824Submission.md
+++ b/docs/tmp/JiraOrchestrateMM824Submission.md
@@ -1,0 +1,22 @@
+# Jira Orchestrate MM-824 Submission
+
+Date: 2026-06-12
+
+Submitted the seeded Jira Orchestrate workflow for `MM-824` from the
+`run-jira-orchestrate-for-mm-824-complete-8ad823ae` publish branch.
+
+- Source story: `STORY-005`
+- Source summary: Complete remaining behavior for Validate and apply checkpoint-backed workspace policies
+- Source Jira issue: unknown
+- Source design document: `docs/Steps/StepExecutionsAndCheckpointing.md`
+- Created workflow ID: `mm:46152089-fdb1-4c46-a8f8-7e8af05a5acd`
+- Run ID: `019eb906-fa66-7363-b29c-bdbad1c36731`
+- Initial observed state: `initializing` / `queued`
+- Follow-up detail check: the submitted workflow is visible through
+  `/api/executions/mm:46152089-fdb1-4c46-a8f8-7e8af05a5acd`.
+- Follow-up observed state: `failed` / `failed`
+- Failure summary: `ValueError: Could not resolve selected skill 'jira-orchestrate'`
+
+This note is a temporary run handoff for publish postcondition repair, not
+canonical design documentation. It does not transition Jira, push a branch, or
+create a pull request.


### PR DESCRIPTION
Run Jira Orchestrate for MM-824.

Source story: STORY-005.
Source summary: Complete remaining behavior for Validate and apply checkpoint-backed workspace policies.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.