### PR TITLE
Add GHCR pull credentials for Docker sidecar and DooD validation

### DIFF
--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -82,6 +82,13 @@ profiles:
       - type: volume
         source: unreal_ubt_volume
         target: /work/ubt-cache
+    credentialMounts:
+      - type: volume
+        source: ghcr_pull_auth_volume
+        target: /home/runner/.docker
+        readOnly: true
+        justification: Read-only Docker client config for GHCR read:packages pulls of curated Unreal runner images.
+        approvalRef: THOR-555
     envAllowlist:
       - CI
       - CCACHE_DIR

--- a/docs/ManagedAgents/DockerOutOfDocker.md
+++ b/docs/ManagedAgents/DockerOutOfDocker.md
@@ -553,6 +553,8 @@ Any auth or credential mount must be:
 * explicitly declared by a runner profile, or
 * explicitly provisioned by MoonMind policy for the unrestricted execution plane
 
+Runner-profile credential mounts are also the parity mechanism for curated control-plane workloads that require registry pull configuration. A profile may declare a read-only Docker config volume, with justification and approval reference, for deployment-approved GHCR `read:packages` pull credentials. The mount declaration is policy metadata and must not expose raw credentials in tool inputs, logs, or diagnostics.
+
 ### 10.5 Output discipline
 
 Workload containers must write only to approved workspace paths and mounted caches.

--- a/docs/ManagedAgents/DockerSidecarRuntime.md
+++ b/docs/ManagedAgents/DockerSidecarRuntime.md
@@ -328,6 +328,7 @@ Start with classic DinD on trusted deployments. Roll rootless out as a hardening
 | `workspace` | session | same path in both (e.g. `/work/agent_jobs`) | agent + sidecar | the agent's repo and run artifacts |
 | `docker-socket` | session | `/var/run/moonmind-docker` | agent + sidecar | Unix socket exposed by `dockerd` |
 | `docker-graph` | session | `/var/lib/docker` (or rootless equivalent) | sidecar only | nested image/container storage |
+| `docker-config` | session | `<sessionWorkspace>/.docker` | agent only | optional Docker client auth config for deployment-approved pull credentials |
 | optional caches | session or user | deployment-defined | agent + sidecar (as declared) | package manager / build caches |
 
 Invariants:
@@ -731,6 +732,8 @@ Every per-session sidecar deployment must be discoverable and traceable. The two
 
 The session-status surface (§13) reports daemon readiness, version, and probe results. Durable evidence for agent work continues to flow through the existing artifact pipeline; the sidecar itself is not the system of record. Per-container stdout/stderr capture for the daemon belongs in worker logs, not in the workflow artifact area, unless explicitly attached for debugging.
 
+When a deployment provides GHCR pull credentials through managed secret references such as `GHCR_PULL_USER` and `GHCR_PULL_TOKEN`, the launcher may materialize a session-scoped Docker client config under the session workspace and set `DOCKER_CONFIG` only for that managed session. The config is ephemeral, contains only pull-scoped registry auth, and is never written into workflow history or durable metadata. Diagnostics record only metadata such as `pullAuth: authenticated|anonymous`, the registry, and manifest probe outcome.
+
 ---
 
 ## 23. Validation rules
@@ -747,6 +750,7 @@ The session launcher must validate at least the following before starting a sess
 8. Admin/ops Docker access must be isolated to the MoonMind ops runtime (§21).
 9. The sidecar image tag must be pinned (`docker:27-dind`, not `docker:latest`).
 10. The Docker daemon scope must be per session — no shared daemon across sessions or users.
+11. If a managed-session Docker manifest preflight image is configured, it must be digest-pinned and `docker manifest inspect` must pass before the session proceeds to agent orchestration.
 
 Example failure message:
 

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -988,6 +988,7 @@ class ManagedSessionDockerCapabilityRequest(BaseModel):
     mode: ManagedSessionDockerCapabilityMode = Field("sidecar-dind", alias="mode")
     docker_host: str | None = Field(None, alias="dockerHost")
     compose_support: bool = Field(False, alias="composeSupport")
+    manifest_image_ref: str | None = Field(None, alias="manifestImageRef")
     timeout_seconds: float = Field(60.0, alias="timeoutSeconds", ge=0)
     interval_seconds: float = Field(2.0, alias="intervalSeconds", ge=0)
 
@@ -997,6 +998,11 @@ class ManagedSessionDockerCapabilityRequest(BaseModel):
             self.docker_host = require_non_blank(
                 self.docker_host,
                 field_name="dockerCapability.dockerHost",
+            )
+        if self.manifest_image_ref is not None:
+            self.manifest_image_ref = require_non_blank(
+                self.manifest_image_ref,
+                field_name="dockerCapability.manifestImageRef",
             )
         return self
 

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -26,6 +26,8 @@ _MANAGED_GITHUB_TOKEN_SLUGS: tuple[str, ...] = (
     "GITHUB_TOKEN",
     "GITHUB_PAT",
 )
