### PR TITLE
MM-837 Close Pentest artifact-publication boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,7 @@ Key diagnostics:
 - existing artifact store/service only; no new persistent tables (001-mm-822-checkpoints)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures, pytest, existing workload launcher/registry, Docker Buildx, GitHub Actions (001-finish-pentestgpt)
 - Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
+- Python 3.12 + Pydantic v2, Temporal Python SDK activity boundaries, SQLAlchemy async artifact repository, existing `TemporalArtifactService`, existing report-bundle helpers (001-close-pentest-publication)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -318,6 +318,7 @@ Key diagnostics:
 - existing artifact store/service only; no new persistent tables (001-mm-822-checkpoints)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, FastAPI, SQLAlchemy async service fixtures, pytest, existing workload launcher/registry, Docker Buildx, GitHub Actions (001-finish-pentestgpt)
 - Existing Temporal workflow history and artifact store; existing provider-profile/secret configuration; no new persistent storage. (001-finish-pentestgpt)
+- Python 3.12 + Pydantic v2, Temporal Python SDK activity boundaries, SQLAlchemy async artifact repository, existing `TemporalArtifactService`, existing report-bundle helpers (001-close-pentest-publication)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -186,6 +186,7 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactService,
     build_artifact_ref,
 )
+from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workflows.temporal.manifest_ingest import (
     build_manifest_run_index,
     build_manifest_summary,
@@ -5513,6 +5514,208 @@ class TemporalAgentRuntimeActivities:
             }
         return dict(normalized)
 
