### PR TITLE
Fail ungated pr-resolver continuation runs instead of false-green

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -45,6 +45,27 @@ This writes:
 
 If this command does not run, does not write `var/pr_resolver/result.json`, or exits before producing a parseable result, stop as blocked with the command output and do not report success.
 
+## Foreground Execution Contract (no backgrounding)
+This skill runs inside a one-shot managed agent run. When your process exits, the
+run is over — there is no event loop that will "notify you on completion" and no
+scheduled wakeup that will resume you later. Those are interactive-harness concepts
+that do not exist here.
+
+Therefore:
+- You MUST run the orchestration command in the **foreground** and block on it until
+  it returns. Do NOT launch it with `&`, `nohup`, a background job, a detached
+  process, or any "run in background and notify me" mechanism.
+- The orchestration command already polls long-running states (especially
+  `ci_running`) internally up to its elapsed budget (`--max-elapsed-seconds`,
+  default 7200s) and finalizes the merge when CI passes. Let it run to completion;
+  do not exit while it is still polling.
+- Do NOT end your turn expecting a callback, notification, or fallback wakeup to
+  finish the merge for you. If you exit while CI is still running, the merge is
+  abandoned and the PR is left unresolved even though your local work succeeded.
+- A run that stops at `ci_running` (or any other non-terminal state) because you
+  backgrounded the orchestrator or returned early is **not** a successful PR
+  resolution.
+
 ## Terminal Success Contract
 Allowed successful terminal states:
 - `var/pr_resolver/result.json` has `status=merged`, `merge_outcome=merged`, and `mergeAutomationDisposition=merged`.
@@ -131,3 +152,4 @@ python3 .agents/skills/pr-resolver/bin/pr_resolve_full.py --pr <pr_number_or_bra
 - Respect retry caps; if retries are exhausted, return `attempts_exhausted` and stop.
 - This skill is allowed to commit/push and merge (task.publish.mode MUST be none).
 - A failed push, missing GitHub auth, or missing remote branch update is an unresolved PR blocker, even if all code changes are committed locally.
+- Never background the orchestration command or rely on notifications/scheduled wakeups to finish the merge; run it in the foreground and wait for it to return (see Foreground Execution Contract).

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -102,6 +102,18 @@ lines before sleeping. These lines are part of the operational contract: they ke
 managed-runtime observability fresh and avoid treating a healthy CI poll loop as
 a silent stuck agent.
 
+The orchestration command MUST run in the foreground for the lifetime of the
+managed run. It polls long-running states (notably `ci_running`) internally up to
+its elapsed budget and finalizes the merge when CI passes. The agent MUST NOT
+background the command or rely on notifications/scheduled wakeups to finish the
+merge after it exits — in a one-shot managed run there is no callback, so exiting
+while CI is still running abandons the merge and leaves the PR unresolved.
+
+A standalone `pr-resolver` run (one not launched by `MoonMind.MergeAutomation`)
+that ends in the continuation state `reenter_gate` has no gate to re-enter, so it
+is not a successful PR resolution; the owning workflow fails such a run terminally
+rather than reporting success. See `docs/Workflows/PrMergeAutomation.md` §13.4.
+
 ---
 
 ## 5. Data Collection (Snapshot)

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -548,6 +548,24 @@ as `ci_running`, resolver tooling SHOULD emit periodic progress output before
 sleeping so managed-runtime stuck detection can distinguish healthy waiting from
 a silent stalled agent.
 
