### PR TITLE
Run Jira Orchestrate for MM-829

### DIFF
--- a/docs/tmp/jira-orchestrate-mm-829-handoff.json
+++ b/docs/tmp/jira-orchestrate-mm-829-handoff.json
@@ -1,0 +1,65 @@
+{
+  "handoffType": "jira-orchestrate-submission",
+  "createdAt": "2026-06-12T00:44:00Z",
+  "jiraIssueKey": "MM-829",
+  "sourceStory": {
+    "id": "STORY-010",
+    "summary": "Complete remaining behavior for Add memory proposal and promotion manifests",
+    "sourceDesignPath": "docs/Steps/StepExecutionsAndCheckpointing.md"
+  },
+  "preset": {
+    "slug": "jira-orchestrate",
+    "version": "1.0.0",
+    "scope": "global"
+  },
+  "repository": "MoonLadderStudios/MoonMind",
+  "targetRuntime": "codex_cli",
+  "idempotencyKey": "jira-orchestrate:MM-829:STORY-010",
+  "submissionStatus": "not_submitted_from_this_workspace",
+  "localBlockers": [
+    {
+      "command": "docker compose up -d",
+      "reason": "Compose cannot start in this managed workspace because Docker bind mounts reject the checkout path containing a colon.",
+      "evidence": "invalid volume specification: '/work/agent_jobs/mm:e9856430-52f7-4a1c-b83e-5dc01f5ee28a/repo/...'"
+    }
+  ],
+  "createExecutionPayload": {
+    "type": "task",
+    "payload": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "targetRuntime": "codex_cli",
+      "publishMode": "pr",
+      "idempotencyKey": "jira-orchestrate:MM-829:STORY-010",
+      "integration": "jira",
+      "task": {
+        "title": "Run Jira Orchestrate for MM-829",
+        "instructions": "Run Jira Orchestrate for MM-829.\n\nSource story: STORY-010. Source summary: Complete remaining behavior for Add memory proposal and promotion manifests. Source design document: docs/Steps/StepExecutionsAndCheckpointing.md. Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.",
+        "runtime": {
+          "mode": "codex_cli"
+        },
+        "publish": {
+          "mode": "pr"
+        },
+        "inputs": {
+          "jira_issue_key": "MM-829",
+          "source_design_path": "docs/Steps/StepExecutionsAndCheckpointing.md",
+          "constraints": "Source story: STORY-010. Preserve traceability to the source story and do not run implementation inline inside a breakdown task."
+        },
+        "taskTemplate": {
+          "slug": "jira-orchestrate",
+          "version": "1.0.0",
+          "scope": "global"
+        },
+        "presetSchedule": {
+          "source": "jira-breakdown-orchestrate",
+          "reason": "source_story_handoff",
+          "presetSlug": "jira-orchestrate",
+          "presetVersion": "1.0.0",
+          "jiraIssueKey": "MM-829",
+          "sourceStoryId": "STORY-010",
+          "sourceDesignPath": "docs/Steps/StepExecutionsAndCheckpointing.md"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Run Jira Orchestrate for MM-829. Source story: STORY-010. Source summary: Complete remaining behavior for Add memory proposal and promotion manifests. Source design document: docs/Steps/StepExecutionsAndCheckpointing.md. Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.