### PR TITLE
[codex] Allow pasted story breakdown Jira output

### DIFF
--- a/docs/Workflows/SkillAndPlanContracts.md
+++ b/docs/Workflows/SkillAndPlanContracts.md
@@ -538,12 +538,16 @@ items and do not create Jira issues. Stories marked
 reports `skippedStories`, `blockedStories`, and `partialStoriesAdjusted` so
 downstream orchestration can create follow-up work only for returned Jira issue mappings.
 
-For breakdown-driven Jira output, the canonical traceability shape is
-`sourceReference.path` on every story, with `source.referencePath` or
-`source.path` as a breakdown-level fallback. The tool also accepts path-only
-generated forms, `sourceReference: "<path>"` and top-level
-`sourceDocument: "<path>"`, and normalizes those before validating that no Jira
-mutation can occur without a source document path.
+For breakdown-driven Jira output derived from a source document, the canonical
+traceability shape is `sourceReference.path` on every story, with
+`source.referencePath` or `source.path` as a breakdown-level fallback. The tool
+also accepts path-only generated forms, `sourceReference: "<path>"` and
+top-level `sourceDocument: "<path>"`, and normalizes those before Jira issue
+creation. Direct pasted declarative text is also valid input: if no source
+document path exists, Jira creation proceeds and issue mappings report an empty
+`sourceDesignPath`. Callers that require every Jira issue to carry document
+traceability must set `sourceReferencePolicy: "required"` on the tool inputs or
+`storyOutput`.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `artifacts/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 

--- a/docs/Workflows/SkillAndPlanContracts.md
+++ b/docs/Workflows/SkillAndPlanContracts.md
@@ -547,7 +547,9 @@ creation. Direct pasted declarative text is also valid input: if no source
 document path exists, Jira creation proceeds and issue mappings report an empty
 `sourceDesignPath`. Callers that require every Jira issue to carry document
 traceability must set `sourceReferencePolicy: "required"` on the tool inputs or
-`storyOutput`.
+`storyOutput`. The policy also accepts booleans and standard truthy/falsy
+strings such as `"true"` and `"false"` for callers that produce typed or form
+encoded payloads.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `artifacts/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -814,13 +814,27 @@ def _requires_story_source_reference(
     story_output: Mapping[str, Any],
     fallback_path: str,
 ) -> bool:
