### PR TITLE
MM-836 Add Pentest workload heartbeat and cleanup supervision

### DIFF
--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -1459,6 +1459,7 @@ def pentest_cleanup_selector(
     selector = {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": PENTEST_RUNTIME_ID,
     }
     if agent_run_id:
         selector["moonmind.agent_run_id"] = str(agent_run_id)
@@ -1732,6 +1733,7 @@ def _pentest_labels(request: "PentestWorkloadRequest") -> dict[str, str]:
     return {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": PENTEST_RUNTIME_ID,
         "moonmind.agent_run_id": request.agent_run_id,
         "moonmind.step_id": request.step_id,
         "moonmind.attempt": str(request.attempt),

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -440,6 +440,7 @@ class WorkloadOwnershipMetadata(BaseModel):
     attempt: int = Field(..., alias="attempt", ge=1)
     tool_name: NonBlankStr = Field(..., alias="toolName")
     workload_profile: NonBlankStr = Field(..., alias="workloadProfile")
+    runtime_id: NonBlankStr | None = Field(None, alias="runtimeId")
     session_id: NonBlankStr | None = Field(None, alias="sessionId")
     session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
     workload_access: WorkloadAccessKind = Field("profile", alias="workloadAccess")
@@ -455,6 +456,8 @@ class WorkloadOwnershipMetadata(BaseModel):
             "moonmind.tool_name": self.tool_name,
             "moonmind.workload_profile": self.workload_profile,
         }
+        if self.runtime_id is not None:
+            labels["moonmind.runtime_id"] = self.runtime_id
         if self.session_id is not None:
             labels["moonmind.session_id"] = self.session_id
         if self.session_epoch is not None:
@@ -473,6 +476,7 @@ class WorkloadRequest(BaseModel):
     step_id: NonBlankStr = Field(..., alias="stepId")
     attempt: int = Field(..., alias="attempt", ge=1)
     tool_name: NonBlankStr = Field(..., alias="toolName")
+    runtime_id: NonBlankStr | None = Field(None, alias="runtimeId")
     repo_dir: NonBlankStr = Field(..., alias="repoDir")
     artifacts_dir: NonBlankStr = Field(..., alias="artifactsDir")
     command: tuple[NonBlankStr, ...] = Field(..., alias="command", min_length=1)
@@ -527,6 +531,7 @@ class WorkloadRequest(BaseModel):
             attempt=self.attempt,
             toolName=self.tool_name,
             workloadProfile=self.profile_id,
+            runtimeId=self.runtime_id,
             sessionId=self.session_id,
             sessionEpoch=self.session_epoch,
             workloadAccess="profile",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -219,6 +219,17 @@ _MANAGED_AGENT_UID = 1000
 _MANAGED_AGENT_GID = 1000
 
 
+class PentestWorkloadHandle(Protocol):
+    async def poll(self) -> Any | None:
+        """Return a workload result once complete, otherwise None."""
+
+    async def stop(self, *, grace_seconds: int) -> Mapping[str, Any] | None:
+        """Attempt graceful workload termination."""
+
+    async def remove(self) -> Mapping[str, Any] | None:
+        """Remove workload runtime resources."""
+
+
 class PentestProviderLeaseManager(Protocol):
     async def acquire(
         self,
@@ -380,7 +391,9 @@ def emit_pentest_activity_heartbeat(
     compact_metadata = {
         str(key): redact_pentest_diagnostic_value(value)
         for key, value in dict(metadata or {}).items()
-        if value is not None and str(key) not in dropped_metadata_keys
+        if value is not None
+        and str(key) not in dropped_metadata_keys
+        and not re.search(r"(?i)(api[_-]?key|token|password|secret)", str(key))
     }
     payload: dict[str, Any] = {
         "phase": build_pentest_progress_annotation(
@@ -445,6 +458,120 @@ async def _await_pentest_workload_with_activity_heartbeats(
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await task
+        raise
+
+async def _supervise_pentest_workload_with_activity_heartbeats(
+    launcher: Any,
+    validated_workload_request: Any,
+    *,
+    request: PentestWorkloadRequest,
+    timeout_seconds: float,
+    heartbeat_interval_seconds: float = _PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS,
+) -> WorkloadResult:
+    """Run a Pentest workload with activity-visible heartbeats and cleanup."""
+
+    if not callable(getattr(launcher, "start", None)):
+        raw_result = await _await_pentest_workload_with_activity_heartbeats(
+            launcher.run(validated_workload_request),
+            request=request,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+        )
+        if isinstance(raw_result, WorkloadResult):
+            return raw_result
+        return WorkloadResult.model_validate(raw_result)
+
+    started_at = datetime.now(UTC)
+    monotonic_started_at = time.monotonic()
+    interval = max(0.001, float(heartbeat_interval_seconds))
+    timeout = max(0.001, float(timeout_seconds))
+    cleanup_metadata: dict[str, Any] = {
+        "gracefulTerminationAttempted": False,
+        "killEscalated": False,
+        "containerRemoved": False,
+        "cleanupErrors": [],
+    }
+
+    def _cleanup_metadata() -> dict[str, Any]:
+        return redact_sensitive_payload(dict(cleanup_metadata))
+
+    def _kill_grace_seconds() -> int:
+        profile = getattr(validated_workload_request, "profile", None)
+        cleanup = getattr(profile, "cleanup", None)
+        return int(getattr(cleanup, "kill_grace_seconds", 30) or 30)
+
+    async def _stop_and_remove(*, terminal_reason: str) -> None:
+        cleanup_metadata["terminalReason"] = terminal_reason
+        cleanup_metadata["gracefulTerminationAttempted"] = True
+        try:
+            stop_result = await handle.stop(grace_seconds=_kill_grace_seconds())
+            if isinstance(stop_result, Mapping):
+                cleanup_metadata.update(dict(stop_result))
+        except Exception as exc:
+            cleanup_metadata["killEscalated"] = True
+            cleanup_metadata["cleanupErrors"].append(
+                redact_pentest_human_text(str(exc))
+            )
+        try:
+            remove_result = await handle.remove()
+            cleanup_metadata["containerRemoved"] = True
+            if isinstance(remove_result, Mapping):
+                cleanup_metadata.update(dict(remove_result))
+        except Exception as exc:
+            cleanup_metadata["containerRemoved"] = False
+            cleanup_metadata["cleanupErrors"].append(
+                redact_pentest_human_text(str(exc))
+            )
+
+    handle: PentestWorkloadHandle = await launcher.start(validated_workload_request)
+    emit_pentest_activity_heartbeat(
+        phase="running",
+        agent_run_id=request.agent_run_id,
+        step_id=request.step_id,
+        attempt=request.attempt,
+        message="Pentest workload is running.",
+        elapsed_seconds=0.0,
+    )
+    try:
+        while True:
+            raw_result = await handle.poll()
+            if raw_result is not None:
+                result = (
+                    raw_result
+                    if isinstance(raw_result, WorkloadResult)
+                    else WorkloadResult.model_validate(raw_result)
+                )
+                result.metadata.setdefault("cleanup", _cleanup_metadata())
+                return result
+            elapsed = time.monotonic() - monotonic_started_at
+            if elapsed >= timeout:
+                await _stop_and_remove(terminal_reason="timeout")
+                completed_at = datetime.now(UTC)
+                return WorkloadResult(
+                    requestId=getattr(
+                        validated_workload_request,
+                        "container_name",
+                        f"pentest-{request.agent_run_id}-{request.step_id}-{request.attempt}",
+                    ),
+                    profileId=request.runner_profile_id,
+                    status="timed_out",
+                    exitCode=None,
+                    startedAt=started_at,
+                    completedAt=completed_at,
+                    durationSeconds=(completed_at - started_at).total_seconds(),
+                    timeoutReason="workload exceeded timeoutSeconds",
+                    metadata={"cleanup": _cleanup_metadata()},
+                )
+            await asyncio.sleep(min(interval, max(0.001, timeout - elapsed)))
+            emit_pentest_activity_heartbeat(
+                phase="running",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest workload is still running.",
+                elapsed_seconds=time.monotonic() - monotonic_started_at,
+            )
+    except asyncio.CancelledError:
+        await _stop_and_remove(terminal_reason="cancellation")
         raise
 
 async def cleanup_pentest_orphan_containers(
@@ -6051,16 +6178,17 @@ class TemporalAgentRuntimeActivities:
                         "container_name": launch_plan.container_name,
                     },
                 )
-                raw_workload_result = (
-                    await _await_pentest_workload_with_activity_heartbeats(
-                        self._workload_launcher.run(validated_workload_request),
+                workload_result = (
+                    await _supervise_pentest_workload_with_activity_heartbeats(
+                        self._workload_launcher,
+                        validated_workload_request,
                         request=request,
+                        timeout_seconds=float(launch_plan.timeout_seconds),
+                        heartbeat_interval_seconds=(
+                            _PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS
+                        ),
                     )
                 )
-                if isinstance(raw_workload_result, WorkloadResult):
-                    workload_result = raw_workload_result
-                else:
-                    workload_result = WorkloadResult.model_validate(raw_workload_result)
         except asyncio.CancelledError:
             provider_lease_released = False
             try:
@@ -6135,6 +6263,13 @@ class TemporalAgentRuntimeActivities:
 
         workload_dump = workload_result.model_dump(mode="json", by_alias=True)
         output["workload_result"] = workload_dump
+        workload_cleanup = (
+            workload_result.metadata.get("cleanup")
+            if isinstance(workload_result.metadata, Mapping)
+            else None
+        )
+        if not isinstance(workload_cleanup, Mapping):
+            workload_cleanup = {}
         runner_findings = self._load_pentest_runner_findings(
             execution_materialization.runtime_paths.normalizer_input_file
         )
@@ -6209,7 +6344,29 @@ class TemporalAgentRuntimeActivities:
             )
             output["terminal_cleanup"]["terminal_reason"] = terminal_reason
             output["terminal_cleanup"]["graceful_termination_attempted"] = True
-            output["terminal_cleanup"]["container_removed"] = True
+            output["terminal_cleanup"]["kill_escalated"] = bool(
+                workload_cleanup.get(
+                    "kill_escalated",
+                    workload_cleanup.get("killEscalated", False),
+                )
+            )
+            output["terminal_cleanup"]["container_removed"] = bool(
+                workload_cleanup.get(
+                    "container_removed",
+                    workload_cleanup.get("containerRemoved", True),
+                )
+            )
+            cleanup_errors = workload_cleanup.get(
+                "cleanup_errors",
+                workload_cleanup.get("cleanupErrors", ()),
+            )
+            if isinstance(cleanup_errors, Sequence) and not isinstance(
+                cleanup_errors, (str, bytes)
+            ):
+                output["terminal_cleanup"]["cleanup_errors"] = [
+                    redact_pentest_human_text(str(item))
+                    for item in cleanup_errors
+                ]
             emit_pentest_activity_heartbeat(
                 phase="cleanup",
                 agent_run_id=request.agent_run_id,
@@ -6219,7 +6376,10 @@ class TemporalAgentRuntimeActivities:
                 metadata={
                     "terminal_reason": terminal_reason,
                     "provider_lease_released": provider_lease_released,
-                    "container_removed": True,
+                    "container_removed": output["terminal_cleanup"][
+                        "container_removed"
+                    ],
+                    "kill_escalated": output["terminal_cleanup"]["kill_escalated"],
                 },
             )
             return output

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5994,13 +5994,6 @@ class TemporalAgentRuntimeActivities:
                 )
             )
             return output
-        emit_pentest_activity_heartbeat(
-            phase="publishing_artifacts",
-            agent_run_id=request.agent_run_id,
-            step_id=request.step_id,
-            attempt=request.attempt,
-            message="Preparing Pentest artifact publication metadata.",
-        )
         publication = build_pentest_publication_result(
             request,
             findings=list(publication_payload.get("findings") or ()),
@@ -6018,18 +6011,6 @@ class TemporalAgentRuntimeActivities:
             errors=list(publication_payload.get("publication_errors") or ()),
         ).model_dump(mode="json")
         output.update(publication)
-        emit_pentest_activity_heartbeat(
-            phase="normalizing_findings",
-            agent_run_id=request.agent_run_id,
-            step_id=request.step_id,
-            attempt=request.attempt,
-            message="Normalizing Pentest findings.",
-            metadata={
-                "findings_count": publication["normalized_findings"]["summary"][
-                    "findings_count"
-                ],
-            },
-        )
         progress_annotations = [
             progress(phase, f"Pentest phase {phase}.")
             for phase in PENTEST_HEARTBEAT_PHASES
@@ -6276,6 +6257,31 @@ class TemporalAgentRuntimeActivities:
         if runner_findings is not None:
             publication["normalized_findings"] = runner_findings
             output["normalized_findings"] = runner_findings
+        emit_pentest_activity_heartbeat(
+            phase="publishing_artifacts",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Publishing Pentest artifact metadata.",
+            metadata={
+                "artifact_count": len(
+                    publication.get("artifact_publication", {}).get("artifacts", ())
+                ),
+                "status": publication.get("artifact_publication", {}).get("status"),
+            },
+        )
+        emit_pentest_activity_heartbeat(
+            phase="normalizing_findings",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Normalizing Pentest findings.",
+            metadata={
+                "findings_count": publication["normalized_findings"]["summary"][
+                    "findings_count"
+                ],
+            },
+        )
         output_refs = workload_result.output_refs or {}
         stdout_ref = workload_result.stdout_ref or _artifact_ref_for_pentest_name(
             publication, "runtime.stdout"

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
 
 from pydantic import BaseModel, ValidationError
+from temporalio import activity as temporal_activity
 from temporalio import exceptions as temporal_exceptions
 
 from moonmind.config.settings import settings
@@ -52,7 +53,9 @@ from moonmind.integrations.pentest.models import (
     build_pentest_launch_plan,
     classify_pentest_failure,
     materialize_pentest_provider_profile,
+    pentest_cleanup_selector,
     pentest_provider_lease_metadata,
+    redact_pentest_diagnostic_value,
     redact_pentest_human_text,
     resolve_pentest_provider_profile,
 )
@@ -211,6 +214,7 @@ async def _run_command(cmd, **kwargs):
 logger = getLogger(__name__)
 
 _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID = "provider-profile-manager:pentestgpt"
+_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS = 60.0
 _MANAGED_AGENT_UID = 1000
 _MANAGED_AGENT_GID = 1000
 
@@ -345,6 +349,133 @@ def _pentest_provider_lease_safe_metadata(
         "target_hash": _pentest_target_hash(request.target),
         "mode": request.operation_mode,
         "runner_profile": request.runner_profile_id,
+    }
+
+def emit_pentest_activity_heartbeat(
+    *,
+    phase: str,
+    agent_run_id: str | None = None,
+    step_id: str | None = None,
+    attempt: int | None = None,
+    message: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    elapsed_seconds: float | None = None,
+) -> dict[str, Any]:
+    """Emit and return a compact redacted Pentest activity heartbeat payload."""
+
+    dropped_metadata_keys = {
+        "stdout",
+        "stderr",
+        "logs",
+        "raw_logs",
+        "raw_evidence",
+        "evidence",
+        "diagnostics_body",
+        "env",
+        "env_overrides",
+        "command",
+        "credentials",
+        "secrets",
+    }
+    compact_metadata = {
+        str(key): redact_pentest_diagnostic_value(value)
+        for key, value in dict(metadata or {}).items()
+        if value is not None and str(key) not in dropped_metadata_keys
+    }
+    payload: dict[str, Any] = {
+        "phase": build_pentest_progress_annotation(
+            phase=phase,
+            message=message or f"Pentest phase {phase}.",
+        ).phase,
+    }
+    if agent_run_id:
+        payload["agent_run_id"] = str(agent_run_id)
+    if step_id:
+        payload["step_id"] = str(step_id)
+    if attempt is not None:
+        payload["attempt"] = int(attempt)
+    if elapsed_seconds is not None:
+        payload["elapsed_seconds"] = max(0.0, round(float(elapsed_seconds), 3))
+    if message:
+        payload["message"] = redact_pentest_human_text(str(message))
+    if compact_metadata:
+        payload["metadata"] = compact_metadata
+    try:
+        temporal_activity.heartbeat(payload)
+    except RuntimeError:
+        # Unit tests and trusted internal callers may exercise the helper
+        # outside a live Temporal activity context.
+        pass
+    return payload
+
+async def _await_pentest_workload_with_activity_heartbeats(
+    workload_awaitable: Awaitable[Any],
+    *,
+    request: PentestWorkloadRequest,
+    heartbeat_interval_seconds: float = _PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS,
+) -> Any:
+    """Await a launched Pentest workload while emitting bounded running heartbeats."""
+
+    started_at = time.monotonic()
+    task = asyncio.create_task(workload_awaitable)
+    emit_pentest_activity_heartbeat(
+        phase="running",
+        agent_run_id=request.agent_run_id,
+        step_id=request.step_id,
+        attempt=request.attempt,
+        message="Pentest workload is running.",
+        elapsed_seconds=0.0,
+    )
+    interval = max(0.001, float(heartbeat_interval_seconds))
+    try:
+        while not task.done():
+            done, _pending = await asyncio.wait({task}, timeout=interval)
+            if done:
+                break
+            emit_pentest_activity_heartbeat(
+                phase="running",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest workload is still running.",
+                elapsed_seconds=time.monotonic() - started_at,
+            )
+        return await task
+    except asyncio.CancelledError:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+        raise
+
+async def cleanup_pentest_orphan_containers(
+    janitor: Any,
+    *,
+    agent_run_id: str | None = None,
+    step_id: str | None = None,
+    runner_profile_id: str | None = None,
+) -> dict[str, Any]:
+    """Remove orphaned Pentest containers selected by deterministic labels."""
+
+    selector = pentest_cleanup_selector(
+        agent_run_id=agent_run_id,
+        step_id=step_id,
+        runner_profile_id=runner_profile_id,
+    )
+    container_ids = await janitor.find_by_labels(selector)
+    removed: list[str] = []
+    errors: list[str] = []
+    for container_id in container_ids:
+        try:
+            await janitor.remove(container_id)
+            removed.append(str(container_id))
+        except Exception as exc:
+            errors.append(redact_pentest_human_text(str(exc)))
+    return {
+        "selector": selector,
+        "selected_count": len(container_ids),
+        "removed_count": len(removed),
+        "removed_container_ids": removed,
+        "cleanup_errors": errors,
     }
 
 _GIT_PUSH_SCAN_MAX_COMMIT_METADATA_CHARS = 100_000
@@ -5534,7 +5665,22 @@ class TemporalAgentRuntimeActivities:
             ),
             default=False,
         )
+        emit_pentest_activity_heartbeat(
+            phase="validating_scope",
+            agent_run_id=str(request_payload.get("agent_run_id") or "") or None,
+            step_id=str(request_payload.get("step_id") or "") or None,
+            attempt=int(request_payload.get("attempt") or 1),
+            message="Validating Pentest scope and policy.",
+        )
         if not enabled:
+            emit_pentest_activity_heartbeat(
+                phase="cleanup",
+                agent_run_id=str(request_payload.get("agent_run_id") or "") or None,
+                step_id=str(request_payload.get("step_id") or "") or None,
+                attempt=int(request_payload.get("attempt") or 1),
+                message="Pentest execution denied before launch.",
+                metadata={"terminal_reason": "failure"},
+            )
             return structured_failure(
                 status="policy_denied",
                 target=str(request_payload.get("target") or "") or None,
@@ -5596,6 +5742,17 @@ class TemporalAgentRuntimeActivities:
                 agent_run_id=request.agent_run_id,
                 step_id=request.step_id,
                 attempt=request.attempt,
+            )
+            emit_pentest_activity_heartbeat(
+                phase="waiting_for_profile_slot",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Waiting for Pentest provider profile capacity.",
+                metadata={
+                    "runtime_id": lease_runtime_id,
+                    "profile_id": lease_profile_id,
+                },
             )
             try:
                 lease_id = await self._pentest_provider_lease_manager.acquire(
@@ -5670,6 +5827,13 @@ class TemporalAgentRuntimeActivities:
         execution_metadata["instruction_bundle"].pop("content", None)
         execution_metadata["instruction_bundle"].pop("objective", None)
         output.update(execution_metadata)
+        emit_pentest_activity_heartbeat(
+            phase="materializing_inputs",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Materializing Pentest input files.",
+        )
         try:
             output.update(
                 self._materialize_pentest_input_files(
@@ -5703,6 +5867,13 @@ class TemporalAgentRuntimeActivities:
                 )
             )
             return output
+        emit_pentest_activity_heartbeat(
+            phase="publishing_artifacts",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Preparing Pentest artifact publication metadata.",
+        )
         publication = build_pentest_publication_result(
             request,
             findings=list(publication_payload.get("findings") or ()),
@@ -5720,6 +5891,18 @@ class TemporalAgentRuntimeActivities:
             errors=list(publication_payload.get("publication_errors") or ()),
         ).model_dump(mode="json")
         output.update(publication)
+        emit_pentest_activity_heartbeat(
+            phase="normalizing_findings",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Normalizing Pentest findings.",
+            metadata={
+                "findings_count": publication["normalized_findings"]["summary"][
+                    "findings_count"
+                ],
+            },
+        )
         progress_annotations = [
             progress(phase, f"Pentest phase {phase}.")
             for phase in PENTEST_HEARTBEAT_PHASES
@@ -5806,6 +5989,20 @@ class TemporalAgentRuntimeActivities:
         workload_request = parse_workload_request(workload_payload)
         try:
             if self._workload_launcher is None:
+                emit_pentest_activity_heartbeat(
+                    phase="launching_container",
+                    agent_run_id=request.agent_run_id,
+                    step_id=request.step_id,
+                    attempt=request.attempt,
+                    message="Using built-in Pentest workload fallback.",
+                )
+                emit_pentest_activity_heartbeat(
+                    phase="running",
+                    agent_run_id=request.agent_run_id,
+                    step_id=request.step_id,
+                    attempt=request.attempt,
+                    message="Pentest workload fallback completed.",
+                )
                 workload_result = WorkloadResult.model_validate(
                     {
                         "requestId": (
@@ -5843,13 +6040,64 @@ class TemporalAgentRuntimeActivities:
                     workload_request,
                     workflow_docker_mode=self._workflow_docker_mode,
                 )
-                raw_workload_result = await self._workload_launcher.run(
-                    validated_workload_request
+                emit_pentest_activity_heartbeat(
+                    phase="launching_container",
+                    agent_run_id=request.agent_run_id,
+                    step_id=request.step_id,
+                    attempt=request.attempt,
+                    message="Launching Pentest workload container.",
+                    metadata={
+                        "profile_id": launch_plan.profile_id,
+                        "container_name": launch_plan.container_name,
+                    },
+                )
+                raw_workload_result = (
+                    await _await_pentest_workload_with_activity_heartbeats(
+                        self._workload_launcher.run(validated_workload_request),
+                        request=request,
+                    )
                 )
                 if isinstance(raw_workload_result, WorkloadResult):
                     workload_result = raw_workload_result
                 else:
                     workload_result = WorkloadResult.model_validate(raw_workload_result)
+        except asyncio.CancelledError:
+            provider_lease_released = False
+            try:
+                provider_lease_released = await release_provider_lease()
+            except Exception as release_exc:
+                logger.warning(
+                    "failed to release Pentest provider lease after workload cancellation: %s",
+                    release_exc,
+                )
+            emit_pentest_activity_heartbeat(
+                phase="cleanup",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest workload cancellation cleanup completed.",
+                metadata={
+                    "terminal_reason": "cancellation",
+                    "provider_lease_released": provider_lease_released,
+                    "container_removed": True,
+                },
+            )
+            output.update(
+                structured_failure(
+                    status="canceled",
+                    target=request.target,
+                    failure_kind="runtime_action",
+                    interaction_state="post_interaction",
+                    phase="running",
+                    reason="Pentest workload cancelled.",
+                    launched=True,
+                    provider_lease_released=provider_lease_released,
+                )
+            )
+            output["terminal_cleanup"]["terminal_reason"] = "cancellation"
+            output["terminal_cleanup"]["graceful_termination_attempted"] = True
+            output["terminal_cleanup"]["container_removed"] = True
+            return output
         except Exception as exc:
             provider_lease_released = False
             try:
@@ -5870,6 +6118,18 @@ class TemporalAgentRuntimeActivities:
                     launched=True,
                     provider_lease_released=provider_lease_released,
                 )
+            )
+            emit_pentest_activity_heartbeat(
+                phase="cleanup",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest workload failure cleanup completed.",
+                metadata={
+                    "terminal_reason": "failure",
+                    "provider_lease_released": provider_lease_released,
+                    "container_removed": True,
+                },
             )
             return output
 
@@ -5948,6 +6208,20 @@ class TemporalAgentRuntimeActivities:
                 )
             )
             output["terminal_cleanup"]["terminal_reason"] = terminal_reason
+            output["terminal_cleanup"]["graceful_termination_attempted"] = True
+            output["terminal_cleanup"]["container_removed"] = True
+            emit_pentest_activity_heartbeat(
+                phase="cleanup",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest terminal workload cleanup completed.",
+                metadata={
+                    "terminal_reason": terminal_reason,
+                    "provider_lease_released": provider_lease_released,
+                    "container_removed": True,
+                },
+            )
             return output
 
         provider_lease_released = False
@@ -6021,6 +6295,18 @@ class TemporalAgentRuntimeActivities:
             stderr_ref=stderr_ref,
             diagnostics_ref=diagnostics_ref,
             evidence_refs=(evidence_ref,),
+        )
+        emit_pentest_activity_heartbeat(
+            phase="cleanup",
+            agent_run_id=request.agent_run_id,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            message="Pentest workload cleanup completed.",
+            metadata={
+                "terminal_reason": "success",
+                "provider_lease_released": provider_lease_released,
+                "container_removed": output["terminal_cleanup"]["container_removed"],
+            },
         )
         return output
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5795,7 +5795,6 @@ class TemporalAgentRuntimeActivities:
             ),
             default=False,
         )
-        pre_validation_attempt = 1
         try:
             pre_validation_attempt = int(request_payload.get("attempt") or 1)
         except (TypeError, ValueError):

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -38,6 +38,7 @@ from moonmind.security.outbound_scan import (
 )
 from moonmind.integrations.pentest.models import (
     PENTEST_HEARTBEAT_PHASES,
+    PENTEST_RUNTIME_ID,
     PentestApprovedScope,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
@@ -430,7 +431,7 @@ async def _await_pentest_workload_with_activity_heartbeats(
     """Await a launched Pentest workload while emitting bounded running heartbeats."""
 
     started_at = time.monotonic()
-    task = asyncio.create_task(workload_awaitable)
+    task = asyncio.ensure_future(workload_awaitable)
     emit_pentest_activity_heartbeat(
         phase="running",
         agent_run_id=request.agent_run_id,
@@ -456,8 +457,7 @@ async def _await_pentest_workload_with_activity_heartbeats(
         return await task
     except asyncio.CancelledError:
         task.cancel()
-        with contextlib.suppress(asyncio.CancelledError, Exception):
-            await task
+        await asyncio.gather(task, return_exceptions=True)
         raise
 
 async def _supervise_pentest_workload_with_activity_heartbeats(
@@ -572,6 +572,9 @@ async def _supervise_pentest_workload_with_activity_heartbeats(
             )
     except asyncio.CancelledError:
         await _stop_and_remove(terminal_reason="cancellation")
+        raise
+    except Exception:
+        await _stop_and_remove(terminal_reason="failure")
         raise
 
 async def cleanup_pentest_orphan_containers(
@@ -5792,11 +5795,16 @@ class TemporalAgentRuntimeActivities:
             ),
             default=False,
         )
+        pre_validation_attempt = 1
+        try:
+            pre_validation_attempt = int(request_payload.get("attempt") or 1)
+        except (TypeError, ValueError):
+            pre_validation_attempt = 1
         emit_pentest_activity_heartbeat(
             phase="validating_scope",
             agent_run_id=str(request_payload.get("agent_run_id") or "") or None,
             step_id=str(request_payload.get("step_id") or "") or None,
-            attempt=int(request_payload.get("attempt") or 1),
+            attempt=pre_validation_attempt,
             message="Validating Pentest scope and policy.",
         )
         if not enabled:
@@ -5804,7 +5812,7 @@ class TemporalAgentRuntimeActivities:
                 phase="cleanup",
                 agent_run_id=str(request_payload.get("agent_run_id") or "") or None,
                 step_id=str(request_payload.get("step_id") or "") or None,
-                attempt=int(request_payload.get("attempt") or 1),
+                attempt=pre_validation_attempt,
                 message="Pentest execution denied before launch.",
                 metadata={"terminal_reason": "failure"},
             )
@@ -5915,6 +5923,7 @@ class TemporalAgentRuntimeActivities:
             PentestScopeValidationError,
             PentestLaunchPolicyError,
             PentestProviderMaterializationError,
+            ValidationError,
         ) as exc:
             provider_lease_released = False
             if lease_id:
@@ -6077,6 +6086,7 @@ class TemporalAgentRuntimeActivities:
             "stepId": request.step_id,
             "attempt": request.attempt,
             "toolName": "security.pentest.run",
+            "runtimeId": PENTEST_RUNTIME_ID,
             "repoDir": request.repo_dir or launch_plan.workdir,
             "artifactsDir": request.artifacts_dir,
             "command": list(execution_materialization.wrapper_invocation.command),

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -167,6 +167,7 @@ class RunnerProfileRegistry:
                     attempt=parsed_request.attempt,
                     toolName=parsed_request.tool_name,
                     workloadProfile=parsed_request.profile_id,
+                    runtimeId=parsed_request.runtime_id,
                     sessionId=parsed_request.session_id,
                     sessionEpoch=parsed_request.session_epoch,
                     workloadAccess="profile",

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -39,6 +39,7 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     _default_registry_skill_payload,
 )
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.artifacts import TemporalArtifactNotFoundError
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
@@ -684,6 +685,45 @@ async def test_security_pentest_execute_enabled_request_returns_report_first_suc
     assert result["terminal_cleanup"]["provider_lease_released"] is True
     assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
     assert result["execution_policy"]["automatic_retries_enabled"] is False
+
+async def test_security_pentest_execute_heartbeat_lifecycle_order_at_activity_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    heartbeats: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeats.append(payload),
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakeLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=_FakePentestLeaseManager(),
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    phases = [heartbeat["phase"] for heartbeat in heartbeats]
+    assert phases == [
+        "validating_scope",
+        "waiting_for_profile_slot",
+        "materializing_inputs",
+        "launching_container",
+        "running",
+        "publishing_artifacts",
+        "normalizing_findings",
+        "cleanup",
+    ]
+    assert "https://lab.example.test" not in str(heartbeats)
+    assert "ANTHROPIC_API_KEY" not in str(heartbeats)
 
 async def test_security_pentest_execute_runtime_failure_returns_structured_cleanup() -> None:
     launcher = _FakeLauncher(status="failed")

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -582,6 +582,7 @@ def test_pentest_launch_plan_uses_deterministic_metadata_and_cleanup_selector() 
     assert plan.labels == {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": "pentestgpt",
         "moonmind.agent_run_id": "run-123",
         "moonmind.step_id": "step-pentest",
         "moonmind.attempt": "1",
@@ -592,10 +593,12 @@ def test_pentest_launch_plan_uses_deterministic_metadata_and_cleanup_selector() 
     assert pentest_cleanup_selector() == {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": "pentestgpt",
     }
     assert pentest_cleanup_selector(agent_run_id="run-123") == {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": "pentestgpt",
         "moonmind.agent_run_id": "run-123",
     }
 
@@ -841,6 +844,7 @@ def test_pentest_orphan_cleanup_matches_deterministic_metadata_only() -> None:
     labels = {
         "moonmind.kind": "workload",
         "moonmind.tool_name": PENTEST_TOOL_NAME,
+        "moonmind.runtime_id": "pentestgpt",
         "moonmind.agent_run_id": "run-123",
     }
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import stat
@@ -66,6 +67,8 @@ from moonmind.workflows.temporal.activity_runtime import (
     build_activity_invocation_envelope,
     build_compact_activity_result,
     build_observability_summary,
+    cleanup_pentest_orphan_containers,
+    emit_pentest_activity_heartbeat,
 )
 from moonmind.workflows.agent_skills.agent_skills_activities import AgentSkillsActivities
 from moonmind.workflows.temporal.artifacts import (
@@ -1101,6 +1104,64 @@ class _FakePentestLeaseManager:
             )
         )
 
+
+class _SupervisedPentestHandle:
+    def __init__(
+        self,
+        *,
+        result_after_polls: int | None = 2,
+        result_status: str = "succeeded",
+    ) -> None:
+        self.result_after_polls = result_after_polls
+        self.result_status = result_status
+        self.polls = 0
+        self.stops: list[int] = []
+        self.removed = False
+
+    async def poll(self) -> WorkloadResult | None:
+        self.polls += 1
+        if self.result_after_polls is None or self.polls < self.result_after_polls:
+            return None
+        return WorkloadResult.model_validate(
+            {
+                "requestId": "supervised-run-123",
+                "profileId": "pentestgpt-safe",
+                "status": self.result_status,
+                "exitCode": 0 if self.result_status == "succeeded" else 2,
+                "stdoutRef": "file:/tmp/artifacts/pentest/runtime/stdout.log",
+                "stderrRef": "file:/tmp/artifacts/pentest/runtime/stderr.log",
+                "diagnosticsRef": "file:/tmp/artifacts/pentest/runtime/diagnostics.json",
+                "outputRefs": {
+                    "report.primary": "file:/tmp/artifacts/pentest/findings/findings.report.md",
+                    "report.summary": "file:/tmp/artifacts/pentest/findings/findings.summary.md",
+                    "report.structured": "file:/tmp/artifacts/pentest/findings/findings.normalizer-input.json",
+                    "report.evidence": "file:/tmp/artifacts/pentest/evidence/bundle.tar.zst",
+                },
+            }
+        )
+
+    async def stop(self, *, grace_seconds: int) -> dict[str, object]:
+        self.stops.append(grace_seconds)
+        return {
+            "gracefulTerminationAttempted": True,
+            "killEscalated": True,
+        }
+
+    async def remove(self) -> dict[str, object]:
+        self.removed = True
+        return {"containerRemoved": True}
+
+
+class _SupervisedPentestLauncher:
+    def __init__(self, handle: _SupervisedPentestHandle) -> None:
+        self.handle = handle
+        self.requests: list[object] = []
+
+    async def start(self, request: object) -> _SupervisedPentestHandle:
+        self.requests.append(request)
+        return self.handle
+
+
 @pytest.fixture(autouse=True)
 def _use_fake_pentest_lease_manager(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
@@ -1964,6 +2025,168 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
     assert "hunter2" not in str(result)
     assert "terminal_control" not in str(live_logs)
     assert "docker attach" not in str(result).lower()
+
+async def test_pentest_heartbeat_emitter_returns_redacted_compact_payload(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    heartbeats: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeats.append(payload),
+    )
+
+    payload = emit_pentest_activity_heartbeat(
+        phase="running",
+        agent_run_id="run-123",
+        step_id="step-pentest",
+        attempt=1,
+        message="Still running with token=hunter2",
+        metadata={
+            "container_name": "mm-pentest-run-123-step-pentest-1",
+            "env": {"ANTHROPIC_API_KEY": "secret"},
+            "stdout": "raw output",
+            "api_key": "hunter2",
+        },
+        elapsed_seconds=1.23456,
+    )
+
+    assert heartbeats == [payload]
+    assert payload["phase"] == "running"
+    assert payload["elapsed_seconds"] == 1.235
+    assert payload["metadata"]["container_name"] == "mm-pentest-run-123-step-pentest-1"
+    assert "env" not in payload.get("metadata", {})
+    assert "stdout" not in payload.get("metadata", {})
+    assert "hunter2" not in str(payload)
+
+async def test_security_pentest_execute_supervised_handle_emits_running_heartbeats(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    heartbeats: list[dict[str, object]] = []
+    monkeypatch.setattr(activity_runtime_module, "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeats.append(payload),
+    )
+    handle = _SupervisedPentestHandle(result_after_polls=2)
+    launcher = _SupervisedPentestLauncher(handle)
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    phases = [heartbeat["phase"] for heartbeat in heartbeats]
+    assert phases == [
+        "validating_scope",
+        "waiting_for_profile_slot",
+        "materializing_inputs",
+        "publishing_artifacts",
+        "normalizing_findings",
+        "launching_container",
+        "running",
+        "running",
+        "cleanup",
+    ]
+    assert handle.polls >= 2
+    for heartbeat in heartbeats:
+        assert "ANTHROPIC_API_KEY" not in str(heartbeat)
+        assert "hunter2" not in str(heartbeat)
+
+async def test_supervised_pentest_workload_timeout_stops_removes_and_returns_cleanup():
+    handle = _SupervisedPentestHandle(result_after_polls=None)
+    launcher = _SupervisedPentestLauncher(handle)
+    request_payload = dict(_pentest_activity_payload()["request"])
+    request_payload.pop("pentest_enabled", None)
+    request = activity_runtime_module.PentestWorkloadRequest.model_validate(
+        request_payload
+    )
+    result = await activity_runtime_module._supervise_pentest_workload_with_activity_heartbeats(
+        launcher,
+        SimpleNamespace(
+            container_name="mm-pentest-run-123-step-pentest-1",
+            profile=SimpleNamespace(
+                cleanup=SimpleNamespace(kill_grace_seconds=7),
+            ),
+        ),
+        request=request,
+        timeout_seconds=0.001,
+        heartbeat_interval_seconds=0.001,
+    )
+
+    assert result.status == "timed_out"
+    assert result.timeout_reason == "workload exceeded timeoutSeconds"
+    assert handle.stops == [7]
+    assert handle.removed is True
+    assert result.metadata["cleanup"]["terminalReason"] == "timeout"
+    assert result.metadata["cleanup"]["gracefulTerminationAttempted"] is True
+    assert result.metadata["cleanup"]["killEscalated"] is True
+    assert result.metadata["cleanup"]["containerRemoved"] is True
+
+async def test_supervised_pentest_workload_cancellation_stops_and_removes():
+    handle = _SupervisedPentestHandle(result_after_polls=None)
+    launcher = _SupervisedPentestLauncher(handle)
+    request_payload = dict(_pentest_activity_payload()["request"])
+    request_payload.pop("pentest_enabled", None)
+    request = activity_runtime_module.PentestWorkloadRequest.model_validate(
+        request_payload
+    )
+
+    task = asyncio.create_task(
+        activity_runtime_module._supervise_pentest_workload_with_activity_heartbeats(
+            launcher,
+            SimpleNamespace(container_name="mm-pentest-run-123-step-pentest-1"),
+            request=request,
+            timeout_seconds=60,
+            heartbeat_interval_seconds=0.001,
+        )
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert handle.stops == [30]
+    assert handle.removed is True
+
+async def test_pentest_orphan_cleanup_uses_deterministic_label_selector():
+    class _Janitor:
+        def __init__(self) -> None:
+            self.selector: dict[str, str] | None = None
+            self.removed: list[str] = []
+
+        async def find_by_labels(self, labels: dict[str, str]) -> tuple[str, ...]:
+            self.selector = dict(labels)
+            return ("container-1", "container-2")
+
+        async def remove(self, container_id: str) -> None:
+            self.removed.append(container_id)
+
+    janitor = _Janitor()
+
+    result = await cleanup_pentest_orphan_containers(
+        janitor,
+        agent_run_id="run-123",
+        step_id="step-pentest",
+        runner_profile_id="pentestgpt-safe",
+    )
+
+    assert janitor.selector == {
+        "moonmind.kind": "workload",
+        "moonmind.tool_name": "security.pentest.run",
+        "moonmind.runtime_id": "pentestgpt",
+        "moonmind.agent_run_id": "run-123",
+        "moonmind.step_id": "step-pentest",
+        "moonmind.workload_profile": "pentestgpt-safe",
+    }
+    assert janitor.removed == ["container-1", "container-2"]
+    assert result["removed_count"] == 2
 
 async def test_security_pentest_execute_coerces_string_publication_flags():
     activities = TemporalAgentRuntimeActivities(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2063,7 +2063,11 @@ async def test_security_pentest_execute_supervised_handle_emits_running_heartbea
     monkeypatch: pytest.MonkeyPatch,
 ):
     heartbeats: list[dict[str, object]] = []
-    monkeypatch.setattr(activity_runtime_module, "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS",
+        0.001,
+    )
     monkeypatch.setattr(
         activity_runtime_module.temporal_activity,
         "heartbeat",
@@ -2086,17 +2090,57 @@ async def test_security_pentest_execute_supervised_handle_emits_running_heartbea
         "validating_scope",
         "waiting_for_profile_slot",
         "materializing_inputs",
-        "publishing_artifacts",
-        "normalizing_findings",
         "launching_container",
         "running",
         "running",
+        "publishing_artifacts",
+        "normalizing_findings",
         "cleanup",
     ]
     assert handle.polls >= 2
     for heartbeat in heartbeats:
         assert "ANTHROPIC_API_KEY" not in str(heartbeat)
         assert "hunter2" not in str(heartbeat)
+
+async def test_security_pentest_execute_emits_publication_heartbeat_after_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    heartbeats: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: heartbeats.append(payload),
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    phases = [heartbeat["phase"] for heartbeat in heartbeats]
+    assert phases == [
+        "validating_scope",
+        "waiting_for_profile_slot",
+        "materializing_inputs",
+        "launching_container",
+        "running",
+        "publishing_artifacts",
+        "normalizing_findings",
+        "cleanup",
+    ]
+    assert phases.index("publishing_artifacts") > phases.index("running")
+    assert phases.index("normalizing_findings") > phases.index(
+        "publishing_artifacts"
+    )
 
 async def test_supervised_pentest_workload_timeout_stops_removes_and_returns_cleanup():
     handle = _SupervisedPentestHandle(result_after_polls=None)

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -39,6 +39,7 @@ from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     DEPLOYMENT_UPDATE_TOOL_VERSION,
 )
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_catalog import (
     AGENT_RUNTIME_FLEET,
     ARTIFACTS_FLEET,
@@ -996,6 +997,18 @@ class _FakePentestLauncher:
             }
         )
 
+class _BlockingPentestLauncher(_FakePentestLauncher):
+    def __init__(self, *, status: str = "succeeded") -> None:
+        super().__init__(status=status)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def run(self, request: object) -> WorkloadResult:
+        self.requests.append(request)
+        self.started.set()
+        await self.release.wait()
+        return await super().run(request)
+
 class _RecordingPentestRegistry:
     """Registry stand-in that validates requests into the launcher contract.
 
@@ -1160,6 +1173,36 @@ async def test_temporal_pentest_provider_lease_manager_fails_closed_without_upda
             metadata={},
         )
 
+async def test_pentest_heartbeat_helper_emits_compact_redacted_payload(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    emitted: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: emitted.append(payload),
+    )
+
+    payload = activity_runtime_module.emit_pentest_activity_heartbeat(
+        phase="running",
+        agent_run_id="run-123",
+        step_id="step-pentest",
+        attempt=1,
+        message="running with token=secret-value",
+        metadata={
+            "stdout": "raw stdout body must be dropped",
+            "safe": "password=hunter2",
+        },
+    )
+
+    assert emitted == [payload]
+    assert payload["phase"] == "running"
+    assert payload["message"] == "running with token=[REDACTED]"
+    assert payload["metadata"] == {"safe": "password=[REDACTED]"}
+    assert "secret-value" not in str(payload)
+    assert "raw stdout body" not in str(payload)
+
 async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
     launcher = _FakePentestLauncher()
     activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
@@ -1175,6 +1218,111 @@ async def test_security_pentest_execute_fails_closed_before_runner_when_disabled
     assert result["failure_classification"]["interaction_state"] == "pre_interaction"
     assert result["terminal_cleanup"]["terminal_reason"] == "failure"
     assert launcher.requests == []
+
+async def test_security_pentest_execute_emits_all_phase_heartbeats(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    emitted: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: emitted.append(payload),
+    )
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        _pentest_activity_payload()
+    )
+
+    assert result["status"] == "completed"
+    phases = [str(item["phase"]) for item in emitted]
+    for phase in (
+        "validating_scope",
+        "waiting_for_profile_slot",
+        "materializing_inputs",
+        "launching_container",
+        "running",
+        "publishing_artifacts",
+        "normalizing_findings",
+        "cleanup",
+    ):
+        assert phase in phases
+
+async def test_security_pentest_execute_repeats_running_heartbeats(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    emitted: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        activity_runtime_module.temporal_activity,
+        "heartbeat",
+        lambda payload: emitted.append(payload),
+    )
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
+    launcher = _BlockingPentestLauncher()
+    activities = TemporalAgentRuntimeActivities(
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    task = asyncio.create_task(
+        activities._security_pentest_execute_trusted_internal(
+            _pentest_activity_payload()
+        )
+    )
+    await asyncio.wait_for(launcher.started.wait(), timeout=1)
+    await asyncio.sleep(0.035)
+    launcher.release.set()
+    result = await task
+
+    assert result["status"] == "completed"
+    running = [item for item in emitted if item["phase"] == "running"]
+    assert len(running) >= 2
+
+async def test_pentest_orphan_cleanup_uses_deterministic_label_selector():
+    class _Janitor:
+        def __init__(self) -> None:
+            self.selectors: list[dict[str, str]] = []
+            self.removed: list[str] = []
+
+        async def find_by_labels(self, labels: dict[str, str]) -> tuple[str, ...]:
+            self.selectors.append(dict(labels))
+            return ("container-1", "container-2")
+
+        async def remove(self, container_id: str) -> None:
+            self.removed.append(container_id)
+
+    janitor = _Janitor()
+
+    result = await activity_runtime_module.cleanup_pentest_orphan_containers(
+        janitor,
+        agent_run_id="run-123",
+        step_id="step-pentest",
+        runner_profile_id="pentestgpt-safe",
+    )
+
+    assert janitor.selectors == [
+        {
+            "moonmind.kind": "workload",
+            "moonmind.tool_name": "security.pentest.run",
+            "moonmind.agent_run_id": "run-123",
+            "moonmind.step_id": "step-pentest",
+            "moonmind.workload_profile": "pentestgpt-safe",
+        }
+    ]
+    assert janitor.removed == ["container-1", "container-2"]
+    assert result["removed_count"] == 2
 
 async def test_security_pentest_execute_fails_closed_before_runner_without_scope():
     launcher = _FakePentestLauncher()

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1111,15 +1111,19 @@ class _SupervisedPentestHandle:
         *,
         result_after_polls: int | None = 2,
         result_status: str = "succeeded",
+        poll_error: Exception | None = None,
     ) -> None:
         self.result_after_polls = result_after_polls
         self.result_status = result_status
+        self.poll_error = poll_error
         self.polls = 0
         self.stops: list[int] = []
         self.removed = False
 
     async def poll(self) -> WorkloadResult | None:
         self.polls += 1
+        if self.poll_error is not None:
+            raise self.poll_error
         if self.result_after_polls is None or self.polls < self.result_after_polls:
             return None
         return WorkloadResult.model_validate(
@@ -1280,6 +1284,21 @@ async def test_security_pentest_execute_fails_closed_before_runner_when_disabled
     assert result["terminal_cleanup"]["terminal_reason"] == "failure"
     assert launcher.requests == []
 
+async def test_security_pentest_execute_malformed_attempt_returns_validation_failure():
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+    payload = dict(_pentest_activity_payload()["request"])
+    payload["attempt"] = "not-an-int"
+
+    result = await activities._security_pentest_execute_trusted_internal(
+        {"request": payload}
+    )
+
+    assert result["status"] == "validation_failed"
+    assert result["failure_classification"]["failure_kind"] == "policy_denied"
+    assert result["failure_classification"]["interaction_state"] == "pre_interaction"
+    assert launcher.requests == []
+
 async def test_security_pentest_execute_emits_all_phase_heartbeats(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -1350,40 +1369,6 @@ async def test_security_pentest_execute_repeats_running_heartbeats(
     assert result["status"] == "completed"
     running = [item for item in emitted if item["phase"] == "running"]
     assert len(running) >= 2
-
-async def test_pentest_orphan_cleanup_uses_deterministic_label_selector():
-    class _Janitor:
-        def __init__(self) -> None:
-            self.selectors: list[dict[str, str]] = []
-            self.removed: list[str] = []
-
-        async def find_by_labels(self, labels: dict[str, str]) -> tuple[str, ...]:
-            self.selectors.append(dict(labels))
-            return ("container-1", "container-2")
-
-        async def remove(self, container_id: str) -> None:
-            self.removed.append(container_id)
-
-    janitor = _Janitor()
-
-    result = await activity_runtime_module.cleanup_pentest_orphan_containers(
-        janitor,
-        agent_run_id="run-123",
-        step_id="step-pentest",
-        runner_profile_id="pentestgpt-safe",
-    )
-
-    assert janitor.selectors == [
-        {
-            "moonmind.kind": "workload",
-            "moonmind.tool_name": "security.pentest.run",
-            "moonmind.agent_run_id": "run-123",
-            "moonmind.step_id": "step-pentest",
-            "moonmind.workload_profile": "pentestgpt-safe",
-        }
-    ]
-    assert janitor.removed == ["container-1", "container-2"]
-    assert result["removed_count"] == 2
 
 async def test_security_pentest_execute_fails_closed_before_runner_without_scope():
     launcher = _FakePentestLauncher()
@@ -1605,8 +1590,9 @@ async def test_security_pentest_execute_reaches_launch_plan_after_scope_validati
     assert isinstance(launcher.requests[0], ValidatedWorkloadRequest)
 
 async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_validation():
+    launcher = _FakePentestLauncher()
     activities = TemporalAgentRuntimeActivities(
-        workload_launcher=_FakePentestLauncher(),
+        workload_launcher=launcher,
         workload_registry=_RecordingPentestRegistry(),
     )
 
@@ -1624,7 +1610,11 @@ async def test_security_pentest_execute_returns_safe_launch_plan_after_scope_val
     assert launch_plan["linux_capabilities"] == []
     assert launch_plan["devices"] == []
     assert launch_plan["labels"]["moonmind.tool_name"] == "security.pentest.run"
+    assert launch_plan["labels"]["moonmind.runtime_id"] == "pentestgpt"
     assert launch_plan["labels"]["moonmind.operation_mode"] == "validate_hypothesis"
+    validated_request = launcher.requests[0]
+    assert validated_request.request.runtime_id == "pentestgpt"
+    assert validated_request.ownership.labels["moonmind.runtime_id"] == "pentestgpt"
 
 async def test_security_pentest_execute_includes_secret_safe_provider_preparation():
     activities = TemporalAgentRuntimeActivities(
@@ -2193,8 +2183,32 @@ async def test_supervised_pentest_workload_cancellation_stops_and_removes():
     await asyncio.sleep(0)
     task.cancel()
 
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    cancellation_result = await asyncio.gather(task, return_exceptions=True)
+
+    assert handle.stops == [30]
+    assert handle.removed is True
+    assert isinstance(cancellation_result[0], asyncio.CancelledError)
+
+async def test_supervised_pentest_workload_poll_error_stops_and_removes():
+    handle = _SupervisedPentestHandle(
+        result_after_polls=None,
+        poll_error=RuntimeError("docker daemon unavailable"),
+    )
+    launcher = _SupervisedPentestLauncher(handle)
+    request_payload = dict(_pentest_activity_payload()["request"])
+    request_payload.pop("pentest_enabled", None)
+    request = activity_runtime_module.PentestWorkloadRequest.model_validate(
+        request_payload
+    )
+
+    with pytest.raises(RuntimeError, match="docker daemon unavailable"):
+        await activity_runtime_module._supervise_pentest_workload_with_activity_heartbeats(
+            launcher,
+            SimpleNamespace(container_name="mm-pentest-run-123-step-pentest-1"),
+            request=request,
+            timeout_seconds=60,
+            heartbeat_interval_seconds=0.001,
+        )
 
     assert handle.stops == [30]
     assert handle.removed is True

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -113,6 +113,13 @@ def test_registry_validates_request_and_derives_required_labels(tmp_path: Path) 
         "moonmind.workload_access": "profile",
         "moonmind.workflow_docker_mode": "profiles",
     }
+
+def test_registry_includes_runtime_id_label_when_supplied(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    validated = registry.validate_request(_request(runtimeId="pentestgpt"))
+
+    assert validated.ownership.labels["moonmind.runtime_id"] == "pentestgpt"
     assert validated.container_name == "mm-workload-task-1-step-test-1"
 
 def test_registry_loads_yaml_profiles(tmp_path: Path) -> None:


### PR DESCRIPTION
## Jira Issue
MM-836 - Add real long-running heartbeat and cleanup supervision for Pentest workloads.

## Active MoonSpec Feature Path
`specs/001-add-pentest-supervision`

## Verification Verdict
Latest post-remediation `moonspec-verify` verdict: `FULLY_IMPLEMENTED` with high confidence.

Verification evidence was recorded in the managed stdout log at `2026-06-13T09:05:24Z` after remediation, with no blocking gaps.

## Tests Run
- `pytest tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_catalog.py -q` - PASS, 185 passed
- `pytest tests/integration/temporal/test_pentest_tool_contract.py -k pentest -q` - PASS, 19 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, Python 6186 passed, 6 skipped, 1 xpassed; frontend 422 passed, 234 skipped
- `./tools/test_integration.sh` - PASS, 310 passed, 1 skipped, 82 deselected

## Doc Reconciliation Outcome
`artifacts/jira-orchestrate-doc-reconcile.json` is present and reports `no_update_required`.

- Canonical doc considered: `docs/Steps/PentestTool.md`
- Updated canonical doc paths: none
- No-update rationale: the latest post-remediation verification verdict is `FULLY_IMPLEMENTED`; the Source Document Drift section reported no blocking drift / none found; no `artifacts/doc-discoveries/001-add-pentest-supervision.json` ledger was present; no definite evidence-backed discovery met the function, consistency, or best-practices update gate.
- Escalation Jira issue key: none

## Remaining Risks
No known blocking implementation risks remain. Runtime cleanup behavior is covered with fake async workload handles and hermetic activity-boundary tests; real provider/container behavior should still be watched in normal operational telemetry after merge.
