### PR TITLE
Run Jira Orchestrate for MM-832: Complete remaining behavior for Finalize docs, terminology, and compatibility cleanup

### DIFF
--- a/docs/tmp/JiraOrchestrateMM832Submission.md
+++ b/docs/tmp/JiraOrchestrateMM832Submission.md
@@ -1,0 +1,16 @@
+# Jira Orchestrate MM-832 Submission
+
+Date: 2026-06-12
+
+Submitted the seeded Jira Orchestrate workflow for `MM-832`.
+
+- Source story: `STORY-013`
+- Source summary: Complete remaining behavior for Finalize docs, terminology, and compatibility cleanup
+- Source Jira issue: unknown
+- Source design document: `docs/Steps/StepExecutionsAndCheckpointing.md`
+- Created workflow ID: `mm:3d9e06e8-e547-4b69-ad78-3daae03b33e2`
+- Run ID: `019eb933-7222-74c9-ac5c-827dd4ebfcf2`
+- Initial observed state: `initializing`
+- Follow-up detail check: 26-step Jira Orchestrate run visible through `/api/executions/mm:3d9e06e8-e547-4b69-ad78-3daae03b33e2`, awaiting a `codex_cli` provider profile slot before the first Jira transition step.
+
+This note is a temporary run handoff, not canonical design documentation.


### PR DESCRIPTION
Run Jira Orchestrate for MM-832.

Source story: STORY-013.
Source summary: Complete remaining behavior for Finalize docs, terminology, and compatibility cleanup.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.