### PR TITLE
[codex] Fix Jira Orchestrate rerun preset expansion

### DIFF
--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -1,0 +1,190 @@
+"""Preset expansion helpers for workflow execution submissions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from moonmind.workflows.executions.preset_goal_scheduler import (
+    goal_from_payloads,
+    schedule_preset_from_goal,
+    workflow_is_already_authored,
+)
+
+
+def preset_seed_dir() -> Path:
+    import api_service
+
+    return Path(api_service.__file__).resolve().parent / "data" / "presets"
+
+
+def _coerce_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def template_slug_from_task(task_payload: Mapping[str, Any]) -> str:
+    template_payload = _coerce_mapping(
+        task_payload.get("taskTemplate") or task_payload.get("task_template")
+    )
+    return str(
+        template_payload.get("slug")
+        or template_payload.get("name")
+        or template_payload.get("id")
+        or ""
+    ).strip()
+
+
+def has_unexpanded_task_template(
+    initial_parameters: Mapping[str, Any] | None,
+) -> bool:
+    parameters = _coerce_mapping(initial_parameters)
+    task_payload = _coerce_mapping(parameters.get("workflow")) or _coerce_mapping(
+        parameters.get("task")
+    )
+    if not task_payload:
+        return False
+    raw_steps = task_payload.get("steps")
+    if isinstance(raw_steps, list) and raw_steps:
+        return False
+    return bool(template_slug_from_task(task_payload))
+
+
+async def expand_preset_for_child_run(
+    *,
+    session: Any,
+    initial_parameters: Mapping[str, Any] | None,
+    allow_goal_schedule: bool = True,
+) -> dict[str, Any]:
+    """Expand stored preset provenance into executable workflow steps."""
+
+    parameters = _coerce_mapping(initial_parameters)
+    workflow_payload = _coerce_mapping(parameters.get("workflow"))
+    if workflow_payload:
+        payload_key = "workflow"
+        task_payload = workflow_payload
+    else:
+        payload_key = "task"
+        task_payload = _coerce_mapping(parameters.get("task"))
+    if not task_payload:
+        return parameters
+    raw_steps = task_payload.get("steps")
+    if isinstance(raw_steps, list) and raw_steps:
+        return parameters
+
+    template_payload = _coerce_mapping(
+        task_payload.get("taskTemplate") or task_payload.get("task_template")
+    )
+    template_slug = template_slug_from_task(task_payload)
+    if not template_slug:
+        if not allow_goal_schedule:
+            return parameters
+        goal = goal_from_payloads(
+            task_payload=task_payload,
+            parameter_payload=parameters,
+        )
+        schedule = (
+            None
+            if workflow_is_already_authored(task_payload)
+            else schedule_preset_from_goal(goal)
+        )
+        if schedule is None:
+            return parameters
+        template_slug = schedule.slug
+        template_payload = {
+            "slug": schedule.slug,
+            "version": schedule.version,
+            "scope": "global",
+        }
+        existing_inputs = _coerce_mapping(task_payload.get("inputs"))
+        task_payload["inputs"] = {**schedule.inputs, **existing_inputs}
+        task_payload["goal"] = schedule.goal
+        task_payload.setdefault("instructions", schedule.goal)
+        task_payload["taskTemplate"] = dict(template_payload)
+        task_payload["presetSchedule"] = {
+            "source": "goal",
+            "reason": schedule.reason,
+            "presetSlug": schedule.slug,
+            "presetVersion": schedule.version,
+            "jiraIssueKey": schedule.issue_key,
+        }
+
+    from api_service.services.presets.catalog import (
+        ExpandOptions,
+        PresetCatalogService,
+        PresetNotFoundError,
+    )
+
+    template_version = str(template_payload.get("version") or "1.0.0").strip()
+    template_scope = str(template_payload.get("scope") or "global").strip() or "global"
+    template_scope_ref = (
+        str(template_payload.get("scopeRef") or template_payload.get("scope_ref") or "")
+        .strip()
+        or None
+    )
+    template_inputs = _coerce_mapping(task_payload.get("inputs"))
+    repository = (
+        task_payload.get("repository")
+        or parameters.get("repository")
+        or parameters.get("repo")
+    )
+    template_context: dict[str, Any] = {}
+    if isinstance(repository, str) and repository.strip():
+        template_context["repository"] = repository.strip()
+        template_context["repo"] = repository.strip()
+    target_runtime = parameters.get("targetRuntime")
+    if isinstance(target_runtime, str) and target_runtime.strip():
+        template_context["targetRuntime"] = target_runtime.strip()
+    catalog = PresetCatalogService(session)
+    expand_kwargs = {
+        "slug": template_slug,
+        "scope": template_scope,
+        "scope_ref": template_scope_ref,
+        "version": template_version,
+        "inputs": template_inputs,
+        "context": template_context,
+        "options": ExpandOptions(should_enforce_step_limit=True),
+    }
+    try:
+        expanded = await catalog.expand_template(**expand_kwargs)
+    except PresetNotFoundError:
+        await catalog.sync_seed_templates(seed_dir=preset_seed_dir())
+        expanded = await catalog.expand_template(**expand_kwargs)
+
+    expanded_steps = expanded.get("steps") if isinstance(expanded, Mapping) else None
+    if not isinstance(expanded_steps, list) or not expanded_steps:
+        raise RuntimeError(
+            f"Preset '{template_slug}' expansion produced no executable steps."
+        )
+
+    applied_template = _coerce_mapping(expanded.get("appliedTemplate"))
+    applied_template_payload: dict[str, Any] = {
+        "slug": str(applied_template.get("slug") or template_slug),
+        "version": str(applied_template.get("version") or template_version),
+        "inputs": _coerce_mapping(applied_template.get("inputs")) or template_inputs,
+        "stepIds": list(applied_template.get("stepIds") or []),
+        "appliedAt": str(applied_template.get("appliedAt") or ""),
+        "capabilities": list(expanded.get("capabilities") or []),
+    }
+    composition = applied_template.get("composition") or expanded.get("composition")
+    if isinstance(composition, Mapping):
+        applied_template_payload["composition"] = dict(composition)
+    authored_presets = applied_template.get("authoredPresets") or expanded.get(
+        "authoredPresets"
+    )
+    if isinstance(authored_presets, list):
+        task_payload["authoredPresets"] = [
+            dict(item) if isinstance(item, Mapping) else item
+            for item in authored_presets
+        ]
+    task_payload["steps"] = list(expanded_steps)
+    task_payload["appliedStepTemplates"] = [applied_template_payload]
+    task_payload["taskTemplate"] = {
+        **template_payload,
+        "slug": str(applied_template.get("slug") or template_slug),
+        "version": str(applied_template.get("version") or template_version),
+        "scope": template_scope,
+    }
+    parameters[payload_key] = task_payload
+    parameters["stepCount"] = len(expanded_steps)
+    return parameters

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -72,6 +72,10 @@ from moonmind.workflows.temporal.runtime.managed_session_store import (
     TERMINAL_MANAGED_SESSION_STATUSES,
 )
 from moonmind.schemas.managed_session_models import canonical_managed_session_runtime_id
+from moonmind.workflows.executions.preset_expansion import (
+    expand_preset_for_child_run,
+    has_unexpanded_task_template,
+)
 
 TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.COMPLETED,
@@ -2726,6 +2730,12 @@ class TemporalExecutionService:
             "runId": record.run_id,
         }
         params["rerunSource"] = rerun_source
+        if has_unexpanded_task_template(params):
+            params = await expand_preset_for_child_run(
+                session=self._session,
+                initial_parameters=params,
+                allow_goal_schedule=False,
+            )
 
         next_input_ref = input_artifact_ref or record.input_ref
         next_plan_ref = plan_artifact_ref or record.plan_ref

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -85,10 +85,8 @@ from moonmind.workflows.temporal.workers import (
 from moonmind.workflows.executions.execution_contract import (
     build_authoritative_workflow_input_snapshot,
 )
-from moonmind.workflows.executions.preset_goal_scheduler import (
-    goal_from_payloads,
-    schedule_preset_from_goal,
-    workflow_is_already_authored,
+from moonmind.workflows.executions.preset_expansion import (
+    expand_preset_for_child_run,
 )
 from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow as MoonMindProviderProfileManager
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
@@ -182,163 +180,15 @@ _OPENTELEMETRY_LOG_FORMAT = (
     "turn_id=%(managed_session_turn_id)s] %(message)s"
 )
 
-def _preset_seed_dir() -> Path:
-    import api_service
-
-    return Path(api_service.__file__).resolve().parent / "data" / "presets"
-
-def _template_slug_from_task(task_payload: Mapping[str, Any]) -> str:
-    template_payload = _coerce_mapping(
-        task_payload.get("taskTemplate") or task_payload.get("task_template")
-    )
-    return str(
-        template_payload.get("slug")
-        or template_payload.get("name")
-        or template_payload.get("id")
-        or ""
-    ).strip()
-
 async def _expand_preset_for_child_run(
     *,
     session: Any,
     initial_parameters: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    """Expand stored preset provenance into executable child-run steps.