+    async def _publish_pentest_success_artifacts(
+        self,
+        *,
+        request: PentestWorkloadRequest,
+        paths: Any,
+        finding_summary: Mapping[str, Any],
+        severity_counts: Mapping[str, int],
+    ) -> dict[str, Any] | None:
+        if (
+            self._artifact_service is None
+            or not hasattr(self._artifact_service, "create")
+            or not hasattr(self._artifact_service, "publish_report_bundle")
+        ):
+            return None
+
+        try:
+            info = temporal_activity.info()
+            namespace = info.namespace
+            workflow_id = info.workflow_id
+            run_id = info.workflow_run_id
+        except Exception:
+            namespace = "default"
+            workflow_id = request.agent_run_id
+            run_id = f"{request.step_id}-{request.attempt}"
+
+        principal = "system:agent_runtime"
+        common_metadata = {
+            "producer": "activity:security.pentest.execute",
+            "subject": request.target,
+            "step_id": request.step_id,
+            "attempt": request.attempt,
+            "scope": request.scope_artifact_ref,
+            "sensitivity": "security_restricted",
+        }
+
+        async def publish_file(
+            *,
+            link_type: str,
+            path: str,
+            content_type: str,
+            metadata: Mapping[str, Any],
+            required: bool = True,
+        ) -> dict[str, Any] | None:
+            file_path = Path(path)
+            try:
+                payload = file_path.read_bytes()
+            except OSError:
+                if required:
+                    raise
+                return None
+            artifact, _upload = await self._artifact_service.create(
+                principal=principal,
+                content_type=content_type,
+                size_bytes=len(payload),
+                link=ExecutionRef(
+                    namespace=namespace,
+                    workflow_id=workflow_id,
+                    run_id=run_id,
+                    link_type=link_type,
+                    label=str(metadata.get("name") or link_type),
+                ),
+                metadata_json=dict(metadata),
+            )
+            completed = await self._artifact_service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal=principal,
+                payload=payload,
+                content_type=content_type,
+            )
+            ref = build_artifact_ref(completed)
+            return {"artifact_ref_v": ref.artifact_ref_v, "artifact_id": ref.artifact_id}
+
+        runtime_refs: dict[str, dict[str, Any] | None] = {}
+        runtime_specs = {
+            "runtime.stdout": (
+                paths.stdout_file,
+                "text/plain",
+                "pentest-stdout.log",
+                "runtime_stdout",
+            ),
+            "runtime.stderr": (
+                paths.stderr_file,
+                "text/plain",
+                "pentest-stderr.log",
+                "runtime_stderr",
+            ),
+            "runtime.diagnostics": (
+                paths.diagnostics_file,
+                "application/json",
+                "pentest-diagnostics.json",
+                "runtime_diagnostics",
+            ),
+            "output.provider_snapshot": (
+                paths.provider_snapshot_file,
+                "application/json",
+                "provider-snapshot.json",
+                "provider_snapshot",
+            ),
+        }
+        for link_type, (path, content_type, name, artifact_kind) in runtime_specs.items():
+            runtime_refs[link_type] = await publish_file(
+                link_type=link_type,
+                path=str(path),
+                content_type=content_type,
+                metadata={
+                    **common_metadata,
+                    "name": name,
+                    "artifact_kind": artifact_kind,
+                },
+                required=link_type != "output.provider_snapshot",
+            )
+
+        counts = {
+            "findings_count": int(finding_summary.get("findings_count") or 0),
+            "confirmed_findings_count": int(
+                finding_summary.get("confirmed_findings_count") or 0
+            ),
+            "high_or_critical_count": int(
+                finding_summary.get("high_or_critical_count") or 0
+            ),
+            "severity_counts": dict(severity_counts),
+        }
+        report_metadata = {
+            "artifact_type": "security_pentest_report",
+            "producer": "activity:security.pentest.execute",
+            "subject": request.target,
+            "counts": counts,
+        }
+        workspace_root = Path(paths.workspace_root)
+        bundle = await self._artifact_service.publish_report_bundle(
+            principal=principal,
+            namespace=namespace,
+            workflow_id=workflow_id,
+            run_id=run_id,
+            report_type="security_pentest_report",
+            report_scope="final",
+            sensitivity="security_restricted",
+            counts=counts,
+            step_id=request.step_id,
+            attempt=request.attempt,
+            scope=request.scope_artifact_ref,
+            primary={
+                "payload": (workspace_root / "findings" / "findings.report.md").read_bytes(),
+                "content_type": "text/markdown",
+                "label": "Pentest primary report",
+                "metadata": {
+                    **report_metadata,
+                    "title": "Pentest report",
+                    "description": "Canonical human-facing Pentest findings report.",
+                    "name": "findings.report.md",
+                    "render_hint": "markdown",
+                },
+            },
+            summary={
+                "payload": (workspace_root / "findings" / "findings.summary.md").read_bytes(),
+                "content_type": "text/markdown",
+                "label": "Pentest report summary",
+                "metadata": {
+                    **report_metadata,
+                    "title": "Pentest report summary",
+                    "description": "Short Pentest findings summary.",
+                    "name": "findings.summary.md",
+                    "render_hint": "markdown",
+                },
+            },
+            structured={
+                "payload": Path(paths.normalizer_input_file).read_bytes(),
+                "content_type": "application/json",
+                "label": "Pentest structured findings",
+                "metadata": {
+                    **report_metadata,
+                    "title": "Pentest structured findings",
+                    "description": "Machine-readable normalized Pentest findings.",
+                    "name": "findings.normalizer-input.json",
+                    "render_hint": "json",
+                },
+            },
+            evidence=[
+                {
+                    "payload": (workspace_root / "evidence" / "bundle.tar.zst").read_bytes(),
+                    "content_type": "application/zstd",
+                    "label": "Pentest restricted evidence bundle",
+                    "metadata": {
+                        **report_metadata,
+                        "title": "Pentest restricted evidence",
+                        "description": "Restricted Pentest evidence bundle.",
+                        "name": "bundle.tar.zst",
+                        "render_hint": "binary",
+                    },
+                }
+            ],
+        )
+        validate_report_bundle_result(bundle)
+        return {
+            "namespace": namespace,
+            "workflow_id": workflow_id,
+            "run_id": run_id,
+            "runtime_refs": runtime_refs,
+            "report_bundle": bundle,
+            "counts": counts,
+        }
+
     async def execution_notify_completion(
         self,
         request: Any = None,
@@ -6828,6 +7031,83 @@ class TemporalAgentRuntimeActivities:
                 "failed to release Pentest provider lease after success: %s",
                 release_exc,
             )
