### PR TITLE
When I try to submit a recurring schedule, I get this error message: target.kind must be one of: queue_task, queue_task_template, manifest_run. This s

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7450,6 +7450,15 @@ def _compute_schedule_delay(
         )
     return delay
 
+def _first_mapping_value(
+    source: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> Any:
+    for key in keys:
+        if key in source:
+            return source[key]
+    return None
+
 def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
     """Transform a workflow request payload into a RecurringWorkflowsService target.
 
@@ -7477,14 +7486,17 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
                 else initial_parameters
             ),
         }
-        for source_key, target_key in (
-            ("title", "title"),
-            ("inputArtifactRef", "inputArtifactRef"),
-            ("planArtifactRef", "planArtifactRef"),
-            ("manifestArtifactRef", "manifestArtifactRef"),
-            ("failurePolicy", "failurePolicy"),
+        for source_keys, target_key in (
+            (("title",), "title"),
+            (("inputArtifactRef", "input_artifact_ref"), "inputArtifactRef"),
+            (("planArtifactRef", "plan_artifact_ref"), "planArtifactRef"),
+            (
+                ("manifestArtifactRef", "manifest_ref", "manifest_artifact_ref"),
+                "manifestArtifactRef",
+            ),
+            (("failurePolicy", "failure_policy"), "failurePolicy"),
         ):
-            value = target_payload.get(source_key)
+            value = _first_mapping_value(target_payload, source_keys)
             if value is not None:
                 target[target_key] = value
         return target
@@ -7520,10 +7532,22 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
         "workflowType": workflow_type,
         "title": str(target_payload.get("title") or "").strip() or None,
         "initialParameters": target_payload,
-        "inputArtifactRef": target_payload.get("inputArtifactRef"),
-        "planArtifactRef": target_payload.get("planArtifactRef"),
-        "manifestArtifactRef": target_payload.get("manifestArtifactRef"),
-        "failurePolicy": target_payload.get("failurePolicy"),
+        "inputArtifactRef": _first_mapping_value(
+            target_payload,
+            ("inputArtifactRef", "input_artifact_ref"),
+        ),
+        "planArtifactRef": _first_mapping_value(
+            target_payload,
+            ("planArtifactRef", "plan_artifact_ref"),
+        ),
+        "manifestArtifactRef": _first_mapping_value(
+            target_payload,
+            ("manifestArtifactRef", "manifest_ref", "manifest_artifact_ref"),
+        ),
+        "failurePolicy": _first_mapping_value(
+            target_payload,
+            ("failurePolicy", "failure_policy"),
+        ),
     }
 
 async def _handle_recurring_schedule(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7453,10 +7453,42 @@ def _compute_schedule_delay(
 def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
     """Transform a workflow request payload into a RecurringWorkflowsService target.
 
-    Constructs the ``kind=workflow_execution`` envelope expected by
+    Constructs the Temporal workflow-start target expected by
     ``RecurringWorkflowsService.create_definition()``.
     """
     target_payload = dict(request_payload)
+    target_payload.pop("schedule", None)
+    workflow_type = str(
+        target_payload.get("workflowType")
+        or target_payload.get("workflow_type")
+        or "MoonMind.UserWorkflow"
+    ).strip()
+    if "initialParameters" in target_payload or "initial_parameters" in target_payload:
+        initial_parameters = (
+            target_payload.get("initialParameters")
+            if "initialParameters" in target_payload
+            else target_payload.get("initial_parameters")
+        )
+        target: dict[str, Any] = {
+            "workflowType": workflow_type,
+            "initialParameters": (
+                dict(initial_parameters)
+                if isinstance(initial_parameters, Mapping)
+                else initial_parameters
+            ),
+        }
+        for source_key, target_key in (
+            ("title", "title"),
+            ("inputArtifactRef", "inputArtifactRef"),
+            ("planArtifactRef", "planArtifactRef"),
+            ("manifestArtifactRef", "manifestArtifactRef"),
+            ("failurePolicy", "failurePolicy"),
+        ):
+            value = target_payload.get(source_key)
+            if value is not None:
+                target[target_key] = value
+        return target
+
     root_propose_tasks = target_payload.pop("proposeTasks", None)
     root_proposal_policy = target_payload.pop("proposalPolicy", None)
     task_node = target_payload.get("workflow")
@@ -7485,11 +7517,13 @@ def _build_recurring_target(request_payload: dict[str, Any]) -> dict[str, Any]:
             task_payload.pop("proposalPolicy", None)
         target_payload["workflow"] = task_payload
     return {
-        "kind": "workflow_execution",
-        "job": {
-            "type": "workflow",
-            "payload": target_payload,
-        },
+        "workflowType": workflow_type,
+        "title": str(target_payload.get("title") or "").strip() or None,
+        "initialParameters": target_payload,
+        "inputArtifactRef": target_payload.get("inputArtifactRef"),
+        "planArtifactRef": target_payload.get("planArtifactRef"),
+        "manifestArtifactRef": target_payload.get("manifestArtifactRef"),
+        "failurePolicy": target_payload.get("failurePolicy"),
     }
 
 async def _handle_recurring_schedule(

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -19,7 +19,6 @@ from api_service.db.models import (
     RecurringWorkflowRunTrigger,
     RecurringWorkflowScopeType,
 )
-from moonmind.workflows.executions.job_types import CANONICAL_WORKFLOW_JOB_TYPE
 from moonmind.workflows.recurring.cron import (
     compute_next_occurrence,
     parse_cron_expression,
@@ -36,6 +35,10 @@ from moonmind.workflows.temporal.schedule_errors import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_SCHEDULER_MAX_BACKFILL = 3
+_SUPPORTED_RECURRING_WORKFLOW_TYPES = (
+    "MoonMind.UserWorkflow",
+    "MoonMind.ManifestIngest",
+)
 
 class RecurringWorkflowValidationError(ValueError):
     """Raised when recurring workflow inputs are invalid."""
@@ -181,79 +184,49 @@ def _catchup_mode_from_temporal_window(catchup_window: object | None) -> str:
     return "all"
 
 def _normalize_target(target_payload: Mapping[str, Any]) -> dict[str, Any]:
-    # legacy_run contract: target.kind values "queue_task" / "queue_task_template" and
-    # target.job.type "task" are persisted in DB rows and Temporal schedule actions;
-    # they rename at the MoonMind.UserWorkflow v2 cutover, not before.
     target = dict(target_payload)
-    kind = str(target.get("kind") or "").strip().lower()
-    if kind not in {
-        "queue_task",
-        "queue_task_template",
-        "manifest_run",
-    }:
+    workflow_type = str(
+        target.get("workflowType") or target.get("workflow_type") or ""
+    ).strip()
+    if workflow_type not in _SUPPORTED_RECURRING_WORKFLOW_TYPES:
         raise RecurringWorkflowValidationError(
-            "target.kind must be one of: queue_task, queue_task_template, manifest_run"
+            "target.workflowType must be one of: "
+            + ", ".join(_SUPPORTED_RECURRING_WORKFLOW_TYPES)
         )
 
-    if kind == "queue_task":
-        job_payload = target.get("job")
-        if not isinstance(job_payload, Mapping):
-            raise RecurringWorkflowValidationError("target.job is required for queue_task")
-        job = dict(job_payload)
-        workflow_type = str(job.get("type") or "").strip().lower() or CANONICAL_WORKFLOW_JOB_TYPE
-        if workflow_type != CANONICAL_WORKFLOW_JOB_TYPE:
-            raise RecurringWorkflowValidationError(
-                "target.job.type must be 'task' for queue_task"
-            )
-        payload = job.get("payload")
-        if not isinstance(payload, Mapping):
-            raise RecurringWorkflowValidationError(
-                "target.job.payload must be an object for queue_task"
-            )
-        job["type"] = CANONICAL_WORKFLOW_JOB_TYPE
-        target["job"] = job
+    initial_parameters = target.get("initialParameters")
+    if initial_parameters is None:
+        initial_parameters = target.get("initial_parameters")
+    if initial_parameters is None:
+        initial_parameters = {}
+    if not isinstance(initial_parameters, Mapping):
+        raise RecurringWorkflowValidationError(
+            "target.initialParameters must be an object when provided"
+        )
 
-    if kind == "queue_task_template":
-        template_payload = target.get("template")
-        if not isinstance(template_payload, Mapping):
-            raise RecurringWorkflowValidationError(
-                "target.template is required for queue_task_template"
-            )
-        template = dict(template_payload)
-        slug = str(template.get("slug") or "").strip()
-        version = str(template.get("version") or "").strip()
-        if not slug or not version:
-            raise RecurringWorkflowValidationError(
-                "target.template.slug and target.template.version are required"
-            )
-        inputs_payload = template.get("inputs")
-        if inputs_payload is None:
-            template["inputs"] = {}
-        elif not isinstance(inputs_payload, Mapping):
-            raise RecurringWorkflowValidationError(
-                "target.template.inputs must be an object when provided"
-            )
-        target["template"] = template
+    target["workflowType"] = workflow_type
+    target["initialParameters"] = dict(initial_parameters)
+    target.pop("workflow_type", None)
+    target.pop("initial_parameters", None)
 
-    if kind == "manifest_run":
-        manifest_name = str(target.get("name") or "").strip()
-        if not manifest_name:
+    if workflow_type == "MoonMind.ManifestIngest":
+        manifest_ref = str(
+            target.get("manifestArtifactRef") or target.get("manifest_ref") or ""
+        ).strip()
+        if not manifest_ref:
             raise RecurringWorkflowValidationError(
-                "target.name is required for manifest_run"
+                "target.manifestArtifactRef is required for MoonMind.ManifestIngest"
             )
-        action = str(target.get("action") or "run").strip().lower() or "run"
-        if action not in {"run", "plan"}:
+        target["manifestArtifactRef"] = manifest_ref
+        options = target.get("options")
+        if options is None:
+            options = {}
+        if not isinstance(options, Mapping):
             raise RecurringWorkflowValidationError(
-                "target.action for manifest_run must be run or plan"
+                "target.options must be an object when provided"
             )
-        options_payload = target.get("options")
-        if options_payload is not None and not isinstance(options_payload, Mapping):
-            raise RecurringWorkflowValidationError(
-                "target.options for manifest_run must be an object"
-            )
-        target["action"] = action
+        target["options"] = dict(options)
 
-    target["kind"] = kind
     return target
 
 def _coerce_utc(value: datetime) -> datetime:
@@ -334,12 +307,40 @@ class RecurringWorkflowsService:
             )
         return definition
 
-    def _expected_workflow_type_for_target_kind(self, kind: str) -> str:
-        if kind in {"workflow_execution", "workflow_template", "queue_task", "queue_task_template"}:
-            return "MoonMind.UserWorkflow"
-        elif kind == "manifest_run":
-            return "MoonMind.ManifestIngest"
-        return "MoonMind.UserWorkflow"
+    def _workflow_bundle_for_target(
+        self,
+        *,
+        definition_id: UUID,
+        name: str,
+        owner_user_id: UUID | None,
+        target_payload: Mapping[str, Any],
+    ) -> tuple[str, dict[str, Any]]:
+        workflow_type = str(target_payload["workflowType"])
+        if workflow_type == "MoonMind.ManifestIngest":
+            return workflow_type, {
+                "workflow_type": workflow_type,
+                "manifest_ref": str(target_payload["manifestArtifactRef"]),
+                "action": str(target_payload.get("action") or "apply").strip()
+                or "apply",
+                "options": dict(target_payload.get("options") or {}),
+            }
+
+        initial_parameters = dict(target_payload.get("initialParameters") or {})
+        system_payload = initial_parameters.get("system")
+        system = dict(system_payload) if isinstance(system_payload, Mapping) else {}
+        recurrence = dict(system.get("recurrence") or {})
+        recurrence["definitionId"] = str(definition_id)
+        system["recurrence"] = recurrence
+        initial_parameters["system"] = system
+        return workflow_type, {
+            "workflowType": workflow_type,
+            "title": str(target_payload.get("title") or name),
+            "ownerUserId": str(owner_user_id) if owner_user_id else None,
+            "initialParameters": initial_parameters,
+            "inputArtifactRef": target_payload.get("inputArtifactRef"),
+            "planArtifactRef": target_payload.get("planArtifactRef"),
+            "failurePolicy": target_payload.get("failurePolicy"),
+        }
 
     async def create_definition(
         self,
@@ -404,18 +405,13 @@ class RecurringWorkflowsService:
         self._session.add(definition)
         await self._session.flush()
 
-        workflow_type = self._expected_workflow_type_for_target_kind(target_payload.get("kind", ""))
-        workflow_input = {
-            "title": name_text,
-            "ownerUserId": str(owner_user_id) if owner_user_id else None,
-            "system": {
-                "recurrence": {
-                    "definitionId": str(definition_id)
-                }
-            },
-            "recurringTarget": target_payload,
-        }
-        
+        workflow_type, workflow_input = self._workflow_bundle_for_target(
+            definition_id=definition_id,
+            name=name_text,
+            owner_user_id=owner_user_id,
+            target_payload=target_payload,
+        )
+
         try:
             await self._adapter.create_schedule(
                 definition_id=definition_id,
@@ -568,16 +564,12 @@ class RecurringWorkflowsService:
         target_payload = (
             dict(dfn.target) if isinstance(dfn.target, Mapping) else {}
         )
-        kind = str(target_payload.get("kind") or "")
-        workflow_type = self._expected_workflow_type_for_target_kind(kind)
-        name_text = dfn.name or ""
-        workflow_input: dict[str, Any] = {
-            "title": name_text,
-            "ownerUserId": str(dfn.owner_user_id) if dfn.owner_user_id else None,
-            "system": {"recurrence": {"definitionId": str(dfn.id)}},
-            "recurringTarget": target_payload,
-        }
-        return workflow_type, workflow_input
+        return self._workflow_bundle_for_target(
+            definition_id=dfn.id,
+            name=dfn.name or "",
+            owner_user_id=dfn.owner_user_id,
+            target_payload=_normalize_target(target_payload),
+        )
 
     async def _recreate_temporal_schedule(
         self, dfn: RecurringWorkflowDefinition, policy_obj: RecurringPolicy

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -183,6 +183,15 @@ def _catchup_mode_from_temporal_window(catchup_window: object | None) -> str:
         return "last"
     return "all"
 
+def _first_mapping_value(
+    source: Mapping[str, Any],
+    keys: tuple[str, ...],
+) -> Any:
+    for key in keys:
+        if key in source:
+            return source[key]
+    return None
+
 def _normalize_target(target_payload: Mapping[str, Any]) -> dict[str, Any]:
     target = dict(target_payload)
     workflow_type = str(
@@ -209,16 +218,36 @@ def _normalize_target(target_payload: Mapping[str, Any]) -> dict[str, Any]:
     target.pop("workflow_type", None)
     target.pop("initial_parameters", None)
 
+    for camel_key, aliases in (
+        ("inputArtifactRef", ("inputArtifactRef", "input_artifact_ref")),
+        ("planArtifactRef", ("planArtifactRef", "plan_artifact_ref")),
+        ("failurePolicy", ("failurePolicy", "failure_policy")),
+    ):
+        value = _first_mapping_value(target, aliases)
+        if value is not None:
+            target[camel_key] = value
+        for alias in aliases:
+            if alias != camel_key:
+                target.pop(alias, None)
+
     if workflow_type == "MoonMind.ManifestIngest":
         manifest_ref = str(
-            target.get("manifestArtifactRef") or target.get("manifest_ref") or ""
+            _first_mapping_value(
+                target,
+                ("manifestArtifactRef", "manifest_ref", "manifest_artifact_ref"),
+            )
+            or ""
         ).strip()
         if not manifest_ref:
             raise RecurringWorkflowValidationError(
                 "target.manifestArtifactRef is required for MoonMind.ManifestIngest"
             )
         target["manifestArtifactRef"] = manifest_ref
+        target.pop("manifest_ref", None)
+        target.pop("manifest_artifact_ref", None)
         options = target.get("options")
+        if options is None:
+            options = target["initialParameters"].get("options")
         if options is None:
             options = {}
         if not isinstance(options, Mapping):
@@ -226,6 +255,11 @@ def _normalize_target(target_payload: Mapping[str, Any]) -> dict[str, Any]:
                 "target.options must be an object when provided"
             )
         target["options"] = dict(options)
+        action = target.get("action")
+        if action is None:
+            action = target["initialParameters"].get("action")
+        if action is not None:
+            target["action"] = str(action).strip() or "apply"
 
     return target
 
@@ -342,6 +376,14 @@ class RecurringWorkflowsService:
             "failurePolicy": target_payload.get("failurePolicy"),
         }
 
+    def _owner_search_attributes(self, owner_user_id: UUID | None) -> dict[str, str]:
+        if owner_user_id is None:
+            return {}
+        return {
+            "mm_owner_type": "user",
+            "mm_owner_id": str(owner_user_id),
+        }
+
     async def create_definition(
         self,
         *,
@@ -425,6 +467,7 @@ class RecurringWorkflowsService:
                 workflow_type=workflow_type,
                 workflow_input=workflow_input,
                 memo={"definitionId": str(definition_id)},
+                search_attributes=self._owner_search_attributes(owner_user_id),
             )
         except Exception as exc:
             logger.error(f"Failed to create temporal schedule for {definition_id}: {exc}")
@@ -588,6 +631,7 @@ class RecurringWorkflowsService:
                 workflow_type=workflow_type,
                 workflow_input=workflow_input,
                 memo={"definitionId": str(dfn.id)},
+                search_attributes=self._owner_search_attributes(dfn.owner_user_id),
             )
         except ScheduleAlreadyExistsError:
             await self._adapter.update_schedule(

--- a/docs/Temporal/TemporalScheduling.md
+++ b/docs/Temporal/TemporalScheduling.md
@@ -212,15 +212,18 @@ The `misfireGraceSeconds` concept is subsumed by `catchup_window`. The `jitterSe
 
 ### 5.7 Target Resolution
 
-Temporal Schedules start workflows. The workflow input payload carries the target specification. Target resolution (expanding templates, resolving manifests) happens **inside the workflow**, not at schedule evaluation time:
+Temporal Schedules start workflows directly. The schedule definition stores a
+Temporal workflow-start target with `target.workflowType` and
+`target.initialParameters`, plus artifact refs when needed. When the schedule
+fires, MoonMind passes that target through as the workflow input:
 
-1. Schedule fires → starts `MoonMind.UserWorkflow` or `MoonMind.ManifestIngest` with the target payload in the workflow input.
-2. The workflow's initialization phase resolves the target:
- - `queue_task` → use payload directly
- - `queue_task_template` → expand the template via an Activity
- - `manifest_run` → resolve the manifest via an Activity
+1. `MoonMind.UserWorkflow` receives `workflowType`,
+   `initialParameters`, and optional input or plan artifact refs.
+2. `MoonMind.ManifestIngest` receives the manifest artifact ref, action, and
+   options required by the manifest workflow.
 
-This avoids needing the Temporal Schedule to know about MoonMind's template or manifest systems.
+Queue-dispatch target kinds are not part of the Temporal-managed recurring
+schedule contract.
 
 ### 5.8 Schedule ID Convention
 

--- a/tests/integration/api/test_recurring_schedule_creation.py
+++ b/tests/integration/api/test_recurring_schedule_creation.py
@@ -108,7 +108,9 @@ def test_executions_recurring_schedule_validation_contract() -> None:
     ) as service_cls:
         service = service_cls.return_value
         service.create_definition = AsyncMock(
-            side_effect=RecurringWorkflowValidationError("target.kind is required")
+            side_effect=RecurringWorkflowValidationError(
+                "target.workflowType is required"
+            )
         )
 
         response = client.post(
@@ -128,5 +130,5 @@ def test_executions_recurring_schedule_validation_contract() -> None:
     assert response.status_code == 422
     assert response.json()["detail"] == {
         "code": "invalid_recurring_workflow",
-        "message": "target.kind is required",
+        "message": "target.workflowType is required",
     }

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -24,6 +24,7 @@ from api_service.api.routers.executions import (
     _get_service,
     _artifact_id_from_ref,
     _build_original_workflow_input_snapshot_payload,
+    _build_recurring_target,
     _expand_goal_preset_for_workflow_submission,
     _extract_cost_estimate_usd,
     _effective_user_roles,
@@ -5905,6 +5906,77 @@ def test_create_task_shaped_recurring_schedule_passes_metadata_and_response(
     assert called_kwargs["enabled"] is False
     assert called_kwargs["scope_type"] == "personal"
     assert called_kwargs["policy"] == policy
+
+
+def test_create_recurring_schedule_accepts_snake_case_target_aliases() -> None:
+    target = _build_recurring_target(
+        {
+            "workflow_type": "MoonMind.ManifestIngest",
+            "schedule": {
+                "mode": "recurring",
+                "cron": "0 * * * *",
+            },
+            "manifest_ref": "artifact://manifest/1",
+            "failure_policy": "best_effort",
+            "initial_parameters": {
+                "action": "plan",
+                "options": {"dryRun": True},
+            },
+        }
+    )
+
+    assert target["workflowType"] == "MoonMind.ManifestIngest"
+    assert target["manifestArtifactRef"] == "artifact://manifest/1"
+    assert target["failurePolicy"] == "best_effort"
+    assert target["initialParameters"] == {
+        "action": "plan",
+        "options": {"dryRun": True},
+    }
+
+
+def test_create_task_shaped_recurring_schedule_lifts_snake_case_artifact_aliases(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, _service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    next_run_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with patch(
+        "api_service.services.recurring_workflows_service.RecurringWorkflowsService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_definition = AsyncMock(
+            return_value=SimpleNamespace(
+                id=uuid4(),
+                name="Inline schedule",
+                cron="0 * * * *",
+                timezone="UTC",
+                next_run_at=next_run_at,
+            )
+        )
+
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "input_artifact_ref": "artifact://input/1",
+                    "plan_artifact_ref": "artifact://plan/1",
+                    "failure_policy": "fail_fast",
+                    "schedule": {
+                        "mode": "recurring",
+                        "cron": "0 * * * *",
+                    },
+                    "workflow": {"instructions": "Run this on a schedule"},
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.json()
+    target = service.create_definition.await_args.kwargs["target"]
+    assert target["inputArtifactRef"] == "artifact://input/1"
+    assert target["planArtifactRef"] == "artifact://plan/1"
+    assert target["failurePolicy"] == "fail_fast"
 
 
 def test_create_task_shaped_recurring_schedule_preserves_missing_policy(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5786,7 +5786,9 @@ def test_create_task_shaped_recurring_schedule_normalizes_proposal_intent(
 
     assert response.status_code == 201, response.json()
     target = service.create_definition.await_args.kwargs["target"]
-    stored_payload = target["job"]["payload"]
+    assert target["workflowType"] == "MoonMind.UserWorkflow"
+    stored_payload = target["initialParameters"]
+    assert "schedule" not in stored_payload
     assert "proposeTasks" not in stored_payload
     assert "proposalPolicy" not in stored_payload
     assert stored_payload["workflow"]["proposeTasks"] is True
@@ -5836,7 +5838,9 @@ def test_create_task_shaped_recurring_schedule_uses_root_proposal_fallbacks(
 
     assert response.status_code == 201, response.json()
     target = service.create_definition.await_args.kwargs["target"]
-    stored_payload = target["job"]["payload"]
+    assert target["workflowType"] == "MoonMind.UserWorkflow"
+    stored_payload = target["initialParameters"]
+    assert "schedule" not in stored_payload
     assert "proposeTasks" not in stored_payload
     assert "proposalPolicy" not in stored_payload
     assert stored_payload["workflow"]["proposeTasks"] is True
@@ -5992,7 +5996,9 @@ def test_create_task_shaped_recurring_schedule_validation_maps_to_422(
     ) as service_cls:
         service = service_cls.return_value
         service.create_definition = AsyncMock(
-            side_effect=RecurringWorkflowValidationError("target.kind is required")
+            side_effect=RecurringWorkflowValidationError(
+                "target.workflowType is required"
+            )
         )
 
         response = test_client.post(
@@ -6014,7 +6020,7 @@ def test_create_task_shaped_recurring_schedule_validation_maps_to_422(
     assert response.status_code == 422
     assert response.json()["detail"] == {
         "code": "invalid_recurring_workflow",
-        "message": "target.kind is required",
+        "message": "target.workflowType is required",
     }
 
 def test_create_execution_surfaces_domain_validation_errors(

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -36,7 +36,10 @@ def _definition(**overrides):
         "owner_user_id": uuid4(),
         "scope_type": RecurringWorkflowScopeType.PERSONAL,
         "scope_ref": None,
-        "target": {"kind": "queue_task", "job": {"type": "task", "payload": {}}},
+        "target": {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {},
+        },
         "policy": {},
         "version": 1,
         "created_at": now,
@@ -69,13 +72,13 @@ def _run(**overrides):
 
 def test_recurring_workflow_validation_error_maps_to_422() -> None:
     exc = recurring_router._map_error(
-        RecurringWorkflowValidationError("target.kind is required")
+        RecurringWorkflowValidationError("target.workflowType is required")
     )
 
     assert exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert exc.detail == {
         "code": "invalid_recurring_workflow",
-        "message": "target.kind is required",
+        "message": "target.workflowType is required",
     }
 
 @pytest.mark.asyncio
@@ -106,16 +109,13 @@ async def test_create_recurring_workflow_returns_serialized_definition() -> None
             cron="0 9 * * *",
             timezone="UTC",
             target={
-                "kind": "queue_task",
-                "job": {
-                    "type": "task",
-                    "payload": {
-                        "repository": "MoonLadderStudios/MoonMind",
-                        "task": {
-                            "instructions": "Queue job",
-                            "publish": {"mode": "none"},
-                            "skill": {"id": "auto", "args": {}},
-                        },
+                "workflowType": "MoonMind.UserWorkflow",
+                "initialParameters": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "task": {
+                        "instructions": "Queue job",
+                        "publish": {"mode": "none"},
+                        "skill": {"id": "auto", "args": {}},
                     },
                 },
             },

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -107,6 +107,103 @@ async def test_create_definition_creates_temporal_schedule(
             assert call_kwargs["workflow_input"]["initialParameters"]["system"][
                 "recurrence"
             ]["definitionId"] == str(definition.id)
+            assert call_kwargs["search_attributes"] == {
+                "mm_owner_type": "user",
+                "mm_owner_id": str(definition.owner_user_id),
+            }
+
+async def test_create_definition_normalizes_snake_case_target_aliases(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflow_type": "MoonMind.UserWorkflow",
+                    "initial_parameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                    "input_artifact_ref": "artifact://input/1",
+                    "plan_artifact_ref": "artifact://plan/1",
+                    "failure_policy": "fail_fast",
+                },
+                policy={},
+            )
+
+            assert definition.target["workflowType"] == "MoonMind.UserWorkflow"
+            assert definition.target["initialParameters"]["task"][
+                "instructions"
+            ] == "Queue job"
+            assert definition.target["inputArtifactRef"] == "artifact://input/1"
+            assert definition.target["planArtifactRef"] == "artifact://plan/1"
+            assert definition.target["failurePolicy"] == "fail_fast"
+            assert "workflow_type" not in definition.target
+            assert "initial_parameters" not in definition.target
+            assert "input_artifact_ref" not in definition.target
+            call_kwargs = mock_temporal_adapter.create_schedule.call_args.kwargs
+            assert call_kwargs["workflow_input"]["inputArtifactRef"] == (
+                "artifact://input/1"
+            )
+            assert call_kwargs["workflow_input"]["planArtifactRef"] == (
+                "artifact://plan/1"
+            )
+            assert call_kwargs["workflow_input"]["failurePolicy"] == "fail_fast"
+
+async def test_create_definition_manifest_reads_action_options_from_initial_parameters(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Manifest Plan",
+                description=None,
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.ManifestIngest",
+                    "manifest_ref": "artifact://manifest/1",
+                    "initialParameters": {
+                        "action": "plan",
+                        "options": {"dryRun": True, "maxDocs": 3},
+                    },
+                },
+                policy={},
+            )
+
+            assert definition.target["manifestArtifactRef"] == "artifact://manifest/1"
+            assert definition.target["action"] == "plan"
+            assert definition.target["options"] == {"dryRun": True, "maxDocs": 3}
+            assert "manifest_ref" not in definition.target
+            call_kwargs = mock_temporal_adapter.create_schedule.call_args.kwargs
+            assert call_kwargs["workflow_type"] == "MoonMind.ManifestIngest"
+            assert call_kwargs["workflow_input"] == {
+                "workflow_type": "MoonMind.ManifestIngest",
+                "manifest_ref": "artifact://manifest/1",
+                "action": "plan",
+                "options": {"dryRun": True, "maxDocs": 3},
+            }
 
 async def test_create_definition_rejects_invalid_policy(tmp_path: Path, mock_temporal_adapter) -> None:
     async with recurring_db(tmp_path) as session_maker:

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -74,19 +74,14 @@ async def test_create_definition_creates_temporal_schedule(
                 scope_ref=None,
                 owner_user_id=uuid4(),
                 target={
-                    "kind": "queue_task",
-                    "job": {
-                        "type": "task",
-                        "priority": 0,
-                        "maxAttempts": 3,
-                        "payload": {
-                            "repository": "MoonLadderStudios/MoonMind",
-                            "targetRuntime": "codex",
-                            "task": {
-                                "instructions": "Queue job",
-                                "publish": {"mode": "none"},
-                                "skill": {"id": "auto", "args": {}},
-                            },
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "targetRuntime": "codex",
+                        "task": {
+                            "instructions": "Queue job",
+                            "publish": {"mode": "none"},
+                            "skill": {"id": "auto", "args": {}},
                         },
                     },
                 },
@@ -105,6 +100,13 @@ async def test_create_definition_creates_temporal_schedule(
             assert call_kwargs["cron_expression"] == "0 6 * * *"
             assert call_kwargs["timezone"] == "UTC"
             assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"]["workflowType"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"]["initialParameters"]["task"][
+                "instructions"
+            ] == "Queue job"
+            assert call_kwargs["workflow_input"]["initialParameters"]["system"][
+                "recurrence"
+            ]["definitionId"] == str(definition.id)
 
 async def test_create_definition_rejects_invalid_policy(tmp_path: Path, mock_temporal_adapter) -> None:
     async with recurring_db(tmp_path) as session_maker:
@@ -122,24 +124,23 @@ async def test_create_definition_rejects_invalid_policy(tmp_path: Path, mock_tem
                     scope_ref=None,
                     owner_user_id=uuid4(),
                     target={
-                        "kind": "queue_task",
-                        "job": {
-                            "type": "task",
-                            "payload": {
-                                "repository": "MoonLadderStudios/MoonMind",
-                                "targetRuntime": "codex",
-                                "task": {
-                                    "instructions": "Queue job",
-                                    "publish": {"mode": "none"},
-                                    "skill": {"id": "auto", "args": {}},
-                                },
+                        "workflowType": "MoonMind.UserWorkflow",
+                        "initialParameters": {
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "targetRuntime": "codex",
+                            "task": {
+                                "instructions": "Queue job",
+                                "publish": {"mode": "none"},
+                                "skill": {"id": "auto", "args": {}},
                             },
                         },
                     },
                     policy={"catchup": {"mode": "invalid"}},
                 )
 
-async def test_target_kind_housekeeping_is_rejected(tmp_path: Path, mock_temporal_adapter) -> None:
+async def test_target_workflow_type_housekeeping_is_rejected(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
     async with recurring_db(tmp_path) as session_maker:
         async with session_maker() as session:
             service = RecurringWorkflowsService(session, temporal_client_adapter=mock_temporal_adapter)
@@ -154,7 +155,10 @@ async def test_target_kind_housekeeping_is_rejected(tmp_path: Path, mock_tempora
                     scope_type="personal",
                     scope_ref=None,
                     owner_user_id=uuid4(),
-                    target={"kind": "housekeeping", "action": "prune_artifacts"},
+                    target={
+                        "workflowType": "MoonMind.Housekeeping",
+                        "initialParameters": {"action": "prune_artifacts"},
+                    },
                     policy={},
                 )
 
@@ -177,13 +181,10 @@ async def test_update_definition_updates_temporal_schedule(
                 scope_ref=None,
                 owner_user_id=uuid4(),
                 target={
-                    "kind": "queue_task",
-                    "job": {
-                        "type": "task",
-                        "payload": {
-                            "task": {
-                                "instructions": "Queue job",
-                            },
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
                         },
                     },
                 },
@@ -231,13 +232,10 @@ async def test_create_manual_run_triggers_temporal_schedule(
                 scope_ref=None,
                 owner_user_id=uuid4(),
                 target={
-                    "kind": "queue_task",
-                    "job": {
-                        "type": "task",
-                        "payload": {
-                            "task": {
-                                "instructions": "Queue job",
-                            },
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
                         },
                     },
                 },


### PR DESCRIPTION
When I try to submit a recurring schedule, I get this error message: target.kind must be one of: queue_task, queue_task_template, manifest_run. This seems to be outdated code that no longer works with the current version. Update it so that it works and I can submit recurring schedules.