### PR TITLE
[codex] Bound Jira blocker wait history growth

### DIFF
--- a/docs/Steps/JiraIntegration.md
+++ b/docs/Steps/JiraIntegration.md
@@ -50,6 +50,20 @@ MoonMind should support Jira in three complementary ways:
    - Merge automation may transition or comment on a Jira issue through trusted Jira activities.
    - Publishing and post-merge completion use exact issue references, not fuzzy issue guessing.
 
+### 2.1 Jira blocker wait history
+
+Trusted Jira blocker checks may wait for external Jira state to change for
+minutes or hours. These waits must follow the Temporal history-management policy
+in [`docs/Temporal/TemporalArchitecture.md`](../Temporal/TemporalArchitecture.md#17-continue-as-new-and-history-management).
+
+In particular, repeated `jira.check_blockers` rechecks must use compact inputs
+containing the target issue key and blocker-link options, not the original
+prompt, large previous outputs, or full step context. The workflow should record
+the first blocked observation, meaningful blocker-state changes, operator
+actions, and the final unblocked or terminal outcome. Unchanged "still blocked"
+samples should be coalesced into bounded current-state metadata instead of
+creating a full artifact and step-attempt record every polling cycle.
+
 ---
 
 ## 3. Non-Negotiable Security Rule

--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -875,6 +875,29 @@ Use it for:
 - explicit reruns that preserve durable identity
 - history growth approaching configured thresholds
 
+Long waits must also avoid creating high-cardinality no-op history before
+Continue-As-New is needed. A wait or polling loop whose domain state has not
+changed should coalesce evidence instead of recording each identical
+observation as a full step attempt.
+
+For unchanged wait cycles:
+
+- preserve the first blocked/waiting observation,
+- preserve the latest observation in compact workflow state,
+- record durable artifacts only for state transitions, terminal outcomes,
+  explicit operator actions, and coarse periodic checkpoints,
+- keep repeated activity inputs compact and free of large previous outputs,
+  prompts, logs, or instructions,
+- avoid memo and Search Attribute upserts on every internal polling tick,
+- avoid per-cycle step-attempt manifests unless a real re-execution attempt or
+  externally visible state transition occurred.
+
+The workflow history is not an evidence store for every "still waiting" sample.
+Detailed repeated observations belong in bounded projection state or external
+artifacts written at controlled intervals. Temporal history should contain the
+commands required to replay the workflow and enough compact state to explain the
+current wait.
+
 Rules:
 
 - preserve Workflow ID

--- a/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
@@ -413,6 +413,18 @@ Continue-As-New must preserve:
 - stable business correlation identifiers
 - any durable request context needed for safe retry/resume
 
+Each workflow type that can wait or poll repeatedly must define:
+
+- the wait-cycle or history threshold that triggers automatic Continue-As-New,
+- the compact carry-forward model used after continuation,
+- which no-op observations are coalesced instead of written as full step
+  attempts,
+- which state changes still require artifacts, memo updates, Search Attribute
+  updates, or step-ledger updates,
+- how the UI and diagnostics show first-observed, latest-observed, and terminal
+  wait evidence without requiring every unchanged poll to remain in workflow
+  history.
+
 ---
 
 ## 9. Timeouts and retry posture

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -353,6 +353,7 @@ RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release
 RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
 RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH = "run-blocked-outcome-short-circuit-v1"
 RUN_JIRA_BLOCKER_RECHECK_PATCH = "run-jira-blocker-recheck-v1"
+RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH = "run-jira-blocker-wait-coalescing-v1"
 # Replay-stable patch id for the v2 workflow-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
@@ -6309,6 +6310,7 @@ class MoonMindRunWorkflow:
         if self._jira_blocker_wait_started_at is None:
             self._jira_blocker_wait_started_at = workflow.now()
         signature = self._jira_blocker_wait_signature(execution_result)
+        coalesce_wait = workflow.patched(RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH)
         should_publish = (
             not self._jira_blocker_wait_active
             or signature != self._jira_blocker_wait_published_signature
@@ -6319,9 +6321,10 @@ class MoonMindRunWorkflow:
         self._jira_blocker_wait_summary = summary
         self._waiting_reason = "jira_blocker_wait"
         self._attention_required = False
-        if not should_publish:
+        if coalesce_wait and not should_publish:
             return
-        self._jira_blocker_wait_published_signature = signature
+        if coalesce_wait:
+            self._jira_blocker_wait_published_signature = signature
         self._set_state(STATE_WAITING_ON_DEPENDENCIES, summary=summary)
         self._mark_step_waiting(
             node_id,
@@ -6467,9 +6470,26 @@ class MoonMindRunWorkflow:
                 break
 
             recheck_count += 1
+            coalesce_wait = workflow.patched(RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH)
+            if not coalesce_wait:
+                self._clear_jira_blocker_wait()
             await self._wait_if_paused_at_safe_boundary()
             if self._cancel_requested:
                 return current_result, skipped
+            if not coalesce_wait:
+                self._set_state(STATE_EXECUTING, summary="Re-checking Jira blockers.")
+                self._mark_step_running(
+                    node_id,
+                    updated_at=workflow.now(),
+                    summary=f"Re-checking Jira blockers for {tool_name}",
+                    increment_attempt=False,
+                )
+                await self._record_step_execution_manifest(
+                    node_id,
+                    phase="start",
+                    updated_at=workflow.now(),
+                    reason="policy_revalidation",
+                )
             recheck_attempt = self._step_execution_for(node_id) or 0
             if self._is_step_execution_launch_blocked(
                 node_id,
@@ -6543,9 +6563,12 @@ class MoonMindRunWorkflow:
                     raise ValueError(
                         "skill Jira blocker recheck requires activity context"
                     )
-                recheck_payload = self._compact_jira_blocker_recheck_payload(
-                    execute_payload
-                )
+                if coalesce_wait:
+                    recheck_payload = self._compact_jira_blocker_recheck_payload(
+                        execute_payload
+                    )
+                else:
+                    recheck_payload = dict(execute_payload)
                 idempotency_key = recheck_payload.get("idempotency_key")
                 if isinstance(idempotency_key, str) and idempotency_key.strip():
                     recheck_payload["idempotency_key"] = (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -750,6 +750,7 @@ class MoonMindRunWorkflow:
         self._jira_blocker_wait_started_at: datetime | None = None
         self._jira_blocker_wait_issue_keys: list[str] = []
         self._jira_blocker_wait_summary: str | None = None
+        self._jira_blocker_wait_published_signature: str | None = None
 
         # Action flags
         self._cancel_requested = False
@@ -6181,6 +6182,120 @@ class MoonMindRunWorkflow:
         )
         return [target_issue_key] if target_issue_key else []
 
+    def _jira_blocker_wait_signature(self, execution_result: Any) -> str:
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return ""
+        blockers = outputs.get("blockingIssues")
+        if blockers is None:
+            blockers = outputs.get("blocking_issues")
+        compact_blockers: list[dict[str, Any]] = []
+        if isinstance(blockers, Sequence) and not isinstance(blockers, (str, bytes)):
+            for blocker in blockers:
+                if not isinstance(blocker, Mapping):
+                    continue
+                compact_blockers.append(
+                    {
+                        "issueKey": self._coerce_text(
+                            blocker.get("issueKey") or blocker.get("issue_key"),
+                            max_chars=80,
+                        ),
+                        "status": self._coerce_text(
+                            blocker.get("status"),
+                            max_chars=80,
+                        ),
+                        "statusKnown": bool(
+                            blocker.get("statusKnown")
+                            if "statusKnown" in blocker
+                            else blocker.get("status_known")
+                        ),
+                        "done": bool(blocker.get("done")),
+                    }
+                )
+        return json.dumps(
+            {
+                "decision": self._coerce_text(outputs.get("decision"), max_chars=40),
+                "targetIssueKey": self._coerce_text(
+                    outputs.get("targetIssueKey")
+                    or outputs.get("target_issue_key")
+                    or outputs.get("issueKey")
+                    or outputs.get("jiraIssueKey"),
+                    max_chars=80,
+                ),
+                "blockingIssues": sorted(
+                    compact_blockers,
+                    key=lambda item: str(item.get("issueKey") or ""),
+                ),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def _compact_jira_blocker_recheck_payload(
+        self,
+        execute_payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        invocation_payload = execute_payload.get("invocation_payload")
+        if not isinstance(invocation_payload, Mapping):
+            return dict(execute_payload)
+        original_inputs = invocation_payload.get("inputs")
+        if not isinstance(original_inputs, Mapping):
+            return dict(execute_payload)
+
+        def first_text(*values: Any) -> str | None:
+            for value in values:
+                text = self._coerce_text(value, max_chars=120)
+                if text:
+                    return text
+            return None
+
+        nested = original_inputs.get("blockerPreflight")
+        if not isinstance(nested, Mapping):
+            nested = original_inputs.get("blocker_preflight")
+        if not isinstance(nested, Mapping):
+            nested = original_inputs.get("jira")
+        if not isinstance(nested, Mapping):
+            nested = {}
+
+        target_issue_key = first_text(
+            original_inputs.get("targetIssueKey"),
+            original_inputs.get("target_issue_key"),
+            original_inputs.get("issueKey"),
+            original_inputs.get("issue_key"),
+            original_inputs.get("jiraIssueKey"),
+            original_inputs.get("jira_issue_key"),
+            nested.get("targetIssueKey"),
+            nested.get("target_issue_key"),
+            nested.get("issueKey"),
+            nested.get("issue_key"),
+        )
+        if not target_issue_key:
+            return dict(execute_payload)
+
+        link_type = first_text(
+            original_inputs.get("linkType"),
+            original_inputs.get("link_type"),
+            nested.get("linkType"),
+            nested.get("link_type"),
+        )
+        compact_inputs: dict[str, Any] = {"targetIssueKey": target_issue_key}
+        blocker_preflight: dict[str, Any] = {"targetIssueKey": target_issue_key}
+        if link_type:
+            blocker_preflight["linkType"] = link_type
+            compact_inputs["linkType"] = link_type
+        compact_inputs["blockerPreflight"] = blocker_preflight
+
+        compact_invocation = {
+            key: value
+            for key, value in invocation_payload.items()
+            if key not in {"inputs", "previousOutputs", "previous_outputs"}
+        }
+        compact_invocation["inputs"] = compact_inputs
+
+        compact_payload = dict(execute_payload)
+        compact_payload["invocation_payload"] = compact_invocation
+        return compact_payload
+
     def _enter_jira_blocker_wait(
         self,
         *,
@@ -6193,12 +6308,20 @@ class MoonMindRunWorkflow:
         issue_keys = self._jira_blocker_issue_keys(execution_result)
         if self._jira_blocker_wait_started_at is None:
             self._jira_blocker_wait_started_at = workflow.now()
+        signature = self._jira_blocker_wait_signature(execution_result)
+        should_publish = (
+            not self._jira_blocker_wait_active
+            or signature != self._jira_blocker_wait_published_signature
+        )
         self._jira_blocker_wait_active = True
         self._jira_blocker_wait_skipped = False
         self._jira_blocker_wait_issue_keys = issue_keys
         self._jira_blocker_wait_summary = summary
         self._waiting_reason = "jira_blocker_wait"
         self._attention_required = False
+        if not should_publish:
+            return
+        self._jira_blocker_wait_published_signature = signature
         self._set_state(STATE_WAITING_ON_DEPENDENCIES, summary=summary)
         self._mark_step_waiting(
             node_id,
@@ -6215,6 +6338,7 @@ class MoonMindRunWorkflow:
         self._jira_blocker_wait_started_at = None
         self._jira_blocker_wait_issue_keys = []
         self._jira_blocker_wait_summary = None
+        self._jira_blocker_wait_published_signature = None
         if self._waiting_reason == "jira_blocker_wait":
             self._waiting_reason = None
         self._attention_required = False
@@ -6343,23 +6467,9 @@ class MoonMindRunWorkflow:
                 break
 
             recheck_count += 1
-            self._clear_jira_blocker_wait()
             await self._wait_if_paused_at_safe_boundary()
             if self._cancel_requested:
                 return current_result, skipped
-            self._set_state(STATE_EXECUTING, summary="Re-checking Jira blockers.")
-            self._mark_step_running(
-                node_id,
-                updated_at=workflow.now(),
-                summary=f"Re-checking Jira blockers for {tool_name}",
-                increment_attempt=False,
-            )
-            await self._record_step_execution_manifest(
-                node_id,
-                phase="start",
-                updated_at=workflow.now(),
-                reason="policy_revalidation",
-            )
             recheck_attempt = self._step_execution_for(node_id) or 0
             if self._is_step_execution_launch_blocked(
                 node_id,
@@ -6433,7 +6543,9 @@ class MoonMindRunWorkflow:
                     raise ValueError(
                         "skill Jira blocker recheck requires activity context"
                     )
-                recheck_payload = dict(execute_payload)
+                recheck_payload = self._compact_jira_blocker_recheck_payload(
+                    execute_payload
+                )
                 idempotency_key = recheck_payload.get("idempotency_key")
                 if isinstance(idempotency_key, str) and idempotency_key.strip():
                     recheck_payload["idempotency_key"] = (

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -7,6 +7,11 @@ from typing import Any, Callable
 import pytest
 
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
+from moonmind.workflows.temporal.activity_catalog import (
+    TemporalActivityRetries,
+    TemporalActivityRoute,
+    TemporalActivityTimeouts,
+)
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 def _normalize_payload(payload: Any) -> dict[str, Any]:
@@ -1096,6 +1101,306 @@ async def test_jira_blocker_recheck_wait_honors_pause_before_activity(
     assert workflow._jira_blocker_wait_started_at is None
     assert workflow._jira_blocker_wait_issue_keys == []
     assert workflow._jira_blocker_wait_summary is None
+
+
+def test_compact_jira_blocker_recheck_payload_strips_large_context() -> None:
+    workflow = MoonMindRunWorkflow()
+    payload = {
+        "registry_snapshot_ref": "art_registry",
+        "principal": "owner-1",
+        "invocation_payload": {
+            "id": "check-blockers",
+            "tool": {
+                "type": "skill",
+                "name": "jira.check_blockers",
+                "version": "1.0",
+            },
+            "skill": {"name": "jira.check_blockers", "version": "1.0"},
+            "inputs": {
+                "targetIssueKey": "MM-686",
+                "blockerPreflight": {
+                    "targetIssueKey": "MM-686",
+                    "linkType": "Blocks",
+                },
+                "instructions": "large prompt" * 100,
+                "previousOutputs": {"summary": "large previous output" * 100},
+            },
+            "options": {"dryRun": False},
+        },
+        "context": {
+            "namespace": "default",
+            "workflow_id": "wf-1",
+            "run_id": "run-1",
+            "node_id": "check-blockers",
+        },
+        "idempotency_key": "base-key",
+    }
+
+    compact = workflow._compact_jira_blocker_recheck_payload(payload)
+
+    invocation = compact["invocation_payload"]
+    assert invocation["tool"] == payload["invocation_payload"]["tool"]
+    assert invocation["skill"] == payload["invocation_payload"]["skill"]
+    assert invocation["options"] == payload["invocation_payload"]["options"]
+    assert invocation["inputs"] == {
+        "targetIssueKey": "MM-686",
+        "blockerPreflight": {
+            "targetIssueKey": "MM-686",
+            "linkType": "Blocks",
+        },
+        "linkType": "Blocks",
+    }
+    assert "previousOutputs" not in invocation["inputs"]
+    assert "instructions" not in invocation["inputs"]
+    assert compact["registry_snapshot_ref"] == "art_registry"
+    assert compact["principal"] == "owner-1"
+    assert compact["context"] == payload["context"]
+
+
+def test_jira_blocker_wait_coalesces_unchanged_observations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    published: list[str] = []
+    waiting_rows: list[str] = []
+    metadata_updates: list[str] = []
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "blockingIssues": [
+                {"issueKey": "MM-685", "status": "In Progress", "done": False}
+            ],
+            "summary": "MM-686 is blocked by MM-685.",
+        },
+    }
+    changed_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "blockingIssues": [
+                {"issueKey": "MM-685", "status": "Review", "done": False}
+            ],
+            "summary": "MM-686 is still blocked by MM-685.",
+        },
+    }
+
+    def fake_set_state(self: MoonMindRunWorkflow, state: str, summary: str) -> None:
+        self._state = state
+        self._summary = summary
+        published.append(summary)
+
+    def fake_mark_waiting(
+        _logical_step_id: str,
+        **kwargs: Any,
+    ) -> None:
+        waiting_rows.append(str(kwargs.get("summary") or ""))
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_set_state", fake_set_state)
+    monkeypatch.setattr(workflow, "_mark_step_waiting", fake_mark_waiting)
+    monkeypatch.setattr(
+        workflow,
+        "_update_search_attributes",
+        lambda: metadata_updates.append("search"),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "_update_memo",
+        lambda: metadata_updates.append("memo"),
+    )
+
+    workflow._enter_jira_blocker_wait(
+        node_id="check-blockers",
+        execution_result=blocked_result,
+    )
+    workflow._enter_jira_blocker_wait(
+        node_id="check-blockers",
+        execution_result=blocked_result,
+    )
+    workflow._enter_jira_blocker_wait(
+        node_id="check-blockers",
+        execution_result=changed_result,
+    )
+
+    assert published == [
+        "Workflow blocked by plan step: MM-686 is blocked by MM-685.",
+        "Workflow blocked by plan step: MM-686 is still blocked by MM-685.",
+    ]
+    assert waiting_rows == published
+    assert metadata_updates == ["search", "memo", "search", "memo"]
+
+
+@pytest.mark.asyncio
+async def test_jira_blocker_wait_rechecks_with_compact_payload_and_no_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    captured_payloads: list[dict[str, Any]] = []
+    manifest_calls = 0
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "blockingIssues": [
+                {"issueKey": "MM-685", "status": "In Progress", "done": False}
+            ],
+            "summary": "MM-686 is blocked by MM-685.",
+        },
+    }
+    continue_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "continue",
+            "blockingIssues": [],
+            "summary": "All Jira blockers are Done.",
+        },
+    }
+    execute_payload = {
+        "registry_snapshot_ref": "art_registry",
+        "principal": "owner-1",
+        "invocation_payload": {
+            "id": "check-blockers",
+            "tool": {
+                "type": "skill",
+                "name": "jira.check_blockers",
+                "version": "1.0",
+            },
+            "skill": {"name": "jira.check_blockers", "version": "1.0"},
+            "inputs": {
+                "targetIssueKey": "MM-686",
+                "blockerPreflight": {
+                    "targetIssueKey": "MM-686",
+                    "linkType": "Blocks",
+                },
+                "instructions": "large prompt" * 100,
+                "previousOutputs": {"summary": "large previous output" * 100},
+            },
+            "options": {},
+        },
+        "context": {
+            "namespace": "default",
+            "workflow_id": "wf-1",
+            "run_id": "run-1",
+            "node_id": "check-blockers",
+        },
+        "idempotency_key": "base-key",
+    }
+    route = TemporalActivityRoute(
+        activity_type="mm.tool.execute",
+        task_queue="mm.activity.integrations",
+        fleet="integrations",
+        capability_class="tools",
+        timeouts=TemporalActivityTimeouts(
+            start_to_close_seconds=30,
+            schedule_to_close_seconds=30,
+        ),
+        retries=TemporalActivityRetries(max_attempts=1, max_interval_seconds=1),
+    )
+
+    async def fake_execute_activity(
+        _activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured_payloads.append(_normalize_payload(payload))
+        return blocked_result if len(captured_payloads) == 1 else continue_result
+
+    async def fake_record_manifest(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal manifest_calls
+        manifest_calls += 1
+
+    async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _timeout_wait_condition,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: type(
+            "WorkflowInfo",
+            (),
+            {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+        )(),
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_record_step_execution_manifest",
+        fake_record_manifest,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_noop_async,
+    )
+
+    result, skipped = await workflow._wait_for_jira_blocker_resolution(
+        execution_result=blocked_result,
+        node_id="check-blockers",
+        tool_name="jira.check_blockers",
+        tool_type="skill",
+        failure_mode="FAIL_FAST",
+        route=route,
+        execute_payload=execute_payload,
+    )
+
+    assert skipped is False
+    assert result == continue_result
+    assert manifest_calls == 0
+    assert len(captured_payloads) == 2
+    for index, payload in enumerate(captured_payloads, start=1):
+        inputs = payload["invocation_payload"]["inputs"]
+        assert inputs == {
+            "targetIssueKey": "MM-686",
+            "blockerPreflight": {
+                "targetIssueKey": "MM-686",
+                "linkType": "Blocks",
+            },
+            "linkType": "Blocks",
+        }
+        assert "previousOutputs" not in inputs
+        assert "instructions" not in inputs
+        assert payload["idempotency_key"] == (
+            f"base-key_jira_blocker_recheck_{index}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1203,6 +1203,14 @@ def test_jira_blocker_wait_coalesces_unchanged_observations(
         "now",
         lambda: datetime.now(timezone.utc),
     )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id
+            == run_workflow_module.RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH
+        ),
+    )
     monkeypatch.setattr(MoonMindRunWorkflow, "_set_state", fake_set_state)
     monkeypatch.setattr(workflow, "_mark_step_waiting", fake_mark_waiting)
     monkeypatch.setattr(
@@ -1235,6 +1243,58 @@ def test_jira_blocker_wait_coalesces_unchanged_observations(
     ]
     assert waiting_rows == published
     assert metadata_updates == ["search", "memo", "search", "memo"]
+
+
+def test_jira_blocker_wait_unpatched_histories_publish_each_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    published: list[str] = []
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "blockingIssues": [
+                {"issueKey": "MM-685", "status": "In Progress", "done": False}
+            ],
+            "summary": "MM-686 is blocked by MM-685.",
+        },
+    }
+
+    def fake_set_state(self: MoonMindRunWorkflow, state: str, summary: str) -> None:
+        self._state = state
+        self._summary = summary
+        published.append(summary)
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_set_state", fake_set_state)
+    monkeypatch.setattr(workflow, "_mark_step_waiting", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(workflow, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(workflow, "_update_memo", lambda: None)
+
+    workflow._enter_jira_blocker_wait(
+        node_id="check-blockers",
+        execution_result=blocked_result,
+    )
+    workflow._enter_jira_blocker_wait(
+        node_id="check-blockers",
+        execution_result=blocked_result,
+    )
+
+    assert published == [
+        "Workflow blocked by plan step: MM-686 is blocked by MM-685.",
+        "Workflow blocked by plan step: MM-686 is blocked by MM-685.",
+    ]
 
 
 @pytest.mark.asyncio
@@ -1350,16 +1410,22 @@ async def test_jira_blocker_wait_rechecks_with_compact_payload_and_no_manifest(
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "patched",
-        lambda _patch_id: False,
+        lambda patch_id: (
+            patch_id
+            == run_workflow_module.RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH
+        ),
     )
-    monkeypatch.setattr(
-        run_workflow_module.workflow,
-        "info",
-        lambda: type(
+    def fake_workflow_info() -> Any:
+        return type(
             "WorkflowInfo",
             (),
             {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
-        )(),
+        )()
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        fake_workflow_info,
     )
     monkeypatch.setattr(
         MoonMindRunWorkflow,


### PR DESCRIPTION
## Summary
- document Temporal history-management rules for long wait/poll loops and Jira blocker rechecks
- compact repeated `jira.check_blockers` recheck payloads so workflow history no longer stores large prior outputs/prompts every cycle
- coalesce unchanged Jira blocker wait observations and stop writing a step execution manifest for every unchanged recheck

## Root Cause
Jira blocker waits were rechecking every 30 seconds while recording large repeated `mm.tool.execute` payloads, memo/search updates, and step manifest artifacts. Long waits could exceed Temporal workflow history size limits before blockers resolved.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py -q -k 'jira_blocker_wait_coalesces_unchanged_observations or compact_jira_blocker_recheck_payload or jira_blocker_wait_rechecks_with_compact_payload'`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py -q`
- `./tools/test_unit.sh`