+_MANAGED_GHCR_PULL_USER_SLUGS: tuple[str, ...] = ("GHCR_PULL_USER",)
+_MANAGED_GHCR_PULL_TOKEN_SLUGS: tuple[str, ...] = ("GHCR_PULL_TOKEN",)
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +87,102 @@ async def resolve_managed_github_token_from_store() -> str | None:
             candidate = str(secret.ciphertext if secret else "").strip()
             if candidate:
                 return candidate
+    return None
+
+async def _resolve_first_active_managed_secret_slug(
+    slugs: Iterable[str],
+) -> str | None:
+    """Return the first active managed secret value for the provided slugs."""
+
+    from api_service.db.base import async_session_maker
+    from api_service.db.models import ManagedSecret, SecretStatus
+
+    async with async_session_maker() as session:
+        for slug in slugs:
+            normalized = str(slug or "").strip()
+            if not normalized:
+                continue
+            result = await session.execute(
+                select(ManagedSecret).where(
+                    ManagedSecret.slug == normalized,
+                    ManagedSecret.status == SecretStatus.ACTIVE,
+                )
+            )
+            secret = result.scalar_one_or_none()
+            candidate = str(secret.ciphertext if secret else "").strip()
+            if candidate:
+                return candidate
+    return None
+
+async def resolve_ghcr_pull_credentials_for_launch(
+    environment: Mapping[str, str] | None = None,
+) -> tuple[str, str] | None:
+    """Resolve deployment-scoped GHCR pull credentials for launch boundaries.
+
+    The returned plaintext is for immediate Docker config materialization only.
+    Callers must not store it in workflow history, logs, or durable metadata.
+    """
+
+    launch_environment = environment or {}
+
+    user_ref = str(
+        launch_environment.get("GHCR_PULL_USER_SECRET_REF")
+        or os.environ.get("MOONMIND_GHCR_PULL_USER_SECRET_REF")
+        or os.environ.get("WORKFLOW_GHCR_PULL_USER_SECRET_REF")
+        or ""
+    ).strip()
+    token_ref = str(
+        launch_environment.get("GHCR_PULL_TOKEN_SECRET_REF")
+        or os.environ.get("MOONMIND_GHCR_PULL_TOKEN_SECRET_REF")
+        or os.environ.get("WORKFLOW_GHCR_PULL_TOKEN_SECRET_REF")
+        or ""
+    ).strip()
+    if user_ref or token_ref:
+        if not user_ref or not token_ref:
+            raise ValueError(
+                "GHCR pull authentication requires both user and token secret refs"
+            )
+        user = await resolve_managed_api_key_reference(
+            user_ref,
+            field_name="GHCR_PULL_USER_SECRET_REF",
+        )
+        token = await resolve_managed_api_key_reference(
+            token_ref,
+            field_name="GHCR_PULL_TOKEN_SECRET_REF",
+        )
+        if user.strip() and token.strip():
+            return user.strip(), token.strip()
+        return None
+
+    user = str(
+        launch_environment.get("GHCR_PULL_USER")
+        or os.environ.get("GHCR_PULL_USER")
+        or ""
+    ).strip()
+    token = str(
+        launch_environment.get("GHCR_PULL_TOKEN")
+        or os.environ.get("GHCR_PULL_TOKEN")
+        or ""
+    ).strip()
+    if user and token:
+        return user, token
+
+    try:
+        stored_user, stored_token = await asyncio.gather(
+            _resolve_first_active_managed_secret_slug(_MANAGED_GHCR_PULL_USER_SLUGS),
+            _resolve_first_active_managed_secret_slug(_MANAGED_GHCR_PULL_TOKEN_SLUGS),
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning(
+            "Failed to resolve GHCR pull credentials from managed secrets store",
+            exc_info=True,
+        )
+        return None
+
+    if stored_user and stored_token:
+        return stored_user.strip(), stored_token.strip()
     return None
 
 async def resolve_github_token_for_launch(

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -164,7 +164,11 @@ async def resolve_ghcr_pull_credentials_for_launch(
         or os.environ.get("GHCR_PULL_TOKEN")
         or ""
     ).strip()
-    if user and token:
+    if user or token:
+        if not user or not token:
+            raise ValueError(
+                "GHCR pull authentication requires both user and token environment variables"
+            )
         return user, token
 
     try:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -548,10 +548,27 @@ class DockerCodexManagedSessionController:
             }
         }
         host_config_path.parent.mkdir(parents=True, exist_ok=True)
