### PR TITLE
[codex] Normalize native PR base refs

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6948,6 +6948,18 @@ class MoonMindRunWorkflow:
             raw_base = publish_payload.get("baseBranch")
         return self._coerce_text(raw_base)
 
+    def _normalize_native_pr_base_branch(self, value: Any) -> str | None:
+        branch = self._coerce_text(value)
+        if not branch:
+            return None
+        if branch.startswith("refs/remotes/origin/"):
+            return branch.removeprefix("refs/remotes/origin/")
+        if branch.startswith("refs/heads/"):
+            return branch.removeprefix("refs/heads/")
+        if branch.startswith("origin/"):
+            return branch.removeprefix("origin/")
+        return branch
+
     def _resolve_native_pr_branches(
         self,
         *,
@@ -7012,7 +7024,8 @@ class MoonMindRunWorkflow:
             (
                 candidate
                 for candidate in (
-                    self._coerce_text(value) for value in base_candidates
+                    self._normalize_native_pr_base_branch(value)
+                    for value in base_candidates
                 )
                 if candidate
             ),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6953,11 +6953,11 @@ class MoonMindRunWorkflow:
         if not branch:
             return None
         if branch.startswith("refs/remotes/origin/"):
-            return branch.removeprefix("refs/remotes/origin/")
-        if branch.startswith("refs/heads/"):
-            return branch.removeprefix("refs/heads/")
+            branch = branch.removeprefix("refs/remotes/origin/")
+        elif branch.startswith("refs/heads/"):
+            branch = branch.removeprefix("refs/heads/")
         if branch.startswith("origin/"):
-            return branch.removeprefix("origin/")
+            branch = branch.removeprefix("origin/")
         return branch
 
     def _resolve_native_pr_branches(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2310,7 +2310,34 @@ def test_native_pr_branch_resolution_prefers_publish_context_branch(
     )
 
     assert head_branch == "804-workflow-detail-tabs"
-    assert base_branch == "origin/main"
+    assert base_branch == "main"
+
+
+def test_native_pr_branch_resolution_normalizes_base_ref_candidates(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+
+    _, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={},
+        workspace_spec={"targetBranch": "feature/expected"},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "refs/remotes/origin/release/1.2"},
+    )
+
+    assert base_branch == "release/1.2"
+
+    _, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={},
+        workspace_spec={"targetBranch": "feature/expected"},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "refs/heads/main"},
+    )
+
+    assert base_branch == "main"
 
 
 def test_publish_repair_feedback_names_branch_and_managed_publish_contract(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2339,6 +2339,16 @@ def test_native_pr_branch_resolution_normalizes_base_ref_candidates(
 
     assert base_branch == "main"
 
+    _, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={},
+        workspace_spec={"targetBranch": "feature/expected"},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "refs/heads/origin/main"},
+    )
+
+    assert base_branch == "main"
+
 
 def test_publish_repair_feedback_names_branch_and_managed_publish_contract(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
## Summary
- normalize native PR base branch candidates before calling `repo.create_pr`
- strip `origin/`, `refs/remotes/origin/`, and `refs/heads/` from base refs
- add regression coverage for publish context and explicit publish base refs

## Root Cause
Workflow `mm:9c6ae3d9-cbc5-45f1-a024-a8e9861ae3b7` failed after pushing its branch because native PR creation sent GitHub `base: origin/main`. GitHub expects the branch name (`main`) for the pull request base and returned HTTP 422 validation failure.

## Validation
- `python3 -m pytest tests/unit/workflows/temporal/workflows/test_run_integration.py -q -k native_pr_branch_resolution`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k native_pr_branch_resolution`
- `git diff --check`

Note: full `./tools/test_unit.sh` was attempted but stopped after about 24 minutes because this environment lacked `pytest-xdist` and was still early in the serial Python suite; no failures appeared before stopping.