### PR TITLE
MM-833 enforce pentest submission roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,8 @@ Key diagnostics:
 - Existing artifact store and workflow history only; no new persistent database tables planned. (001-pentest-activity-handler)
 - Python 3.12 + Pydantic v2, FastAPI, Temporal Python SDK, `httpx`, existing MoonMind outbound scan and redaction helpers (001-scan-message-send)
 - No new persistent storage; diagnostics are returned/logged through existing activity/API/workflow update failure result paths (001-scan-message-send)
+- Python 3.12; TypeScript/React present for Mission Control but not expected for this story. + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, existing executable tool registry and Temporal execution router. (001-enforce-pentest-role)
+- Existing execution records and task input snapshot artifacts only; no new persistent storage. (001-enforce-pentest-role)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5444,6 +5444,156 @@ def _normalize_task_tool(task_payload: dict[str, Any]) -> dict[str, Any] | None:
         normalized["inputs"] = dict(inline_inputs)
     return normalized
 
+_PENTEST_TOOL_NAME = "security.pentest.run"
+_PENTEST_ALLOWED_ROLES = frozenset({"admin", "security_operator"})
+_PENTEST_PRIVILEGED_INPUT_FIELDS = frozenset(
+    {
+        "image",
+        "runner_image",
+        "provider_secret",
+        "provider_secret_ref",
+        "provider_secret_id",
+        "secret",
+        "secrets",
+        "env",
+        "environment",
+        "environment_variables",
+        "network",
+        "network_mode",
+        "mount",
+        "mounts",
+        "host_mount",
+        "host_mounts",
+        "capability",
+        "capabilities",
+        "docker_args",
+        "docker",
+        "command",
+        "raw_command",
+        "args",
+    }
+)
+
+def _tool_payload_name(payload: Mapping[str, Any] | None) -> str:
+    if not isinstance(payload, Mapping):
+        return ""
+    return str(payload.get("name") or payload.get("id") or "").strip()
+
+def _is_pentest_tool_payload(payload: Mapping[str, Any] | None) -> bool:
+    return _tool_payload_name(payload).lower() == _PENTEST_TOOL_NAME
+
+def _pentest_input_payloads_for_submission(
+    *,
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: list[dict[str, Any]],
+) -> list[Mapping[str, Any]]:
+    payloads: list[Mapping[str, Any]] = []
+    if _is_pentest_tool_payload(normalized_tool):
+        if isinstance(normalized_tool.get("inputs"), Mapping):
+            payloads.append(normalized_tool["inputs"])
+        if isinstance(task_payload.get("inputs"), Mapping):
+            payloads.append(task_payload["inputs"])
+
+    for step in normalized_steps:
+        step_tool = step.get("tool") if isinstance(step.get("tool"), Mapping) else None
+        step_skill = (
+            step.get("skill") if isinstance(step.get("skill"), Mapping) else None
+        )
+        selected = step_tool if _is_pentest_tool_payload(step_tool) else step_skill
+        if not _is_pentest_tool_payload(selected):
+            continue
+        for key in ("inputs", "args"):
+            value = selected.get(key) if isinstance(selected, Mapping) else None
+            if isinstance(value, Mapping):
+                payloads.append(value)
+    return payloads
+
+def _submission_contains_pentest_tool(
+    *,
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: list[dict[str, Any]],
+) -> bool:
+    if _is_pentest_tool_payload(normalized_tool):
+        return True
+    for step in normalized_steps:
+        step_tool = step.get("tool") if isinstance(step.get("tool"), Mapping) else None
+        step_skill = (
+            step.get("skill") if isinstance(step.get("skill"), Mapping) else None
+        )
+        if _is_pentest_tool_payload(step_tool) or _is_pentest_tool_payload(step_skill):
+            return True
+    return False
+
+def _normalize_user_role_name(value: Any) -> str:
+    if isinstance(value, Mapping):
+        value = value.get("name") or value.get("role") or value.get("id")
+    return str(value or "").strip().lower()
+
+def _effective_user_roles(user: Any) -> set[str]:
+    roles: set[str] = set()
+    for attr_name in ("roles", "role_names", "groups"):
+        raw = getattr(user, attr_name, None)
+        if isinstance(raw, str):
+            roles.update(
+                role for role in (_normalize_user_role_name(raw),) if role
+            )
+        elif isinstance(raw, (list, tuple, set, frozenset)):
+            roles.update(
+                role
+                for item in raw
+                for role in (_normalize_user_role_name(item),)
+                if role
+            )
+    role = _normalize_user_role_name(getattr(user, "role", None))
+    if role:
+        roles.add(role)
+    if bool(getattr(user, "is_superuser", False)):
+        roles.add("admin")
+    return roles
+
+def _validate_pentest_submission_boundary(
+    *,
+    task_payload: Mapping[str, Any],
+    normalized_tool: Mapping[str, Any] | None,
+    normalized_steps: list[dict[str, Any]],
+    user: Any,
+) -> None:
+    if not _submission_contains_pentest_tool(
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+    ):
+        return
+
+    if not settings.pentest.enabled:
+        raise _invalid_workflow_request(
+            "security.pentest.run submission is disabled by MOONMIND_PENTEST_ENABLED."
+        )
+
+    user_roles = _effective_user_roles(user)
+    if user_roles.isdisjoint(_PENTEST_ALLOWED_ROLES):
+        raise _invalid_workflow_request(
+            "security.pentest.run submission requires an admin or security_operator role."
+        )
+
+    for inputs in _pentest_input_payloads_for_submission(
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+    ):
+        blocked = sorted(
+            str(key)
+            for key in inputs.keys()
+            if str(key).strip().lower() in _PENTEST_PRIVILEGED_INPUT_FIELDS
+        )
+        if blocked:
+            raise _invalid_workflow_request(
+                "security.pentest.run submission contains privileged input fields "
+                f"that are not user-editable: {', '.join(blocked)}."
+            )
+
 def _validate_workflow_runtime_requirements(
     *,
     task_payload: dict[str, Any],
@@ -6368,6 +6518,12 @@ async def _create_execution_from_workflow_request(
         payload.get("report_output"),
     )
     normalized_tool = _normalize_task_tool(task_payload)
+    _validate_pentest_submission_boundary(
+        task_payload=task_payload,
+        normalized_tool=normalized_tool,
+        normalized_steps=normalized_steps,
+        user=user,
+    )
     publish_payload = _resolve_workflow_publish_payload(
         payload=payload,
         task_payload=task_payload,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5453,6 +5453,7 @@ _PENTEST_PRIVILEGED_INPUT_FIELDS = frozenset(
         "provider_secret",
         "provider_secret_ref",
         "provider_secret_id",
+        "provider_runtime_state",
         "secret",
         "secrets",
         "env",
@@ -5529,9 +5530,45 @@ def _submission_contains_pentest_tool(
 def _normalize_user_role_name(value: Any) -> str:
     if isinstance(value, Mapping):
         value = value.get("name") or value.get("role") or value.get("id")
+    elif value is not None and not isinstance(value, str):
+        value = (
+            getattr(value, "name", None)
+            or getattr(value, "role", None)
+            or getattr(value, "id", None)
+            or value
+        )
     return str(value or "").strip().lower()
 
-def _effective_user_roles(user: Any) -> set[str]:
+def _role_values_from_claims(claims: Any) -> list[Any]:
+    if not isinstance(claims, Mapping):
+        return []
+
+    values: list[Any] = []
+    for key in ("roles", "role_names", "groups", "role"):
+        value = claims.get(key)
+        if isinstance(value, (list, tuple, set, frozenset)):
+            values.extend(value)
+        elif value is not None:
+            values.append(value)
+
+    realm_access = claims.get("realm_access")
+    if isinstance(realm_access, Mapping):
+        realm_roles = realm_access.get("roles")
+        if isinstance(realm_roles, (list, tuple, set, frozenset)):
+            values.extend(realm_roles)
+
+    resource_access = claims.get("resource_access")
+    if isinstance(resource_access, Mapping):
+        for resource_claims in resource_access.values():
+            if not isinstance(resource_claims, Mapping):
+                continue
+            resource_roles = resource_claims.get("roles")
+            if isinstance(resource_roles, (list, tuple, set, frozenset)):
+                values.extend(resource_roles)
+
+    return values
+
+def _effective_user_roles(user: Any, request: Any | None = None) -> set[str]:
     roles: set[str] = set()
     for attr_name in ("roles", "role_names", "groups"):
         raw = getattr(user, attr_name, None)
@@ -5549,6 +5586,32 @@ def _effective_user_roles(user: Any) -> set[str]:
     role = _normalize_user_role_name(getattr(user, "role", None))
     if role:
         roles.add(role)
+    for claim_attr in ("claims", "oidc_claims", "token_claims"):
+        roles.update(
+            role
+            for value in _role_values_from_claims(getattr(user, claim_attr, None))
+            for role in (_normalize_user_role_name(value),)
+            if role
+        )
+    if request is not None:
+        request_state = getattr(request, "state", None)
+        for claim_attr in ("claims", "oidc_claims", "token_claims"):
+            roles.update(
+                role
+                for value in _role_values_from_claims(
+                    getattr(request_state, claim_attr, None)
+                )
+                for role in (_normalize_user_role_name(value),)
+                if role
+            )
+        scope = getattr(request, "scope", None)
+        if isinstance(scope, Mapping):
+            roles.update(
+                role
+                for value in _role_values_from_claims(scope.get("claims"))
+                for role in (_normalize_user_role_name(value),)
+                if role
+            )
     if bool(getattr(user, "is_superuser", False)):
         roles.add("admin")
     return roles
@@ -5559,6 +5622,7 @@ def _validate_pentest_submission_boundary(
     normalized_tool: Mapping[str, Any] | None,
     normalized_steps: list[dict[str, Any]],
     user: Any,
+    request: Any | None = None,
 ) -> None:
     if not _submission_contains_pentest_tool(
         task_payload=task_payload,
@@ -5572,7 +5636,7 @@ def _validate_pentest_submission_boundary(
             "security.pentest.run submission is disabled by MOONMIND_PENTEST_ENABLED."
         )
 
-    user_roles = _effective_user_roles(user)
+    user_roles = _effective_user_roles(user, request=request)
     if user_roles.isdisjoint(_PENTEST_ALLOWED_ROLES):
         raise _invalid_workflow_request(
             "security.pentest.run submission requires an admin or security_operator role."
@@ -6523,6 +6587,7 @@ async def _create_execution_from_workflow_request(
         normalized_tool=normalized_tool,
         normalized_steps=normalized_steps,
         user=user,
+        request=(principal_context or {}).get("request"),
     )
     publish_payload = _resolve_workflow_publish_payload(
         payload=payload,

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 
+from api_service.api.routers.executions import _create_execution_from_workflow_request
+from api_service.api.schemas import CreateJobRequest
+from moonmind.config.settings import settings
 from moonmind.integrations.pentest.models import (
     PentestWorkloadRequest,
     PentestWorkloadResult,
@@ -259,6 +264,61 @@ async def test_security_pentest_tool_contract_routes_to_curated_activity() -> No
     ]
     assert result.outputs["summary_artifact_ref"] == "art:sha256:summary"
     assert result.outputs["confirmed_findings_count"] == 1
+
+async def test_security_pentest_submission_boundary_rejects_unauthorized_before_execution_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+    service = AsyncMock()
+    user = SimpleNamespace(
+        id="user-security",
+        roles=["developer"],
+        is_superuser=False,
+    )
+    request = CreateJobRequest(
+        type="workflow",
+        payload={
+            "workflow": {
+                "title": "Pentest recon",
+                "instructions": "Run approved pentest recon.",
+                "tool": {
+                    "type": "skill",
+                    "name": "security.pentest.run",
+                    "version": "1.0.0",
+                    "inputs": {
+                        "target": "https://lab.example.test",
+                        "scope_artifact_ref": "art_scope_valid",
+                        "operation_mode": "recon_only",
+                        "runner_profile_id": "pentestgpt-safe",
+                        "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                        "time_budget_minutes": 60,
+                        "evidence_level": "standard",
+                        "approved_scope": {
+                            "authorized_principals": ["user-security"],
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _create_execution_from_workflow_request(
+            request=request,
+            service=service,
+            user=user,
+            session=None,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == {
+        "code": "invalid_execution_request",
+        "message": (
+            "security.pentest.run submission requires an admin or "
+            "security_operator role."
+        ),
+    }
+    service.create_execution.assert_not_awaited()
 
 async def test_security_pentest_execute_accepts_valid_artifact_backed_scope() -> None:
     artifact_service = _FakeArtifactService({"art_scope_valid": _scope_bytes()})

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7,6 +7,7 @@ import base64
 import json
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, Mock, call, patch
@@ -404,12 +405,18 @@ def _override_query_client(
     app.dependency_overrides[get_temporal_client] = lambda: client
     return client
 
-def _override_user_dependencies(app: FastAPI, *, is_superuser: bool) -> SimpleNamespace:
+def _override_user_dependencies(
+    app: FastAPI,
+    *,
+    is_superuser: bool,
+    roles: list[str] | None = None,
+) -> SimpleNamespace:
     mock_user = SimpleNamespace(
         id=uuid4(),
         email="executions@example.com",
         is_active=True,
         is_superuser=is_superuser,
+        roles=list(roles or []),
     )
     user_dependencies = {
         dep.call
@@ -4141,6 +4148,210 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
     assert initial_parameters["workflow"]["git"] == {
         "startingBranch": "feature/resolve-pr"
     }
+
+def _pentest_workflow_payload(
+    *,
+    tool_inputs: dict[str, object] | None = None,
+    step_inputs: dict[str, object] | None = None,
+    authorized_principals: list[str] | None = None,
+) -> dict[str, object]:
+    safe_inputs: dict[str, object] = {
+        "target": "https://lab.example.test",
+        "scope_artifact_ref": "art_scope_valid",
+        "objective": "Recon only",
+        "operation_mode": "recon_only",
+        "runner_profile_id": "pentestgpt-safe",
+        "execution_profile_ref": "pentestgpt_anthropic_api_team",
+        "time_budget_minutes": 60,
+        "evidence_level": "standard",
+    }
+    if authorized_principals is not None:
+        safe_inputs["approved_scope"] = {
+            "authorized_principals": authorized_principals,
+        }
+    if tool_inputs:
+        safe_inputs.update(tool_inputs)
+    step_safe_inputs = dict(safe_inputs)
+    if step_inputs:
+        step_safe_inputs.update(step_inputs)
+    return {
+        "type": "workflow",
+        "payload": {
+            "workflow": {
+                "title": "Pentest recon",
+                "instructions": "Run the approved pentest.",
+                "tool": {
+                    "type": "skill",
+                    "name": "security.pentest.run",
+                    "version": "1.0.0",
+                    "inputs": safe_inputs,
+                },
+                "steps": [
+                    {
+                        "id": "step-pentest",
+                        "type": "tool",
+                        "instructions": "Run the curated pentest tool.",
+                        "tool": {
+                            "type": "skill",
+                            "name": "security.pentest.run",
+                            "version": "1.0.0",
+                            "inputs": step_safe_inputs,
+                        },
+                    }
+                ],
+            }
+        },
+    }
+
+def test_create_task_shaped_execution_rejects_disabled_pentest_submission(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, user = client
+    user.roles = ["admin"]
+    monkeypatch.setattr(settings.pentest, "enabled", False)
+
+    response = test_client.post("/api/executions", json=_pentest_workflow_payload())
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "disabled" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+@pytest.mark.parametrize("role", ["admin", "security_operator"])
+def test_create_task_shaped_execution_accepts_authorized_pentest_roles(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+) -> None:
+    test_client, service, user = client
+    user.roles = [role]
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post("/api/executions", json=_pentest_workflow_payload())
+
+    assert response.status_code == 201
+    workflow = service.create_execution.await_args.kwargs["initial_parameters"][
+        "workflow"
+    ]
+    assert workflow["tool"] == {
+        "type": "skill",
+        "name": "security.pentest.run",
+        "version": "1.0.0",
+        "inputs": {
+            "target": "https://lab.example.test",
+            "scope_artifact_ref": "art_scope_valid",
+            "objective": "Recon only",
+            "operation_mode": "recon_only",
+            "runner_profile_id": "pentestgpt-safe",
+            "execution_profile_ref": "pentestgpt_anthropic_api_team",
+            "time_budget_minutes": 60,
+            "evidence_level": "standard",
+        },
+    }
+
+@pytest.mark.parametrize("roles", [[], [""], ["developer"], ["viewer", "auditor"]])
+def test_create_task_shaped_execution_rejects_non_security_pentest_roles(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+    roles: list[str],
+) -> None:
+    test_client, service, user = client
+    user.roles = roles
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+
+    response = test_client.post("/api/executions", json=_pentest_workflow_payload())
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "admin or security_operator" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+def test_create_task_shaped_execution_rejects_scope_member_without_pentest_role(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, user = client
+    user.roles = ["developer"]
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+
+    response = test_client.post(
+        "/api/executions",
+        json=_pentest_workflow_payload(authorized_principals=[str(user.id)]),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    service.create_execution.assert_not_awaited()
+
+def test_create_task_shaped_execution_rejects_pentest_privileged_overrides(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, user = client
+    user.roles = ["security_operator"]
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+
+    response = test_client.post(
+        "/api/executions",
+        json=_pentest_workflow_payload(
+            tool_inputs={
+                "image": "unsafe:latest",
+                "provider_secret": "secret-value",
+                "env": {"TOKEN": "secret-value"},
+                "network": "host",
+                "mounts": ["/:/host"],
+                "capabilities": ["SYS_ADMIN"],
+                "raw_command": "sh -lc id",
+            }
+        ),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    message = response.json()["detail"]["message"]
+    assert "privileged" in message
+    assert "secret-value" not in message
+    service.create_execution.assert_not_awaited()
+
+def test_pentest_safe_preset_exposes_only_ordinary_inputs() -> None:
+    import yaml
+
+    preset_path = Path("api_service/data/presets/pentest-recon.yaml")
+    preset = yaml.safe_load(preset_path.read_text())
+    schema_props = set(preset["annotations"]["inputSchema"]["properties"])
+    exposed_inputs = {item["name"] for item in preset["inputs"]}
+    step_inputs = preset["steps"][0]["tool"]["inputs"]
+    privileged = {
+        "image",
+        "provider_secret",
+        "provider_secret_ref",
+        "env",
+        "environment",
+        "network",
+        "mount",
+        "mounts",
+        "capability",
+        "capabilities",
+        "command",
+        "raw_command",
+    }
+
+    assert schema_props == {
+        "target",
+        "scope_artifact_ref",
+        "objective",
+        "operation_mode",
+        "evidence_level",
+        "time_budget_minutes",
+        "execution_profile_ref",
+    }
+    assert exposed_inputs == schema_props
+    assert privileged.isdisjoint(schema_props)
+    assert privileged.isdisjoint(exposed_inputs)
+    assert step_inputs["runner_profile_id"] == "pentestgpt-safe"
+    assert privileged.isdisjoint(step_inputs)
 
 def test_create_task_shaped_submit_accepts_task_payload_pr_resolver(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -26,6 +26,7 @@ from api_service.api.routers.executions import (
     _build_original_workflow_input_snapshot_payload,
     _expand_goal_preset_for_workflow_submission,
     _extract_cost_estimate_usd,
+    _effective_user_roles,
     _hydrate_related_run_metadata,
     _merge_workflow_preserving_artifact_instructions,
     _recovery_not_available_reason,
@@ -4313,7 +4314,55 @@ def test_create_task_shaped_execution_rejects_pentest_privileged_overrides(
     message = response.json()["detail"]["message"]
     assert "privileged" in message
     assert "secret-value" not in message
+
+def test_create_task_shaped_execution_rejects_pentest_provider_runtime_state_override(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, user = client
+    user.roles = ["security_operator"]
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+
+    response = test_client.post(
+        "/api/executions",
+        json=_pentest_workflow_payload(
+            tool_inputs={
+                "provider_runtime_state": {
+                    "pentestgpt_anthropic_api_team": {"available_slots": 100}
+                }
+            }
+        ),
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "provider_runtime_state" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
+
+def test_pentest_role_resolution_reads_object_values_and_request_claims() -> None:
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            claims={
+                "realm_access": {"roles": ["security_operator"]},
+                "resource_access": {
+                    "moonmind": {"roles": ["workflow_submitter"]},
+                },
+            }
+        ),
+        scope={},
+    )
+    user = SimpleNamespace(
+        is_superuser=False,
+        roles=[SimpleNamespace(name="viewer")],
+        groups=[SimpleNamespace(role="auditor")],
+    )
+
+    assert _effective_user_roles(user, request=request) == {
+        "auditor",
+        "security_operator",
+        "viewer",
+        "workflow_submitter",
+    }
 
 def test_pentest_safe_preset_exposes_only_ordinary_inputs() -> None:
     import yaml


### PR DESCRIPTION
Jira issue key: MM-833

Active MoonSpec feature path: specs/001-enforce-pentest-role

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py - PASS (265 Python tests passed; frontend wrapper tests passed: 27 files, 422 passed, 234 skipped)
- ./tools/test_integration.sh - PASS (295 passed, 1 skipped, 82 deselected)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh - PASS (6098 passed, 6 skipped, 1 xpassed; frontend wrapper tests passed: 27 files, 422 passed, 234 skipped)

Remaining risks:
- None blocking identified by post-remediation MoonSpec verification.
- Runtime authorization depends on authenticated user role metadata being populated consistently by the execution submission path.

Doc reconciliation outcome:
- artifacts/jira-orchestrate-doc-reconcile.json reports no_update_required.
- Canonical doc paths considered: docs/Steps/PentestTool.md.
- No-update rationale: the latest MM-833 post-remediation verification verdict was FULLY_IMPLEMENTED; the Source Document Drift section found no blocking drift; docs/Steps/PentestTool.md already describes the implemented desired state for gated discovery, allowed roles, curated activity routing, safe runner constraints, and non-terminal ordinary UX; no doc discovery ledger was present, so no definite evidence-backed discovery passed the update gate.
