### PR TITLE
[codex] Prioritize merge automation resolver runs

### DIFF
--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -657,7 +657,7 @@ The manager is the source of truth for:
 
 | Signal            | Direction          | Payload                                                                                                                         |
 | ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `request_slot`    | AgentRun → Manager | `{requester_workflow_id, runtime_id, requested_profile_id?, provider_id?, tags_any?, tags_all?, runtime_materialization_mode?}` |
+| `request_slot`    | AgentRun → Manager | `{requester_workflow_id, runtime_id, priority?, requested_profile_id?, provider_id?, tags_any?, tags_all?, runtime_materialization_mode?}` |
 | `release_slot`    | AgentRun → Manager | `{requester_workflow_id, profile_id}`                                                                                           |
 | `report_cooldown` | AgentRun → Manager | `{profile_id, cooldown_seconds}`                                                                                                |
 | `sync_profiles`   | System → Manager   | `{profiles: [...]}`                                                                                                             |

--- a/docs/Temporal/TemporalSignalsResearch.md
+++ b/docs/Temporal/TemporalSignalsResearch.md
@@ -160,6 +160,7 @@ Below are recommended canonical contracts. Where MoonMind already has a shape, i
 class SlotRequest(SignalEnvelope):
     requester_workflow_id: str
     runtime_id: str
+    priority: int = 0
     profile_selector: dict | None = None
 
 class SlotRelease(SignalEnvelope):
@@ -433,4 +434,3 @@ If/when scanning the repo locally (all branches, full history), prioritize these
 - Test suites under `/tests/unit` and `/tests/integration/orchestrator` (docker-compose points to these). citeturn58view0turn60view1
 
 Unspecified items (need local scan): exact branch coverage, PR/issue motivations for current signal naming, and any deprecated signal names that may exist only in older branches or commits.
-

--- a/docs/Temporal/TemporalSignalsSystem.md
+++ b/docs/Temporal/TemporalSignalsSystem.md
@@ -338,6 +338,7 @@ Canonical payload concepts:
 
 - `requester_workflow_id`
 - `runtime_id`
+- `priority`
 - `profile_selector`
 - stable dedupe key for the request
 
@@ -345,7 +346,8 @@ Required behavior:
 
 - treat duplicate requests from the same requester as idempotent,
 - avoid enqueuing duplicate pending requests,
-- preserve FIFO semantics unless selector rules require otherwise.
+- assign higher-priority pending requests before lower-priority requests while
+  preserving FIFO order within the same priority.
 
 #### `release_slot`
 

