### PR TITLE
MM-834 Wire Pentest provider-profile capacity leases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,8 @@ Key diagnostics:
 - No new persistent storage; diagnostics are returned/logged through existing activity/API/workflow update failure result paths (001-scan-message-send)
 - Python 3.12; TypeScript/React present for Mission Control but not expected for this story. + FastAPI, Pydantic v2, SQLAlchemy async ORM, Temporal Python SDK, existing executable tool registry and Temporal execution router. (001-enforce-pentest-role)
 - Existing execution records and task input snapshot artifacts only; no new persistent storage. (001-enforce-pentest-role)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing Pentest workload launcher and artifact services (001-pentest-provider-leases)
+- Existing Temporal workflow/activity payloads and provider-profile manager workflow signals; no new persistent storage (001-pentest-provider-leases)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -45,6 +45,7 @@ PentestFailureKind = Literal[
     "image_pull",
     "container_start",
     "provider_slot_timeout",
+    "provider_capacity",
     "transient_infrastructure",
     "runtime_action",
     "provider_error",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -255,9 +255,12 @@ class TemporalPentestProviderLeaseManager:
         owner: str,
         metadata: Mapping[str, Any],
     ) -> str:
-        await self._client_adapter.signal_workflow(
+        update_workflow = getattr(self._client_adapter, "update_workflow", None)
+        if update_workflow is None:
+            raise RuntimeError("Temporal client adapter does not support workflow updates")
+        await update_workflow(
             _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
-            "request_slot",
+            "AcquireSlot",
             {
                 "requester_workflow_id": owner,
                 "runtime_id": runtime_id,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -207,6 +207,138 @@ async def _run_command(cmd, **kwargs):
 
 logger = getLogger(__name__)
 
+_PENTEST_PROVIDER_MANAGER_WORKFLOW_ID = "provider-profile-manager:pentestgpt"
+
+
+class PentestProviderLeaseManager(Protocol):
+    async def acquire(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        metadata: Mapping[str, Any],
+    ) -> str:
+        """Acquire provider capacity for one PentestGPT attempt."""
+
+    async def release(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        lease_id: str,
+    ) -> None:
+        """Release provider capacity for one PentestGPT attempt."""
+
+    async def record_cooldown(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        cooldown_seconds: int,
+        reason: str,
+    ) -> None:
+        """Record provider cooldown for a quota or rate-limit failure."""
+
+
+class TemporalPentestProviderLeaseManager:
+    def __init__(self, client_adapter: Any) -> None:
+        self._client_adapter = client_adapter
+
+    async def acquire(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        metadata: Mapping[str, Any],
+    ) -> str:
+        await self._client_adapter.signal_workflow(
+            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
+            "request_slot",
+            {
+                "requester_workflow_id": owner,
+                "runtime_id": runtime_id,
+                "execution_profile_ref": profile_id,
+                "metadata": dict(metadata),
+            },
+        )
+        return owner
+
+    async def release(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        lease_id: str,
+    ) -> None:
+        await self._client_adapter.signal_workflow(
+            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
+            "release_slot",
+            {
+                "requester_workflow_id": owner,
+                "runtime_id": runtime_id,
+                "profile_id": profile_id,
+                "lease_id": lease_id,
+            },
+        )
+
+    async def record_cooldown(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        cooldown_seconds: int,
+        reason: str,
+    ) -> None:
+        await self._client_adapter.signal_workflow(
+            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
+            "report_cooldown",
+            {
+                "runtime_id": runtime_id,
+                "profile_id": profile_id,
+                "requester_workflow_id": owner,
+                "cooldown_seconds": cooldown_seconds,
+                "reason": reason,
+            },
+        )
+
+
+def _pentest_provider_lease_owner(
+    *,
+    agent_run_id: str,
+    step_id: str,
+    attempt: int,
+) -> str:
+    return f"pentest:{agent_run_id}:{step_id}:{attempt}"
+
+
+def _pentest_target_hash(target: str) -> str:
+    return hashlib.sha256(target.encode("utf-8")).hexdigest()
+
+
+def _pentest_provider_lease_safe_metadata(
+    request: PentestWorkloadRequest,
+    *,
+    runtime_id: str,
+    profile_id: str,
+) -> dict[str, Any]:
+    return {
+        "tool": "security.pentest.run",
+        "runtime_id": runtime_id,
+        "profile_id": profile_id,
+        "agent_run_id": request.agent_run_id,
+        "step_id": request.step_id,
+        "attempt": request.attempt,
+        "target_hash": _pentest_target_hash(request.target),
+        "mode": request.operation_mode,
+        "runner_profile": request.runner_profile_id,
+    }
+
 _GIT_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS = 100_000
 _GIT_PUSH_SCAN_MAX_FILE_DIFF_CHARS = 200_000
 _GIT_PUSH_SCAN_MAX_CHANGED_FILES = 200
@@ -4300,6 +4432,7 @@ class TemporalAgentRuntimeActivities:
         workload_registry: Any | None = None,
         workflow_docker_mode: str = "profiles",
         client_adapter: Any = None,
+        pentest_provider_lease_manager: PentestProviderLeaseManager | None = None,
     ) -> None:
         self._artifact_service = artifact_service
         self._run_store = run_store
@@ -4314,6 +4447,10 @@ class TemporalAgentRuntimeActivities:
 
             client_adapter = temporal_client_module.TemporalClientAdapter()
         self._client_adapter = client_adapter
+        self._pentest_provider_lease_manager = (
+            pentest_provider_lease_manager
+            or TemporalPentestProviderLeaseManager(client_adapter)
+        )
         self._supervision_tasks: set[asyncio.Task] = set()
 
     @staticmethod
@@ -5319,6 +5456,29 @@ class TemporalAgentRuntimeActivities:
                 },
             }
 