+        published_artifacts = await self._publish_pentest_success_artifacts(
+            request=request,
+            paths=execution_materialization.runtime_paths,
+            finding_summary=finding_summary,
+            severity_counts=severity_counts,
+        )
+        report_bundle = None
+        counts = {
+            "findings_count": finding_summary["findings_count"],
+            "confirmed_findings_count": finding_summary[
+                "confirmed_findings_count"
+            ],
+            "high_or_critical_count": finding_summary["high_or_critical_count"],
+            "severity_counts": severity_counts,
+        }
+        if published_artifacts is not None:
+            runtime_refs = published_artifacts["runtime_refs"]
+            stdout_artifact = runtime_refs.get("runtime.stdout")
+            stderr_artifact = runtime_refs.get("runtime.stderr")
+            diagnostics_artifact = runtime_refs.get("runtime.diagnostics")
+            provider_snapshot_artifact = runtime_refs.get("output.provider_snapshot")
+            report_bundle = published_artifacts["report_bundle"]
+            counts = dict(published_artifacts["counts"])
+
+            if isinstance(stdout_artifact, Mapping):
+                stdout_ref = str(stdout_artifact.get("artifact_id") or stdout_ref)
+            if isinstance(stderr_artifact, Mapping):
+                stderr_ref = str(stderr_artifact.get("artifact_id") or stderr_ref)
+            if isinstance(diagnostics_artifact, Mapping):
+                diagnostics_ref = str(
+                    diagnostics_artifact.get("artifact_id") or diagnostics_ref
+                )
+            primary_report_ref = report_bundle.get("primary_report_ref")
+            summary_report_ref = report_bundle.get("summary_ref")
+            structured_report_ref = report_bundle.get("structured_ref")
+            evidence_report_refs = report_bundle.get("evidence_refs") or []
+            if isinstance(primary_report_ref, Mapping):
+                primary_ref = str(primary_report_ref.get("artifact_id") or primary_ref)
+            if isinstance(summary_report_ref, Mapping):
+                summary_ref = str(summary_report_ref.get("artifact_id") or summary_ref)
+            if isinstance(structured_report_ref, Mapping):
+                structured_ref = str(
+                    structured_report_ref.get("artifact_id") or structured_ref
+                )
+            if evidence_report_refs and isinstance(evidence_report_refs[0], Mapping):
+                evidence_ref = str(
+                    evidence_report_refs[0].get("artifact_id") or evidence_ref
+                )
+            if isinstance(provider_snapshot_artifact, Mapping):
+                provider_snapshot_ref = str(
+                    provider_snapshot_artifact.get("artifact_id") or ""
+                )
+            else:
+                provider_snapshot_ref = None
+        else:
+            provider_snapshot_ref = _artifact_ref_for_pentest_name(
+                publication, "output.provider_snapshot"
+            )
+            report_bundle = {
+                "report_bundle_v": 1,
+                "primary_report_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": primary_ref,
+                },
+                "summary_ref": {"artifact_ref_v": 1, "artifact_id": summary_ref},
+                "structured_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": structured_ref,
+                },
+                "evidence_refs": [
+                    {"artifact_ref_v": 1, "artifact_id": evidence_ref}
+                ],
+                "report_type": "security_pentest_report",
+                "report_scope": "final",
+                "sensitivity": "security_restricted",
+                "counts": counts,
+            }
         result = PentestWorkloadResult(
             status="completed",
             target=request.target,
@@ -6839,9 +7119,7 @@ class TemporalAgentRuntimeActivities:
             summary_artifact_ref=summary_ref,
             findings_artifact_ref=structured_ref,
             evidence_bundle_artifact_ref=evidence_ref,
-            provider_snapshot_artifact_ref=_artifact_ref_for_pentest_name(
-                publication, "output.provider_snapshot"
-            ),
+            provider_snapshot_artifact_ref=provider_snapshot_ref,
             findings_count=finding_summary["findings_count"],
             confirmed_findings_count=finding_summary["confirmed_findings_count"],
         )
@@ -6865,22 +7143,9 @@ class TemporalAgentRuntimeActivities:
             ],
         }
         output["severity_counts"] = severity_counts
