### PR TITLE
Fix root-owned skill projection blocking verification

### DIFF
--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -106,10 +106,11 @@ git status --porcelain -- .agents/skills .gemini/skills skills_active
 If `.agents/skills` or `.gemini/skills` is an active projection symlink, repair
 the checkout view before running full-suite evidence. Prefer restoring the
 tracked repository files or using a clean reclone/worktree. If repair is not
-possible, stop with verdict `ADDITIONAL_WORK_NEEDED`, include the diagnostic
-`ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`, and do not report
-`NO_DETERMINATION` merely because MoonMind's active projection masked tracked
-skill files.
+possible in the current runtime, stop with verdict `BLOCKED`, include the
+diagnostic `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`, set
+`recoverableInCurrentRuntime: false`, set `recommendedNextAction: blocked`, and
+do not report `NO_DETERMINATION` merely because MoonMind's active projection
+masked tracked skill files.
 
 Real repo-authored `.agents/skills` directories are valid source input and must
 not be deleted, moved, or treated as the active selected skill snapshot.

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -30,6 +30,8 @@ class AgentSkillMaterializer:
         artifact_service: Any | None = None,
         backing_root: str | None = None,
         source_preservation_root: str | None = None,
+        projection_owner_uid: int | None = None,
+        projection_owner_gid: int | None = None,
     ) -> None:
         if not workspace_root:
             raise ValueError("workspace_root must be provided")
@@ -41,6 +43,8 @@ class AgentSkillMaterializer:
             if source_preservation_root
             else None
         )