-    raw_policy = _string(
-        story_output.get("sourceReferencePolicy")
-        or story_output.get("source_reference_policy")
-        or inputs.get("sourceReferencePolicy")
-        or inputs.get("source_reference_policy")
-    ).lower()
+    raw_value = None
+    policy_provided = False
+    for container in (story_output, inputs):
+        for key in ("sourceReferencePolicy", "source_reference_policy"):
+            if key in container:
+                raw_value = container.get(key)
+                policy_provided = True
+                break
+        if policy_provided:
+            break
+    if raw_value is None:
+        return bool(fallback_path)
+    if isinstance(raw_value, bool):
+        return raw_value
+
+    raw_policy = str(raw_value).strip().lower()
     if raw_policy in {
+        "true",
+        "yes",
+        "1",
+        "on",
         "require",
         "required",
         "source_required",
@@ -829,6 +843,10 @@ def _requires_story_source_reference(
     }:
         return True
     if raw_policy in {
+        "false",
+        "no",
+        "0",
+        "off",
         "allow_missing",
         "inline",
         "optional",
@@ -1951,10 +1969,7 @@ async def create_jira_issues_from_stories(
             )
         raise ValueError(reason)
 
-    story_breakdown_path = _string(
-        inputs.get("storyBreakdownPath") or story_output.get("storyBreakdownPath")
-    )
-    if story_breakdown_path and _requires_story_source_reference(
+    if _requires_story_source_reference(
         inputs=inputs,
         story_output=story_output,
         fallback_path=breakdown_source_path,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -808,6 +808,37 @@ def _missing_source_reference_story_ids(
             missing.append(_story_id(story, index=index))
     return missing
 
+def _requires_story_source_reference(
+    *,
+    inputs: Mapping[str, Any],
+    story_output: Mapping[str, Any],
+    fallback_path: str,
+) -> bool:
+    raw_policy = _string(
+        story_output.get("sourceReferencePolicy")
+        or story_output.get("source_reference_policy")
+        or inputs.get("sourceReferencePolicy")
+        or inputs.get("source_reference_policy")
+    ).lower()
+    if raw_policy in {
+        "require",
+        "required",
+        "source_required",
+        "source-reference-required",
+        "source_reference_required",
+    }:
+        return True
+    if raw_policy in {
+        "allow_missing",
+        "inline",
+        "optional",
+        "source_optional",
+        "source-reference-optional",
+        "source_reference_optional",
+    }:
+        return False
+    return bool(fallback_path)
+
 def _story_description_with_source(
     story: Mapping[str, Any],
     *,
@@ -1923,7 +1954,11 @@ async def create_jira_issues_from_stories(
     story_breakdown_path = _string(
         inputs.get("storyBreakdownPath") or story_output.get("storyBreakdownPath")
     )
-    if story_breakdown_path:
+    if story_breakdown_path and _requires_story_source_reference(
+        inputs=inputs,
+        story_output=story_output,
+        fallback_path=breakdown_source_path,
+    ):
         missing_source_ids = _missing_source_reference_story_ids(
             stories,
             fallback_path=breakdown_source_path,

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -794,12 +794,38 @@ async def test_create_jira_issues_preserves_source_reference_when_description_tr
     assert request.description.endswith("[Truncated by MoonMind before Jira export]")
 
 @pytest.mark.asyncio
-async def test_create_jira_issues_blocks_story_breakdown_without_source_reference():
+async def test_create_jira_issues_accepts_pasted_story_breakdown_without_source_reference():
     service = _FakeJiraService()
 
     result = await create_jira_issues_from_stories(
         {
             "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            },
+            "stories": [{"id": "STORY-001", "summary": "No source"}],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert result.outputs["jira"]["issueMappings"][0]["sourceDesignPath"] == ""
+    assert len(service.requests) == 1
+    assert not service.requests[0].description.startswith("Source Reference")
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_blocks_story_breakdown_when_source_reference_required():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "sourceReferencePolicy": "required",
             "storyOutput": {
                 "mode": "jira",
                 "jira": {

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -824,7 +824,6 @@ async def test_create_jira_issues_blocks_story_breakdown_when_source_reference_r
 
     result = await create_jira_issues_from_stories(
         {
-            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
             "sourceReferencePolicy": "required",
             "storyOutput": {
                 "mode": "jira",
@@ -843,6 +842,28 @@ async def test_create_jira_issues_blocks_story_breakdown_when_source_reference_r
     assert result.outputs["storyOutput"]["status"] == "fallback"
     assert "requires sourceReference.path" in result.outputs["storyOutput"]["reason"]
     assert "STORY-001" in result.outputs["storyOutput"]["reason"]
+
+@pytest.mark.parametrize("policy", [True, "true", "yes", "1", "on"])
+def test_requires_story_source_reference_accepts_truthy_policy_values(policy):
+    assert (
+        story_tools._requires_story_source_reference(
+            inputs={"sourceReferencePolicy": policy},
+            story_output={},
+            fallback_path="",
+        )
+        is True
+    )
+
+@pytest.mark.parametrize("policy", [False, "false", "no", "0", "off"])
+def test_requires_story_source_reference_accepts_falsy_policy_values(policy):
+    assert (
+        story_tools._requires_story_source_reference(
+            inputs={},
+            story_output={"sourceReferencePolicy": policy},
+            fallback_path="docs/Designs/RuntimeTypes.md",
+        )
+        is False
+    )
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_accepts_string_source_reference_from_breakdown():


### PR DESCRIPTION
## Summary

This PR fixes Jira story creation for MoonSpec breakdown workflows whose declarative design was pasted directly into the task instead of coming from a docs path.

## Root Cause

`story.create_jira_issues` treated any payload with `storyBreakdownPath` as document-derived and required every story to include `sourceReference.path` or a breakdown-level `source.referencePath`. Pasted declarative text has no canonical source document path, so valid inline/artifact-backed breakdowns failed before Jira issue creation.

## Changes

- Adds `sourceReferencePolicy` handling so source document traceability can be explicitly required when needed.
- Allows pasted/direct breakdowns with no source document path to create Jira issues, preserving an empty `sourceDesignPath` in issue mappings.
- Updates unit coverage and the tool contract docs for direct pasted declarative text.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`
- Full Python unit suite via `./tools/test_unit.sh`: `6297 passed`

Note: the full wrapper still reports an unrelated frontend LiveLogsPanel Vitest failure where mocked live-log content does not appear; no frontend files are changed in this PR.