+        lease_runtime_id: str | None = None
+        lease_profile_id: str | None = None
+        lease_owner: str | None = None
+        lease_id: str | None = None
+        lease_release_attempted = False
+
+        async def release_provider_lease() -> bool:
+            nonlocal lease_release_attempted
+            if not all(
+                (lease_id, lease_runtime_id, lease_profile_id, lease_owner)
+            ):
+                return False
+            if lease_release_attempted:
+                return True
+            lease_release_attempted = True
+            await self._pentest_provider_lease_manager.release(
+                runtime_id=lease_runtime_id,
+                profile_id=lease_profile_id,
+                owner=lease_owner,
+                lease_id=lease_id,
+            )
+            return True
+
         enabled = _coerce_bool(
             policy_payload.get(
                 "pentest_enabled",
@@ -5381,6 +5541,34 @@ class TemporalAgentRuntimeActivities:
                 provider_selector=request.provider_selector,
                 runtime_state=request.provider_runtime_state,
             )
+            lease_runtime_id = provider_profile.runtime_id
+            lease_profile_id = provider_profile.profile_id
+            lease_owner = _pentest_provider_lease_owner(
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+            )
+            try:
+                lease_id = await self._pentest_provider_lease_manager.acquire(
+                    runtime_id=lease_runtime_id,
+                    profile_id=lease_profile_id,
+                    owner=lease_owner,
+                    metadata=_pentest_provider_lease_safe_metadata(
+                        request,
+                        runtime_id=lease_runtime_id,
+                        profile_id=lease_profile_id,
+                    ),
+                )
+            except Exception as exc:
+                return structured_failure(
+                    status="provider_capacity_failed",
+                    target=request.target,
+                    failure_kind="provider_capacity",
+                    interaction_state="pre_interaction",
+                    phase="waiting_for_profile_slot",
+                    reason=str(exc),
+                    diagnostics={"provider_capacity": "lease_manager_failure"},
+                )
             provider_materialization = materialize_pentest_provider_profile(
                 provider_profile
             )
@@ -5395,6 +5583,15 @@ class TemporalAgentRuntimeActivities:
             PentestLaunchPolicyError,
             PentestProviderMaterializationError,
         ) as exc:
+            provider_lease_released = False
+            if lease_id:
+                try:
+                    provider_lease_released = await release_provider_lease()
+                except Exception as release_exc:
+                    logger.warning(
+                        "failed to release Pentest provider lease after validation failure: %s",
+                        release_exc,
+                    )
             diagnostics = dict(getattr(exc, "diagnostics", {}) or {})
             reason_code = getattr(exc, "reason", None)
             if reason_code:
@@ -5407,10 +5604,18 @@ class TemporalAgentRuntimeActivities:
                 phase="validating_scope",
                 reason=str(exc),
                 diagnostics=diagnostics if isinstance(diagnostics, Mapping) else {},
+                provider_lease_released=provider_lease_released,
             )
         output = launch_plan.to_activity_output(request)
         output["provider_profile"] = provider_materialization.model_dump(mode="json")
         provider_lease = pentest_provider_lease_metadata(provider_profile)
+        provider_lease["lease_id"] = lease_id
+        provider_lease["lease_owner"] = lease_owner
+        provider_lease["metadata"] = _pentest_provider_lease_safe_metadata(
+            request,
+            runtime_id=provider_profile.runtime_id,
+            profile_id=provider_profile.profile_id,
+        )
         output["provider_lease"] = provider_lease
         execution_metadata = execution_materialization.model_dump(mode="json")
         execution_metadata["instruction_bundle"].pop("content", None)
