### PR TITLE
[codex] fix Jira Orchestrate workflow preset expansion

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -211,7 +211,13 @@ async def _expand_preset_for_child_run(
     """
 
     parameters = dict(initial_parameters or {})
+    payload_key = "task"
     task_payload = _coerce_mapping(parameters.get("task"))
+    if not task_payload:
+        workflow_payload = _coerce_mapping(parameters.get("workflow"))
+        if workflow_payload:
+            payload_key = "workflow"
+            task_payload = workflow_payload
     if not task_payload:
         return parameters
     raw_steps = task_payload.get("steps")
@@ -330,7 +336,7 @@ async def _expand_preset_for_child_run(
         "version": str(applied_template.get("version") or template_version),
         "scope": template_scope,
     }
-    parameters["task"] = task_payload
+    parameters[payload_key] = task_payload
     parameters["stepCount"] = len(expanded_steps)
     return parameters
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -211,13 +211,13 @@ async def _expand_preset_for_child_run(
     """
 
     parameters = dict(initial_parameters or {})
-    payload_key = "task"
-    task_payload = _coerce_mapping(parameters.get("task"))
-    if not task_payload:
-        workflow_payload = _coerce_mapping(parameters.get("workflow"))
-        if workflow_payload:
-            payload_key = "workflow"
-            task_payload = workflow_payload
+    workflow_payload = _coerce_mapping(parameters.get("workflow"))
+    if workflow_payload:
+        payload_key = "workflow"
+        task_payload = workflow_payload
+    else:
+        payload_key = "task"
+        task_payload = _coerce_mapping(parameters.get("task"))
     if not task_payload:
         return parameters
     raw_steps = task_payload.get("steps")

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1810,6 +1810,74 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_child_jira_orchestrate_workflow_payload_expands_seeded_template_steps(
+    tmp_path,
+):
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "workflow",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                    "publishMode": "pr",
+                    "workflow": {
+                        "title": "Run Jira Orchestrate for MM-820: Conformance",
+                        "instructions": "Use the existing Jira Orchestrate workflow.",
+                        "tool": {
+                            "type": "skill",
+                            "name": "jira-orchestrate",
+                            "version": "1.0",
+                        },
+                        "skill": {"name": "jira-orchestrate", "version": "1.0"},
+                        "inputs": {
+                            "jira_issue_key": "MM-820",
+                            "source_design_path": (
+                                "docs/Steps/StepExecutionsAndCheckpointing.md"
+                            ),
+                            "constraints": "Do not run implementation inline.",
+                        },
+                        "runtime": {"mode": "codex_cli"},
+                        "publish": {"mode": "pr"},
+                        "taskTemplate": {
+                            "slug": "jira-orchestrate",
+                            "version": "1.0.0",
+                        },
+                    },
+                },
+            )
+
+    task = expanded_parameters["workflow"]
+    assert "task" not in expanded_parameters
+    assert expanded_parameters["stepCount"] == 26
+    assert len(task["steps"]) == 26
+    assert task["steps"][0]["skill"]["id"] == "jira-issue-updater"
+    assert task["steps"][0]["type"] == "skill"
+    assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
+    assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
+
+    planner = _build_runtime_planner()
+    plan = planner(
+        inputs={"workflow": task},
+        parameters={"targetRuntime": "codex_cli"},
+        snapshot=SimpleNamespace(
+            digest="reg:sha256:test",
+            artifact_ref="art_registry_123",
+        ),
+    )
+
+    first_node = plan["nodes"][0]
+    assert first_node["id"].startswith("tpl:jira-orchestrate:1.0.0:01")
+    assert first_node["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert first_node["inputs"]["selectedSkill"] == "jira-issue-updater"
+
+
+@pytest.mark.asyncio
 async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
     tmp_path,
 ):

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1878,6 +1878,48 @@ async def test_child_jira_orchestrate_workflow_payload_expands_seeded_template_s
 
 
 @pytest.mark.asyncio
+async def test_child_preset_expansion_prefers_workflow_payload_over_legacy_task(
+    tmp_path,
+):
+    legacy_task = {
+        "title": "Legacy task should not be used",
+        "instructions": "Leave this legacy task alone.",
+        "steps": [{"id": "legacy-step", "instructions": "Already authored."}],
+    }
+
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "workflow",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                    "task": legacy_task,
+                    "workflow": {
+                        "title": "Run Jira Orchestrate for MM-821",
+                        "instructions": "Use the existing Jira Orchestrate workflow.",
+                        "inputs": {
+                            "jira_issue_key": "MM-821",
+                            "source_design_path": "",
+                            "constraints": "Prefer workflow payload.",
+                        },
+                        "taskTemplate": {
+                            "slug": "jira-orchestrate",
+                            "version": "1.0.0",
+                        },
+                    },
+                },
+            )
+
+    assert expanded_parameters["task"] == legacy_task
+    task = expanded_parameters["workflow"]
+    assert expanded_parameters["stepCount"] == 26
+    assert task["steps"][0]["skill"]["id"] == "jira-issue-updater"
+    assert "MM-821" in task["steps"][0]["instructions"]
+
+
+@pytest.mark.asyncio
 async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Expand Jira Orchestrate child-run preset payloads when the authored workflow is stored under `workflow` instead of legacy `task`.
- Preserve the original payload key when writing expanded steps back into initial parameters.
- Add regression coverage proving the expanded workflow plans the first concrete skill as `jira-issue-updater`, not the `jira-orchestrate` preset slug.

## Root Cause
The failed workflow carried `requestType: workflow` with `workflow.taskTemplate.slug = jira-orchestrate`. `_expand_preset_for_child_run()` only inspected `initial_parameters["task"]`, so the preset was not expanded before planning and skill resolution tried to resolve `jira-orchestrate` as an agent skill.

## Validation
- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q -k "child_jira_orchestrate"`
- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q -k "runtime_planner_single_step_tool_does_not_override_top_level_publish_scope or runtime_planner_maps_explicit_skill_step_to_agent_runtime_node"`
- `git diff --check -- moonmind/workflows/temporal/worker_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`

Note: `./tools/test_unit.sh` was started but stopped because pytest-xdist was unavailable and the full unit suite had only reached about 10% after an extended wait.