-        output["report_bundle"] = {
-            "report_bundle_v": 1,
-            "primary_report_ref": primary_ref,
-            "summary_ref": summary_ref,
-            "structured_ref": structured_ref,
-            "evidence_refs": [evidence_ref],
-            "report_type": "security_pentest_report",
-            "report_scope": "final",
-            "sensitivity": output["sensitivity"],
-            "findings_count": finding_summary["findings_count"],
-            "confirmed_findings_count": finding_summary[
-                "confirmed_findings_count"
-            ],
-            "high_or_critical_count": finding_summary["high_or_critical_count"],
-            "severity_counts": severity_counts,
-        }
+        output["counts"] = counts
+        output["report_bundle"] = report_bundle
+        validate_report_bundle_result(output["report_bundle"])
         output["execution_policy"] = execution_policy.model_dump(mode="json")
         output["terminal_cleanup"] = cleanup(
             terminal_reason="success",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5539,7 +5539,7 @@ class TemporalAgentRuntimeActivities:
             workflow_id = request.agent_run_id
             run_id = f"{request.step_id}-{request.attempt}"
 
-        principal = "system:agent_runtime"
+        principal = request.principal_id
         common_metadata = {
             "producer": "activity:security.pentest.execute",
             "subject": request.target,
@@ -5559,7 +5559,7 @@ class TemporalAgentRuntimeActivities:
         ) -> dict[str, Any] | None:
             file_path = Path(path)
             try:
-                payload = file_path.read_bytes()
+                payload = await asyncio.to_thread(file_path.read_bytes)
             except OSError:
                 if required:
                     raise
@@ -5643,6 +5643,19 @@ class TemporalAgentRuntimeActivities:
             "counts": counts,
         }
         workspace_root = Path(paths.workspace_root)