--- a/moonmind/schemas/temporal_signal_contracts.py
+++ b/moonmind/schemas/temporal_signal_contracts.py
@@ -60,6 +60,8 @@ class RequestSlotSignal(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     requester_workflow_id: str = Field(..., alias="requesterWorkflowId")
+    runtime_id: str | None = Field(None, alias="runtimeId")
+    priority: int = Field(0, alias="priority")
 
 class ReleaseSlotSignal(BaseModel):
     """Payload for release_slot signals.

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1509,8 +1509,11 @@ class MoonMindAgentRun:
 
     @staticmethod
     def _request_priority(request: AgentExecutionRequest) -> int:
+        parameters = request.parameters
+        if not isinstance(parameters, Mapping):
+            return 0
         try:
-            return int(request.parameters.get("priority", 0))
+            return int(parameters.get("priority", 0))
         except (TypeError, ValueError):
             return 0
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1450,6 +1450,7 @@ class MoonMindAgentRun:
         request_slot: bool = True,
         execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
+        request_priority: int | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Signal the ProviderProfileManager for slot requests; auto-start it on first failure.
 
@@ -1469,6 +1470,8 @@ class MoonMindAgentRun:
             "requester_workflow_id": workflow.info().workflow_id,
             "runtime_id": runtime_id,
         }
+        if request_priority is not None:
+            signal_payload["priority"] = request_priority
         if workflow.patched(SLOT_HANDOFF_PATCH_ID):
             lease_group_id = self._lease_group_id()
             if lease_group_id:
@@ -1504,6 +1507,13 @@ class MoonMindAgentRun:
             manager_handle = workflow.get_external_workflow_handle(manager_id)
         return manager_handle
 
+    @staticmethod
+    def _request_priority(request: AgentExecutionRequest) -> int:
+        try:
+            return int(request.parameters.get("priority", 0))
+        except (TypeError, ValueError):
+            return 0
+
     async def _manager_state_for_slot_wait(
         self,
         *,
@@ -1531,6 +1541,7 @@ class MoonMindAgentRun:
         *,
         execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
+        request_priority: int | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Terminate a stuck manager, start a fresh one, and re-request a slot.
 
@@ -1552,6 +1563,7 @@ class MoonMindAgentRun:
             request_slot=True,
             execution_profile_ref=execution_profile_ref,
             profile_selector=profile_selector,
+            request_priority=request_priority,
         )
 
     async def _ensure_manager_started(
@@ -1566,6 +1578,7 @@ class MoonMindAgentRun:
             request_slot=False,
             execution_profile_ref=None,
             profile_selector=None,
+            request_priority=None,
         )
 
     async def _sync_manager_profiles(
@@ -1959,6 +1972,7 @@ class MoonMindAgentRun:
             request_slot=True,
             execution_profile_ref=request.execution_profile_ref,
             profile_selector=selector_payload,
+            request_priority=self._request_priority(request),
         )
         self._awaiting_slot_reason_override = None
         self._slot_wait_timeout_override_seconds = None
@@ -2229,6 +2243,7 @@ class MoonMindAgentRun:
                             request_slot=True,
                             execution_profile_ref=request.execution_profile_ref,
                             profile_selector=selector_payload,
+                            request_priority=self._request_priority(request),
                         )
                     else:
                         manager_handle = await self._ensure_manager_and_signal(
@@ -2237,6 +2252,7 @@ class MoonMindAgentRun:
                             request_slot=True,
                             execution_profile_ref=request.execution_profile_ref,
                             profile_selector=selector_payload,
+                            request_priority=self._request_priority(request),
                         )
                         profile_count = await self._sync_manager_profiles(
                             manager_id=manager_id,
@@ -2366,6 +2382,7 @@ class MoonMindAgentRun:
                                             request_slot=True,
                                             execution_profile_ref=request.execution_profile_ref,
                                             profile_selector=selector_payload,
+                                            request_priority=self._request_priority(request),
                                         )
                                         await self._sync_manager_profiles(
                                             manager_id=manager_id,
@@ -2379,6 +2396,7 @@ class MoonMindAgentRun:
                                     runtime_id,
                                     execution_profile_ref=request.execution_profile_ref,
                                     profile_selector=selector_payload,
+                                    request_priority=self._request_priority(request),
                                 )
                                 await self._sync_manager_profiles(
                                     manager_id=manager_id,
@@ -2457,6 +2475,7 @@ class MoonMindAgentRun:
                         payload = {
                             "requester_workflow_id": wf_id,
                             "runtime_id": kw.get("runtime_id", runtime_id),
+                            "priority": self._request_priority(request),
                         }
                         if workflow.patched(SLOT_HANDOFF_PATCH_ID):
                             lease_group_id = self._lease_group_id()

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -50,6 +50,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_interval=timedelta(minutes=1),
     maximum_attempts=5,
 )
+MERGE_AUTOMATION_RESOLVER_PRIORITY = 10
 _TOKEN_ASSIGNMENT_PATTERN = re.compile(
     r"(?i)(token|password|authorization|cookie)=\S+"
 )
@@ -332,6 +333,7 @@ def build_resolver_run_request(
     initial_parameters: dict[str, Any] = {
         "repo": pr.repo,
         "repository": pr.repo,
+        "priority": MERGE_AUTOMATION_RESOLVER_PRIORITY,
         "publishMode": "none",
         "targetRuntime": target_runtime,
         "task": {

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -46,6 +46,9 @@ DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH = (
 BILLING_AWARE_PROFILE_SELECTION_PATCH = (
     "provider-profile-manager-billing-aware-selection-v1"
 )
+PRIORITY_PENDING_REQUESTS_PATCH = (
+    "provider-profile-manager-priority-pending-requests-v1"
+)
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -73,7 +76,7 @@ class ProviderProfileManagerInput(TypedDict, total=False):
     leases: dict[str, list[str]]
     cooldowns: dict[str, str]
     lease_granted_at: dict[str, dict[str, str]]
-    pending_requests: list[dict[str, str]]
+    pending_requests: list[dict[str, Any]]
     handoff_reservations: dict[str, dict[str, str]]
 
 class ProviderProfileManagerOutput(TypedDict):
@@ -89,6 +92,7 @@ class SlotRequestPayload(TypedDict):
 
     requester_workflow_id: str
     runtime_id: str
+    priority: int
     execution_profile_ref: str | None
     lease_group_id: str | None
 
@@ -234,6 +238,7 @@ class PendingRequest:
 
     requester_workflow_id: str
     runtime_id: str
+    priority: int = 0
     execution_profile_ref: str | None = None
     profile_selector: Optional[dict[str, Any]] = None
     lease_group_id: str | None = None
@@ -306,11 +311,13 @@ class MoonMindProviderProfileManagerWorkflow:
         """An AgentRun requests a profile slot for this runtime family."""
         self._event_count += 1
         self._has_new_events = True
+        priority = self._normalize_request_priority(payload.get("priority"))
         if not workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
             self._pending_requests.append(
                 PendingRequest(
                     requester_workflow_id=payload["requester_workflow_id"],
                     runtime_id=payload.get("runtime_id", self._runtime_id or ""),
+                    priority=priority,
                     execution_profile_ref=payload.get("execution_profile_ref"),
                     profile_selector=payload.get("profile_selector"),
                 )
@@ -319,6 +326,7 @@ class MoonMindProviderProfileManagerWorkflow:
         request = PendingRequest(
             requester_workflow_id=payload["requester_workflow_id"],
             runtime_id=payload.get("runtime_id", self._runtime_id or ""),
+            priority=priority,
             execution_profile_ref=payload.get("execution_profile_ref"),
             profile_selector=payload.get("profile_selector"),
             lease_group_id=self._normalize_optional_string(
@@ -498,6 +506,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 {
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
+                    "priority": r.priority,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                     "lease_group_id": r.lease_group_id,
@@ -632,6 +641,7 @@ class MoonMindProviderProfileManagerWorkflow:
             PendingRequest(
                 requester_workflow_id=req.get("requester_workflow_id", ""),
                 runtime_id=req.get("runtime_id", ""),
+                priority=self._normalize_request_priority(req.get("priority")),
                 execution_profile_ref=req.get("execution_profile_ref"),
                 profile_selector=req.get("profile_selector"),
                 lease_group_id=self._normalize_optional_string(
@@ -776,6 +786,13 @@ class MoonMindProviderProfileManagerWorkflow:
         return normalized or None
 
     @staticmethod
+    def _normalize_request_priority(value: object) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
     def _coerce_handoff_ttl_seconds(value: object) -> int:
         try:
             seconds = int(value or 0)
@@ -866,12 +883,18 @@ class MoonMindProviderProfileManagerWorkflow:
         return True
 
     async def _drain_queue(self) -> None:
-        """Try to assign slots to pending requests in FIFO order."""
+        """Try to assign slots to pending requests in priority order."""
         now = workflow.now()
         self._clear_expired_handoff_reservations(now)
         remaining: list[PendingRequest] = []
         leases_changed = False
-        for req in self._pending_requests:
+        pending_requests = self._pending_requests
+        if workflow.patched(PRIORITY_PENDING_REQUESTS_PATCH):
+            pending_requests = sorted(
+                self._pending_requests,
+                key=lambda request: -request.priority,
+            )
+        for req in pending_requests:
             # Check if this requester already has a lease (e.g. from a retried workflow task)
             existing_profile_id = None
             for p in self._profiles.values():
@@ -1283,6 +1306,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 {
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
+                    "priority": r.priority,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                     "lease_group_id": r.lease_group_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -8896,6 +8896,7 @@ class MoonMindRunWorkflow:
             "publishMode",
             "commitMessage",
             "allowed_tools",
+            "priority",
             "stepCount",
             "maxAttempts",
             "steps",
@@ -8907,6 +8908,8 @@ class MoonMindRunWorkflow:
             "story_breakdown_markdown_path",
         ):
             param_val = runtime_block.get(param_key) or node_inputs.get(param_key)
+            if param_val is None and workflow_parameters is not None:
+                param_val = workflow_parameters.get(param_key)
             if param_val is not None:
                 parameters[param_key] = param_val
         profile_selector = self._build_profile_selector(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -8907,7 +8907,9 @@ class MoonMindRunWorkflow:
             "storyBreakdownMarkdownPath",
             "story_breakdown_markdown_path",
         ):
-            param_val = runtime_block.get(param_key) or node_inputs.get(param_key)
+            param_val = runtime_block.get(param_key)
+            if param_val is None:
+                param_val = node_inputs.get(param_key)
             if param_val is None and workflow_parameters is not None:
                 param_val = workflow_parameters.get(param_key)
             if param_val is not None:

--- a/tests/unit/schemas/test_temporal_signal_contracts.py
+++ b/tests/unit/schemas/test_temporal_signal_contracts.py
@@ -72,10 +72,14 @@ def test_reschedule_signal_valid():
 
 def test_request_slot_signal_valid():
     data = {
-        "requesterWorkflowId": "wf-123"
+        "requesterWorkflowId": "wf-123",
+        "runtimeId": "codex_cli",
+        "priority": 10,
     }
     model = RequestSlotSignal.model_validate(data)
     assert model.requester_workflow_id == "wf-123"
+    assert model.runtime_id == "codex_cli"
+    assert model.priority == 10
 
 def test_release_slot_signal_valid():
     data = {

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -249,6 +249,7 @@ def test_build_resolver_run_request_uses_pr_resolver_and_publish_none() -> None:
     )
 
     assert request["workflow_type"] == "MoonMind.UserWorkflow"
+    assert request["initial_parameters"]["priority"] == 10
     assert request["initial_parameters"]["task"]["skill"]["id"] == "pr-resolver"
     assert request["initial_parameters"]["task"]["publish"]["mode"] == "none"
     assert request["initial_parameters"]["task"]["tool"]["name"] == "pr-resolver"

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH,
     HandoffReservation,
     PendingRequest,
+    PRIORITY_PENDING_REQUESTS_PATCH,
     SLOT_HANDOFF_RESERVATION_PATCH,
     VERIFY_PENDING_REQUESTS_PATCH,
     WORKFLOW_NAME,
@@ -1103,6 +1104,53 @@ class TestProviderProfileManagerHelpers:
             "run-2:agent:step-1"
         ]
         assert "run-1" not in wf._handoff_reservations
+
+    @pytest.mark.asyncio
+    async def test_drain_queue_assigns_higher_priority_before_older_normal_request(
+        self,
+    ):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="normal-run:agent:step-1",
+                runtime_id="codex_cli",
+                priority=0,
+            ),
+            PendingRequest(
+                requester_workflow_id="resolver-run:agent:step-1",
+                runtime_id="codex_cli",
+                priority=10,
+            ),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = now
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == PRIORITY_PENDING_REQUESTS_PATCH
+            )
+            await wf._drain_queue()
+
+        assert assigned == [("resolver-run:agent:step-1", "p1")]
+        assert wf._profiles["p1"].current_leases == ["resolver-run:agent:step-1"]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "normal-run:agent:step-1"
+        ]
 
     @pytest.mark.asyncio
     async def test_verify_pending_requesters_prunes_terminal_workflows(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -349,6 +349,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -491,6 +492,7 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -614,6 +616,7 @@ async def test_agent_run_starts_deferred_codex_session_only_after_slot_assignmen
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         if request_slot:
             order.append("request_slot")
@@ -807,6 +810,7 @@ async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -939,6 +943,7 @@ async def test_agent_run_managed_session_start_runtime_error_returns_failed_resu
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1048,6 +1053,7 @@ async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1151,6 +1157,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         if request_slot:
             ensure_profile_refs.append(execution_profile_ref)
@@ -1285,6 +1292,7 @@ async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1383,6 +1391,7 @@ async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_hist
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1480,6 +1489,7 @@ async def test_agent_run_preserves_pre_launch_instruction_order_for_pre_defer_hi
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -469,3 +469,44 @@ class TestEnsureManagerAutoStart:
             "_ensure_manager_and_signal must include signal_payload['execution_profile_ref'] "
             "so the ProviderProfileManager can honor exact profile selections."
         )
+
+    def test_manager_signal_payload_carries_priority(self):
+        """Slot requests must include queue priority when the AgentRun has one."""
+        source = textwrap.dedent(
+            inspect.getsource(MoonMindAgentRun._ensure_manager_and_signal)
+        )
+        tree = ast.parse(source)
+
+        found_guard = False
+        found_payload_write = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            test = node.test
+            if not (
+                isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Name)
+                and test.left.id == "request_priority"
+            ):
+                continue
+            found_guard = True
+            for child in node.body:
+                if not isinstance(child, ast.Assign):
+                    continue
+                for target in child.targets:
+                    if not isinstance(target, ast.Subscript):
+                        continue
+                    if not (
+                        isinstance(target.value, ast.Name)
+                        and target.value.id == "signal_payload"
+                    ):
+                        continue
+                    slice_node = target.slice
+                    if (
+                        isinstance(slice_node, ast.Constant)
+                        and slice_node.value == "priority"
+                    ):
+                        found_payload_write = True
+
+        assert found_guard
+        assert found_payload_write

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -10,6 +10,7 @@ fallback and causes ExternalWorkflowExecutionNotFound crashes.
 import ast
 import inspect
 import textwrap
+from types import SimpleNamespace
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
@@ -510,3 +511,14 @@ class TestEnsureManagerAutoStart:
 
         assert found_guard
         assert found_payload_write
+
+    def test_request_priority_handles_missing_or_invalid_parameters(self):
+        assert MoonMindAgentRun._request_priority(
+            SimpleNamespace(parameters=None)  # type: ignore[arg-type]
+        ) == 0
+        assert MoonMindAgentRun._request_priority(
+            SimpleNamespace(parameters=[])  # type: ignore[arg-type]
+        ) == 0
+        assert MoonMindAgentRun._request_priority(
+            SimpleNamespace(parameters={"priority": "bad"})  # type: ignore[arg-type]
+        ) == 0

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -518,6 +518,7 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "default-managed"
@@ -658,6 +659,7 @@ async def test_agent_run_managed_preserves_workflow_scoped_session_metadata(
         request_slot: bool,
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
+        request_priority: int | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "default-managed"

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1325,6 +1325,33 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.parameters["priority"], 10)
 
+    def test_build_agent_execution_request_preserves_explicit_zero_priority(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex",
+                        "priority": 0,
+                    },
+                },
+                node_id="node-priority-zero",
+                tool_name="pr-resolver",
+                workflow_parameters={"priority": 10},
+            )
+
+        self.assertEqual(request.parameters["priority"], 0)
+
     def test_build_agent_execution_request_falls_back_on_invalid_profile_ref(self) -> None:
         """When a plan node carries a profile ID that doesn't match any known
         profile for the runtime (e.g. AI-hallucinated 'default:codex_cli'),

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1299,6 +1299,32 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.execution_profile_ref, "runtime-planner-profile")
 
+    def test_build_agent_execution_request_inherits_workflow_priority(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex",
+                    },
+                },
+                node_id="node-priority",
+                tool_name="pr-resolver",
+                workflow_parameters={"priority": 10},
+            )
+
+        self.assertEqual(request.parameters["priority"], 10)
+
     def test_build_agent_execution_request_falls_back_on_invalid_profile_ref(self) -> None:
         """When a plan node carries a profile ID that doesn't match any known
         profile for the runtime (e.g. AI-hallucinated 'default:codex_cli'),


### PR DESCRIPTION
## Summary
- assign merge-automation pr-resolver child workflows priority 10
- propagate workflow priority into AgentRun provider-slot requests
- drain provider profile pending requests by priority while preserving same-priority FIFO behavior
- document request_slot priority and add boundary/unit coverage

## Validation
- Passed: `python3` AST parse for edited Python files
- Passed: `git diff --check`
- Passed: `./tools/test_unit.sh tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/schemas/test_temporal_signal_contracts.py`
- Attempted: `./tools/test_unit.sh` full suite; stopped after it reached about 10% because pytest-xdist is unavailable and the serial run was taking too long