### PR TITLE
[codex] Improve workflow failure summaries

### DIFF
--- a/docs/Workflows/WorkflowFinishSummarySystem.md
+++ b/docs/Workflows/WorkflowFinishSummarySystem.md
@@ -2,7 +2,7 @@
 
 Status: Active  
 Owners: MoonMind Engineering  
-Last Updated: 2026-05-17  
+Last Updated: 2026-06-15
 Related: `docs/Workflows/WorkflowArchitecture.md`, `docs/Workflows/WorkflowProposalSystem.md`,
 `docs/Temporal/ErrorTaxonomy.md`, `docs/Temporal/StepLedgerAndProgressModel.md`
 
@@ -128,6 +128,76 @@ Field semantics:
   diagnostics. Large diagnostic payloads MUST NOT be embedded inline — they
   belong in artifacts. See `docs/Temporal/StepLedgerAndProgressModel.md` for
   the same rule applied to per-step `lastError`.
+
+Failed runs MAY also include a `failureSummary` object. `failure` remains the
+low-level diagnostic captured at the failure boundary; `failureSummary` is the
+compact operator classification that Mission Control can render without parsing
+Markdown reports or long failure strings.
+
+For MoonSpec publication gates, `failureSummary` uses this shape:
+
+```json
+{
+  "failureSummary": {
+    "type": "moonspec_verification_gate",
+    "category": "validation_environment_blocked",
+    "blockedBy": "moonspec_verify",
+    "verdict": "BLOCKED",
+    "classification": "environment failure / validation infrastructure unavailable",
+    "diagnosticsRef": "art_...",
+    "recommendedNextAction": "restore_validation_environment",
+    "summary": "MoonSpec verification blocked publication: BLOCKED. environment failure / validation infrastructure unavailable.",
+    "blockers": [
+      "native_unreal_toolchain_missing",
+      "docker_registry_unauthorized"
+    ],
+    "publishContext": {
+      "branch": "jira-orchestrate-example",
+      "baseRef": "origin/main",
+      "headSha": "abc123",
+      "commitCount": 6,
+      "pullRequestUrl": "https://github.com/org/repo/pull/123"
+    }
+  }
+}
+```
+
+Allowed MoonSpec summary categories are:
+
+* `validation_environment_blocked`: required local/CI validation
+  infrastructure is unavailable, for example native Unreal tooling is missing
+  or a required Docker registry pull is unauthorized.
+* `validation_evidence_missing`: implementation may be present, but required
+  current-head CI or lane evidence is missing.
+* `verification_gaps_remaining`: the verifier reported concrete remaining
+  implementation or validation gaps.
+
+For managed agent runtime failures, `failureSummary` uses:
+
+```json
+{
+  "failureSummary": {
+    "type": "agent_runtime_failure",
+    "category": "transient_agent_runtime",
+    "failureCause": "app_server_protocol_empty_turn",
+    "retryRecommendedAction": "clear_session",
+    "diagnosticsRef": "art_...",
+    "recommendedNextAction": "retry_finalization_after_clear_session",
+    "summary": "Agent runtime failed with execution_error ...",
+    "partialSuccess": {
+      "moonSpecVerdict": "FULLY_IMPLEMENTED",
+      "pullRequestUrl": "https://github.com/org/repo/pull/123",
+      "branch": "jira-orchestrate-example",
+      "headSha": "abc123"
+    }
+  }
+}
+```
+
+When a managed-runtime failure occurs after a publishable verification result or
+after a pull request has already been created, `partialSuccess` MUST preserve
+that evidence so the UI can distinguish "implementation verified but final
+runtime turn failed" from "implementation failed".
 
 When a structured `failure` is present, the `lastStep` block SHOULD reflect
 the failure so operators see the failing tool, not a stale prior step:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -227,7 +227,12 @@ Workflows that include MoonSpec verification gates must use the latest structure
 
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 
-When MoonSpec verification blocks publication, the workflow records `publicationBlockedBy: "moonspec_verify"` in publish context, preserves the latest verification report and evidence refs, and marks downstream publication or Jira handoff steps skipped rather than creating a pull request with known incomplete work.
+When MoonSpec verification blocks publication, the workflow records
+`publicationBlockedBy: "moonspec_verify"` in publish context, preserves the
+latest verification report and evidence refs, writes a compact
+`failureSummary.type = "moonspec_verification_gate"` block in
+`reports/run_summary.json`, and marks downstream publication or Jira handoff
+steps skipped rather than creating a pull request with known incomplete work.
 
 ### Agent Instructions
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -11025,7 +11025,6 @@ class MoonMindRunWorkflow:
                 **self._execute_kwargs_for_route(artifact_write_route),
             )
             self._summary_ref = resolved_artifact_id