@@ -5428,6 +5633,14 @@ class TemporalAgentRuntimeActivities:
                 )
             )
         except OSError as exc:
+            provider_lease_released = False
+            try:
+                provider_lease_released = await release_provider_lease()
+            except Exception as release_exc:
+                logger.warning(
+                    "failed to release Pentest provider lease after materialization failure: %s",
+                    release_exc,
+                )
             output.update(
                 structured_failure(
                     status="failed",
@@ -5437,6 +5650,7 @@ class TemporalAgentRuntimeActivities:
                     phase="materializing_inputs",
                     reason=str(exc),
                     diagnostics={"materialization": "input_file_write_failed"},
+                    provider_lease_released=provider_lease_released,
                 )
             )
             return output
@@ -5471,6 +5685,27 @@ class TemporalAgentRuntimeActivities:
                 cooldown_seconds=provider_profile.cooldown_after_429_seconds,
                 reason=failure_category,
             ).model_dump(mode="json")
+            try:
+                await self._pentest_provider_lease_manager.record_cooldown(
+                    runtime_id=provider_profile.runtime_id,
+                    profile_id=provider_profile.profile_id,
+                    owner=lease_owner or "",
+                    cooldown_seconds=provider_profile.cooldown_after_429_seconds,
+                    reason=failure_category,
+                )
+            except Exception as cooldown_exc:
+                logger.warning(
+                    "failed to record Pentest provider cooldown: %s",
+                    cooldown_exc,
+                )
+            provider_lease_released = False
+            try:
+                provider_lease_released = await release_provider_lease()
+            except Exception as release_exc:
+                logger.warning(
+                    "failed to release Pentest provider lease after cooldown: %s",
+                    release_exc,
+                )
             output.update(
                 structured_failure(
                     status="provider_cooldown",
@@ -5480,12 +5715,19 @@ class TemporalAgentRuntimeActivities:
                     phase="waiting_for_profile_slot",
                     reason=failure_category,
                     diagnostics={"provider_cooldown": cooldown},
-                    provider_lease_released=False,
+                    provider_lease_released=provider_lease_released,
                 )
             )
             output["provider_cooldown"] = cooldown
             output["provider_lease"] = pentest_provider_lease_metadata(
                 provider_profile, release_required=True
+            )
+            output["provider_lease"]["lease_id"] = lease_id
+            output["provider_lease"]["lease_owner"] = lease_owner
+            output["provider_lease"]["metadata"] = _pentest_provider_lease_safe_metadata(
+                request,
+                runtime_id=provider_profile.runtime_id,
+                profile_id=provider_profile.profile_id,
             )
             return output
 
@@ -5560,6 +5802,14 @@ class TemporalAgentRuntimeActivities:
                 else:
                     workload_result = WorkloadResult.model_validate(raw_workload_result)
         except Exception as exc:
+            provider_lease_released = False
+            try:
+                provider_lease_released = await release_provider_lease()
+            except Exception as release_exc:
+                logger.warning(
+                    "failed to release Pentest provider lease after workload failure: %s",
+                    release_exc,
+                )
             output.update(
                 structured_failure(
                     status="failed",
@@ -5569,7 +5819,7 @@ class TemporalAgentRuntimeActivities:
                     phase="running",
                     reason=str(exc),
                     launched=True,
-                    provider_lease_released=True,
+                    provider_lease_released=provider_lease_released,
                 )
             )
             return output
@@ -5614,6 +5864,14 @@ class TemporalAgentRuntimeActivities:
             severity_counts[severity] = severity_counts.get(severity, 0) + 1
 
         if workload_result.status != "succeeded":