+### 13.4 Ungated resolver runs MUST NOT report continuation as success
+
+A continuation disposition (`reenter_gate`) only has meaning when a
+`MoonMind.MergeAutomation` gate owns the next cycle: re-enter `awaiting_external`,
+poll CI on the new head, and finalize the merge. Merge automation marks the
+resolver child it launches by injecting a `mergeGate` block
+(`mergeGate.parentWorkflowId`) into the resolver's `initial_parameters`.
+
+When `pr-resolver` is instead submitted as a **standalone top-level
+`MoonMind.UserWorkflow`** (no `mergeGate` owner), there is no gate to re-enter. A
+run that ends with `mergeAutomationDisposition = "reenter_gate"` in that case has
+**not** resolved the PR — CI/merge finalization never happens — so the parent
+workflow MUST NOT report `status: success`. It MUST fail the run terminally with
+an actionable summary directing the operator to re-submit under merge automation
+or finalize manually. This prevents a false-green completion where the PR is left
+open and unmerged. Terminal dispositions (`merged`, `already_merged`) and
+gated continuation runs are unaffected.
+
 ---
 
 ## 14. Post-Resolver Re-Gating

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -8401,13 +8401,23 @@ class MoonMindRunWorkflow:
         message = ". ".join(part.rstrip(".") for part in parts if part)
         return f"{message}." if message else "Workflow completed successfully"
 
+    def _actual_parent_workflow_id(self) -> str | None:
+        try:
+            parent_info = workflow.info().parent
+        except Exception:
+            return None
+        if parent_info is None:
+            return None
+        return self._coerce_text(parent_info.workflow_id, max_chars=200)
+
     def _is_merge_automation_gated(self, parameters: Mapping[str, Any]) -> bool:
         """Return True when this run was launched by a MoonMind.MergeAutomation gate.
 
         Merge automation tags the resolver child's parameters with a ``mergeGate``
         block carrying the owning ``parentWorkflowId`` (see
-        ``build_resolver_run_request``). A standalone resolver submission has no such
-        block, so its continuation dispositions have no gate to re-enter.
+        ``build_resolver_run_request``). The payload is user-controlled for
+        standalone runs, so ownership is trusted only when the tagged parent matches
+        Temporal's actual parent workflow id.
         """
 
         merge_gate = self._mapping_value(parameters, "mergeGate", "merge_gate")
@@ -8418,7 +8428,9 @@ class MoonMindRunWorkflow:
             or merge_gate.get("parent_workflow_id"),
             max_chars=200,
         )
