### PR TITLE
MM-835 Harden image provenance and profile drift validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,8 @@ Key diagnostics:
 - No new persistent storage; conformance fixtures are deterministic repository test data and command output only (001-step-execution-conformance)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing Pentest workload launcher and artifact services (001-pentest-provider-leases)
 - Existing Temporal workflow/activity payloads and provider-profile manager workflow signals; no new persistent storage (001-pentest-provider-leases)
+- Python 3.12 + Pydantic v2 settings/models, PyYAML-backed workload profile loading, Temporal activity boundary helpers (001-harden-pentest-provenance)
+- No new persistent storage; deterministic validation only (001-harden-pentest-provenance)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -31,7 +31,9 @@ _PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY = (
 )
 _PENTEST_APPROVED_RUNNER_IMAGE_TAGS = frozenset(("1.0",))
 _PENTEST_RUNNER_IMAGE_PATTERN = re.compile(
-    r"^(?P<repository>ghcr\.io/moonladderstudios/moonmind-pentestgpt)"
+    r"^(?P<repository>"
+    + re.escape(_PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY)
+    + r")"
     r"(?::(?P<tag>[A-Za-z0-9_.-]+))?"
     r"(?:@(?P<digest>sha256:[a-f0-9]{64}))?$"
 )

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -26,6 +26,15 @@ _PENTEST_ALLOWED_OPERATION_MODES = (
     "full_authorized",
 )
 _PENTEST_ALLOWED_EVIDENCE_LEVELS = ("minimal", "standard", "full")
+_PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt"
+)
+_PENTEST_APPROVED_RUNNER_IMAGE_TAGS = frozenset(("1.0",))
+_PENTEST_RUNNER_IMAGE_PATTERN = re.compile(
+    r"^(?P<repository>ghcr\.io/moonladderstudios/moonmind-pentestgpt)"
+    r"(?::(?P<tag>[A-Za-z0-9_.-]+))?"
+    r"(?:@(?P<digest>sha256:[a-f0-9]{64}))?$"
+)
 _OWNER_REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _JIRA_PROJECT_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9]+$")
 _JIRA_ALLOWED_ACTIONS = frozenset(
@@ -1452,6 +1461,16 @@ class PentestSettings(BaseSettings):
         validation_alias=AliasChoices("MOONMIND_PENTEST_RUNNER_IMAGE"),
         description="Curated PentestGPT runner image tag or digest.",
     )
+    unsafe_dev_runner_image_override: bool = Field(
+        False,
+        validation_alias=AliasChoices(
+            "MOONMIND_PENTEST_UNSAFE_DEV_RUNNER_IMAGE_OVERRIDE"
+        ),
+        description=(
+            "Allow an unapproved PentestGPT runner image for explicit local "
+            "development only."
+        ),
+    )
     safe_profile_id: str = Field(
         "pentestgpt-safe",
         validation_alias=AliasChoices("MOONMIND_PENTEST_SAFE_PROFILE_ID"),
@@ -1651,6 +1670,8 @@ class PentestSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_default_values_are_allowlisted(self) -> Self:
+        if not self.unsafe_dev_runner_image_override:
+            _validate_pentest_runner_image(self.runner_image)
         if self.default_operation_mode not in self.allowed_operation_modes:
             raise ValueError(
                 "default pentest operation mode must be included in "
@@ -1670,6 +1691,27 @@ class PentestSettings(BaseSettings):
                 "pentest runner profiles"
             )
         return self
+
+def _validate_pentest_runner_image(value: str) -> None:
+    image = str(value or "").strip()
+    match = _PENTEST_RUNNER_IMAGE_PATTERN.fullmatch(image)
+    if not match:
+        raise ValueError(
+            "Pentest runner image must be an approved MoonMind-owned "
+            "ghcr.io/moonladderstudios/moonmind-pentestgpt tag or digest-pinned "
+            "reference"
+        )
+    if match.group("repository") != _PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY:
+        raise ValueError("Pentest runner image repository is not approved")
+    tag = match.group("tag")
+    digest = match.group("digest")
+    if not tag and not digest:
+        raise ValueError("Pentest runner image must include an approved tag or digest")
+    if tag and tag not in _PENTEST_APPROVED_RUNNER_IMAGE_TAGS:
+        raise ValueError(
+            "Pentest runner image tag is not approved; use an approved "
+            "MoonMind-owned tag, digest pin, or explicit unsafe dev override"
+        )
 
 DEFAULT_GOOGLE_EMBEDDING_DIMENSIONS: int = 3072
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4634,6 +4634,23 @@ class TemporalAgentRuntimeActivities:
                 reason="runner_profile_not_registered",
                 diagnostics={"runner_profile_ids": missing_profiles},
             )
