### PR TITLE
[codex] Fix pr-resolver merge automation reentry

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -115,6 +115,11 @@ def merge_automation_disposition_for_result(
     normalized_next_step = normalize_text(next_step).lower()
     if normalized_next_step.startswith("run_fix_"):
         return MERGE_AUTOMATION_DISPOSITION_REENTER_GATE
+    if normalized_next_step in {
+        "retry_finalize_after_backoff",
+        "wait_for_ci_and_retry_finalize",
+    }:
+        return MERGE_AUTOMATION_DISPOSITION_REENTER_GATE
     if normalized_status == "merged" and normalized_outcome == "merged":
         if normalized_reason == "already_merged":
             return MERGE_AUTOMATION_DISPOSITION_ALREADY_MERGED

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -331,12 +331,28 @@ def run_orchestration(
                     "timestamp": now_utc_iso(),
                 }
             )
+            print(
+                (
+                    "pr-resolver waiting: "
+                    f"attempt={attempt} reason={reason or 'unknown'} "
+                    f"sleep_seconds={sleep_seconds}"
+                ),
+                flush=True,
+            )
             if sleep_seconds > 0:
                 sleep_fn(sleep_seconds)
             continue
 
         escalations += 1
         pending_progress_reason = reason
+        print(
+            (
+                "pr-resolver remediation: "
+                f"attempt={attempt} reason={reason or 'unknown'} "
+                f"escalation={escalations}"
+            ),
+            flush=True,
+        )
         full_payload = full_runner(attempt, escalations, reason)
         full_status = _normalize_full_status(full_payload)
         full_reason = parse_reason(full_payload) or reason

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -89,6 +89,19 @@ Result should include:
 * `mergeAutomationDisposition` for merge automation consumers:
   `merged`, `already_merged`, `reenter_gate`, `manual_review`, or `failed`
 
+Continuation blockers use `reenter_gate`, not generic failure. This includes
+resolver-owned remediation steps (`run_fix_comments_skill`, `run_fix_ci_skill`,
+`run_fix_merge_conflicts_skill`) and transient finalize-only waits
+(`retry_finalize_after_backoff`, `wait_for_ci_and_retry_finalize`). Managed
+runtime adapters preserve that disposition even when the resolver command exits
+non-zero, so `MoonMind.MergeAutomation` can re-enter the gate instead of failing
+the parent workflow.
+
+During long waits, especially `ci_running`, the resolver emits concise progress
+lines before sleeping. These lines are part of the operational contract: they keep
+managed-runtime observability fresh and avoid treating a healthy CI poll loop as
+a silent stuck agent.
+
 ---
 
 ## 5. Data Collection (Snapshot)

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -532,6 +532,22 @@ MUST include this field. A resolver run that is explicitly launched by
 `MoonMind.MergeAutomation` but does not write a parseable resolver result is a
 resolver failure, not a generic successful child run.
 
+Resolver adapter boundaries MUST preserve continuation dispositions. When a
+resolver artifact reports `mergeAutomationDisposition = "reenter_gate"`, or when
+older artifacts encode the same intent through a continuation `next_step` such
+as `run_fix_comments_skill`, `run_fix_ci_skill`,
+`run_fix_merge_conflicts_skill`, `retry_finalize_after_backoff`, or
+`wait_for_ci_and_retry_finalize`, the managed-agent adapter returns a successful
+child result carrying `mergeAutomationDisposition = "reenter_gate"`. It MUST NOT
+convert that state into an agent failure merely because the resolver process used
+a non-zero exit code such as `attempts_exhausted`; merge automation owns the next
+gate cycle.
+
+Long resolver waits also remain observable. While polling transient states such
+as `ci_running`, resolver tooling SHOULD emit periodic progress output before
+sleeping so managed-runtime stuck detection can distinguish healthy waiting from
+a silent stalled agent.
+
 ---
 
 ## 14. Post-Resolver Re-Gating

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -871,7 +871,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     )
                     resolver_disposition = str(
                         metadata.get("mergeAutomationDisposition") or ""
-                    ).strip()
+                    ).strip().lower()
                     updated_result = False
                     if derived_failure_class is not None:
                         should_apply_derived = False

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -869,6 +869,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     derived_failure_class, derived_summary = (
                         _derive_pr_resolver_failure(record.workspace_path)
                     )
