### PR TITLE
Reject generated Jira PR head as base branch

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5707,6 +5707,38 @@ def _resolve_workflow_publish_payload(
     resolved["mode"] = publish_mode
     return resolved
 
+_GENERATED_JIRA_PR_HEAD_BRANCH_RE = re.compile(
+    r"^moonmind/jira-(?:orchestrate|implement)-[a-z][a-z0-9]*-\d+(?:[-_].*)?$",
+    re.IGNORECASE,
+)
+
+
+def _validate_pr_base_branch_submission(
+    *,
+    publish_payload: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+    git_payload: Mapping[str, Any],
+) -> None:
+    if str(publish_payload.get("mode") or "").strip().lower() != "pr":
+        return
+
+    branch = str(
+        git_payload.get("branch")
+        or git_payload.get("startingBranch")
+        or task_payload.get("branch")
+        or task_payload.get("startingBranch")
+        or ""
+    ).strip()
+    if not branch:
+        return
+
+    if _GENERATED_JIRA_PR_HEAD_BRANCH_RE.match(branch):
+        raise _invalid_workflow_request(
+            "payload.workflow.git.branch is the PR base branch for publishMode 'pr', "
+            "but it looks like a generated Jira work/head branch. Use an existing "
+            "base branch such as 'main'; MoonMind creates the PR head branch separately."
+        )
+
 def _normalize_merge_automation_payload(raw_merge_automation: Any) -> dict[str, Any]:
     return _coerce_mapping(raw_merge_automation)
 
@@ -7046,6 +7078,11 @@ async def _create_execution_from_workflow_request(
         raise _invalid_workflow_request(
             "payload.workflow.targetBranch is not supported; use payload.workflow.git.branch."
         )
+    _validate_pr_base_branch_submission(
+        publish_payload=publish_payload,
+        task_payload=task_payload,
+        git_payload=git_payload,
+    )
     if git_payload:
         normalized_git_payload: dict[str, str] = {}
         for git_key in ("startingBranch", "branch"):

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5708,36 +5708,43 @@ def _resolve_workflow_publish_payload(
     return resolved
 
 _GENERATED_JIRA_PR_HEAD_BRANCH_RE = re.compile(
-    r"^moonmind/jira-(?:orchestrate|implement)-[a-z][a-z0-9]*-\d+(?:[-_].*)?$",
+    r"^(?:moonmind/jira-(?:orchestrate|implement)-[a-z][a-z0-9]*-\d+(?:[-_].*)?|"
+    r"(?:run-)?jira-(?:orchestrate|implement)(?:-[a-z0-9]+)*-mm-\d+"
+    r"(?:-[a-z0-9]+)*(?:-[0-9a-f]{8})?)$",
     re.IGNORECASE,
 )
 
 
 def _validate_pr_base_branch_submission(
     *,
-    publish_payload: Mapping[str, Any],
-    task_payload: Mapping[str, Any],
-    git_payload: Mapping[str, Any],
+    publish_payload: Mapping[str, Any] | None,
+    task_payload: Mapping[str, Any] | None,
+    git_payload: Mapping[str, Any] | None,
 ) -> None:
-    if str(publish_payload.get("mode") or "").strip().lower() != "pr":
+    publish = publish_payload or {}
+    task = task_payload or {}
+    git = git_payload or {}
+    if str(publish.get("mode") or "").strip().lower() != "pr":
         return
 
-    branch = str(
-        git_payload.get("branch")
-        or git_payload.get("startingBranch")
-        or task_payload.get("branch")
-        or task_payload.get("startingBranch")
-        or ""
-    ).strip()
-    if not branch:
-        return
+    for field_name, value in (
+        ("payload.workflow.publish.prBaseBranch", publish.get("prBaseBranch")),
+        ("payload.workflow.publish.baseBranch", publish.get("baseBranch")),
+        ("payload.workflow.git.branch", git.get("branch")),
+        ("payload.workflow.git.startingBranch", git.get("startingBranch")),
+        ("payload.workflow.branch", task.get("branch")),
+        ("payload.workflow.startingBranch", task.get("startingBranch")),
+    ):
+        branch = str(value or "").strip()
+        if not branch:
+            continue
+        if _GENERATED_JIRA_PR_HEAD_BRANCH_RE.match(branch):
+            raise _invalid_workflow_request(
+                f"{field_name} is the PR base branch for publishMode 'pr', "
+                "but it looks like a generated Jira work/head branch. Use an existing "
+                "base branch such as 'main'; MoonMind creates the PR head branch separately."
+            )
 
-    if _GENERATED_JIRA_PR_HEAD_BRANCH_RE.match(branch):
-        raise _invalid_workflow_request(
-            "payload.workflow.git.branch is the PR base branch for publishMode 'pr', "
-            "but it looks like a generated Jira work/head branch. Use an existing "
-            "base branch such as 'main'; MoonMind creates the PR head branch separately."
-        )
 
 def _normalize_merge_automation_payload(raw_merge_automation: Any) -> dict[str, Any]:
     return _coerce_mapping(raw_merge_automation)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2348,6 +2348,69 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_pr_publish(
     assert initial_parameters["workflow"]["publish"]["mode"] == "pr"
 
 
+def test_create_task_shaped_execution_preserves_pr_base_branch(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "workflow": {
+                    "instructions": "Run Jira Orchestrate for MM-825.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "git": {"branch": "main"},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    service.create_execution.assert_awaited_once()
+    initial_parameters = service.create_execution.call_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["publishMode"] == "pr"
+    assert initial_parameters["workflow"]["git"] == {"branch": "main"}
+
+
+def test_create_task_shaped_execution_rejects_generated_jira_pr_head_as_base_branch(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "workflow": {
+                    "instructions": "Run Jira Orchestrate for MM-825.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "git": {"branch": "moonmind/jira-orchestrate-mm-825"},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "PR base branch" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_pr_publish(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2411,6 +2411,80 @@ def test_create_task_shaped_execution_rejects_generated_jira_pr_head_as_base_bra
     service.create_execution.assert_not_awaited()
 
 
+def test_create_task_shaped_execution_rejects_generated_jira_pr_head_in_publish_base(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "workflow": {
+                    "instructions": "Run Jira Orchestrate for MM-825.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "git": {"branch": "main"},
+                    "publish": {
+                        "mode": "pr",
+                        "prBaseBranch": "moonmind/jira-orchestrate-mm-825",
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert (
+        "payload.workflow.publish.prBaseBranch"
+        in response.json()["detail"]["message"]
+    )
+    service.create_execution.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "run-jira-orchestrate-for-mm-824-complete-8ad823ae",
+        "jira-implement-mm-697",
+    ],
+)
+def test_create_task_shaped_execution_rejects_runtime_generated_jira_pr_head_names(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    branch: str,
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "publishMode": "pr",
+                "workflow": {
+                    "instructions": "Run Jira Orchestrate for MM-824.",
+                    "tool": {"type": "skill", "name": "jira-orchestrate"},
+                    "runtime": {"mode": "codex"},
+                    "git": {"branch": branch},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "payload.workflow.git.branch" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_pr_publish(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:


### PR DESCRIPTION
## Summary
- reject PR-mode submissions that put generated Jira work/head branches in `workflow.git.branch`
- preserve normal PR submissions that use an existing base branch like `main`
- add API regression coverage for the failed batch pattern

## Tests
- `pytest tests/unit/api/routers/test_executions.py -q --tb=short -k "pr_base_branch or generated_jira_pr_head or jira_orchestrate_pr_publish"`
- `git diff --check`

Note: `./tools/test_unit.sh` was attempted, but with `pytest-xdist` missing it was only around 10% after an extended non-parallel run and was stopped.