### PR TITLE
MM-809 Add PentestGPT task metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,8 @@ Key diagnostics:
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing Temporal activity catalog/runtime helpers, existing artifact services and sandbox/runtime helpers (001-checkpoint-activity-substrate)
 - Existing Temporal workflow history, step ledger rows/projections, and artifact store refs only; no new persistent tables planned (001-checkpoint-activity-substrate)
 - TypeScript/React for Mission Control UI; Python 3.12 remains present but is not part of this story + React, TanStack Query, Zod, Testing Library, Vitest, existing Mission Control stylesheet (001-remove-step-dag)
+- Python 3.12 for backend, Temporal activities, Pydantic models, FastAPI routes, and pytest; Bash/Python runner wrapper inside a Docker image. + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures where API tests apply, existing workload launcher/registry, Docker Buildx/GitHub Actions for image publishing. (001-finish-pentestgpt)
+- Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,7 +321,7 @@ Key diagnostics:
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing Temporal activity catalog/runtime helpers, existing artifact services and sandbox/runtime helpers (001-checkpoint-activity-substrate)
 - Existing Temporal workflow history, step ledger rows/projections, and artifact store refs only; no new persistent tables planned (001-checkpoint-activity-substrate)
 - TypeScript/React for Mission Control UI; Python 3.12 remains present but is not part of this story + React, TanStack Query, Zod, Testing Library, Vitest, existing Mission Control stylesheet (001-remove-step-dag)
-- Python 3.12 for backend, Temporal activities, Pydantic models, FastAPI routes, and pytest; Bash/Python runner wrapper inside a Docker image. + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures where API tests apply, existing workload launcher/registry, Docker Buildx/GitHub Actions for image publishing. (001-finish-pentestgpt)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures, pytest, existing workload launcher/registry, Docker Buildx, GitHub Actions (001-finish-pentestgpt)
 - Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
 
 ## Recent Changes

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -314,7 +314,7 @@ Key diagnostics:
 - No new persistent storage; deterministic validation only (001-harden-pentest-provenance)
 - Python 3.12; TypeScript/React for Mission Control. + FastAPI, Pydantic v2, SQLAlchemy async ORM where persisted execution records are read, Temporal Python SDK workflow/query surfaces, React, TanStack Query, Zod, Vitest, Testing Library. (001-ui-api-recovery-panels)
 - Existing Temporal execution records, workflow query payloads, and Temporal artifact metadata/content store only. No new persistent tables are planned. (001-ui-api-recovery-panels)
-- Python 3.12 for backend, Temporal activities, Pydantic models, FastAPI routes, and pytest; Bash/Python runner wrapper inside a Docker image. + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures where API tests apply, existing workload launcher/registry, Docker Buildx/GitHub Actions for image publishing. (001-finish-pentestgpt)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures, pytest, existing workload launcher/registry, Docker Buildx, GitHub Actions (001-finish-pentestgpt)
 - Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
 
 ## Recent Changes

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -314,6 +314,8 @@ Key diagnostics:
 - No new persistent storage; deterministic validation only (001-harden-pentest-provenance)
 - Python 3.12; TypeScript/React for Mission Control. + FastAPI, Pydantic v2, SQLAlchemy async ORM where persisted execution records are read, Temporal Python SDK workflow/query surfaces, React, TanStack Query, Zod, Vitest, Testing Library. (001-ui-api-recovery-panels)
 - Existing Temporal execution records, workflow query payloads, and Temporal artifact metadata/content store only. No new persistent tables are planned. (001-ui-api-recovery-panels)
+- Python 3.12 for backend, Temporal activities, Pydantic models, FastAPI routes, and pytest; Bash/Python runner wrapper inside a Docker image. + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures where API tests apply, existing workload launcher/registry, Docker Buildx/GitHub Actions for image publishing. (001-finish-pentestgpt)
+- Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers


### PR DESCRIPTION
Jira issue key: MM-809

Active MoonSpec feature path: `specs/001-finish-pentestgpt`

Verification verdict: `FULLY_IMPLEMENTED`

Tests run:
- `./tools/test_unit.sh tests/unit/mcp/test_executable_tool_registry.py tests/unit/api/test_mcp_tools_router.py tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workloads/test_workload_contract.py tests/contract/test_temporal_execution_api.py` - PASS (`538 passed`; frontend `428 passed / 234 skipped`)
- `pytest tests/integration/temporal/test_pentest_tool_contract.py -q --tb=short` - PASS (`19 passed`)
- `./tools/test_unit.sh` - PASS (`6278 passed, 6 skipped, 1 xpassed`; frontend `428 passed / 234 skipped`)
- `./tools/test_integration.sh` - PASS (`333 passed, 1 skipped, 82 deselected`)

Remaining risks:
- This publication branch only contains the generated MM-809 task metadata additions in `AGENTS.md` and `GEMINI.md`; the controlling verify report found no implementation gaps.
- No provider-verification suite was run as part of the reported gate; the passing evidence is unit plus hermetic integration coverage.

Doc reconciliation outcome:
- `artifacts/jira-orchestrate-doc-reconcile.json` reports `action: no_update_required`.
- Reviewed canonical doc paths: `docs/Steps/PentestTool.md`, `docs/Artifacts/ReportArtifacts.md`.
- No canonical doc edits were made because the MM-809 verification report contained no definite Source Document Drift entries, listed no gaps, and no `artifacts/doc-discoveries/001-finish-pentestgpt.json` ledger was present.
