### PR TITLE
MM-822 Complete checkpoint activity recovery substrate

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2028,6 +2028,142 @@ class MoonMindRunWorkflow:
         self._recovery_workspace_restored_ref = checkpoint_ref
         return checkpoint_ref
 
+    async def _prepare_recovery_workspace_for_failed_step(
+        self,
+        logical_step_id: str,
+    ) -> str | None:
+        if (
+            not self._recovery_failed_step_id
+            or logical_step_id != self._recovery_failed_step_id
+        ):
+            return None
+        if self._recovery_workspace_restored_ref:
+            return self._recovery_workspace_restored_ref
+        if not isinstance(self._recovery_source, Mapping):
+            return None
+
+        checkpoint_ref = self._recovery_workspace_checkpoint_ref(self._recovery_workspace)
+        if not checkpoint_ref:
+            return None
+
+        checkpoint_payload = self._recovery_workspace.get("checkpoint")
+        if not isinstance(checkpoint_payload, Mapping):
+            checkpoint_payload = self._recovery_workspace.get("checkpointPayload")
+        if not isinstance(checkpoint_payload, Mapping):
+            checkpoint_payload = {
+                key: value
+                for key, value in self._recovery_workspace.items()
+                if key not in {"checkpointRef", "checkpoint_ref"}
+            }
+
+        source_workflow_id = self._recovery_source_text(
+            self._recovery_source,
+            "sourceWorkflowId",
+            "source_workflow_id",
+        )
+        source_run_id = self._recovery_source_text(
+            self._recovery_source,
+            "sourceRunId",
+            "source_run_id",
+        )
+        execution_ordinal = self._recovery_source_int(
+            self._recovery_source,
+            "failedStepExecution",
+            "failed_step_execution",
+            "sourceExecutionOrdinal",
+            "source_execution_ordinal",
+        ) or 1
+        task_input_snapshot_ref = self._recovery_source_text(
+            self._recovery_source,
+            "sourceTaskInputSnapshotRef",
+            "source_task_input_snapshot_ref",
+        )
+        source_plan_ref = self._recovery_source_text(
+            self._recovery_source,
+            "sourcePlanRef",
+            "source_plan_ref",
+        )
+        source_plan_digest = self._recovery_source_text(
+            self._recovery_source,
+            "sourcePlanDigest",
+            "source_plan_digest",
+        )
+        workspace_policy = self._recovery_source_text(
+            self._recovery_workspace,
+            "workspacePolicy",
+            "workspace_policy",
+        ) or "restore_pre_execution"
+
+        validate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "step_checkpoint.validate"
+        )
+        validate_payload = {
+            "checkpoint": dict(checkpoint_payload),
+            "expectedSource": {
+                "workflowId": source_workflow_id,
+                "runId": source_run_id,
+                "logicalStepId": logical_step_id,
+                "executionOrdinal": execution_ordinal,
+            },
+            "expectedTaskInputSnapshotRef": task_input_snapshot_ref,
+            "expectedPlanRef": source_plan_ref or None,
+            "expectedPlanDigest": source_plan_digest or None,
+            "workspacePolicy": workspace_policy,
+            "checkpointRef": checkpoint_ref,
+        }
+        validation = await workflow.execute_activity(
+            validate_route.activity_type,
+            validate_payload,
+            **self._execute_kwargs_for_route(validate_route),
+        )
+        if not isinstance(validation, Mapping) or validation.get("valid") is not True:
+            failure_code = "invalid_checkpoint"
+            if isinstance(validation, Mapping):
+                failure_code = str(validation.get("failureCode") or failure_code)
+            raise ValueError(
+                f"recovery checkpoint validation failed: {failure_code}"
+            )
+
+        target_workspace_ref = self._recovery_source_text(
+            self._recovery_workspace,
+            "targetWorkspaceRef",
+            "target_workspace_ref",
+            "workspaceRef",
+            "workspace_ref",
+        ) or checkpoint_ref
+        apply_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("workspace.apply_policy")
+        apply_payload = {
+            "identity": {
+                "workflowId": source_workflow_id,
+                "runId": source_run_id,
+                "logicalStepId": logical_step_id,
+                "executionOrdinal": execution_ordinal,
+            },
+            "workspacePolicy": workspace_policy,
+            "checkpointRef": checkpoint_ref,
+            "checkpoint": dict(checkpoint_payload),
+            "targetWorkspaceRef": target_workspace_ref,
+            "expectedPlanRef": source_plan_ref or None,
+            "expectedPlanDigest": source_plan_digest or None,
+            "idempotencyKey": f"{checkpoint_ref}:workspace_policy:{workspace_policy}",
+        }
+        policy = await workflow.execute_activity(
+            apply_route.activity_type,
+            apply_payload,
+            **self._execute_kwargs_for_route(apply_route),
+        )
+        if not isinstance(policy, Mapping) or policy.get("status") != "prepared":
+            failure_code = "policy_incompatible"
+            if isinstance(policy, Mapping):
+                failure_code = str(policy.get("failureCode") or failure_code)
+            raise ValueError(
+                f"recovery workspace policy application failed: {failure_code}"
+            )
+
+        workspace_ref = str(policy.get("workspaceRef") or target_workspace_ref).strip()
+        self._recovery_workspace_restored_ref = workspace_ref or checkpoint_ref
+        return self._recovery_workspace_restored_ref
+
     def _preserved_outputs_for_step(
         self,
         logical_step_id: str,
@@ -4867,6 +5003,7 @@ class MoonMindRunWorkflow:
                 )
                 self._update_memo()
                 self._refresh_step_readiness(updated_at=workflow.now())
