### PR TITLE
Report managed-session turn timeouts and enforce turn budget at workflow boundary

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    TimeoutError as TemporalTimeoutError,
+)
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -512,6 +516,52 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     "CodexTransientTurnError",
                     "CodexPermanentTurnError",
                 ):
+                    if isinstance(exc.cause, TemporalTimeoutError):
+                        # The turn activity hit a Temporal timeout
+                        # (ScheduleToClose/StartToClose/Heartbeat) without the
+                        # runtime producing a completed turn. Surface an
+                        # operator-actionable summary instead of letting the
+                        # generic failure handler collapse to "Activity task
+                        # failed" / a bare failure class.
+                        timeout_type = getattr(exc.cause, "type", None)
+                        timeout_label = (
+                            str(getattr(timeout_type, "name", timeout_type) or "")
+                            .replace("TIMEOUT_TYPE_", "")
+                            .replace("_", " ")
+                            .strip()
+                            .lower()
+                            or "timeout"
+                        )
+                        timeout_reason = (
+                            "Managed-session turn activity timed out "
+                            f"({timeout_label}) without producing a completed "
+                            "turn; retry or human intervention is required."
+                        )
+                        timeout_failure_result = self._persist_failed_run_state(
+                            run_id=run_id,
+                            agent_id=request.agent_id,
+                            managed_run_id=binding.agent_run_id,
+                            binding=binding,
+                            workspace_path=workspace_path,
+                            locator=current_locator.model_dump(
+                                mode="json", by_alias=True
+                            ),
+                            active_turn_id=current_active_turn_id,
+                            summary=timeout_reason,
+                            default_summary=timeout_reason,
+                            started_at=started_at,
+                            finished_at=_current_time(),
+                            instruction_ref=original_instruction_ref,
+                            resolved_skillset_ref=original_skillset_ref,
+                            turn_id=None,
+                            profile_id=launch_context.profile_id or None,
+                            turn_status="timed_out",
+                        )
+                        failed_state_persisted = True
+                        raise CodexSessionRunFailedError(
+                            timeout_reason,
+                            result=timeout_failure_result,
+                        ) from exc
                     raise
                 turn_metadata = _turn_failure_metadata_from_activity_error(turn_error)
                 if (

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -159,6 +159,17 @@ MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
 AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
     "agent-run-workflow-child-task-queue-v2"
 )
+# Enforce the agent-run execution budget at the workflow boundary for the
+# managed-session (codex) turn. The codex turn runs as a single long-blocking
+# ``agent_runtime.send_turn`` activity, so while the workflow is parked on that
+# await it cannot run its own elapsed/no-progress checks; it relies solely on
+# the activity's server-side ScheduleToClose timeout. When that timer is not
+# enforced promptly a stuck turn can run far past its budget before failing.
+# This patch races the turn against a deterministic workflow timer so a stuck
+# or parked turn is aborted at its budget and reported with a real summary.
+MANAGED_SESSION_TURN_DEADLINE_PATCH_ID = (
+    "agent-run-managed-session-turn-deadline-v1"
+)
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.UserWorkflow (run.py:50).
@@ -179,6 +190,9 @@ _DEFAULT_SESSION_IMAGE_REF = os.environ.get(
     "ghcr.io/moonladderstudios/moonmind:latest",
 )
 _SLOT_HANDOFF_TTL_SECONDS = 10
+# Floor for the workflow-side managed-session turn deadline so a nearly-exhausted
+# budget still gives the turn a usable, non-zero window before being aborted.
+_MIN_MANAGED_TURN_DEADLINE_SECONDS = 60
 
 def _request_selected_skill(
     request: AgentExecutionRequest,
@@ -761,6 +775,93 @@ class MoonMindAgentRun:
             providerErrorCode="intervention_requested",
             metadata=result_metadata,
         )