+            provider_lease_released = False
+            try:
+                provider_lease_released = await release_provider_lease()
+            except Exception as release_exc:
+                logger.warning(
+                    "failed to release Pentest provider lease after terminal workload status: %s",
+                    release_exc,
+                )
             terminal_reason = (
                 "timeout"
                 if workload_result.status == "timed_out"
@@ -5633,7 +5891,7 @@ class TemporalAgentRuntimeActivities:
                     reason=workload_result.timeout_reason
                     or f"Pentest workload ended with status {workload_result.status}.",
                     launched=True,
-                    provider_lease_released=True,
+                    provider_lease_released=provider_lease_released,
                     stdout_ref=stdout_ref,
                     stderr_ref=stderr_ref,
                     diagnostics_ref=diagnostics_ref,
@@ -5643,6 +5901,14 @@ class TemporalAgentRuntimeActivities:
             output["terminal_cleanup"]["terminal_reason"] = terminal_reason
             return output
 
+        provider_lease_released = False
+        try:
+            provider_lease_released = await release_provider_lease()
+        except Exception as release_exc:
+            logger.warning(
+                "failed to release Pentest provider lease after success: %s",
+                release_exc,
+            )
         result = PentestWorkloadResult(
             status="completed",
             target=request.target,
@@ -5701,7 +5967,7 @@ class TemporalAgentRuntimeActivities:
             terminal_reason="success",
             last_phase="cleanup",
             launched=True,
-            provider_lease_released=True,
+            provider_lease_released=provider_lease_released,
             stdout_ref=stdout_ref,
             stderr_ref=stderr_ref,
             diagnostics_ref=diagnostics_ref,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -92,6 +92,16 @@ class SlotRequestPayload(TypedDict):
     execution_profile_ref: str | None
     lease_group_id: str | None
 
+class SlotAcquirePayload(TypedDict, total=False):
+    """Update payload: synchronously reserve a provider slot for an activity caller."""
+
+    requester_workflow_id: str
+    runtime_id: str
+    execution_profile_ref: str | None
+    profile_selector: dict[str, Any] | None
+    lease_group_id: str | None
+    metadata: dict[str, Any]
+
 class SlotReleasePayload(TypedDict):
     """Signal payload: an AgentRun releases its profile slot."""
 
@@ -399,6 +409,79 @@ class MoonMindProviderProfileManagerWorkflow:
         """Gracefully shut down the manager."""
         self._shutdown_requested = True
         self._has_new_events = True
+
+    @workflow.update(name="AcquireSlot")
+    async def acquire_slot(self, payload: SlotAcquirePayload) -> dict[str, Any]:
+        """Reserve and return a slot without requiring a callback signal.
+
+        Activity-owned workloads cannot receive ``slot_assigned``. This update
+        keeps those callers on the same manager-owned capacity ledger while
+        preserving the existing signal protocol for AgentRun workflows.
+        """
+
+        requester_id = self._normalize_optional_string(
+            payload.get("requester_workflow_id")
+        )
+        if requester_id is None:
+            raise exceptions.ApplicationError(
+                "requester_workflow_id is required", non_retryable=True
+            )
+        runtime_id = self._normalize_optional_string(payload.get("runtime_id"))
+        if runtime_id is None:
+            raise exceptions.ApplicationError(
+                "runtime_id is required", non_retryable=True
+            )
+
+        selector = self._normalize_selector(payload.get("profile_selector"))
+        execution_profile_ref = self._normalize_optional_string(
+            payload.get("execution_profile_ref")
+        )
+        lease_group_id = self._normalize_optional_string(payload.get("lease_group_id"))
+
+        while not self._shutdown_requested:
+            existing_profile_id = self._profile_id_for_lease(requester_id)
+            if existing_profile_id is not None:
+                return {
+                    "profile_id": existing_profile_id,
+                    "lease_id": requester_id,
+                    "already_held": True,
+                }
+
+            now = workflow.now()
+            self._clear_expired_handoff_reservations(now)
+            self._clear_expired_cooldowns()
+            profile = self._find_available_profile(
+                selector=selector,
+                execution_profile_ref=execution_profile_ref,
+                lease_group_id=lease_group_id,
+            )
+            if profile and profile.reserve(requester_id, now):
+                if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+                    await self._sync_leases_to_db()
+                self._has_new_events = True
+                return {
+                    "profile_id": profile.profile_id,
+                    "lease_id": requester_id,
+                    "already_held": False,
+                }
+
+            try:
+                await workflow.wait_condition(
+                    lambda: self._shutdown_requested
+                    or self._profile_id_for_lease(requester_id) is not None
+                    or self._has_available_profile(
+                        selector=selector,
+                        execution_profile_ref=execution_profile_ref,
+                        lease_group_id=lease_group_id,
+                    ),
+                    timeout=timedelta(seconds=60),
+                )
+            except TimeoutError:
+                pass
+
+        raise exceptions.ApplicationError(
+            "provider profile manager is shutting down", non_retryable=True
+        )
 
     # -- Queries ---------------------------------------------------------------
 
@@ -723,6 +806,28 @@ class MoonMindProviderProfileManagerWorkflow:
             if reserved_group_id != lease_group_id:
                 reserved_slots += 1
         return reserved_slots
+
+    def _profile_id_for_lease(self, requester_workflow_id: str) -> str | None:
+        for profile in self._profiles.values():
+            if requester_workflow_id in profile.current_leases:
+                return profile.profile_id
+        return None
+
+    def _has_available_profile(
+        self,
+        *,
+        selector: Optional[dict[str, Any]],
+        execution_profile_ref: str | None,
+        lease_group_id: str | None,
+    ) -> bool:
+        return (
+            self._find_available_profile(
+                selector=selector,
+                execution_profile_ref=execution_profile_ref,
+                lease_group_id=lease_group_id,
+            )
+            is not None
+        )
 
     @staticmethod
     def _profile_matches_request(

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -477,7 +477,8 @@ class MoonMindProviderProfileManagerWorkflow:
                     timeout=timedelta(seconds=60),
                 )
             except TimeoutError:
-                pass
+                # Periodic wake-up: re-check capacity, cooldowns, and shutdown.
+                continue
 
         raise exceptions.ApplicationError(
             "provider profile manager is shutting down", non_retryable=True

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any, Mapping
 from unittest.mock import AsyncMock
 
 import pytest
@@ -155,6 +156,73 @@ class _FakeLauncher:
                     "report.evidence": "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst",
                 },
             }
+        )
+
+class _FakePentestLeaseManager:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, object]]] = []
+
+    async def acquire(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        metadata: Mapping[str, Any],
+    ) -> str:
+        self.events.append(
+            (
+                "acquire",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "metadata": dict(metadata),
+                },
+            )
+        )
+        return f"lease:{owner}"
+
+    async def release(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        lease_id: str,
+    ) -> None:
+        self.events.append(
+            (
+                "release",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "lease_id": lease_id,
+                },
+            )
+        )
+
+    async def record_cooldown(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        cooldown_seconds: int,
+        reason: str,
+    ) -> None:
+        self.events.append(
+            (
+                "cooldown",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "cooldown_seconds": cooldown_seconds,
+                    "reason": reason,
+                },
+            )
         )
 
 class _RecordingPentestRegistry:
@@ -322,10 +390,12 @@ async def test_security_pentest_submission_boundary_rejects_unauthorized_before_
 
 async def test_security_pentest_execute_accepts_valid_artifact_backed_scope() -> None:
     artifact_service = _FakeArtifactService({"art_scope_valid": _scope_bytes()})
+    lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         artifact_service=artifact_service,
         workload_launcher=_FakeLauncher(),
         workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
     )
 
     result = await activities.security_pentest_execute(_pentest_execute_payload())
@@ -333,6 +403,10 @@ async def test_security_pentest_execute_accepts_valid_artifact_backed_scope() ->
     assert artifact_service.read_count == 1
     assert result["status"] == "completed"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+    assert result["provider_lease"]["lease_id"] == "lease:pentest:run-123:step-pentest:1"
+    assert result["provider_lease"]["metadata"]["target_hash"]
+    assert "https://lab.example.test" not in str(result["provider_lease"]["metadata"])
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
 
 @pytest.mark.parametrize(
     ("artifact_payload", "request_overrides", "error_code", "reason"),
@@ -429,9 +503,11 @@ async def test_security_pentest_execute_rejects_ordinary_inline_scope() -> None:
     assert launcher.requests == []
 
 async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -> None:
+    lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=_FakeLauncher(),
         workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
     )
 
     result = await activities._security_pentest_execute_trusted_internal(
@@ -443,6 +519,7 @@ async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -
     )
 
     assert result["status"] == "completed"
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
 
 async def test_security_pentest_execute_rejects_caller_supplied_trust_flag() -> None:
     """The registry-dispatched activity must not honor request-supplied trust."""
@@ -566,9 +643,11 @@ async def test_security_pentest_execute_disabled_policy_denies_before_launcher()
 async def test_security_pentest_execute_enabled_request_returns_report_first_success() -> None:
     launcher = _FakeLauncher()
     registry = _RecordingPentestRegistry()
+    lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=launcher,
         workload_registry=registry,
+        pentest_provider_lease_manager=lease_manager,
     )
 
     result = await activities._security_pentest_execute_trusted_internal(
@@ -603,13 +682,16 @@ async def test_security_pentest_execute_enabled_request_returns_report_first_suc
     }.issubset(artifact_names)
     assert result["terminal_cleanup"]["terminal_reason"] == "success"
     assert result["terminal_cleanup"]["provider_lease_released"] is True
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
     assert result["execution_policy"]["automatic_retries_enabled"] is False
 
 async def test_security_pentest_execute_runtime_failure_returns_structured_cleanup() -> None:
     launcher = _FakeLauncher(status="failed")