+        drifted_profiles = []
+        for profile_id in configured_profiles:
+            if not profile_id:
+                continue
+            profile = self._workload_registry.get(profile_id)
+            if profile is not None and profile.image != pentest_settings.runner_image:
+                drifted_profiles.append(profile_id)
+        drifted_profiles.sort()
+        if drifted_profiles:
+            raise PentestLaunchPolicyError(
+                "Configured Pentest runner profile image does not match approved runner image",
+                reason="runner_profile_image_drift",
+                diagnostics={
+                    "runner_profile_ids": drifted_profiles,
+                    "approved_runner_image": pentest_settings.runner_image,
+                },
+            )
 
     @staticmethod
     def _write_pentest_json(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4612,6 +4612,29 @@ class TemporalAgentRuntimeActivities:
                 diagnostics={"scope_id": scope.scope_id, "target": request.target},
             )
 
+    def _validate_pentest_runner_profiles_registered(self) -> None:
+        if self._workload_registry is None or not hasattr(
+            self._workload_registry, "get"
+        ):
+            return
+        pentest_settings = settings.pentest
+        configured_profiles = set(pentest_settings.allowed_runner_profiles)
+        configured_profiles.add(pentest_settings.default_runner_profile)
+        configured_profiles.add(pentest_settings.safe_profile_id)
+        if pentest_settings.allow_vpn_lab_profile:
+            configured_profiles.add(pentest_settings.vpn_lab_profile_id)
+        missing_profiles = sorted(
+            profile_id
+            for profile_id in configured_profiles
+            if profile_id and self._workload_registry.get(profile_id) is None
+        )
+        if missing_profiles:
+            raise PentestLaunchPolicyError(
+                "Configured Pentest runner profile is not present in workload registry",
+                reason="runner_profile_not_registered",
+                diagnostics={"runner_profile_ids": missing_profiles},
+            )
+
     @staticmethod
     def _write_pentest_json(
         path: str,
@@ -5543,6 +5566,7 @@ class TemporalAgentRuntimeActivities:
                     diagnostics={"scope_artifact_ref": request.scope_artifact_ref},
                 )
             self._validate_pentest_request_policy(request, request.approved_scope)