-
-    Internal story-output tools create child executions directly, bypassing the
-    API/UI submit path that normally expands presets. The stored run contract
-    must still contain the flattened steps before ``MoonMind.UserWorkflow`` plans it.
-    """
-
-    parameters = dict(initial_parameters or {})
-    workflow_payload = _coerce_mapping(parameters.get("workflow"))
-    if workflow_payload:
-        payload_key = "workflow"
-        task_payload = workflow_payload
-    else:
-        payload_key = "task"
-        task_payload = _coerce_mapping(parameters.get("task"))
-    if not task_payload:
-        return parameters
-    raw_steps = task_payload.get("steps")
-    if isinstance(raw_steps, list) and raw_steps:
-        return parameters
-
-    template_payload = _coerce_mapping(
-        task_payload.get("taskTemplate") or task_payload.get("task_template")
+    return await expand_preset_for_child_run(
+        session=session,
+        initial_parameters=initial_parameters,
     )
-    template_slug = _template_slug_from_task(task_payload)
-    if not template_slug:
-        goal = goal_from_payloads(
-            task_payload=task_payload,
-            parameter_payload=parameters,
-        )
-        schedule = (
-            None
-            if workflow_is_already_authored(task_payload)
-            else schedule_preset_from_goal(goal)
-        )
-        if schedule is None:
-            return parameters
-        template_slug = schedule.slug
-        template_payload = {
-            "slug": schedule.slug,
-            "version": schedule.version,
-            "scope": "global",
-        }
-        existing_inputs = _coerce_mapping(task_payload.get("inputs"))
-        task_payload["inputs"] = {**schedule.inputs, **existing_inputs}
-        task_payload["goal"] = schedule.goal
-        task_payload.setdefault("instructions", schedule.goal)
-        task_payload["taskTemplate"] = dict(template_payload)
-        task_payload["presetSchedule"] = {
-            "source": "goal",
-            "reason": schedule.reason,
-            "presetSlug": schedule.slug,
-            "presetVersion": schedule.version,
-            "jiraIssueKey": schedule.issue_key,
-        }
-
-    from api_service.services.presets.catalog import (
-        ExpandOptions,
-        PresetCatalogService,
-        PresetNotFoundError,
-    )
-
-    template_version = str(template_payload.get("version") or "1.0.0").strip()
-    template_scope = str(template_payload.get("scope") or "global").strip() or "global"
-    template_scope_ref = (
-        str(template_payload.get("scopeRef") or template_payload.get("scope_ref") or "")
-        .strip()
-        or None
-    )
-    template_inputs = _coerce_mapping(task_payload.get("inputs"))
-    repository = (
-        task_payload.get("repository")
-        or parameters.get("repository")
-        or parameters.get("repo")
-    )
-    template_context: dict[str, Any] = {}
-    if isinstance(repository, str) and repository.strip():
-        template_context["repository"] = repository.strip()
-        template_context["repo"] = repository.strip()
-    target_runtime = parameters.get("targetRuntime")
-    if isinstance(target_runtime, str) and target_runtime.strip():
-        template_context["targetRuntime"] = target_runtime.strip()
-    catalog = PresetCatalogService(session)
-    expand_kwargs = {
-        "slug": template_slug,
-        "scope": template_scope,
-        "scope_ref": template_scope_ref,
-        "version": template_version,
-        "inputs": template_inputs,
-        "context": template_context,
-        "options": ExpandOptions(should_enforce_step_limit=True),
-    }
-    try:
-        expanded = await catalog.expand_template(**expand_kwargs)
-    except PresetNotFoundError:
-        await catalog.sync_seed_templates(seed_dir=_preset_seed_dir())
-        expanded = await catalog.expand_template(**expand_kwargs)
-
-    expanded_steps = expanded.get("steps") if isinstance(expanded, Mapping) else None
-    if not isinstance(expanded_steps, list) or not expanded_steps:
-        raise RuntimeError(
-            f"Preset '{template_slug}' expansion produced no executable steps."
-        )
-
-    applied_template = _coerce_mapping(expanded.get("appliedTemplate"))
-    applied_template_payload: dict[str, Any] = {
-        "slug": str(applied_template.get("slug") or template_slug),
-        "version": str(applied_template.get("version") or template_version),
-        "inputs": _coerce_mapping(applied_template.get("inputs"))
-        or template_inputs,
-        "stepIds": list(applied_template.get("stepIds") or []),
-        "appliedAt": str(applied_template.get("appliedAt") or ""),
-        "capabilities": list(expanded.get("capabilities") or []),
-    }
-    composition = applied_template.get("composition") or expanded.get("composition")
-    if isinstance(composition, Mapping):
-        applied_template_payload["composition"] = dict(composition)
-    authored_presets = applied_template.get("authoredPresets") or expanded.get(
-        "authoredPresets"
-    )
-    if isinstance(authored_presets, list):
-        task_payload["authoredPresets"] = [
-            dict(item) if isinstance(item, Mapping) else item
-            for item in authored_presets
-        ]
-    task_payload["steps"] = list(expanded_steps)
-    task_payload["appliedStepTemplates"] = [applied_template_payload]
-    task_payload["taskTemplate"] = {
-        **template_payload,
-        "slug": str(applied_template.get("slug") or template_slug),
-        "version": str(applied_template.get("version") or template_version),
-        "scope": template_scope,
-    }
-    parameters[payload_key] = task_payload
-    parameters["stepCount"] = len(expanded_steps)
-    return parameters
 
 
 def _enum_value(value: Any) -> str:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3277,6 +3277,90 @@ async def test_request_rerun_creates_fresh_execution_when_temporal_reports_compl
         assert rerun.parameters["rerunSource"]["workflowId"] == source_workflow_id
         assert service._client_adapter.update_workflow.await_count == 1
 
+
+@pytest.mark.asyncio
+async def test_fresh_rerun_expands_unexpanded_jira_orchestrate_template(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        source = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="Run Jira Orchestrate for MM-820",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "requestType": "workflow",
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "publishMode": "pr",
+                "workflow": {
+                    "title": "Run Jira Orchestrate for MM-820",
+                    "instructions": "Use the existing Jira Orchestrate workflow.",
+                    "tool": {
+                        "type": "skill",
+                        "name": "jira-orchestrate",
+                        "version": "1.0",
+                    },
+                    "skill": {"name": "jira-orchestrate", "version": "1.0"},
+                    "inputs": {
+                        "jira_issue_key": "MM-820",
+                        "source_design_path": (
+                            "docs/Steps/StepExecutionsAndCheckpointing.md"
+                        ),
+                        "constraints": "Do not run implementation inline.",
+                    },
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
+                    "taskTemplate": {
+                        "slug": "jira-orchestrate",
+                        "version": "1.0.0",
+                    },
+                },
+            },
+            idempotency_key=None,
+        )
+        await service.record_terminal_state(
+            workflow_id=source.workflow_id,
+            state="failed",
+            close_status="failed",
+            summary="failed before template expansion",
+        )
+
+        response = await service.update_execution(
+            workflow_id=source.workflow_id,
+            update_name="RequestRerun",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title=None,
+            new_manifest_artifact_ref=None,
+            mode=None,
+            max_concurrency=None,
+            node_ids=None,
+            idempotency_key="rerun-jira-orchestrate-template",
+        )
+        rerun = await service.describe_execution(response["workflow_id"])
+
+    workflow_payload = rerun.parameters["workflow"]
+    assert rerun.parameters["stepCount"] == 26
+    assert len(workflow_payload["steps"]) == 26
+    assert workflow_payload["steps"][0]["skill"]["id"] == "jira-issue-updater"
+    assert workflow_payload["steps"][7]["skill"]["id"] == "moonspec-tasks"
+    assert workflow_payload["steps"][9]["skill"]["id"] == "moonspec-implement"
+    assert workflow_payload["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
+    assert workflow_payload["recovery"] == {
+        "kind": "exact_full_rerun",
+        "sourceWorkflowId": source.workflow_id,
+        "sourceRunId": source.run_id,
+    }
+
+
 @pytest.mark.asyncio
 async def test_manifest_only_updates_rejected_for_non_manifest_workflow(
     tmp_path, mock_client_adapter


### PR DESCRIPTION
## Summary

- Extract shared workflow preset expansion logic so reruns and worker-created child runs use the same implementation.
- Expand explicit unexpanded task templates during fresh rerun creation before storing and starting the new execution.
- Add regression coverage for Jira Orchestrate reruns expanding into concrete executable steps instead of resolving the preset slug as an agent skill.

## Root Cause

Jira Orchestrate is a preset slug, not an agent skill. Fresh exact reruns could preserve workflow.taskTemplate but omit the flattened workflow.steps, so the runtime planner generated one node with selectedSkill=jira-orchestrate. The agent skill resolver then correctly failed because no such skill exists in the catalog.

## Validation

- pytest tests/unit/workflows/temporal/test_temporal_service.py::test_fresh_rerun_expands_unexpanded_jira_orchestrate_template -q --tb=short
- pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_child_jira_orchestrate_workflow_payload_expands_seeded_template_steps -q --tb=short
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
- python3 -m py_compile moonmind/workflows/executions/preset_expansion.py moonmind/workflows/temporal/service.py moonmind/workflows/temporal/worker_runtime.py

Note: full ./tools/test_unit.sh was started and stopped at 10%% after about 26 minutes with no failures observed; without xdist it was too slow for this turn.