+                await self._prepare_recovery_workspace_for_failed_step(node_id)
                 self._mark_step_running(
                     node_id,
                     updated_at=workflow.now(),

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -20,6 +20,8 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalCheckpointActivities,
     TemporalSandboxActivities,
 )
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
 
@@ -57,6 +59,47 @@ def _assert_secret_absent(payload: object) -> None:
     assert "GHCR_PULL_USER" not in rendered
     assert "GHCR_PULL_TOKEN" not in rendered
     assert "secret-token" not in rendered
+
+
+def _recovery_source_with_checkpoint_payload() -> dict[str, object]:
+    return {
+        "sourceWorkflowId": "source-workflow",
+        "sourceRunId": "source-run",
+        "sourceTaskInputSnapshotRef": "artifact-input",
+        "sourcePlanDigest": "sha256:plan",
+        "failedStepId": "implement",
+        "failedStepExecution": 2,
+        "recoveryCheckpointRef": "artifact-checkpoint",
+        "recoveryWorkspace": {
+            "checkpointRef": "artifact-checkpoint",
+            "targetWorkspaceRef": "workspace-target",
+            "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+            "checkpoint": {
+                "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+                "schemaVersion": "v1",
+                "checkpointId": (
+                    "source-workflow:source-run:implement:execution:2:"
+                    "checkpoint:before_execution"
+                ),
+                "checkpointKind": "step_boundary",
+                "boundary": "before_execution",
+                "source": {
+                    "workflowId": "source-workflow",
+                    "runId": "source-run",
+                    "logicalStepId": "implement",
+                    "executionOrdinal": 2,
+                },
+                "taskInputSnapshotRef": "artifact-input",
+                "planDigest": "sha256:plan",
+                "workspace": {
+                    "kind": "git_patch",
+                    "baseCommit": "abc123",
+                    "patchRef": "artifact-patch",
+                },
+                "createdAt": "2026-06-13T12:00:00+00:00",
+            },
+        },
+    }
 
 
 async def test_capture_git_patch_and_create_checkpoint_write_compact_artifacts(
@@ -409,6 +452,100 @@ async def test_checkpoint_activity_failures_are_typed_and_secret_safe(
     )
     assert policy["status"] == "rejected"
     assert policy["failureCode"] == "policy_incompatible"
+
+
+async def test_workflow_recovery_routes_checkpoint_validation_before_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        calls.append((activity_type, payload))
+        if activity_type == "step_checkpoint.validate":
+            return {
+                "valid": True,
+                "failureCode": None,
+                "message": "checkpoint validation passed",
+                "checkpointId": payload["checkpoint"]["checkpointId"],
+                "checkpointRef": payload["checkpointRef"],
+            }
+        if activity_type == "workspace.apply_policy":
+            return {
+                "status": "prepared",
+                "workspaceRef": "workspace-target",
+                "appliedCheckpointRef": payload["checkpointRef"],
+                "providerLeaseRefs": [],
+                "summary": "workspace policy prepared",
+                "failureCode": None,
+            }
+        raise AssertionError(f"unexpected activity {activity_type}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    workflow = MoonMindRunWorkflow()
+    workflow._recovery_source = _recovery_source_with_checkpoint_payload()
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "title": "Implement"}],
+        dependency_map={"implement": []},
+        updated_at=datetime(2026, 6, 13, 12, 0, tzinfo=UTC),
+    )
+
+    restored_ref = await workflow._prepare_recovery_workspace_for_failed_step(
+        "implement"
+    )
+
+    assert restored_ref == "workspace-target"
+    assert [activity_type for activity_type, _payload in calls] == [
+        "step_checkpoint.validate",
+        "workspace.apply_policy",
+    ]
+    validate_payload = calls[0][1]
+    assert validate_payload["checkpointRef"] == "artifact-checkpoint"
+    assert validate_payload["workspacePolicy"] == (
+        "apply_previous_execution_diff_to_clean_baseline"
+    )
+    policy_payload = calls[1][1]
+    assert policy_payload["checkpointRef"] == "artifact-checkpoint"
+    assert policy_payload["targetWorkspaceRef"] == "workspace-target"
+
+
+async def test_workflow_recovery_validation_failure_blocks_policy_application(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        calls.append(activity_type)
+        if activity_type == "step_checkpoint.validate":
+            return {
+                "valid": False,
+                "failureCode": "artifact_unauthorized",
+                "message": "unauthorized",
+                "checkpointId": payload["checkpoint"]["checkpointId"],
+                "checkpointRef": payload["checkpointRef"],
+            }
+        raise AssertionError("workspace policy must not run after failed validation")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    workflow = MoonMindRunWorkflow()
+    workflow._recovery_source = _recovery_source_with_checkpoint_payload()
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "title": "Implement"}],
+        dependency_map={"implement": []},
+        updated_at=datetime(2026, 6, 13, 12, 0, tzinfo=UTC),
+    )
+
+    with pytest.raises(ValueError, match="artifact_unauthorized"):
+        await workflow._prepare_recovery_workspace_for_failed_step("implement")
+
+    assert calls == ["step_checkpoint.validate"]
 
 
 async def test_checkpoint_validate_activity_reports_boundary_failure_classes(


### PR DESCRIPTION
## Jira

- Jira issue key: MM-822

## MoonSpec

- Active feature path: `specs/001-complete-checkpoint-activities`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary

- Routes recovery of the failed step through checkpoint validation before workspace policy application.
- Adds integration coverage confirming valid checkpoints invoke `workspace.apply_policy` and invalid checkpoints block policy application with typed failures.

## Tests Run

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_step_checkpoint_contracts.py tests/unit/workflows/temporal/test_step_checkpoints.py` - PASS (`22 passed`; wrapper UI phase: `27 passed`, `428 passed`, `234 skipped`)
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/workflows/temporal/test_step_checkpoint_activities.py tests/integration/workflows/temporal/test_step_checkpoint_validation.py -q` - PASS (`14 passed`)
- `python -m moonmind.workflows.temporal.step_execution_conformance` - PASS (`overallResult: passed`)
- `pytest tests/unit/workflows/temporal/test_step_executions.py tests/unit/workflows/temporal/test_step_checkpoints.py tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py -q` - PASS (`40 passed`)
- `./tools/test_unit.sh` - PASS (Python: `6323 passed`, `6 skipped`, `1 xpassed`, `16 subtests passed`; UI: `27 passed`, `428 passed`, `234 skipped`)

## Doc Reconciliation

- Outcome: no canonical doc update required.
- Canonical doc considered: `docs/Steps/StepExecutionsAndCheckpointing.md`
- Rationale from `/work/agent_jobs/mm:07ef3ed8-1efc-4a0a-88ca-72e994c06c76/artifacts/jira-orchestrate-doc-reconcile.json`: latest MM-822 MoonSpec verification verdict is `FULLY_IMPLEMENTED`; the canonical source document was eligible for reconciliation, but the verification report found no definite canonical-document drift and no `artifacts/doc-discoveries` ledger was present.

## Remaining Risks

- No known remaining implementation work. Recovery-path behavior is covered by focused integration tests and the full unit suite; broader compose-backed integration was not rerun in this publication step.
