### PR TITLE
There's supposed to be a button using a menu icon of some kind in a new column for the Workflows page. This will show the same dropdown options as the

### DIFF
--- a/frontend/src/components/WorkflowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowActionsMenu.tsx
@@ -67,8 +67,20 @@ export function WorkflowActionsMenu({
   };
 
   useEffect(() => {
-    onOpenChange?.(open);
-  }, [onOpenChange, open]);
+    itemRefs.current = itemRefs.current.slice(0, items.length);
+  }, [items]);
+
+  // Keep the latest onOpenChange in a ref so the open/close notification effect
+  // does not re-run (and re-fire) whenever the parent passes a new inline
+  // callback identity on every render.
+  const onOpenChangeRef = useRef(onOpenChange);
+  useEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  }, [onOpenChange]);
+
+  useEffect(() => {
+    onOpenChangeRef.current?.(open);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return undefined;

--- a/frontend/src/components/WorkflowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowActionsMenu.tsx
@@ -1,0 +1,241 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+
+import type { WorkflowActionMenuItem } from '../lib/workflowActions';
+
+export type WorkflowActionsMenuProps = {
+  items: WorkflowActionMenuItem[];
+  /** Content rendered inside the trigger button. Defaults to a "Workflow actions" label. */
+  triggerContent?: ReactNode;
+  /** Accessible name for the trigger button. Required when triggerContent is an icon. */
+  triggerAriaLabel?: string;
+  /** Class applied to the trigger button. */
+  triggerClassName?: string;
+  /** Accessible name for the open menu popover. */
+  menuAriaLabel?: string;
+  /** Message rendered when there are no items to show (e.g. loading or empty). */
+  emptyMessage?: ReactNode;
+  /** Notifies the parent when the menu opens or closes (used for lazy loading). */
+  onOpenChange?: (open: boolean) => void;
+};
+
+/**
+ * Accessible dropdown that renders a list of workflow action options. Shared by
+ * the Workflow Detail "Workflow actions" surface and the Workflows table row
+ * "Actions" menu so both present identical behavior and option semantics.
+ */
+export function WorkflowActionsMenu({
+  items,
+  triggerContent = 'Workflow actions',
+  triggerAriaLabel,
+  triggerClassName = 'secondary td-workflow-actions-trigger',
+  menuAriaLabel = 'Workflow actions',
+  emptyMessage = 'No workflow actions are currently available.',
+  onOpenChange,
+}: WorkflowActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | HTMLAnchorElement | null>>([]);
+  const availableIndexes = useMemo(
+    () => items
+      .map((item, index) => (item.disabledReason ? -1 : index))
+      .filter((index) => index >= 0),
+    [items],
+  );
+
+  const closeMenu = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+  const focusItem = (index: number) => {
+    const nextIndex = items[index] ? index : availableIndexes[0] ?? 0;
+    setActiveIndex(nextIndex);
+  };
+  const selectItem = (item: WorkflowActionMenuItem) => {
+    if (item.disabledReason) return;
+    item.onSelect?.();
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [onOpenChange, open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const preferredIndex = availableIndexes.includes(activeIndex)
+      ? activeIndex
+      : availableIndexes[0] ?? 0;
+    setActiveIndex(preferredIndex);
+  }, [activeIndex, availableIndexes, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const activeItem = itemRefs.current[activeIndex];
+    if (activeItem && document.activeElement !== activeItem) {
+      activeItem.focus();
+    }
+  }, [activeIndex, open]);
+
+  const onTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setOpen(true);
+      focusItem(availableIndexes[0] ?? 0);
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setOpen(true);
+      focusItem(availableIndexes[0] ?? 0);
+    }
+  };
+  const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (availableIndexes.length === 0) return;
+      const currentAvailableIndex = Math.max(0, availableIndexes.indexOf(activeIndex));
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
+      const next =
+        availableIndexes[
+          (currentAvailableIndex + direction + availableIndexes.length) % availableIndexes.length
+        ] ?? availableIndexes[0] ?? 0;
+      focusItem(next);
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      itemRefs.current[activeIndex]?.click();
+    }
+  };
+
+  return (
+    <div
+      className="td-workflow-actions-menu"
+      ref={rootRef}
+      onBlur={(event) => {
+        if (open && !event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        ref={triggerRef}
+        className={triggerClassName}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={triggerAriaLabel}
+        onClick={() => {
+          const nextOpen = !open;
+          setOpen(nextOpen);
+          if (nextOpen) {
+            const firstAvailable = availableIndexes[0] ?? 0;
+            setActiveIndex(firstAvailable);
+          }
+        }}
+        onKeyDown={onTriggerKeyDown}
+      >
+        {triggerContent}
+      </button>
+      {open ? (
+        <div
+          className="td-workflow-actions-popover"
+          role="menu"
+          aria-label={menuAriaLabel}
+          onKeyDown={onMenuKeyDown}
+        >
+          {items.length === 0 ? (
+            <p className="td-workflow-actions-empty">{emptyMessage}</p>
+          ) : (
+            items.map((item, index) => {
+              const disabledReasonId = item.disabledReason
+                ? `workflow-action-${item.id}-disabled-reason`
+                : undefined;
+              const commonProps = {
+                role: 'menuitem',
+                tabIndex: index === activeIndex ? 0 : -1,
+                'aria-label': item.label,
+                'aria-disabled': item.disabledReason ? true : undefined,
+                'aria-describedby': disabledReasonId,
+                className: [
+                  'td-workflow-actions-item',
+                  item.danger ? 'td-workflow-actions-item-danger' : '',
+                  item.disabledReason ? 'td-workflow-actions-item-disabled' : '',
+                ].filter(Boolean).join(' '),
+                ref: (node: HTMLButtonElement | HTMLAnchorElement | null) => {
+                  itemRefs.current[index] = node;
+                },
+                onFocus: () => setActiveIndex(index),
+              };
+              const content = (
+                <>
+                  <span>{item.label}</span>
+                  {item.disabledReason ? (
+                    <span
+                      id={disabledReasonId}
+                      className="td-workflow-actions-disabled-reason"
+                    >
+                      {item.label} unavailable: {item.disabledReason}
+                    </span>
+                  ) : null}
+                </>
+              );
+              if (item.href && !item.disabledReason) {
+                return (
+                  <a
+                    key={item.id}
+                    {...commonProps}
+                    href={item.href}
+                    onClick={() => {
+                      item.onSelect?.();
+                      setOpen(false);
+                    }}
+                  >
+                    {content}
+                  </a>
+                );
+              }
+              return (
+                <button
+                  key={item.id}
+                  {...commonProps}
+                  type="button"
+                  onClick={() => selectItem(item)}
+                >
+                  {content}
+                </button>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type { WorkflowActionMenuItem };

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -21,7 +21,7 @@ describe('WorkflowRowActionsMenu', () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.endsWith('/executions/wf-123')) {
+      if (url === '/api/executions/wf-123?source=temporal') {
         return Promise.resolve({
           ok: true,
           json: async () => detailResponse,
@@ -57,8 +57,26 @@ describe('WorkflowRowActionsMenu', () => {
     expect(await screen.findByRole('menuitem', { name: 'Pause' })).toBeTruthy();
     expect(screen.getByRole('menuitem', { name: 'Cancel' })).toBeTruthy();
     expect(
-      fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions/wf-123'),
+      fetchSpy.mock.calls.filter(
+        ([url]) => String(url) === '/api/executions/wf-123?source=temporal',
+      ),
     ).toHaveLength(1);
+  });
+
+  it('requests the lazy detail with the Temporal source so projection reads sync', async () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    await screen.findByRole('menuitem', { name: 'Pause' });
+    // Match only the detail request (path ends at wf-123, optionally followed by
+    // a query string) and not nested action endpoints like /signal or /cancel.
+    const detailUrls = fetchSpy.mock.calls
+      .map(([url]) => String(url))
+      .filter((url) => /\/executions\/wf-123(\?|$)/.test(url));
+    expect(detailUrls.length).toBeGreaterThan(0);
+    // The Workflows table reads `source=temporal`; the lazy detail request must
+    // carry it too so orphaned/Temporal-only projections still resolve actions.
+    expect(detailUrls.every((url) => url === '/api/executions/wf-123?source=temporal')).toBe(true);
   });
 
   it('invokes the signal endpoint when a lifecycle action is selected', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { renderWithClient } from '../utils/test-utils';
+import { WorkflowRowActionsMenu } from './WorkflowRowActionsMenu';
+
+describe('WorkflowRowActionsMenu', () => {
+  let fetchSpy: MockInstance;
+
+  const detailResponse = {
+    workflowId: 'wf-123',
+    runId: 'run-1',
+    title: 'Example workflow',
+    state: 'executing',
+    actions: {
+      canPause: true,
+      canCancel: true,
+    },
+  };
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/executions/wf-123')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => detailResponse,
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+  });
+
+  const renderMenu = () =>
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled={false}
+      />,
+    );
+
+  it('renders an icon trigger labeled "Actions" and does not fetch until opened', () => {
+    renderMenu();
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeTruthy();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('lazily loads action capabilities the first time the menu opens', async () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    // While the detail request is in flight, a loading message is shown.
+    expect(screen.getByText('Loading actions…')).toBeTruthy();
+
+    expect(await screen.findByRole('menuitem', { name: 'Pause' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Cancel' })).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions/wf-123'),
+    ).toHaveLength(1);
+  });
+
+  it('invokes the signal endpoint when a lifecycle action is selected', async () => {
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Pause' }));
+
+    await waitFor(() => {
+      const signalCall = fetchSpy.mock.calls.find(
+        ([url]) => String(url) === '/api/executions/wf-123/signal',
+      );
+      expect(signalCall).toBeTruthy();
+      expect(JSON.parse(String((signalCall?.[1] as RequestInit).body))).toMatchObject({
+        signalName: 'Pause',
+      });
+    });
+  });
+
+  it('confirms before cancelling and posts to the cancel endpoint', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      const cancelCall = fetchSpy.mock.calls.find(
+        ([url]) => String(url) === '/api/executions/wf-123/cancel',
+      );
+      expect(cancelCall).toBeTruthy();
+      expect(JSON.parse(String((cancelCall?.[1] as RequestInit).body))).toMatchObject({
+        action: 'cancel',
+        graceful: true,
+      });
+    });
+    confirmSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -1,0 +1,425 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { formatStatusLabel } from '../utils/formatters';
+import { navigateTo } from '../lib/navigation';
+import {
+  taskCompareHref,
+  taskEditForRerunHref,
+  taskEditHref,
+} from '../lib/temporalTaskEditing';
+import {
+  buildRemediationRuntimeRequestFields,
+  buildWorkflowActionMenuItems,
+  DEFAULT_REMEDIATION_ACTION_POLICY,
+  DEFAULT_REMEDIATION_AUTHORITY,
+  DEFAULT_REMEDIATION_MODE,
+  ExecutionActionsSchema,
+  isRemediationEligibleTarget,
+  type WorkflowActionMenuItem,
+} from '../lib/workflowActions';
+import { WorkflowActionsMenu } from './WorkflowActionsMenu';
+
+/**
+ * Focused projection of the execution detail payload. The row actions menu only
+ * needs the action capabilities plus the few fields required to build control
+ * and remediation requests; the full detail schema lives on the detail page.
+ */
+const RowActionsExecutionSchema = z
+  .object({
+    workflowId: z.string().nullable().optional(),
+    runId: z.string().nullable().optional(),
+    temporalRunId: z.string().nullable().optional(),
+    title: z.string().nullable().optional(),
+    repository: z.string().nullable().optional(),
+    state: z.string().nullable().optional(),
+    rawState: z.string().nullable().optional(),
+    status: z.string().nullable().optional(),
+    attentionRequired: z.boolean().nullable().optional(),
+    waitingReason: z.string().nullable().optional(),
+    targetRuntime: z.string().nullable().optional(),
+    profileId: z.string().nullable().optional(),
+    model: z.string().nullable().optional(),
+    resolvedModel: z.string().nullable().optional(),
+    requestedModel: z.string().nullable().optional(),
+    effort: z.string().nullable().optional(),
+    resume: z
+      .object({
+        checkpointRef: z.string().nullable().optional(),
+        sourceRunId: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+    actions: ExecutionActionsSchema.optional(),
+  })
+  .passthrough();
+
+type RowActionsExecution = z.infer<typeof RowActionsExecutionSchema>;
+
+const KEBAB_ICON = (
+  <svg
+    aria-hidden="true"
+    className="td-workflow-actions-trigger-icon"
+    viewBox="0 0 16 16"
+    focusable="false"
+  >
+    <circle cx="8" cy="3" r="1.5" />
+    <circle cx="8" cy="8" r="1.5" />
+    <circle cx="8" cy="13" r="1.5" />
+  </svg>
+);
+
+export type WorkflowRowActionsMenuProps = {
+  workflowId: string;
+  apiBase: string;
+  actionsEnabled: boolean;
+  taskEditingEnabled: boolean;
+};
+
+/**
+ * Self-contained actions dropdown rendered per Workflows table row. It lazily
+ * loads the workflow's action capabilities the first time the menu is opened,
+ * then exposes the same options as the Workflow Detail "Workflow actions" menu
+ * without requiring navigation to the detail page.
+ */
+export function WorkflowRowActionsMenu({
+  workflowId,
+  apiBase,
+  actionsEnabled,
+  taskEditingEnabled,
+}: WorkflowRowActionsMenuProps) {
+  const queryClient = useQueryClient();
+  const [hasOpened, setHasOpened] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const detailQuery = useQuery({
+    queryKey: ['workflow-row-actions-detail', workflowId],
+    enabled: actionsEnabled && hasOpened && Boolean(workflowId),
+    staleTime: 5000,
+    queryFn: async () => {
+      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}`);
+      if (!response.ok) {
+        throw new Error(`Workflow actions: ${response.statusText}`);
+      }
+      return RowActionsExecutionSchema.parse(await response.json());
+    },
+  });
+
+  const execution: RowActionsExecution | undefined = detailQuery.data;
+  const actions = execution?.actions;
+  const runId = execution?.temporalRunId?.trim() || execution?.runId?.trim() || '';
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['workflow-row-actions-detail', workflowId] });
+    void queryClient.invalidateQueries({ queryKey: ['workflow-list'] });
+  }, [queryClient, workflowId]);
+
+  const onMutationError = useCallback((error: Error) => {
+    setActionError(error.message);
+  }, []);
+
+  const updateMutation = useMutation({
+    mutationFn: async (body: Record<string, unknown>) => {
+      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: invalidate,
+    onError: onMutationError,
+  });
+
+  const signalMutation = useMutation({
+    mutationFn: async ({
+      signalName,
+      payload: signalPayload,
+    }: {
+      signalName: string;
+      payload?: Record<string, unknown>;
+    }) => {
+      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/signal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ signalName, payload: signalPayload ?? {} }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: invalidate,
+    onError: onMutationError,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: async ({
+      action = 'cancel',
+      graceful = true,
+      reason,
+    }: {
+      action?: 'cancel' | 'reject';
+      graceful?: boolean;
+      reason?: string;
+    }) => {
+      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ action, graceful, ...(reason ? { reason } : {}) }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: invalidate,
+    onError: onMutationError,
+  });
+
+  const failedStepResumeMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(
+        `${apiBase}/executions/${encodeURIComponent(workflowId)}/recover-from-failed-step`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({
+            idempotencyKey: `resume-${workflowId}-${runId || 'latest'}`,
+            ...(execution?.resume?.checkpointRef
+              ? { recoveryCheckpointRef: execution.resume.checkpointRef }
+              : {}),
+            operatorMetadata: { requestedFrom: 'workflow-list' },
+          }),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: invalidate,
+    onError: onMutationError,
+  });
+
+  const createRemediationMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/remediation`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          repository: execution?.repository ?? null,
+          ...buildRemediationRuntimeRequestFields(execution),
+          instructions: `Investigate and remediate target execution ${workflowId} using bounded evidence.`,
+          remediation: {
+            mode: DEFAULT_REMEDIATION_MODE,
+            authorityMode: DEFAULT_REMEDIATION_AUTHORITY,
+            target: { runId: runId || undefined },
+            actionPolicyRef: DEFAULT_REMEDIATION_ACTION_POLICY,
+            evidencePolicy: {
+              includeStepLedger: true,
+              includeDiagnostics: true,
+              tailLines: 2000,
+            },
+            trigger: { type: 'manual' },
+          },
+        }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return response.json();
+    },
+    onSuccess: invalidate,
+    onError: onMutationError,
+  });
+
+  const busy =
+    updateMutation.isPending ||
+    signalMutation.isPending ||
+    cancelMutation.isPending ||
+    failedStepResumeMutation.isPending ||
+    createRemediationMutation.isPending;
+
+  const editHref = workflowId
+    ? actions?.canEditForRerun
+      ? taskEditForRerunHref(workflowId)
+      : taskEditHref(workflowId)
+    : '';
+  const compareHref =
+    workflowId && actions?.canEditForRerun ? taskCompareHref(workflowId) : '';
+  const canShowEditWorkflow = Boolean(actions?.canUpdateInputs || actions?.canEditForRerun);
+  const editTaskUnavailableReason = canShowEditWorkflow
+    ? null
+    : actions?.disabledReasons?.canEditForRerun ||
+      actions?.disabledReasons?.canUpdateInputs ||
+      null;
+  const rerunUnavailableReason = actions?.disabledReasons?.canRerun || null;
+  const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
+  const disabledReason = useCallback(
+    (key: string): string | null => {
+      const reason = actions?.disabledReasons?.[key];
+      return reason ? formatStatusLabel(reason) : null;
+    },
+    [actions],
+  );
+
+  const items: WorkflowActionMenuItem[] = useMemo(() => {
+    if (!actionsEnabled || !actions) return [];
+    return buildWorkflowActionMenuItems({
+      actionsOn: actionsEnabled,
+      actions,
+      busy,
+      taskEditingOn: taskEditingEnabled,
+      disabledReason,
+      editHref,
+      compareHref,
+      canShowEditWorkflow,
+      editTaskDisabledReason: editTaskUnavailableReason
+        ? formatStatusLabel(editTaskUnavailableReason)
+        : null,
+      rerunDisabledReason: rerunUnavailableReason
+        ? formatStatusLabel(rerunUnavailableReason)
+        : null,
+      selectedRecoveryOptionCount: 0,
+      selectedRecoveryStepEligible: false,
+      selectedRecoveryStepDisabledReason: null,
+      canCreateRemediation,
+      handlers: {
+        onRename: () => {
+          setActionError(null);
+          const title = window.prompt('New task title', execution?.title || '');
+          if (title === null || !title.trim()) return;
+          updateMutation.mutate({ updateName: 'SetTitle', title: title.trim() });
+        },
+        onEditTask: () => {},
+        onCompareRun: () => {},
+        onRerun: () => {
+          setActionError(null);
+          if (busy || !workflowId) return;
+          updateMutation.mutate(
+            { updateName: 'RequestRerun' },
+            {
+              onSuccess: (result: unknown) => {
+                const payloadResult = result as {
+                  execution?: { workflowId?: string | null };
+                  workflow_id?: string | null;
+                };
+                const redirectWorkflowId =
+                  String(payloadResult.execution?.workflowId || '').trim() ||
+                  String(payloadResult.workflow_id || '').trim() ||
+                  workflowId;
+                navigateTo(`/workflows/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
+              },
+            },
+          );
+        },
+        onResumeFromFailedStep: () => {
+          setActionError(null);
+          if (!window.confirm('Resume from the failed step using the original task input snapshot?')) {
+            return;
+          }
+          failedStepResumeMutation.mutate();
+        },
+        onRecoverFromSelectedStep: () => {},
+        onPause: () => {
+          setActionError(null);
+          signalMutation.mutate({ signalName: 'Pause', payload: {} });
+        },
+        onResume: () => {
+          setActionError(null);
+          signalMutation.mutate({ signalName: 'Resume', payload: {} });
+        },
+        onApprove: () => {
+          setActionError(null);
+          signalMutation.mutate({ signalName: 'Approve', payload: {} });
+        },
+        onReject: () => {
+          setActionError(null);
+          if (!window.confirm('Reject this task?')) return;
+          cancelMutation.mutate({ action: 'reject', graceful: true, reason: 'Rejected by operator.' });
+        },
+        onCancel: () => {
+          setActionError(null);
+          if (!window.confirm('Cancel this task?')) return;
+          cancelMutation.mutate({ action: 'cancel', graceful: true });
+        },
+        onSendMessage: () => {
+          setActionError(null);
+          const message = window.prompt('Operator message', '');
+          if (message?.trim()) {
+            signalMutation.mutate({ signalName: 'SendMessage', payload: { message: message.trim() } });
+          }
+        },
+        onBypassDependencies: () => {
+          setActionError(null);
+          if (!window.confirm('Bypass dependency waiting for this task?')) return;
+          signalMutation.mutate({
+            signalName: 'BypassDependencies',
+            payload: { reason: 'Dependency wait bypassed by operator from Mission Control.' },
+          });
+        },
+        onCreateRemediation: () => {
+          setActionError(null);
+          createRemediationMutation.mutate();
+        },
+      },
+    });
+  }, [
+    actions,
+    actionsEnabled,
+    busy,
+    canCreateRemediation,
+    canShowEditWorkflow,
+    cancelMutation,
+    compareHref,
+    createRemediationMutation,
+    disabledReason,
+    editHref,
+    editTaskUnavailableReason,
+    execution,
+    failedStepResumeMutation,
+    rerunUnavailableReason,
+    signalMutation,
+    taskEditingEnabled,
+    updateMutation,
+    workflowId,
+  ]);
+
+  const emptyMessage = detailQuery.isLoading
+    ? 'Loading actions…'
+    : detailQuery.isError
+      ? 'Unable to load workflow actions.'
+      : 'No workflow actions are currently available.';
+
+  return (
+    <div className="workflow-row-actions">
+      <WorkflowActionsMenu
+        items={items}
+        triggerContent={KEBAB_ICON}
+        triggerAriaLabel="Actions"
+        triggerClassName="secondary td-workflow-actions-trigger td-workflow-actions-trigger-compact"
+        menuAriaLabel="Actions"
+        emptyMessage={emptyMessage}
+        onOpenChange={(open) => {
+          if (open) setHasOpened(true);
+        }}
+      />
+      {actionError ? (
+        <p className="workflow-row-actions-error" role="alert">
+          {actionError}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -99,7 +99,9 @@ export function WorkflowRowActionsMenu({
     enabled: actionsEnabled && hasOpened && Boolean(workflowId),
     staleTime: 5000,
     queryFn: async () => {
-      const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}`);
+      const response = await fetch(
+        `${apiBase}/executions/${encodeURIComponent(workflowId)}?source=temporal`,
+      );
       if (!response.ok) {
         throw new Error(`Workflow actions: ${response.statusText}`);
       }
@@ -311,10 +313,13 @@ export function WorkflowRowActionsMenu({
             { updateName: 'RequestRerun' },
             {
               onSuccess: (result: unknown) => {
-                const payloadResult = result as {
-                  execution?: { workflowId?: string | null };
-                  workflow_id?: string | null;
-                };
+                const payloadResult =
+                  result && typeof result === 'object'
+                    ? (result as {
+                        execution?: { workflowId?: string | null };
+                        workflow_id?: string | null;
+                      })
+                    : {};
                 const redirectWorkflowId =
                   String(payloadResult.execution?.workflowId || '').trim() ||
                   String(payloadResult.workflow_id || '').trim() ||

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import Anser from 'anser';
 import { Virtuoso } from 'react-virtuoso';
@@ -15,6 +15,17 @@ import {
   taskEditHref,
 } from '../lib/temporalTaskEditing';
 import { navigateTo } from '../lib/navigation';
+import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
+import {
+  buildRemediationRuntimeRequestFields,
+  buildWorkflowActionMenuItems,
+  DEFAULT_REMEDIATION_ACTION_POLICY,
+  DEFAULT_REMEDIATION_AUTHORITY,
+  DEFAULT_REMEDIATION_MODE,
+  ExecutionActionsSchema,
+  isRemediationEligibleTarget,
+  type WorkflowActionMenuItem,
+} from '../lib/workflowActions';
 
 type DashboardConfig = {
   pollIntervalsMs?: { list?: number; detail?: number; events?: number };
@@ -577,24 +588,7 @@ const ExecutionDetailSchema = z
       .passthrough()
       .nullable()
       .optional(),
-    actions: z
-      .object({
-        canSetTitle: z.boolean().optional(),
-        canUpdateInputs: z.boolean().optional(),
-        canEditForRerun: z.boolean().optional(),
-        canRerun: z.boolean().optional(),
-        canApprove: z.boolean().optional(),
-        canPause: z.boolean().optional(),
-        canResume: z.boolean().optional(),
-        canResumeFromFailedStep: z.boolean().optional(),
-        canCancel: z.boolean().optional(),
-        canReject: z.boolean().optional(),
-        canSendMessage: z.boolean().optional(),
-        canBypassDependencies: z.boolean().optional(),
-        disabledReasons: z.record(z.string(), z.string()).optional(),
-      })
-      .passthrough()
-      .optional(),
+    actions: ExecutionActionsSchema.optional(),
     resume: z
       .object({
         available: z.boolean().optional(),
@@ -644,28 +638,6 @@ const ExecutionDetailSchema = z
   .passthrough();
 
 type ExecutionDetail = z.infer<typeof ExecutionDetailSchema>;
-
-function buildRemediationRuntimeRequestFields(
-  execution: ExecutionDetail | null | undefined,
-): Record<string, unknown> {
-  const mode = detailStringValue(execution?.targetRuntime);
-  const profileId = detailStringValue(execution?.profileId);
-  const model = detailStringValue(
-    execution?.model,
-    execution?.resolvedModel,
-    execution?.requestedModel,
-  );
-  const effort = detailStringValue(execution?.effort);
-  const runtime: Record<string, string> = {};
-  if (mode) runtime.mode = mode;
-  if (model) runtime.model = model;
-  if (effort) runtime.effort = effort;
-  if (profileId) runtime.profileId = profileId;
-
-  return {
-    ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
-  };
-}
 
 const RemediationApprovalStateSchema = z
   .object({
@@ -3271,214 +3243,6 @@ function InterventionPanel({
   );
 }
 
-type WorkflowActionMenuItem = {
-  id: string;
-  label: string;
-  href?: string;
-  danger?: boolean;
-  disabledReason?: string | null;
-  onSelect?: () => void;
-};
-
-function WorkflowActionsMenu({
-  items,
-}: {
-  items: WorkflowActionMenuItem[];
-}) {
-  const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const itemRefs = useRef<Array<HTMLButtonElement | HTMLAnchorElement | null>>([]);
-  const availableIndexes = useMemo(
-    () => items
-      .map((item, index) => (item.disabledReason ? -1 : index))
-      .filter((index) => index >= 0),
-    [items],
-  );
-
-  const closeMenu = () => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  };
-  const focusItem = (index: number) => {
-    const nextIndex = items[index] ? index : availableIndexes[0] ?? 0;
-    setActiveIndex(nextIndex);
-  };
-  const selectItem = (item: WorkflowActionMenuItem) => {
-    if (item.disabledReason) return;
-    item.onSelect?.();
-    setOpen(false);
-    triggerRef.current?.focus();
-  };
-
-  useEffect(() => {
-    if (!open) return undefined;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('pointerdown', onPointerDown);
-    return () => document.removeEventListener('pointerdown', onPointerDown);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const preferredIndex = availableIndexes.includes(activeIndex)
-      ? activeIndex
-      : availableIndexes[0] ?? 0;
-    setActiveIndex(preferredIndex);
-  }, [activeIndex, availableIndexes, open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const activeItem = itemRefs.current[activeIndex];
-    if (activeItem && document.activeElement !== activeItem) {
-      activeItem.focus();
-    }
-  }, [activeIndex, open]);
-
-  const onTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      setOpen(true);
-      focusItem(availableIndexes[0] ?? 0);
-    }
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      setOpen(true);
-      focusItem(availableIndexes[0] ?? 0);
-    }
-  };
-  const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      closeMenu();
-      return;
-    }
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (availableIndexes.length === 0) return;
-      const currentAvailableIndex = Math.max(0, availableIndexes.indexOf(activeIndex));
-      const direction = event.key === 'ArrowDown' ? 1 : -1;
-      const next =
-        availableIndexes[
-          (currentAvailableIndex + direction + availableIndexes.length) % availableIndexes.length
-        ] ?? availableIndexes[0] ?? 0;
-      focusItem(next);
-      return;
-    }
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      itemRefs.current[activeIndex]?.click();
-    }
-  };
-
-  return (
-    <div
-      className="td-workflow-actions-menu"
-      ref={rootRef}
-      onBlur={(event) => {
-        if (open && !event.currentTarget.contains(event.relatedTarget as Node | null)) {
-          setOpen(false);
-        }
-      }}
-    >
-      <button
-        type="button"
-        ref={triggerRef}
-        className="secondary td-workflow-actions-trigger"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => {
-          const nextOpen = !open;
-          setOpen(nextOpen);
-          if (nextOpen) {
-            const firstAvailable = availableIndexes[0] ?? 0;
-            setActiveIndex(firstAvailable);
-          }
-        }}
-        onKeyDown={onTriggerKeyDown}
-      >
-        Workflow actions
-      </button>
-      {open ? (
-        <div
-          className="td-workflow-actions-popover"
-          role="menu"
-          aria-label="Workflow actions"
-          onKeyDown={onMenuKeyDown}
-        >
-          {items.length === 0 ? (
-            <p className="td-workflow-actions-empty">No workflow actions are currently available.</p>
-          ) : (
-            items.map((item, index) => {
-              const disabledReasonId = item.disabledReason
-                ? `workflow-action-${item.id}-disabled-reason`
-                : undefined;
-              const commonProps = {
-                role: 'menuitem',
-                tabIndex: index === activeIndex ? 0 : -1,
-                'aria-label': item.label,
-                'aria-disabled': item.disabledReason ? true : undefined,
-                'aria-describedby': disabledReasonId,
-                className: [
-                  'td-workflow-actions-item',
-                  item.danger ? 'td-workflow-actions-item-danger' : '',
-                  item.disabledReason ? 'td-workflow-actions-item-disabled' : '',
-                ].filter(Boolean).join(' '),
-                ref: (node: HTMLButtonElement | HTMLAnchorElement | null) => {
-                  itemRefs.current[index] = node;
-                },
-                onFocus: () => setActiveIndex(index),
-              };
-              const content = (
-                <>
-                  <span>{item.label}</span>
-                  {item.disabledReason ? (
-                    <span
-                      id={disabledReasonId}
-                      className="td-workflow-actions-disabled-reason"
-                    >
-                      {item.label} unavailable: {item.disabledReason}
-                    </span>
-                  ) : null}
-                </>
-              );
-              if (item.href && !item.disabledReason) {
-                return (
-                  <a
-                    key={item.id}
-                    {...commonProps}
-                    href={item.href}
-                    onClick={() => {
-                      item.onSelect?.();
-                      setOpen(false);
-                    }}
-                  >
-                    {content}
-                  </a>
-                );
-              }
-              return (
-                <button
-                  key={item.id}
-                  {...commonProps}
-                  type="button"
-                  onClick={() => selectItem(item)}
-                >
-                  {content}
-                </button>
-              );
-            })
-          )}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 function StaticLogPanel({
   apiBase,
   agentRunId,
@@ -4098,17 +3862,6 @@ function renderMissingAgentRunCopy(state: MissingAgentRunState): string {
     return 'This execution is running but has not received its managed runtime binding yet.';
   }
   return 'Waiting for managed runtime launch to create live logs.';
-}
-
-function isRemediationEligibleTarget(execution: z.infer<typeof ExecutionDetailSchema>): boolean {
-  const state = (execution.rawState || execution.state || execution.status || '').toLowerCase();
-  return (
-    execution.attentionRequired === true ||
-    Boolean(execution.waitingReason) ||
-    state.includes('failed') ||
-    state.includes('stuck') ||
-    state === 'awaiting_external'
-  );
 }
 
 function remediationArtifactType(artifact: z.infer<typeof ArtifactSummarySchema>): string | null {
@@ -4783,9 +4536,11 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const [liveUpdates, setLiveUpdates] = useState(true);
   const [expandedSteps, setExpandedSteps] = useState<Record<string, boolean>>({});
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
-  const [remediationMode, setRemediationMode] = useState('snapshot_then_follow');
-  const [remediationAuthority, setRemediationAuthority] = useState('approval_gated');
-  const [remediationActionPolicy, setRemediationActionPolicy] = useState('admin_healer_default');
+  const [remediationMode, setRemediationMode] = useState(DEFAULT_REMEDIATION_MODE);
+  const [remediationAuthority, setRemediationAuthority] = useState(DEFAULT_REMEDIATION_AUTHORITY);
+  const [remediationActionPolicy, setRemediationActionPolicy] = useState(
+    DEFAULT_REMEDIATION_ACTION_POLICY,
+  );
   const [selectedRecoveryStepId, setSelectedRecoveryStepId] = useState('');
 
   const detailQuery = useQuery({
@@ -5407,207 +5162,62 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     const reason = actions?.disabledReasons?.[key];
     return reason ? formatStatusLabel(reason) : null;
   };
-  const workflowActionMenuItems = (() => {
-    if (!actionsOn || !actions) return [];
-    const items: WorkflowActionMenuItem[] = [];
-    const pendingActionReason = busy ? 'action pending' : null;
-    const addButton = ({
-      id,
-      label,
-      available,
-      disabledReason,
-      danger,
-      onSelect,
-    }: {
-      id: string;
-      label: string;
-      available: boolean;
-      disabledReason?: string | null;
-      danger?: boolean;
-      onSelect: () => void;
-    }) => {
-      const effectiveDisabledReason = available ? pendingActionReason : disabledReason ?? null;
-      if (available) {
-        items.push({
-          id,
-          label,
-          ...(danger ? { danger: true } : {}),
-          onSelect,
-          ...(effectiveDisabledReason ? { disabledReason: effectiveDisabledReason } : {}),
+  const workflowActionMenuItems: WorkflowActionMenuItem[] = buildWorkflowActionMenuItems({
+    actionsOn,
+    actions,
+    busy,
+    taskEditingOn,
+    disabledReason: actionDisabledReason,
+    editHref,
+    compareHref,
+    canShowEditWorkflow,
+    editTaskDisabledReason: editTaskUnavailableReason
+      ? formatStatusLabel(editTaskUnavailableReason)
+      : null,
+    rerunDisabledReason: rerunUnavailableReason ? formatStatusLabel(rerunUnavailableReason) : null,
+    selectedRecoveryOptionCount: selectedRecoveryOptions.length,
+    selectedRecoveryStepEligible: Boolean(selectedRecoveryStep?.eligible),
+    selectedRecoveryStepDisabledReason: selectedRecoveryStep?.reason
+      ? formatStatusLabel(selectedRecoveryStep.reason)
+      : 'selected step is not eligible',
+    canCreateRemediation,
+    handlers: {
+      onRename,
+      onEditTask: () => {
+        if (busy) return;
+        recordTemporalTaskEditingClientEvent({
+          event: 'detail_edit_click',
+          mode: 'detail',
+          workflowId,
         });
-      } else if (effectiveDisabledReason) {
-        items.push({
-          id,
-          label,
-          ...(danger ? { danger: true } : {}),
-          disabledReason: effectiveDisabledReason,
+      },
+      onCompareRun: () => {
+        if (busy) return;
+        recordTemporalTaskEditingClientEvent({
+          event: 'detail_compare_click',
+          mode: 'detail',
+          workflowId,
         });
-      }
-    };
-    const addLink = ({
-      id,
-      label,
-      href,
-      available,
-      disabledReason,
-      onSelect,
-    }: {
-      id: string;
-      label: string;
-      href: string;
-      available: boolean;
-      disabledReason?: string | null;
-      onSelect: () => void;
-    }) => {
-      const effectiveDisabledReason = available ? pendingActionReason : disabledReason ?? null;
-      if (available && href) {
-        items.push({
-          id,
-          label,
-          href,
-          onSelect,
-          ...(effectiveDisabledReason ? { disabledReason: effectiveDisabledReason } : {}),
-        });
-      } else if (effectiveDisabledReason) {
-        items.push({
-          id,
-          label,
-          disabledReason: effectiveDisabledReason,
-        });
-      }
-    };
-
-    addButton({
-      id: 'rename',
-      label: 'Rename',
-      available: Boolean(actions.canSetTitle),
-      disabledReason: actionDisabledReason('canSetTitle'),
-      onSelect: onRename,
-    });
-    if (taskEditingOn) {
-      addLink({
-        id: 'edit-task',
-        label: 'Edit task',
-        href: editHref,
-        available: Boolean(canShowEditWorkflow && editHref),
-        disabledReason: editTaskUnavailableReason ? formatStatusLabel(editTaskUnavailableReason) : null,
-        onSelect: () => {
-          if (busy) return;
-          recordTemporalTaskEditingClientEvent({
-            event: 'detail_edit_click',
-            mode: 'detail',
-            workflowId,
-          });
-        },
-      });
-      addLink({
-        id: 'compare-run',
-        label: 'Compare run',
-        href: compareHref,
-        available: Boolean(compareHref),
-        disabledReason: actionDisabledReason('canEditForRerun'),
-        onSelect: () => {
-          if (busy) return;
-          recordTemporalTaskEditingClientEvent({
-            event: 'detail_compare_click',
-            mode: 'detail',
-            workflowId,
-          });
-        },
-      });
-      addButton({
-        id: 'rerun',
-        label: 'Rerun',
-        available: Boolean(actions.canRerun),
-        disabledReason: rerunUnavailableReason ? formatStatusLabel(rerunUnavailableReason) : null,
-        onSelect: onRerun,
-      });
-      addButton({
-        id: 'resume-from-failed-step',
-        label: 'Resume from failed step',
-        available: Boolean(actions.canResumeFromFailedStep),
-        disabledReason: actionDisabledReason('canResumeFromFailedStep'),
-        onSelect: onResumeFromFailedStep,
-      });
-      if (actions.canResumeFromFailedStep && selectedRecoveryOptions.length > 0) {
-        addButton({
-          id: 'recover-from-selected-step',
-          label: 'Recover from selected step',
-          available: Boolean(selectedRecoveryStep?.eligible),
-          disabledReason: selectedRecoveryStep?.reason
-            ? formatStatusLabel(selectedRecoveryStep.reason)
-            : 'selected step is not eligible',
-          onSelect: onRecoverFromSelectedStep,
-        });
-      }
-    }
-    addButton({
-      id: 'pause',
-      label: 'Pause',
-      available: Boolean(actions.canPause),
-      disabledReason: actionDisabledReason('canPause'),
-      onSelect: onPause,
-    });
-    addButton({
-      id: 'resume',
-      label: 'Resume',
-      available: Boolean(actions.canResume),
-      disabledReason: actionDisabledReason('canResume'),
-      onSelect: onResume,
-    });
-    addButton({
-      id: 'approve',
-      label: 'Approve',
-      available: Boolean(actions.canApprove),
-      disabledReason: actionDisabledReason('canApprove'),
-      onSelect: onApprove,
-    });
-    addButton({
-      id: 'reject',
-      label: 'Reject',
-      available: Boolean(actions.canReject),
-      disabledReason: actionDisabledReason('canReject'),
-      danger: true,
-      onSelect: onReject,
-    });
-    addButton({
-      id: 'cancel',
-      label: 'Cancel',
-      available: Boolean(actions.canCancel),
-      disabledReason: actionDisabledReason('canCancel'),
-      danger: true,
-      onSelect: onCancel,
-    });
-    addButton({
-      id: 'send-message',
-      label: 'Send Message',
-      available: Boolean(actions.canSendMessage),
-      disabledReason: actionDisabledReason('canSendMessage'),
-      onSelect: () => {
+      },
+      onRerun,
+      onResumeFromFailedStep,
+      onRecoverFromSelectedStep,
+      onPause,
+      onResume,
+      onApprove,
+      onReject,
+      onCancel,
+      onSendMessage: () => {
         const message = window.prompt('Operator message', '');
         if (message?.trim()) onSendMessage(message.trim());
       },
-    });
-    addButton({
-      id: 'bypass-dependency-wait',
-      label: 'Bypass Dependency Wait',
-      available: Boolean(actions.canBypassDependencies),
-      disabledReason: actionDisabledReason('canBypassDependencies'),
-      danger: true,
-      onSelect: onBypassDependencies,
-    });
-    addButton({
-      id: 'create-remediation-task',
-      label: 'Create remediation task',
-      available: canCreateRemediation,
-      disabledReason: null,
-      onSelect: () => {
+      onBypassDependencies,
+      onCreateRemediation: () => {
         setActionError(null);
         createRemediationMutation.mutate();
       },
-    });
-    return items;
-  })();
+    },
+  });
   const toggleStep = (logicalStepId: string) => {
     setExpandedSteps((prev) => ({
       ...prev,

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1395,4 +1395,37 @@ describe('Workflows Entrypoint', () => {
     const idCell = table?.querySelector('td.queue-table-cell-id');
     expect(idCell?.textContent).toBe(longWorkflowId);
   });
+
+  it('does not render an Actions column when workflow actions are disabled', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    expect(screen.queryByRole('columnheader', { name: 'Actions' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Actions' })).toBeNull();
+  });
+
+  it('renders a per-row Actions menu trigger when workflow actions are enabled', async () => {
+    const actionsPayload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard: { listEnabled: true, actionsEnabled: true } },
+        },
+      },
+    };
+
+    renderWithClient(<WorkflowListPage payload={actionsPayload} />);
+
+    await screen.findAllByText('Example task');
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy();
+    const triggers = screen.getAllByRole('button', { name: 'Actions' });
+    expect(triggers.length).toBeGreaterThanOrEqual(1);
+
+    // Opening the menu lazily fetches the workflow's action capabilities.
+    const detailCallsBefore = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).endsWith('/executions/task-123'),
+    );
+    expect(detailCallsBefore).toHaveLength(0);
+  });
 });

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -6,6 +6,7 @@ import { BootPayload } from '../boot/parseBootPayload';
 import { formatRuntimeLabel, formatStatusLabel, formatTaskSkills } from '../utils/formatters';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
+import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
 
 const POLL_MS_DEFAULT = 5000;
 
@@ -14,6 +15,9 @@ type ListDashboardConfig = {
   features?: {
     temporalDashboard?: {
       listEnabled?: boolean;
+      actionsEnabled?: boolean;
+      temporalWorkflowEditing?: boolean;
+      temporalTaskEditing?: boolean;
     };
   };
 };
@@ -598,6 +602,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     return typeof candidate === 'number' && candidate > 0 ? candidate : POLL_MS_DEFAULT;
   }, [dashboardCfg]);
   const listEnabled = dashboardCfg?.features?.temporalDashboard?.listEnabled !== false;
+  const actionsEnabled = Boolean(dashboardCfg?.features?.temporalDashboard?.actionsEnabled);
+  const taskEditingEnabled = Boolean(
+    dashboardCfg?.features?.temporalDashboard?.temporalWorkflowEditing ??
+      dashboardCfg?.features?.temporalDashboard?.temporalTaskEditing,
+  );
 
   const initial = useMemo(() => new URLSearchParams(window.location.search), []);
 
@@ -1471,6 +1480,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                     <col className="queue-table-column-date" />
                     <col className="queue-table-column-date" />
                     <col className="queue-table-column-date" />
+                    {actionsEnabled ? <col className="queue-table-column-actions" /> : null}
                   </colgroup>
                   <thead>
                     <tr>
@@ -1530,6 +1540,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                           </th>
                         );
                       })}
+                      {actionsEnabled ? (
+                        <th scope="col" className="queue-table-actions-header">
+                          Actions
+                        </th>
+                      ) : null}
                     </tr>
                   </thead>
                   <tbody>
@@ -1563,6 +1578,16 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                           <td className="queue-table-cell-date">{formatWhen(row.scheduledFor)}</td>
                           <td className="queue-table-cell-date">{formatWhen(row.createdAt)}</td>
                           <td className="queue-table-cell-date">{formatWhen(row.closedAt)}</td>
+                          {actionsEnabled ? (
+                            <td className="queue-table-cell-actions">
+                              <WorkflowRowActionsMenu
+                                workflowId={rowWorkflowId(row)}
+                                apiBase={payload.apiBase}
+                                actionsEnabled={actionsEnabled}
+                                taskEditingEnabled={taskEditingEnabled}
+                              />
+                            </td>
+                          ) : null}
                         </tr>
                       );
                     })}
@@ -1648,6 +1673,14 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                       >
                         View details
                       </a>
+                      {actionsEnabled ? (
+                        <WorkflowRowActionsMenu
+                          workflowId={rowWorkflowId(row)}
+                          apiBase={payload.apiBase}
+                          actionsEnabled={actionsEnabled}
+                          taskEditingEnabled={taskEditingEnabled}
+                        />
+                      ) : null}
                     </div>
                   </li>
                       );

--- a/frontend/src/lib/workflowActions.test.ts
+++ b/frontend/src/lib/workflowActions.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildRemediationRuntimeRequestFields,
+  buildWorkflowActionMenuItems,
+  isRemediationEligibleTarget,
+  type ExecutionActionCapabilities,
+  type WorkflowActionHandlers,
+} from './workflowActions';
+
+function noopHandlers(): WorkflowActionHandlers {
+  return {
+    onRename: vi.fn(),
+    onEditTask: vi.fn(),
+    onCompareRun: vi.fn(),
+    onRerun: vi.fn(),
+    onResumeFromFailedStep: vi.fn(),
+    onRecoverFromSelectedStep: vi.fn(),
+    onPause: vi.fn(),
+    onResume: vi.fn(),
+    onApprove: vi.fn(),
+    onReject: vi.fn(),
+    onCancel: vi.fn(),
+    onSendMessage: vi.fn(),
+    onBypassDependencies: vi.fn(),
+    onCreateRemediation: vi.fn(),
+  };
+}
+
+function buildParams(
+  overrides: Partial<Parameters<typeof buildWorkflowActionMenuItems>[0]> = {},
+) {
+  return {
+    actionsOn: true,
+    actions: {} as ExecutionActionCapabilities,
+    busy: false,
+    taskEditingOn: false,
+    disabledReason: () => null,
+    editHref: '',
+    compareHref: '',
+    canShowEditWorkflow: false,
+    editTaskDisabledReason: null,
+    rerunDisabledReason: null,
+    selectedRecoveryOptionCount: 0,
+    selectedRecoveryStepEligible: false,
+    selectedRecoveryStepDisabledReason: null,
+    canCreateRemediation: false,
+    handlers: noopHandlers(),
+    ...overrides,
+  };
+}
+
+describe('buildWorkflowActionMenuItems', () => {
+  it('returns no items when actions are disabled', () => {
+    expect(buildWorkflowActionMenuItems(buildParams({ actionsOn: false }))).toEqual([]);
+  });
+
+  it('returns no items when no capability payload is present', () => {
+    expect(buildWorkflowActionMenuItems(buildParams({ actions: null }))).toEqual([]);
+  });
+
+  it('builds the available intervention and lifecycle options', () => {
+    const items = buildWorkflowActionMenuItems(
+      buildParams({
+        actions: {
+          canSetTitle: true,
+          canPause: true,
+          canResume: true,
+          canApprove: true,
+          canReject: true,
+          canCancel: true,
+          canSendMessage: true,
+          canBypassDependencies: true,
+        },
+        canCreateRemediation: true,
+      }),
+    );
+    expect(items.map((item) => item.id)).toEqual([
+      'rename',
+      'pause',
+      'resume',
+      'approve',
+      'reject',
+      'cancel',
+      'send-message',
+      'bypass-dependency-wait',
+      'create-remediation-task',
+    ]);
+    expect(items.find((item) => item.id === 'reject')?.danger).toBe(true);
+    expect(items.find((item) => item.id === 'cancel')?.danger).toBe(true);
+    expect(items.find((item) => item.id === 'bypass-dependency-wait')?.danger).toBe(true);
+  });
+
+  it('includes the task-editing options only when task editing is enabled', () => {
+    const withoutEditing = buildWorkflowActionMenuItems(
+      buildParams({ actions: { canRerun: true } }),
+    );
+    expect(withoutEditing.some((item) => item.id === 'rerun')).toBe(false);
+
+    const withEditing = buildWorkflowActionMenuItems(
+      buildParams({
+        taskEditingOn: true,
+        canShowEditWorkflow: true,
+        editHref: '/tasks/abc/edit',
+        compareHref: '/tasks/abc/compare',
+        actions: { canRerun: true, canResumeFromFailedStep: true },
+      }),
+    );
+    expect(withEditing.map((item) => item.id)).toEqual([
+      'edit-task',
+      'compare-run',
+      'rerun',
+      'resume-from-failed-step',
+    ]);
+    expect(withEditing.find((item) => item.id === 'edit-task')?.href).toBe('/tasks/abc/edit');
+  });
+
+  it('omits recover-from-selected-step unless a recovery option is selected', () => {
+    const base = {
+      taskEditingOn: true,
+      actions: { canResumeFromFailedStep: true } as ExecutionActionCapabilities,
+    };
+    const withoutSelection = buildWorkflowActionMenuItems(buildParams(base));
+    expect(withoutSelection.some((item) => item.id === 'recover-from-selected-step')).toBe(false);
+
+    const withSelection = buildWorkflowActionMenuItems(
+      buildParams({
+        ...base,
+        selectedRecoveryOptionCount: 1,
+        selectedRecoveryStepEligible: true,
+      }),
+    );
+    expect(withSelection.some((item) => item.id === 'recover-from-selected-step')).toBe(true);
+  });
+
+  it('surfaces a disabled reason for unavailable actions that report one', () => {
+    const items = buildWorkflowActionMenuItems(
+      buildParams({
+        actions: { canPause: false },
+        disabledReason: (key) => (key === 'canPause' ? 'Not pausable' : null),
+      }),
+    );
+    const pause = items.find((item) => item.id === 'pause');
+    expect(pause?.disabledReason).toBe('Not pausable');
+    expect(pause?.onSelect).toBeUndefined();
+  });
+
+  it('marks available actions as pending while another action is in flight', () => {
+    const items = buildWorkflowActionMenuItems(
+      buildParams({ busy: true, actions: { canPause: true } }),
+    );
+    expect(items.find((item) => item.id === 'pause')?.disabledReason).toBe('action pending');
+  });
+});
+
+describe('buildRemediationRuntimeRequestFields', () => {
+  it('returns an empty object when no runtime fields are present', () => {
+    expect(buildRemediationRuntimeRequestFields({})).toEqual({});
+    expect(buildRemediationRuntimeRequestFields(null)).toEqual({});
+  });
+
+  it('coalesces model candidates and trims runtime fields', () => {
+    expect(
+      buildRemediationRuntimeRequestFields({
+        targetRuntime: 'codex_cli',
+        profileId: 'profile-1',
+        model: '',
+        resolvedModel: 'gpt-x',
+        effort: 'high',
+      }),
+    ).toEqual({
+      runtime: {
+        mode: 'codex_cli',
+        model: 'gpt-x',
+        effort: 'high',
+        profileId: 'profile-1',
+      },
+    });
+  });
+});
+
+describe('isRemediationEligibleTarget', () => {
+  it('is eligible for failed, stuck, or awaiting-external states', () => {
+    expect(isRemediationEligibleTarget({ state: 'failed' })).toBe(true);
+    expect(isRemediationEligibleTarget({ rawState: 'stuck_runtime' })).toBe(true);
+    expect(isRemediationEligibleTarget({ status: 'awaiting_external' })).toBe(true);
+  });
+
+  it('is eligible when attention is required or a waiting reason is present', () => {
+    expect(isRemediationEligibleTarget({ attentionRequired: true })).toBe(true);
+    expect(isRemediationEligibleTarget({ waitingReason: 'blocked' })).toBe(true);
+  });
+
+  it('is not eligible for healthy terminal states', () => {
+    expect(isRemediationEligibleTarget({ state: 'completed' })).toBe(false);
+  });
+});

--- a/frontend/src/lib/workflowActions.ts
+++ b/frontend/src/lib/workflowActions.ts
@@ -1,0 +1,350 @@
+import { z } from 'zod';
+
+/**
+ * Shared workflow-action contracts used by both the Workflow Detail page and the
+ * Workflows list page. The list page exposes the same dropdown options directly
+ * from each table row, so the option-building logic, capability schema, and
+ * remediation request helpers live here as a single source of truth.
+ */
+
+export const ExecutionActionsSchema = z
+  .object({
+    canSetTitle: z.boolean().optional(),
+    canUpdateInputs: z.boolean().optional(),
+    canEditForRerun: z.boolean().optional(),
+    canRerun: z.boolean().optional(),
+    canApprove: z.boolean().optional(),
+    canPause: z.boolean().optional(),
+    canResume: z.boolean().optional(),
+    canResumeFromFailedStep: z.boolean().optional(),
+    canCancel: z.boolean().optional(),
+    canReject: z.boolean().optional(),
+    canSendMessage: z.boolean().optional(),
+    canBypassDependencies: z.boolean().optional(),
+    disabledReasons: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+export type ExecutionActionCapabilities = z.infer<typeof ExecutionActionsSchema>;
+
+export const DEFAULT_REMEDIATION_MODE = 'snapshot_then_follow';
+export const DEFAULT_REMEDIATION_AUTHORITY = 'approval_gated';
+export const DEFAULT_REMEDIATION_ACTION_POLICY = 'admin_healer_default';
+
+export type WorkflowActionMenuItem = {
+  id: string;
+  label: string;
+  href?: string;
+  danger?: boolean;
+  disabledReason?: string | null;
+  onSelect?: () => void;
+};
+
+export type WorkflowActionHandlers = {
+  onRename: () => void;
+  onEditTask: () => void;
+  onCompareRun: () => void;
+  onRerun: () => void;
+  onResumeFromFailedStep: () => void;
+  onRecoverFromSelectedStep: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onApprove: () => void;
+  onReject: () => void;
+  onCancel: () => void;
+  onSendMessage: () => void;
+  onBypassDependencies: () => void;
+  onCreateRemediation: () => void;
+};
+
+export type WorkflowActionMenuBuilderParams = {
+  actionsOn: boolean;
+  actions: ExecutionActionCapabilities | null | undefined;
+  busy: boolean;
+  taskEditingOn: boolean;
+  /** Returns a display-ready disabled reason for a capability key, or null. */
+  disabledReason: (key: string) => string | null;
+  editHref: string;
+  compareHref: string;
+  canShowEditWorkflow: boolean;
+  /** Display-ready reason for an unavailable Edit task action, or null. */
+  editTaskDisabledReason: string | null;
+  /** Display-ready reason for an unavailable Rerun action, or null. */
+  rerunDisabledReason: string | null;
+  /**
+   * Number of operator-selected recovery steps. The "Recover from selected step"
+   * action only applies when a step is selected on the detail page, so the list
+   * row passes 0 and that option is omitted.
+   */
+  selectedRecoveryOptionCount: number;
+  selectedRecoveryStepEligible: boolean;
+  /** Display-ready reason for an ineligible selected recovery step. */
+  selectedRecoveryStepDisabledReason: string | null;
+  canCreateRemediation: boolean;
+  handlers: WorkflowActionHandlers;
+};
+
+/**
+ * Build the ordered list of workflow action options shown in the actions dropdown.
+ *
+ * This is the single source of truth shared by the Workflow Detail "Workflow
+ * actions" menu and the Workflows table row "Actions" menu so both surfaces
+ * always present the same options, ordering, and disabled semantics.
+ */
+export function buildWorkflowActionMenuItems(
+  params: WorkflowActionMenuBuilderParams,
+): WorkflowActionMenuItem[] {
+  const {
+    actionsOn,
+    actions,
+    busy,
+    taskEditingOn,
+    disabledReason,
+    editHref,
+    compareHref,
+    canShowEditWorkflow,
+    editTaskDisabledReason,
+    rerunDisabledReason,
+    selectedRecoveryOptionCount,
+    selectedRecoveryStepEligible,
+    selectedRecoveryStepDisabledReason,
+    canCreateRemediation,
+    handlers,
+  } = params;
+
+  if (!actionsOn || !actions) return [];
+  const items: WorkflowActionMenuItem[] = [];
+  const pendingActionReason = busy ? 'action pending' : null;
+  const addButton = ({
+    id,
+    label,
+    available,
+    disabledReason: itemDisabledReason,
+    danger,
+    onSelect,
+  }: {
+    id: string;
+    label: string;
+    available: boolean;
+    disabledReason?: string | null;
+    danger?: boolean;
+    onSelect: () => void;
+  }) => {
+    const effectiveDisabledReason = available ? pendingActionReason : itemDisabledReason ?? null;
+    if (available) {
+      items.push({
+        id,
+        label,
+        ...(danger ? { danger: true } : {}),
+        onSelect,
+        ...(effectiveDisabledReason ? { disabledReason: effectiveDisabledReason } : {}),
+      });
+    } else if (effectiveDisabledReason) {
+      items.push({
+        id,
+        label,
+        ...(danger ? { danger: true } : {}),
+        disabledReason: effectiveDisabledReason,
+      });
+    }
+  };
+  const addLink = ({
+    id,
+    label,
+    href,
+    available,
+    disabledReason: itemDisabledReason,
+    onSelect,
+  }: {
+    id: string;
+    label: string;
+    href: string;
+    available: boolean;
+    disabledReason?: string | null;
+    onSelect: () => void;
+  }) => {
+    const effectiveDisabledReason = available ? pendingActionReason : itemDisabledReason ?? null;
+    if (available && href) {
+      items.push({
+        id,
+        label,
+        href,
+        onSelect,
+        ...(effectiveDisabledReason ? { disabledReason: effectiveDisabledReason } : {}),
+      });
+    } else if (effectiveDisabledReason) {
+      items.push({
+        id,
+        label,
+        disabledReason: effectiveDisabledReason,
+      });
+    }
+  };
+
+  addButton({
+    id: 'rename',
+    label: 'Rename',
+    available: Boolean(actions.canSetTitle),
+    disabledReason: disabledReason('canSetTitle'),
+    onSelect: handlers.onRename,
+  });
+  if (taskEditingOn) {
+    addLink({
+      id: 'edit-task',
+      label: 'Edit task',
+      href: editHref,
+      available: Boolean(canShowEditWorkflow && editHref),
+      disabledReason: editTaskDisabledReason,
+      onSelect: handlers.onEditTask,
+    });
+    addLink({
+      id: 'compare-run',
+      label: 'Compare run',
+      href: compareHref,
+      available: Boolean(compareHref),
+      disabledReason: disabledReason('canEditForRerun'),
+      onSelect: handlers.onCompareRun,
+    });
+    addButton({
+      id: 'rerun',
+      label: 'Rerun',
+      available: Boolean(actions.canRerun),
+      disabledReason: rerunDisabledReason,
+      onSelect: handlers.onRerun,
+    });
+    addButton({
+      id: 'resume-from-failed-step',
+      label: 'Resume from failed step',
+      available: Boolean(actions.canResumeFromFailedStep),
+      disabledReason: disabledReason('canResumeFromFailedStep'),
+      onSelect: handlers.onResumeFromFailedStep,
+    });
+    if (actions.canResumeFromFailedStep && selectedRecoveryOptionCount > 0) {
+      addButton({
+        id: 'recover-from-selected-step',
+        label: 'Recover from selected step',
+        available: selectedRecoveryStepEligible,
+        disabledReason: selectedRecoveryStepDisabledReason ?? 'selected step is not eligible',
+        onSelect: handlers.onRecoverFromSelectedStep,
+      });
+    }
+  }
+  addButton({
+    id: 'pause',
+    label: 'Pause',
+    available: Boolean(actions.canPause),
+    disabledReason: disabledReason('canPause'),
+    onSelect: handlers.onPause,
+  });
+  addButton({
+    id: 'resume',
+    label: 'Resume',
+    available: Boolean(actions.canResume),
+    disabledReason: disabledReason('canResume'),
+    onSelect: handlers.onResume,
+  });
+  addButton({
+    id: 'approve',
+    label: 'Approve',
+    available: Boolean(actions.canApprove),
+    disabledReason: disabledReason('canApprove'),
+    onSelect: handlers.onApprove,
+  });
+  addButton({
+    id: 'reject',
+    label: 'Reject',
+    available: Boolean(actions.canReject),
+    disabledReason: disabledReason('canReject'),
+    danger: true,
+    onSelect: handlers.onReject,
+  });
+  addButton({
+    id: 'cancel',
+    label: 'Cancel',
+    available: Boolean(actions.canCancel),
+    disabledReason: disabledReason('canCancel'),
+    danger: true,
+    onSelect: handlers.onCancel,
+  });
+  addButton({
+    id: 'send-message',
+    label: 'Send Message',
+    available: Boolean(actions.canSendMessage),
+    disabledReason: disabledReason('canSendMessage'),
+    onSelect: handlers.onSendMessage,
+  });
+  addButton({
+    id: 'bypass-dependency-wait',
+    label: 'Bypass Dependency Wait',
+    available: Boolean(actions.canBypassDependencies),
+    disabledReason: disabledReason('canBypassDependencies'),
+    danger: true,
+    onSelect: handlers.onBypassDependencies,
+  });
+  addButton({
+    id: 'create-remediation-task',
+    label: 'Create remediation task',
+    available: canCreateRemediation,
+    disabledReason: null,
+    onSelect: handlers.onCreateRemediation,
+  });
+  return items;
+}
+
+function coalesceString(...values: unknown[]): string {
+  for (const value of values) {
+    const normalized = String(value ?? '').trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return '';
+}
+
+export type RemediationRuntimeInput = {
+  targetRuntime?: string | null | undefined;
+  profileId?: string | null | undefined;
+  model?: string | null | undefined;
+  resolvedModel?: string | null | undefined;
+  requestedModel?: string | null | undefined;
+  effort?: string | null | undefined;
+};
+
+export function buildRemediationRuntimeRequestFields(
+  input: RemediationRuntimeInput | null | undefined,
+): Record<string, unknown> {
+  const mode = coalesceString(input?.targetRuntime);
+  const profileId = coalesceString(input?.profileId);
+  const model = coalesceString(input?.model, input?.resolvedModel, input?.requestedModel);
+  const effort = coalesceString(input?.effort);
+  const runtime: Record<string, string> = {};
+  if (mode) runtime.mode = mode;
+  if (model) runtime.model = model;
+  if (effort) runtime.effort = effort;
+  if (profileId) runtime.profileId = profileId;
+
+  return {
+    ...(Object.keys(runtime).length > 0 ? { runtime } : {}),
+  };
+}
+
+export type RemediationEligibilityInput = {
+  rawState?: string | null | undefined;
+  state?: string | null | undefined;
+  status?: string | null | undefined;
+  attentionRequired?: boolean | null | undefined;
+  waitingReason?: string | null | undefined;
+};
+
+export function isRemediationEligibleTarget(
+  input: RemediationEligibilityInput,
+): boolean {
+  const state = (input.rawState || input.state || input.status || '').toLowerCase();
+  return (
+    input.attentionRequired === true ||
+    Boolean(input.waitingReason) ||
+    state.includes('failed') ||
+    state.includes('stuck') ||
+    state === 'awaiting_external'
+  );
+}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -5384,6 +5384,58 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   padding: 0.45rem 0.55rem;
 }
 
+.queue-table-column-actions {
+  width: 4.5rem;
+}
+
+.queue-table-actions-header {
+  text-align: right;
+}
+
+.queue-table-cell-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.workflow-row-actions {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.queue-card-actions .workflow-row-actions {
+  align-items: flex-start;
+}
+
+.td-workflow-actions-trigger-compact {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.45rem;
+}
+
+.td-workflow-actions-trigger-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  fill: currentColor;
+}
+
+.workflow-row-actions-error {
+  max-width: 16rem;
+  margin: 0;
+  color: rgb(var(--mm-danger));
+  font-size: 0.74rem;
+  font-weight: 500;
+  line-height: 1.3;
+  text-align: right;
+}
+
 .td-evidence-slab {
   background: rgb(var(--mm-panel) / 0.94);
 }


### PR DESCRIPTION
There's supposed to be a button using a menu icon of some kind in a new column for the Workflows page. This will show the same dropdown options as the "Workflow Actions" available on the Workflow Details page. In other words, it can be directly accessed from the Workflows table page and does not require navigating the Workflow Details page just to access the Workflow Actions. Also note that it should not say Workflow Actions. It should just be an icon or say simply Actions. Implement this.