### PR TITLE
Add managed-runtime UE validation preflight and blocked stop behavior

### DIFF
--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -186,7 +186,7 @@ steps:
 
       Run moonspec-verify as the final read-only gate unless an up-to-date verification report already covers the current code and artifacts.
       If the verdict is ADDITIONAL_WORK_NEEDED, preserve the report as the mandatory remediation input for the next step.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, classify it as an environment or setup failure when the verifier identifies missing runtime infrastructure, stop immediately, skip all remediation attempts, and do not create a pull request.
       Do not create a pull request from this step. Pull request creation is allowed only after the post-remediation verification step reports FULLY_IMPLEMENTED.
     skill:
       id: moonspec-verify
@@ -205,7 +205,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -225,7 +225,7 @@ steps:
       Run moonspec-verify after remediation attempt 1, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -245,7 +245,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -265,7 +265,7 @@ steps:
       Run moonspec-verify after remediation attempt 2, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -285,7 +285,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -305,7 +305,7 @@ steps:
       Run moonspec-verify after remediation attempt 3, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -325,7 +325,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -345,7 +345,7 @@ steps:
       Run moonspec-verify after remediation attempt 4, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -365,7 +365,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -385,7 +385,7 @@ steps:
       Run moonspec-verify after remediation attempt 5, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
       If the verdict is ADDITIONAL_WORK_NEEDED and another remediation attempt remains, preserve the verification report as the mandatory input for the next remediation attempt.
-      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context unless the missing evidence is recoverable in the current runtime by the next remediation attempt. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Continue toward pull request creation only when the latest post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -405,7 +405,7 @@ steps:
 
       If the latest verdict is ADDITIONAL_WORK_NEEDED, treat the verification report's gaps and remaining work as the authoritative bounded implementation backlog. Run moonspec-implement to fix the reported implementation or validation gaps, update tasks.md only for work actually completed, and run the focused unit or integration checks named by the verification report when feasible.
 
-      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker.
+      If the latest verdict is NO_DETERMINATION, only proceed when the missing evidence is recoverable in this runtime, such as by running a skipped command or inspecting available files. Otherwise stop and report the exact blocker. If the latest verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, treat it as terminal for Jira Orchestrate remediation, classify runtime or infrastructure causes as environment failure, skip every remaining remediation attempt, and do not create a pull request.
 
       Do not broaden the selected story scope, do not create a pull request, and do not move Jira during remediation.
     skill:
@@ -424,7 +424,7 @@ steps:
 
       Run moonspec-verify after remediation attempt 6, even when remediation was skipped because the prior verdict was FULLY_IMPLEMENTED.
 
-      This is the controlling verification gate for Jira Orchestrate publication. If the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, the remediation budget is exhausted: stop the orchestration, report the gaps or missing evidence, and do not continue to pull request creation.
+      This is the controlling verification gate for Jira Orchestrate publication. If the verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, the remediation budget is exhausted: stop the orchestration, report the gaps or missing evidence, and do not continue to pull request creation. If the verdict is BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, classify runtime or infrastructure causes as environment failure, stop immediately, and do not create a pull request.
 
       Continue to pull request creation only when this post-remediation verdict is FULLY_IMPLEMENTED.
     skill:
@@ -458,7 +458,7 @@ steps:
 
       Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
 
-      Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED or NO_DETERMINATION, stop without committing, pushing, creating a pull request, or changing Jira.
+      Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop without committing, pushing, creating a pull request, or changing Jira. Classify runtime or infrastructure causes as environment failure.
 
       This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Code Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
 

--- a/moonmind/agents/codex_worker/cli.py
+++ b/moonmind/agents/codex_worker/cli.py
@@ -38,6 +38,7 @@ from moonmind.jules.runtime import (
 )
 from moonmind.rag.guardrails import GuardrailError, ensure_rag_ready
 from moonmind.rag.settings import RagRuntimeSettings
+from moonmind.workflows.automation.preflight import run_docker_sidecar_preflight_check
 
 logger = logging.getLogger(__name__)
 
@@ -339,6 +340,12 @@ def run_preflight(env: Mapping[str, str] | None = None) -> None:
         ensure_rag_ready(RagRuntimeSettings.from_env(source))
     except GuardrailError as exc:
         raise RuntimeError(str(exc)) from exc
