### PR TITLE
[codex] fix workflow replay queue polling

### DIFF
--- a/moonmind/workflows/temporal/__init__.py
+++ b/moonmind/workflows/temporal/__init__.py
@@ -23,6 +23,7 @@ from moonmind.workflows.temporal.activity_catalog import (
     TemporalActivityTimeouts,
     TemporalWorkerFleet,
     build_default_activity_catalog,
+    get_workflow_poll_task_queues,
     skill_policy_as_route,
 )
 from moonmind.workflows.temporal.activity_runtime import (
@@ -225,6 +226,7 @@ __all__ = [
     "build_activity_execution_context",
     "build_activity_invocation_envelope",
     "build_default_activity_catalog",
+    "get_workflow_poll_task_queues",
     "build_compact_activity_result",
     "build_worker_activity_bindings",
     "build_worker_topology",

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -43,6 +43,24 @@ def get_workflow_task_queue(
         temporal_settings or settings.temporal
     ).task_queue
 
+def get_workflow_poll_task_queues(
+    temporal_settings: TemporalSettings | None = None,
+) -> tuple[str, ...]:
+    """Resolve workflow queues the workflow fleet must poll.
+
+    New workflow starts use the hard-switch start contract queue.  In-flight
+    histories may still contain pre-patch child-workflow commands recorded on
+    TEMPORAL_WORKFLOW_TASK_QUEUE, so the workflow fleet must keep polling that
+    queue until those histories have drained.
+    """
+
+    cfg = temporal_settings or settings.temporal
+    start_queue = get_workflow_task_queue(cfg)
+    replay_queue = str(cfg.workflow_task_queue).strip()
+    if replay_queue and replay_queue != start_queue:
+        return (start_queue, replay_queue)
+    return (start_queue,)
+
 class TemporalActivityCatalogError(ValueError):
     """Raised when Temporal activity routing metadata is invalid."""
 
@@ -305,6 +323,7 @@ def build_default_activity_catalog(
 
     cfg = temporal_settings or settings.temporal
     workflow_task_queue = get_workflow_task_queue(cfg)
+    workflow_poll_task_queues = get_workflow_poll_task_queues(cfg)
     
     # See docs/Temporal/ErrorTaxonomy.md
     NON_RETRYABLE_ERRORS = ("INVALID_INPUT", "ProfileResolutionError", "UnsupportedStatus")
@@ -1119,7 +1138,7 @@ def build_default_activity_catalog(
     fleets = (
         TemporalWorkerFleet(
             fleet=WORKFLOW_FLEET,
-            task_queues=(workflow_task_queue,),
+            task_queues=workflow_poll_task_queues,
             capabilities=("workflow",),
             privileges=("temporal",),
             scaling_notes="Workflow code only; no side effects.",
@@ -1292,6 +1311,7 @@ __all__ = [
     "WORKFLOW_TASK_QUEUE",
     "build_default_activity_catalog",
     "get_workflow_task_queue",
+    "get_workflow_poll_task_queues",
     "manifest_ingest_activity_routes",
     "skill_policy_as_route",
 ]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -56,8 +56,13 @@ def get_workflow_poll_task_queues(
 
     cfg = temporal_settings or settings.temporal
     start_queue = get_workflow_task_queue(cfg)
-    replay_queue = str(cfg.workflow_task_queue).strip()
-    if replay_queue and replay_queue != start_queue:
+    replay_queue = (
+        str(cfg.workflow_task_queue).strip()
+        if cfg.workflow_task_queue is not None
+        else ""
+    )
+    merge_queue = str(cfg.merge_automation_workflow_task_queue).strip()
+    if replay_queue and replay_queue != start_queue and start_queue != merge_queue:
         return (start_queue, replay_queue)
     return (start_queue,)
 

--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -89,7 +89,9 @@ async def main():
         topology.fleet,
         ", ".join(topology.task_queues),
     )
-    await asyncio.gather(*(worker.run() for worker in workers))
+    async with asyncio.TaskGroup() as tg:
+        for worker in workers:
+            tg.create_task(worker.run())
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -72,19 +72,24 @@ async def main():
     bindings = build_worker_activity_bindings(fleet=topology.fleet)
     activities = [b.handler for b in bindings]
 
-    worker = Worker(
-        client,
-        task_queue=topology.task_queues[0],
-        workflows=workflows,
-        activities=activities,
-        max_concurrent_activities=topology.concurrency_limit or 100,
-        workflow_runner=UnsandboxedWorkflowRunner(),
-    )
+    workers = [
+        Worker(
+            client,
+            task_queue=task_queue,
+            workflows=workflows,
+            activities=activities,
+            max_concurrent_activities=topology.concurrency_limit or 100,
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        )
+        for task_queue in topology.task_queues
+    ]
 
     logger.info(
-        f"Starting Temporal worker for fleet '{topology.fleet}' on queue '{topology.task_queues[0]}'"
+        "Starting Temporal worker for fleet '%s' on queues '%s'",
+        topology.fleet,
+        ", ".join(topology.task_queues),
     )
-    await worker.run()
+    await asyncio.gather(*(worker.run() for worker in workers))
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2335,17 +2335,26 @@ async def main_async() -> None:
         runtime_resources, activities = await _build_runtime_activities(topology)
 
     try:
-        worker = Worker(
-            client,
-            task_queue=topology.task_queues[0],
-            workflows=workflows,
-            activities=activities,
-            workflow_runner=UnsandboxedWorkflowRunner(),
+        worker_kwargs = {
+            "workflows": workflows,
+            "activities": activities,
+            "workflow_runner": UnsandboxedWorkflowRunner(),
             **_worker_concurrency_kwargs(topology),
-        )
+        }
+        workers = [
+            Worker(
+                client,
+                task_queue=task_queue,
+                **worker_kwargs,
+            )
+            for task_queue in topology.task_queues
+        ]
 
-        logger.info("Worker started, polling task queues...")
-        await worker.run()
+        logger.info(
+            "Worker started, polling task queues: %s",
+            ", ".join(topology.task_queues),
+        )
+        await asyncio.gather(*(worker.run() for worker in workers))
     finally:
         if runtime_resources is not None:
             await runtime_resources.aclose()

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2354,7 +2354,9 @@ async def main_async() -> None:
             "Worker started, polling task queues: %s",
             ", ".join(topology.task_queues),
         )
-        await asyncio.gather(*(worker.run() for worker in workers))
+        async with asyncio.TaskGroup() as tg:
+            for worker in workers:
+                tg.create_task(worker.run())
     finally:
         if runtime_resources is not None:
             await runtime_resources.aclose()

--- a/tests/contract/test_temporal_activity_topology.py
+++ b/tests/contract/test_temporal_activity_topology.py
@@ -33,13 +33,16 @@ def test_temporal_activity_topology_contract_uses_canonical_v1_queue_set() -> No
         "mm.activity.integrations",
     }
     assert {fleet.task_queues[0] for fleet in catalog.fleets} == {
-        "mm.workflow",
+        "mm.workflow.user.v2",
         "mm.activity.artifacts",
         "mm.activity.llm",
         "mm.activity.sandbox",
         "mm.activity.integrations",
         "mm.activity.agent_runtime",
+        "mm.activity.deployment",
     }
+    workflow_fleet = next(fleet for fleet in catalog.fleets if fleet.fleet == "workflow")
+    assert workflow_fleet.task_queues == ("mm.workflow.user.v2", "mm.workflow")
 
 def test_shared_envelope_contract_requires_idempotency_for_side_effecting_inputs() -> (
     None

--- a/tests/unit/workflows/temporal/test_hard_switch_cutover.py
+++ b/tests/unit/workflows/temporal/test_hard_switch_cutover.py
@@ -11,6 +11,7 @@ from moonmind.workflows.temporal.activity_catalog import (
     WORKFLOW_FLEET,
     WORKFLOW_TASK_QUEUE,
     build_default_activity_catalog,
+    get_workflow_poll_task_queues,
     get_workflow_task_queue,
 )
 from moonmind.workflows.temporal.client import TemporalClientAdapter
@@ -146,6 +147,10 @@ def test_workflow_task_queue_constant_stays_replay_stable_while_start_queue_is_l
 
     assert WORKFLOW_TASK_QUEUE == "mm.workflow"
     assert get_workflow_task_queue(temporal_settings) == "mm.workflow.user.v2"
+    assert get_workflow_poll_task_queues(temporal_settings) == (
+        "mm.workflow.user.v2",
+        "mm.workflow",
+    )
 
 
 def test_renamed_contract_resolution_caches_cutover_file_validation(
@@ -183,7 +188,9 @@ def test_worker_registration_serves_only_one_user_workflow_type(tmp_path: Path) 
     assert LEGACY_USER_WORKFLOW_TYPE not in renamed_types
 
 
-def test_renamed_contract_workflow_fleet_polls_start_queue(tmp_path: Path) -> None:
+def test_renamed_contract_workflow_fleet_polls_start_and_replay_queues(
+    tmp_path: Path,
+) -> None:
     temporal_settings = _renamed_contract_settings(tmp_path)
     catalog = build_default_activity_catalog(temporal_settings)
     topology = describe_configured_worker(
@@ -193,7 +200,7 @@ def test_renamed_contract_workflow_fleet_polls_start_queue(tmp_path: Path) -> No
         catalog=catalog,
     )
 
-    assert topology.task_queues == ("mm.workflow.user.v2",)
+    assert topology.task_queues == ("mm.workflow.user.v2", "mm.workflow")
     assert (
         catalog.resolve_activity("integration.resolve_adapter_metadata").task_queue
         == "mm.workflow.user.v2"

--- a/tests/unit/workflows/temporal/test_hard_switch_cutover.py
+++ b/tests/unit/workflows/temporal/test_hard_switch_cutover.py
@@ -153,6 +153,29 @@ def test_workflow_task_queue_constant_stays_replay_stable_while_start_queue_is_l
     )
 
 
+def test_workflow_poll_task_queues_ignore_missing_replay_queue(tmp_path: Path) -> None:
+    temporal_settings = _renamed_contract_settings(tmp_path).model_copy(
+        update={"workflow_task_queue": None}
+    )
+
+    assert get_workflow_poll_task_queues(temporal_settings) == ("mm.workflow.user.v2",)
+
+
+def test_merge_automation_workflow_fleet_does_not_poll_user_replay_queue(
+    tmp_path: Path,
+) -> None:
+    temporal_settings = _renamed_contract_settings(tmp_path).model_copy(
+        update={
+            "user_workflow_v2_task_queue": "mm.workflow.merge_automation",
+            "merge_automation_workflow_task_queue": "mm.workflow.merge_automation",
+        }
+    )
+
+    assert get_workflow_poll_task_queues(temporal_settings) == (
+        "mm.workflow.merge_automation",
+    )
+
+
 def test_renamed_contract_resolution_caches_cutover_file_validation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3167,24 +3167,29 @@ async def test_main_async_workflow_fleet(
     mock_healthcheck.return_value = mock_healthcheck_server
     mock_topology = MagicMock()
     mock_topology.fleet = WORKFLOW_FLEET
-    mock_topology.task_queues = ["mm.workflow"]
+    mock_topology.task_queues = ["mm.workflow.user.v2", "mm.workflow"]
     mock_topology.concurrency_limit = 7
     mock_describe.return_value = mock_topology
 
     mock_client = MagicMock()
     mock_connect.return_value = mock_client
 
-    mock_worker = MagicMock()
-    mock_worker_cls.return_value = mock_worker
-    mock_worker.run = AsyncMock()
+    mock_worker_v2 = MagicMock()
+    mock_worker_v2.run = AsyncMock()
+    mock_worker_replay = MagicMock()
+    mock_worker_replay.run = AsyncMock()
+    mock_worker_cls.side_effect = [mock_worker_v2, mock_worker_replay]
 
     # Run
     await main_async()
 
     # Verify Worker creation uses the mock workflows
-    mock_worker_cls.assert_called_once()
-    kwargs = mock_worker_cls.call_args.kwargs
-    assert kwargs["task_queue"] == "mm.workflow"
+    assert mock_worker_cls.call_count == 2
+    assert [call.kwargs["task_queue"] for call in mock_worker_cls.call_args_list] == [
+        "mm.workflow.user.v2",
+        "mm.workflow",
+    ]
+    kwargs = mock_worker_cls.call_args_list[0].kwargs
     from moonmind.workflows.temporal.workflows.agent_session import (
         MoonMindAgentSessionWorkflow,
     )
@@ -3219,7 +3224,8 @@ async def test_main_async_workflow_fleet(
     assert "max_concurrent_activities" not in kwargs
 
     # Verify worker run is called
-    mock_worker.run.assert_awaited_once()
+    mock_worker_v2.run.assert_awaited_once()
+    mock_worker_replay.run.assert_awaited_once()
 
 @pytest.mark.asyncio
 @patch("moonmind.workflows.temporal.worker_runtime.start_healthcheck_server")


### PR DESCRIPTION
## Summary

- Make the workflow fleet poll both the current `mm.workflow.user.v2` queue and the replay/legacy `mm.workflow` queue.
- Start one Temporal worker per configured workflow queue in both worker entrypoints.
- Cover the hard-switch queue behavior and multi-worker launch path with tests.

## Root Cause

In-flight histories can still contain pre-patch child workflow commands recorded on `TEMPORAL_WORKFLOW_TASK_QUEUE` (`mm.workflow`). The workflow fleet had moved to polling only the new start queue, so those child workflow tasks could remain backlogged with no poller.

## Impact

New workflow starts continue to route to `mm.workflow.user.v2`, while old in-flight histories can drain safely from `mm.workflow` instead of stalling before `MoonMind.AgentRun` starts.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_hard_switch_cutover.py tests/unit/workflows/temporal/test_temporal_workers.py tests/contract/test_temporal_activity_topology.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_main_async_workflow_fleet`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_hard_switch_cutover.py tests/contract/test_temporal_activity_topology.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_main_async_workflow_fleet`

Both runs completed successfully, including the frontend unit pass invoked by the test runner.