+            self._validate_pentest_runner_profiles_registered()
             launch_plan = build_pentest_launch_plan(request)
             provider_profile = resolve_pentest_provider_profile(
                 execution_profile_ref=request.execution_profile_ref,

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
+from moonmind.config.settings import PentestSettings
 from moonmind.integrations.pentest.models import (
     PENTEST_TOOL_NAME,
     PENTEST_HEARTBEAT_PHASES,
@@ -168,6 +169,46 @@ def test_pentest_workload_request_rejects_invalid_values(
     with pytest.raises(ValidationError):
         PentestWorkloadRequest.model_validate(payload)
 
+@pytest.mark.parametrize(
+    "runner_image",
+    [
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt@sha256:" + "a" * 64,
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:" + "b" * 64,
+    ],
+)
+def test_pentest_settings_accepts_approved_runner_images(runner_image: str) -> None:
+    parsed = PentestSettings(MOONMIND_PENTEST_RUNNER_IMAGE=runner_image)
+
+    assert parsed.runner_image == runner_image
+
+@pytest.mark.parametrize(
+    "runner_image",
+    [
+        "docker.io/moonladderstudios/moonmind-pentestgpt:1.0",
+        "ghcr.io/other/moonmind-pentestgpt:1.0",
+        "ghcr.io/moonladderstudios/not-pentestgpt:1.0",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt:latest",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt@sha256:notadigest",
+    ],
+)
+def test_pentest_settings_rejects_unapproved_runner_images(
+    runner_image: str,
+) -> None:
+    with pytest.raises(ValueError, match="Pentest runner image"):
+        PentestSettings(MOONMIND_PENTEST_RUNNER_IMAGE=runner_image)
+
+def test_pentest_settings_allows_unapproved_runner_image_with_explicit_dev_override(
+) -> None:
+    parsed = PentestSettings(
+        MOONMIND_PENTEST_RUNNER_IMAGE="localhost:5000/dev/pentestgpt:debug",
+        MOONMIND_PENTEST_UNSAFE_DEV_RUNNER_IMAGE_OVERRIDE="true",
+    )
+
+    assert parsed.runner_image == "localhost:5000/dev/pentestgpt:debug"
+    assert parsed.unsafe_dev_runner_image_override is True
+
 def test_pentest_scope_validation_accepts_authorized_scope() -> None:
     payload = _valid_request_payload()
     payload["approved_scope"] = _approved_scope_payload()
@@ -177,6 +218,30 @@ def test_pentest_scope_validation_accepts_authorized_scope() -> None:
     validate_authorized_scope_for_request(
         request, now=datetime(2026, 4, 22, 12, tzinfo=UTC)
     )
+
+def test_pentest_workload_request_rejects_user_controlled_docker_launch_fields() -> None:
+    payload = _valid_request_payload()
+    payload.update(
+        {
+            "image": "attacker/image:1.0",
+            "network_name": "raw-docker-network",
+            "host_mounts": ["/:/host"],
+            "devices": ["/dev/net/tun:/dev/net/tun"],
+            "linux_capabilities": ["NET_ADMIN"],
+            "docker_socket": "/var/run/docker.sock",
+        }
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        PentestWorkloadRequest.model_validate(payload)
+
+    errors = {tuple(error["loc"]) for error in exc_info.value.errors()}
+    assert ("image",) in errors
+    assert ("network_name",) in errors
+    assert ("host_mounts",) in errors
+    assert ("devices",) in errors
+    assert ("linux_capabilities",) in errors
+    assert ("docker_socket",) in errors
 
 @pytest.mark.parametrize(
     ("mutate_request", "scope_overrides", "error_code", "reason"),

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -178,7 +178,10 @@ def test_pentest_workload_request_rejects_invalid_values(
     ],
 )
 def test_pentest_settings_accepts_approved_runner_images(runner_image: str) -> None:
-    parsed = PentestSettings(MOONMIND_PENTEST_RUNNER_IMAGE=runner_image)
+    parsed = PentestSettings(
+        MOONMIND_PENTEST_RUNNER_IMAGE=runner_image,
+        MOONMIND_PENTEST_UNSAFE_DEV_RUNNER_IMAGE_OVERRIDE="false",
+    )
 
     assert parsed.runner_image == runner_image
 
@@ -197,7 +200,10 @@ def test_pentest_settings_rejects_unapproved_runner_images(
     runner_image: str,
 ) -> None:
     with pytest.raises(ValueError, match="Pentest runner image"):
-        PentestSettings(MOONMIND_PENTEST_RUNNER_IMAGE=runner_image)
+        PentestSettings(
+            MOONMIND_PENTEST_RUNNER_IMAGE=runner_image,
+            MOONMIND_PENTEST_UNSAFE_DEV_RUNNER_IMAGE_OVERRIDE="false",
+        )
 
 def test_pentest_settings_allows_unapproved_runner_image_with_explicit_dev_override(
 ) -> None:

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1918,6 +1918,78 @@ async def test_security_pentest_execute_rejects_configured_profiles_missing_from
     assert "pentestgpt-missing" in str(result["diagnostics"])
     assert launcher.requests == []
 
+async def test_security_pentest_execute_rejects_registered_runner_image_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    launcher = _FakePentestLauncher()
+    registry_path = tmp_path / "profiles.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "id": "pentestgpt-safe",
+                        "kind": "one_shot",
+                        "image": "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0-drift",
+                        "workdirTemplate": "/work/agent_jobs/${agent_run_id}/repo",
+                        "requiredMounts": [
+                            {
+                                "type": "volume",
+                                "source": "agent_workspaces",
+                                "target": "/work/agent_jobs",
+                            }
+                        ],
+                        "envAllowlist": ["ANTHROPIC_API_KEY"],
+                        "networkPolicy": "bridge",
+                        "resources": {
+                            "cpu": "4",
+                            "memory": "8g",
+                            "shmSize": "1g",
+                            "maxCpu": "4",
+                            "maxMemory": "8g",
+                            "maxShmSize": "1g",
+                        },
+                        "timeoutSeconds": 28800,
+                        "maxTimeoutSeconds": 28800,
+                        "cleanup": {
+                            "removeContainerOnExit": True,
+                            "killGraceSeconds": 30,
+                        },
+                        "devicePolicy": {"mode": "none"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = RunnerProfileRegistry.load_file(
+        registry_path,
+        workspace_root="/work/agent_jobs",
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=registry,
+    )
+    monkeypatch.setattr(
+        settings.pentest,
+        "runner_image",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+    )
+    monkeypatch.setattr(
+        settings.pentest, "allowed_runner_profiles", ("pentestgpt-safe",)
+    )
+    monkeypatch.setattr(settings.pentest, "allow_vpn_lab_profile", False)
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "validation_failed"
+    assert "runner_profile_image_drift" in str(result["diagnostics"])
+    assert "pentestgpt-safe" in str(result["diagnostics"])
+    assert launcher.requests == []
+
 async def test_security_pentest_execute_validates_safe_profile_against_registry(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1891,6 +1891,61 @@ async def test_pentest_workload_profile_registry_includes_safe_runner():
     assert profile.network_policy == "bridge"
     assert "ANTHROPIC_API_KEY" in profile.env_allowlist
 
+async def test_security_pentest_execute_rejects_configured_profiles_missing_from_registry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    launcher = _FakePentestLauncher()
+    registry = RunnerProfileRegistry.load_file(
+        Path("config/workloads/default-runner-profiles.yaml"),
+        workspace_root="/work/agent_jobs",
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=registry,
+    )
+    monkeypatch.setattr(
+        settings.pentest,
+        "allowed_runner_profiles",
+        ("pentestgpt-safe", "pentestgpt-missing"),
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "validation_failed"
+    assert "runner_profile_not_registered" in str(result["diagnostics"])
+    assert "pentestgpt-missing" in str(result["diagnostics"])
+    assert launcher.requests == []
+
+async def test_security_pentest_execute_validates_safe_profile_against_registry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    launcher = _FakePentestLauncher()
+    registry = RunnerProfileRegistry.load_file(
+        Path("config/workloads/default-runner-profiles.yaml"),
+        workspace_root="/work/agent_jobs",
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=registry,
+    )
+    monkeypatch.setattr(
+        settings.pentest, "allowed_runner_profiles", ("pentestgpt-safe",)
+    )
+    monkeypatch.setattr(settings.pentest, "allow_vpn_lab_profile", False)
+
+    payload = _pentest_activity_payload()
+    payload["request"]["repo_dir"] = "/work/agent_jobs/run-123/repo"
+    payload["request"][
+        "artifacts_dir"
+    ] = "/work/agent_jobs/run-123/artifacts/pentest"
+
+    result = await activities._security_pentest_execute_trusted_internal(payload)
+
+    assert result["status"] == "completed"
+    assert len(launcher.requests) == 1
+
 async def test_security_pentest_execute_materializes_input_files_without_secrets(
     tmp_path: Path,
 ):

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2003,6 +2003,13 @@ async def test_security_pentest_execute_validates_safe_profile_against_registry(
         workload_registry=registry,
     )
     monkeypatch.setattr(
+        settings.pentest,
+        "runner_image",
+        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+    )
+    monkeypatch.setattr(settings.pentest, "safe_profile_id", "pentestgpt-safe")
+    monkeypatch.setattr(settings.pentest, "default_runner_profile", "pentestgpt-safe")
+    monkeypatch.setattr(
         settings.pentest, "allowed_runner_profiles", ("pentestgpt-safe",)
     )
     monkeypatch.setattr(settings.pentest, "allow_vpn_lab_profile", False)

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1991,12 +1991,13 @@ async def test_security_pentest_execute_rejects_registered_runner_image_drift(
     assert launcher.requests == []
 
 async def test_security_pentest_execute_validates_safe_profile_against_registry(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
     launcher = _FakePentestLauncher()
     registry = RunnerProfileRegistry.load_file(
         Path("config/workloads/default-runner-profiles.yaml"),
-        workspace_root="/work/agent_jobs",
+        workspace_root=tmp_path,
     )
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=launcher,
@@ -2015,10 +2016,10 @@ async def test_security_pentest_execute_validates_safe_profile_against_registry(
     monkeypatch.setattr(settings.pentest, "allow_vpn_lab_profile", False)
 
     payload = _pentest_activity_payload()
-    payload["request"]["repo_dir"] = "/work/agent_jobs/run-123/repo"
-    payload["request"][
-        "artifacts_dir"
-    ] = "/work/agent_jobs/run-123/artifacts/pentest"
+    payload["request"]["repo_dir"] = str(tmp_path / "run-123" / "repo")
+    payload["request"]["artifacts_dir"] = str(
+        tmp_path / "run-123" / "artifacts" / "pentest"
+    )
 
     result = await activities._security_pentest_execute_trusted_internal(payload)
 

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import re
 
 import pytest
 from pydantic import ValidationError
@@ -392,8 +391,15 @@ def test_default_registry_contains_unreal_pilot_profile() -> None:
     assert profile.max_timeout_seconds == 7200
     assert profile.max_concurrency == 1
 
-def test_pentest_runner_defaults_registry_and_publish_workflow_do_not_drift() -> None:
-    settings_image = PentestSettings().runner_image
+def test_pentest_runner_defaults_registry_and_publish_workflow_do_not_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings
+
+    default_image = PentestSettings.model_fields["runner_image"].default
+    monkeypatch.setattr(settings.pentest, "runner_image", default_image)
+
+    settings_image = settings.pentest.runner_image
     domain_profile = get_pentest_runner_profile("pentestgpt-safe")
     registry = RunnerProfileRegistry.load_file(
         Path("config/workloads/default-runner-profiles.yaml"),

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 
 import pytest
 from pydantic import ValidationError
 
+from moonmind.config.settings import PentestSettings
+from moonmind.integrations.pentest.models import get_pentest_runner_profile
 from moonmind.schemas.workload_models import (
     UnrestrictedContainerRequest,
     UnrestrictedDockerRequest,
@@ -388,22 +391,26 @@ def test_default_registry_contains_unreal_pilot_profile() -> None:
     assert profile.timeout_seconds == 7200
     assert profile.max_timeout_seconds == 7200
     assert profile.max_concurrency == 1
-    assert {mount.source for mount in profile.required_mounts} == {"agent_workspaces"}
-    assert {mount.source for mount in profile.optional_mounts} == {
-        "unreal_ccache_volume",
-        "unreal_ubt_volume",
-    }
-    assert set(profile.env_allowlist) == {
-        "CI",
-        "CCACHE_DIR",
-        "UBT_CACHE_DIR",
-        "UE_PROJECT_PATH",
-        "UE_TARGET",
-        "UE_TEST_SELECTOR",
-        "UE_REPORT_PATH",
-        "UE_SUMMARY_PATH",
-        "UE_JUNIT_PATH",
-    }
+
+def test_pentest_runner_defaults_registry_and_publish_workflow_do_not_drift() -> None:
+    settings_image = PentestSettings().runner_image
+    domain_profile = get_pentest_runner_profile("pentestgpt-safe")
+    registry = RunnerProfileRegistry.load_file(
+        Path("config/workloads/default-runner-profiles.yaml"),
+        workspace_root=WORKSPACE_ROOT,
+        allowed_image_registries=("ghcr.io",),
+    )
+    workload_profile = registry.get("pentestgpt-safe")
+    publish_workflow = Path(".github/workflows/docker-publish.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert domain_profile.image == settings_image
+    assert workload_profile is not None
+    assert workload_profile.image == settings_image
+    assert settings_image == "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+    assert "pentest_image_name=${IMAGE_NAME}-pentestgpt" in publish_workflow
+    assert "./docker/pentestgpt-runner/Dockerfile" in publish_workflow
 
 @pytest.mark.parametrize(
     ("overrides", "message"),


### PR DESCRIPTION
Jira issue key: MM-835

Active MoonSpec feature path: `specs/001-harden-pentest-provenance`

Verification verdict: `FULLY_IMPLEMENTED`

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workloads/test_workload_contract.py` - PASS, 216 Python tests passed; UI phase passed with 422 passed and 234 skipped.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, 6175 Python tests passed, 6 skipped, 1 xpassed; UI phase passed with 422 passed and 234 skipped.
- `./tools/test_integration.sh` - PASS, 309 integration_ci tests passed, 1 skipped, 82 deselected.

Remaining risks: None identified in the latest MoonSpec verification report.

Doc reconciliation outcome: `no_update_required` for `docs/Steps/PentestTool.md`. Rationale: the latest post-remediation MoonSpec verify verdict for MM-835 is `FULLY_IMPLEMENTED`; no definite source-document drift discovery was present, and the verified implementation already matches the relevant Pentest Tool sections. No canonical docs were edited.
