### PR TITLE
MM-821 consolidate typed Step Execution manifest writing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,8 @@ Key diagnostics:
 - Existing artifact store and workflow history only; no new persistent database tables planned. (001-pentest-activity-handler)
 - Python 3.12 + Pydantic v2, FastAPI, Temporal Python SDK, `httpx`, existing MoonMind outbound scan and redaction helpers (001-scan-message-send)
 - No new persistent storage; diagnostics are returned/logged through existing activity/API/workflow update failure result paths (001-scan-message-send)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind workflow/activity helpers and schemas (001-consolidate-step-manifests)
+- Existing Temporal workflow history and artifact-backed JSON manifests; no new persistent storage (001-consolidate-step-manifests)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -590,10 +590,8 @@ def build_step_execution_idempotency_key(
     normalized_operation = str(operation or "").strip()
     if not normalized_operation:
         raise ValueError("operation must be a non-empty string")
-    return (
-        f"{identity.workflow_id}:{identity.run_id}:"
-        f"{identity.logical_step_id}:{identity.execution_ordinal}:{normalized_operation}"
-    )
+    return f"{build_step_execution_id(identity)}:{normalized_operation}"
+
 
 class PullRequestRefModel(BaseModel):
     """Compact pull request identity carried through merge automation history."""

--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -11,10 +11,11 @@ from typing import Any, Literal
 from pydantic import ValidationError
 
 from moonmind.schemas.step_execution_models import (
-    StepExecutionReason,
-    StepExecutionStatus,
     StepExecutionIdentityModel,
     StepExecutionManifestModel,
+    StepExecutionReason,
+    StepExecutionStatus,
+    StepExecutionTerminalDisposition,
 )
 from moonmind.schemas.temporal_models import (
     StepExecutionManifestModel as BoundaryStepExecutionManifestModel,
@@ -476,6 +477,7 @@ def build_step_execution_manifest_payload(
     execution_ordinal: int,
     reason: StepExecutionReason,
     status: StepExecutionStatus,
+    terminal_disposition: StepExecutionTerminalDisposition | None = None,
     updated_at: datetime,
     started_at: datetime | None = None,
     summary: str | None = None,
@@ -513,6 +515,7 @@ def build_step_execution_manifest_payload(
         lineage=dict(lineage) if lineage is not None else None,
         reason=reason,
         status=status,
+        terminalDisposition=terminal_disposition,
         startedAt=started_at or updated_at,
         updatedAt=updated_at,
         input=input_payload,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -310,6 +310,7 @@ RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
+RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
@@ -4633,41 +4634,42 @@ class MoonMindRunWorkflow:
                     if self._cancel_requested:
                         return
 
-                    await self._record_step_execution_manifest(
-                        node_id,
-                        phase="start",
-                        updated_at=workflow.now(),
-                        summary=self._summary,
-                        reason=attempt_reason,
-                        input_refs=(
-                            node_inputs.get("inputRefs")
-                            if isinstance(node_inputs.get("inputRefs"), list)
-                            else []
-                        ),
-                        execution={
-                            "kind": tool_type,
-                            "toolName": tool_name,
-                            "idempotencyKey": step_execution_operation_idempotency_key(
-                                workflow_id=workflow.info().workflow_id,
-                                run_id=workflow.info().run_id,
-                                logical_step_id=node_id,
-                                execution_ordinal=current_step_execution,
-                                operation="execute",
+                    if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):
+                        await self._record_step_execution_manifest(
+                            node_id,
+                            phase="start",
+                            updated_at=workflow.now(),
+                            summary=self._summary,
+                            reason=attempt_reason,
+                            input_refs=(
+                                node_inputs.get("inputRefs")
+                                if isinstance(node_inputs.get("inputRefs"), list)
+                                else []
                             ),
-                        },
-                        budget=self._review_gate_budget_metadata(
-                            max_review_attempts=max_review_attempts,
-                            review_retry_count=review_retry_count,
-                            max_consecutive_no_progress_attempts=(
-                                max_consecutive_no_progress_attempts
-                            ),
-                            consecutive_no_progress_attempts=(
-                                consecutive_no_progress_attempts
-                            ),
+                            execution={
+                                "kind": tool_type,
+                                "toolName": tool_name,
+                                "idempotencyKey": step_execution_operation_idempotency_key(
+                                    workflow_id=workflow.info().workflow_id,
+                                    run_id=workflow.info().run_id,
+                                    logical_step_id=node_id,
+                                    execution_ordinal=current_step_execution,
+                                    operation="execute",
+                                ),
+                            },
+                            budget=self._review_gate_budget_metadata(
+                                max_review_attempts=max_review_attempts,
+                                review_retry_count=review_retry_count,
+                                max_consecutive_no_progress_attempts=(
+                                    max_consecutive_no_progress_attempts
+                                ),
+                                consecutive_no_progress_attempts=(
+                                    consecutive_no_progress_attempts
+                                ),
+                            )
+                            if review_gate_active
+                            else None,
                         )
-                        if review_gate_active
-                        else None,
-                    )
                     if self._is_step_execution_launch_blocked(
                         node_id,
                         attempt=current_step_execution,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -821,79 +821,12 @@ class MoonMindRunWorkflow:
         updated_at: datetime,
         reason: str,
     ) -> str | None:
-        attempt = self._step_execution_for(logical_step_id)
-        if attempt is None or attempt < 1:
-            return None
-        identity = StepExecutionIdentityModel(
-            workflowId=workflow.info().workflow_id,
-            runId=workflow.info().run_id,
-            logicalStepId=logical_step_id,
-            executionOrdinal=attempt,
-        )
-        step_execution_id = build_step_execution_id(identity)
-        idempotency_key = build_step_execution_idempotency_key(identity, "manifest")
-        source_execution_ordinal = self._step_execution_source_identity(
+        return await self._record_step_execution_manifest_started(
             logical_step_id,
-            attempt=attempt,
-        )
-        lineage = self._step_execution_lineage(
-            logical_step_id,
-            reason=reason,
-            source_execution_ordinal=source_execution_ordinal,
-        )
-        workspace = self._step_execution_workspace(
-            logical_step_id,
-            attempt=identity.execution_ordinal,
-            source_execution_ordinal=source_execution_ordinal,
-        )
-        launch_blocked = self._workspace_policy_launch_blocked(workspace)
-        manifest = StepExecutionManifestModel(
-            schemaVersion="v1",
-            stepExecutionId=step_execution_id,
-            workflowId=identity.workflow_id,
-            runId=identity.run_id,
-            logicalStepId=identity.logical_step_id,
-            executionOrdinal=identity.execution_ordinal,
-            executionScope="run",
-            lineage=lineage,
-            reason=reason,
-            status="blocked" if launch_blocked else "running",
-            terminalDisposition="blocked" if launch_blocked else None,
-            startedAt=updated_at,
-            updatedAt=updated_at,
-            input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
-            context={},
-            workspace=workspace,
-            execution=self._step_execution_compact_execution_refs(logical_step_id),
-            outputs={
-                "summary": "Workspace policy rejected before launch."
-            }
-            if launch_blocked
-            else {},
-            checks=[],
-            sideEffects={},
-            dependencyEffects={"invalidatedLogicalStepIds": []},
-            budget={},
-        )
-        manifest_ref = await self._write_step_execution_manifest(
-            logical_step_id,
-            attempt=attempt,
-            manifest=manifest,
-            step_execution_id=step_execution_id,
-            idempotency_key=idempotency_key,
             updated_at=updated_at,
+            reason=reason,
+            input_refs=self._prepared_artifact_refs,
         )
-        if launch_blocked:
-            self._record_workspace_policy_launch_block(
-                logical_step_id,
-                attempt=attempt,
-                updated_at=updated_at,
-                reason=str(
-                    workspace.get("rejectionReason")
-                    or "missing_required_checkpoint_evidence"
-                ),
-            )
-        return manifest_ref
 
     async def _record_step_execution_manifest_terminal(
         self,
@@ -925,6 +858,10 @@ class MoonMindRunWorkflow:
             reason=reason,
             source_execution_ordinal=source_execution_ordinal,
         )
+        git_effect = self._step_execution_git_effect(
+            logical_step_id,
+            terminal_disposition=terminal_disposition,
+        )
         manifest = StepExecutionManifestModel(
             schemaVersion="v1",
             stepExecutionId=step_execution_id,
@@ -939,18 +876,24 @@ class MoonMindRunWorkflow:
             terminalDisposition=terminal_disposition,
             startedAt=self._step_execution_started_at(logical_step_id),
             updatedAt=updated_at,
-            input={"preparedArtifactRefs": list(self._prepared_artifact_refs)},
-            context={},
+            input={
+                "preparedInputRefs": self._combined_step_execution_input_refs(
+                    self._prepared_artifact_refs,
+                )
+            },
+            context=self._step_execution_manifest_context_projection(
+                logical_step_id,
+                attempt=identity.execution_ordinal,
+                reason=reason,
+                execution=self._step_execution_compact_execution_refs(logical_step_id),
+            ),
             workspace={
                 **self._step_execution_workspace(
                     logical_step_id,
                     attempt=identity.execution_ordinal,
                     source_execution_ordinal=source_execution_ordinal,
                 ),
-                "gitEffect": self._step_execution_git_effect(
-                    logical_step_id,
-                    terminal_disposition=terminal_disposition,
-                ),
+                "gitEffect": git_effect,
             },
             execution=self._step_execution_compact_execution_refs(logical_step_id),
             outputs=self._step_execution_compact_output_refs(logical_step_id),
@@ -958,7 +901,10 @@ class MoonMindRunWorkflow:
                 (self._step_ledger_row_for(logical_step_id) or {}).get("checks")
                 or []
             ),
-            sideEffects=self._step_execution_side_effects(logical_step_id),
+            sideEffects=self._step_execution_side_effects(
+                logical_step_id,
+                git_effect=git_effect,
+            ),
             dependencyEffects=self._step_dependency_effects.get(
                 logical_step_id,
                 {"invalidatedLogicalStepIds": []},
@@ -1039,6 +985,12 @@ class MoonMindRunWorkflow:
                 logical_step_id,
                 updated_at=updated_at,
                 refs=refs,
+            )
+            mark_step_execution_manifest_evidence(
+                self._step_ledger_rows,
+                logical_step_id,
+                updated_at=updated_at,
+                step_execution_manifest_ref=manifest_ref,
             )
             self._sync_progress_snapshot(updated_at=updated_at)
             return manifest_ref
@@ -1629,12 +1581,80 @@ class MoonMindRunWorkflow:
                 outputs[target_key] = value.strip()
         return outputs
 
-    def _step_execution_side_effects(self, logical_step_id: str) -> dict[str, Any]:
+    def _step_execution_side_effects(
+        self,
+        logical_step_id: str,
+        *,
+        git_effect: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
         records = [
             dict(record)
             for record in self._step_side_effect_records.get(logical_step_id, ())
         ]
-        return {"records": records} if records else {}
+        summary = self._step_execution_side_effect_summary(
+            records,
+            git_effect=git_effect,
+        )
+        if records:
+            return {"records": records, "summary": summary}
+        return {"summary": summary} if summary else {}
+
+    def _step_execution_side_effect_summary(
+        self,
+        records: Sequence[Mapping[str, Any]],
+        *,
+        git_effect: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        categories = {
+            "git": 0,
+            "external": 0,
+            "artifact": 0,
+            "publication": 0,
+            "compensation": 0,
+            "memory": 0,
+            "retrieval": 0,
+            "record": 0,
+        }
+        by_class: dict[str, int] = {}
+        by_disposition: dict[str, int] = {}
+        by_kind: dict[str, int] = {}
+        if git_effect:
+            disposition = str(git_effect.get("disposition") or "").strip()
+            if disposition:
+                categories["git"] = 1
+                by_disposition[disposition] = by_disposition.get(disposition, 0) + 1
+        for record in records:
+            effect_class = str(record.get("class") or "unknown").strip() or "unknown"
+            disposition = (
+                str(record.get("disposition") or "unknown").strip() or "unknown"
+            )
+            kind = str(record.get("kind") or "normal").strip() or "normal"
+            by_class[effect_class] = by_class.get(effect_class, 0) + 1
+            by_disposition[disposition] = by_disposition.get(disposition, 0) + 1
+            by_kind[kind] = by_kind.get(kind, 0) + 1
+            categories["record"] += 1
+            if kind == "compensation":
+                categories["compensation"] += 1
+            if (
+                effect_class.startswith("external_")
+                or effect_class == "provider_account"
+            ):
+                categories["external"] += 1
+            elif effect_class == "artifact_write":
+                categories["artifact"] += 1
+            elif effect_class == "publication":
+                categories["publication"] += 1
+            elif effect_class == "memory_update":
+                categories["memory"] += 1
+            elif effect_class == "retrieval_index_update":
+                categories["retrieval"] += 1
+        return {
+            "totalRecords": len(records),
+            "categories": categories,
+            "byClass": by_class,
+            "byDisposition": by_disposition,
+            "byKind": by_kind,
+        }
 
     def _recovery_workspace_checkpoint_ref(
         self,
@@ -2214,6 +2234,7 @@ class MoonMindRunWorkflow:
             side_effects_payload["reattemptCompensation"] = compensation_plan
             side_effect_records = list(compensation_plan.get("compensations", ()))
         launch_blocked = self._workspace_policy_launch_blocked(workspace)
+        prepared_input_refs = self._combined_step_execution_input_refs(input_refs)
         manifest_payload = build_step_execution_manifest_payload(
             workflow_id=workflow.info().workflow_id,
             run_id=workflow.info().run_id,
@@ -2228,7 +2249,13 @@ class MoonMindRunWorkflow:
                 else summary
             ),
             lineage=lineage,
-            input_refs=input_refs,
+            input_refs=prepared_input_refs,
+            context=self._step_execution_manifest_context_projection(
+                logical_step_id,
+                attempt=attempt,
+                reason=reason,
+                execution=execution,
+            ),
             workspace=workspace,
             execution={
                 **self._step_execution_compact_execution_refs(logical_step_id),
@@ -2240,53 +2267,27 @@ class MoonMindRunWorkflow:
         )
         if launch_blocked:
             manifest_payload["terminalDisposition"] = "blocked"
-        try:
-            manifest_ref = await self._write_json_artifact(
-                name=f"reports/step_execution_{logical_step_id}_attempt_{attempt}.json",
-                payload=manifest_payload,
-            )
-        except ValueError as exc:
-            if (
-                "artifact.create returned no artifact_id" not in str(exc)
-                and "too many values to unpack" not in str(exc)
-            ):
-                raise
-            logging.getLogger(__name__).warning(
-                "Step Execution manifest artifact could not be created for %s "
-                "attempt %d: %s",
-                logical_step_id,
-                attempt,
-                exc,
-            )
-            return None
-        except AssertionError as exc:
-            logging.getLogger(__name__).warning(
-                "Step Execution manifest artifact creation was rejected by the "
-                "activity test double for %s attempt %d: %s",
-                logical_step_id,
-                attempt,
-                exc,
-            )
-            return None
-        except Exception as exc:
-            if "Not in workflow event loop" not in str(exc):
-                raise
-            logging.getLogger(__name__).warning(
-                "Step Execution manifest artifact creation skipped outside workflow "
-                "event loop for %s attempt %d",
-                logical_step_id,
-                attempt,
-            )
-            return None
-        try:
-            mark_step_execution_manifest_evidence(
-                self._step_ledger_rows,
-                logical_step_id,
-                updated_at=updated_at,
-                step_execution_manifest_ref=manifest_ref,
-            )
-        except KeyError:
-            return manifest_ref
+        manifest_model_payload = dict(manifest_payload)
+        manifest_model_payload.pop("contentType", None)
+        identity = StepExecutionIdentityModel(
+            workflowId=workflow.info().workflow_id,
+            runId=workflow.info().run_id,
+            logicalStepId=logical_step_id,
+            executionOrdinal=attempt,
+        )
+        manifest_ref = await self._write_step_execution_manifest(
+            logical_step_id,
+            attempt=attempt,
+            manifest=StepExecutionManifestModel.model_validate(
+                manifest_model_payload
+            ),
+            step_execution_id=build_step_execution_id(identity),
+            idempotency_key=build_step_execution_idempotency_key(
+                identity,
+                "manifest",
+            ),
+            updated_at=updated_at,
+        )
         if launch_blocked:
             self._record_workspace_policy_launch_block(
                 logical_step_id,
@@ -2299,6 +2300,50 @@ class MoonMindRunWorkflow:
             )
         self._sync_progress_snapshot(updated_at=updated_at)
         return manifest_ref
+
+    def _combined_step_execution_input_refs(
+        self,
+        input_refs: Sequence[str],
+    ) -> list[str]:
+        refs: list[str] = []
+        for ref in (*input_refs, *self._prepared_artifact_refs):
+            candidate = str(ref or "").strip()
+            if candidate and candidate not in refs:
+                refs.append(candidate)
+        return refs
+
+    def _step_execution_manifest_context_projection(
+        self,
+        logical_step_id: str,
+        *,
+        attempt: int,
+        reason: str,
+        execution: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        runtime_selection: dict[str, Any] = {}
+        if isinstance(execution, Mapping):
+            for source_key, target_key in (
+                ("runtimeId", "runtimeId"),
+                ("toolName", "runtimeId"),
+                ("model", "model"),
+                ("effort", "effort"),
+                ("executionProfileRef", "executionProfileRef"),
+            ):
+                value = execution.get(source_key)
+                if value is not None and target_key not in runtime_selection:
+                    runtime_selection[target_key] = value
+        projection = build_execution_context_bundle(
+            workflow_id=workflow.info().workflow_id,
+            run_id=workflow.info().run_id,
+            logical_step_id=logical_step_id,
+            execution_ordinal=attempt,
+            reason=reason,
+            runtime_selection=runtime_selection,
+        ).to_manifest_projection()
+        context = projection.get("context")
+        if isinstance(context, Mapping):
+            return dict(context)
+        return {}
 
     def _mark_step_waiting(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -310,7 +310,6 @@ RUN_TERMINAL_STATE_ACTIVITY_PATCH = "run-terminal-state-activity-v1"
 RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
-RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
@@ -814,33 +813,25 @@ class MoonMindRunWorkflow:
         )
         return str(artifact_id)
 
-    async def _record_step_execution_manifest_start(
+    async def _record_step_execution_manifest(
         self,
         logical_step_id: str,
         *,
+        phase: str,
         updated_at: datetime,
         reason: str,
-    ) -> str | None:
-        return await self._record_step_execution_manifest_started(
-            logical_step_id,
-            updated_at=updated_at,
-            reason=reason,
-            input_refs=self._prepared_artifact_refs,
-        )
-
-    async def _record_step_execution_manifest_terminal(
-        self,
-        logical_step_id: str,
-        *,
-        updated_at: datetime,
-        reason: str,
-        status: str,
-        terminal_disposition: str,
+        status: str | None = None,
+        terminal_disposition: str | None = None,
+        summary: str | None = None,
+        input_refs: Sequence[str] = (),
+        execution: Mapping[str, Any] | None = None,
         budget: Mapping[str, Any] | None = None,
     ) -> str | None:
         attempt = self._step_execution_for(logical_step_id)
-        if attempt is None or attempt < 1:
+        if attempt is None or attempt <= 0:
             return None
+        if phase not in {"start", "launch_blocked", "terminal"}:
+            raise ValueError(f"unsupported step execution manifest phase: {phase}")
         identity = StepExecutionIdentityModel(
             workflowId=workflow.info().workflow_id,
             runId=workflow.info().run_id,
@@ -858,68 +849,122 @@ class MoonMindRunWorkflow:
             reason=reason,
             source_execution_ordinal=source_execution_ordinal,
         )
-        git_effect = self._step_execution_git_effect(
+        workspace = self._step_execution_workspace(
             logical_step_id,
-            terminal_disposition=terminal_disposition,
+            attempt=attempt,
+            source_execution_ordinal=source_execution_ordinal,
         )
-        manifest = StepExecutionManifestModel(
-            schemaVersion="v1",
-            stepExecutionId=step_execution_id,
-            workflowId=identity.workflow_id,
-            runId=identity.run_id,
-            logicalStepId=identity.logical_step_id,
-            executionOrdinal=identity.execution_ordinal,
-            executionScope="run",
-            lineage=lineage,
-            reason=reason,
-            status=status,
-            terminalDisposition=terminal_disposition,
-            startedAt=self._step_execution_started_at(logical_step_id),
-            updatedAt=updated_at,
-            input={
-                "preparedInputRefs": self._combined_step_execution_input_refs(
-                    self._prepared_artifact_refs,
+        execution_payload = {
+            **self._step_execution_compact_execution_refs(logical_step_id),
+            **(execution or {}),
+        }
+        side_effects_payload: dict[str, Any] = {}
+        side_effect_records: list[Mapping[str, Any]] = []
+        outputs: Mapping[str, Any] | None = None
+        checks: Sequence[Mapping[str, Any]] = ()
+        dependency_effects: Mapping[str, Any] | None = None
+        git_effect: Mapping[str, Any] | None = None
+        resolved_status = status
+        resolved_terminal_disposition = terminal_disposition
+        resolved_summary = summary
+
+        if phase in {"start", "launch_blocked"}:
+            compensation_plan = self._orchestrate_reattempt_compensation(
+                logical_step_id,
+                execution_ordinal=attempt,
+                updated_at=updated_at,
+            )
+            if compensation_plan and compensation_plan.get("requiresCompensation"):
+                side_effects_payload["reattemptCompensation"] = compensation_plan
+                side_effect_records = list(compensation_plan.get("compensations", ()))
+            launch_blocked = phase == "launch_blocked" or (
+                self._workspace_policy_launch_blocked(workspace)
+            )
+            resolved_status = "blocked" if launch_blocked else "running"
+            if launch_blocked:
+                resolved_terminal_disposition = "blocked"
+                resolved_summary = "Workspace policy rejected before launch."
+        else:
+            if not resolved_status or not resolved_terminal_disposition:
+                raise ValueError(
+                    "terminal step execution manifests require status and "
+                    "terminal_disposition"
                 )
-            },
+            git_effect = self._step_execution_git_effect(
+                logical_step_id,
+                terminal_disposition=resolved_terminal_disposition,
+            )
+            outputs = self._step_execution_compact_output_refs(logical_step_id)
+            checks = list(
+                (self._step_ledger_row_for(logical_step_id) or {}).get("checks")
+                or []
+            )
+            side_effects_payload = self._step_execution_side_effects(
+                logical_step_id,
+                git_effect=git_effect,
+            )
+            dependency_effects = self._step_dependency_effects.get(
+                logical_step_id,
+                {"invalidatedLogicalStepIds": []},
+            )
+
+        manifest_payload = build_step_execution_manifest_payload(
+            workflow_id=identity.workflow_id,
+            run_id=identity.run_id,
+            logical_step_id=identity.logical_step_id,
+            execution_ordinal=identity.execution_ordinal,
+            reason=reason,  # type: ignore[arg-type]
+            status=resolved_status,  # type: ignore[arg-type]
+            terminal_disposition=resolved_terminal_disposition,  # type: ignore[arg-type]
+            started_at=self._step_execution_started_at(logical_step_id),
+            updated_at=updated_at,
+            summary=resolved_summary,
+            lineage=lineage,
+            input_refs=self._combined_step_execution_input_refs(input_refs),
             context=self._step_execution_manifest_context_projection(
                 logical_step_id,
                 attempt=identity.execution_ordinal,
                 reason=reason,
-                execution=self._step_execution_compact_execution_refs(logical_step_id),
+                execution=execution_payload,
             ),
-            workspace={
-                **self._step_execution_workspace(
-                    logical_step_id,
-                    attempt=identity.execution_ordinal,
-                    source_execution_ordinal=source_execution_ordinal,
-                ),
-                "gitEffect": git_effect,
-            },
-            execution=self._step_execution_compact_execution_refs(logical_step_id),
-            outputs=self._step_execution_compact_output_refs(logical_step_id),
-            checks=list(
-                (self._step_ledger_row_for(logical_step_id) or {}).get("checks")
-                or []
-            ),
-            sideEffects=self._step_execution_side_effects(
-                logical_step_id,
-                git_effect=git_effect,
-            ),
-            dependencyEffects=self._step_dependency_effects.get(
-                logical_step_id,
-                {"invalidatedLogicalStepIds": []},
-            ),
-            budget=dict(budget or {}),
+            workspace=workspace,
+            git_effect=git_effect,
+            execution=execution_payload,
+            outputs=outputs,
+            checks=checks,
+            side_effects=side_effects_payload,
+            side_effect_records=side_effect_records,
+            dependency_effects=dependency_effects,
+            budget=budget,
         )
-        self._step_terminal_dispositions[logical_step_id] = terminal_disposition
-        return await self._write_step_execution_manifest(
+        manifest_model_payload = dict(manifest_payload)
+        manifest_model_payload.pop("contentType", None)
+        manifest_ref = await self._write_step_execution_manifest(
             logical_step_id,
             attempt=attempt,
-            manifest=manifest,
+            manifest=StepExecutionManifestModel.model_validate(manifest_model_payload),
             step_execution_id=step_execution_id,
             idempotency_key=idempotency_key,
             updated_at=updated_at,
         )
+        if phase in {"start", "launch_blocked"} and (
+            resolved_terminal_disposition == "blocked"
+        ):
+            self._record_workspace_policy_launch_block(
+                logical_step_id,
+                attempt=attempt,
+                updated_at=updated_at,
+                reason=str(
+                    workspace.get("rejectionReason")
+                    or "missing_required_checkpoint_evidence"
+                ),
+            )
+        if phase == "terminal" and resolved_terminal_disposition:
+            self._step_terminal_dispositions[logical_step_id] = (
+                resolved_terminal_disposition
+            )
+        self._sync_progress_snapshot(updated_at=updated_at)
+        return manifest_ref
 
     async def _write_step_execution_manifest(
         self,
@@ -2194,112 +2239,6 @@ class MoonMindRunWorkflow:
                 },
             )
         return plan
-
-    async def _record_step_execution_manifest_started(
-        self,
-        logical_step_id: str,
-        *,
-        updated_at: datetime,
-        summary: str | None = None,
-        reason: str = "initial_execution",
-        input_refs: Sequence[str] = (),
-        execution: Mapping[str, Any] | None = None,
-        budget: Mapping[str, Any] | None = None,
-    ) -> str | None:
-        attempt = self._step_execution_for(logical_step_id)
-        if attempt is None or attempt <= 0:
-            return None
-        source_execution_ordinal = self._step_execution_source_identity(
-            logical_step_id,
-            attempt=attempt,
-        )
-        lineage = self._step_execution_lineage(
-            logical_step_id,
-            reason=reason,
-            source_execution_ordinal=source_execution_ordinal,
-        )
-        workspace = self._step_execution_workspace(
-            logical_step_id,
-            attempt=attempt,
-            source_execution_ordinal=source_execution_ordinal,
-        )
-        compensation_plan = self._orchestrate_reattempt_compensation(
-            logical_step_id,
-            execution_ordinal=attempt,
-            updated_at=updated_at,
-        )
-        side_effects_payload: dict[str, Any] = {}
-        side_effect_records: list[Mapping[str, Any]] = []
-        if compensation_plan and compensation_plan.get("requiresCompensation"):
-            side_effects_payload["reattemptCompensation"] = compensation_plan
-            side_effect_records = list(compensation_plan.get("compensations", ()))
-        launch_blocked = self._workspace_policy_launch_blocked(workspace)
-        prepared_input_refs = self._combined_step_execution_input_refs(input_refs)
-        manifest_payload = build_step_execution_manifest_payload(
-            workflow_id=workflow.info().workflow_id,
-            run_id=workflow.info().run_id,
-            logical_step_id=logical_step_id,
-            execution_ordinal=attempt,
-            reason=reason,  # type: ignore[arg-type]
-            status="blocked" if launch_blocked else "running",
-            updated_at=updated_at,
-            summary=(
-                "Workspace policy rejected before launch."
-                if launch_blocked
-                else summary
-            ),
-            lineage=lineage,
-            input_refs=prepared_input_refs,
-            context=self._step_execution_manifest_context_projection(
-                logical_step_id,
-                attempt=attempt,
-                reason=reason,
-                execution=execution,
-            ),
-            workspace=workspace,
-            execution={
-                **self._step_execution_compact_execution_refs(logical_step_id),
-                **(execution or {}),
-            },
-            side_effects=side_effects_payload,
-            side_effect_records=side_effect_records,
-            budget=budget,
-        )
-        if launch_blocked:
-            manifest_payload["terminalDisposition"] = "blocked"
-        manifest_model_payload = dict(manifest_payload)
-        manifest_model_payload.pop("contentType", None)
-        identity = StepExecutionIdentityModel(
-            workflowId=workflow.info().workflow_id,
-            runId=workflow.info().run_id,
-            logicalStepId=logical_step_id,
-            executionOrdinal=attempt,
-        )
-        manifest_ref = await self._write_step_execution_manifest(
-            logical_step_id,
-            attempt=attempt,
-            manifest=StepExecutionManifestModel.model_validate(
-                manifest_model_payload
-            ),
-            step_execution_id=build_step_execution_id(identity),
-            idempotency_key=build_step_execution_idempotency_key(
-                identity,
-                "manifest",
-            ),
-            updated_at=updated_at,
-        )
-        if launch_blocked:
-            self._record_workspace_policy_launch_block(
-                logical_step_id,
-                attempt=attempt,
-                updated_at=updated_at,
-                reason=str(
-                    workspace.get("rejectionReason")
-                    or "missing_required_checkpoint_evidence"
-                ),
-            )
-        self._sync_progress_snapshot(updated_at=updated_at)
-        return manifest_ref
 
     def _combined_step_execution_input_refs(
         self,
@@ -4694,56 +4633,54 @@ class MoonMindRunWorkflow:
                     if self._cancel_requested:
                         return
 
-                    if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):
-                        await self._record_step_execution_manifest_started(
-                            node_id,
-                            updated_at=workflow.now(),
-                            summary=self._summary,
-                            reason=attempt_reason,
-                            input_refs=(
-                                node_inputs.get("inputRefs")
-                                if isinstance(node_inputs.get("inputRefs"), list)
-                                else []
+                    await self._record_step_execution_manifest(
+                        node_id,
+                        phase="start",
+                        updated_at=workflow.now(),
+                        summary=self._summary,
+                        reason=attempt_reason,
+                        input_refs=(
+                            node_inputs.get("inputRefs")
+                            if isinstance(node_inputs.get("inputRefs"), list)
+                            else []
+                        ),
+                        execution={
+                            "kind": tool_type,
+                            "toolName": tool_name,
+                            "idempotencyKey": step_execution_operation_idempotency_key(
+                                workflow_id=workflow.info().workflow_id,
+                                run_id=workflow.info().run_id,
+                                logical_step_id=node_id,
+                                execution_ordinal=current_step_execution,
+                                operation="execute",
                             ),
-                            execution={
-                                "kind": tool_type,
-                                "toolName": tool_name,
-                                "idempotencyKey": step_execution_operation_idempotency_key(
-                                    workflow_id=workflow.info().workflow_id,
-                                    run_id=workflow.info().run_id,
-                                    logical_step_id=node_id,
-                                    execution_ordinal=current_step_execution,
-                                    operation="execute",
-                                ),
-                            },
-                            budget=self._review_gate_budget_metadata(
-                                max_review_attempts=max_review_attempts,
-                                review_retry_count=review_retry_count,
-                                max_consecutive_no_progress_attempts=(
-                                    max_consecutive_no_progress_attempts
-                                ),
-                                consecutive_no_progress_attempts=(
-                                    consecutive_no_progress_attempts
-                                ),
-                            )
-                            if review_gate_active
-                            else None,
+                        },
+                        budget=self._review_gate_budget_metadata(
+                            max_review_attempts=max_review_attempts,
+                            review_retry_count=review_retry_count,
+                            max_consecutive_no_progress_attempts=(
+                                max_consecutive_no_progress_attempts
+                            ),
+                            consecutive_no_progress_attempts=(
+                                consecutive_no_progress_attempts
+                            ),
                         )
-                        if self._is_step_execution_launch_blocked(
-                            node_id,
-                            attempt=current_step_execution,
-                        ):
-                            execution_result = {
-                                "status": "FAILED",
-                                "outputs": {
-                                    "error": "missing_required_checkpoint_evidence",
-                                    "summary": (
-                                        "Workspace policy rejected before launch."
-                                    ),
-                                },
-                            }
-                            result_status = "FAILED"
-                            break
+                        if review_gate_active
+                        else None,
+                    )
+                    if self._is_step_execution_launch_blocked(
+                        node_id,
+                        attempt=current_step_execution,
+                    ):
+                        execution_result = {
+                            "status": "FAILED",
+                            "outputs": {
+                                "error": "missing_required_checkpoint_evidence",
+                                "summary": "Workspace policy rejected before launch.",
+                            },
+                        }
+                        result_status = "FAILED"
+                        break
 
                     route = None
                     execute_payload = None
@@ -4800,10 +4737,7 @@ class MoonMindRunWorkflow:
                             child_workflow_id = (
                                 f"{workflow.info().workflow_id}:agent:{node_id}"
                             )
-                            if (
-                                current_step_execution > 1
-                                and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)
-                            ):
+                            if current_step_execution > 1:
                                 step_execution_label = "attempt"
                                 if workflow.patched(RUN_STEP_EXECUTION_NAMING_PATCH):
                                     step_execution_label = "execution"
@@ -4983,8 +4917,9 @@ class MoonMindRunWorkflow:
                                 summary=f"{tool_name} failed",
                                 last_error=failure_message,
                             )
-                            await self._record_step_execution_manifest_terminal(
+                            await self._record_step_execution_manifest(
                                 node_id,
+                                phase="terminal",
                                 updated_at=workflow.now(),
                                 reason=attempt_reason,
                                 status="failed",
@@ -5017,8 +4952,9 @@ class MoonMindRunWorkflow:
                             or f"{tool_name} failed",
                             last_error=failure_message,
                         )
-                        await self._record_step_execution_manifest_terminal(
+                        await self._record_step_execution_manifest(
                             node_id,
+                            phase="terminal",
                             updated_at=workflow.now(),
                             reason=attempt_reason,
                             status="failed",
@@ -5163,8 +5099,9 @@ class MoonMindRunWorkflow:
                         summary=failed_review_summary,
                         last_error="review_failed",
                     )
-                    await self._record_step_execution_manifest_terminal(
+                    await self._record_step_execution_manifest(
                         node_id,
+                        phase="terminal",
                         updated_at=workflow.now(),
                         reason=attempt_reason,
                         status="blocked"
@@ -5218,8 +5155,9 @@ class MoonMindRunWorkflow:
                         summary=missing_evidence_summary,
                         last_error="missing_accepted_output_evidence",
                     )
-                    await self._record_step_execution_manifest_terminal(
+                    await self._record_step_execution_manifest(
                         node_id,
+                        phase="terminal",
                         updated_at=workflow.now(),
                         reason=attempt_reason,
                         status="failed",
@@ -5280,8 +5218,9 @@ class MoonMindRunWorkflow:
                 node_id,
                 updated_at=workflow.now(),
             )
-            await self._record_step_execution_manifest_terminal(
+            await self._record_step_execution_manifest(
                 node_id,
+                phase="terminal",
                 updated_at=workflow.now(),
                 reason=attempt_reason,
                 status="succeeded",
@@ -6191,8 +6130,9 @@ class MoonMindRunWorkflow:
                 summary=f"Re-checking Jira blockers for {tool_name}",
                 increment_attempt=False,
             )
-            await self._record_step_execution_manifest_start(
+            await self._record_step_execution_manifest(
                 node_id,
+                phase="start",
                 updated_at=workflow.now(),
                 reason="policy_revalidation",
             )
@@ -8893,11 +8833,7 @@ class MoonMindRunWorkflow:
             )
         wf_info = workflow.info()
         correlation_id = wf_info.workflow_id
-        if (
-            step_execution is not None
-            and step_execution > 0
-            and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)
-        ):
+        if step_execution is not None and step_execution > 0:
             idempotency_key = step_execution_operation_idempotency_key(
                 workflow_id=wf_info.workflow_id,
                 run_id=wf_info.run_id,

--- a/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
@@ -71,8 +71,9 @@ async def test_step_execution_manifest_refs_are_append_only_for_reexecution(
     )
 
     workflow._mark_step_running("implement", updated_at=now, summary="Initial")
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "implement",
+        phase="start",
         updated_at=now,
         reason="initial_execution",
     )
@@ -83,8 +84,9 @@ async def test_step_execution_manifest_refs_are_append_only_for_reexecution(
         summary="Failed gate",
     )
     workflow._mark_step_running("implement", updated_at=now, summary="Retry")
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "implement",
+        phase="start",
         updated_at=now,
         reason="quality_gate_failed",
     )
@@ -163,8 +165,9 @@ async def test_recovery_step_execution_manifest_carries_lineage_without_large_pa
     )
 
     workflow._mark_step_running("implement", updated_at=now, summary="Resume")
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "implement",
+        phase="start",
         updated_at=now,
         reason="recover_from_failed_step",
     )
@@ -180,3 +183,126 @@ async def test_recovery_step_execution_manifest_carries_lineage_without_large_pa
     )
     assert manifest["workspace"]["evidenceAccepted"] is True
     assert "payload" not in manifest
+
+
+async def test_terminal_manifest_aggregates_required_side_effect_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    writes: list[dict[str, Any]] = []
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact-execution-{len(writes)}"
+
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "publish", "title": "Publish"}],
+        dependency_map={"publish": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running("publish", updated_at=now, summary="Publishing")
+    await workflow._record_step_execution_manifest(
+        "publish",
+        phase="start",
+        updated_at=now,
+        reason="initial_execution",
+    )
+    workflow._record_step_result_evidence(
+        "publish",
+        execution_result={
+            "status": "COMPLETED",
+            "outputs": {
+                "outputSummaryRef": "artifact://summary/publish",
+                "stdoutArtifactRef": "artifact://stdout/publish",
+            },
+        },
+        updated_at=now,
+    )
+    for record in (
+        {
+            "effect_class": "external_idempotent",
+            "operation": "jira.comment",
+            "target": "MM-821",
+            "idempotency_key": "wf-boundary:publish:external",
+        },
+        {
+            "effect_class": "artifact_write",
+            "operation": "artifact.write",
+            "target": "artifact://manifest",
+        },
+        {
+            "effect_class": "publication",
+            "operation": "github.comment",
+            "target": "PR-1",
+            "idempotency_key": "wf-boundary:publish:publication",
+        },
+        {
+            "effect_class": "external_non_idempotent",
+            "effect_kind": "compensation",
+            "operation": "compensate:jira.transition",
+            "target": "MM-821",
+            "idempotency_key": "wf-boundary:publish:compensation",
+        },
+        {
+            "effect_class": "memory_update",
+            "operation": "memory.write",
+            "target": "memory://run",
+        },
+        {
+            "effect_class": "retrieval_index_update",
+            "operation": "retrieval.index",
+            "target": "retrieval://run",
+        },
+    ):
+        workflow._record_step_side_effect(
+            "publish",
+            workflow_state_accepted=True,
+            **record,
+        )
+    workflow._mark_step_terminal(
+        "publish",
+        status="succeeded",
+        updated_at=now,
+        summary="Published",
+    )
+
+    await workflow._record_step_execution_manifest(
+        "publish",
+        phase="terminal",
+        updated_at=now,
+        reason="initial_execution",
+        status="succeeded",
+        terminal_disposition="accepted",
+    )
+
+    terminal = writes[-1]["payload"]
+    assert terminal["terminalDisposition"] == "accepted"
+    assert terminal["outputs"]["summaryRef"] == "artifact://summary/publish"
+    assert terminal["workspace"]["gitEffect"]["disposition"] == "accepted"
+    assert terminal["sideEffects"]["summary"]["categories"] == {
+        "git": 1,
+        "external": 2,
+        "artifact": 1,
+        "publication": 1,
+        "compensation": 1,
+        "memory": 1,
+        "retrieval": 1,
+        "record": 6,
+    }
+    assert len(terminal["sideEffects"]["records"]) == 6

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -20,7 +20,12 @@ def _step_execution_artifact_create_result(
     artifact_ids: count,
 ) -> tuple[dict[str, str], dict[str, str]] | None:
     normalized = _normalize_payload(payload)
-    if not str(normalized.get("name") or "").startswith("reports/step_executions/"):
+    if (
+        normalized.get("content_type")
+        != "application/vnd.moonmind.step-execution+json;version=1"
+        or (normalized.get("metadata_json") or {}).get("artifact_kind")
+        != "step_execution_manifest"
+    ):
         return None
     return (
         {"artifact_id": f"art_step_execution_{next(artifact_ids)}"},
@@ -158,7 +163,7 @@ async def test_run_planning_stage_extracts_plan_ref_from_activity_result(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: False)
     monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
 
     resolved = await workflow._run_planning_stage(
@@ -285,6 +290,12 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
     assert captured[3][0] == "artifact.read"
     assert captured[3][1]["artifact_ref"] == "art_plan_1"
     assert captured[4][0] == "artifact.create"
+    assert captured[4][1]["content_type"] == (
+        "application/vnd.moonmind.step-execution+json;version=1"
+    )
+    assert captured[4][1]["metadata_json"]["artifact_kind"] == (
+        "step_execution_manifest"
+    )
     assert not any(
         payload.get("artifact_ref") == "artifact://registry/1"
         for activity_type, payload in captured

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -2471,6 +2471,7 @@ async def test_run_execution_stage_fail_fast_raises_agent_runtime_failure_summar
             diagnosticsRef="art_empty_turn",
             metadata={
                 "profileId": "codex_default",
+                "stateCheckpointRef": f"art_checkpoint_{child_attempts}",
                 "turnStatus": "failed",
                 "turnMetadata": {
                     "failureCause": "app_server_protocol_empty_turn",

--- a/tests/unit/workflows/temporal/test_step_execution_manifest.py
+++ b/tests/unit/workflows/temporal/test_step_execution_manifest.py
@@ -374,7 +374,7 @@ def test_step_execution_idempotency_key_uses_attempt_identity_and_operation() ->
 
     key = build_step_execution_idempotency_key(identity, "manifest")
 
-    assert key == "workflow-1:run-1:implement-story:2:manifest"
+    assert key == "workflow-1:run-1:implement-story:execution:2:manifest"
     assert build_step_execution_idempotency_key(identity, "gate:unit") != key
     changed_attempt = identity.model_copy(update={"execution_ordinal": 3})
     assert build_step_execution_idempotency_key(changed_attempt, "manifest") != key
@@ -385,7 +385,7 @@ def test_step_execution_boundary_result_is_compact_and_typed() -> None:
         {
             "identity": _identity(),
             "manifestArtifactRef": "artifact-step-execution-2",
-            "idempotencyKey": "workflow-1:run-1:implement-story:2:manifest",
+            "idempotencyKey": "workflow-1:run-1:implement-story:execution:2:manifest",
             "summary": "Step execution manifest created.",
         }
     )

--- a/tests/unit/workflows/temporal/test_step_executions.py
+++ b/tests/unit/workflows/temporal/test_step_executions.py
@@ -81,6 +81,58 @@ def test_manifest_payload_is_compact_boundary_contract() -> None:
     assert payload["outputs"] == {"summary": "Executing plan step"}
 
 
+def test_manifest_payload_accepts_terminal_disposition_and_effect_matrices() -> None:
+    now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
+    payload = build_step_execution_manifest_payload(
+        workflow_id="wf-1",
+        run_id="run-1",
+        logical_step_id="implement",
+        execution_ordinal=1,
+        reason="initial_execution",
+        status="succeeded",
+        terminal_disposition="accepted",
+        updated_at=now,
+        input_refs=["artifact://input"],
+        context={"bundleRef": "artifact://context"},
+        workspace={"policy": "fresh_branch_from_source"},
+        git_effect={"disposition": "accepted", "acceptedOutputPresent": True},
+        execution={"kind": "agent_runtime"},
+        outputs={"summaryRef": "artifact://summary"},
+        checks=[{"kind": "approval_policy", "status": "passed"}],
+        side_effects={
+            "summary": {
+                "categories": {
+                    "git": 1,
+                    "external": 1,
+                    "artifact": 1,
+                    "publication": 1,
+                    "compensation": 1,
+                    "memory": 1,
+                    "retrieval": 1,
+                    "record": 7,
+                }
+            }
+        },
+        side_effect_records=[
+            {"class": "external_idempotent", "kind": "normal", "operation": "jira"},
+            {"class": "artifact_write", "kind": "normal", "operation": "artifact"},
+            {"class": "publication", "kind": "normal", "operation": "publish"},
+            {"class": "external_non_idempotent", "kind": "compensation", "operation": "compensate"},
+            {"class": "memory_update", "kind": "normal", "operation": "memory"},
+            {"class": "retrieval_index_update", "kind": "normal", "operation": "retrieval"},
+            {"class": "workspace_mutation", "kind": "normal", "operation": "record"},
+        ],
+        dependency_effects={"invalidatedLogicalStepIds": ["verify"]},
+        budget={"maxReviewAttempts": 2},
+    )
+
+    assert payload["terminalDisposition"] == "accepted"
+    assert payload["workspace"]["gitEffect"]["disposition"] == "accepted"
+    assert payload["sideEffects"]["summary"]["categories"]["retrieval"] == 1
+    assert len(payload["sideEffects"]["records"]) == 7
+    assert payload["dependencyEffects"]["invalidatedLogicalStepIds"] == ["verify"]
+
+
 def test_workspace_policy_metadata_rejects_missing_required_checkpoint() -> None:
     decision = validate_workspace_policy_launch(
         policy="apply_previous_execution_diff_to_clean_baseline",

--- a/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -352,8 +352,9 @@ async def test_recover_step_execution_manifest_preserves_source_lineage(
     )
 
     workflow._mark_step_running("implement", updated_at=now, summary="Resuming")
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "implement",
+        phase="start",
         updated_at=now,
         reason="recover_from_failed_step",
     )

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -107,7 +108,23 @@ def test_run_exposes_one_canonical_step_execution_manifest_record_surface() -> N
     }
 
     assert workflow_attrs == {"_record_step_execution_manifest"}
-    assert not hasattr(run_module, "RUN_STEP_EXECUTION_MANIFEST_PATCH")
+    assert run_module.RUN_STEP_EXECUTION_MANIFEST_PATCH == (
+        "run-step-attempt-manifest-v1"
+    )
+
+
+def test_step_execution_manifest_start_write_keeps_replay_patch_guard() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow.run)
+
+    guard = "if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):"
+    start_manifest_call = (
+        "await self._record_step_execution_manifest(\n"
+        "                            node_id,\n"
+        '                            phase="start",'
+    )
+
+    assert source.index(guard) < source.index(start_manifest_call)
+
 
 def _registry_payload() -> dict[str, Any]:
     return {

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -691,7 +691,7 @@ async def test_run_records_step_execution_manifest_ref_when_work_begins(
         "wf-run-1:run-1:delegate-agent:execution:1"
     )
     assert writes[0]["metadata_json"]["idempotencyKey"] == (
-        "wf-run-1:run-1:delegate-agent:1:manifest"
+        "wf-run-1:run-1:delegate-agent:execution:1:manifest"
     )
     assert writes[0]["payload"]["reason"] == "initial_execution"
     assert writes[0]["payload"]["context"]["contextBundleRef"].startswith(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -98,6 +98,17 @@ def _approval_policy_plan_payload() -> dict[str, Any]:
         "edges": [],
     }
 
+
+def test_run_exposes_one_canonical_step_execution_manifest_record_surface() -> None:
+    workflow_attrs = {
+        name
+        for name in dir(MoonMindRunWorkflow)
+        if name.startswith("_record_step_execution_manifest")
+    }
+
+    assert workflow_attrs == {"_record_step_execution_manifest"}
+    assert not hasattr(run_module, "RUN_STEP_EXECUTION_MANIFEST_PATCH")
+
 def _registry_payload() -> dict[str, Any]:
     return {
         "skills": [
@@ -630,8 +641,9 @@ async def test_run_records_step_execution_manifest_ref_when_work_begins(
         updated_at=now,
         summary="Launching child runtime",
     )
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "delegate-agent",
+        phase="start",
         updated_at=now,
         reason="initial_execution",
     )
@@ -658,8 +670,9 @@ async def test_run_records_step_execution_manifest_ref_when_work_begins(
         updated_at=now,
         summary="Retrying child runtime",
     )
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "delegate-agent",
+        phase="start",
         updated_at=now,
         reason="runtime_recovered",
     )
@@ -788,8 +801,9 @@ async def test_step_execution_manifest_merges_explicit_execution_with_refs(
         updated_at=now,
     )
 
-    await workflow._record_step_execution_manifest_started(
+    await workflow._record_step_execution_manifest(
         "delegate-external",
+        phase="start",
         updated_at=now,
         reason="initial_execution",
         execution={
@@ -801,9 +815,9 @@ async def test_step_execution_manifest_merges_explicit_execution_with_refs(
     assert writes[0]["content_type"] == (
         "application/vnd.moonmind.step-execution+json;version=1"
     )
-    assert writes[0]["name"] == (
-        "reports/step_executions/delegate-external_attempt_1.json"
-    )
+    assert writes[0]["metadata_json"]["artifact_kind"] == "step_execution_manifest"
+    assert writes[0]["metadata_json"]["logicalStepId"] == "delegate-external"
+    assert writes[0]["metadata_json"]["attempt"] == 1
     assert writes[0]["payload"]["context"]["contextBundleRef"].startswith(
         "execution-context-bundle://sha256:"
     )
@@ -904,8 +918,9 @@ async def test_external_continuation_manifest_records_side_effects_and_checkpoin
         workflow_state_accepted=True,
     )
 
-    await workflow._record_step_execution_manifest_started(
+    await workflow._record_step_execution_manifest(
         "delegate-external",
+        phase="start",
         updated_at=now,
         reason="initial_execution",
     )
@@ -988,8 +1003,9 @@ async def test_run_records_terminal_step_execution_manifest_with_result_refs(
     )
 
     workflow._mark_step_running("run-tests", updated_at=now, summary="Run tests")
-    await workflow._record_step_execution_manifest_start(
+    await workflow._record_step_execution_manifest(
         "run-tests",
+        phase="start",
         updated_at=now,
         reason="initial_execution",
     )
@@ -1020,8 +1036,9 @@ async def test_run_records_terminal_step_execution_manifest_with_result_refs(
         idempotency_key="wf-run-1:run-1:run-tests:execution:1:publish-pr",
         workflow_state_accepted=True,
     )
-    await workflow._record_step_execution_manifest_terminal(
+    await workflow._record_step_execution_manifest(
         "run-tests",
+        phase="terminal",
         updated_at=now,
         reason="initial_execution",
         status="succeeded",
@@ -1105,7 +1122,7 @@ async def test_write_step_execution_manifest_requires_real_artifact_id(
         match="artifact.create returned no artifact_id",
     ):
         await workflow._write_json_artifact(
-            name="reports/step_executions/run-tests_attempt_1.json",
+            name="step-execution-manifest.json",
             payload={"schemaVersion": "v1"},
             content_type=STEP_EXECUTION_MANIFEST_CONTENT_TYPE,
         )

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -681,6 +681,15 @@ async def test_run_records_step_execution_manifest_ref_when_work_begins(
         "wf-run-1:run-1:delegate-agent:1:manifest"
     )
     assert writes[0]["payload"]["reason"] == "initial_execution"
+    assert writes[0]["payload"]["context"]["contextBundleRef"].startswith(
+        "execution-context-bundle://sha256:"
+    )
+    assert writes[0]["payload"]["context"]["contextBundleDigest"].startswith(
+        "sha256:"
+    )
+    assert writes[0]["payload"]["context"]["builderVersion"] == (
+        "execution-context-builder-v1"
+    )
     assert writes[0]["payload"]["execution"] == {
         "runtimeContextPolicy": "fresh_agent_run"
     }
@@ -789,6 +798,15 @@ async def test_step_execution_manifest_merges_explicit_execution_with_refs(
         },
     )
 
+    assert writes[0]["content_type"] == (
+        "application/vnd.moonmind.step-execution+json;version=1"
+    )
+    assert writes[0]["name"] == (
+        "reports/step_executions/delegate-external_attempt_1.json"
+    )
+    assert writes[0]["payload"]["context"]["contextBundleRef"].startswith(
+        "execution-context-bundle://sha256:"
+    )
     assert writes[0]["payload"]["execution"] == {
         "runtimeContextPolicy": "external_provider_continuation",
         "externalProviderContinuation": {
@@ -830,7 +848,14 @@ async def test_external_continuation_manifest_records_side_effects_and_checkpoin
         content_type: str = "application/json",
         metadata_json: dict[str, Any] | None = None,
     ) -> str:
-        writes.append({"name": name, "payload": payload})
+        writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
         return f"artifact-attempt-{len(writes)}"
 
     monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
@@ -885,6 +910,9 @@ async def test_external_continuation_manifest_records_side_effects_and_checkpoin
         reason="initial_execution",
     )
 
+    assert writes[0]["content_type"] == (
+        "application/vnd.moonmind.step-execution+json;version=1"
+    )
     execution = writes[0]["payload"]["execution"]
     assert execution["runtimeContextPolicy"] == "external_provider_continuation"
     # Attempt identity / context refs are still recorded.
@@ -1026,7 +1054,23 @@ async def test_run_records_terminal_step_execution_manifest_with_result_refs(
                 "workflowStateAccepted": True,
                 "disposition": "accepted",
             }
-        ]
+        ],
+        "summary": {
+            "totalRecords": 1,
+            "categories": {
+                "git": 1,
+                "external": 0,
+                "artifact": 0,
+                "publication": 1,
+                "compensation": 0,
+                "memory": 0,
+                "retrieval": 0,
+                "record": 1,
+            },
+            "byClass": {"publication": 1},
+            "byDisposition": {"accepted": 2},
+            "byKind": {"normal": 1},
+        },
     }
 
 
@@ -1496,6 +1540,9 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
             if getattr(payload, "content_type", "") == (
                 "application/vnd.moonmind.step-execution+json;version=1"
             ):
+                written_review_payloads.append(
+                    json.loads(payload.payload.decode("utf-8"))
+                )
                 return {"ok": True}
             written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
             return {"ok": True}
@@ -1564,12 +1611,12 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
     ]
     assert review_payloads[0]["verdict"]["verdict"] == "FULLY_IMPLEMENTED"
     attempt_payloads = [
-        payload for payload in written_review_payloads if payload.get("contentType")
+        payload for payload in written_review_payloads if payload.get("stepExecutionId")
     ]
     assert attempt_payloads[0]["stepExecutionId"] == (
         "wf-run-review-1:run-review-1:apply-patch:execution:1"
     )
-    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_1"
+    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_1_terminal"
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retry_count(
@@ -1726,10 +1773,11 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     ]
     assert review_payloads[0]["verdict"]["verdict"] == "ADDITIONAL_WORK_NEEDED"
     assert review_payloads[1]["verdict"]["verdict"] == "FULLY_IMPLEMENTED"
-    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_2"
+    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_2_terminal"
     assert step["artifacts"]["stepExecutionManifestRefs"] == [
         "art_attempt_1",
         "art_attempt_2",
+        "art_attempt_2_terminal",
     ]
 
 
@@ -2157,14 +2205,19 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
     assert workflow._publish_reason == (
         "Structured gate stopped before downstream handoff."
     )
-    assert [payload["logicalStepId"] for payload in step_execution_payloads] == [
+    terminal_payloads = [
+        payload
+        for payload in step_execution_payloads
+        if payload.get("terminalDisposition")
+    ]
+    assert [payload["logicalStepId"] for payload in terminal_payloads] == [
         "implement",
         "publish",
     ]
-    assert step_execution_payloads[0]["terminalDisposition"] == (
+    assert terminal_payloads[0]["terminalDisposition"] == (
         "failed_with_remaining_work"
     )
-    assert step_execution_payloads[-1]["terminalDisposition"] == "accepted"
+    assert terminal_payloads[-1]["terminalDisposition"] == "accepted"
 
 
 @pytest.mark.asyncio
@@ -2324,4 +2377,4 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
     ]
     assert review_payloads[0]["attempt"] == 1
     assert review_payloads[1]["attempt"] == 2
-    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_2"
+    assert step["artifacts"]["stepExecutionManifestRef"] == "art_attempt_2_terminal"

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import inspect
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -114,7 +114,7 @@ def test_run_exposes_one_canonical_step_execution_manifest_record_surface() -> N
 
 
 def test_step_execution_manifest_start_write_keeps_replay_patch_guard() -> None:
-    source = inspect.getsource(MoonMindRunWorkflow.run)
+    source = Path(run_module.__file__).read_text()
 
     guard = "if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):"
     start_manifest_call = (


### PR DESCRIPTION
## Jira
- Issue: MM-821

## MoonSpec
- Active feature path: `specs/001-consolidate-step-manifests`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary
- Consolidates Step Execution start, launch-blocked, and terminal manifest recording through the canonical typed workflow writer path.
- Preserves execution context projection, input refs, workspace policy, budget/execution metadata, output refs, checks, dependency effects, compensation, and side-effect summaries in typed manifests.
- Removes the patched/unpatched legacy split and adds workflow-boundary coverage for the canonical manifest evidence.

## Tests Run
- `pytest tests/unit/workflows/temporal/test_step_executions.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py tests/unit/workflows/temporal/test_run_artifacts.py -q` PASS, 117 passed
- `pytest tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py -m 'integration_ci' -q --tb=short` PASS, 3 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS, 6,090 Python tests passed, 6 skipped, 1 xpassed; Vitest 422 passed, 234 skipped
- `./tools/test_integration.sh` PASS, 295 passed, 1 skipped, 82 deselected

## Remaining Risks
- No known functional gaps from MoonSpec verification.
- Local repository metadata had root-owned `.git` files, so the push completed while the local remote-tracking reflog update failed; the remote branch was verified with `git ls-remote`.

## Doc Reconciliation
- Outcome: `no_update_required`
- Canonical doc path evaluated: `docs/Steps/StepExecutionsAndCheckpointing.md`
- Rationale: latest moonspec-verify verdict for MM-821 was `FULLY_IMPLEMENTED`; the Source Document Drift section reported no blocking drift, and no `artifacts/doc-discoveries/001-consolidate-step-manifests.json` ledger was present. No canonical doc edits were required.