+        self.projection_owner_uid = projection_owner_uid
+        self.projection_owner_gid = projection_owner_gid
 
     async def materialize(
         self,
@@ -143,12 +147,15 @@ class AgentSkillMaterializer:
 
             try:
                 require_agents_link = not self._is_repo_authored_skills_dir(alias_dir)
+                require_gemini_link = self._runtime_needs_gemini_projection(runtime_id)
                 links = ensure_shared_skill_links(
                     run_root=self.workspace_root,
                     skills_active_path=active_dir,
                     require_agents_link=require_agents_link,
-                    require_gemini_link=False,
+                    require_gemini_link=require_gemini_link,
                     owned_roots=(active_dir.parent, active_dir),
+                    owner_uid=self.projection_owner_uid,
+                    owner_gid=self.projection_owner_gid,
                 )
                 alias_available = links.agents_skills_available
                 if alias_available:
@@ -265,6 +272,11 @@ class AgentSkillMaterializer:
         if visible_dir.is_symlink():
             return False
         return not visible_dir.exists() or visible_dir.is_dir()
+
+    @staticmethod
+    def _runtime_needs_gemini_projection(runtime_id: str) -> bool:
+        normalized = str(runtime_id or "").strip().lower()
+        return normalized in {"gemini", "gemini_cli"}
 
     @staticmethod
     def _verify_payload_digest(entry: Any, payload: bytes) -> None:

--- a/moonmind/workflows/skills/__init__.py
+++ b/moonmind/workflows/skills/__init__.py
@@ -89,8 +89,10 @@ from .run_projection import (
     verify_skill_projection,
 )
 from .workspace_links import (
+    SkillProjectionCleanupResult,
     SkillWorkspaceError,
     SkillWorkspaceLinks,
+    cleanup_moonmind_skill_projections,
     ensure_shared_skill_links,
     validate_shared_skill_links,
 )
@@ -157,6 +159,8 @@ __all__ = [
     "materialize_run_skill_workspace",
     "SkillWorkspaceLinks",
     "SkillWorkspaceError",
+    "SkillProjectionCleanupResult",
+    "cleanup_moonmind_skill_projections",
     "ensure_shared_skill_links",
     "validate_shared_skill_links",
     "SkillProjectionError",

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -28,7 +28,6 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
     RuntimeMaterializationMode,
 )
-from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.services.skills_on_demand import skills_on_demand_runtime_instruction
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.temporal.artifacts import TemporalArtifactError
@@ -86,6 +85,8 @@ async def materialize_run_skill_snapshot(
     resolved_skillset: ResolvedSkillSet,
     artifact_service: Any,
     mode: RuntimeMaterializationMode = RuntimeMaterializationMode.HYBRID,
+    projection_owner_uid: int | None = None,
+    projection_owner_gid: int | None = None,
 ) -> dict[str, Any]:
     """Materialize a resolved snapshot for one run and return its metadata.
 
@@ -100,11 +101,15 @@ async def materialize_run_skill_snapshot(
     backing_root = root / "runtime" / "skills_active" / resolved_skillset.snapshot_id
     source_preservation_root = root / "runtime" / "skill_sources" / "repo_agents_skills"
 
+    from moonmind.services.skill_materialization import AgentSkillMaterializer
+
     materializer = AgentSkillMaterializer(
         workspace_root=str(workspace),
         artifact_service=artifact_service,
         backing_root=str(backing_root),
         source_preservation_root=str(source_preservation_root),
+        projection_owner_uid=projection_owner_uid,
+        projection_owner_gid=projection_owner_gid,
     )
     try:
         materialization = await materializer.materialize(

--- a/moonmind/workflows/skills/workspace_links.py
+++ b/moonmind/workflows/skills/workspace_links.py
@@ -30,6 +30,13 @@ class SkillAliasResult:
     reason: str | None = None
 
 @dataclass(frozen=True, slots=True)
+class SkillProjectionCleanupResult:
+    """Outcome from removing MoonMind-owned adapter projections."""
+
+    removed_paths: tuple[Path, ...] = ()
+    skipped_paths: tuple[Path, ...] = ()
+
+@dataclass(frozen=True, slots=True)
 class SkillWorkspaceLinks:
     """Resolved adapter link paths for one run workspace."""
 
@@ -91,11 +98,20 @@ def _replace_link(
     target: Path,
     owned_roots: Sequence[Path] = (),
     optional: bool = False,
+    owner_uid: int | None = None,
+    owner_gid: int | None = None,
 ) -> SkillAliasResult:
+    parent_exists = path.parent.exists()
     if path.exists() or path.is_symlink():
         if path.is_symlink():
             current = path.resolve(strict=False)
             if current == target.resolve(strict=False):
+                _align_projection_ownership(
+                    path,
+                    parent_created=False,
+                    owner_uid=owner_uid,
+                    owner_gid=owner_gid,
+                )
                 return SkillAliasResult(
                     path=path,
                     status=SkillAliasStatus.REUSED,
@@ -135,11 +151,40 @@ def _replace_link(
     path.parent.mkdir(parents=True, exist_ok=True)
     relative_target = Path(os.path.relpath(target, path.parent))
     path.symlink_to(relative_target)
+    _align_projection_ownership(
+        path,
+        parent_created=not parent_exists,
+        owner_uid=owner_uid,
+        owner_gid=owner_gid,
+    )
     return SkillAliasResult(
         path=path,
         status=SkillAliasStatus.CREATED,
         available=True,
     )
+
+def _align_projection_ownership(
+    path: Path,
+    *,
+    parent_created: bool,
+    owner_uid: int | None,
+    owner_gid: int | None,
+) -> None:
+    if owner_uid is None or owner_gid is None:
+        return
+    if os.name != "posix":
+        return
+    try:
+        if parent_created:
+            os.chown(path.parent, owner_uid, owner_gid, follow_symlinks=False)
+        if path.is_symlink() and hasattr(os, "lchown"):
+            os.lchown(path, owner_uid, owner_gid)
+        else:
+            os.chown(path, owner_uid, owner_gid, follow_symlinks=False)
+    except OSError as exc:
+        raise SkillWorkspaceError(
+            f"Failed to align adapter projection ownership for {path}: {exc}"
+        ) from exc
 
 def ensure_shared_skill_links(
     *,
@@ -148,6 +193,8 @@ def ensure_shared_skill_links(
     require_gemini_link: bool = True,
     require_agents_link: bool = True,
     owned_roots: Sequence[Path] = (),
+    owner_uid: int | None = None,
+    owner_gid: int | None = None,
 ) -> SkillWorkspaceLinks:
     """Create safe optional adapter links to `skills_active`."""
 
@@ -164,25 +211,27 @@ def ensure_shared_skill_links(
         target=skills_active_path,
         owned_roots=owned_roots,
         optional=not require_agents_link,
+        owner_uid=owner_uid,
+        owner_gid=owner_gid,
     )
-    gemini_skills_available = True
+    gemini_skills_available = False
+    gemini_skills_status = SkillAliasStatus.SKIPPED.value
     gemini_skills_error = None
-    try:
-        gemini_result = _replace_link(
-            gemini_skills,
-            target=skills_active_path,
-            owned_roots=owned_roots,
-            optional=not require_gemini_link,
-        )
-        gemini_skills_available = gemini_result.available
-        gemini_skills_status = gemini_result.status.value
-        gemini_skills_error = gemini_result.reason
-    except SkillWorkspaceError as ex:
-        if require_gemini_link:
+    if require_gemini_link:
+        try:
+            gemini_result = _replace_link(
+                gemini_skills,
+                target=skills_active_path,
+                owned_roots=owned_roots,
+                optional=False,
+                owner_uid=owner_uid,
+                owner_gid=owner_gid,
+            )
+            gemini_skills_available = gemini_result.available
+            gemini_skills_status = gemini_result.status.value
+            gemini_skills_error = gemini_result.reason
+        except SkillWorkspaceError:
             raise
-        gemini_skills_available = False
-        gemini_skills_status = SkillAliasStatus.FAILED.value
-        gemini_skills_error = str(ex)
 
     links = SkillWorkspaceLinks(
         skills_active_path=skills_active_path,
@@ -201,6 +250,53 @@ def ensure_shared_skill_links(
         require_agents_link=require_agents_link,
     )
     return links
+
+def cleanup_moonmind_skill_projections(
+    *,
+    run_root: Path,
+    skills_active_path: Path | None = None,
+    owned_roots: Sequence[Path] = (),
+) -> SkillProjectionCleanupResult:
+    """Remove only MoonMind-owned runtime adapter projections from a workspace."""
+
+    resolved_run_root = run_root.resolve(strict=False)
+    active_path = (
+        skills_active_path
+        if skills_active_path is not None
+        else resolved_run_root / "runtime" / "skills_active"
+    )
+    owned = tuple(owned_roots) or (active_path, resolved_run_root / "skills_active")
+    candidates = (
+        resolved_run_root / ".agents" / "skills",
+        resolved_run_root / ".gemini" / "skills",
+        resolved_run_root / "skills_active",
+    )
+    removed: list[Path] = []
+    skipped: list[Path] = []
+    for candidate in candidates:
+        if not candidate.exists() and not candidate.is_symlink():
+            continue
+        if not candidate.is_symlink():
+            skipped.append(candidate)
+            continue
+        if not is_moonmind_owned_projection(
+            candidate,
+            target=active_path,
+            owned_roots=owned,
+        ):
+            skipped.append(candidate)
+            continue
+        candidate.unlink()
+        removed.append(candidate)
+        if candidate.parent.name == ".gemini":
+            try:
+                candidate.parent.rmdir()
+            except OSError:
+                pass
+    return SkillProjectionCleanupResult(
+        removed_paths=tuple(removed),
+        skipped_paths=tuple(skipped),
+    )
 
 def validate_shared_skill_links(
     links: SkillWorkspaceLinks,

--- a/moonmind/workflows/skills/workspace_links.py
+++ b/moonmind/workflows/skills/workspace_links.py
@@ -101,14 +101,12 @@ def _replace_link(
     owner_uid: int | None = None,
     owner_gid: int | None = None,
 ) -> SkillAliasResult:
-    parent_exists = path.parent.exists()
     if path.exists() or path.is_symlink():
         if path.is_symlink():
             current = path.resolve(strict=False)
             if current == target.resolve(strict=False):
                 _align_projection_ownership(
                     path,
-                    parent_created=False,
                     owner_uid=owner_uid,
                     owner_gid=owner_gid,
                 )
@@ -153,7 +151,6 @@ def _replace_link(
     path.symlink_to(relative_target)
     _align_projection_ownership(
         path,
-        parent_created=not parent_exists,
         owner_uid=owner_uid,
         owner_gid=owner_gid,
     )
@@ -166,7 +163,6 @@ def _replace_link(
 def _align_projection_ownership(
     path: Path,
     *,
-    parent_created: bool,
     owner_uid: int | None,
     owner_gid: int | None,
 ) -> None:
@@ -174,9 +170,10 @@ def _align_projection_ownership(
         return
     if os.name != "posix":
         return
+    if hasattr(os, "geteuid") and os.geteuid() != 0:
+        return
     try:
-        if parent_created:
-            os.chown(path.parent, owner_uid, owner_gid, follow_symlinks=False)
+        os.chown(path.parent, owner_uid, owner_gid)
         if path.is_symlink() and hasattr(os, "lchown"):
             os.lchown(path, owner_uid, owner_gid)
         else:
@@ -292,6 +289,7 @@ def cleanup_moonmind_skill_projections(
             try:
                 candidate.parent.rmdir()
             except OSError:
+                # Removing the empty adapter parent is optional.
                 pass
     return SkillProjectionCleanupResult(
         removed_paths=tuple(removed),

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -98,7 +98,6 @@ from moonmind.schemas.agent_skill_models import (
     RuntimeMaterializationMode,
 )
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
-from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     build_deployment_update_tool_definition_payload,
@@ -140,6 +139,9 @@ from moonmind.schemas.managed_session_models import (
     TerminateCodexManagedSessionRequest,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.workspace_links import (
+    cleanup_moonmind_skill_projections,
+)
 from moonmind.workflows.skills.plan_validation import validate_plan_payload
 
 from moonmind.workflows.skills.skill_dispatcher import execute_skill_activity
@@ -208,6 +210,8 @@ async def _run_command(cmd, **kwargs):
 logger = getLogger(__name__)
 
 _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID = "provider-profile-manager:pentestgpt"
+_MANAGED_AGENT_UID = 1000
+_MANAGED_AGENT_GID = 1000
 
 
 class PentestProviderLeaseManager(Protocol):
@@ -6882,6 +6886,9 @@ class TemporalAgentRuntimeActivities:
             payload.get("skipSkillMaterialization")
             or payload.get("skip_skill_materialization")
         )
+        if self._is_verification_class_request(request):
+            self._cleanup_skill_projections_for_workspace(workspace_path_raw)
+            skip_skill_materialization = True
         skill_materialization_metadata: Mapping[str, Any] | None = None
         if not skip_skill_materialization:
             skill_materialization_metadata = await self._materialize_selected_agent_skill_for_turn(
@@ -6983,11 +6990,15 @@ class TemporalAgentRuntimeActivities:
             skill_source_preservation_root = (
                 run_root / "runtime" / "skill_sources" / "repo_agents_skills"
             )
+            from moonmind.services.skill_materialization import AgentSkillMaterializer
+
             materializer = AgentSkillMaterializer(
                 workspace_root=str(workspace),
                 artifact_service=self._artifact_service,
                 backing_root=str(skills_backing_root),
                 source_preservation_root=str(skill_source_preservation_root),
+                projection_owner_uid=_MANAGED_AGENT_UID,
+                projection_owner_gid=_MANAGED_AGENT_GID,
             )
             materialization = await materializer.materialize(
                 resolved_skillset=resolved_skillset,
@@ -7019,6 +7030,30 @@ class TemporalAgentRuntimeActivities:
             ) from exc
 
         return metadata
+
+    @staticmethod
+    def _is_verification_class_request(request: AgentExecutionRequest) -> bool:
+        params = request.parameters if isinstance(request.parameters, Mapping) else {}
+        selected_skill = str(selected_agent_skill(params) or "").strip().lower()
+        if selected_skill in {"moonspec-verify", "jira-verify", "jira-pr-verify"}:
+            return True
+        title = str(params.get("title") or params.get("name") or "").strip().lower()
+        if "verification" in title or "verify" in title:
+            return True
+        return selected_skill.endswith("-verify")
+
+    @staticmethod
+    def _cleanup_skill_projections_for_workspace(workspace_path: str) -> None:
+        normalized = str(workspace_path or "").strip()
+        if not normalized:
+            return
+        workspace = Path(normalized).expanduser().resolve()
+        active_root = workspace.parent / "runtime" / "skills_active"
+        cleanup_moonmind_skill_projections(
+            run_root=workspace,
+            skills_active_path=active_root,
+            owned_roots=(active_root,),
+        )
 
     @staticmethod
     def _validate_selected_skill_projection(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -97,6 +97,7 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
     RuntimeMaterializationMode,
 )
+from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
@@ -6990,8 +6991,6 @@ class TemporalAgentRuntimeActivities:
             skill_source_preservation_root = (
                 run_root / "runtime" / "skill_sources" / "repo_agents_skills"
             )
-            from moonmind.services.skill_materialization import AgentSkillMaterializer
-
             materializer = AgentSkillMaterializer(
                 workspace_root=str(workspace),
                 artifact_service=self._artifact_service,
@@ -7035,12 +7034,16 @@ class TemporalAgentRuntimeActivities:
     def _is_verification_class_request(request: AgentExecutionRequest) -> bool:
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         selected_skill = str(selected_agent_skill(params) or "").strip().lower()
-        if selected_skill in {"moonspec-verify", "jira-verify", "jira-pr-verify"}:
-            return True
+        if selected_skill:
+            return selected_skill in {
+                "moonspec-verify",
+                "jira-verify",
+                "jira-pr-verify",
+            } or selected_skill.endswith("-verify")
         title = str(params.get("title") or params.get("name") or "").strip().lower()
         if "verification" in title or "verify" in title:
             return True
-        return selected_skill.endswith("-verify")
+        return False
 
     @staticmethod
     def _cleanup_skill_projections_for_workspace(workspace_path: str) -> None:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -907,6 +907,8 @@ class ManagedRuntimeLauncher:
             runtime_id=str(profile.runtime_id or "managed-runtime"),
             resolved_skillset=resolved_skillset,
             artifact_service=self._artifact_service,
+            projection_owner_uid=1000,
+            projection_owner_gid=1000,
         )
 
         params = request.parameters if isinstance(request.parameters, Mapping) else {}

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -42,6 +42,7 @@ from moonmind.workflows.codex_session_timeouts import (
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
     resolve_github_token_for_launch,
 )
+from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 from moonmind.workflow_docker_mode import normalize_workflow_docker_mode
 
@@ -2541,6 +2542,7 @@ class DockerCodexManagedSessionController:
                         ignore_failure=True,
                     )
                 await self._github_auth_brokers.stop(request.session_id)
+                self._cleanup_skill_projections_for_session(record)
                 return CodexManagedSessionHandle(
                     runtimeFamily=request.runtime_family,
                     sessionState=record.session_state(),
@@ -2561,6 +2563,7 @@ class DockerCodexManagedSessionController:
                 remove_volumes_if_container_missing=False,
             )
         await self._github_auth_brokers.stop(request.session_id)
+        self._cleanup_skill_projections_for_session(record)
         handle = CodexManagedSessionHandle(
             runtimeFamily=request.runtime_family,
             sessionState={
@@ -2602,6 +2605,27 @@ class DockerCodexManagedSessionController:
                     updated_at=datetime.now(tz=UTC),
                 )
         return handle
+
+    @staticmethod
+    def _cleanup_skill_projections_for_session(
+        record: CodexManagedSessionRecord | None,
+    ) -> None:
+        if record is None or not record.workspace_path:
+            return
+        workspace = Path(record.workspace_path)
+        active_root = workspace.parent / "runtime" / "skills_active"
+        try:
+            cleanup_moonmind_skill_projections(
+                run_root=workspace,
+                skills_active_path=active_root,
+                owned_roots=(active_root,),
+            )
+        except OSError:
+            logger.debug(
+                "Best-effort skill projection cleanup failed for session %s",
+                record.session_id,
+                exc_info=True,
+            )
 
     async def fetch_session_summary(
         self,

--- a/tests/unit/agents/test_moonspec_verify_skill.py
+++ b/tests/unit/agents/test_moonspec_verify_skill.py
@@ -17,3 +17,7 @@ def test_moonspec_verify_skill_includes_projection_contamination_preflight() -> 
     assert "test ! -L .gemini/skills" in text
     assert "git status --porcelain -- .agents/skills .gemini/skills skills_active" in text
     assert "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION" in text
+    assert "verdict `BLOCKED`" in text
+    assert "`recoverableInCurrentRuntime: false`" in text
+    assert "`recommendedNextAction: blocked`" in text
+    assert "stop with verdict `ADDITIONAL_WORK_NEEDED`" not in text

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -72,6 +72,44 @@ def _workspace_git_command(workspace_path: str | Path, *args: str) -> tuple[str,
         *args,
     )
 
+
+def test_controller_session_end_cleanup_removes_moonmind_skill_projections(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "agent_jobs" / "job-1" / "repo"
+    active = tmp_path / "agent_jobs" / "job-1" / "runtime" / "skills_active" / "snap"
+    active.mkdir(parents=True)
+    (active / "_manifest.json").write_text('{"snapshot_id": "snap"}\n', encoding="utf-8")
+    agents_projection = workspace / ".agents" / "skills"
+    gemini_projection = workspace / ".gemini" / "skills"
+    agents_projection.parent.mkdir(parents=True)
+    gemini_projection.parent.mkdir(parents=True)
+    agents_projection.symlink_to(active)
+    gemini_projection.symlink_to(active)
+    record = CodexManagedSessionRecord(
+        sessionId="sess-cleanup",
+        sessionEpoch=1,
+        agentRunId="task-1",
+        containerId="ctr-1",
+        threadId="thread-1",
+        runtimeId="codex_cli",
+        imageRef="img",
+        controlUrl="docker-exec://ctr-1",
+        status="ready",
+        workspacePath=str(workspace),
+        sessionWorkspacePath=str(tmp_path / "session"),
+        artifactSpoolPath=str(tmp_path / "artifacts"),
+        startedAt="2026-04-06T12:00:00Z",
+    )
+
+    DockerCodexManagedSessionController._cleanup_skill_projections_for_session(record)
+
+    assert not agents_projection.exists()
+    assert not agents_projection.is_symlink()
+    assert not gemini_projection.exists()
+    assert not gemini_projection.is_symlink()
+    assert (workspace / ".agents").is_dir()
+
 @pytest.mark.asyncio
 async def test_default_command_runner_clears_supplemental_groups_when_uid_changes(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -264,10 +264,10 @@ async def test_materializer_reports_structured_alias_projection_diagnostics(
                 tmp_path / "runtime" / "skills_active" / "active_snap"
             ),
             "aliasPath": str(tmp_path / ".gemini" / "skills"),
-            "event": "skill_projection_alias_created",
+            "event": "skill_projection_alias_skipped",
             "reason": None,
             "snapshotId": "active_snap",
-            "status": "created",
+            "status": "skipped",
             "workspace": str(tmp_path),
         },
     ]
@@ -477,10 +477,45 @@ async def test_materializer_does_not_block_on_incompatible_gemini_skills_path(
     compatibility = result.metadata["compatibilityPaths"]
     assert compatibility["geminiSkillsPath"] == str(gemini_skill)
     assert compatibility["geminiSkillsAvailable"] is False
-    assert "existing non-symlink path present" in compatibility["geminiSkillsError"]
+    assert compatibility["geminiSkillsStatus"] == "skipped"
+    assert "geminiSkillsError" not in compatibility
     assert (
         gemini_skill / "SKILL.md"
     ).read_text(encoding="utf-8") == "local gemini skill"
+
+
+@pytest.mark.asyncio
+async def test_materializer_creates_gemini_projection_only_for_gemini_runtime(
+    tmp_path: Path,
+):
+    materializer = AgentSkillMaterializer(str(tmp_path))
+    skillset = ResolvedSkillSet(
+        snapshot_id="gemini_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[],
+    )
+
+    codex_result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="codex_cli",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
+
+    assert not (tmp_path / ".gemini").exists()
+    assert codex_result.metadata["compatibilityPaths"]["geminiSkillsStatus"] == "skipped"
+
+    gemini_result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="gemini_cli",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
+
+    gemini_skills = tmp_path / ".gemini" / "skills"
+    assert gemini_skills.is_symlink()
+    assert gemini_skills.resolve() == (
+        tmp_path / "runtime" / "skills_active" / "gemini_snap"
+    ).resolve()
+    assert gemini_result.metadata["compatibilityPaths"]["geminiSkillsAvailable"] is True
 
 @pytest.mark.asyncio
 async def test_materializer_hybrid_returns_compact_metadata_without_skill_body(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -4003,6 +4003,57 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_verifier_step(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "agent_jobs"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
+    job_root = managed_root / "job-verify"
+    workspace = job_root / "repo"
+    active_root = job_root / "runtime" / "skills_active" / "skillset-verify"
+    active_root.mkdir(parents=True)
+    (active_root / "_manifest.json").write_text(
+        '{"snapshot_id": "skillset-verify"}\n",
+        encoding="utf-8",
+    )
+    agents_projection = workspace / ".agents" / "skills"
+    gemini_projection = workspace / ".gemini" / "skills"
+    agents_projection.parent.mkdir(parents=True)
+    gemini_projection.parent.mkdir(parents=True)
+    agents_projection.symlink_to(active_root)
+    gemini_projection.symlink_to(active_root)
+    activities = TemporalAgentRuntimeActivities(artifact_service=_StaticArtifactService({}))
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-verify",
+                "idempotencyKey": "idem-verify",
+                "parameters": {
+                    "instructions": "Run final verification.",
+                    "metadata": {
+                        "moonmind": {
+                            "selectedSkill": "moonspec-verify",
+                        },
+                    },
+                },
+            },
+            "workspacePath": str(workspace),
+        }
+    )
+
+    assert "Run final verification." in result
+    assert "Active MoonMind skill snapshot:" not in result
+    assert not agents_projection.exists()
+    assert not agents_projection.is_symlink()
+    assert not gemini_projection.exists()
+    assert not gemini_projection.is_symlink()
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_can_skip_skill_materialization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3969,6 +3969,7 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
                 "idempotencyKey": "idem-1",
                 "resolvedSkillsetRef": "art-pr-resolver-snapshot",
                 "parameters": {
+                    "title": "Verify PR resolver outcome",
                     "instructions": "Resolve the PR.",
                     "publishMode": "none",
                     "metadata": {
@@ -4014,7 +4015,7 @@ async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_ver
     active_root = job_root / "runtime" / "skills_active" / "skillset-verify"
     active_root.mkdir(parents=True)
     (active_root / "_manifest.json").write_text(
-        '{"snapshot_id": "skillset-verify"}\n",
+        '{"snapshot_id": "skillset-verify"}\n',
         encoding="utf-8",
     )
     agents_projection = workspace / ".agents" / "skills"

--- a/tests/unit/workflows/test_workspace_links.py
+++ b/tests/unit/workflows/test_workspace_links.py
@@ -8,6 +8,7 @@ import pytest
 
 from moonmind.workflows.skills.workspace_links import (
     SkillWorkspaceError,
+    cleanup_moonmind_skill_projections,
     ensure_shared_skill_links,
     validate_shared_skill_links,
 )
@@ -45,7 +46,6 @@ def test_ensure_shared_skill_links_can_treat_gemini_link_as_optional(tmp_path):
     run_root = tmp_path / "runs" / "run-optional-gemini"
     skills_active = run_root / "skills_active"
     skills_active.mkdir(parents=True)
-    (run_root / ".gemini" / "skills").mkdir(parents=True)
 
     links = ensure_shared_skill_links(
         run_root=run_root,
@@ -57,9 +57,60 @@ def test_ensure_shared_skill_links_can_treat_gemini_link_as_optional(tmp_path):
     assert links.agents_skills_path.resolve() == skills_active.resolve()
     assert not links.gemini_skills_path.is_symlink()
     assert links.gemini_skills_available is False
-    assert links.gemini_skills_error is not None
-    assert "existing non-symlink path present" in links.gemini_skills_error
+    assert links.gemini_skills_status == "skipped"
+    assert links.gemini_skills_error is None
+    assert not (run_root / ".gemini").exists()
     validate_shared_skill_links(links, require_gemini_link=False)
+
+
+def test_ensure_shared_skill_links_chowns_created_links_without_following(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    run_root = tmp_path / "runs" / "run-owned"
+    skills_active = run_root / "skills_active"
+    skills_active.mkdir(parents=True)
+    chowned_dirs: list[Path] = []
+    lchowned_links: list[Path] = []
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        assert uid == 1000
+        assert gid == 1000
+        assert follow_symlinks is False
+        chowned_dirs.append(Path(path))
+
+    def _fake_lchown(path: str | Path, uid: int, gid: int) -> None:
+        assert uid == 1000
+        assert gid == 1000
+        lchowned_links.append(Path(path))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.chown",
+        _fake_chown,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.lchown",
+        _fake_lchown,
+        raising=False,
+    )
+
+    links = ensure_shared_skill_links(
+        run_root=run_root,
+        skills_active_path=skills_active,
+        owner_uid=1000,
+        owner_gid=1000,
+    )
+
+    assert links.agents_skills_path in lchowned_links
+    assert links.gemini_skills_path in lchowned_links
+    assert links.agents_skills_path.parent in chowned_dirs
+    assert links.gemini_skills_path.parent in chowned_dirs
 
 
 def test_ensure_shared_skill_links_replaces_stale_owned_agents_symlink(tmp_path):
@@ -123,3 +174,53 @@ def test_ensure_shared_skill_links_rejects_unknown_symlink(tmp_path):
 
     with pytest.raises(SkillWorkspaceError, match="existing symlink"):
         ensure_shared_skill_links(run_root=run_root, skills_active_path=skills_active)
+
+
+def test_cleanup_moonmind_skill_projections_removes_only_owned_symlinks(tmp_path):
+    run_root = tmp_path / "runs" / "run-clean"
+    active = run_root / "runtime" / "skills_active" / "active"
+    active.mkdir(parents=True)
+    (active / "_manifest.json").write_text('{"snapshot_id": "active"}\n')
+    agents = run_root / ".agents" / "skills"
+    gemini = run_root / ".gemini" / "skills"
+    agents.parent.mkdir(parents=True)
+    gemini.parent.mkdir(parents=True)
+    agents.symlink_to(active)
+    gemini.symlink_to(active)
+    repo_authored = run_root / ".agents" / "local"
+    repo_authored.mkdir(parents=True)
+
+    result = cleanup_moonmind_skill_projections(
+        run_root=run_root,
+        skills_active_path=active.parent,
+        owned_roots=(active.parent,),
+    )
+
+    assert result.removed_paths == (agents, gemini)
+    assert not agents.exists()
+    assert not agents.is_symlink()
+    assert not gemini.exists()
+    assert not gemini.is_symlink()
+    assert repo_authored.is_dir()
+    assert (run_root / ".agents").is_dir()
+    assert not (run_root / ".gemini").exists()
+
+
+def test_cleanup_moonmind_skill_projections_preserves_repo_authored_agents_skills(
+    tmp_path,
+):
+    run_root = tmp_path / "runs" / "run-preserve"
+    active = run_root / "runtime" / "skills_active" / "active"
+    active.mkdir(parents=True)
+    repo_skill = run_root / ".agents" / "skills" / "repo-skill"
+    repo_skill.mkdir(parents=True)
+
+    result = cleanup_moonmind_skill_projections(
+        run_root=run_root,
+        skills_active_path=active.parent,
+        owned_roots=(active.parent,),
+    )
+
+    assert result.removed_paths == ()
+    assert result.skipped_paths == (run_root / ".agents" / "skills",)
+    assert repo_skill.is_dir()

--- a/tests/unit/workflows/test_workspace_links.py
+++ b/tests/unit/workflows/test_workspace_links.py
@@ -63,7 +63,7 @@ def test_ensure_shared_skill_links_can_treat_gemini_link_as_optional(tmp_path):
     validate_shared_skill_links(links, require_gemini_link=False)
 
 
-def test_ensure_shared_skill_links_chowns_created_links_without_following(
+def test_ensure_shared_skill_links_chowns_created_links(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -82,7 +82,7 @@ def test_ensure_shared_skill_links_chowns_created_links_without_following(
     ) -> None:
         assert uid == 1000
         assert gid == 1000
-        assert follow_symlinks is False
+        assert follow_symlinks is True
         chowned_dirs.append(Path(path))
 
     def _fake_lchown(path: str | Path, uid: int, gid: int) -> None:
@@ -93,6 +93,11 @@ def test_ensure_shared_skill_links_chowns_created_links_without_following(
     monkeypatch.setattr(
         "moonmind.workflows.skills.workspace_links.os.chown",
         _fake_chown,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.geteuid",
+        lambda: 0,
+        raising=False,
     )
     monkeypatch.setattr(
         "moonmind.workflows.skills.workspace_links.os.lchown",
@@ -109,6 +114,61 @@ def test_ensure_shared_skill_links_chowns_created_links_without_following(
 
     assert links.agents_skills_path in lchowned_links
     assert links.gemini_skills_path in lchowned_links
+    assert links.agents_skills_path.parent in chowned_dirs
+    assert links.gemini_skills_path.parent in chowned_dirs
+
+
+def test_ensure_shared_skill_links_chowns_reused_link_parents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    run_root = tmp_path / "runs" / "run-reused-owned"
+    skills_active = run_root / "skills_active"
+    skills_active.mkdir(parents=True)
+    agents = run_root / ".agents" / "skills"
+    gemini = run_root / ".gemini" / "skills"
+    agents.parent.mkdir(parents=True)
+    gemini.parent.mkdir(parents=True)
+    agents.symlink_to(skills_active)
+    gemini.symlink_to(skills_active)
+    chowned_dirs: list[Path] = []
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        assert uid == 1000
+        assert gid == 1000
+        assert follow_symlinks is True
+        chowned_dirs.append(Path(path))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.chown",
+        _fake_chown,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.geteuid",
+        lambda: 0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.workspace_links.os.lchown",
+        lambda _path, _uid, _gid: None,
+        raising=False,
+    )
+
+    links = ensure_shared_skill_links(
+        run_root=run_root,
+        skills_active_path=skills_active,
+        owner_uid=1000,
+        owner_gid=1000,
+    )
+
+    assert links.agents_skills_status == "reused"
+    assert links.gemini_skills_status == "reused"
     assert links.agents_skills_path.parent in chowned_dirs
     assert links.gemini_skills_path.parent in chowned_dirs
 


### PR DESCRIPTION
Implement the MoonMind remediation for Unreal hard blocker 1 from the revised 2026-06-12 plan.

Context: parent workflow mm:0dc7a4d3-cf7a-4922-a50f-5fdf674deb8c for Jira Orchestrate THOR-555 pushed target branch `run-jira-orchestrate-for-thor-555-comple-1952cd6a` at `a82dbe8b`, but PR publication was blocked after 6/6 remediation attempts. This blocker is environmental, not a THOR source-code gap.

Scope for this workflow:
1. In `moonmind/workflows/skills/workspace_links.py` and related activity/service boundaries, align ownership for MoonMind-created adapter projection links and parent directories with the run agent uid/gid. Use symlink-safe ownership (`os.lchown` for links) and ensure newly-created `.gemini/` parents are agent-removable where appropriate.
2. Tighten `moonmind/services/skill_materialization.py` so `.gemini/skills` is created only for runtimes/adapters that need the Gemini projection. Keep `.agents/skills` as the canonical active path.
3. Add a runtime-owned cleanup hook at the same privileged boundary that created MoonMind-owned projections. It should remove only MoonMind-owned projections before verification-class steps and at session end; never delete repo-authored `.agents/skills`.
4. Update `.agents/skills/moonspec-verify/SKILL.md` workspace projection preflight to emit `BLOCKED` with `recoverableInCurrentRuntime: false` and `recommendedNextAction: blocked` for environment-invalid states such as `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`, replacing the old `ADDITIONAL_WORK_NEEDED` instruction.
5. Add required tests: unit coverage for ownership/link behavior, adapter/activity-boundary coverage that the agent uid can remove projections, conditional `.gemini` creation, cleanup behavior, and verifier skill snapshot/update coverage.

Constraints: do not mutate checked-in skill folders as runtime setup; preserve `.agents/skills` as canonical runtime-visible path; do not add compatibility aliases for this pre-release internal contract. Publish as a PR and allow merge automation to run.