+                    resolver_disposition = str(
+                        metadata.get("mergeAutomationDisposition") or ""
+                    ).strip()
+                    updated_result = False
                     if derived_failure_class is not None:
                         should_apply_derived = False
                         if record.status == "completed" and failure_class is None:
@@ -887,9 +891,24 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                                     "metadata": metadata,
                                 }
                             )
-                        elif metadata != result.metadata:
-                            result = result.model_copy(update={"metadata": metadata})
-                    elif metadata != result.metadata:
+                            updated_result = True
+                    elif (
+                        resolver_disposition == "reenter_gate"
+                        and record.status == "failed"
+                        and failure_class in {None, "execution_error"}
+                        and _is_generic_process_exit_summary(summary)
+                    ):
+                        result = result.model_copy(
+                            update={
+                                "failure_class": None,
+                                "summary": (
+                                    "pr-resolver requested merge automation re-entry."
+                                ),
+                                "metadata": metadata,
+                            }
+                        )
+                        updated_result = True
+                    if not updated_result and metadata != result.metadata:
                         result = result.model_copy(update={"metadata": metadata})
             return result
         return AgentRunResult(

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -77,6 +77,15 @@ _PR_RESOLVER_MERGED_STATUSES: frozenset[str] = frozenset({"merged"})
 _PR_RESOLVER_TERMINAL_STATUSES: frozenset[str] = (
     _PR_RESOLVER_FAILURE_STATUSES | _PR_RESOLVER_MERGED_STATUSES
 )
+_PR_RESOLVER_REENTER_NEXT_STEPS: frozenset[str] = frozenset(
+    {
+        "run_fix_comments_skill",
+        "run_fix_ci_skill",
+        "run_fix_merge_conflicts_skill",
+        "retry_finalize_after_backoff",
+        "wait_for_ci_and_retry_finalize",
+    }
+)
 _PR_RESOLVER_RESULT_PATH_LIST = ", ".join(
     str(path) for path in _PR_RESOLVER_RESULT_PATHS
 )
@@ -201,6 +210,51 @@ def _pr_resolver_final_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(merge, dict):
         return merge
     return {}
+
+
+def _pr_resolver_next_step(payload: dict[str, Any]) -> str:
+    """Return the resolver's normalized next-step action when present."""
+
+    final = _pr_resolver_final_payload(payload)
+    return _first_stripped_text(
+        payload.get("next_step"),
+        payload.get("nextStep"),
+        payload.get("retryRecommendedAction"),
+        payload.get("retry_recommended_action"),
+        final.get("next_step"),
+        final.get("nextStep"),
+        final.get("retryRecommendedAction"),
+        final.get("retry_recommended_action"),
+    )
+
+
+def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
+    """Return explicit or derived merge-automation disposition for a resolver result."""
+
+    final = _pr_resolver_final_payload(payload)
+    explicit = _first_stripped_text(
+        payload.get("mergeAutomationDisposition"),
+        payload.get("merge_automation_disposition"),
+        final.get("mergeAutomationDisposition"),
+        final.get("merge_automation_disposition"),
+    )
+    if explicit:
+        return explicit
+
+    status = _pr_resolver_status(payload)
+    reason = _first_stripped_text(
+        payload.get("final_reason"),
+        payload.get("reason"),
+        final.get("final_reason"),
+        final.get("reason"),
+    )
+    if status in _PR_RESOLVER_MERGED_STATUSES:
+        return "already_merged" if reason == "already_merged" else "merged"
+
+    next_step = _pr_resolver_next_step(payload)
+    if next_step in _PR_RESOLVER_REENTER_NEXT_STEPS:
+        return "reenter_gate"
+    return ""
 
 
 def _first_stripped_text(*values: Any) -> str:
@@ -421,11 +475,13 @@ def _derive_pr_resolver_failure(
         )
 
     status = _pr_resolver_status(payload)
+    if _pr_resolver_disposition(payload) == "reenter_gate":
+        return None, None
     if status not in _PR_RESOLVER_FAILURE_STATUSES:
         return None, None
 
     reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
-    next_step = str(payload.get("next_step") or "").strip()
+    next_step = _pr_resolver_next_step(payload)
     summary_parts = [f"pr-resolver reported status '{status}'"]
     if reason:
         summary_parts.append(reason)
@@ -445,13 +501,9 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
     status = _pr_resolver_status(payload)
     reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
     metadata: dict[str, Any] = {}
-    explicit_disposition = str(payload.get("mergeAutomationDisposition") or "").strip()
-    if explicit_disposition:
-        metadata["mergeAutomationDisposition"] = explicit_disposition
-    elif status in _PR_RESOLVER_MERGED_STATUSES:
-        metadata["mergeAutomationDisposition"] = (
-            "already_merged" if reason == "already_merged" else "merged"
-        )
+    disposition = _pr_resolver_disposition(payload)
+    if disposition:
+        metadata["mergeAutomationDisposition"] = disposition
     final = _pr_resolver_final_payload(payload)
     head_sha = _first_stripped_text(
         payload.get("headSha"),
@@ -742,6 +794,9 @@ class ManagedAgentAdapter:
                     derived_failure_class, derived_summary = _derive_pr_resolver_failure(
                         record.workspace_path
                     )
+                    resolver_disposition = str(
+                        metadata.get("mergeAutomationDisposition") or ""
+                    ).strip()
                     if derived_failure_class is not None:
                         should_apply_derived = False
                         if record.status == "completed" and failure_class is None:
@@ -756,6 +811,14 @@ class ManagedAgentAdapter:
                             failure_class = derived_failure_class
                             if derived_summary:
                                 summary = derived_summary
+                    elif (
+                        resolver_disposition == "reenter_gate"
+                        and record.status == "failed"
+                        and failure_class in {None, "execution_error"}
+                        and _is_generic_process_exit_summary(summary)
+                    ):
+                        failure_class = None
+                        summary = "pr-resolver requested merge automation re-entry."
                 return AgentRunResult(
                     summary=summary,
                     output_refs=output_refs,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -239,7 +239,7 @@ def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
         final.get("merge_automation_disposition"),
     )
     if explicit:
-        return explicit
+        return explicit.lower()
 
     status = _pr_resolver_status(payload)
     reason = _first_stripped_text(
@@ -247,12 +247,12 @@ def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
         payload.get("reason"),
         final.get("final_reason"),
         final.get("reason"),
-    )
+    ).lower()
     if status in _PR_RESOLVER_MERGED_STATUSES:
         return "already_merged" if reason == "already_merged" else "merged"
 
-    next_step = _pr_resolver_next_step(payload)
-    if next_step in _PR_RESOLVER_REENTER_NEXT_STEPS:
+    next_step = _pr_resolver_next_step(payload).lower()
+    if next_step in _PR_RESOLVER_REENTER_NEXT_STEPS or next_step.startswith("run_fix_"):
         return "reenter_gate"
     return ""
 
@@ -796,7 +796,7 @@ class ManagedAgentAdapter:
                     )
                     resolver_disposition = str(
                         metadata.get("mergeAutomationDisposition") or ""
-                    ).strip()
+                    ).strip().lower()
                     if derived_failure_class is not None:
                         should_apply_derived = False
                         if record.status == "completed" and failure_class is None:

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -934,6 +934,22 @@ def test_contract_run_fix_next_step_returns_reenter_gate(
 
     assert disposition == "reenter_gate"
 
+def test_contract_finalize_retry_next_step_returns_reenter_gate(
+    pr_resolve_contract_module: dict[str, Any],
+) -> None:
+    disposition_for_result = pr_resolve_contract_module[
+        "merge_automation_disposition_for_result"
+    ]
+
+    disposition = disposition_for_result(
+        status="blocked",
+        merge_outcome="blocked",
+        final_reason="ci_running",
+        next_step="retry_finalize_after_backoff",
+    )
+
+    assert disposition == "reenter_gate"
+
 def test_finalize_snapshot_refresh_failure_is_blocked_retryable(
     pr_resolve_finalize_module: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
@@ -975,7 +991,7 @@ def test_finalize_snapshot_refresh_failure_is_blocked_retryable(
     payload = result_path.read_text(encoding="utf-8")
     assert '"status": "blocked"' in payload
     assert '"reason": "snapshot_refresh_failed"' in payload
-    assert '"mergeAutomationDisposition": "manual_review"' in payload
+    assert '"mergeAutomationDisposition": "reenter_gate"' in payload
 
     monkeypatch.setattr(
         "sys.argv",

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3377,7 +3377,7 @@ async def test_fetch_result_maps_failed_pr_resolver_artifact_for_completed_run(
     assert "pr-resolver reported status 'failed'" in result.summary
     assert "pr_not_found" in result.summary
 
-async def test_fetch_result_maps_blocked_pr_resolver_artifact_for_completed_run(
+async def test_fetch_result_treats_pr_resolver_reenter_gate_as_continuation(
     tmp_path: Path,
 ) -> None:
     workspace_path = tmp_path / "workspace"
@@ -3387,6 +3387,7 @@ async def test_fetch_result_maps_blocked_pr_resolver_artifact_for_completed_run(
         (
             "{\n"
             '  "status": "attempts_exhausted",\n'
+            '  "mergeAutomationDisposition": "reenter_gate",\n'
             '  "final_reason": "actionable_comments",\n'
             '  "next_step": "run_fix_comments_skill"\n'
             "}\n"
@@ -3453,10 +3454,91 @@ async def test_fetch_result_maps_blocked_pr_resolver_artifact_for_completed_run(
 
     result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
 
-    assert result.failure_class == "user_error"
-    assert result.summary is not None
-    assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
-    assert "run_fix_comments_skill" in result.summary
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+
+async def test_fetch_result_clears_generic_failed_exit_for_pr_resolver_reentry(
+    tmp_path: Path,
+) -> None:
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "blocked",\n'
+            '  "final_reason": "ci_running",\n'
+            '  "next_step": "wait_for_ci_and_retry_finalize"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    run_id = "run-result-pr-ci-reenter"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="failed",
+            failureClass="execution_error",
+            errorMessage="Process exited with code 3",
+            startedAt=datetime.now(tz=UTC),
+            workspacePath=str(workspace_path),
+        )
+    )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_async_noop,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=run_id,
+        agent_id="codex_cli",
+        locator={
+            "sessionId": "sess:wf-task-1:codex_cli",
+            "sessionEpoch": 1,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Process exited with code 3",
+            "failureClass": "execution_error",
+            "metadata": {},
+        },
+        status="failed",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+
+    assert result.failure_class is None
+    assert result.summary == "pr-resolver requested merge automation re-entry."
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
 async def test_fetch_result_maps_merged_pr_resolver_artifact_metadata(
     tmp_path: Path,

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1301,7 +1301,7 @@ async def test_fetch_result_marks_failed_pr_resolver_artifact_as_failure(
     assert "pr-resolver reported status 'failed'" in result.summary
     assert "manual_review" in result.summary
 
-async def test_fetch_result_maps_blocked_pr_resolver_result_to_user_error(
+async def test_fetch_result_treats_pr_resolver_reenter_gate_as_continuation(
     tmp_path: Path,
 ):
     from datetime import UTC, datetime
@@ -1316,6 +1316,7 @@ async def test_fetch_result_maps_blocked_pr_resolver_result_to_user_error(
         (
             "{\n"
             '  "status": "attempts_exhausted",\n'
+            '  "mergeAutomationDisposition": "reenter_gate",\n'
             '  "final_reason": "actionable_comments",\n'
             '  "next_step": "run_fix_comments_skill"\n'
             "}\n"
@@ -1347,10 +1348,57 @@ async def test_fetch_result_maps_blocked_pr_resolver_result_to_user_error(
     result = await adapter.fetch_result(
         "run-result-pr-blocked", pr_resolver_expected=True
     )
-    assert result.failure_class == "user_error"
-    assert result.summary is not None
-    assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
-    assert "run_fix_comments_skill" in result.summary
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+
+async def test_fetch_result_derives_pr_resolver_reenter_gate_from_next_step(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "blocked",\n'
+            '  "final_reason": "ci_running",\n'
+            '  "next_step": "retry_finalize_after_backoff"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-ci-wait",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-ci-wait",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-ci-wait", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
 async def test_fetch_result_prefers_terminal_status_over_skipped_merge_outcome(
     tmp_path: Path,
@@ -1399,10 +1447,8 @@ async def test_fetch_result_prefers_terminal_status_over_skipped_merge_outcome(
     result = await adapter.fetch_result(
         "run-result-pr-blocked-skipped", pr_resolver_expected=True
     )
-    assert result.failure_class == "user_error"
-    assert result.summary is not None
-    assert "pr-resolver reported status 'blocked'" in result.summary
-    assert "run_fix_comments_skill" in result.summary
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
 async def test_fetch_result_upgrades_generic_failed_exit_with_pr_result(
     tmp_path: Path,
@@ -1420,7 +1466,7 @@ async def test_fetch_result_upgrades_generic_failed_exit_with_pr_result(
             "{\n"
             '  "status": "attempts_exhausted",\n'
             '  "final_reason": "actionable_comments",\n'
-            '  "next_step": "run_fix_comments_skill"\n'
+            '  "next_step": "manual_review"\n'
             "}\n"
         ),
         encoding="utf-8",
@@ -1455,7 +1501,60 @@ async def test_fetch_result_upgrades_generic_failed_exit_with_pr_result(
     assert result.failure_class == "user_error"
     assert result.summary is not None
     assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
-    assert "run_fix_comments_skill" in result.summary
+    assert "manual_review" in result.summary
+
+async def test_fetch_result_clears_generic_failed_exit_for_reenter_gate(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "attempts_exhausted",\n'
+            '  "mergeAutomationDisposition": "reenter_gate",\n'
+            '  "final_reason": "actionable_comments",\n'
+            '  "next_step": "run_fix_comments_skill"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-generic-reenter",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="failed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+            failure_class="execution_error",
+            error_message="Process exited with code 3",
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-generic-reenter",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-generic-reenter", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.summary == "pr-resolver requested merge automation re-entry."
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
 async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
     tmp_path: Path,
@@ -1516,11 +1615,8 @@ async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
     result = await adapter.fetch_result(
         "run-result-pr-latest-attempt", pr_resolver_expected=True
     )
-    assert result.failure_class == "user_error"
-    assert result.summary is not None
-    assert "pr-resolver reported status 'blocked'" in result.summary
-    assert "ci_running" in result.summary
-    assert "merge_conflicts" not in result.summary
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
 async def test_fetch_result_ignores_stale_failure_when_newer_attempt_is_merged(
     tmp_path: Path,

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1400,6 +1400,58 @@ async def test_fetch_result_derives_pr_resolver_reenter_gate_from_next_step(
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
+async def test_fetch_result_normalizes_pr_resolver_reenter_values(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "blocked",\n'
+            '  "mergeAutomationDisposition": "Reenter_Gate",\n'
+            '  "final_reason": "actionable_comments",\n'
+            '  "next_step": "RUN_FIX_COMMENTS_SKILL"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-mixed-case",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="failed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+            failure_class="execution_error",
+            error_message="Process exited with code 3",
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-mixed-case",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-mixed-case", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+
 async def test_fetch_result_prefers_terminal_status_over_skipped_merge_outcome(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Summary
- Preserve pr-resolver continuation states as `mergeAutomationDisposition=reenter_gate` instead of converting them into failed child workflows.
- Treat transient finalize waits (`ci_running`, snapshot refresh retry) as merge-automation re-entry states and emit flushed resolver progress lines before long waits.
- Update resolver and merge automation docs plus adapter/contract tests for the corrected boundary behavior.

## Root Cause
Managed runtime adapters were mapping `blocked` / `attempts_exhausted` pr-resolver artifacts to agent failures before `MoonMind.MergeAutomation` could consume the resolver's continuation disposition. That made review-remediation and CI-wait loops fail parent workflows even when the resolver intended another gate cycle.

## Validation
- `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`
- `./tools/test_unit.sh` Python phase: 6336 passed, 6 skipped, 1 xpassed, 16 subtests passed
- `npm run ui:test`: 27 files passed, 428 tests passed, 234 skipped
- `npm run ui:test -- entrypoints/workflow-detail.test.tsx`: 120 passed

Note: one full `./tools/test_unit.sh` run had a transient UI failure in `workflow-detail.test.tsx` while the Python phase passed; the failed file and the full UI suite both passed on direct rerun.