+
+    def _timed_out_result(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        timeout_seconds: float,
+        detail: str,
+        elapsed_seconds: float | None = None,
+    ) -> AgentRunResult:
+        """Build a failed result for an agent-run timeout with an actionable summary.
+
+        ``failure_class`` stays ``execution_error`` so retry/category/billing
+        semantics are unchanged; this only guarantees a non-empty, descriptive
+        ``summary`` so downstream operator surfaces never collapse to the bare
+        ``execution_error`` token (the runtime emits no summary of its own when
+        the turn is aborted by a timeout).
+        """
+        elapsed_text = (
+            f" after {int(elapsed_seconds)}s"
+            if elapsed_seconds is not None
+            else ""
+        )
+        summary = (
+            f"Managed agent run {detail}{elapsed_text} "
+            f"(execution budget {int(timeout_seconds)}s). No completed turn or "
+            "result was produced; retry or human intervention is required."
+        )
+        metadata: dict[str, Any] = {
+            "reason": "timed_out",
+            "timeoutSeconds": int(timeout_seconds),
+            "agentId": request.agent_id,
+            "agentKind": request.agent_kind,
+        }
+        if elapsed_seconds is not None:
+            metadata["elapsedSeconds"] = int(elapsed_seconds)
+        return AgentRunResult(
+            summary=summary,
+            failure_class="execution_error",
+            metadata=metadata,
+        )
+
+    async def _send_turn_within_budget(
+        self,
+        request_payload: Any,
+        *,
+        timeout_seconds: float,
+        overall_start: datetime,
+    ) -> Any:
+        """Dispatch the managed-session turn activity under a workflow-side budget.
+
+        The codex turn runs as a single long-blocking ``agent_runtime.send_turn``
+        activity, so while the workflow is parked on that await it cannot run its
+        own elapsed/no-progress checks; it relies solely on the activity's
+        server-side timeout. When that timer is not enforced promptly a stuck or
+        parked turn can run far past its budget before failing. Race the turn
+        against a deterministic workflow timer so it is aborted at its budget.
+
+        On deadline a typed ``ApplicationError`` is raised; it flows through the
+        adapter's failure path so the operator gets a real summary rather than a
+        bare ``execution_error``. Real activity errors/completions are returned or
+        re-raised unchanged so existing retry/empty-turn handling is preserved.
+        """
+        turn_coro = self._execute_routed_activity(
+            "agent_runtime.send_turn",
+            request_payload,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        if not workflow.patched(MANAGED_SESSION_TURN_DEADLINE_PATCH_ID):
+            return await turn_coro
+        remaining = timeout_seconds - (workflow.now() - overall_start).total_seconds()
+        deadline = max(remaining, _MIN_MANAGED_TURN_DEADLINE_SECONDS)
+        turn_task = asyncio.create_task(turn_coro)
+        try:
+            await workflow.wait_condition(
+                lambda: turn_task.done(),
+                timeout=timedelta(seconds=deadline),
+            )
+        except asyncio.TimeoutError:
+            turn_task.cancel()
+            raise ApplicationError(
+                f"Managed-session turn exceeded its {int(deadline)}s budget "
+                "without completing; the turn was aborted and requires retry or "
+                "human intervention.",
+                type="ManagedSessionTurnDeadlineExceeded",
+                non_retryable=True,
+            )
+        return turn_task.result()
 
     def _enrich_result_metadata(
         self,
@@ -2208,7 +2309,15 @@ class MoonMindAgentRun:
                     self.run_status = RunStatus.timed_out
                     return await self._publish_terminal_result(
                         request=request,
-                        result=AgentRunResult(failure_class="execution_error"),
+                        result=self._timed_out_result(
+                            request=request,
+                            timeout_seconds=timeout_seconds,
+                            elapsed_seconds=elapsed,
+                            detail=(
+                                "exceeded its execution budget before dispatching "
+                                "a turn"
+                            ),
+                        ),
                     )
 
                 manager_handle = None
@@ -2607,10 +2716,10 @@ class MoonMindAgentRun:
                             )
 
                         async def _send_turn(request_payload: Any) -> Any:
-                            return await self._execute_routed_activity(
-                                "agent_runtime.send_turn",
+                            return await self._send_turn_within_budget(
                                 request_payload,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                timeout_seconds=timeout_seconds,
+                                overall_start=overall_start,
                             )
 
                         async def _interrupt_turn(request_payload: Any) -> Any:
@@ -3103,7 +3212,15 @@ class MoonMindAgentRun:
                         )
                     return await self._publish_terminal_result(
                         request=request,
-                        result=AgentRunResult(failure_class="execution_error"),
+                        result=self._timed_out_result(
+                            request=request,
+                            timeout_seconds=timeout_seconds,
+                            elapsed_seconds=elapsed,
+                            detail=(
+                                "made no observable progress and exceeded its "
+                                "execution budget"
+                            ),
+                        ),
                     )
 
                 if self.final_result is None:
@@ -3339,7 +3456,14 @@ class MoonMindAgentRun:
                     self._get_logger().warning("Failed to release slot on timeout, which may lead to a leak.", exc_info=True)
             return await self._publish_terminal_result(
                 request=request,
-                result=AgentRunResult(failure_class="execution_error"),
+                result=self._timed_out_result(
+                    request=request,
+                    timeout_seconds=timeout_seconds,
+                    elapsed_seconds=(
+                        workflow.now() - overall_start
+                    ).total_seconds(),
+                    detail="timed out without completing the turn",
+                ),
             )
 
         except CancelledError:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5338,7 +5338,9 @@ class MoonMindRunWorkflow:
                             )
                         )
                         operator_failure_summary = (
-                            provider_failure_summary or failure_message
+                            provider_failure_summary
+                            or self._activity_result_operator_summary(execution_result)
+                            or failure_message
                         )
                         step_failure_summary = self._humanize_step_failure_summary(
                             summary=operator_failure_summary,
@@ -6170,6 +6172,17 @@ class MoonMindRunWorkflow:
             if isinstance(details, str) and details.strip():
                 return details.strip()
         return ""
+
+    def _activity_result_operator_summary(self, result: Any) -> str | None:
+        outputs = self._get_from_result(result, "outputs")
+        if isinstance(outputs, Mapping):
+            summary = outputs.get("summary")
+            if isinstance(summary, str) and summary.strip():
+                return summary.strip()
+        summary = self._get_from_result(result, "summary")
+        if isinstance(summary, str) and summary.strip():
+            return summary.strip()
+        return None
 
     def _activity_result_provider_failure_summary(self, result: Any) -> str | None:
         outputs = self._get_from_result(result, "outputs")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -593,6 +593,42 @@ class MoonMindRunWorkflow:
             return "integration_error"
         return "execution_error"
 
+    # Canonical errorCategory tokens. These are machine classifications, not
+    # operator-readable messages, so they must never be surfaced verbatim as a
+    # step/plan summary.
+    _ERROR_CATEGORY_TOKENS = frozenset(
+        {"user_error", "integration_error", "execution_error", "system_error"}
+    )
+
+    @classmethod
+    def _humanize_step_failure_summary(
+        cls,
+        *,
+        summary: str | None,
+        tool_name: str,
+        failure_message: str | None,
+    ) -> str:
+        """Return an operator-actionable step-failure summary.
+
+        When the only text a failed step result carries is a bare error-category
+        token (e.g. a runtime that timed out and emitted ``execution_error`` with
+        no provider detail), surface a descriptive line instead of propagating
+        the token. Otherwise the token would become the terminal summary, the
+        finish-outcome reason, and the workflow's ApplicationError message —
+        leaving operators with nothing actionable. The raw category is preserved
+        separately via ``errorCategory``.
+        """
+        text = (summary or "").strip()
+        if text and text not in cls._ERROR_CATEGORY_TOKENS:
+            return text
+        category = (failure_message or "").strip()
+        if category in cls._ERROR_CATEGORY_TOKENS:
+            return (
+                f"{tool_name} failed ({category}); the runtime reported no "
+                "diagnostic detail — inspect step diagnostics/artifacts."
+            )
+        return f"{tool_name} failed"
+
     def _failure_diagnostic_from_exception(
         self,
         exc: BaseException,
@@ -5304,9 +5340,10 @@ class MoonMindRunWorkflow:
                         operator_failure_summary = (
                             provider_failure_summary or failure_message
                         )
-                        step_failure_summary = (
-                            operator_failure_summary
-                            or f"{tool_name} failed"
+                        step_failure_summary = self._humanize_step_failure_summary(
+                            summary=operator_failure_summary,
+                            tool_name=tool_name,
+                            failure_message=failure_message,
                         )
 
                         retryable = failure_message == "system_error" or (

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -7,7 +7,12 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import (
+    ActivityError,
+    ApplicationError,
+    TimeoutError as TemporalTimeoutError,
+    TimeoutType,
+)
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -71,6 +76,29 @@ def _raise_activity_error_from_application_error(error: ApplicationError) -> Non
             activity_id="activity-1",
             retry_state=None,
         ) from exc
+
+def _raise_activity_error_from_timeout(
+    timeout_type: TimeoutType = TimeoutType.SCHEDULE_TO_CLOSE,
+) -> None:
+    """Mimic a Temporal activity timeout: ActivityError whose cause is a
+    temporalio TimeoutError (not an ApplicationError turn error)."""
+    try:
+        raise TemporalTimeoutError(
+            "activity ScheduleToClose timeout",
+            type=timeout_type,
+            last_heartbeat_details=[],
+        )
+    except TemporalTimeoutError as exc:
+        raise ActivityError(
+            "activity failed",
+            scheduled_event_id=1,
+            started_event_id=2,
+            identity="test-worker",
+            activity_type="agent_runtime.send_turn",
+            activity_id="activity-1",
+            retry_state=None,
+        ) from exc
+
 
 def _binding() -> CodexManagedSessionBinding:
     return CodexManagedSessionBinding(
@@ -1770,6 +1798,81 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
     assert persisted_record.stdout_artifact_ref == "artifact:stdout"
     assert persisted_record.stderr_artifact_ref == "artifact:stderr"
     assert persisted_record.diagnostics_ref == "artifact:diagnostics"
+
+async def test_start_classifies_send_turn_timeout_with_actionable_summary(
+    tmp_path: Path,
+) -> None:
+    """A Temporal activity timeout on send_turn must surface a descriptive,
+    operator-actionable failed result instead of an empty/bare-token summary.
+
+    Regression for mm:4b897068, where a timed-out codex turn produced
+    failure_class="execution_error" with summary=null.
+    """
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        _raise_activity_error_from_timeout()
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=AsyncMock(),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(CodexSessionRunFailedError) as excinfo:
+        await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    result = excinfo.value.agent_run_result
+    assert result.failure_class == "execution_error"
+    assert result.summary
+    assert result.summary not in {
+        "user_error",
+        "integration_error",
+        "execution_error",
+        "system_error",
+    }
+    assert "timed out" in result.summary.lower()
+    assert "schedule to close" in result.summary.lower()
+    assert result.metadata.get("turnStatus") == "timed_out"
+
+    persisted_record = run_store.load(binding.agent_run_id)
+    assert persisted_record is not None
+    assert persisted_record.failure_class == "execution_error"
+
 
 async def test_start_classifies_codex_auth_failure_as_user_error(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_timeout_reporting.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_timeout_reporting.py
@@ -1,0 +1,236 @@
+"""Regression tests for managed agent-run timeout reporting and the
+workflow-side turn deadline.
+
+Context: workflow mm:4b897068 failed because a codex ``send_turn`` activity
+ran ~2h45m and timed out, and the AgentRun reduced that to a bare
+``failure_class="execution_error"`` with an empty summary. These tests lock in:
+
+- Fix A: timeout results carry an actionable, non-token summary
+  (``_timed_out_result``).
+- Fix B: the codex blocking turn is bounded by a deterministic workflow-side
+  deadline that fails fast with a descriptive error
+  (``_send_turn_within_budget``), without touching the managed agent runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+import moonmind.workflows.temporal.workflows.agent_run as agent_run_mod
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.workflows.agent_run import (
+    _MIN_MANAGED_TURN_DEADLINE_SECONDS,
+    MoonMindAgentRun,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+_CATEGORY_TOKENS = {
+    "user_error",
+    "integration_error",
+    "execution_error",
+    "system_error",
+}
+
+
+def _request() -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+    )
+
+
+# --- Fix A: timeout results carry an actionable, non-token summary ---
+
+
+async def test_timed_out_result_emits_actionable_summary_and_metadata() -> None:
+    workflow = MoonMindAgentRun()
+    result = workflow._timed_out_result(
+        request=_request(),
+        timeout_seconds=3600,
+        elapsed_seconds=9932,
+        detail="made no observable progress and exceeded its execution budget",
+    )
+
+    assert result.failure_class == "execution_error"
+    # The operator summary must never be empty nor a bare category token.
+    assert result.summary
+    assert result.summary not in _CATEGORY_TOKENS
+    assert "execution budget 3600s" in result.summary
+    assert "9932s" in result.summary
+    assert "intervention" in result.summary.lower()
+    assert result.metadata["reason"] == "timed_out"
+    assert result.metadata["timeoutSeconds"] == 3600
+    assert result.metadata["elapsedSeconds"] == 9932
+    assert result.metadata["agentId"] == "codex_cli"
+
+
+async def test_timed_out_result_without_elapsed_omits_elapsed_metadata() -> None:
+    workflow = MoonMindAgentRun()
+    result = workflow._timed_out_result(
+        request=_request(),
+        timeout_seconds=3600,
+        detail="exceeded its execution budget before dispatching a turn",
+    )
+
+    assert result.summary
+    assert result.summary not in _CATEGORY_TOKENS
+    assert "elapsedSeconds" not in result.metadata
+
+
+# --- Fix B: workflow-side deadline on the codex blocking turn ---
+
+
+def _patch_workflow_primitives(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    patched: bool,
+    now: datetime,
+    wait_condition,
+) -> None:
+    monkeypatch.setattr(
+        agent_run_mod.workflow, "patched", lambda _id: patched, raising=True
+    )
+    monkeypatch.setattr(agent_run_mod.workflow, "now", lambda: now, raising=True)
+    monkeypatch.setattr(
+        agent_run_mod.workflow, "wait_condition", wait_condition, raising=True
+    )
+
+
+async def test_send_turn_within_budget_passthrough_when_patch_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentRun()
+    sentinel = object()
+
+    async def _fake_activity(*_args, **_kwargs):
+        return sentinel
+
+    # Patch disabled -> no race, just await the activity directly.
+    monkeypatch.setattr(
+        agent_run_mod.workflow, "patched", lambda _id: False, raising=True
+    )
+    monkeypatch.setattr(
+        workflow, "_execute_routed_activity", _fake_activity, raising=True
+    )
+
+    result = await workflow._send_turn_within_budget(
+        {"instructions": "hello"},
+        timeout_seconds=3600,
+        overall_start=datetime(2026, 6, 15, tzinfo=timezone.utc),
+    )
+    assert result is sentinel
+
+
+async def test_send_turn_within_budget_returns_completed_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentRun()
+    sentinel = {"status": "completed"}
+
+    async def _fake_activity(*_args, **_kwargs):
+        return sentinel
+
+    async def _wait_condition(_predicate, *, timeout):
+        # Turn finishes within budget: let the scheduled task run to completion.
+        await asyncio.sleep(0)
+        return True
+
+    start = datetime(2026, 6, 15, tzinfo=timezone.utc)
+    _patch_workflow_primitives(
+        monkeypatch, patched=True, now=start, wait_condition=_wait_condition
+    )
+    monkeypatch.setattr(
+        workflow, "_execute_routed_activity", _fake_activity, raising=True
+    )
+
+    result = await workflow._send_turn_within_budget(
+        {"instructions": "hello"},
+        timeout_seconds=3600,
+        overall_start=start,
+    )
+    assert result == sentinel
+
+
+async def test_send_turn_within_budget_aborts_on_deadline_with_descriptive_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentRun()
+    cancelled = asyncio.Event()
+
+    async def _never_completes(*_args, **_kwargs):
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def _wait_condition(_predicate, *, timeout):
+        # Let the scheduled turn task start (reach its await) before the
+        # deterministic workflow timer "fires".
+        await asyncio.sleep(0)
+        raise asyncio.TimeoutError()
+
+    start = datetime(2026, 6, 15, tzinfo=timezone.utc)
+    _patch_workflow_primitives(
+        monkeypatch, patched=True, now=start, wait_condition=_wait_condition
+    )
+    monkeypatch.setattr(
+        workflow, "_execute_routed_activity", _never_completes, raising=True
+    )
+
+    with pytest.raises(ApplicationError) as excinfo:
+        await workflow._send_turn_within_budget(
+            {"instructions": "hello"},
+            timeout_seconds=3600,
+            overall_start=start,
+        )
+
+    err = excinfo.value
+    assert err.type == "ManagedSessionTurnDeadlineExceeded"
+    assert err.non_retryable is True
+    assert "budget" in str(err)
+    assert "without completing" in str(err)
+    # The in-flight turn activity task must be cancelled.
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert cancelled.is_set()
+
+
+async def test_send_turn_within_budget_floors_deadline_for_exhausted_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentRun()
+    captured_timeout: list[timedelta] = []
+
+    async def _fake_activity(*_args, **_kwargs):
+        return {"status": "completed"}
+
+    async def _wait_condition(_predicate, *, timeout):
+        captured_timeout.append(timeout)
+        await asyncio.sleep(0)
+        return True
+
+    start = datetime(2026, 6, 15, tzinfo=timezone.utc)
+    # "now" is far past the budget so remaining is negative -> floor applies.
+    now = start + timedelta(seconds=10_000)
+    _patch_workflow_primitives(
+        monkeypatch, patched=True, now=now, wait_condition=_wait_condition
+    )
+    monkeypatch.setattr(
+        workflow, "_execute_routed_activity", _fake_activity, raising=True
+    )
+
+    await workflow._send_turn_within_budget(
+        {"instructions": "hello"},
+        timeout_seconds=3600,
+        overall_start=start,
+    )
+    assert captured_timeout == [
+        timedelta(seconds=_MIN_MANAGED_TURN_DEADLINE_SECONDS)
+    ]

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_timeout_reporting.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_timeout_reporting.py
@@ -20,11 +20,11 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from temporalio.exceptions import ApplicationError
 
-import moonmind.workflows.temporal.workflows.agent_run as agent_run_mod
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.agent_run import (
     _MIN_MANAGED_TURN_DEADLINE_SECONDS,
     MoonMindAgentRun,
+    workflow as agent_run_workflow,
 )
 
 pytestmark = [pytest.mark.asyncio]
@@ -95,11 +95,11 @@ def _patch_workflow_primitives(
     wait_condition,
 ) -> None:
     monkeypatch.setattr(
-        agent_run_mod.workflow, "patched", lambda _id: patched, raising=True
+        agent_run_workflow, "patched", lambda _id: patched, raising=True
     )
-    monkeypatch.setattr(agent_run_mod.workflow, "now", lambda: now, raising=True)
+    monkeypatch.setattr(agent_run_workflow, "now", lambda: now, raising=True)
     monkeypatch.setattr(
-        agent_run_mod.workflow, "wait_condition", wait_condition, raising=True
+        agent_run_workflow, "wait_condition", wait_condition, raising=True
     )
 
 
@@ -114,7 +114,7 @@ async def test_send_turn_within_budget_passthrough_when_patch_disabled(
 
     # Patch disabled -> no race, just await the activity directly.
     monkeypatch.setattr(
-        agent_run_mod.workflow, "patched", lambda _id: False, raising=True
+        agent_run_workflow, "patched", lambda _id: False, raising=True
     )
     monkeypatch.setattr(
         workflow, "_execute_routed_activity", _fake_activity, raising=True
@@ -138,7 +138,7 @@ async def test_send_turn_within_budget_returns_completed_turn(
         return sentinel
 
     async def _wait_condition(_predicate, *, timeout):
-        # Turn finishes within budget: let the scheduled task run to completion.
+        # The turn finishes within budget: let the scheduled coroutine complete.
         await asyncio.sleep(0)
         return True
 

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2786,6 +2786,40 @@ def test_humanize_step_failure_summary_preserves_real_provider_summary() -> None
     assert summary == provider_summary
 
 
+def test_step_failure_summary_preserves_timed_out_child_output_summary() -> None:
+    workflow = MoonMindRunWorkflow()
+    timeout_summary = (
+        "Managed session turn exceeded execution budget 3600s after 9932s; "
+        "request intervention or rerun with a larger budget."
+    )
+    execution_result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "execution_error",
+            "summary": timeout_summary,
+        },
+    }
+
+    failure_message = workflow._activity_result_failure_message(execution_result)
+    provider_failure_summary = workflow._activity_result_provider_failure_summary(
+        execution_result
+    )
+    operator_failure_summary = (
+        provider_failure_summary
+        or workflow._activity_result_operator_summary(execution_result)
+        or failure_message
+    )
+    summary = MoonMindRunWorkflow._humanize_step_failure_summary(
+        summary=operator_failure_summary,
+        tool_name="codex_cli",
+        failure_message=failure_message,
+    )
+
+    assert failure_message == "execution_error"
+    assert provider_failure_summary is None
+    assert summary == timeout_summary
+
+
 def test_humanize_step_failure_summary_blank_inputs_fall_back_to_tool_failed() -> None:
     summary = MoonMindRunWorkflow._humanize_step_failure_summary(
         summary=None,

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2750,3 +2750,57 @@ def test_determine_publish_completion_fails_for_unknown_branch_publish_outcome(
     assert status == "failed"
     assert message == "branch publish outcome unknown"
     assert publish_failure is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: a failed step result that carries only a bare error-category
+# token (e.g. a managed runtime that timed out and emitted "execution_error"
+# with no provider detail) must never surface that token as the operator
+# summary. Otherwise the terminal summary, finish-outcome reason, and the
+# workflow's ApplicationError message all collapse to "execution_error" — with
+# nothing actionable for an operator. See mm:4b897068 troubleshooting.
+# ---------------------------------------------------------------------------
+
+def test_humanize_step_failure_summary_replaces_bare_category_token() -> None:
+    summary = MoonMindRunWorkflow._humanize_step_failure_summary(
+        summary="execution_error",
+        tool_name="jira-orchestrate",
+        failure_message="execution_error",
+    )
+    assert summary not in MoonMindRunWorkflow._ERROR_CATEGORY_TOKENS
+    assert "jira-orchestrate failed" in summary
+    assert "(execution_error)" in summary
+    assert "diagnostic" in summary.lower()
+
+
+def test_humanize_step_failure_summary_preserves_real_provider_summary() -> None:
+    provider_summary = (
+        "pr-resolver reported status 'blocked'; ci_running; "
+        "next_step=retry_finalize_after_backoff"
+    )
+    summary = MoonMindRunWorkflow._humanize_step_failure_summary(
+        summary=provider_summary,
+        tool_name="pr-resolver",
+        failure_message="user_error",
+    )
+    assert summary == provider_summary
+
+
+def test_humanize_step_failure_summary_blank_inputs_fall_back_to_tool_failed() -> None:
+    summary = MoonMindRunWorkflow._humanize_step_failure_summary(
+        summary=None,
+        tool_name="codex-runtime",
+        failure_message=None,
+    )
+    assert summary == "codex-runtime failed"
+
+
+def test_humanize_step_failure_summary_handles_all_category_tokens() -> None:
+    for token in ("user_error", "integration_error", "execution_error", "system_error"):
+        summary = MoonMindRunWorkflow._humanize_step_failure_summary(
+            summary=token,
+            tool_name="agent_runtime",
+            failure_message=token,
+        )
+        assert summary not in MoonMindRunWorkflow._ERROR_CATEGORY_TOKENS
+        assert f"({token})" in summary


### PR DESCRIPTION
## Problem

Workflow `mm:4b897068` failed with a terminal summary of only `execution_error`, which is not actionable without deep investigation.

Root cause, traced through workflow history + artifacts:
- Plan step 04's Codex turn ran as a single long-blocking `agent_runtime.send_turn` activity for **~2h45m** and hit a Temporal `SCHEDULE_TO_CLOSE` timeout (the configured `start_to_close=3600s` / `schedule_to_close=3900s` caps were not enforced promptly during a loaded window).
- The child `MoonMind.AgentRun` reduced the timeout to `failure_class="execution_error"` with a **null `summary`**.
- The parent workflow then propagated that bare category token verbatim into the terminal `summary`, the `finishOutcome.reason`, the `publish.reason`, and the workflow's `ApplicationError` message — leaving operators with nothing to act on.

This is **codex-specific**: `claude_code` runs go through the poll-based no-progress watchdog and already produce good messages (e.g. *"Agent run made no observable progress for 1500s; human intervention is required…"*), but the codex blocking-turn path had no equivalent. The same bare `execution_error` recurred on another codex run (`mm:7bc25f31`).

## Fix A — never surface a bare error-category token (the reporting bug)

Defense-in-depth across all three layers so the operator always gets a real message regardless of which path a timeout takes:

- **`agent_run.py`** — new `_timed_out_result()`; the three timeout sites that built `AgentRunResult(failure_class="execution_error")` with no summary now produce a descriptive summary (reason + elapsed + budget). `failure_class` is unchanged, so retry/category/billing semantics are untouched.
- **`codex_session_adapter.py`** — the `except ActivityError` path now detects a Temporal `TimeoutError` cause (not just Codex turn errors) and emits *"Managed-session turn activity timed out (schedule to close) without producing a completed turn…"* with `turnStatus="timed_out"`.
- **`run.py`** — new `_humanize_step_failure_summary()` backstop: a known `errorCategory` token is never used as the step/plan operator summary; it becomes *"`<tool>` failed (execution_error); the runtime reported no diagnostic detail — inspect step diagnostics/artifacts."* The raw category is still preserved in `errorCategory`.

## Fix B — fail fast at the budget (workflow-side only, no runtime changes)

The codex turn is a single long-blocking activity, so the workflow can't run its own elapsed/no-progress checks while parked on it. New `_send_turn_within_budget()` races the turn against a **deterministic workflow timer** (`create_task` + `workflow.wait_condition(timeout=…)`); on deadline it cancels the turn and raises a typed `ApplicationError` that flows through the adapter's failure path → descriptive summary.

- **Patch-gated** (`agent-run-managed-session-turn-deadline-v1`) so in-flight runs replay deterministically (pre-patch histories take the original passthrough).
- **No changes to `moonmind/agents/codex_worker/`** — intentionally avoids modifying the managed agent runtime; enforcement lives entirely at the workflow boundary.

## Tests (workflow/adapter boundary)

- `_humanize_step_failure_summary` — bare token → humanized, real provider message → passthrough, all four category tokens, blank fallback.
- `_timed_out_result` — actionable summary + metadata, with/without elapsed.
- `_send_turn_within_budget` — passthrough when unpatched, completion within budget, deadline → descriptive `ApplicationError` + turn-task cancellation, budget floor.
- Adapter `start()` with a timeout-caused `ActivityError` → descriptive `CodexSessionRunFailedError` (`failure_class="execution_error"`, non-empty/non-token summary, `turnStatus="timed_out"`).

All new tests are unit/boundary tests and run in required CI. `./tools/test_unit.sh` on the affected files passes (131 Python tests; frontend suite unaffected).

## Follow-up (out of scope, infra)

The configured `send_turn` activity timeouts (`3600s`/`3900s`) were not enforced by the Temporal server during the incident window (single attempt ran 9,932s). Fix B makes MoonMind resilient to this, but the underlying server timer behavior under load is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
