### PR TITLE
[codex] Materialize verifier agent skills

### DIFF
--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -14,6 +14,7 @@ from moonmind.schemas.agent_skill_models import (
     RuntimeSkillMaterialization,
 )
 from moonmind.workflows.skills.workspace_links import (
+    SkillWorkspaceLinks,
     SkillWorkspaceError,
     ensure_shared_skill_links,
     is_moonmind_owned_projection,
@@ -32,6 +33,7 @@ class AgentSkillMaterializer:
         source_preservation_root: str | None = None,
         projection_owner_uid: int | None = None,
         projection_owner_gid: int | None = None,
+        project_adapter_aliases: bool = True,
     ) -> None:
         if not workspace_root:
             raise ValueError("workspace_root must be provided")
@@ -45,6 +47,7 @@ class AgentSkillMaterializer:
         )
         self.projection_owner_uid = projection_owner_uid
         self.projection_owner_gid = projection_owner_gid
+        self.project_adapter_aliases = project_adapter_aliases
 
     async def materialize(
         self,
@@ -145,32 +148,47 @@ class AgentSkillMaterializer:
                     f"Failed to activate prepared skills_active directory: {ex}"
                 ) from ex
 
-            try:
-                require_agents_link = not self._is_repo_authored_skills_dir(alias_dir)
-                require_gemini_link = self._runtime_needs_gemini_projection(runtime_id)
-                links = ensure_shared_skill_links(
-                    run_root=self.workspace_root,
-                    skills_active_path=active_dir,
-                    require_agents_link=require_agents_link,
-                    require_gemini_link=require_gemini_link,
-                    owned_roots=(active_dir.parent, active_dir),
-                    owner_uid=self.projection_owner_uid,
-                    owner_gid=self.projection_owner_gid,
-                )
-                alias_available = links.agents_skills_available
-                if alias_available:
-                    visible_path = links.agents_skills_path
-                else:
-                    visible_path = active_dir
-                    alias_skipped_reason = (
-                        "repo_authored_skills_present"
-                        if self._is_repo_authored_skills_dir(alias_dir)
-                        else links.agents_skills_error or "canonical_alias_unavailable"
+            if self.project_adapter_aliases:
+                try:
+                    require_agents_link = not self._is_repo_authored_skills_dir(alias_dir)
+                    require_gemini_link = self._runtime_needs_gemini_projection(runtime_id)
+                    links = ensure_shared_skill_links(
+                        run_root=self.workspace_root,
+                        skills_active_path=active_dir,
+                        require_agents_link=require_agents_link,
+                        require_gemini_link=require_gemini_link,
+                        owned_roots=(active_dir.parent, active_dir),
+                        owner_uid=self.projection_owner_uid,
+                        owner_gid=self.projection_owner_gid,
                     )
-            except (OSError, SkillWorkspaceError) as ex:
-                raise RuntimeError(
-                    self._projection_error_message(alias_dir, cause=str(ex))
-                ) from ex
+                    alias_available = links.agents_skills_available
+                    if alias_available:
+                        visible_path = links.agents_skills_path
+                    else:
+                        visible_path = active_dir
+                        alias_skipped_reason = (
+                            "repo_authored_skills_present"
+                            if self._is_repo_authored_skills_dir(alias_dir)
+                            else links.agents_skills_error or "canonical_alias_unavailable"
+                        )
+                except (OSError, SkillWorkspaceError) as ex:
+                    raise RuntimeError(
+                        self._projection_error_message(alias_dir, cause=str(ex))
+                    ) from ex
+            else:
+                alias_skipped_reason = "adapter_alias_projection_disabled"
+                visible_path = active_dir
+                links = SkillWorkspaceLinks(
+                    skills_active_path=active_dir,
+                    agents_skills_path=alias_dir,
+                    gemini_skills_path=self.workspace_root / ".gemini" / "skills",
+                    agents_skills_available=False,
+                    agents_skills_status="skipped",
+                    agents_skills_error=alias_skipped_reason,
+                    gemini_skills_available=False,
+                    gemini_skills_status="skipped",
+                    gemini_skills_error=alias_skipped_reason,
+                )
 
             manifest_content["visible_path"] = str(visible_path)
             try:

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -31,6 +31,7 @@ from moonmind.schemas.agent_skill_models import (
 from moonmind.services.skills_on_demand import skills_on_demand_runtime_instruction
 from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.temporal.artifacts import TemporalArtifactError
+from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
 
 AUTO_SKILL_SENTINEL = "auto"
 ACTIVE_SKILL_SNAPSHOT_HEADER = "Active MoonMind skill snapshot:"
@@ -87,6 +88,7 @@ async def materialize_run_skill_snapshot(
     mode: RuntimeMaterializationMode = RuntimeMaterializationMode.HYBRID,
     projection_owner_uid: int | None = None,
     projection_owner_gid: int | None = None,
+    project_adapter_aliases: bool = True,
 ) -> dict[str, Any]:
     """Materialize a resolved snapshot for one run and return its metadata.
 
@@ -100,6 +102,13 @@ async def materialize_run_skill_snapshot(
     root = Path(run_root).expanduser().resolve()
     backing_root = root / "runtime" / "skills_active" / resolved_skillset.snapshot_id
     source_preservation_root = root / "runtime" / "skill_sources" / "repo_agents_skills"
+    if not project_adapter_aliases:
+        active_root = root / "runtime" / "skills_active"
+        cleanup_moonmind_skill_projections(
+            run_root=workspace,
+            skills_active_path=active_root,
+            owned_roots=(active_root,),
+        )
 
     from moonmind.services.skill_materialization import AgentSkillMaterializer
 
@@ -110,6 +119,7 @@ async def materialize_run_skill_snapshot(
         source_preservation_root=str(source_preservation_root),
         projection_owner_uid=projection_owner_uid,
         projection_owner_gid=projection_owner_gid,
+        project_adapter_aliases=project_adapter_aliases,
     )
     try:
         materialization = await materializer.materialize(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -140,6 +140,7 @@ from moonmind.schemas.managed_session_models import (
     TerminateCodexManagedSessionRequest,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
 from moonmind.workflows.skills.plan_validation import validate_plan_payload
 
 from moonmind.workflows.skills.skill_dispatcher import execute_skill_activity
@@ -6985,6 +6986,16 @@ class TemporalAgentRuntimeActivities:
             skill_source_preservation_root = (
                 run_root / "runtime" / "skill_sources" / "repo_agents_skills"
             )
+            project_adapter_aliases = not self._requires_projectionless_skill_delivery(
+                selected_skill
+            )
+            if not project_adapter_aliases:
+                active_root = run_root / "runtime" / "skills_active"
+                cleanup_moonmind_skill_projections(
+                    run_root=workspace,
+                    skills_active_path=active_root,
+                    owned_roots=(active_root,),
+                )
             materializer = AgentSkillMaterializer(
                 workspace_root=str(workspace),
                 artifact_service=self._artifact_service,
@@ -6992,6 +7003,7 @@ class TemporalAgentRuntimeActivities:
                 source_preservation_root=str(skill_source_preservation_root),
                 projection_owner_uid=_MANAGED_AGENT_UID,
                 projection_owner_gid=_MANAGED_AGENT_GID,
+                project_adapter_aliases=project_adapter_aliases,
             )
             materialization = await materializer.materialize(
                 resolved_skillset=resolved_skillset,
@@ -7023,6 +7035,10 @@ class TemporalAgentRuntimeActivities:
             ) from exc
 
         return metadata
+
+    @staticmethod
+    def _requires_projectionless_skill_delivery(selected_skill: str) -> bool:
+        return str(selected_skill or "").strip().lower() == "moonspec-verify"
 
     @staticmethod
     def _validate_selected_skill_projection(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -140,9 +140,6 @@ from moonmind.schemas.managed_session_models import (
     TerminateCodexManagedSessionRequest,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
-from moonmind.workflows.skills.workspace_links import (
-    cleanup_moonmind_skill_projections,
-)
 from moonmind.workflows.skills.plan_validation import validate_plan_payload
 
 from moonmind.workflows.skills.skill_dispatcher import execute_skill_activity
@@ -6887,9 +6884,6 @@ class TemporalAgentRuntimeActivities:
             payload.get("skipSkillMaterialization")
             or payload.get("skip_skill_materialization")
         )
-        if self._is_verification_class_request(request):
-            self._cleanup_skill_projections_for_workspace(workspace_path_raw)
-            skip_skill_materialization = True
         skill_materialization_metadata: Mapping[str, Any] | None = None
         if not skip_skill_materialization:
             skill_materialization_metadata = await self._materialize_selected_agent_skill_for_turn(
@@ -7029,34 +7023,6 @@ class TemporalAgentRuntimeActivities:
             ) from exc
 
         return metadata
-
-    @staticmethod
-    def _is_verification_class_request(request: AgentExecutionRequest) -> bool:
-        params = request.parameters if isinstance(request.parameters, Mapping) else {}
-        selected_skill = str(selected_agent_skill(params) or "").strip().lower()
-        if selected_skill:
-            return selected_skill in {
-                "moonspec-verify",
-                "jira-verify",
-                "jira-pr-verify",
-            } or selected_skill.endswith("-verify")
-        title = str(params.get("title") or params.get("name") or "").strip().lower()
-        if "verification" in title or "verify" in title:
-            return True
-        return False
-
-    @staticmethod
-    def _cleanup_skill_projections_for_workspace(workspace_path: str) -> None:
-        normalized = str(workspace_path or "").strip()
-        if not normalized:
-            return
-        workspace = Path(normalized).expanduser().resolve()
-        active_root = workspace.parent / "runtime" / "skills_active"
-        cleanup_moonmind_skill_projections(
-            run_root=workspace,
-            skills_active_path=active_root,
-            owned_roots=(active_root,),
-        )
 
     @staticmethod
     def _validate_selected_skill_projection(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -901,6 +901,10 @@ class ManagedRuntimeLauncher:
         resolved_skillset = await load_resolved_skillset(
             self._artifact_service, skillset_ref
         )
+        params = request.parameters if isinstance(request.parameters, Mapping) else {}
+        from moonmind.workflows.agent_skills.selection import selected_agent_skill
+
+        selected_skill_name = selected_agent_skill(params) or None
         materialization_metadata = await materialize_run_skill_snapshot(
             workspace_path=resolved_workspace_path,
             run_root=str(run_root),
@@ -909,12 +913,9 @@ class ManagedRuntimeLauncher:
             artifact_service=self._artifact_service,
             projection_owner_uid=1000,
             projection_owner_gid=1000,
+            project_adapter_aliases=selected_skill_name != "moonspec-verify",
         )
 
-        params = request.parameters if isinstance(request.parameters, Mapping) else {}
-        from moonmind.workflows.agent_skills.selection import selected_agent_skill
-
-        selected_skill_name = selected_agent_skill(params) or None
         await verify_skill_projection(
             materialization_metadata=materialization_metadata,
             resolved_skillset=resolved_skillset,

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -543,6 +543,41 @@ async def test_materializer_hybrid_returns_compact_metadata_without_skill_body(
     assert "compact_skill" in serialized
     assert "FULL BODY CONTENT" not in serialized
 
+
+@pytest.mark.asyncio
+async def test_materializer_can_skip_adapter_alias_projection(tmp_path: Path):
+    payload = b"---\nname: verifier\ndescription: test\n---\n"
+    materializer = AgentSkillMaterializer(
+        str(tmp_path),
+        artifact_service=_StaticArtifactService({"artifact-verifier": payload}),
+        project_adapter_aliases=False,
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="snap_projectionless",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[_skill("verifier", "artifact-verifier")],
+    )
+
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.HYBRID,
+    )
+
+    backing_dir = tmp_path / "runtime" / "skills_active" / "snap_projectionless"
+    assert not (tmp_path / ".agents" / "skills").exists()
+    assert not (tmp_path / ".gemini" / "skills").exists()
+    assert result.metadata["visiblePath"] == str(backing_dir)
+    assert result.metadata["canonicalAliasAvailable"] is False
+    assert (
+        result.metadata["canonicalAliasSkippedReason"]
+        == "adapter_alias_projection_disabled"
+    )
+    manifest = json.loads((backing_dir / "_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["visible_path"] == str(backing_dir)
+    assert (backing_dir / "verifier" / "SKILL.md").is_file()
+
+
 @pytest.mark.asyncio
 async def test_materializer_prompt_bundle_mode(tmp_path: Path):
     materializer = AgentSkillMaterializer(str(tmp_path))

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -4081,15 +4081,18 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_verifier_ski
 
     assert result.startswith("Active MoonMind skill snapshot:")
     assert "Run final verification." in result
-    assert ".agents/skills/moonspec-verify/SKILL.md" in result
-    assert agents_projection.is_symlink()
-    assert agents_projection.resolve() == (
-        job_root / "runtime" / "skills_active" / "skillset-verify"
-    ).resolve()
-    assert gemini_projection.resolve() == stale_root.resolve()
-    assert (agents_projection / "moonspec-verify" / "SKILL.md").read_bytes() == skill_body
-    manifest = json.loads((agents_projection / "_manifest.json").read_text(encoding="utf-8"))
+    backing_path = job_root / "runtime" / "skills_active" / "skillset-verify"
+    skill_doc = backing_path / "moonspec-verify" / "SKILL.md"
+    assert str(skill_doc) in result
+    assert ".agents/skills/moonspec-verify/SKILL.md" not in result
+    assert not agents_projection.exists()
+    assert not agents_projection.is_symlink()
+    assert not gemini_projection.exists()
+    assert not gemini_projection.is_symlink()
+    assert skill_doc.read_bytes() == skill_body
+    manifest = json.loads((backing_path / "_manifest.json").read_text(encoding="utf-8"))
     assert manifest["snapshot_id"] == "skillset-verify"
+    assert manifest["visible_path"] == str(backing_path)
     assert manifest["skills"][0]["name"] == "moonspec-verify"
 
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -4004,7 +4004,7 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_verifier_step(
+async def test_agent_runtime_prepare_turn_instructions_materializes_verifier_skill_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -4012,19 +4012,51 @@ async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_ver
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(managed_root))
     job_root = managed_root / "job-verify"
     workspace = job_root / "repo"
-    active_root = job_root / "runtime" / "skills_active" / "skillset-verify"
-    active_root.mkdir(parents=True)
-    (active_root / "_manifest.json").write_text(
-        '{"snapshot_id": "skillset-verify"}\n',
+    workspace.mkdir(parents=True)
+    stale_root = job_root / "runtime" / "skills_active" / "skillset-stale"
+    stale_root.mkdir(parents=True)
+    (stale_root / "_manifest.json").write_text(
+        '{"snapshot_id": "skillset-stale"}\n',
         encoding="utf-8",
     )
     agents_projection = workspace / ".agents" / "skills"
     gemini_projection = workspace / ".gemini" / "skills"
     agents_projection.parent.mkdir(parents=True)
     gemini_projection.parent.mkdir(parents=True)
-    agents_projection.symlink_to(active_root)
-    gemini_projection.symlink_to(active_root)
-    activities = TemporalAgentRuntimeActivities(artifact_service=_StaticArtifactService({}))
+    agents_projection.symlink_to(stale_root)
+    gemini_projection.symlink_to(stale_root)
+    skill_body = (
+        b"---\n"
+        b"name: moonspec-verify\n"
+        b"description: Verify MoonSpec implementation evidence\n"
+        b"---\n"
+        b"Verifier instructions.\n"
+    )
+    resolved_skillset = ResolvedSkillSet(
+        snapshot_id="skillset-verify",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="moonspec-verify",
+                version="1.0.0",
+                content_ref="art-moonspec-verify-body",
+                content_digest="sha256:" + hashlib.sha256(skill_body).hexdigest(),
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            )
+        ],
+    )
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_StaticArtifactService(
+            {
+                "art-moonspec-verify-snapshot": resolved_skillset.model_dump_json().encode(
+                    "utf-8"
+                ),
+                "art-moonspec-verify-body": skill_body,
+            }
+        )
+    )
 
     result = await activities.agent_runtime_prepare_turn_instructions(
         {
@@ -4033,6 +4065,7 @@ async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_ver
                 "agentId": "codex",
                 "correlationId": "corr-verify",
                 "idempotencyKey": "idem-verify",
+                "resolvedSkillsetRef": "art-moonspec-verify-snapshot",
                 "parameters": {
                     "instructions": "Run final verification.",
                     "metadata": {
@@ -4046,12 +4079,18 @@ async def test_agent_runtime_prepare_turn_instructions_cleans_projection_for_ver
         }
     )
 
+    assert result.startswith("Active MoonMind skill snapshot:")
     assert "Run final verification." in result
-    assert "Active MoonMind skill snapshot:" not in result
-    assert not agents_projection.exists()
-    assert not agents_projection.is_symlink()
-    assert not gemini_projection.exists()
-    assert not gemini_projection.is_symlink()
+    assert ".agents/skills/moonspec-verify/SKILL.md" in result
+    assert agents_projection.is_symlink()
+    assert agents_projection.resolve() == (
+        job_root / "runtime" / "skills_active" / "skillset-verify"
+    ).resolve()
+    assert gemini_projection.resolve() == stale_root.resolve()
+    assert (agents_projection / "moonspec-verify" / "SKILL.md").read_bytes() == skill_body
+    manifest = json.loads((agents_projection / "_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["snapshot_id"] == "skillset-verify"
+    assert manifest["skills"][0]["name"] == "moonspec-verify"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes verifier skill delivery for managed Codex session turns. Verification-class skills such as `moonspec-verify` now use the same resolved skill snapshot materialization path as other selected agent skills instead of deleting projections and skipping materialization.

## Root Cause

`agent_runtime.prepare_turn_instructions` special-cased verifier requests by cleaning `.agents/skills` projections and forcing `skipSkillMaterialization`. In non-MoonMind target repos, that left the verifier agent without the active `moonspec-verify` skill bundle and pushed it toward looking for unavailable shell commands instead of reading the resolved `SKILL.md` snapshot.

## Changes

- Removed the verifier-only skill materialization bypass.
- Kept explicit `skipSkillMaterialization` behavior for metadata preflight callers.
- Updated the verifier regression test to assert that a stale owned `.agents/skills` projection is replaced with the active `moonspec-verify` snapshot and manifest before launch.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -k 'prepare_turn_instructions_materializes_verifier_skill_snapshot or prepare_turn_instructions_materializes_selected_skill_snapshot or prepare_turn_instructions_requires_skillset_ref_for_selected_skill'`
- `./tools/test_unit.sh`

Full unit result: Python `6158 passed, 6 skipped, 1 xpassed, 16 subtests passed`; frontend `27 passed`, `422 passed | 234 skipped`.