+        # Docker requires plaintext registry auth in config.json; this file is
+        # session-scoped, mode 0600, owned by the agent user, and cleaned up.
+        # codeql[py/clear-text-storage-sensitive-data]
         host_config_path.write_text(
             json.dumps(config_payload, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+        geteuid = getattr(os, "geteuid", None)
+        if os.name == "posix" and callable(geteuid) and geteuid() == 0:
+            try:
+                os.chown(
+                    host_config_path,
+                    _MANAGED_SESSION_CONTAINER_UID,
+                    _MANAGED_SESSION_CONTAINER_GID,
+                )
+            except OSError:
+                logger.debug(
+                    "Could not chown session Docker config at %s",
+                    host_config_path,
+                    exc_info=True,
+                )
         try:
             host_config_path.chmod(0o600)
         except OSError:
@@ -560,6 +577,8 @@ class DockerCodexManagedSessionController:
                 host_config_path,
                 exc_info=True,
             )
+        session_environment.pop("GHCR_PULL_USER", None)
+        session_environment.pop("GHCR_PULL_TOKEN", None)
         session_environment["DOCKER_CONFIG"] = str(container_config_path.parent)
         return {
             **diagnostics,
@@ -2221,10 +2240,14 @@ class DockerCodexManagedSessionController:
                 request,
                 session_environment,
             )
-            manifest_probe = await self._preflight_docker_manifest_probe(
-                request=request,
-                pull_auth_diagnostics=docker_pull_diagnostics,
-            )
+            try:
+                manifest_probe = await self._preflight_docker_manifest_probe(
+                    request=request,
+                    pull_auth_diagnostics=docker_pull_diagnostics,
+                )
+            except Exception:
+                self._cleanup_session_docker_config(request.session_workspace_path)
+                raise
             docker_pull_diagnostics = {
                 **docker_pull_diagnostics,
                 "manifestProbe": manifest_probe,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -40,6 +41,7 @@ from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_ghcr_pull_credentials_for_launch,
     resolve_github_token_for_launch,
 )
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
@@ -69,6 +71,8 @@ _LAST_ASSISTANT_TEXT_METADATA_MAX_BYTES = 4 * 1024
 _SESSION_DOCKER_SOCKET_DIR = "/var/run/moonmind-docker"
 _SESSION_DOCKER_SOCKET_PATH = f"{_SESSION_DOCKER_SOCKET_DIR}/docker.sock"
 _SESSION_DOCKER_GRAPH_PATH = "/var/lib/docker"
+_SESSION_DOCKER_CONFIG_DIRNAME = ".docker"
+_SESSION_DOCKER_CONFIG_FILENAME = "config.json"
 _DEFAULT_SESSION_DOCKER_SIDECAR_IMAGE = "docker:27-dind"
 _SESSION_DOCKER_MODE_ENABLED_VALUES = {"docker-sidecar"}
 _SESSION_DOCKER_MODE_DISABLED_VALUES = {"no-docker", "disabled", "none", "off"}
@@ -469,6 +473,166 @@ class DockerCodexManagedSessionController:
             raise RuntimeError("docker sidecar run returned a blank container id")
         await self._wait_docker_sidecar_ready(sidecar_id)
         return sidecar_id
+
+    def _session_docker_config_path(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> tuple[Path, PurePosixPath]:
+        host_path = (
+            Path(request.session_workspace_path)
+            / _SESSION_DOCKER_CONFIG_DIRNAME
+            / _SESSION_DOCKER_CONFIG_FILENAME
+        )
+        container_path = (
+            PurePosixPath(request.session_workspace_path)
+            / _SESSION_DOCKER_CONFIG_DIRNAME
+            / _SESSION_DOCKER_CONFIG_FILENAME
+        )
+        return host_path, container_path
+
+    def _cleanup_session_docker_config(
+        self,
+        session_workspace_path: str,
+    ) -> None:
+        docker_config_dir = (
+            Path(session_workspace_path) / _SESSION_DOCKER_CONFIG_DIRNAME
+        )
+        if not self._is_within_workspace_root(docker_config_dir):
+            return
+        config_path = docker_config_dir / _SESSION_DOCKER_CONFIG_FILENAME
+        try:
+            if config_path.exists():
+                config_path.unlink()
+            docker_config_dir.rmdir()
+        except FileNotFoundError:
+            return
+        except OSError:
+            logger.debug(
+                "Could not remove session Docker config at %s",
+                docker_config_dir,
+                exc_info=True,
+            )
+
+    async def _configure_session_ghcr_pull_auth(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+        session_environment: dict[str, str],
+    ) -> dict[str, Any]:
+        credentials = await resolve_ghcr_pull_credentials_for_launch(
+            session_environment
+        )
+        diagnostics: dict[str, Any] = {
+            "pullAuth": "anonymous",
+            "registry": "ghcr.io",
+            "dockerConfig": "not_materialized",
+        }
+        if credentials is None:
+            return diagnostics
+
+        username, token = credentials
+        host_config_path, container_config_path = self._session_docker_config_path(
+            request
+        )
+        self._validate_workspace_path(
+            str(host_config_path),
+            field_name="dockerConfigPath",
+        )
+        auth_payload = base64.b64encode(
+            f"{username}:{token}".encode("utf-8")
+        ).decode("ascii")
+        config_payload = {
+            "auths": {
+                "ghcr.io": {
+                    "auth": auth_payload,
+                }
+            }
+        }
+        host_config_path.parent.mkdir(parents=True, exist_ok=True)
+        host_config_path.write_text(
+            json.dumps(config_payload, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        try:
+            host_config_path.chmod(0o600)
+        except OSError:
+            logger.debug(
+                "Could not chmod session Docker config at %s",
+                host_config_path,
+                exc_info=True,
+            )
+        session_environment["DOCKER_CONFIG"] = str(container_config_path.parent)
+        return {
+            **diagnostics,
+            "pullAuth": "authenticated",
+            "dockerConfig": "session_workspace",
+            "dockerConfigPath": str(container_config_path),
+        }
+
+    @staticmethod
+    def _docker_manifest_probe_image_ref(
+        request: LaunchCodexManagedSessionRequest,
+    ) -> str | None:
+        capability = request.docker_capability
+        raw = (
+            getattr(capability, "manifest_image_ref", None)
+            if capability is not None
+            else None
+        )
+        if not raw:
+            raw = request.environment.get("MOONMIND_DOCKER_PREFLIGHT_IMAGE_REF")
+        text = str(raw or "").strip()
+        return text or None
+
+    @staticmethod
+    def _image_ref_is_pinned_digest(image_ref: str) -> bool:
+        return "@sha256:" in str(image_ref or "").strip()
+
+    async def _preflight_docker_manifest_probe(
+        self,
+        *,
+        request: LaunchCodexManagedSessionRequest,
+        pull_auth_diagnostics: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        image_ref = self._docker_manifest_probe_image_ref(request)
+        if not image_ref:
+            return {"status": "skipped", "reason": "no_manifest_image_ref"}
+        if not self._image_ref_is_pinned_digest(image_ref):
+            raise RuntimeError(
+                "Docker preflight image ref must be pinned to a digest"
+            )
+        docker_config_path, _container_config_path = self._session_docker_config_path(
+            request
+        )
+        docker_config_dir = docker_config_path.parent
+        command = [
+            self._docker_binary,
+            "manifest",
+            "inspect",
+            image_ref,
+        ]
+        extra_env: dict[str, str] | None = None
+        if pull_auth_diagnostics.get("pullAuth") == "authenticated":
+            extra_env = {"DOCKER_CONFIG": str(docker_config_dir)}
+        returncode, stdout, stderr = await self._command_runner(
+            tuple(command),
+            env={**self._docker_env(), **(extra_env or {})},
+        )
+        detail = (stderr.strip() or stdout.strip())[:500]
+        if returncode != 0:
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                command,
+                detail,
+                extra_env=extra_env,
+            )
+            raise RuntimeError(
+                "Docker preflight manifest probe failed: "
+                f"{rendered_command}: {rendered_detail}"
+            )
+        return {
+            "status": "passed",
+            "imageRef": image_ref,
+            "pullAuth": str(pull_auth_diagnostics.get("pullAuth") or "anonymous"),
+        }
 
     async def _wait_docker_sidecar_ready(self, sidecar_id: str) -> None:
         command = (
@@ -2046,6 +2210,25 @@ class DockerCodexManagedSessionController:
             session_environment.pop("SYSTEM_DOCKER_HOST", None)
         else:
             self._apply_unrestricted_docker_session_environment(session_environment)
+        docker_pull_diagnostics: dict[str, Any] = {
+            "pullAuth": "anonymous",
+            "registry": "ghcr.io",
+            "dockerConfig": "not_materialized",
+            "manifestProbe": {"status": "skipped", "reason": "docker_sidecar_disabled"},
+        }
+        if docker_sidecar_enabled:
+            docker_pull_diagnostics = await self._configure_session_ghcr_pull_auth(
+                request,
+                session_environment,
+            )
+            manifest_probe = await self._preflight_docker_manifest_probe(
+                request=request,
+                pull_auth_diagnostics=docker_pull_diagnostics,
+            )
+            docker_pull_diagnostics = {
+                **docker_pull_diagnostics,
+                "manifestProbe": manifest_probe,
+            }
         container_name = (
             self._sidecar_agent_container_name(request.session_id)
             if docker_sidecar_enabled
@@ -2186,6 +2369,7 @@ class DockerCodexManagedSessionController:
                     request.session_id,
                     ignore_failure=True,
                 )
+                self._cleanup_session_docker_config(request.session_workspace_path)
             if github_broker_started:
                 await self._github_auth_brokers.stop(request.session_id)
             raise
@@ -2194,6 +2378,14 @@ class DockerCodexManagedSessionController:
             docker_capability_metadata = await self._evaluate_docker_capability(
                 container_id=container_id,
                 request=request.model_copy(update={"environment": session_environment}),
+            )
+            docker_capability_metadata = self._merge_capability_metadata(
+                {
+                    "capabilities": {
+                        "dockerPull": docker_pull_diagnostics,
+                    },
+                },
+                docker_capability_metadata,
             )
             launch_metadata = self._merge_capability_metadata(
                 request.metadata,
@@ -2222,6 +2414,7 @@ class DockerCodexManagedSessionController:
                     request.session_id,
                     ignore_failure=True,
                 )
+                self._cleanup_session_docker_config(request.session_workspace_path)
             if github_broker_started:
                 await self._github_auth_brokers.stop(request.session_id)
             raise
@@ -2540,6 +2733,7 @@ class DockerCodexManagedSessionController:
                         request.session_id,
                         ignore_failure=True,
                     )
+                    self._cleanup_session_docker_config(record.session_workspace_path)
                 await self._github_auth_brokers.stop(request.session_id)
                 return CodexManagedSessionHandle(
                     runtimeFamily=request.runtime_family,
@@ -2554,6 +2748,7 @@ class DockerCodexManagedSessionController:
                 request.session_id,
                 ignore_failure=True,
             )
+            self._cleanup_session_docker_config(record.session_workspace_path)
         elif record is None:
             await self._cleanup_docker_sidecar_resources(
                 request.session_id,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -556,7 +556,7 @@ class DockerCodexManagedSessionController:
         # session-scoped, mode 0600, owned by the agent user, and cleaned up.
         # codeql[py/clear-text-storage-sensitive-data]
         host_config_path.write_text(
-            config_json,
+            config_json,  # codeql[py/clear-text-storage-sensitive-data] # lgtm[py/clear-text-storage-sensitive-data]
             encoding="utf-8",
         )
         geteuid = getattr(os, "geteuid", None)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -548,11 +548,15 @@ class DockerCodexManagedSessionController:
             }
         }
         host_config_path.parent.mkdir(parents=True, exist_ok=True)
+        # Docker requires plaintext registry auth in config.json; this file is
+        # session-scoped, mode 0600, owned by the agent user, and cleaned up.
+        # codeql[py/clear-text-storage-sensitive-data]
+        config_json = json.dumps(config_payload, sort_keys=True) + "\n"
+        # Docker requires plaintext registry auth in config.json; this file is
+        # session-scoped, mode 0600, owned by the agent user, and cleaned up.
+        # codeql[py/clear-text-storage-sensitive-data]
         host_config_path.write_text(
-            # Docker requires plaintext registry auth in config.json; this file is
-            # session-scoped, mode 0600, owned by the agent user, and cleaned up.
-            # codeql[py/clear-text-storage-sensitive-data]
-            json.dumps(config_payload, sort_keys=True) + "\n",
+            config_json,
             encoding="utf-8",
         )
         geteuid = getattr(os, "geteuid", None)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -548,10 +548,10 @@ class DockerCodexManagedSessionController:
             }
         }
         host_config_path.parent.mkdir(parents=True, exist_ok=True)
-        # Docker requires plaintext registry auth in config.json; this file is
-        # session-scoped, mode 0600, owned by the agent user, and cleaned up.
-        # codeql[py/clear-text-storage-sensitive-data]
         host_config_path.write_text(
+            # Docker requires plaintext registry auth in config.json; this file is
+            # session-scoped, mode 0600, owned by the agent user, and cleaned up.
+            # codeql[py/clear-text-storage-sensitive-data]
             json.dumps(config_payload, sort_keys=True) + "\n",
             encoding="utf-8",
         )

--- a/tests/integration/temporal/test_managed_session_ghcr_pull_auth.py
+++ b/tests/integration/temporal/test_managed_session_ghcr_pull_auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -142,6 +143,8 @@ async def test_sidecar_bootstrap_writes_session_docker_config_when_ghcr_secret_p
     assert config["auths"]["ghcr.io"]["auth"] == base64.b64encode(
         b"pull-user:pull-token"
     ).decode("ascii")
+    if os.name == "posix" and os.geteuid() == 0:
+        assert (config_path.stat().st_uid, config_path.stat().st_gid) == (1000, 1000)
 
     manifest_call = next(
         item for item in commands if item[0][:3] == ("docker", "manifest", "inspect")
@@ -210,3 +213,102 @@ async def test_sidecar_bootstrap_uses_anonymous_pull_auth_when_ghcr_secret_absen
     assert docker_pull["pullAuth"] == "anonymous"
     assert docker_pull["manifestProbe"]["status"] == "passed"
     assert docker_pull["manifestProbe"]["pullAuth"] == "anonymous"
+
+
+@pytest.mark.asyncio
+async def test_sidecar_bootstrap_scrubs_ghcr_env_credentials_from_agent_container(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = _request(workspace_root).model_copy(
+        update={
+            "environment": {
+                **_request(workspace_root).environment,
+                "GHCR_PULL_USER": "pull-user",
+                "GHCR_PULL_TOKEN": "pull-token",
+            }
+        }
+    )
+
+    _controller, store, commands = await _launch_with_fake_docker(
+        request,
+        tmp_path=tmp_path,
+    )
+
+    config_path = Path(request.session_workspace_path) / ".docker" / "config.json"
+    assert config_path.exists()
+
+    manifest_call = next(
+        item for item in commands if item[0][:3] == ("docker", "manifest", "inspect")
+    )
+    assert manifest_call[1] == {"DOCKER_CONFIG": str(config_path.parent)}
+
+    agent_run = next(
+        command
+        for command, _env in commands
+        if command[:2] == ("docker", "run")
+        and "moonmind-session-sess-1-agent" in command
+    )
+    rendered_agent_run = " ".join(agent_run)
+    assert f"DOCKER_CONFIG={request.session_workspace_path}/.docker" in agent_run
+    assert "GHCR_PULL_USER=" not in rendered_agent_run
+    assert "GHCR_PULL_TOKEN=" not in rendered_agent_run
+    assert "pull-token" not in rendered_agent_run
+
+    record = store.load(request.session_id)
+    assert record is not None
+    assert "pull-token" not in json.dumps(record.metadata)
+
+
+@pytest.mark.asyncio
+async def test_sidecar_bootstrap_cleans_docker_config_when_preflight_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = _request(workspace_root)
+    commands: list[tuple[tuple[str, ...], dict[str, str] | None]] = []
+
+    async def _fake_resolver(_environment: dict[str, str]) -> tuple[str, str]:
+        return "pull-user", "pull-token"
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[int, str, str]:
+        del input_text
+        commands.append((command, env))
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:3] == ("docker", "manifest", "inspect"):
+            return 1, "", "denied"
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller."
+        "resolve_ghcr_pull_credentials_for_launch",
+        _fake_resolver,
+    )
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(Path(request.workspace_path).parents[1]),
+        session_store=ManagedSessionStore(tmp_path / "session-store"),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    with pytest.raises(RuntimeError, match="preflight manifest probe failed"):
+        await controller.launch_session(request)
+
+    config_path = Path(request.session_workspace_path) / ".docker" / "config.json"
+    assert not config_path.exists()
+    assert any(
+        command[:3] == ("docker", "manifest", "inspect") for command, _env in commands
+    )

--- a/tests/integration/temporal/test_managed_session_ghcr_pull_auth.py
+++ b/tests/integration/temporal/test_managed_session_ghcr_pull_auth.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.managed_session_models import LaunchCodexManagedSessionRequest
+from moonmind.workflows.temporal.runtime.managed_session_controller import (
+    DockerCodexManagedSessionController,
+)
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _request(workspace_root: Path) -> LaunchCodexManagedSessionRequest:
+    return LaunchCodexManagedSessionRequest(
+        agentRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:1.0",
+        environment={
+            "MOONMIND_MANAGED_SESSION_DOCKER_MODE": "docker-sidecar",
+            "MOONMIND_WORKFLOW_DOCKER_MODE": "profiles",
+        },
+        dockerCapability={
+            "required": True,
+            "manifestImageRef": (
+                "ghcr.io/moonladderstudios/moonmind-unreal-runner"
+                "@sha256:"
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            "timeoutSeconds": 0,
+            "intervalSeconds": 0,
+        },
+    )
+
+
+async def _launch_with_fake_docker(
+    request: LaunchCodexManagedSessionRequest,
+    *,
+    tmp_path: Path,
+) -> tuple[
+    DockerCodexManagedSessionController,
+    ManagedSessionStore,
+    list[tuple[tuple[str, ...], dict[str, str] | None]],
+]:
+    commands: list[tuple[tuple[str, ...], dict[str, str] | None]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[int, str, str]:
+        commands.append((command, env))
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:3] == ("docker", "volume", "create"):
+            return 0, command[3] + "\n", ""
+        if command[:3] == ("docker", "manifest", "inspect"):
+            return 0, '{"schemaVersion": 2}\n', ""
+        if command[:2] == ("docker", "run"):
+            name = command[command.index("--name") + 1]
+            if name.endswith("-docker"):
+                return 0, "sidecar-ctr\n", ""
+            if name.endswith("-agent"):
+                return 0, "agent-ctr\n", ""
+        if command[:3] == ("docker", "exec", "-e") and "docker" in command:
+            if "version" in command:
+                return 0, "27.0.0\n", ""
+            return 0, '"27.0.0"\n', ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "agent-ctr",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://moonmind-session-sess-1-agent",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    store = ManagedSessionStore(tmp_path / "session-store")
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(Path(request.workspace_path).parents[1]),
+        session_store=store,
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+    await controller.launch_session(request)
+    return controller, store, commands
+
+
+@pytest.mark.asyncio
+async def test_sidecar_bootstrap_writes_session_docker_config_when_ghcr_secret_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = _request(workspace_root)
+
+    async def _fake_resolver(_environment: dict[str, str]) -> tuple[str, str]:
+        return "pull-user", "pull-token"
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller."
+        "resolve_ghcr_pull_credentials_for_launch",
+        _fake_resolver,
+    )
+
+    _controller, store, commands = await _launch_with_fake_docker(
+        request,
+        tmp_path=tmp_path,
+    )
+
+    config_path = (
+        Path(request.session_workspace_path) / ".docker" / "config.json"
+    )
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert config["auths"]["ghcr.io"]["auth"] == base64.b64encode(
+        b"pull-user:pull-token"
+    ).decode("ascii")
+
+    manifest_call = next(
+        item for item in commands if item[0][:3] == ("docker", "manifest", "inspect")
+    )
+    assert manifest_call[1] is not None
+    assert manifest_call[1]["DOCKER_CONFIG"] == str(config_path.parent)
+
+    agent_run = next(
+        command
+        for command, _env in commands
+        if command[:2] == ("docker", "run")
+        and "moonmind-session-sess-1-agent" in command
+    )
+    assert f"DOCKER_CONFIG={request.session_workspace_path}/.docker" in agent_run
+
+    record = store.load(request.session_id)
+    assert record is not None
+    docker_pull = record.metadata["capabilities"]["dockerPull"]
+    assert docker_pull["pullAuth"] == "authenticated"
+    assert docker_pull["manifestProbe"]["status"] == "passed"
+    assert docker_pull["manifestProbe"]["pullAuth"] == "authenticated"
+    assert "pull-token" not in json.dumps(record.metadata)
+
+
+@pytest.mark.asyncio
+async def test_sidecar_bootstrap_uses_anonymous_pull_auth_when_ghcr_secret_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = _request(workspace_root)
+
+    async def _fake_resolver(_environment: dict[str, str]) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller."
+        "resolve_ghcr_pull_credentials_for_launch",
+        _fake_resolver,
+    )
+
+    _controller, store, commands = await _launch_with_fake_docker(
+        request,
+        tmp_path=tmp_path,
+    )
+
+    config_path = Path(request.session_workspace_path) / ".docker" / "config.json"
+    assert not config_path.exists()
+
+    manifest_call = next(
+        item for item in commands if item[0][:3] == ("docker", "manifest", "inspect")
+    )
+    assert manifest_call[1] == {}
+
+    agent_run = next(
+        command
+        for command, _env in commands
+        if command[:2] == ("docker", "run")
+        and "moonmind-session-sess-1-agent" in command
+    )
+    assert "DOCKER_CONFIG=" not in " ".join(agent_run)
+
+    record = store.load(request.session_id)
+    assert record is not None
+    docker_pull = record.metadata["capabilities"]["dockerPull"]
+    assert docker_pull["pullAuth"] == "anonymous"
+    assert docker_pull["manifestProbe"]["status"] == "passed"
+    assert docker_pull["manifestProbe"]["pullAuth"] == "anonymous"

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -215,6 +215,7 @@ def test_mm693_launch_request_serializes_docker_capability_contract() -> None:
         "mode": "sidecar-dind-rootless",
         "dockerHost": "unix:///var/run/moonmind-docker/docker.sock",
         "composeSupport": True,
