### PR TITLE
MM-842 remove step DAG

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5068,7 +5068,7 @@ def _normalize_task_input_attachments(
 def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
     raw_edges = task_payload.get("edges")
     if isinstance(raw_edges, list):
-        if any(raw_edges):
+        if raw_edges:
             raise _invalid_workflow_request(
                 "payload.workflow.edges is no longer supported. Authored workflow "
                 "steps are ordered by their steps[] position; use "

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5066,6 +5066,22 @@ def _normalize_task_input_attachments(
     return normalized
 
 def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_edges = task_payload.get("edges")
+    if isinstance(raw_edges, list):
+        if any(raw_edges):
+            raise _invalid_workflow_request(
+                "payload.workflow.edges is no longer supported. Authored workflow "
+                "steps are ordered by their steps[] position; use "
+                "payload.workflow.dependsOn only for dependencies between workflow executions."
+            )
+        task_payload.pop("edges", None)
+    elif raw_edges is not None:
+        raise _invalid_workflow_request(
+            "payload.workflow.edges is no longer supported. Authored workflow "
+            "steps are ordered by their steps[] position; use "
+            "payload.workflow.dependsOn only for dependencies between workflow executions."
+        )
+
     raw_steps = task_payload.get("steps")
     if raw_steps is None:
         return []
@@ -5102,6 +5118,18 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
             formatted = ", ".join(blocked)
             raise _invalid_workflow_request(
                 f"payload.workflow.steps[{index}] may not define workflow-scoped overrides: {formatted}"
+            )
+        for graph_key in ("dependsOn", "depends_on", "dependencies"):
+            if graph_key not in step_payload:
+                continue
+            graph_value = step_payload.get(graph_key)
+            if graph_value in (None, "", [], (), {}):
+                step_payload.pop(graph_key, None)
+                continue
+            raise _invalid_workflow_request(
+                f"payload.workflow.steps[{index}].{graph_key} is no longer supported. "
+                "Authored workflow steps are ordered by their steps[] position; use "
+                "payload.workflow.dependsOn only for dependencies between workflow executions."
             )
 
         normalized_step: dict[str, Any] = {}

--- a/api_service/api/routers/workflow_proposals.py
+++ b/api_service/api/routers/workflow_proposals.py
@@ -7,6 +7,7 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.auth_providers import get_current_user, get_current_user_optional
@@ -39,6 +40,10 @@ from moonmind.workflows.proposals.service import (
     WorkflowProposalValidationError,
 )
 from moonmind.workflows.proposals.delivery import ProviderDecisionEvent
+from moonmind.workflows.executions.execution_contract import (
+    CanonicalWorkflowExecutionPayload,
+    WorkflowContractError,
+)
 
 router = APIRouter(prefix="/api/proposals", tags=["workflow-proposals"])
 
@@ -487,6 +492,16 @@ async def _create_promoted_execution(
     idempotency_key: str,
 ) -> str:
     initial_parameters = dict(final_request.get("payload") or {})
+    try:
+        CanonicalWorkflowExecutionPayload.model_validate(initial_parameters)
+    except (ValidationError, WorkflowContractError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": "invalid_execution_request",
+                "message": str(exc),
+            },
+        ) from exc
     execution_record = await execution_service.create_execution(
         workflow_type="MoonMind.UserWorkflow",
         owner_id=getattr(user, "id"),

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -545,7 +545,8 @@ describe('Workflow Detail Entrypoint', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
-    expect(screen.getAllByText((_, element) => element?.textContent === 'Depends on: plan').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Depends on: plan')).toBeNull();
+    expect(screen.getAllByText((_, element) => element?.textContent === 'Prior step evidence: plan').length).toBeGreaterThan(0);
   });
 
   it('MM-842 renders empty steps without a separate Step DAG panel', async () => {
@@ -834,16 +835,19 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByText('Apply patch').length).toBeGreaterThan(0);
       expect(screen.getAllByText('Verify tests').length).toBeGreaterThan(0);
       expect(screen.queryByRole('heading', { name: 'Step DAG' })).toBeNull();
-      expect(screen.getAllByText('Depends on: plan').length).toBeGreaterThan(0);
+      expect(screen.queryByText('Depends on: plan')).toBeNull();
+      expect(screen.getAllByText('Prior step evidence: plan').length).toBeGreaterThan(0);
       expect(screen.queryByLabelText('plan to apply')).toBeNull();
       expect(screen.queryByLabelText('apply to verify')).toBeNull();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
     });
 
-    expect(screen.getAllByText((_, element) => element?.textContent === 'Depends on: plan').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Depends on: plan')).toBeNull();
+    expect(screen.getAllByText((_, element) => element?.textContent === 'Prior step evidence: plan').length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
-    expect(screen.getAllByText((_, element) => element?.textContent === 'Depends on: plan').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Depends on: plan')).toBeNull();
+    expect(screen.getAllByText((_, element) => element?.textContent === 'Prior step evidence: plan').length).toBeGreaterThan(0);
 
     const stepsHeading = screen.getByRole('heading', { name: 'Workflow Steps' });
     const timelineHeading = screen.getByRole('heading', { name: 'Timeline' });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2562,7 +2562,9 @@ function StepMetadataList({
       <li><strong>Run id:</strong> <code className="text-xs break-all">{runId}</code></li>
       <li><strong>Tool:</strong> <code className="text-xs break-all">{formatStepToolLabel(row.tool)}</code></li>
       <li><strong>Execution ordinal:</strong> {row.executionOrdinal}</li>
-      <li><strong>Depends on:</strong> {row.dependsOn.length > 0 ? row.dependsOn.join(', ') : 'None'}</li>
+      {row.dependsOn.length > 0 ? (
+        <li><strong>Prior step evidence:</strong> {row.dependsOn.join(', ')}</li>
+      ) : null}
       <li><strong>Child workflow:</strong> {row.refs.childWorkflowId ? <code className="text-xs break-all">{row.refs.childWorkflowId}</code> : '—'}</li>
       <li><strong>Child run:</strong> {row.refs.childRunId ? <code className="text-xs break-all">{row.refs.childRunId}</code> : '—'}</li>
       <li><strong>Workflow run:</strong> {row.refs.agentRunId ? <code className="text-xs break-all">{row.refs.agentRunId}</code> : '—'}</li>
@@ -2809,7 +2811,7 @@ function StepLedgerRowCard({
             <p className="step-tl-summary">{row.summary}</p>
           ) : null}
           {!expanded && row.dependsOn.length > 0 ? (
-            <p className="step-tl-summary">Depends on: {row.dependsOn.join(', ')}</p>
+            <p className="step-tl-summary">Prior step evidence: {row.dependsOn.join(', ')}</p>
           ) : null}
           {!expanded && row.checks.length > 0 ? (
             <div className="step-check-badges">

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2562,7 +2562,7 @@ function StepMetadataList({
       <li><strong>Run id:</strong> <code className="text-xs break-all">{runId}</code></li>
       <li><strong>Tool:</strong> <code className="text-xs break-all">{formatStepToolLabel(row.tool)}</code></li>
       <li><strong>Execution ordinal:</strong> {row.executionOrdinal}</li>
-      {row.dependsOn.length > 0 ? (
+      {row.dependsOn && row.dependsOn.length > 0 ? (
         <li><strong>Prior step evidence:</strong> {row.dependsOn.join(', ')}</li>
       ) : null}
       <li><strong>Child workflow:</strong> {row.refs.childWorkflowId ? <code className="text-xs break-all">{row.refs.childWorkflowId}</code> : '—'}</li>
@@ -2810,7 +2810,7 @@ function StepLedgerRowCard({
           {!expanded && row.summary ? (
             <p className="step-tl-summary">{row.summary}</p>
           ) : null}
-          {!expanded && row.dependsOn.length > 0 ? (
+          {!expanded && row.dependsOn && row.dependsOn.length > 0 ? (
             <p className="step-tl-summary">Prior step evidence: {row.dependsOn.join(', ')}</p>
           ) : null}
           {!expanded && row.checks.length > 0 ? (

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2562,11 +2562,6 @@ def build_authoritative_workflow_input_snapshot(
             "title": _clean_optional_str(step.get("title")),
             "instructions": _raw_instruction_string(step.get("instructions")),
             "inputAttachments": _safe_list(step.get("inputAttachments")),
-            "dependencies": _first_present_snapshot_list(
-                step,
-                "dependsOn",
-                "dependencies",
-            ),
             "templateStepId": _clean_optional_str(step.get("templateStepId")),
             "stepType": _clean_optional_str(step.get("type")),
             "presetProvenance": _safe_mapping(step.get("presetProvenance")),

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -1497,6 +1497,17 @@ class WorkflowStepSpec(BaseModel):
             raise WorkflowContractError(
                 f"workflow.steps entries may not define workflow-scoped overrides: {formatted}"
             )
+        for graph_key in ("dependsOn", "depends_on", "dependencies"):
+            if graph_key not in payload:
+                continue
+            graph_value = payload.get(graph_key)
+            if graph_value in (None, "", [], (), {}):
+                continue
+            raise WorkflowContractError(
+                f"workflow.steps[].{graph_key} is no longer supported. "
+                "Authored workflow steps are ordered by their steps[] position; use "
+                "workflow.dependsOn only for dependencies between workflow executions"
+            )
         return payload
 
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1489,7 +1489,17 @@ def _build_runtime_planner():
                     **{
                         k: v
                         for k, v in step_entry.items()
-                        if k not in {"id", "tool", "skill", "instructions", "runtime"}
+                        if k
+                        not in {
+                            "id",
+                            "tool",
+                            "skill",
+                            "instructions",
+                            "runtime",
+                            "dependsOn",
+                            "depends_on",
+                            "dependencies",
+                        }
                     },
                     "instructions": step_instructions,
                 }

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -136,6 +136,40 @@ def test_mm641_task_shaped_submission_boundary_exposes_canonical_task_parameters
     assert task["steps"][0]["jiraOrchestration"] == {"issueKey": "MM-641"}
 
 
+def test_mm842_task_shaped_submission_rejects_stale_step_graph_metadata() -> None:
+    test_client, service = _client()
+
+    with test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "repository": "Moon/Mind",
+                    "targetRuntime": "codex",
+                    "workflow": {
+                        "instructions": "Run ordered steps.",
+                        "steps": [
+                            {"id": "plan", "instructions": "Plan."},
+                            {
+                                "id": "implement",
+                                "instructions": "Implement.",
+                                "dependsOn": ["plan"],
+                            },
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_execution_request"
+    assert "payload.workflow.steps[1].dependsOn" in detail["message"]
+    assert "ordered by their steps[] position" in detail["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_task_shaped_submission_boundary_assigns_step_id_for_step_attachment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -336,6 +336,90 @@ def test_step_execution_detail_payload_exposes_environment_fix_guidance() -> Non
     assert recovery["operatorGuidance"] == "fix_environment"
     assert diagnostic_kinds == {"provider_lease", "sidecar", "ghcr", "preflight"}
     assert "source-code" not in json.dumps(payload, default=str).lower()
+
+
+def test_mm842_task_steps_accept_ordered_steps_without_graph_metadata() -> None:
+    task_payload = {
+        "steps": [
+            {"id": "plan", "instructions": "Plan the work."},
+            {"id": "implement", "instructions": "Implement the work."},
+        ]
+    }
+
+    steps = _normalize_task_steps(task_payload)
+
+    assert [step["id"] for step in steps] == ["plan", "implement"]
+    assert all("dependsOn" not in step for step in steps)
+    assert all("depends_on" not in step for step in steps)
+    assert all("dependencies" not in step for step in steps)
+
+
+@pytest.mark.parametrize("field_name", ["dependsOn", "depends_on", "dependencies"])
+def test_mm842_task_steps_reject_non_empty_step_graph_metadata(field_name: str) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _normalize_task_steps(
+            {
+                "steps": [
+                    {"id": "plan", "instructions": "Plan."},
+                    {
+                        "id": "implement",
+                        "instructions": "Implement.",
+                        field_name: ["plan"],
+                    },
+                ]
+            }
+        )
+
+    detail = exc_info.value.detail
+    assert detail["code"] == "invalid_execution_request"
+    assert f"payload.workflow.steps[1].{field_name}" in detail["message"]
+    assert "ordered by their steps[] position" in detail["message"]
+
+
+@pytest.mark.parametrize("field_name", ["dependsOn", "depends_on", "dependencies"])
+def test_mm842_task_steps_strip_empty_step_graph_metadata(field_name: str) -> None:
+    task_payload = {
+        "steps": [
+            {
+                "id": "plan",
+                "instructions": "Plan.",
+                field_name: [],
+            }
+        ]
+    }
+
+    steps = _normalize_task_steps(task_payload)
+
+    assert field_name not in steps[0]
+    assert "dependsOn" not in steps[0]
+    assert "depends_on" not in steps[0]
+    assert "dependencies" not in steps[0]
+
+
+def test_mm842_task_steps_reject_non_empty_active_edges() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _normalize_task_steps(
+            {
+                "steps": [{"id": "plan", "instructions": "Plan."}],
+                "edges": [{"from": "plan", "to": "implement"}],
+            }
+        )
+
+    detail = exc_info.value.detail
+    assert detail["code"] == "invalid_execution_request"
+    assert "payload.workflow.edges" in detail["message"]
+    assert "ordered by their steps[] position" in detail["message"]
+
+
+def test_mm842_task_steps_strip_empty_active_edges() -> None:
+    task_payload = {
+        "steps": [{"id": "plan", "instructions": "Plan."}],
+        "edges": [],
+    }
+
+    _normalize_task_steps(task_payload)
+
+    assert "edges" not in task_payload
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -312,6 +312,41 @@ def test_promote_proposal_uses_first_non_empty_instruction_line_for_title(
     call_kwargs = execution_service.create_execution.await_args.kwargs
     assert call_kwargs["title"] == "First line with spaces"
 
+def test_promote_proposal_rejects_stale_step_graph_metadata(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, execution_service = client
+    proposal = _build_proposal()
+    final_request = {
+        "payload": {
+            "repository": "Moon/Repo",
+            "workflow": {
+                "instructions": "Run ordered steps.",
+                "steps": [
+                    {
+                        "id": "implement",
+                        "instructions": "Implement.",
+                        "dependsOn": ["plan"],
+                    },
+                    {"id": "plan", "instructions": "Plan."},
+                ],
+            },
+        }
+    }
+    service.promote_proposal.return_value = (proposal, final_request)
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/promote",
+        json={"priority": 5},
+    )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "invalid_execution_request"
+    assert "workflow.steps[].dependsOn" in detail["message"]
+    assert "ordered by their steps[] position" in detail["message"]
+    execution_service.create_execution.assert_not_awaited()
+
 def test_promote_proposal_rejects_workflow_create_request_override(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -53,24 +53,42 @@ def test_task_skills_accepts_valid_properties() -> None:
     assert spec.skills.materialization_mode == "hybrid"
 
 
-def test_authoritative_snapshot_preserves_explicit_empty_dependencies() -> None:
+def test_mm842_authoritative_snapshot_omits_authored_step_graph_metadata() -> None:
     snapshot = build_authoritative_workflow_input_snapshot(
         task_payload={
-            "instructions": "Run MM-639 without dependencies.",
-            "dependencies": [],
+            "instructions": "Run MM-842 as ordered steps.",
             "steps": [
                 {
-                    "id": "step-1",
-                    "instructions": "Use the explicit empty dependency list.",
+                    "id": "plan",
+                    "instructions": "Plan the change.",
                     "dependsOn": [],
-                }
+                    "dependencies": [],
+                },
+                {
+                    "id": "implement",
+                    "instructions": "Implement the change.",
+                    "dependsOn": ["plan"],
+                    "dependencies": ["plan"],
+                },
             ],
         },
-        dependency_declarations=["MM-638"],
+        dependency_declarations=["mm:upstream-workflow"],
     )
 
-    assert snapshot["dependencyDeclarations"] == []
-    assert snapshot["steps"][0]["dependencies"] == []
+    assert [step["id"] for step in snapshot["steps"]] == ["plan", "implement"]
+    assert [step["instructions"] for step in snapshot["steps"]] == [
+        "Plan the change.",
+        "Implement the change.",
+    ]
+    assert snapshot["finalSubmittedOrder"] == [
+        {"stepId": "plan", "ordinal": 0},
+        {"stepId": "implement", "ordinal": 1},
+    ]
+    assert "dependencies" not in snapshot["steps"][0]
+    assert "dependencies" not in snapshot["steps"][1]
+    assert "dependsOn" not in snapshot["steps"][0]
+    assert "dependsOn" not in snapshot["steps"][1]
+    assert snapshot["dependencyDeclarations"] == ["mm:upstream-workflow"]
 
 
 def test_authoritative_snapshot_detects_jira_key_without_serializing_metadata() -> None:


### PR DESCRIPTION
## Jira
MM-842: Remove Step DAG

## MoonSpec
Active feature path: `specs/001-remove-step-dag`

## Verification
Verdict: `FULLY_IMPLEMENTED`

Latest post-remediation MoonSpec verification report confirmed:
- Spec: `/work/agent_jobs/mm:02a4db72-078a-4c36-8206-ef7a213ab0c9/repo/specs/001-remove-step-dag/spec.md`
- Confidence: HIGH
- Remaining work: none required before closure

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS (`6287 passed, 6 skipped, 1 xpassed`; Vitest: `428 passed, 234 skipped`)
- `./tools/test_integration.sh` - PASS (`334 passed, 1 skipped, 82 deselected`)

## Doc Reconciliation
Outcome from `artifacts/jira-orchestrate-doc-reconcile.json`: `no_update_required`.

Updated canonical doc paths: none.

No-update rationale: `specs/001-remove-step-dag/spec.md` records no canonical `docs/` source document, the latest MM-842 MoonSpec verification report found no definite source-document drift, and no `artifacts/doc-discoveries/001-remove-step-dag.json` ledger was present. Under the active doc reconciliation gate, no canonical docs may be edited.

Escalation Jira issue key: none.

## Remaining Risks
None known beyond normal CI validation on the pull request.