+        primary_payload = await asyncio.to_thread(
+            (workspace_root / "findings" / "findings.report.md").read_bytes
+        )
+        summary_payload = await asyncio.to_thread(
+            (workspace_root / "findings" / "findings.summary.md").read_bytes
+        )
+        structured_payload = await asyncio.to_thread(
+            Path(paths.normalizer_input_file).read_bytes
+        )
+        evidence_payload = await asyncio.to_thread(
+            (workspace_root / "evidence" / "bundle.tar.zst").read_bytes
+        )
+
         bundle = await self._artifact_service.publish_report_bundle(
             principal=principal,
             namespace=namespace,
@@ -5656,7 +5669,7 @@ class TemporalAgentRuntimeActivities:
             attempt=request.attempt,
             scope=request.scope_artifact_ref,
             primary={
-                "payload": (workspace_root / "findings" / "findings.report.md").read_bytes(),
+                "payload": primary_payload,
                 "content_type": "text/markdown",
                 "label": "Pentest primary report",
                 "metadata": {
@@ -5668,7 +5681,7 @@ class TemporalAgentRuntimeActivities:
                 },
             },
             summary={
-                "payload": (workspace_root / "findings" / "findings.summary.md").read_bytes(),
+                "payload": summary_payload,
                 "content_type": "text/markdown",
                 "label": "Pentest report summary",
                 "metadata": {
@@ -5680,7 +5693,7 @@ class TemporalAgentRuntimeActivities:
                 },
             },
             structured={
-                "payload": Path(paths.normalizer_input_file).read_bytes(),
+                "payload": structured_payload,
                 "content_type": "application/json",
                 "label": "Pentest structured findings",
                 "metadata": {
@@ -5693,7 +5706,7 @@ class TemporalAgentRuntimeActivities:
             },
             evidence=[
                 {
-                    "payload": (workspace_root / "evidence" / "bundle.tar.zst").read_bytes(),
+                    "payload": evidence_payload,
                     "content_type": "application/zstd",
                     "label": "Pentest restricted evidence bundle",
                     "metadata": {

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Mapping
 from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
 from api_service.api.routers.executions import _create_execution_from_workflow_request
 from api_service.api.schemas import CreateJobRequest
+from api_service.db.models import Base
 from moonmind.config.settings import settings
 from moonmind.integrations.pentest.models import (
     PentestWorkloadRequest,
@@ -40,9 +45,29 @@ from moonmind.workflows.temporal.activity_runtime import (
     _default_registry_skill_payload,
 )
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
-from moonmind.workflows.temporal.artifacts import TemporalArtifactNotFoundError
+from moonmind.workflows.temporal.artifacts import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactNotFoundError,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
+from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+@asynccontextmanager
+async def temporal_db(tmp_path: Path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/pentest_tool_contract.db"
+    engine = create_async_engine(db_url, future=True)
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        yield session_maker
+    finally:
+        await engine.dispose()
 
 def _approved_scope() -> dict[str, object]:
     return {
@@ -158,6 +183,51 @@ class _FakeLauncher:
                 },
             }
         )
+
+class _FileWritingLauncher(_FakeLauncher):
+    async def run(self, request: object) -> WorkloadResult:
+        workload_request = getattr(request, "request", request)
+        artifacts_dir = Path(str(getattr(workload_request, "artifacts_dir")))
+        base = artifacts_dir / "pentest"
+        files = {
+            "runtime/stdout.log": "stdout token=ghp_rawshouldnotleak1234567890\n",
+            "runtime/stderr.log": "stderr password=rawshouldnotleak\n",
+            "runtime/diagnostics.json": json.dumps({"status": "ok"}),
+            "findings/findings.summary.md": "Summary without raw evidence.\n",
+            "findings/findings.report.md": "# Pentest report\n\nPrimary report.\n",
+            "findings/findings.normalizer-input.json": json.dumps(
+                {
+                    "tool_name": "security.pentest.run",
+                    "target": "https://lab.example.test",
+                    "scope_artifact_ref": "art:sha256:scope",
+                    "operation_mode": "validate_hypothesis",
+                    "runner_profile_id": "pentestgpt-safe",
+                    "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                    "produced_at": "2026-06-14T00:00:00Z",
+                    "findings": [
+                        {
+                            "finding_id": "finding-1",
+                            "title": "Supported issue",
+                            "severity": "high",
+                            "confidence": "confirmed",
+                            "target": "https://lab.example.test",
+                            "summary": "Evidence supports issue",
+                        }
+                    ],
+                    "summary": {
+                        "findings_count": 1,
+                        "confirmed_findings_count": 1,
+                        "high_or_critical_count": 1,
+                    },
+                }
+            ),
+            "evidence/bundle.tar.zst": "fake evidence body ghp_evidenceshouldnotleak123456\n",
+        }
+        for relative, body in files.items():
+            path = base / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        return await super().run(request)
 
 class _FakePentestLeaseManager:
     def __init__(self) -> None:
@@ -685,6 +755,72 @@ async def test_security_pentest_execute_enabled_request_returns_report_first_suc
     assert result["terminal_cleanup"]["provider_lease_released"] is True
     assert [event[0] for event in lease_manager.events] == ["acquire", "release"]
     assert result["execution_policy"]["automatic_retries_enabled"] is False
+
+async def test_security_pentest_execute_publishes_report_bundle_artifacts(
+    tmp_path: Path,
+) -> None:
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifact-store"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workload_launcher=_FileWritingLauncher(),
+                workload_registry=_RecordingPentestRegistry(),
+                pentest_provider_lease_manager=_FakePentestLeaseManager(),
+            )
+
+            result = await activities._security_pentest_execute_trusted_internal(
+                _activity_payload(artifacts_dir=str(tmp_path / "runner-artifacts"))
+            )
+
+            assert result["status"] == "completed"
+            validate_report_bundle_result(result["report_bundle"])
+            assert result["report_bundle"]["counts"] == {
+                "findings_count": 1,
+                "confirmed_findings_count": 1,
+                "high_or_critical_count": 1,
+                "severity_counts": {"high": 1},
+            }
+
+            expected_link_types = {
+                "runtime.stdout",
+                "runtime.stderr",
+                "runtime.diagnostics",
+                "output.provider_snapshot",
+                "report.primary",
+                "report.summary",
+                "report.structured",
+                "report.evidence",
+            }
+            by_link_type = {}
+            for link_type in expected_link_types:
+                artifacts = await service.list_for_execution(
+                    namespace="default",
+                    workflow_id="run-123",
+                    run_id="step-pentest-1",
+                    principal="system:agent_runtime",
+                    link_type=link_type,
+                    latest_only=True,
+                )
+                assert artifacts, link_type
+                by_link_type[link_type] = artifacts[0]
+
+            assert by_link_type["report.primary"].metadata_json["is_final_report"] is True
+            assert (
+                by_link_type["report.primary"].metadata_json["report_type"]
+                == "security_pentest_report"
+            )
+            assert (
+                by_link_type["report.primary"].metadata_json["sensitivity"]
+                == "security_restricted"
+            )
+            assert result["primary_report_ref"].startswith("art_")
+            assert result["summary_ref"].startswith("art_")
+            assert result["structured_ref"].startswith("art_")
+            assert result["evidence_refs"][0].startswith("art_")
 
 async def test_security_pentest_execute_heartbeat_lifecycle_order_at_activity_boundary(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -801,7 +801,7 @@ async def test_security_pentest_execute_publishes_report_bundle_artifacts(
                     namespace="default",
                     workflow_id="run-123",
                     run_id="step-pentest-1",
-                    principal="system:agent_runtime",
+                    principal="user-security",
                     link_type=link_type,
                     latest_only=True,
                 )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2273,7 +2273,7 @@ async def test_security_pentest_execute_publishes_runner_outputs_through_artifac
                     namespace="default",
                     workflow_id="run-123",
                     run_id="step-pentest-1",
-                    principal="system:agent_runtime",
+                    principal="user-security",
                     link_type=link_type,
                     latest_only=True,
                 )
@@ -2343,7 +2343,7 @@ async def test_security_pentest_serialized_result_and_metadata_stay_compact_and_
                 namespace="default",
                 workflow_id="run-123",
                 run_id="step-pentest-1",
-                principal="system:agent_runtime",
+                principal="user-security",
                 latest_only=False,
             )
             metadata_payload = json.dumps(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -89,6 +89,7 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactValidationError,
     build_artifact_ref,
 )
+from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workloads.registry import RunnerProfileRegistry
 
 pytestmark = [pytest.mark.asyncio]
@@ -1149,6 +1150,53 @@ class _FakePentestLauncher:
             }
         )
 
+class _FileWritingPentestLauncher(_FakePentestLauncher):
+    async def run(self, request: object) -> WorkloadResult:
+        workload_request = getattr(request, "request", request)
+        artifacts_dir = Path(str(getattr(workload_request, "artifacts_dir")))
+        base = artifacts_dir / "pentest"
+        files = {
+            "runtime/stdout.log": "stdout token=ghp_rawshouldnotleak1234567890\n",
+            "runtime/stderr.log": "stderr password=rawshouldnotleak\n",
+            "runtime/diagnostics.json": json.dumps(
+                {"status": "ok", "raw_log": "must stay in artifact body"}
+            ),
+            "findings/findings.summary.md": "Summary without secrets.\n",
+            "findings/findings.report.md": "# Pentest report\n\nPrimary report.\n",
+            "findings/findings.normalizer-input.json": json.dumps(
+                {
+                    "tool_name": "security.pentest.run",
+                    "target": "https://lab.example.test",
+                    "scope_artifact_ref": "art:sha256:scope",
+                    "operation_mode": "validate_hypothesis",
+                    "runner_profile_id": "pentestgpt-safe",
+                    "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                    "produced_at": "2026-06-14T00:00:00Z",
+                    "findings": [
+                        {
+                            "finding_id": "finding-1",
+                            "title": "Supported issue",
+                            "severity": "high",
+                            "confidence": "confirmed",
+                            "target": "https://lab.example.test",
+                            "summary": "Evidence supports issue",
+                        }
+                    ],
+                    "summary": {
+                        "findings_count": 1,
+                        "confirmed_findings_count": 1,
+                        "high_or_critical_count": 1,
+                    },
+                }
+            ),
+            "evidence/bundle.tar.zst": "fake evidence body ghp_evidenceshouldnotleak123456\n",
+        }
+        for relative, body in files.items():
+            path = base / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        return await super().run(request)
+
 class _BlockingPentestLauncher(_FakePentestLauncher):
     def __init__(self, *, status: str = "succeeded") -> None:
         super().__init__(status=status)
@@ -2132,11 +2180,8 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
     assert result["evidence_refs"]
     assert result["report_bundle"]["report_type"] == "security_pentest_report"
     assert result["report_bundle"]["report_scope"] == "final"
-    assert (
-        result["report_bundle"]["sensitivity"]["classification"]
-        == "security_restricted"
-    )
-    assert result["report_bundle"]["high_or_critical_count"] == 1
+    assert result["report_bundle"]["sensitivity"] == "security_restricted"
+    assert result["report_bundle"]["counts"]["high_or_critical_count"] == 1
     assert result["severity_counts"] == {"high": 1}
     assert "session.summary" not in artifact_names
     assert "session.step_checkpoint" not in artifact_names
@@ -2164,6 +2209,149 @@ async def test_security_pentest_execute_includes_publication_metadata_without_se
     assert "hunter2" not in str(result)
     assert "terminal_control" not in str(live_logs)
     assert "docker attach" not in str(result).lower()
+
+async def test_security_pentest_execute_publishes_runner_outputs_through_artifact_service(
+    tmp_path: Path,
+):
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifact-store"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workload_launcher=_FileWritingPentestLauncher(),
+                workload_registry=_RecordingPentestRegistry(),
+            )
+
+            result = await activities._security_pentest_execute_trusted_internal(
+                _pentest_activity_payload(
+                    artifacts_dir=str(tmp_path / "runner-artifacts"),
+                    findings=[],
+                    provider_snapshot_available=True,
+                )
+            )
+
+            assert result["status"] == "completed"
+            artifact_ref_fields = {
+                "stdout_artifact_ref",
+                "stderr_artifact_ref",
+                "diagnostics_artifact_ref",
+                "provider_snapshot_artifact_ref",
+                "primary_report_ref",
+                "summary_ref",
+                "structured_ref",
+                "evidence_bundle_artifact_ref",
+            }
+            for field in artifact_ref_fields:
+                assert str(result[field]).startswith("art_"), field
+
+            validate_report_bundle_result(result["report_bundle"])
+            assert result["report_bundle"]["counts"] == {
+                "findings_count": 1,
+                "confirmed_findings_count": 1,
+                "high_or_critical_count": 1,
+                "severity_counts": {"high": 1},
+            }
+            assert "findings_count" not in result["report_bundle"]
+            assert "high_or_critical_count" not in result["report_bundle"]
+
+            expected_link_types = {
+                "runtime.stdout",
+                "runtime.stderr",
+                "runtime.diagnostics",
+                "output.provider_snapshot",
+                "report.primary",
+                "report.summary",
+                "report.structured",
+                "report.evidence",
+            }
+            by_link_type = {}
+            for link_type in expected_link_types:
+                artifacts = await service.list_for_execution(
+                    namespace="default",
+                    workflow_id="run-123",
+                    run_id="step-pentest-1",
+                    principal="system:agent_runtime",
+                    link_type=link_type,
+                    latest_only=True,
+                )
+                assert artifacts, link_type
+                by_link_type[link_type] = artifacts[0]
+            assert by_link_type["report.primary"].metadata_json["is_final_report"] is True
+            assert (
+                by_link_type["report.primary"].metadata_json["sensitivity"]
+                == "security_restricted"
+            )
+
+async def test_security_pentest_report_bundle_rejects_unsafe_custom_keys():
+    unsafe_cases = (
+        {"raw_log": "inline log"},
+        {"finding_details": {"body": "raw finding"}},
+        {"presigned_url": "https://example.invalid/raw"},
+        {"evidence_body": "raw evidence"},
+    )
+
+    for unsafe in unsafe_cases:
+        bundle = {"report_bundle_v": 1, **unsafe}
+        with pytest.raises(TemporalArtifactValidationError, match="unsafe report bundle"):
+            validate_report_bundle_result(bundle)
+
+async def test_security_pentest_serialized_result_and_metadata_stay_compact_and_secret_safe(
+    tmp_path: Path,
+):
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifact-store"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workload_launcher=_FileWritingPentestLauncher(),
+                workload_registry=_RecordingPentestRegistry(),
+            )
+
+            result = await activities._security_pentest_execute_trusted_internal(
+                _pentest_activity_payload(
+                    artifacts_dir=str(tmp_path / "runner-artifacts"),
+                    summary_text="Pentest finished with token=ghp_summaryshouldnotleak",
+                    provider_snapshot_available=True,
+                )
+            )
+
+            serialized = json.dumps(result, sort_keys=True)
+            assert len(serialized.encode("utf-8")) < 60000
+            blocked_patterns = (
+                "ghp_rawshouldnotleak",
+                "rawshouldnotleak",
+                "ghp_evidenceshouldnotleak",
+                "ghp_summaryshouldnotleak",
+                "presigned_url",
+                "finding_details",
+                "evidence_body",
+                "session.summary",
+                "session.step_checkpoint",
+                "session.control_event",
+                "session.reset_boundary",
+            )
+            for pattern in blocked_patterns:
+                assert pattern not in serialized
+
+            artifacts = await service.list_for_execution(
+                namespace="default",
+                workflow_id="run-123",
+                run_id="step-pentest-1",
+                principal="system:agent_runtime",
+                latest_only=False,
+            )
+            metadata_payload = json.dumps(
+                [artifact.metadata_json for artifact in artifacts],
+                sort_keys=True,
+            )
+            for pattern in blocked_patterns:
+                assert pattern not in metadata_payload
 
 async def test_pentest_heartbeat_emitter_returns_redacted_compact_payload(
     monkeypatch: pytest.MonkeyPatch,
@@ -2732,7 +2920,7 @@ async def test_security_pentest_execute_uses_runner_normalized_findings_after_la
     assert result["status"] == "completed"
     assert result["findings_count"] == 1
     assert result["confirmed_findings_count"] == 1
-    assert result["report_bundle"]["high_or_critical_count"] == 1
+    assert result["report_bundle"]["counts"]["high_or_critical_count"] == 1
     assert result["severity_counts"] == {"critical": 1}
     assert [
         item["finding_id"] for item in result["normalized_findings"]["findings"]


### PR DESCRIPTION
## Jira
- Jira issue key: MM-837

## MoonSpec
- Active feature path: `specs/001-close-pentest-publication`
- Verification verdict: FULLY_IMPLEMENTED

## Summary
- Publishes Pentest runtime stdout, stderr, diagnostics, provider snapshot, primary report, summary, structured report, and evidence artifacts through `TemporalArtifactService`.
- Validates the Pentest report bundle with the shared report-bundle validator before returning activity output.
- Keeps the activity result compact with artifact refs, counts, report bundle metadata, status/profile ids, and cleanup metadata only.
- Adds publication, compactness, metadata, and secret-scan regression coverage.

## Tests run
- `pytest tests/unit/workflows/temporal/test_activity_runtime.py -k 'security_pentest_report_bundle_rejects_unsafe_custom_keys or security_pentest_serialized_result_and_metadata_stay_compact_and_secret_safe' -q` PASS, 2 passed
- `pytest tests/integration/temporal/test_pentest_tool_contract.py -k 'publishes_report_bundle_artifacts or report_first_success' -q` PASS, 2 passed
- `pytest tests/unit/workflows/temporal/test_activity_runtime.py -k pentest -q` PASS, 63 passed
- `pytest tests/integration/temporal/test_pentest_tool_contract.py -k pentest -q` PASS, 20 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS, Python 6282 passed, 6 skipped, 1 xpassed; frontend 27 files passed, 428 tests passed, 234 skipped
- `./tools/test_integration.sh` PASS, 336 passed, 1 skipped, 82 deselected

## Doc reconciliation
- Outcome: no_update_required
- Canonical doc paths considered: `docs/Steps/PentestTool.md`
- Rationale: the latest verification report found no blocking source-document drift. `docs/Steps/PentestTool.md` already describes the desired published artifact set, normalized findings contract, no-session-artifacts rule, and compact canonical response payload. No `artifacts/doc-discoveries/001-close-pentest-publication.json` ledger was present.

## Remaining risks
- No known implementation gaps from MoonSpec verification.
- CI should re-run the full required suites on the pushed branch.
