### PR TITLE
[codex] Classify Claude auth failures

### DIFF
--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -53,6 +53,8 @@ _AUTH_FAILURE_MARKERS = (
     "invalid token",
     "expired token",
     "authentication failed",
+    "not logged in",
+    "please run /login",
 )
 
 @dataclass(frozen=True)

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -105,13 +105,14 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
                 failure_class="integration_error",
                 provider_error_code="429",
             )
-        provider_failure = classify_provider_failure(f"{stdout}\n{stderr}")
-        if provider_failure is not None:
-            return ManagedRuntimeExitResult(
-                status="failed",
-                failure_class=provider_failure.failure_class,
-                provider_error_code=provider_failure.provider_error_code,
-            )
+        if exit_code != 0:
+            provider_failure = classify_provider_failure(f"{stdout}\n{stderr}")
+            if provider_failure is not None:
+                return ManagedRuntimeExitResult(
+                    status="failed",
+                    failure_class=provider_failure.failure_class,
+                    provider_error_code=provider_failure.provider_error_code,
+                )
         # Defer the default exit-code mapping to the base classify_exit.
         # Calling super().classify_result here would recurse via self.classify_exit.
         status, failure_class = super().classify_exit(

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.runtime.strategies.base import (
     ManagedRuntimeExitResult,
     ManagedRuntimeStrategy,
 )
+from moonmind.workflows.provider_failures import classify_provider_failure
 
 class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     """Strategy for launching ``claude`` CLI runs."""
@@ -103,6 +104,13 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
                 status="failed",
                 failure_class="integration_error",
                 provider_error_code="429",
+            )
+        provider_failure = classify_provider_failure(f"{stdout}\n{stderr}")
+        if provider_failure is not None:
+            return ManagedRuntimeExitResult(
+                status="failed",
+                failure_class=provider_failure.failure_class,
+                provider_error_code=provider_failure.provider_error_code,
             )
         # Defer the default exit-code mapping to the base classify_exit.
         # Calling super().classify_result here would recurse via self.classify_exit.

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -443,6 +443,11 @@ class ManagedRunSupervisor:
                     )
                 elif exit_result.provider_error_code == "429":
                     error_message = "Provider API rate limit exceeded"
+                elif exit_result.provider_error_code == "401":
+                    error_message = (
+                        "Provider authentication required; reauthenticate the "
+                        "selected provider profile"
+                    )
                 else:
                     error_message = f"Process exited with code {exit_code}"
                     if parsed_output.error_messages:

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -361,6 +361,35 @@ async def test_supervise_classifies_claude_not_logged_in_as_auth_failure(
         "Provider authentication required; reauthenticate the selected provider profile"
     )
 
+@pytest.mark.asyncio
+async def test_supervise_allows_successful_claude_output_with_auth_text(
+    tmp_path: Path,
+) -> None:
+    """Successful Claude runs may legitimately emit auth text in task output."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+    run_id = "run-claude-auth-text-success"
+    _save_record(store, run_id, runtime_id="claude_code")
+
+    process = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        "print('Docs example: Not logged in. Please run /login'); raise SystemExit(0)",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    result = await supervisor.supervise(
+        run_id=run_id,
+        process=process,
+        timeout_seconds=10,
+    )
+
+    assert result.status == "completed"
+    assert result.failure_class is None
+    assert result.provider_error_code is None
+    assert result.error_message is None
+
 # ---------------------------------------------------------------------------
 # Test 8 — streaming starts during process execution, not after
 #

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -55,13 +55,18 @@ def _make_supervisor(
     supervisor = ManagedRunSupervisor(store, streamer)
     return supervisor, store, storage
 
-def _save_record(store: ManagedRunStore, run_id: str) -> ManagedRunRecord:
+def _save_record(
+    store: ManagedRunStore,
+    run_id: str,
+    *,
+    runtime_id: str = "gemini_cli",
+) -> ManagedRunRecord:
     workspace_path = store.store_root.parent / "workspace" / run_id
     workspace_path.mkdir(parents=True, exist_ok=True)
     record = ManagedRunRecord(
         run_id=run_id,
         agent_id="test-agent",
-        runtime_id="gemini_cli",
+        runtime_id=runtime_id,
         status="launching",
         pid=12345,
         started_at=datetime.now(tz=UTC),
@@ -324,6 +329,37 @@ async def test_supervise_terminates_gemini_on_live_rate_limit(tmp_path: Path):
         storage.resolve_storage_path(result.diagnostics_ref).read_text(encoding="utf-8")
     )
     assert diagnostics["parsed_output"]["rate_limited"] is True
+
+@pytest.mark.asyncio
+async def test_supervise_classifies_claude_not_logged_in_as_auth_failure(
+    tmp_path: Path,
+) -> None:
+    """Claude Code login failures should surface as operator auth errors."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+    run_id = "run-claude-auth"
+    _save_record(store, run_id, runtime_id="claude_code")
+
+    process = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        "print('Not logged in. Please run /login'); raise SystemExit(1)",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    result = await supervisor.supervise(
+        run_id=run_id,
+        process=process,
+        timeout_seconds=10,
+    )
+
+    assert result.status == "failed"
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.error_message == (
+        "Provider authentication required; reauthenticate the selected provider profile"
+    )
 
 # ---------------------------------------------------------------------------
 # Test 8 — streaming starts during process execution, not after

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -80,6 +80,14 @@ def test_classifies_http_401_as_auth_user_error() -> None:
     assert result.provider_error_code == "401"
     assert result.retry_recommendation == "reauthenticate"
 
+def test_classifies_claude_not_logged_in_as_auth_user_error() -> None:
+    result = classify_provider_failure("Not logged in. Please run /login")
+
+    assert result is not None
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
+
 def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> None:
     assert provider_error_requires_cooldown(
         provider_error_code="provider_capacity",


### PR DESCRIPTION
## Summary

This fixes the failure mode observed in workflow `mm:27049c27-deef-4d5a-9ed8-3a54cd4f23fd`.

Root cause: the managed Claude Code run exited immediately after printing `Not logged in. Please run /login`, but MoonMind classified the process as a generic `execution_error` with only `Process exited with code 1`.

## Changes

- Recognize Claude Code unauthenticated output as a provider auth failure in the shared provider-failure classifier.
- Have the Claude managed-runtime strategy return `failureClass=user_error` and `providerErrorCode=401` for that output.
- Surface an operator-actionable supervisor message telling the user to reauthenticate the selected provider profile.
- Add unit coverage for both the shared marker and the real managed-run supervisor path.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/test_provider_failures.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py`
- `./tools/test_unit.sh`

Full unit result: 6325 Python tests passed, 6 skipped, 1 xpassed, 16 subtests passed; frontend unit result: 428 passed, 234 skipped.