+        "manifestImageRef": None,
         "timeoutSeconds": 30.0,
         "intervalSeconds": 1.0,
     }

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3226,6 +3226,14 @@ async def test_controller_terminate_removes_session_docker_sidecar_resources(
     tmp_path: Path,
 ) -> None:
     store = ManagedSessionStore(tmp_path / "session-store")
+    workspace_root = tmp_path / "agent_jobs"
+    session_workspace = workspace_root / "task-1" / "session"
+    docker_config = session_workspace / ".docker" / "config.json"
+    docker_config.parent.mkdir(parents=True)
+    docker_config.write_text(
+        '{"auths":{"ghcr.io":{"auth":"secret"}}}\n',
+        encoding="utf-8",
+    )
     store.save(
         CodexManagedSessionRecord(
             sessionId="sess-1",
@@ -3237,9 +3245,9 @@ async def test_controller_terminate_removes_session_docker_sidecar_resources(
             imageRef="img",
             controlUrl="docker-exec://moonmind-session-sess-1-agent",
             status="ready",
-            workspacePath="/work/agent_jobs/task-1/repo",
-            sessionWorkspacePath="/work/agent_jobs/task-1/session",
-            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            workspacePath=str(workspace_root / "task-1" / "repo"),
+            sessionWorkspacePath=str(session_workspace),
+            artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
             metadata={"dockerSidecarEnabled": True},
             startedAt="2026-04-06T12:00:00Z",
         )
@@ -3263,7 +3271,7 @@ async def test_controller_terminate_removes_session_docker_sidecar_resources(
     controller = DockerCodexManagedSessionController(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
-        workspace_root="/work/agent_jobs",
+        workspace_root=str(workspace_root),
         session_store=store,
         command_runner=_fake_runner,
     )
@@ -3294,6 +3302,7 @@ async def test_controller_terminate_removes_session_docker_sidecar_resources(
         "-f",
         "moonmind-session-sess-1-docker-socket",
     ) in commands
+    assert not docker_config.exists()
 
 @pytest.mark.asyncio
 async def test_controller_terminate_without_store_removes_deterministic_sidecar(

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -12,6 +12,7 @@ from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
     SecretRefLaunchBlockedError,
     assert_managed_secret_refs_active_for_launch,
     inspect_managed_secret_refs_for_launch,
+    resolve_ghcr_pull_credentials_for_launch,
     resolve_github_token_for_launch,
     resolve_managed_api_key_reference,
     resolve_managed_github_token_from_store,
@@ -154,6 +155,35 @@ async def test_resolve_github_token_for_launch_uses_canonical_workflow_env(
     out = await resolve_github_token_for_launch({})
 
     assert out == "workflow-token"
+
+async def test_resolve_ghcr_pull_credentials_requires_complete_env_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
+    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="requires both user and token"):
+        await resolve_ghcr_pull_credentials_for_launch(
+            {"GHCR_PULL_USER": "pull-user"}
+        )
+
+    with pytest.raises(ValueError, match="requires both user and token"):
+        await resolve_ghcr_pull_credentials_for_launch(
+            {"GHCR_PULL_TOKEN": "pull-token"}
+        )
+
+async def test_resolve_ghcr_pull_credentials_uses_complete_env_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
+    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+
+    assert await resolve_ghcr_pull_credentials_for_launch(
+        {
+            "GHCR_PULL_USER": " pull-user ",
+            "GHCR_PULL_TOKEN": " pull-token ",
+        }
+    ) == ("pull-user", "pull-token")
 
 async def test_shape_launch_github_auth_environment_uses_ambient_token_before_store(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -480,8 +480,13 @@ def test_unreal_profile_launch_args_include_cache_volumes_and_safe_posture() -> 
     assert "type=volume,source=agent_workspaces,target=/work/agent_jobs" in run_args
     assert "type=volume,source=unreal_ccache_volume,target=/work/.ccache" in run_args
     assert "type=volume,source=unreal_ubt_volume,target=/work/ubt-cache" in run_args
+    assert (
+        "type=volume,source=ghcr_pull_auth_volume,target=/home/runner/.docker,readonly"
+        in run_args
+    )
     assert "ghcr.io/moonladderstudios/moonmind-unreal-runner:5.3" in run_args
     assert "/var/run/docker.sock" not in " ".join(run_args)
+    assert "read:packages" not in " ".join(run_args)
 
 def test_launcher_mounts_only_explicit_credential_declarations(
     tmp_path: Path,

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -274,6 +274,22 @@ def test_registry_allows_explicit_credential_mount_declarations(
     )
     assert validated.profile.credential_mounts[0].approval_ref == "MM-318"
 
+def test_default_unreal_profile_declares_read_only_ghcr_pull_auth_mount() -> None:
+    registry = RunnerProfileRegistry.load_file(
+        Path("config/workloads/default-runner-profiles.yaml"),
+        workspace_root=WORKSPACE_ROOT,
+        allowed_image_registries=("ghcr.io",),
+    )
+    profile = registry.get("unreal-5_3-linux")
+
+    assert profile is not None
+    mount = profile.credential_mounts[0]
+    assert mount.source == "ghcr_pull_auth_volume"
+    assert mount.target == "/home/runner/.docker"
+    assert mount.read_only is True
+    assert "read:packages" in mount.justification
+    assert mount.approval_ref == "THOR-555"
+
 def test_registry_rejects_credential_mount_without_justification(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Implement the MoonMind remediation for Unreal hard blocker 3 from the revised 2026-06-12 plan.

Context: parent workflow mm:0dc7a4d3-cf7a-4922-a50f-5fdf674deb8c for Jira Orchestrate THOR-555 pushed target branch `run-jira-orchestrate-for-thor-555-comple-1952cd6a` at `a82dbe8b`, but PR publication was blocked after 6/6 remediation attempts. Docker fallback failed because the pinned UE image was not cached and GHCR pull returned `unauthorized`. The current sidecar path is credential-free, while DooD runner profiles already have a sanctioned `credential_mounts` hook.

Scope for this workflow:
1. Add a managed-secret GHCR pull credential path, using deployment-scoped secret refs such as `GHCR_PULL_USER` / `GHCR_PULL_TOKEN` with `read:packages` only, resolved through the existing managed-secret resolver. Do not expose raw secrets in durable workflow history or logs.
2. At Docker sidecar bootstrap in `moonmind/workflows/temporal/runtime/managed_session_controller.py`, materialize an ephemeral session-scoped Docker config for `ghcr.io` when the managed secret is present, or perform an equivalent one-time login against the session sidecar daemon. Scope it to the run/session, never the host daemon, and route redaction through existing `SecretRedactor` paths.
3. Add DooD path parity via a curated runner-profile `credential_mounts` entry (read-only Docker config volume) so `container.run_workload` pulls can authenticate using the existing `WorkloadCredentialMount` contract with justification and approvalRef.
4. Record diagnostics for `pullAuth: authenticated|anonymous` and pull outcome in the workload/session diagnostics artifacts.
5. Add a preflight manifest probe (`docker manifest inspect` of the pinned digest) before orchestration starts and mark failures blocked/system-error up front.
6. Add hermetic `integration_ci` coverage proving bootstrap writes Docker config only when the secret is present and diagnostics record auth mode, without making a real GHCR call.

Out of scope: target THOR/Tactics image retargeting and provisioning the actual GHCR token value. Publish as a PR and allow merge automation to run.