### PR TITLE
[codex] Block PR publish after failed Jira step

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5427,7 +5427,6 @@ class MoonMindRunWorkflow:
                     continue
                 if (
                     publish_mode in {"pr", "branch"}
-                    and result_status is not None
                     and result_status != "COMPLETED"
                 ):
                     self._plan_blocked_message = (
@@ -5443,14 +5442,9 @@ class MoonMindRunWorkflow:
                     require_pull_request_url = False
                     pull_request_url = None
                     self._summary = self._plan_blocked_message
-                    self._mark_remaining_plan_steps_skipped(
-                        ordered_nodes=ordered_nodes,
-                        completed_index=index - 1,
-                        summary=self._plan_blocked_message,
-                    )
                     self._refresh_step_readiness(updated_at=workflow.now())
                     self._update_memo()
-                    break
+                    continue
                 continue
 
             self._mark_step_terminal(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4787,6 +4787,7 @@ class MoonMindRunWorkflow:
             execution_result = None
             accepted_execution = False
             gate_stop_requested = False
+            step_failure_summary: str | None = None
             blocked_outcome_wait_skipped = False
             current_review_attempt = 1
 
@@ -5121,6 +5122,10 @@ class MoonMindRunWorkflow:
                         operator_failure_summary = (
                             provider_failure_summary or failure_message
                         )
+                        step_failure_summary = (
+                            operator_failure_summary
+                            or f"{tool_name} failed"
+                        )
 
                         retryable = failure_message == "system_error" or (
                             failure_message == "execution_error"
@@ -5165,8 +5170,7 @@ class MoonMindRunWorkflow:
                             node_id,
                             status="failed",
                             updated_at=workflow.now(),
-                            summary=operator_failure_summary
-                            or f"{tool_name} failed",
+                            summary=step_failure_summary,
                             last_error=failure_message,
                         )
                         await self._record_step_execution_manifest(
@@ -5421,6 +5425,32 @@ class MoonMindRunWorkflow:
                     self._publish_reason = self._plan_blocked_message
                     self._refresh_step_readiness(updated_at=workflow.now())
                     continue
+                if (
+                    publish_mode in {"pr", "branch"}
+                    and result_status is not None
+                    and result_status != "COMPLETED"
+                ):
+                    self._plan_blocked_message = (
+                        step_failure_summary
+                        or self._activity_result_provider_failure_summary(
+                            execution_result
+                        )
+                        or self._activity_result_failure_message(execution_result)
+                        or f"{tool_name} failed"
+                    )
+                    self._publish_status = "not_required"
+                    self._publish_reason = self._plan_blocked_message
+                    require_pull_request_url = False
+                    pull_request_url = None
+                    self._summary = self._plan_blocked_message
+                    self._mark_remaining_plan_steps_skipped(
+                        ordered_nodes=ordered_nodes,
+                        completed_index=index - 1,
+                        summary=self._plan_blocked_message,
+                    )
+                    self._refresh_step_readiness(updated_at=workflow.now())
+                    self._update_memo()
+                    break
                 continue
 
             self._mark_step_terminal(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1515,6 +1515,125 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
     assert child_calls == 2
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    child_calls = 0
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+        if activity_type == "artifact.read":
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Jira Orchestrate Publish Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "CONTINUE", "max_concurrency": 1},
+                    "nodes": [
+                        _agent_runtime_step(
+                            "tpl:jira-orchestrate:1.0.0:01:update"
+                        ),
+                        _agent_runtime_step(
+                            "tpl:jira-orchestrate:1.0.0:02:verify"
+                        ),
+                    ],
+                    "edges": [
+                        {
+                            "from": "tpl:jira-orchestrate:1.0.0:01:update",
+                            "to": "tpl:jira-orchestrate:1.0.0:02:verify",
+                        }
+                    ],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal child_calls
+        child_calls += 1
+        return {
+            "summary": "codex app-server turn/completed produced no assistant output",
+            "failureClass": "execution_error",
+            "diagnosticsRef": "art_empty_turn",
+            "metadata": {
+                "profileId": "codex_default",
+                "turnStatus": "failed",
+                "turnMetadata": {
+                    "failureCause": "app_server_protocol_empty_turn",
+                    "retryRecommendedAction": "clear_session",
+                },
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={
+            "repo": "MoonLadderStudios/MoonMind",
+            "publishMode": "pr",
+        },
+        plan_ref="art_plan_1",
+    )
+
+    status, message, publish_failure = workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert child_calls >= 1
+    assert not create_pr_called
+    assert workflow._publish_status == "not_required"
+    assert status == "failed"
+    assert publish_failure is True
+    assert "app_server_protocol_empty_turn" in message
+    assert "no PR was created" not in message
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_publish_mode_pr_requires_pull_request_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1521,8 +1521,17 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
     workflow = MoonMindRunWorkflow()
     workflow._owner_id = "owner-1"
     workflow._repo = "MoonLadderStudios/MoonMind"
+    step_execution_artifact_ids = count(1)
     child_calls = 0
     create_pr_called = False
+    executed_steps: list[str] = []
+
+    def _request_step_id(request: object) -> str:
+        parameters = getattr(request, "parameters", {})
+        metadata = parameters.get("metadata") if isinstance(parameters, dict) else {}
+        moonmind = metadata.get("moonmind") if isinstance(metadata, dict) else {}
+        step_ledger = moonmind.get("stepLedger") if isinstance(moonmind, dict) else {}
+        return str(step_ledger.get("logicalStepId") or "")
 
     async def fake_execute_activity(
         activity_type: str,
@@ -1533,6 +1542,13 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
         if activity_type == "repo.create_pr":
             create_pr_called = True
             return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+        if activity_type == "artifact.create":
+            artifact_create_result = _step_execution_artifact_create_result(
+                payload,
+                step_execution_artifact_ids,
+            )
+            if artifact_create_result is not None:
+                return artifact_create_result
         if activity_type == "artifact.read":
             return json.dumps(
                 {
@@ -1553,6 +1569,9 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
                         _agent_runtime_step(
                             "tpl:jira-orchestrate:1.0.0:02:verify"
                         ),
+                        _agent_runtime_step(
+                            "tpl:jira-orchestrate:1.0.0:03:notify"
+                        ),
                     ],
                     "edges": [
                         {
@@ -1571,6 +1590,14 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
     ) -> object:
         nonlocal child_calls
         child_calls += 1
+        step_id = _request_step_id(_args)
+        executed_steps.append(step_id)
+        if step_id.endswith(":03:notify"):
+            return {
+                "summary": "Independent notification completed.",
+                "metadata": {"push_status": "not_requested"},
+                "output_refs": [],
+            }
         return {
             "summary": "codex app-server turn/completed produced no assistant output",
             "failureClass": "execution_error",
@@ -1626,6 +1653,8 @@ async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(
     )
 
     assert child_calls >= 1
+    assert any(step.endswith(":03:notify") for step in executed_steps)
+    assert not any(step.endswith(":02:verify") for step in executed_steps)
     assert not create_pr_called
     assert workflow._publish_status == "not_required"
     assert status == "failed"


### PR DESCRIPTION
## Summary
- Stop PR/branch publication when a publishing workflow has an unaccepted failed plan step.
- Preserve the failed agent/runtime summary as the workflow blocking reason instead of falling through to a generic missing-PR failure.
- Add regression coverage for a Jira Orchestrate-style PR workflow where the first agent step fails under CONTINUE policy.

## Root Cause
A failed child AgentRun could be marked failed, but non-FAIL_FAST plan execution continued across pending downstream steps. Finalization then still enforced publishMode=pr and attempted native PR creation from an empty or unpublishable branch, hiding the real agent failure behind `publishMode 'pr' requested but no PR was created`.

## Validation
- `pytest tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/workflows/test_run_integration.py -q --tb=short` -> 124 passed
- `./tools/test_unit.sh` was started but interrupted after about 33 minutes because it was still early in the suite and making very slow progress in this environment.