+    lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=launcher,
         workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
     )
 
     result = await activities._security_pentest_execute_trusted_internal(
@@ -623,3 +705,4 @@ async def test_security_pentest_execute_runtime_failure_returns_structured_clean
     assert result["terminal_cleanup"]["terminal_reason"] == "failure"
     assert result["terminal_cleanup"]["container_removed"] is True
     assert result["terminal_cleanup"]["provider_lease_released"] is True
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -47,6 +47,7 @@ from moonmind.workflows.temporal.activity_catalog import (
     SANDBOX_FLEET,
     build_default_activity_catalog,
 )
+import moonmind.workflows.temporal.activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_runtime import (
     SandboxCommandResult,
     TemporalActivityRuntimeError,
@@ -1019,6 +1020,82 @@ class _RecordingPentestRegistry:
             containerName=request.container_name,
         )
 
+class _FakePentestLeaseManager:
+    def __init__(self, client_adapter: object | None = None) -> None:
+        self.client_adapter = client_adapter
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def acquire(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        metadata: dict[str, Any],
+    ) -> str:
+        self.events.append(
+            (
+                "acquire",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "metadata": dict(metadata),
+                },
+            )
+        )
+        return f"lease:{owner}"
+
+    async def release(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        lease_id: str,
+    ) -> None:
+        self.events.append(
+            (
+                "release",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "lease_id": lease_id,
+                },
+            )
+        )
+
+    async def record_cooldown(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str,
+        owner: str,
+        cooldown_seconds: int,
+        reason: str,
+    ) -> None:
+        self.events.append(
+            (
+                "cooldown",
+                {
+                    "runtime_id": runtime_id,
+                    "profile_id": profile_id,
+                    "owner": owner,
+                    "cooldown_seconds": cooldown_seconds,
+                    "reason": reason,
+                },
+            )
+        )
+
+@pytest.fixture(autouse=True)
+def _use_fake_pentest_lease_manager(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "TemporalPentestProviderLeaseManager",
+        _FakePentestLeaseManager,
+    )
+
 async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
     launcher = _FakePentestLauncher()
     activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
@@ -1371,10 +1448,125 @@ async def test_security_pentest_execute_filters_provider_runtime_state():
     assert result["provider_profile"]["profile_id"] == "pentestgpt_openrouter_default"
     assert result["provider_lease"]["profile_id"] == "pentestgpt_openrouter_default"
 
-async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
+async def test_security_pentest_execute_acquires_lease_after_scope_validation_before_secret_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    order: list[str] = []
+    lease_manager = _FakePentestLeaseManager()
+    artifact_service = _FakePentestArtifactService(
+        {"art_scope_valid": _scope_artifact_bytes()}
+    )
+
+    original_read = artifact_service.read
+
+    async def _recording_read(**kwargs):
+        order.append("scope_read")
+        return await original_read(**kwargs)
+
+    async def _fake_resolver(ref: object, *, field_name: str) -> str:
+        order.append("secret_resolve")
+        return "sk-resolved-provider-value"
+
+    async def _recording_acquire(**kwargs):
+        order.append("lease_acquire")
+        return await _FakePentestLeaseManager.acquire(lease_manager, **kwargs)
+
+    artifact_service.read = _recording_read  # type: ignore[method-assign]
+    lease_manager.acquire = _recording_acquire  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.activity_runtime.resolve_managed_api_key_reference",
+        _fake_resolver,
+    )
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=artifact_service,
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    result = await activities.security_pentest_execute(
+        _pentest_artifact_activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    assert order[:3] == ["scope_read", "lease_acquire", "secret_resolve"]
+    acquire_event = lease_manager.events[0]
+    assert acquire_event[0] == "acquire"
+    payload = acquire_event[1]
+    assert payload["owner"] == "pentest:run-123:step-pentest:1"
+    assert payload["metadata"] == {
+        "tool": "security.pentest.run",
+        "runtime_id": "pentestgpt",
+        "profile_id": "pentestgpt_anthropic_api_team",
+        "agent_run_id": "run-123",
+        "step_id": "step-pentest",
+        "attempt": 1,
+        "target_hash": "af009b45becaa02be2c95bfdd8a055c52fc3c0ec440b24d73fb14783c9b7786e",
+        "mode": "validate_hypothesis",
+        "runner_profile": "pentestgpt-safe",
+    }
+    assert "https://lab.example.test" not in str(payload["metadata"])
+    assert "sk-resolved-provider-value" not in str(result)
+
+async def test_security_pentest_execute_does_not_acquire_lease_for_invalid_scope():
+    lease_manager = _FakePentestLeaseManager()
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakePentestArtifactService(
+            {"art_scope_valid": _scope_artifact_bytes(expires_at="2020-01-01T00:00:00Z")}
+        ),
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    result = await activities.security_pentest_execute(
+        _pentest_artifact_activity_payload()
+    )
+
+    assert result["status"] == "validation_failed"
+    assert lease_manager.events == []
+    assert launcher.requests == []
+
+async def test_security_pentest_execute_releases_acquired_lease_on_success():
+    lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=_FakePentestLauncher(),
         workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
+    assert result["terminal_cleanup"]["provider_lease_released"] is True
+    assert result["provider_lease"]["lease_id"] == "lease:pentest:run-123:step-pentest:1"
+
+async def test_security_pentest_execute_releases_acquired_lease_on_workload_failure():
+    lease_manager = _FakePentestLeaseManager()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(status="failed"),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "failed"
+    assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
+    assert result["terminal_cleanup"]["provider_lease_released"] is True
+
+async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
+    lease_manager = _FakePentestLeaseManager()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
     )
 
     result = await activities._security_pentest_execute_trusted_internal(
@@ -1392,8 +1584,39 @@ async def test_security_pentest_execute_reports_secret_safe_provider_cooldown():
         "retry_allowed": False,
     }
     assert result["provider_lease"]["release_required"] is True
