### PR TITLE
Run Jira Orchestrate for MM-821: Complete remaining behavior for Consolidate typed Step Execution manifest writing

### DIFF
--- a/docs/tmp/JiraOrchestrateMM821Submission.md
+++ b/docs/tmp/JiraOrchestrateMM821Submission.md
@@ -1,0 +1,16 @@
+# Jira Orchestrate MM-821 Submission
+
+Date: 2026-06-12
+
+Submitted the seeded Jira Orchestrate workflow for `MM-821`.
+
+- Source story: `STORY-002`
+- Source summary: Complete remaining behavior for Consolidate typed Step Execution manifest writing
+- Source Jira issue: unknown
+- Source design document: `docs/Steps/StepExecutionsAndCheckpointing.md`
+- Created workflow ID: `mm:aaf21766-5885-41ee-bc26-b6d17a7d020b`
+- Run ID: `019eb97b-07a3-7437-8bdc-e4eec6454ea6`
+- Initial observed state: `queued` / `awaiting_slot`
+- Follow-up detail check: 26-step Jira Orchestrate run visible through `/api/executions/mm:aaf21766-5885-41ee-bc26-b6d17a7d020b`, waiting for a `codex_cli` provider profile slot at step 1 (`Move Jira issue to In Progress`).
+
+This note is a temporary run handoff, not canonical design documentation.


### PR DESCRIPTION
Run Jira Orchestrate for MM-821.

Source story: STORY-002.
Source summary: Complete remaining behavior for Consolidate typed Step Execution manifest writing.
Source Jira issue: unknown.
Source design document: docs/Steps/StepExecutionsAndCheckpointing.md.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.