-        return bool(parent)
+        if not parent:
+            return False
+        return parent == self._actual_parent_workflow_id()
 
     def _continuation_disposition_failure_message(
         self, parameters: Mapping[str, Any]

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -383,6 +383,14 @@ RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH = (
     "run-stop-on-publish-handoff-failure-v1"
 )
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
+RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH = (
+    "run-ungated-continuation-disposition-v1"
+)
+# Merge-automation dispositions that are *continuations*: they only have meaning
+# when a MoonMind.MergeAutomation gate re-enters and finalizes the merge. A
+# standalone (ungated) resolver run that ends in one of these states has not
+# resolved the PR and must not be reported as a success.
+MERGE_AUTOMATION_CONTINUATION_DISPOSITIONS = frozenset({"reenter_gate"})
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
@@ -4492,11 +4500,25 @@ class MoonMindRunWorkflow:
             elif output_status == "no_changes":
                 finalizing_error = self._publish_reason or output_message
 
+        continuation_failure = False
+        if not publish_failure and workflow.patched(
+            RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH
+        ):
+            continuation_message = self._continuation_disposition_failure_message(
+                parameters
+            )
+            if continuation_message:
+                continuation_failure = True
+                output_status = "needs_continuation"
+                output_message = continuation_message
+                finalizing_status = "failed"
+                finalizing_error = continuation_message
+
         await self._run_finalizing_stage(
             parameters=parameters, status=finalizing_status, error=finalizing_error
         )
 
-        if publish_failure:
+        if publish_failure or continuation_failure:
             self._close_status = CLOSE_STATUS_FAILED
             self._set_state(STATE_FAILED, summary=output_message)
             await self._record_terminal_state(
@@ -8378,6 +8400,53 @@ class MoonMindRunWorkflow:
             return parts[0]
         message = ". ".join(part.rstrip(".") for part in parts if part)
         return f"{message}." if message else "Workflow completed successfully"
+
+    def _is_merge_automation_gated(self, parameters: Mapping[str, Any]) -> bool:
+        """Return True when this run was launched by a MoonMind.MergeAutomation gate.
+
+        Merge automation tags the resolver child's parameters with a ``mergeGate``
+        block carrying the owning ``parentWorkflowId`` (see
+        ``build_resolver_run_request``). A standalone resolver submission has no such
+        block, so its continuation dispositions have no gate to re-enter.
+        """
+
+        merge_gate = self._mapping_value(parameters, "mergeGate", "merge_gate")
+        if not merge_gate:
+            return False
+        parent = self._coerce_text(
+            merge_gate.get("parentWorkflowId")
+            or merge_gate.get("parent_workflow_id"),
+            max_chars=200,
+        )
+        return bool(parent)
+
+    def _continuation_disposition_failure_message(
+        self, parameters: Mapping[str, Any]
+    ) -> str | None:
+        """Return a failure message for an ungated continuation disposition.
+
+        ``reenter_gate`` (and any future continuation disposition) tells
+        ``MoonMind.MergeAutomation`` to re-open the readiness gate, poll CI, and
+        finalize the merge on a later cycle. When the resolver runs as a standalone
+        top-level ``MoonMind.UserWorkflow`` there is no owning gate, so the
+        continuation is dropped: CI/merge finalization never happens and the pull
+        request is left unresolved. Reporting such a run as ``success`` is a
+        false-green outcome, so we surface it as an actionable failure instead.
+        """
+
+        disposition = (self._merge_automation_disposition or "").strip()
+        if disposition not in MERGE_AUTOMATION_CONTINUATION_DISPOSITIONS:
+            return None
+        if self._is_merge_automation_gated(parameters):
+            return None
+        return (
+            "pr-resolver reported mergeAutomationDisposition="
+            f"'{disposition}', a continuation state that requires a "
+            "MoonMind.MergeAutomation gate to re-enter, poll CI, and finalize the "
+            "merge. This run is not owned by merge automation, so the pull request "
+            "was not resolved. Re-submit the resolution under merge automation or "
+            "finalize the merge manually."
+        )
 
     def _determine_publish_completion(
         self,

--- a/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
+++ b/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
@@ -11,12 +11,21 @@ so the run must not be treated as a successful PR resolution.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
+from temporalio import client, exceptions
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from moonmind.workflows.temporal.workflows.merge_gate import (
     build_resolver_run_request,
 )
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows import run as run_workflow_module
+from moonmind.workflows.temporal.workflows.run import (
+    MoonMindRunWorkflow,
+    MoonMindUserWorkflow,
+)
 
 
 def _ungated_resolver_parameters() -> dict[str, object]:
@@ -60,7 +69,17 @@ def _gated_resolver_parameters() -> dict[str, object]:
     return request["initial_parameters"]
 
 
-def test_gated_parameters_are_recognized_as_merge_automation_owned() -> None:
+def test_gated_parameters_are_recognized_as_merge_automation_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_info = type(
+        "ParentInfo",
+        (),
+        {"workflow_id": "mm:parent-merge-automation"},
+    )
+    workflow_info = type("WorkflowInfo", (), {"parent": parent_info})
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+
     workflow = MoonMindRunWorkflow()
     assert workflow._is_merge_automation_gated(_gated_resolver_parameters()) is True
 
@@ -77,6 +96,29 @@ def test_empty_merge_gate_without_parent_is_not_gated() -> None:
     assert workflow._is_merge_automation_gated(params) is False
 
 
+def test_stale_merge_gate_payload_without_temporal_parent_is_not_gated() -> None:
+    workflow = MoonMindRunWorkflow()
+    params = _ungated_resolver_parameters()
+    params["mergeGate"] = {
+        "parentWorkflowId": "mm:parent-merge-automation",
+        "pullRequestUrl": "https://example/pr/1",
+    }
+
+    assert workflow._is_merge_automation_gated(params) is False
+
+
+def test_mismatched_temporal_parent_is_not_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_info = type("ParentInfo", (), {"workflow_id": "mm:other-parent"})
+    workflow_info = type("WorkflowInfo", (), {"parent": parent_info})
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+
+    workflow = MoonMindRunWorkflow()
+
+    assert workflow._is_merge_automation_gated(_gated_resolver_parameters()) is False
+
+
 def test_ungated_reenter_gate_disposition_blocks_success() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._merge_automation_disposition = "reenter_gate"
@@ -90,7 +132,17 @@ def test_ungated_reenter_gate_disposition_blocks_success() -> None:
     assert "MergeAutomation" in message
 
 
-def test_gated_reenter_gate_disposition_is_allowed() -> None:
+def test_gated_reenter_gate_disposition_is_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_info = type(
+        "ParentInfo",
+        (),
+        {"workflow_id": "mm:parent-merge-automation"},
+    )
+    workflow_info = type("WorkflowInfo", (), {"parent": parent_info})
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+
     workflow = MoonMindRunWorkflow()
     workflow._merge_automation_disposition = "reenter_gate"
 
@@ -100,6 +152,89 @@ def test_gated_reenter_gate_disposition_is_allowed() -> None:
         )
         is None
     )
+
+
+@pytest.fixture
+def ungated_continuation_workflow_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        MoonMindUserWorkflow, "_trusted_owner_metadata", lambda self: ("user", "user-1")
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+
+    async def fake_planning_stage(self: MoonMindUserWorkflow, **_kwargs: Any) -> str:
+        return "artifact://plan/ungated-continuation"
+
+    async def fake_execution_stage(self: MoonMindUserWorkflow, **_kwargs: Any) -> None:
+        self._merge_automation_disposition = "reenter_gate"
+
+    async def fake_finalizing_stage(
+        self: MoonMindUserWorkflow,
+        *,
+        parameters: dict[str, Any],
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        self._finish_summary = {
+            "finishOutcome": {
+                "code": "FAILED" if status == "failed" else "PUBLISH_DISABLED",
+                "reason": error or status,
+            },
+            "publish": {"mode": self._publish_mode(parameters), "status": status},
+        }
+
+    async def fake_record_terminal_state(
+        self: MoonMindUserWorkflow, **_kwargs: Any
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(MoonMindUserWorkflow, "_run_planning_stage", fake_planning_stage)
+    monkeypatch.setattr(
+        MoonMindUserWorkflow, "_run_execution_stage", fake_execution_stage
+    )
+    monkeypatch.setattr(
+        MoonMindUserWorkflow, "_run_finalizing_stage", fake_finalizing_stage
+    )
+    monkeypatch.setattr(
+        MoonMindUserWorkflow, "_record_terminal_state", fake_record_terminal_state
+    )
+
+
+@pytest.mark.asyncio
+async def test_user_workflow_ungated_reenter_gate_disposition_fails_at_boundary(
+    ungated_continuation_workflow_environment: None,
+) -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-ungated-continuation-disposition",
+            workflows=[MoonMindUserWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(client.WorkflowFailureError) as exc_info:
+                await env.client.execute_workflow(
+                    MoonMindUserWorkflow.run,
+                    {
+                        "workflowType": "MoonMind.UserWorkflow",
+                        "initialParameters": _ungated_resolver_parameters(),
+                    },
+                    id="test-user-workflow-ungated-continuation",
+                    task_queue="test-ungated-continuation-disposition",
+                )
+
+            assert isinstance(exc_info.value.cause, exceptions.ApplicationError)
+            assert exc_info.value.cause.non_retryable is True
+            assert (
+                "mergeAutomationDisposition='reenter_gate'"
+                in exc_info.value.cause.message
+            )
+            assert "not owned by merge automation" in exc_info.value.cause.message
 
 
 @pytest.mark.parametrize("disposition", ["merged", "already_merged"])

--- a/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
+++ b/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
@@ -1,0 +1,130 @@
+"""Regression coverage for ungated merge-automation continuation dispositions.
+
+Incident background: a top-level ``MoonMind.UserWorkflow`` running ``pr-resolver``
+finished with ``mergeAutomationDisposition = "reenter_gate"`` and was reported as
+``status: success`` even though the pull request was never merged. ``reenter_gate``
+is a *continuation* disposition that only has meaning inside a
+``MoonMind.MergeAutomation`` gate that re-enters and finalizes the merge. When the
+resolver runs standalone (no owning gate), that continuation can never be re-entered,
+so the run must not be treated as a successful PR resolution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.workflows.merge_gate import (
+    build_resolver_run_request,
+)
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _ungated_resolver_parameters() -> dict[str, object]:
+    """Parameters matching the standalone pr-resolver run from the incident.
+
+    These mirror the real ``initial_parameters`` shape: a ``workflow`` block selecting
+    the ``pr-resolver`` skill with ``publishMode=none`` and *no* ``mergeGate`` block.
+    """
+
+    return {
+        "requestType": "task",
+        "repository": "MoonLadderStudios/Tactics",
+        "publishMode": "none",
+        "targetRuntime": "claude_code",
+        "workflow": {
+            "instructions": "Resolve PR #1863 on branch story-006.",
+            "tool": {"type": "skill", "name": "pr-resolver", "version": "1.0"},
+            "skill": {"name": "pr-resolver", "version": "1.0"},
+            "inputs": {"repo": "MoonLadderStudios/Tactics", "pr": "1863"},
+            "publish": {"mode": "none"},
+        },
+    }
+
+
+def _gated_resolver_parameters() -> dict[str, object]:
+    """Parameters produced by MoonMind.MergeAutomation when it launches the resolver."""
+
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent-merge-automation",
+        pull_request={
+            "repo": "MoonLadderStudios/Tactics",
+            "number": 1863,
+            "url": "https://github.com/MoonLadderStudios/Tactics/pull/1863",
+            "headBranch": "story-006",
+            "baseBranch": "main",
+            "headSha": "e7a62914",
+        },
+        jira_issue_key=None,
+        merge_method="squash",
+    )
+    return request["initial_parameters"]
+
+
+def test_gated_parameters_are_recognized_as_merge_automation_owned() -> None:
+    workflow = MoonMindRunWorkflow()
+    assert workflow._is_merge_automation_gated(_gated_resolver_parameters()) is True
+
+
+def test_standalone_resolver_parameters_are_not_gated() -> None:
+    workflow = MoonMindRunWorkflow()
+    assert workflow._is_merge_automation_gated(_ungated_resolver_parameters()) is False
+
+
+def test_empty_merge_gate_without_parent_is_not_gated() -> None:
+    workflow = MoonMindRunWorkflow()
+    params = _ungated_resolver_parameters()
+    params["mergeGate"] = {"pullRequestUrl": "https://example/pr/1"}
+    assert workflow._is_merge_automation_gated(params) is False
+
+
+def test_ungated_reenter_gate_disposition_blocks_success() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._merge_automation_disposition = "reenter_gate"
+
+    message = workflow._continuation_disposition_failure_message(
+        _ungated_resolver_parameters()
+    )
+
+    assert message is not None
+    assert "reenter_gate" in message
+    assert "MergeAutomation" in message
+
+
+def test_gated_reenter_gate_disposition_is_allowed() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._merge_automation_disposition = "reenter_gate"
+
+    assert (
+        workflow._continuation_disposition_failure_message(
+            _gated_resolver_parameters()
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("disposition", ["merged", "already_merged"])
+def test_terminal_dispositions_are_not_continuation_failures(disposition: str) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._merge_automation_disposition = disposition
+
+    assert (
+        workflow._continuation_disposition_failure_message(
+            _ungated_resolver_parameters()
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("disposition", ["", None, "   ", "manual_review", "totally_new_state"])
+def test_blank_or_unknown_dispositions_do_not_block(disposition) -> None:
+    """Degraded/unknown provider dispositions must not trip the continuation guard."""
+
+    workflow = MoonMindRunWorkflow()
+    workflow._merge_automation_disposition = disposition
+
+    assert (
+        workflow._continuation_disposition_failure_message(
+            _ungated_resolver_parameters()
+        )
+        is None
+    )


### PR DESCRIPTION
## Problem

Investigating workflow `mm:81a7e8c0-dab2-4291-9b9b-9da0781c1dc4` (resolving PR `MoonLadderStudios/Tactics#1863`) surfaced a **false-green completion**:

- The run was a **standalone top-level `MoonMind.UserWorkflow`** running `pr-resolver` (`publishMode=none`), *not* launched under a `MoonMind.MergeAutomation` gate (`RootWorkflowId == itself`).
- The agent did real work — resolved review comments, merged `main`, pushed the conflict resolution (`e7a62914`), re-ran the orchestrator → entered `ci_running` — then **backgrounded the CI poll and exited**, expecting a "notification"/"scheduled wakeup" that does not exist in a one-shot managed run.
- It returned `mergeAutomationDisposition: "reenter_gate"` and the workflow completed as `status: success` / `mm_state: completed`.
- `reenter_gate` is a **continuation** disposition that only has meaning inside a `MoonMind.MergeAutomation` gate (re-enter `awaiting_external`, poll CI, finalize). With no owning gate, the continuation was dropped: the merge was never finalized. PR #1863 was left **OPEN** (now CLEAN/MERGEABLE) while the run looked green.

## Changes

1. **`run.py` — never report an ungated continuation as success.** When a run ends with a continuation disposition (`reenter_gate`) and is **not** owned by merge automation (no `mergeGate.parentWorkflowId` in `initial_parameters`), the workflow now fails terminally with an actionable message (re-submit under merge automation or finalize manually) instead of reporting success. Gated behind `run-ungated-continuation-disposition-v1` for replay safety. Terminal dispositions (`merged`, `already_merged`) and gated continuation runs are unaffected.

2. **`pr-resolver` SKILL.md + canonical docs — Foreground Execution Contract (behavioral root cause).** Explicitly forbids backgrounding the orchestration command or relying on notifications/scheduled wakeups within a one-shot managed run. The orchestration bin already block-polls `ci_running` up to its elapsed budget; the agent must run it in the foreground and wait.

3. **Docs.** `docs/Workflows/PrMergeAutomation.md` §13.4 and `docs/Steps/SkillGithubPrResolver.md` document the ungated-continuation rule and the foreground contract.

## Tests (TDD)

New workflow-boundary regression suite `tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py`:
- gated (`build_resolver_run_request`) vs ungated (the real incident parameter shape) ownership detection,
- ungated `reenter_gate` → blocks success; gated `reenter_gate` → allowed,
- terminal dispositions (`merged`/`already_merged`) and degraded/blank/unknown dispositions → no false failure.

`./tools/test_unit.sh --python-only` over the new suite + `test_run_parent_owned_merge_automation.py` → **27 passed**. Related adapter/merge-automation suites (`test_managed_agent_adapter`, `test_codex_session_adapter`, `test_merge_automation_temporal`, `test_run_artifacts`, `test_pr_resolver_tools`) → green, no regressions.

## Deferred (follow-up)

Routing "Resolve PR #N" submissions *through* `MoonMind.MergeAutomation` (so `reenter_gate` actually loops to finalize) is a larger orchestration change left as follow-up. This PR makes the ungated path fail loudly rather than silently green, which is the immediate correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)