+    assert [event[0] for event in lease_manager.events] == [
+        "acquire",
+        "cooldown",
+        "release",
+    ]
+    assert lease_manager.events[1][1]["reason"] == "provider_429"
+    assert result["terminal_cleanup"]["provider_lease_released"] is True
     assert "OPENROUTER_API_KEY" not in str(result["provider_cooldown"])
     assert "token" not in str(result).lower()
+
+async def test_security_pentest_execute_classifies_lease_manager_failure_as_provider_capacity():
+    class _FailingLeaseManager(_FakePentestLeaseManager):
+        async def acquire(self, **kwargs) -> str:
+            self.events.append(("acquire", dict(kwargs)))
+            raise RuntimeError("slot service unavailable")
+
+    lease_manager = _FailingLeaseManager()
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "provider_capacity_failed"
+    assert result["failure_classification"]["failure_kind"] == "provider_capacity"
+    assert result["failure_classification"]["interaction_state"] == "pre_interaction"
+    assert [event[0] for event in lease_manager.events] == ["acquire"]
+    assert launcher.requests == []
 
 async def test_security_pentest_execute_includes_instruction_materialization_metadata():
     activities = TemporalAgentRuntimeActivities(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -47,7 +47,6 @@ from moonmind.workflows.temporal.activity_catalog import (
     SANDBOX_FLEET,
     build_default_activity_catalog,
 )
-import moonmind.workflows.temporal.activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_runtime import (
     SandboxCommandResult,
     TemporalActivityRuntimeError,
@@ -58,6 +57,7 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalProposalActivities,
     TemporalSandboxActivities,
     TemporalSkillActivities,
+    TemporalPentestProviderLeaseManager,
     _default_registry_skill_payload,
     _default_skill_registry_payload,
     build_activity_bindings,
@@ -1091,10 +1091,74 @@ class _FakePentestLeaseManager:
 @pytest.fixture(autouse=True)
 def _use_fake_pentest_lease_manager(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        activity_runtime_module,
-        "TemporalPentestProviderLeaseManager",
+        (
+            "moonmind.workflows.temporal.activity_runtime."
+            "TemporalPentestProviderLeaseManager"
+        ),
         _FakePentestLeaseManager,
     )
+
+async def test_temporal_pentest_provider_lease_manager_acquires_slot_with_update():
+    class _ClientAdapter:
+        def __init__(self) -> None:
+            self.updates: list[tuple[str, str, dict[str, object]]] = []
+            self.signals: list[tuple[str, str, dict[str, object]]] = []
+
+        async def update_workflow(
+            self, workflow_id: str, update_name: str, arg: dict[str, object]
+        ) -> dict[str, object]:
+            self.updates.append((workflow_id, update_name, arg))
+            return {
+                "profile_id": "pentestgpt_anthropic_api_team",
+                "lease_id": "owner-1",
+            }
+
+        async def signal_workflow(
+            self, workflow_id: str, signal_name: str, arg: dict[str, object]
+        ) -> None:
+            self.signals.append((workflow_id, signal_name, arg))
+
+    client = _ClientAdapter()
+    manager = TemporalPentestProviderLeaseManager(client)
+
+    lease_id = await manager.acquire(
+        runtime_id="pentestgpt",
+        profile_id="pentestgpt_anthropic_api_team",
+        owner="owner-1",
+        metadata={"target_hash": "hash-1"},
+    )
+
+    assert lease_id == "owner-1"
+    assert client.signals == []
+    assert client.updates == [
+        (
+            "provider-profile-manager:pentestgpt",
+            "AcquireSlot",
+            {
+                "requester_workflow_id": "owner-1",
+                "runtime_id": "pentestgpt",
+                "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                "metadata": {"target_hash": "hash-1"},
+            },
+        )
+    ]
+
+async def test_temporal_pentest_provider_lease_manager_fails_closed_without_updates():
+    class _ClientAdapter:
+        async def signal_workflow(
+            self, workflow_id: str, signal_name: str, arg: dict[str, object]
+        ) -> None:
+            raise AssertionError("acquire must not use asynchronous request_slot signals")
+
+    manager = TemporalPentestProviderLeaseManager(_ClientAdapter())
+
+    with pytest.raises(RuntimeError, match="workflow updates"):
+        await manager.acquire(
+            runtime_id="pentestgpt",
+            profile_id="pentestgpt_anthropic_api_team",
+            owner="owner-1",
+            metadata={},
+        )
 
 async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
     launcher = _FakePentestLauncher()

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -966,6 +966,58 @@ class TestProviderProfileManagerHelpers:
         assert wf._pending_requests[0].lease_group_id == "run-1"
 
     @pytest.mark.asyncio
+    async def test_acquire_slot_update_reserves_without_callback_signal(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "pentestgpt"
+        wf._profiles["pentestgpt_anthropic_api_team"] = ProfileSlotState(
+            profile_id="pentestgpt_anthropic_api_team",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        now = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = now
+            mock_wf.patched.return_value = False
+            first = await wf.acquire_slot(
+                {
+                    "requester_workflow_id": "pentest:run-1:step-1:1",
+                    "runtime_id": "pentestgpt",
+                    "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                    "metadata": {"target_hash": "hash-1"},
+                }
+            )
+            second = await wf.acquire_slot(
+                {
+                    "requester_workflow_id": "pentest:run-1:step-1:1",
+                    "runtime_id": "pentestgpt",
+                    "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                }
+            )
+
+        assert first == {
+            "profile_id": "pentestgpt_anthropic_api_team",
+            "lease_id": "pentest:run-1:step-1:1",
+            "already_held": False,
+        }
+        assert second == {
+            "profile_id": "pentestgpt_anthropic_api_team",
+            "lease_id": "pentest:run-1:step-1:1",
+            "already_held": True,
+        }
+        profile = wf._profiles["pentestgpt_anthropic_api_team"]
+        assert profile.current_leases == ["pentest:run-1:step-1:1"]
+        assert profile.lease_granted_at == {
+            "pentest:run-1:step-1:1": "2026-06-12T00:00:00+00:00"
+        }
+        assert wf._pending_requests == []
+
+    @pytest.mark.asyncio
     async def test_release_slot_creates_short_handoff_reservation(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(


### PR DESCRIPTION
Jira issue key: MM-834

Active MoonSpec feature path: `specs/001-pentest-provider-leases`

Verification verdict: `FULLY_IMPLEMENTED`

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/integrations/pentest/test_pentest_models.py` - PASS, 152 Python tests passed; frontend runner passed 27 files / 422 tests.
- `./tools/test_integration.sh` - PASS, 295 passed, 1 skipped, 82 deselected; includes `tests/integration/temporal/test_pentest_tool_contract.py`.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, 6107 passed, 6 skipped, 1 xpassed; frontend runner passed 27 files / 422 tests.

Remaining risks:
- Provider-profile lease behavior is covered with fake manager/unit tests and hermetic integration coverage; live provider capacity behavior still depends on the configured provider-profile manager in deployed environments.
- Push succeeded, but the local remote-tracking reflog could not update because `.git/logs/refs/remotes/origin/run-jira-orchestrate-for-mm-834-wire-pen-7de30c70` is permission-restricted in this managed workspace.

Doc reconciliation outcome:
- Action: `no_update_required`
- Canonical doc path checked: `docs/Steps/PentestTool.md`
- Rationale: Latest MM-834 post-remediation `moonspec-verify` verdict is `FULLY_IMPLEMENTED`; the Source Document Drift section reports severity none because `docs/Steps/PentestTool.md` sections 11.4, 11.5, 12.1, and 17 already match the verified provider selection, lease coordination, launch ordering, cooldown, and cleanup contract. No definite evidence-backed discovery satisfies the function, consistency, or best-practices update gate.