-            self._update_memo()
         except Exception as exc:
             self._get_logger().warning(f"Failed to generate finish summary: {exc}")
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -10657,8 +10657,7 @@ class MoonMindRunWorkflow:
         if (
             "ci" in lowered
             and (
-                "no current-head" in lowered
-                or "current-head" in lowered
+                "current-head" in lowered
                 or "pending" in lowered
                 or "no run evidence" in lowered
             )
@@ -10679,7 +10678,6 @@ class MoonMindRunWorkflow:
         if (
             "environment" in lowered
             or "infrastructure" in lowered
-            or "validation infrastructure" in lowered
             or "docker_registry_unauthorized" in blockers
             or "native_unreal_toolchain_missing" in blockers
         ):
@@ -10698,7 +10696,7 @@ class MoonMindRunWorkflow:
         if classification:
             return (
                 f"MoonSpec verification blocked publication: {verdict}. "
-                f"{classification}."
+                f"{classification.rstrip('.')}."
             )
         if category == "validation_environment_blocked":
             suffix = "validation environment unavailable"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -10566,6 +10566,251 @@ class MoonMindRunWorkflow:
             )
             self._proposals_errors.append(f"submission failed: {str(exc)[:200]}")
 
+    def _finish_summary_failure_summary(self) -> dict[str, Any] | None:
+        moonspec_summary = self._moonspec_gate_failure_summary()
+        if moonspec_summary is not None:
+            return moonspec_summary
+        return self._agent_runtime_failure_summary()
+
+    def _moonspec_gate_failure_summary(self) -> dict[str, Any] | None:
+        gate_context = self._publish_context.get("moonSpecGate")
+        if not isinstance(gate_context, Mapping):
+            return None
+        if self._publish_context.get("publicationBlockedBy") != "moonspec_verify":
+            return None
+
+        verdict = self._coerce_text(gate_context.get("verdict"), max_chars=80)
+        if not verdict:
+            return None
+        classification = self._coerce_text(
+            gate_context.get("classification"), max_chars=200
+        )
+        raw_summary = self._coerce_text(gate_context.get("summary"), max_chars=1000)
+        combined_text = " ".join(
+            part
+            for part in (
+                verdict,
+                classification,
+                raw_summary,
+                self._publish_reason,
+                self._plan_blocked_message,
+            )
+            if isinstance(part, str) and part
+        )
+        blockers = self._validation_blockers_from_text(combined_text)
+        category = self._moonspec_failure_category(
+            classification=classification,
+            blockers=blockers,
+            text=combined_text,
+        )
+        if category == "validation_environment_blocked":
+            recommended_next_action = "restore_validation_environment"
+        elif category == "validation_evidence_missing":
+            recommended_next_action = "provide_current_head_validation_evidence"
+        else:
+            recommended_next_action = "address_verification_gaps"
+
+        compact: dict[str, Any] = {
+            "type": "moonspec_verification_gate",
+            "category": category,
+            "blockedBy": "moonspec_verify",
+            "verdict": verdict,
+            "recommendedNextAction": recommended_next_action,
+            "summary": self._moonspec_failure_headline(
+                verdict=verdict,
+                classification=classification,
+                category=category,
+            ),
+        }
+        if classification:
+            compact["classification"] = classification
+        diagnostics_ref = self._coerce_text(
+            gate_context.get("diagnosticsRef"), max_chars=400
+        )
+        if diagnostics_ref:
+            compact["diagnosticsRef"] = diagnostics_ref
+        if blockers:
+            compact["blockers"] = blockers
+        publish_context = self._compact_publish_failure_context()
+        if publish_context:
+            compact["publishContext"] = publish_context
+        return compact
+
+    def _validation_blockers_from_text(self, text: str) -> list[str]:
+        lowered = text.lower()
+        blockers: list[str] = []
+        if (
+            (
+                "native" in lowered
+                or "windows/wsl" in lowered
+                or "ue/toolchain" in lowered
+            )
+            and (
+                "missing" in lowered
+                or "unavailable" in lowered
+                or "not run" in lowered
+            )
+        ):
+            blockers.append("native_unreal_toolchain_missing")
+        if "unauthorized" in lowered and ("ghcr" in lowered or "docker" in lowered):
+            blockers.append("docker_registry_unauthorized")
+        if (
+            "ci" in lowered
+            and (
+                "no current-head" in lowered
+                or "current-head" in lowered
+                or "pending" in lowered
+                or "no run evidence" in lowered
+            )
+        ):
+            blockers.append("current_head_ci_evidence_missing")
+        return blockers
+
+    @staticmethod
+    def _moonspec_failure_category(
+        *,
+        classification: str | None,
+        blockers: list[str],
+        text: str,
+    ) -> str:
+        lowered = " ".join(
+            part for part in (classification or "", text) if part
+        ).lower()
+        if (
+            "environment" in lowered
+            or "infrastructure" in lowered
+            or "validation infrastructure" in lowered
+            or "docker_registry_unauthorized" in blockers
+            or "native_unreal_toolchain_missing" in blockers
+        ):
+            return "validation_environment_blocked"
+        if "ci" in lowered or "evidence" in lowered or "required lane" in lowered:
+            return "validation_evidence_missing"
+        return "verification_gaps_remaining"
+
+    @staticmethod
+    def _moonspec_failure_headline(
+        *,
+        verdict: str,
+        classification: str | None,
+        category: str,
+    ) -> str:
+        if classification:
+            return (
+                f"MoonSpec verification blocked publication: {verdict}. "
+                f"{classification}."
+            )
+        if category == "validation_environment_blocked":
+            suffix = "validation environment unavailable"
+        elif category == "validation_evidence_missing":
+            suffix = "required validation evidence missing"
+        else:
+            suffix = "verification gaps remain"
+        return f"MoonSpec verification blocked publication: {verdict}. {suffix}."
+
+    def _compact_publish_failure_context(self) -> dict[str, Any]:
+        compact: dict[str, Any] = {}
+        for key in (
+            "branch",
+            "baseRef",
+            "headSha",
+            "commitCount",
+            "pullRequestUrl",
+        ):
+            value = self._publish_context.get(key)
+            if key == "commitCount":
+                if isinstance(value, int):
+                    compact[key] = value
+                continue
+            text = self._coerce_text(value, max_chars=500)
+            if text:
+                compact[key] = text
+        return compact
+
+    def _agent_runtime_failure_summary(self) -> dict[str, Any] | None:
+        if not isinstance(self._failure_diagnostic, Mapping):
+            return None
+        diagnostic = self._failure_diagnostic
+        message = self._coerce_text(diagnostic.get("message"), max_chars=1000)
+        if not message:
+            return None
+        lowered = message.lower()
+        failure_cause = None
+        if "app_server_protocol_empty_turn" in lowered:
+            failure_cause = "app_server_protocol_empty_turn"
+        retry_action = self._retry_action_from_failure_message(message)
+        diagnostics_ref = self._coerce_text(
+            diagnostic.get("diagnosticsRef"), max_chars=400
+        )
+
+        if failure_cause == "app_server_protocol_empty_turn":
+            category = "transient_agent_runtime"
+            recommended_next_action = (
+                "retry_finalization_after_clear_session"
+                if self._pull_request_url
+                or self._compact_publish_failure_context().get("pullRequestUrl")
+                else "retry_step_after_clear_session"
+            )
+            retry_action = retry_action or "clear_session"
+        else:
+            category = self._coerce_text(diagnostic.get("category"), max_chars=80)
+            if category not in {
+                "user_error",
+                "integration_error",
+                "execution_error",
+                "system_error",
+            }:
+                category = "execution_error"
+            recommended_next_action = "inspect_diagnostics"
+
+        compact: dict[str, Any] = {
+            "type": "agent_runtime_failure",
+            "category": category,
+            "recommendedNextAction": recommended_next_action,
+            "summary": message,
+        }
+        if failure_cause:
+            compact["failureCause"] = failure_cause
+        if retry_action:
+            compact["retryRecommendedAction"] = retry_action
+        if diagnostics_ref:
+            compact["diagnosticsRef"] = diagnostics_ref
+        partial_success = self._partial_success_summary()
+        if partial_success:
+            compact["partialSuccess"] = partial_success
+        return compact
+
+    @staticmethod
+    def _retry_action_from_failure_message(message: str) -> str | None:
+        marker = "retryRecommendedAction:"
+        index = message.find(marker)
+        if index < 0:
+            return None
+        remainder = message[index + len(marker) :].strip()
+        token = remainder.split(";", 1)[0].split(")", 1)[0].strip()
+        return token or None
+
+    def _partial_success_summary(self) -> dict[str, Any]:
+        compact: dict[str, Any] = {}
+        gate_context = self._publish_context.get("moonSpecGate")
+        if isinstance(gate_context, Mapping):
+            verdict = self._coerce_text(gate_context.get("verdict"), max_chars=80)
+            if verdict:
+                compact["moonSpecVerdict"] = verdict
+        pull_request_url = self._coerce_text(
+            self._pull_request_url or self._publish_context.get("pullRequestUrl"),
+            max_chars=500,
+        )
+        if pull_request_url:
+            compact["pullRequestUrl"] = pull_request_url
+        branch = self._coerce_text(self._publish_context.get("branch"), max_chars=500)
+        if branch:
+            compact["branch"] = branch
+        head_sha = self._coerce_text(self._publish_context.get("headSha"), max_chars=80)
+        if head_sha:
+            compact["headSha"] = head_sha
+        return compact
+
     async def _run_finalizing_stage(
         self, *, parameters: dict[str, Any], status: str, error: Optional[str] = None
     ) -> None:
@@ -10705,6 +10950,10 @@ class MoonMindRunWorkflow:
                 merge_automation_summary = self._merge_automation_summary_from_context()
                 if merge_automation_summary:
                     finish_summary["mergeAutomation"] = merge_automation_summary
+            if status == "failed":
+                failure_summary = self._finish_summary_failure_summary()
+                if failure_summary:
+                    finish_summary["failureSummary"] = failure_summary
             last_step_summary = self._last_step_summary
             last_step_id = self._last_step_id
             last_diagnostics_ref = self._last_diagnostics_ref
@@ -10776,6 +11025,7 @@ class MoonMindRunWorkflow:
                 **self._execute_kwargs_for_route(artifact_write_route),
             )
             self._summary_ref = resolved_artifact_id
+            self._update_memo()
         except Exception as exc:
             self._get_logger().warning(f"Failed to generate finish summary: {exc}")
 

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -385,6 +385,244 @@ async def test_run_finalizing_stage_writes_dependency_summary_metadata(
     }
 
 @pytest.mark.asyncio
+async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._state = "finalizing"
+    workflow._publish_status = "not_required"
+    workflow._publish_reason = (
+        "MoonSpec verification did not approve publication. verdict BLOCKED. "
+        "Classification: environment failure / validation infrastructure unavailable. "
+        "Docker UE image access failed: GHCR returned `unauthorized`; native UE "
+        "paths missing."
+    )
+    workflow._publish_context = {
+        "publicationBlockedBy": "moonspec_verify",
+        "branch": "jira-orchestrate-thor-509-c173f338",
+        "baseRef": "origin/main",
+        "headSha": "2c6584dc4487629eaee43bd4a9bcb8974e7e8dae",
+        "commitCount": 6,
+        "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/1845",
+        "moonSpecGate": {
+            "logicalStepId": "tpl:jira-orchestrate:1.0.0:23:ceb64b9f",
+            "verdict": "BLOCKED",
+            "classification": (
+                "environment failure / validation infrastructure unavailable"
+            ),
+            "diagnosticsRef": "art_verify_report",
+            "summary": (
+                "Native UE/toolchain NOT RUN; all required native Windows/WSL "
+                "paths missing. Docker UE image access FAIL: GHCR returned "
+                "`unauthorized`; Docker fallback cannot start Unreal."
+            ),
+        },
+    }
+
+    written_payloads: list[dict[str, Any]] = []
+    captured_memo: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.create":
+            return ({"artifact_id": "art_summary_1"}, {"upload_url": "unused"})
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, bool]:
+        assert activity_type == "artifact.write_complete"
+        written_payloads.append(json.loads(payload.payload.decode("utf-8")))
+        return {"ok": True}
+
+    start_time = datetime(2026, 6, 15, 2, 41, tzinfo=timezone.utc)
+    finish_time = datetime(2026, 6, 15, 9, 7, tzinfo=timezone.utc)
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "mm:wf-1",
+            "run_id": "run-1",
+            "start_time": start_time,
+        },
+    )
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: finish_time)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda memo: captured_memo.append(dict(memo)),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+
+    await workflow._run_finalizing_stage(
+        parameters={"runtime": {"mode": "codex"}, "publishMode": "pr"},
+        status="failed",
+        error=workflow._publish_reason,
+    )
+
+    assert written_payloads
+    failure_summary = written_payloads[-1]["failureSummary"]
+    assert failure_summary == {
+        "type": "moonspec_verification_gate",
+        "category": "validation_environment_blocked",
+        "blockedBy": "moonspec_verify",
+        "verdict": "BLOCKED",
+        "classification": "environment failure / validation infrastructure unavailable",
+        "diagnosticsRef": "art_verify_report",
+        "recommendedNextAction": "restore_validation_environment",
+        "summary": (
+            "MoonSpec verification blocked publication: BLOCKED. "
+            "environment failure / validation infrastructure unavailable."
+        ),
+        "blockers": [
+            "native_unreal_toolchain_missing",
+            "docker_registry_unauthorized",
+        ],
+        "publishContext": {
+            "branch": "jira-orchestrate-thor-509-c173f338",
+            "baseRef": "origin/main",
+            "headSha": "2c6584dc4487629eaee43bd4a9bcb8974e7e8dae",
+            "commitCount": 6,
+            "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/1845",
+        },
+    }
+    assert captured_memo[-1]["summary_artifact_ref"] == "art_summary_1"
+
+
+@pytest.mark.asyncio
+async def test_run_finalizing_stage_writes_transient_codex_failure_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._state = "finalizing"
+    workflow._pull_request_url = "https://github.com/MoonLadderStudios/Tactics/pull/1844"
+    workflow._publish_context = {
+        "branch": "jira-orchestrate-thor-508-ab3bfbd4",
+        "baseRef": "origin/main",
+        "headSha": "e35729fa58541d0eeca33f4f91015c9d06fc0569",
+        "commitCount": 4,
+        "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/1844",
+        "moonSpecGate": {
+            "logicalStepId": "tpl:jira-orchestrate:1.0.0:21:6e2de025",
+            "verdict": "FULLY_IMPLEMENTED",
+            "diagnosticsRef": "art_verify_pass",
+        },
+    }
+    workflow._failure_diagnostic = {
+        "stage": "finalizing",
+        "category": "execution_error",
+        "source": "child_workflow",
+        "stepId": "tpl:jira-orchestrate:1.0.0:22:6e2de025",
+        "message": (
+            "Agent runtime failed with execution_error for profile codex_default "
+            "due to app_server_protocol_empty_turn: codex app-server "
+            "turn/completed produced no assistant output "
+            "(retryRecommendedAction: clear_session; diagnosticsRef: art_empty_turn)"
+        ),
+        "diagnosticsRef": "art_empty_turn",
+    }
+
+    written_payloads: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.create":
+            return ({"artifact_id": "art_summary_2"}, {"upload_url": "unused"})
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, bool]:
+        assert activity_type == "artifact.write_complete"
+        written_payloads.append(json.loads(payload.payload.decode("utf-8")))
+        return {"ok": True}
+
+    start_time = datetime(2026, 6, 15, 2, 41, tzinfo=timezone.utc)
+    finish_time = datetime(2026, 6, 15, 8, 46, tzinfo=timezone.utc)
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "mm:wf-2",
+            "run_id": "run-2",
+            "start_time": start_time,
+        },
+    )
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: finish_time)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+
+    await workflow._run_finalizing_stage(
+        parameters={"runtime": {"mode": "codex"}, "publishMode": "pr"},
+        status="failed",
+        error=workflow._failure_diagnostic["message"],
+    )
+
+    failure_summary = written_payloads[-1]["failureSummary"]
+    assert failure_summary["type"] == "agent_runtime_failure"
+    assert failure_summary["category"] == "transient_agent_runtime"
+    assert failure_summary["failureCause"] == "app_server_protocol_empty_turn"
+    assert failure_summary["retryRecommendedAction"] == "clear_session"
+    assert failure_summary["diagnosticsRef"] == "art_empty_turn"
+    assert failure_summary["recommendedNextAction"] == (
+        "retry_finalization_after_clear_session"
+    )
+    assert failure_summary["partialSuccess"] == {
+        "moonSpecVerdict": "FULLY_IMPLEMENTED",
+        "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/1844",
+        "branch": "jira-orchestrate-thor-508-ab3bfbd4",
+        "headSha": "e35729fa58541d0eeca33f4f91015c9d06fc0569",
+    }
+
+@pytest.mark.asyncio
 async def test_run_execution_stage_rejects_legacy_skill_registry_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -409,7 +409,7 @@ async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
             "logicalStepId": "tpl:jira-orchestrate:1.0.0:23:ceb64b9f",
             "verdict": "BLOCKED",
             "classification": (
-                "environment failure / validation infrastructure unavailable"
+                "environment failure / validation infrastructure unavailable."
             ),
             "diagnosticsRef": "art_verify_report",
             "summary": (
@@ -491,7 +491,7 @@ async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
         "category": "validation_environment_blocked",
         "blockedBy": "moonspec_verify",
         "verdict": "BLOCKED",
-        "classification": "environment failure / validation infrastructure unavailable",
+        "classification": "environment failure / validation infrastructure unavailable.",
         "diagnosticsRef": "art_verify_report",
         "recommendedNextAction": "restore_validation_environment",
         "summary": (

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -510,6 +510,7 @@ async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
             "pullRequestUrl": "https://github.com/MoonLadderStudios/Tactics/pull/1845",
         },
     }
+    workflow._set_state("failed", summary="blocked")
     assert captured_memo[-1]["summary_artifact_ref"] == "art_summary_1"
 
 


### PR DESCRIPTION
## Summary

- Add compact structured failureSummary blocks to workflow finish summaries for MoonSpec gate failures and managed agent runtime failures.
- Classify validation-environment blockers such as missing native UE tooling and unauthorized Docker registry access, and preserve publish context for operator triage.
- Preserve partial success details when a transient Codex empty-turn failure happens after MoonSpec verification or PR creation.
- Document the finish-summary and MoonSpec publishing contract updates.

## Validation

- git diff --check
- ./tools/test_unit.sh

## Root Cause

Recent Jira Orchestrate failures had useful evidence in artifacts, but the terminal summary repeated truncated Markdown or generic runtime text. This change makes the actionable cause and next action first-class in reports/run_summary.json.