### PR TITLE
[codex] Fix failed agent child finalization

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -353,6 +353,7 @@ RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release
 RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
 RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH = "run-blocked-outcome-short-circuit-v1"
 RUN_JIRA_BLOCKER_RECHECK_PATCH = "run-jira-blocker-recheck-v1"
+RUN_FAILED_RESULT_BLOCKER_PATCH = "run-failed-result-blocker-v1"
 RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH = "run-jira-blocker-wait-coalescing-v1"
 # Replay-stable patch id for the v2 workflow-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
@@ -4946,9 +4947,9 @@ class MoonMindRunWorkflow:
 
                     route = None
                     execute_payload = None
+                    child_workflow_id: str | None = None
                     if tool_type == "agent_runtime":
                         # --- Agent dispatch: child workflow ---
-                        child_workflow_id: str | None = None
                         try:
                             resolved_skillset_ref = (
                                 await self._resolve_agent_node_skillset_ref(
@@ -5212,7 +5213,10 @@ class MoonMindRunWorkflow:
 
                         diagnostics_ref = None
                         outputs = self._get_from_result(execution_result, "outputs")
-                        if isinstance(outputs, Mapping):
+                        if (
+                            isinstance(outputs, Mapping)
+                            and workflow.patched(RUN_FAILED_RESULT_BLOCKER_PATCH)
+                        ):
                             diagnostics_ref = self._coerce_text(
                                 outputs.get("diagnosticsRef")
                                 or outputs.get("diagnostics_ref"),
@@ -5229,11 +5233,7 @@ class MoonMindRunWorkflow:
                                 step_id=node_id,
                                 step_title=tool_name,
                                 message=step_failure_summary,
-                                child_workflow_id=(
-                                    child_workflow_id
-                                    if tool_type == "agent_runtime"
-                                    else None
-                                ),
+                                child_workflow_id=child_workflow_id,
                                 diagnostics_ref=diagnostics_ref,
                             )
                         self._mark_step_terminal(
@@ -5495,7 +5495,13 @@ class MoonMindRunWorkflow:
                     self._publish_reason = self._plan_blocked_message
                     self._refresh_step_readiness(updated_at=workflow.now())
                     continue
-                if result_status != "COMPLETED":
+                if (
+                    result_status != "COMPLETED"
+                    and (
+                        publish_mode in {"pr", "branch"}
+                        or workflow.patched(RUN_FAILED_RESULT_BLOCKER_PATCH)
+                    )
+                ):
                     self._plan_blocked_message = (
                         step_failure_summary
                         or self._activity_result_provider_failure_summary(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -662,6 +662,48 @@ class MoonMindRunWorkflow:
             self._failure_diagnostic = diagnostic
         return diagnostic
 
+    def _record_result_failure_diagnostic(
+        self,
+        *,
+        stage: str | None,
+        category: str | None,
+        source: str,
+        step_id: str,
+        step_title: str,
+        message: str,
+        child_workflow_id: str | None = None,
+        diagnostics_ref: str | None = None,
+    ) -> dict[str, Any]:
+        """Capture a failure diagnostic from a completed-but-failed step result."""
+
+        normalized_category = self._coerce_text(category, max_chars=80)
+        if normalized_category not in {
+            "user_error",
+            "integration_error",
+            "execution_error",
+            "system_error",
+        }:
+            normalized_category = "execution_error"
+        sanitized = self._sanitize_operator_summary(message) or message
+        diagnostic: dict[str, Any] = {
+            "stage": self._coerce_text(stage or self._state, max_chars=80),
+            "category": normalized_category,
+            "source": self._coerce_text(source, max_chars=40) or "workflow",
+            "stepId": self._coerce_text(step_id, max_chars=120),
+            "stepTitle": self._coerce_text(step_title, max_chars=200),
+            "childWorkflowId": self._coerce_text(child_workflow_id, max_chars=400),
+            "message": self._coerce_text(sanitized, max_chars=1000)
+            or "plan step failed",
+            "rootCauseType": "AgentRunResult"
+            if source == "child_workflow"
+            else "ActivityResult",
+            "diagnosticsRef": self._coerce_text(diagnostics_ref, max_chars=400),
+        }
+        compact = {key: value for key, value in diagnostic.items() if value is not None}
+        if self._failure_diagnostic is None:
+            self._failure_diagnostic = compact
+        return compact
+
     def __init__(self) -> None:
         self._state = STATE_INITIALIZING
         self._owner_type: Optional[str] = None
@@ -5168,6 +5210,32 @@ class MoonMindRunWorkflow:
                             attempt_reason = "runtime_recovered"
                             continue
 
+                        diagnostics_ref = None
+                        outputs = self._get_from_result(execution_result, "outputs")
+                        if isinstance(outputs, Mapping):
+                            diagnostics_ref = self._coerce_text(
+                                outputs.get("diagnosticsRef")
+                                or outputs.get("diagnostics_ref"),
+                                max_chars=400,
+                            )
+                            self._record_result_failure_diagnostic(
+                                stage=self._state,
+                                category=failure_message,
+                                source=(
+                                    "child_workflow"
+                                    if tool_type == "agent_runtime"
+                                    else "activity"
+                                ),
+                                step_id=node_id,
+                                step_title=tool_name,
+                                message=step_failure_summary,
+                                child_workflow_id=(
+                                    child_workflow_id
+                                    if tool_type == "agent_runtime"
+                                    else None
+                                ),
+                                diagnostics_ref=diagnostics_ref,
+                            )
                         self._mark_step_terminal(
                             node_id,
                             status="failed",
@@ -5427,10 +5495,7 @@ class MoonMindRunWorkflow:
                     self._publish_reason = self._plan_blocked_message
                     self._refresh_step_readiness(updated_at=workflow.now())
                     continue
-                if (
-                    publish_mode in {"pr", "branch"}
-                    and result_status != "COMPLETED"
-                ):
+                if result_status != "COMPLETED":
                     self._plan_blocked_message = (
                         step_failure_summary
                         or self._activity_result_provider_failure_summary(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1819,6 +1819,11 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
         payload: dict[str, object],
         **_kwargs: object,
     ) -> object:
+        if activity_type == "artifact.create":
+            return (
+                {"artifact_id": f"art_step_execution_{child_calls}"},
+                {"upload_url": "unused"},
+            )
         if activity_type == "artifact.read":
             return json.dumps(
                 {
@@ -1884,6 +1889,139 @@ async def test_run_execution_stage_continue_mode_keeps_running_after_failed_stat
     )
 
     assert child_calls == 2
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_publish_none_blocks_after_failed_agent_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    child_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        if activity_type == "artifact.create":
+            return (
+                {"artifact_id": f"art_step_execution_{child_calls}"},
+                {"upload_url": "unused"},
+            )
+        if activity_type == "artifact.read":
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Dry Run Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "CONTINUE", "max_concurrency": 1},
+                    "nodes": [_agent_runtime_step("step-1")],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        _workflow_type: str,
+        _args: object,
+        **_kwargs: object,
+    ) -> object:
+        nonlocal child_calls
+        child_calls += 1
+        return {
+            "summary": "Process exited with code 1",
+            "failureClass": "execution_error",
+            "diagnosticsRef": "art_failed_agent_result",
+            "metadata": {
+                "childWorkflowId": "wf-1:agent:step-1",
+                "outputAgentResultRef": "art_failed_agent_result",
+            },
+            "outputRefs": ["run-1/stdout.log", "run-1/stderr.log"],
+        }
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> object:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_activity(activity_type, payload, **kwargs)
+
+    async def fake_bind_workflow_scoped_session(
+        _self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _immediate_wait_condition,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_workflow_scoped_session",
+        fake_bind_workflow_scoped_session,
+    )
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "none"},
+        plan_ref="art_plan_1",
+    )
+
+    status, message, publish_failure = workflow._determine_publish_completion(
+        parameters={"publishMode": "none"}
+    )
+
+    assert child_calls == 4
+    assert workflow._publish_status == "not_required"
+    expected_message = (
+        "Agent runtime failed with execution_error: Process exited with code 1 "
+        "(diagnosticsRef: art_failed_agent_result)"
+    )
+    assert workflow._plan_blocked_message == expected_message
+    assert status == "failed"
+    assert message == expected_message
+    assert publish_failure is True
+    assert workflow._failure_diagnostic == {
+        "stage": "executing",
+        "category": "execution_error",
+        "source": "child_workflow",
+        "stepId": "step-1",
+        "stepTitle": "codex_cli",
+        "childWorkflowId": "wf-1:agent:step-1:attempt4:retry3",
+        "message": expected_message,
+        "rootCauseType": "AgentRunResult",
+        "diagnosticsRef": "art_failed_agent_result",
+    }
 
 @pytest.mark.asyncio
 async def test_run_execution_stage_publish_pr_blocks_after_failed_continue_step(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1980,7 +1980,11 @@ async def test_run_execution_stage_publish_none_blocks_after_failed_agent_child(
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
     )
     monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
-    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_workflow_module.RUN_FAILED_RESULT_BLOCKER_PATCH,
+    )
     monkeypatch.setattr(
         run_workflow_module.workflow,
         "wait_condition",


### PR DESCRIPTION
## Summary

- Treat completed child agent workflows that return failed business results as terminal blockers regardless of publish mode.
- Record compact diagnostics from failed child results, including failure class, diagnostics ref, child workflow ID, and step metadata.
- Add regression coverage for the `publishMode: none` path that previously finalized as successful.

## Root Cause

The parent workflow only converted failed child results into a blocking completion state for PR/branch publish modes. With `publishMode: none`, a child agent could return `failureClass: execution_error` while the parent still emitted a successful completion summary.

## Validation

- `bash tools/run_repo_python.sh -m py_compile moonmind/workflows/temporal/workflows/run.py`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py::test_run_execution_stage_publish_none_blocks_after_failed_agent_child`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_artifacts.py`
- `./tools/test_unit.sh`
- `git diff --check`