+    docker_sidecar_preflight = run_docker_sidecar_preflight_check(env=source)
+    if docker_sidecar_preflight.status.value == "failed":
+        message = docker_sidecar_preflight.message or "Docker sidecar preflight failed."
+        if docker_sidecar_preflight.diagnostics_ref:
+            message = f"{message} diagnosticsRef={docker_sidecar_preflight.diagnostics_ref}"
+        raise RuntimeError(message)
 
     github_token = str(source.get("GITHUB_TOKEN", "")).strip()
     redaction_values = (github_token,) if github_token else ()

--- a/moonmind/workflows/automation/preflight.py
+++ b/moonmind/workflows/automation/preflight.py
@@ -96,8 +96,25 @@ def _run_docker_command(
         capture_output=True,
         text=True,
         timeout=timeout,
-        env={**os.environ, **dict(env)},
+        env={**os.environ, **{k: str(v) for k, v in env.items() if v is not None}},
     )
+
+
+def _docker_preflight_os_error_result(
+    exc: OSError,
+    *,
+    diagnostics_ref: str,
+) -> CodexPreflightResult:
+    message = "Docker sidecar preflight failed: docker CLI is not installed."
+    if not isinstance(exc, FileNotFoundError):
+        message = f"Docker sidecar preflight failed: {exc}"
+    return CodexPreflightResult(
+        status=models.CodexPreflightStatus.FAILED,
+        message=message,
+        failure_class="system_error",
+        diagnostics_ref=diagnostics_ref,
+    )
+
 
 def run_docker_sidecar_preflight_check(
     *,
@@ -122,11 +139,9 @@ def run_docker_sidecar_preflight_check(
             env=source,
             timeout=timeout,
         )
-    except FileNotFoundError:
-        return CodexPreflightResult(
-            status=models.CodexPreflightStatus.FAILED,
-            message="Docker sidecar preflight failed: docker CLI is not installed.",
-            failure_class="system_error",
+    except OSError as exc:
+        return _docker_preflight_os_error_result(
+            exc,
             diagnostics_ref=diagnostics_ref,
         )
     except subprocess.TimeoutExpired:
@@ -181,6 +196,11 @@ def run_docker_sidecar_preflight_check(
             ["docker", "manifest", "inspect", image],
             env=source,
             timeout=timeout,
+        )
+    except OSError as exc:
+        return _docker_preflight_os_error_result(
+            exc,
+            diagnostics_ref=diagnostics_ref,
         )
     except subprocess.TimeoutExpired:
         return CodexPreflightResult(

--- a/moonmind/workflows/automation/preflight.py
+++ b/moonmind/workflows/automation/preflight.py
@@ -6,9 +6,11 @@ This module validates prerequisites before starting a workflow run.
 from __future__ import annotations
 
 import logging
+import os
 import re
+import subprocess
 from dataclasses import dataclass
-from typing import Optional
+from typing import Mapping, Optional
 
 from moonmind.config.settings import settings
 from moonmind.workflows.automation import models
@@ -30,6 +32,8 @@ class CodexPreflightResult:
     exit_code: Optional[int] = None
     stdout: Optional[str] = None
     stderr: Optional[str] = None
+    failure_class: Optional[str] = None
+    diagnostics_ref: Optional[str] = None
 
 def _summarize_preflight_output(stdout: str, stderr: str) -> Optional[str]:
     """Return a one-line summary extracted from preflight output."""
@@ -39,6 +43,184 @@ def _summarize_preflight_output(stdout: str, stderr: str) -> Optional[str]:
         if stripped:
             return stripped[:200]
     return None
+
+def _is_pinned_container_image(image: str) -> bool:
+    """Return whether an image reference is pinned to a non-latest tag or digest."""
+
+    normalized = image.strip()
+    if not normalized:
+        return False
+    if "@" in normalized:
+        return True
+    last_segment = normalized.rsplit("/", 1)[-1]
+    if ":" not in last_segment:
+        return False
+    tag = last_segment.rsplit(":", 1)[-1].strip().lower()
+    return bool(tag) and tag != "latest"
+
+def _configured_pinned_ue_image(
+    env: Mapping[str, str],
+    *,
+    pinned_image: str | None = None,
+) -> str | None:
+    """Resolve the optional pinned Unreal Engine validation image."""
+
+    candidates = (
+        pinned_image,
+        env.get("MOONMIND_UNREAL_ENGINE_IMAGE"),
+        env.get("MOONMIND_UNREAL_DOCKER_IMAGE"),
+        env.get("MOONMIND_PINNED_UE_IMAGE"),
+        env.get("MOONMIND_PINNED_UNREAL_ENGINE_IMAGE"),
+    )
+    for candidate in candidates:
+        image = str(candidate or "").strip()
+        if image:
+            return image
+    return None
+
+def _docker_sidecar_preflight_enabled(env: Mapping[str, str]) -> bool:
+    mode = str(env.get("MOONMIND_MANAGED_SESSION_DOCKER_MODE") or "").strip().lower()
+    if mode in {"no-docker", "disabled", "none", "off"}:
+        return False
+    return mode == "docker-sidecar" or bool(str(env.get("DOCKER_HOST") or "").strip())
+
+def _run_docker_command(
+    args: list[str],
+    *,
+    env: Mapping[str, str],
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, **dict(env)},
+    )
+
+def run_docker_sidecar_preflight_check(
+    *,
+    env: Mapping[str, str] | None = None,
+    timeout: int = 30,
+    pinned_ue_image: str | None = None,
+) -> CodexPreflightResult:
+    """Validate Docker sidecar readiness and optional pinned UE image access."""
+
+    source = env if env is not None else os.environ
+    diagnostics_ref = "preflight://docker-sidecar"
+    if not _docker_sidecar_preflight_enabled(source):
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.SKIPPED,
+            message="Docker sidecar preflight skipped because sidecar Docker is not enabled.",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    try:
+        info = _run_docker_command(
+            ["docker", "info"],
+            env=source,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message="Docker sidecar preflight failed: docker CLI is not installed.",
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+    except subprocess.TimeoutExpired:
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message=(
+                "Docker sidecar preflight failed: docker info timed out after "
+                f"{timeout} seconds."
+            ),
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    if info.returncode != 0:
+        summary = _summarize_preflight_output(info.stdout, info.stderr)
+        message = "Docker sidecar preflight failed: docker info did not succeed."
+        if summary:
+            message = f"{message} Details: {summary}"
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message=message,
+            exit_code=info.returncode,
+            stdout=info.stdout,
+            stderr=info.stderr,
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    image = _configured_pinned_ue_image(source, pinned_image=pinned_ue_image)
+    if not image:
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.PASSED,
+            message="Docker sidecar preflight passed; no pinned UE image probe configured.",
+            exit_code=info.returncode,
+            stdout=info.stdout,
+            stderr=info.stderr,
+            diagnostics_ref=diagnostics_ref,
+        )
+    if not _is_pinned_container_image(image):
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message=(
+                "Docker sidecar preflight failed: configured UE image must be pinned "
+                f"to a non-latest tag or digest: {image}"
+            ),
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    try:
+        manifest = _run_docker_command(
+            ["docker", "manifest", "inspect", image],
+            env=source,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message=(
+                "Docker sidecar preflight failed: docker manifest inspect timed "
+                f"out after {timeout} seconds for {image}."
+            ),
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    stdout = f"{info.stdout}\n{manifest.stdout}".strip()
+    stderr = f"{info.stderr}\n{manifest.stderr}".strip()
+    if manifest.returncode != 0:
+        summary = _summarize_preflight_output(manifest.stdout, manifest.stderr)
+        message = (
+            "Docker sidecar preflight failed: pinned UE image manifest could not "
+            f"be inspected: {image}."
+        )
+        if summary:
+            message = f"{message} Details: {summary}"
+        return CodexPreflightResult(
+            status=models.CodexPreflightStatus.FAILED,
+            message=message,
+            exit_code=manifest.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            failure_class="system_error",
+            diagnostics_ref=diagnostics_ref,
+        )
+
+    return CodexPreflightResult(
+        status=models.CodexPreflightStatus.PASSED,
+        message=f"Docker sidecar preflight passed for pinned UE image {image}.",
+        exit_code=0,
+        stdout=stdout,
+        stderr=stderr,
+        diagnostics_ref=diagnostics_ref,
+    )
 
 def _run_codex_preflight_check(
     *, timeout: int = 60, volume_name: str | None = None
@@ -189,4 +371,8 @@ def run_codex_preflight_check(
 
     return _run_codex_preflight_check(timeout=timeout, volume_name=volume_name)
 
-__all__ = ["CodexPreflightResult", "run_codex_preflight_check"]
+__all__ = [
+    "CodexPreflightResult",
+    "run_codex_preflight_check",
+    "run_docker_sidecar_preflight_check",
+]

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -38,6 +38,9 @@ from moonmind.schemas.managed_session_models import (
     SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
+from moonmind.workflows.automation.preflight import (
+    run_docker_sidecar_preflight_check,
+)
 from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
@@ -2720,6 +2723,16 @@ def _validated_runtime_environment() -> dict[str, str]:
         "image_ref": image_ref,
     }
 
+def _run_docker_sidecar_runtime_preflight() -> None:
+    result = run_docker_sidecar_preflight_check(env=os.environ)
+    if result.status.value != "failed":
+        return
+    message = result.message or "Docker sidecar preflight failed."
+    if result.diagnostics_ref:
+        message = f"{message} diagnosticsRef={result.diagnostics_ref}"
+    raise RuntimeError(message)
+
+
 def _runtime_from_environment() -> CodexManagedSessionRuntime:
     env = _validated_runtime_environment()
     workspace_path = env["workspace_path"]
@@ -2771,10 +2784,12 @@ def _emit_json(payload: BaseModel | Mapping[str, Any], *, exit_code: int = 0) ->
 
 def _run_ready() -> int:
     _validated_runtime_environment()
+    _run_docker_sidecar_runtime_preflight()
     return _emit_json({"ready": True})
 
 def _run_serve() -> int:
     _validated_runtime_environment()
+    _run_docker_sidecar_runtime_preflight()
     stopping = False
 
     def _handle_signal(signum: int, _frame: object) -> None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -177,6 +177,7 @@ _MOONSPEC_GATE_BLOCKING_VERDICTS = frozenset(
         "NO_DETERMINATION",
         "BLOCKED",
         "FAILED_UNRECOVERABLE",
+        "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION",
     }
 )
 _MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
@@ -184,6 +185,7 @@ _MOONSPEC_GATE_VERDICT_TEXT_PATTERN = re.compile(
     r"FULLY_IMPLEMENTED|"
     r"ADDITIONAL_WORK_NEEDED|"
     r"NO_DETERMINATION|"
+    r"ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION|"
     r"FAILED_UNRECOVERABLE|"
     r"BLOCKED"
     r")\b",
@@ -2616,6 +2618,7 @@ class MoonMindRunWorkflow:
             "ADDITIONAL_WORK_NEEDED",
             "BLOCKED",
             "FAILED_UNRECOVERABLE",
+            "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION",
         }:
             return "failed"
         return "inconclusive"
@@ -2710,9 +2713,12 @@ class MoonMindRunWorkflow:
                 "verificationVerdict",
                 "verification_verdict",
             ):
-                verdict = self._normalize_moonspec_verify_verdict(source.get(key))
+                raw_verdict = source.get(key)
+                verdict = self._normalize_moonspec_verify_verdict(raw_verdict)
                 if verdict:
                     return verdict
+                if isinstance(raw_verdict, str) and raw_verdict.strip():
+                    return "NO_DETERMINATION"
         for key in (
             "operator_summary",
             "operatorSummary",
@@ -2944,6 +2950,8 @@ class MoonMindRunWorkflow:
             return "blocked"
         if normalized == "FAILED_UNRECOVERABLE":
             return "failed_unrecoverable"
+        if normalized == "ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION":
+            return "environment_contaminated_by_skill_projection"
         if normalized == "ADDITIONAL_WORK_NEEDED":
             return "failed_with_remaining_work"
         return "needs_human"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import time
 from datetime import UTC, datetime, timedelta
-import sqlite3
 from pathlib import Path
 
 import pytest
@@ -16,6 +16,8 @@ from moonmind.schemas.managed_session_models import (
     SendCodexManagedSessionTurnRequest,
     SteerCodexManagedSessionTurnRequest,
 )
+from moonmind.workflows.automation import models as automation_models
+from moonmind.workflows.automation.preflight import CodexPreflightResult
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexAppServerRpcClient,
     CodexManagedSessionRuntime,
@@ -3357,6 +3359,50 @@ def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch,
     )
 
     with pytest.raises(RuntimeError, match="MOONMIND_SESSION_IMAGE_REF is required"):
+        _run_ready()
+
+
+def test_run_ready_fails_when_docker_sidecar_preflight_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_path = tmp_path / "repo"
+    workspace_path.mkdir()
+    monkeypatch.setenv("MOONMIND_SESSION_WORKSPACE_PATH", str(workspace_path))
+    monkeypatch.setenv(
+        "MOONMIND_SESSION_WORKSPACE_STATE_PATH",
+        str(tmp_path / "session"),
+    )
+    monkeypatch.setenv(
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+        str(tmp_path / "artifacts"),
+    )
+    monkeypatch.setenv(
+        "MOONMIND_SESSION_CODEX_HOME_PATH",
+        str(tmp_path / "codex-home"),
+    )
+    monkeypatch.setenv("MOONMIND_SESSION_IMAGE_REF", "ghcr.io/acme/moonmind:runtime")
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", "docker-sidecar")
+    monkeypatch.setenv("DOCKER_HOST", "unix:///var/run/moonmind-docker/docker.sock")
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.shutil.which",
+        lambda _name: "/usr/bin/codex",
+    )
+
+    def fake_preflight(**_kwargs: object) -> CodexPreflightResult:
+        return CodexPreflightResult(
+            status=automation_models.CodexPreflightStatus.FAILED,
+            message="Docker sidecar preflight failed: docker info did not succeed.",
+            failure_class="system_error",
+            diagnostics_ref="preflight://docker-sidecar",
+        )
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.run_docker_sidecar_preflight_check",
+        fake_preflight,
+    )
+
+    with pytest.raises(RuntimeError, match="Docker sidecar preflight failed"):
         _run_ready()
 
 

--- a/tests/unit/workflows/automation/test_preflight.py
+++ b/tests/unit/workflows/automation/test_preflight.py
@@ -9,9 +9,11 @@ def test_docker_sidecar_preflight_probes_info_and_pinned_ue_manifest(
     monkeypatch,
 ) -> None:
     calls: list[list[str]] = []
+    captured_envs: list[dict[str, object]] = []
 
     def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
         calls.append(args)
+        captured_envs.append(kwargs["env"])
         assert kwargs["timeout"] == 15
         if args == ["docker", "info"]:
             return subprocess.CompletedProcess(args, 0, stdout="Server OK\n", stderr="")
@@ -30,6 +32,8 @@ def test_docker_sidecar_preflight_probes_info_and_pinned_ue_manifest(
         env={
             "DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock",
             "MOONMIND_UNREAL_ENGINE_IMAGE": "ghcr.io/acme/unreal-engine:5.4",
+            "MOONMIND_NUMERIC_ENV": 5,
+            "MOONMIND_NULL_ENV": None,
         },
         timeout=15,
     )
@@ -41,6 +45,8 @@ def test_docker_sidecar_preflight_probes_info_and_pinned_ue_manifest(
         ["docker", "info"],
         ["docker", "manifest", "inspect", "ghcr.io/acme/unreal-engine:5.4"],
     ]
+    assert captured_envs[0]["MOONMIND_NUMERIC_ENV"] == "5"
+    assert "MOONMIND_NULL_ENV" not in captured_envs[0]
 
 
 def test_docker_sidecar_preflight_fails_as_system_error_when_info_fails(
@@ -65,6 +71,25 @@ def test_docker_sidecar_preflight_fails_as_system_error_when_info_fails(
     assert result.failure_class == "system_error"
     assert result.diagnostics_ref == "preflight://docker-sidecar"
     assert "Cannot connect to the Docker daemon" in (result.message or "")
+
+
+def test_docker_sidecar_preflight_fails_as_system_error_on_os_error(
+    monkeypatch,
+) -> None:
+    def fake_run(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args == ["docker", "info"]
+        raise PermissionError("docker is not executable")
+
+    monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+
+    result = preflight.run_docker_sidecar_preflight_check(
+        env={"MOONMIND_MANAGED_SESSION_DOCKER_MODE": "docker-sidecar"}
+    )
+
+    assert result.status is models.CodexPreflightStatus.FAILED
+    assert result.failure_class == "system_error"
+    assert result.diagnostics_ref == "preflight://docker-sidecar"
+    assert "docker is not executable" in (result.message or "")
 
 
 def test_docker_sidecar_preflight_rejects_unpinned_ue_image(monkeypatch) -> None:

--- a/tests/unit/workflows/automation/test_preflight.py
+++ b/tests/unit/workflows/automation/test_preflight.py
@@ -1,0 +1,86 @@
+import subprocess
+from typing import Any
+
+from moonmind.workflows.automation import models
+from moonmind.workflows.automation import preflight
+
+
+def test_docker_sidecar_preflight_probes_info_and_pinned_ue_manifest(
+    monkeypatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        assert kwargs["timeout"] == 15
+        if args == ["docker", "info"]:
+            return subprocess.CompletedProcess(args, 0, stdout="Server OK\n", stderr="")
+        if args == [
+            "docker",
+            "manifest",
+            "inspect",
+            "ghcr.io/acme/unreal-engine:5.4",
+        ]:
+            return subprocess.CompletedProcess(args, 0, stdout='{"schemaVersion":2}', stderr="")
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+
+    result = preflight.run_docker_sidecar_preflight_check(
+        env={
+            "DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock",
+            "MOONMIND_UNREAL_ENGINE_IMAGE": "ghcr.io/acme/unreal-engine:5.4",
+        },
+        timeout=15,
+    )
+
+    assert result.status is models.CodexPreflightStatus.PASSED
+    assert result.failure_class is None
+    assert result.diagnostics_ref == "preflight://docker-sidecar"
+    assert calls == [
+        ["docker", "info"],
+        ["docker", "manifest", "inspect", "ghcr.io/acme/unreal-engine:5.4"],
+    ]
+
+
+def test_docker_sidecar_preflight_fails_as_system_error_when_info_fails(
+    monkeypatch,
+) -> None:
+    def fake_run(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args == ["docker", "info"]
+        return subprocess.CompletedProcess(
+            args,
+            1,
+            stdout="",
+            stderr="Cannot connect to the Docker daemon",
+        )
+
+    monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+
+    result = preflight.run_docker_sidecar_preflight_check(
+        env={"MOONMIND_MANAGED_SESSION_DOCKER_MODE": "docker-sidecar"}
+    )
+
+    assert result.status is models.CodexPreflightStatus.FAILED
+    assert result.failure_class == "system_error"
+    assert result.diagnostics_ref == "preflight://docker-sidecar"
+    assert "Cannot connect to the Docker daemon" in (result.message or "")
+
+
+def test_docker_sidecar_preflight_rejects_unpinned_ue_image(monkeypatch) -> None:
+    def fake_run(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args == ["docker", "info"]
+        return subprocess.CompletedProcess(args, 0, stdout="Server OK\n", stderr="")
+
+    monkeypatch.setattr(preflight.subprocess, "run", fake_run)
+
+    result = preflight.run_docker_sidecar_preflight_check(
+        env={
+            "DOCKER_HOST": "unix:///var/run/moonmind-docker/docker.sock",
+            "MOONMIND_UNREAL_ENGINE_IMAGE": "ghcr.io/acme/unreal-engine:latest",
+        },
+    )
+
+    assert result.status is models.CodexPreflightStatus.FAILED
+    assert result.failure_class == "system_error"
+    assert "must be pinned" in (result.message or "")

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2151,6 +2151,70 @@ def test_moonspec_verify_gate_records_nested_summary_and_report(
     assert gate_context["diagnosticsRef"] == "art_nested_verify_report"
 
 
+def test_moonspec_verify_blocked_attempt_one_stops_with_remaining_budget(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    ordered_nodes = [
+        {
+            "id": "verify-1",
+            "inputs": {
+                "title": "Verify remediation 1 of 6",
+                "selectedSkill": "moonspec-verify",
+            },
+        },
+        {
+            "id": "remediate-2",
+            "annotations": {"jiraOrchestrateRole": "moonspec-remediation"},
+            "skill": {"id": "moonspec-implement"},
+            "inputs": {"title": "Remediate verification gaps 2 of 6"},
+        },
+    ]
+
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-1",
+        outputs={
+            "verdict": "BLOCKED",
+            "operator_summary": "UE Docker sidecar is not reachable.",
+            "diagnostics_ref": "art_verify_blocked",
+        },
+    )
+
+    assert mock_run_workflow._has_remaining_moonspec_remediation_step(
+        ordered_nodes=ordered_nodes,
+        current_index=0,
+    )
+    assert mock_run_workflow._normalize_moonspec_verify_verdict(
+        mock_run_workflow._moonspec_gate_verdict
+    ) == "BLOCKED"
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
+    assert mock_run_workflow._publish_status == "not_required"
+    assert mock_run_workflow._publish_context["publicationBlockedBy"] == (
+        "moonspec_verify"
+    )
+    assert "UE Docker sidecar is not reachable" in (
+        mock_run_workflow._plan_blocked_message or ""
+    )
+
+
+def test_moonspec_verify_gate_degrades_unknown_verdict_to_no_determination(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_moonspec_verify_gate(
+        node_id="verify-1",
+        outputs={
+            "verdict": "UNREAL_VALIDATION_ENVIRONMENT_MISSING",
+            "operator_summary": "Verifier returned an unsupported environment verdict.",
+            "diagnostics_ref": "art_unknown_verdict",
+        },
+    )
+
+    gate_context = mock_run_workflow._publish_context["moonSpecGate"]
+    assert gate_context["verdict"] == "NO_DETERMINATION"
+    assert mock_run_workflow._apply_blocking_moonspec_gate_to_publish() is True
+    assert "NO_DETERMINATION" in (mock_run_workflow._plan_blocked_message or "")
+    assert "art_unknown_verdict" in (mock_run_workflow._plan_blocked_message or "")
+
+
 def test_moonspec_verify_gate_accepts_fully_implemented_publish(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:


### PR DESCRIPTION
Implement the MoonMind remediation for Unreal hard blocker 2 from the revised 2026-06-12 plan.

Context: parent workflow mm:0dc7a4d3-cf7a-4922-a50f-5fdf674deb8c for Jira Orchestrate THOR-555 pushed target branch `run-jira-orchestrate-for-thor-555-comple-1952cd6a` at `a82dbe8b`, but PR publication was blocked after 6/6 remediation attempts. The managed worker is a Linux container, so native Windows UE tools (`UnrealEditor-Cmd.exe`, `Build.bat`, `vswhere.exe`) cannot be expected inside it. The intended validation path is the per-session Docker sidecar described in `docs/ManagedAgents/DockerSidecarRuntime.md`.

Scope for this workflow:
1. Extend the existing Jira Orchestrate/preflight pattern in `moonmind/workflows/automation/preflight.py` with environment checks before agent steps start: sidecar `docker info`, plus a cheap authenticated `docker manifest inspect <pinned UE image>` probe when a pinned image is configured.
2. On preflight failure, fail/stop up front as an infrastructure/setup outcome, not as a source-code remediation loop. Use `failure_class="system_error"` and preserve a diagnostics ref.
3. Ensure environment-invalid verifier outcomes (`BLOCKED`, `FAILED_UNRECOVERABLE`, and `ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION`) stop retry/remediation early in the Jira Orchestrate path instead of burning all six attempts. Coordinate with the existing workflow gate behavior in `moonmind/workflows/temporal/workflows/run.py`, which already treats `BLOCKED` as terminal.
4. Update `api_service/data/presets/jira-orchestrate.yaml` remediation instructions/gates so they branch on `BLOCKED` and `FAILED_UNRECOVERABLE`, classify environment failure, skip remaining remediation attempts, and avoid PR creation when the environment is invalid.
5. Add workflow-boundary tests covering a `BLOCKED` verdict at remediation attempt 1 and a degraded unknown verdict string.

Out of scope: target THOR/Tactics repo validation-ladder edits, native UE installation, or GitHub Actions secret changes. Publish as a PR and allow merge automation to run.