### PR TITLE
MM-823 capture canonical workflow checkpoints

### DIFF
--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -7779,6 +7779,14 @@ export interface components {
             latestStepExecutionManifestRef?: string | null;
             /** Stepexecutionmanifestrefs */
             stepExecutionManifestRefs?: string[];
+            /** Lateststepexecutioncheckpointref */
+            latestStepExecutionCheckpointRef?: string | null;
+            /** Stepexecutioncheckpointrefs */
+            stepExecutionCheckpointRefs?: string[];
+            /** Checkpointrefsbyboundary */
+            checkpointRefsByBoundary?: {
+                [key: string]: string;
+            };
         };
         /**
          * StepLedgerResumePreservationModel

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2312,6 +2312,15 @@ class StepLedgerRefsModel(BaseModel):
     step_execution_manifest_refs: list[str] = Field(
         default_factory=list, alias="stepExecutionManifestRefs"
     )
+    latest_step_execution_checkpoint_ref: str | None = Field(
+        None, alias="latestStepExecutionCheckpointRef"
+    )
+    step_execution_checkpoint_refs: list[str] = Field(
+        default_factory=list, alias="stepExecutionCheckpointRefs"
+    )
+    checkpoint_refs_by_boundary: dict[str, str] = Field(
+        default_factory=dict, alias="checkpointRefsByBoundary"
+    )
 
 class StepLedgerArtifactsModel(BaseModel):
     """Stable semantic artifact slots for step evidence."""

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -20,6 +20,9 @@ def default_step_refs() -> dict[str, Any]:
         "agentRunId": None,
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
 
 def default_step_artifacts() -> dict[str, Any]:
@@ -544,6 +547,7 @@ def mark_step_checkpoint_evidence(
     state_checkpoint_ref: str | None = None,
     workspace_checkpoint_ref: str | None = None,
     step_checkpoint_ref: str | None = None,
+    boundary: str | None = None,
 ) -> dict[str, Any]:
     """Attach checkpoint evidence and preservation eligibility to a step row."""
 
@@ -556,6 +560,39 @@ def mark_step_checkpoint_evidence(
             row["workspaceCheckpointRef"] = workspace_checkpoint_ref
         if step_checkpoint_ref is not None:
             row["stepCheckpointRef"] = step_checkpoint_ref
+        canonical_ref = str(step_checkpoint_ref or "").strip()
+        canonical_boundary = str(boundary or "").strip()
+        if canonical_ref:
+            refs = default_step_refs()
+            current_refs = row.get("refs")
+            if isinstance(current_refs, Mapping):
+                refs.update(current_refs)
+            history = refs.get("stepExecutionCheckpointRefs")
+            if not isinstance(history, list):
+                history = []
+            normalized_history = [
+                item.strip()
+                for item in history
+                if isinstance(item, str) and item.strip()
+            ]
+            if canonical_ref not in normalized_history:
+                normalized_history.append(canonical_ref)
+            refs["latestStepExecutionCheckpointRef"] = canonical_ref
+            refs["stepExecutionCheckpointRefs"] = normalized_history
+            by_boundary = refs.get("checkpointRefsByBoundary")
+            if not isinstance(by_boundary, Mapping):
+                by_boundary = {}
+            normalized_by_boundary = {
+                str(key): str(value).strip()
+                for key, value in by_boundary.items()
+                if str(key).strip()
+                and isinstance(value, str)
+                and str(value).strip()
+            }
+            if canonical_boundary:
+                normalized_by_boundary[canonical_boundary] = canonical_ref
+            refs["checkpointRefsByBoundary"] = normalized_by_boundary
+            row["refs"] = refs
         existing_checkpoint = str(row.get("stateCheckpointRef") or "").strip()
         status = str(row.get("status") or "").strip()
         if status not in {"succeeded", "skipped"}:
@@ -639,6 +676,11 @@ def clear_step_checkpoint_evidence(
         row.pop("stateCheckpointRef", None)
         row.pop("workspaceCheckpointRef", None)
         row.pop("stepCheckpointRef", None)
+        refs = row.get("refs")
+        if isinstance(refs, dict):
+            refs["latestStepExecutionCheckpointRef"] = None
+            refs["stepExecutionCheckpointRefs"] = []
+            refs["checkpointRefsByBoundary"] = {}
         row.pop("recoveryPreservation", None)
         row["updatedAt"] = updated_at.isoformat()
         return row
@@ -723,6 +765,10 @@ def update_step_row(
                 for key, value in refs.items():
                     if key in merged_refs:
                         merged_refs[key] = value
+            if not isinstance(merged_refs.get("stepExecutionCheckpointRefs"), list):
+                merged_refs["stepExecutionCheckpointRefs"] = []
+            if not isinstance(merged_refs.get("checkpointRefsByBoundary"), Mapping):
+                merged_refs["checkpointRefsByBoundary"] = {}
             row["refs"] = merged_refs
         if artifacts is not _UNSET:
             merged_artifacts = default_step_artifacts()

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -406,6 +406,7 @@ RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 # Replay-stable patch id for stamping mm_started_at when real work begins.
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
 RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
+RUN_CANONICAL_STEP_CHECKPOINTS_PATCH = "run-canonical-step-checkpoints-v1"
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
@@ -2982,7 +2983,7 @@ class MoonMindRunWorkflow:
         checkpoint_ref = (
             self._step_checkpoint_refs.get(logical_step_id)
             or self._previous_step_checkpoint_refs.get(logical_step_id)
-            or self._recovery_workspace_restored_ref
+            or getattr(self, "_recovery_workspace_restored_ref", None)
         )
         workspace_ref = checkpoint_ref or (
             "temporal://"
@@ -3004,6 +3005,8 @@ class MoonMindRunWorkflow:
         step_outputs: Mapping[str, Any] | None = None,
         diagnostic_refs: Sequence[str] = (),
     ) -> str | None:
+        if not workflow.patched(RUN_CANONICAL_STEP_CHECKPOINTS_PATCH):
+            return None
         identity = self._canonical_step_checkpoint_identity(logical_step_id)
         if identity is None:
             return None
@@ -5105,6 +5108,13 @@ class MoonMindRunWorkflow:
                 )
                 self._update_memo()
                 self._refresh_step_readiness(updated_at=workflow.now())
+                if node_id == self._recovery_failed_step_id:
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="before_recovery_restoration",
+                        updated_at=workflow.now(),
+                    )
+                await self._prepare_recovery_workspace_for_failed_step(node_id)
                 self._mark_step_running(
                     node_id,
                     updated_at=workflow.now(),
@@ -5124,13 +5134,6 @@ class MoonMindRunWorkflow:
                         )
                     )
                 )
-                if node_id == self._recovery_failed_step_id:
-                    await self._record_canonical_step_checkpoint(
-                        node_id,
-                        boundary="before_recovery_restoration",
-                        updated_at=workflow.now(),
-                    )
-                await self._prepare_recovery_workspace_for_failed_step(node_id)
                 await self._record_canonical_step_checkpoint(
                     node_id,
                     boundary="after_prepare",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -771,6 +771,7 @@ class MoonMindRunWorkflow:
         self._prepared_artifact_refs: list[str] = []
         self._step_checkpoint_refs: dict[str, str] = {}
         self._previous_step_checkpoint_refs: dict[str, str] = {}
+        self._step_checkpoint_refs_by_boundary: dict[str, dict[str, str]] = {}
         self._step_execution_launch_blocks: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
         self._step_terminal_dispositions: dict[str, str] = {}
@@ -1527,10 +1528,15 @@ class MoonMindRunWorkflow:
                     "sourceExecutionOrdinal": dict(source_execution_ordinal),
                 }
             )
+            self._apply_step_checkpoint_manifest_refs(
+                workspace,
+                self._step_checkpoint_refs_by_boundary.get(logical_step_id, {}),
+            )
             return workspace
         checkpoint_ref = self._step_checkpoint_refs.get(
             logical_step_id
         ) or self._previous_step_checkpoint_refs.get(logical_step_id)
+        boundary_refs = self._step_checkpoint_refs_by_boundary.get(logical_step_id, {})
         if attempt > 1:
             workspace = workspace_policy_metadata(
                 policy="continue_from_previous_execution",
@@ -1538,12 +1544,27 @@ class MoonMindRunWorkflow:
                 checkpoint_valid=bool(checkpoint_ref) if checkpoint_ref else None,
             )
             workspace["sourceExecutionOrdinal"] = dict(source_execution_ordinal) if source_execution_ordinal else None
+            self._apply_step_checkpoint_manifest_refs(workspace, boundary_refs)
             return workspace
-        return workspace_policy_metadata(
+        workspace = workspace_policy_metadata(
             policy="fresh_branch_from_source",
             checkpoint_ref=checkpoint_ref,
             checkpoint_valid=None,
         )
+        self._apply_step_checkpoint_manifest_refs(workspace, boundary_refs)
+        return workspace
+
+    @staticmethod
+    def _apply_step_checkpoint_manifest_refs(
+        workspace: dict[str, Any],
+        boundary_refs: Mapping[str, str],
+    ) -> None:
+        before_ref = str(boundary_refs.get("before_execution") or "").strip()
+        after_ref = str(boundary_refs.get("after_execution") or "").strip()
+        if before_ref:
+            workspace["checkpointBeforeRef"] = before_ref
+        if after_ref:
+            workspace["checkpointAfterRef"] = after_ref
 
     def _step_execution_git_effect(
         self,
@@ -2364,6 +2385,7 @@ class MoonMindRunWorkflow:
                 previous_checkpoint_ref
             )
         self._step_checkpoint_refs.pop(logical_step_id, None)
+        self._step_checkpoint_refs_by_boundary.pop(logical_step_id, None)
         try:
             clear_step_checkpoint_evidence(
                 self._step_ledger_rows,
@@ -2917,19 +2939,99 @@ class MoonMindRunWorkflow:
         if isinstance(result, Mapping):
             checkpoint_ref = str(result.get("checkpointRef") or "").strip()
             if checkpoint_ref:
+                boundary_key = str(boundary)
                 try:
                     mark_step_checkpoint_evidence(
                         self._step_ledger_rows,
                         identity.logical_step_id,
                         updated_at=created_at,
                         step_checkpoint_ref=checkpoint_ref,
+                        boundary=boundary_key,
                     )
                 except KeyError:
                     pass
                 else:
+                    refs_by_boundary = self._step_checkpoint_refs_by_boundary.setdefault(
+                        identity.logical_step_id,
+                        {},
+                    )
+                    refs_by_boundary[boundary_key] = checkpoint_ref
                     self._sync_progress_snapshot(updated_at=created_at)
             return dict(result)
         raise ValueError("step_checkpoint.create returned a non-mapping result")
+
+    def _canonical_step_checkpoint_identity(
+        self,
+        logical_step_id: str,
+    ) -> StepExecutionIdentityModel | None:
+        attempt = self._step_execution_for(logical_step_id)
+        if attempt is None or attempt <= 0:
+            return None
+        return StepExecutionIdentityModel(
+            workflowId=workflow.info().workflow_id,
+            runId=workflow.info().run_id,
+            logicalStepId=logical_step_id,
+            executionOrdinal=attempt,
+        )
+
+    def _canonical_step_checkpoint_workspace(
+        self,
+        logical_step_id: str,
+        boundary: StepExecutionCheckpointBoundary,
+    ) -> dict[str, Any]:
+        checkpoint_ref = (
+            self._step_checkpoint_refs.get(logical_step_id)
+            or self._previous_step_checkpoint_refs.get(logical_step_id)
+            or self._recovery_workspace_restored_ref
+        )
+        workspace_ref = checkpoint_ref or (
+            "temporal://"
+            f"{workflow.info().workflow_id}/{workflow.info().run_id}/"
+            f"{logical_step_id}/{boundary}"
+        )
+        return {
+            "kind": "ephemeral_workspace_ref",
+            "workspaceRef": workspace_ref,
+            "createdAt": workflow.now().isoformat(),
+        }
+
+    async def _record_canonical_step_checkpoint(
+        self,
+        logical_step_id: str,
+        *,
+        boundary: StepExecutionCheckpointBoundary,
+        updated_at: datetime,
+        step_outputs: Mapping[str, Any] | None = None,
+        diagnostic_refs: Sequence[str] = (),
+    ) -> str | None:
+        identity = self._canonical_step_checkpoint_identity(logical_step_id)
+        if identity is None:
+            return None
+        task_input_snapshot_ref = (
+            self._input_ref
+            or f"temporal://{identity.workflow_id}/{identity.run_id}/task-input"
+        )
+        result = await self._create_step_checkpoint_via_activity(
+            identity=identity,
+            boundary=boundary,
+            task_input_snapshot_ref=task_input_snapshot_ref,
+            workspace=self._canonical_step_checkpoint_workspace(
+                logical_step_id,
+                boundary,
+            ),
+            created_at=updated_at,
+            plan_ref=self._plan_ref
+            or f"temporal://{identity.workflow_id}/{identity.run_id}/plan",
+            prepared_input_refs=self._prepared_artifact_refs,
+            step_outputs=step_outputs or self._step_execution_compact_output_refs(
+                logical_step_id
+            ),
+            diagnostic_refs=diagnostic_refs,
+        )
+        checkpoint_ref = str(result.get("checkpointRef") or "").strip()
+        if checkpoint_ref:
+            self._step_checkpoint_refs[logical_step_id] = checkpoint_ref
+        return checkpoint_ref or None
 
     def _refresh_step_readiness(self, *, updated_at: datetime) -> None:
         refresh_ready_steps(self._step_ledger_rows, updated_at=updated_at)
@@ -5003,7 +5105,6 @@ class MoonMindRunWorkflow:
                 )
                 self._update_memo()
                 self._refresh_step_readiness(updated_at=workflow.now())
-                await self._prepare_recovery_workspace_for_failed_step(node_id)
                 self._mark_step_running(
                     node_id,
                     updated_at=workflow.now(),
@@ -5023,6 +5124,18 @@ class MoonMindRunWorkflow:
                         )
                     )
                 )
+                if node_id == self._recovery_failed_step_id:
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="before_recovery_restoration",
+                        updated_at=workflow.now(),
+                    )
+                await self._prepare_recovery_workspace_for_failed_step(node_id)
+                await self._record_canonical_step_checkpoint(
+                    node_id,
+                    boundary="after_prepare",
+                    updated_at=workflow.now(),
+                )
 
                 system_retries = 0
                 while system_retries <= 3:
@@ -5031,6 +5144,11 @@ class MoonMindRunWorkflow:
                     await self._wait_if_paused_at_safe_boundary()
                     if self._cancel_requested:
                         return
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="before_execution",
+                        updated_at=workflow.now(),
+                    )
 
                     if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):
                         await self._record_step_execution_manifest(
@@ -5254,6 +5372,11 @@ class MoonMindRunWorkflow:
                     self._record_step_result_evidence(
                         node_id,
                         execution_result=execution_result,
+                        updated_at=workflow.now(),
+                    )
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="after_execution",
                         updated_at=workflow.now(),
                     )
                     if (
@@ -5527,6 +5650,11 @@ class MoonMindRunWorkflow:
                         summary=failed_review_summary,
                         last_error="review_failed",
                     )
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="after_gate",
+                        updated_at=workflow.now(),
+                    )
                     await self._record_step_execution_manifest(
                         node_id,
                         phase="terminal",
@@ -5583,6 +5711,11 @@ class MoonMindRunWorkflow:
                         summary=missing_evidence_summary,
                         last_error="missing_accepted_output_evidence",
                     )
+                    await self._record_canonical_step_checkpoint(
+                        node_id,
+                        boundary="after_gate",
+                        updated_at=workflow.now(),
+                    )
                     await self._record_step_execution_manifest(
                         node_id,
                         phase="terminal",
@@ -5618,6 +5751,11 @@ class MoonMindRunWorkflow:
                     ),
                     retry_count=review_retry_count,
                     artifact_ref=review_artifact_ref,
+                )
+                await self._record_canonical_step_checkpoint(
+                    node_id,
+                    boundary="after_gate",
+                    updated_at=workflow.now(),
                 )
                 accepted_execution = True
                 break
@@ -5725,6 +5863,11 @@ class MoonMindRunWorkflow:
                 self._update_memo()
                 break
             publish_status_before = self._publish_status
+            await self._record_canonical_step_checkpoint(
+                node_id,
+                boundary="before_publication",
+                updated_at=workflow.now(),
+            )
             self._record_publish_result(
                 parameters=parameters,
                 execution_result=execution_result,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -37,6 +37,25 @@ def _step_execution_artifact_create_result(
         {"upload_url": "unused"},
     )
 
+def _checkpoint_create_result(payload: Any) -> dict[str, Any]:
+    normalized = _normalize_payload(payload)
+    boundary = str(normalized.get("boundary") or "unknown")
+    checkpoint_id = str(normalized.get("idempotencyKey") or f"checkpoint:{boundary}")
+    workspace = normalized.get("workspace")
+    workspace_kind = (
+        workspace.get("kind")
+        if isinstance(workspace, dict)
+        else "ephemeral_workspace_ref"
+    )
+    return {
+        "checkpointRef": f"artifact://checkpoint/{boundary}",
+        "checkpointId": checkpoint_id,
+        "contentType": "application/vnd.moonmind.step-execution-checkpoint+json;version=1",
+        "workspaceKind": workspace_kind,
+        "diagnosticRefs": [],
+        "idempotencyKey": checkpoint_id,
+    }
+
 async def _immediate_wait_condition(
     predicate: Callable[[], bool],
     **_kwargs: Any,
@@ -202,6 +221,8 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         captured.append((activity_type, _normalize_payload(payload)))
         if activity_type == "provider_profile.list":
             return {"profiles": []}
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         if activity_type == "artifact.read":
             if (
                 payload.get("artifact_ref")
@@ -289,16 +310,21 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         plan_ref="art_plan_1",
     )
 
-    # provider_profile.list calls (3) happen first, then artifact.read for plan,
-    # then the step execution manifest artifact.create is recorded before
-    # child workflow dispatch.
+    # provider_profile.list calls (3) happen first, then artifact.read for plan.
+    # Canonical checkpoint writes may occur before the manifest artifact create.
     assert captured[3][0] == "artifact.read"
     assert captured[3][1]["artifact_ref"] == "art_plan_1"
-    assert captured[4][0] == "artifact.create"
-    assert captured[4][1]["content_type"] == (
+    manifest_create = next(
+        payload
+        for activity_type, payload in captured[4:]
+        if activity_type == "artifact.create"
+        and payload.get("content_type")
+        == "application/vnd.moonmind.step-execution+json;version=1"
+    )
+    assert manifest_create["content_type"] == (
         "application/vnd.moonmind.step-execution+json;version=1"
     )
-    assert captured[4][1]["metadata_json"]["artifact_kind"] == (
+    assert manifest_create["metadata_json"]["artifact_kind"] == (
         "step_execution_manifest"
     )
     assert not any(
@@ -329,6 +355,8 @@ async def test_run_finalizing_stage_writes_dependency_summary_metadata(
     ) -> Any:
         if activity_type == "artifact.create":
             return ({"artifact_id": "art_summary_1"}, {"upload_url": "unused"})
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_typed_activity(
@@ -430,6 +458,8 @@ async def test_run_finalizing_stage_writes_structured_moonspec_failure_summary(
     ) -> Any:
         if activity_type == "artifact.create":
             return ({"artifact_id": "art_summary_1"}, {"upload_url": "unused"})
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_typed_activity(
@@ -557,6 +587,8 @@ async def test_run_finalizing_stage_writes_transient_codex_failure_summary(
     ) -> Any:
         if activity_type == "artifact.create":
             return ({"artifact_id": "art_summary_2"}, {"upload_url": "unused"})
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_typed_activity(
@@ -907,6 +939,8 @@ async def test_run_execution_stage_stops_plan_after_structured_blocked_outcome(
                     "edges": [{"from": "check-blockers", "to": "implement"}],
                 }
             ).encode("utf-8")
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -1152,6 +1186,8 @@ async def test_run_execution_stage_rejects_legacy_jira_blocker_skill_plan(
                     },
                 }
             return {"status": "COMPLETED", "outputs": {"summary": "Implemented."}}
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity {activity_type}")
 
     async def fake_execute_typed_activity(
@@ -3130,6 +3166,8 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
             )
             if artifact_create_result is not None:
                 return artifact_create_result
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         assert activity_type == "artifact.read"
         return json.dumps(
             {
@@ -3277,6 +3315,8 @@ async def test_run_execution_stage_fail_fast_raises_agent_runtime_failure_summar
             )
             if artifact_create_result is not None:
                 return artifact_create_result
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         assert activity_type == "artifact.read"
         return json.dumps(
             {

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -52,6 +52,9 @@ def test_build_initial_step_rows_uses_plan_metadata_and_dependencies() -> None:
     assert rows[1]["tool"] == {"type": "skill", "name": "repo.test", "version": "1"}
     assert rows[0]["refs"]["latestStepExecutionManifestRef"] is None
     assert rows[0]["refs"]["stepExecutionManifestRefs"] == []
+    assert rows[0]["refs"]["latestStepExecutionCheckpointRef"] is None
+    assert rows[0]["refs"]["stepExecutionCheckpointRefs"] == []
+    assert rows[0]["refs"]["checkpointRefsByBoundary"] == {}
 
 
 def test_step_ledger_refs_track_latest_and_historical_step_execution_manifests() -> None:
@@ -62,6 +65,15 @@ def test_step_ledger_refs_track_latest_and_historical_step_execution_manifests()
             "agentRunId": "agent-run",
             "latestStepExecutionManifestRef": "artifact-attempt-2",
             "stepExecutionManifestRefs": ["artifact-attempt-1", "artifact-attempt-2"],
+            "latestStepExecutionCheckpointRef": "artifact-checkpoint-2",
+            "stepExecutionCheckpointRefs": [
+                "artifact-checkpoint-1",
+                "artifact-checkpoint-2",
+            ],
+            "checkpointRefsByBoundary": {
+                "before_execution": "artifact-checkpoint-1",
+                "after_execution": "artifact-checkpoint-2",
+            },
         }
     )
 
@@ -70,6 +82,15 @@ def test_step_ledger_refs_track_latest_and_historical_step_execution_manifests()
         "artifact-attempt-1",
         "artifact-attempt-2",
     ]
+    assert refs.latest_step_execution_checkpoint_ref == "artifact-checkpoint-2"
+    assert refs.step_execution_checkpoint_refs == [
+        "artifact-checkpoint-1",
+        "artifact-checkpoint-2",
+    ]
+    assert refs.checkpoint_refs_by_boundary == {
+        "before_execution": "artifact-checkpoint-1",
+        "after_execution": "artifact-checkpoint-2",
+    }
     assert refs.model_dump(by_alias=True)["latestStepExecutionManifestRef"] == (
         "artifact-attempt-2"
     )
@@ -115,6 +136,9 @@ def test_build_initial_step_rows_skips_blank_node_ids() -> None:
                 "agentRunId": None,
                 "latestStepExecutionManifestRef": None,
                 "stepExecutionManifestRefs": [],
+                "latestStepExecutionCheckpointRef": None,
+                "stepExecutionCheckpointRefs": [],
+                "checkpointRefsByBoundary": {},
             },
             "artifacts": {
                 "outputSummary": None,
@@ -349,6 +373,9 @@ def test_row_defaults_remain_bounded_and_structured() -> None:
         "agentRunId": None,
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
     assert artifacts.model_dump(by_alias=True) == {
         "outputSummary": None,
@@ -387,12 +414,22 @@ def test_mark_step_checkpoint_evidence_marks_completed_step_eligible() -> None:
         state_checkpoint_ref="artifact://checkpoint/implement/1",
         workspace_checkpoint_ref="artifact://workspace/implement/1",
         step_checkpoint_ref="artifact://step/implement/1",
+        boundary="after_execution",
     )
 
     row = StepLedgerRowModel.model_validate(rows[0])
     assert row.state_checkpoint_ref == "artifact://checkpoint/implement/1"
     assert row.workspace_checkpoint_ref == "artifact://workspace/implement/1"
     assert row.step_checkpoint_ref == "artifact://step/implement/1"
+    assert row.refs.latest_step_execution_checkpoint_ref == (
+        "artifact://step/implement/1"
+    )
+    assert row.refs.step_execution_checkpoint_refs == [
+        "artifact://step/implement/1"
+    ]
+    assert row.refs.checkpoint_refs_by_boundary == {
+        "after_execution": "artifact://step/implement/1"
+    }
     assert row.resume_preservation is not None
     assert row.resume_preservation.eligible is True
     assert row.resume_preservation.reason == "complete"
@@ -534,6 +571,9 @@ def test_update_step_row_merges_structured_refs_and_artifacts() -> None:
         "agentRunId": "550e8400-e29b-41d4-a716-446655440000",
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
     assert row["artifacts"] == {
         "outputSummary": "art_summary_1",

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -770,6 +770,44 @@ async def test_run_execution_stage_honors_pause_between_managed_session_steps(
     async def fake_bind_workflow_scoped_session(request: Any) -> Any:
         return request
 
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_type == "artifact.create":
+            return ({"artifact_id": "artifact://manifest"}, {"upload_url": "unused"})
+        if activity_type == "step_checkpoint.create":
+            normalized = _normalize_payload(payload)
+            boundary = str(normalized.get("boundary") or "unknown")
+            checkpoint_id = str(
+                normalized.get("idempotencyKey") or f"checkpoint:{boundary}"
+            )
+            workspace = normalized.get("workspace")
+            workspace_kind = (
+                workspace.get("kind")
+                if isinstance(workspace, dict)
+                else "ephemeral_workspace_ref"
+            )
+            return {
+                "checkpointRef": f"artifact://checkpoint/{boundary}",
+                "checkpointId": checkpoint_id,
+                "contentType": "application/vnd.moonmind.step-execution-checkpoint+json;version=1",
+                "workspaceKind": workspace_kind,
+                "diagnosticRefs": [],
+                "idempotencyKey": checkpoint_id,
+            }
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_write_manifest_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_typed_activity(activity_type, payload, **_kwargs)
+
     workflow_info = type(
         "WorkflowInfo",
         (),
@@ -807,7 +845,12 @@ async def test_run_execution_stage_honors_pause_between_managed_session_steps(
     monkeypatch.setattr(
         run_workflow_module,
         "execute_typed_activity",
-        fake_execute_typed_activity,
+        fake_write_manifest_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,

--- a/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -207,6 +207,9 @@ def test_parent_owned_checkpoint_evidence_survives_child_runtime_projection() ->
         "agentRunId": None,
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
     assert rows[0]["stateCheckpointRef"] == "artifact://child-checkpoint"
     assert rows[0]["recoveryPreservation"] == {

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -148,6 +148,28 @@ def test_step_execution_manifest_start_write_keeps_replay_patch_guard() -> None:
     assert source.index(guard) < source.index(start_manifest_call)
 
 
+def test_canonical_step_checkpoint_writes_keep_replay_patch_guard() -> None:
+    source = Path(run_module.__file__).read_text()
+
+    assert run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH == (
+        "run-canonical-step-checkpoints-v1"
+    )
+    guard = "if not workflow.patched(RUN_CANONICAL_STEP_CHECKPOINTS_PATCH):"
+    activity_call = "result = await self._create_step_checkpoint_via_activity("
+
+    assert source.index(guard) < source.index(activity_call)
+
+
+def test_recovery_workspace_prepares_before_marking_failed_step_running() -> None:
+    source = Path(run_module.__file__).read_text()
+
+    prepare_call = (
+        "await self._prepare_recovery_workspace_for_failed_step(node_id)\n"
+        "                self._mark_step_running("
+    )
+    assert prepare_call in source
+
+
 def _registry_payload() -> dict[str, Any]:
     return {
         "skills": [
@@ -1486,6 +1508,15 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_STEP_EXECUTION_MANIFEST_PATCH,
+        },
+    )
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
     workflow._input_ref = "artifact://task-input"
@@ -1588,6 +1619,46 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
         [call["payload"] for call in captured],
         sort_keys=True,
     ).lower()
+
+
+@pytest.mark.asyncio
+async def test_run_skips_canonical_boundary_checkpoint_when_unpatched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    captured: list[str] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append(activity)
+        return {}
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    assert result is None
+    assert captured == []
 
 
 def test_run_marks_completed_step_without_checkpoint_ineligible(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -66,6 +66,24 @@ def _ordered_nodes() -> list[dict]:
 def _dependency_map() -> dict[str, list[str]]:
     return {"prepare": [], "run-tests": ["prepare"]}
 
+def _checkpoint_create_result(payload: Any) -> dict[str, Any]:
+    boundary = str(payload.get("boundary") or "unknown")
+    checkpoint_id = str(payload.get("idempotencyKey") or f"checkpoint:{boundary}")
+    workspace = payload.get("workspace")
+    workspace_kind = (
+        workspace.get("kind")
+        if isinstance(workspace, dict)
+        else "ephemeral_workspace_ref"
+    )
+    return {
+        "checkpointRef": f"artifact://checkpoint/{boundary}",
+        "checkpointId": checkpoint_id,
+        "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+        "workspaceKind": workspace_kind,
+        "diagnosticRefs": [],
+        "idempotencyKey": checkpoint_id,
+    }
+
 def _approval_policy_plan_payload() -> dict[str, Any]:
     return {
         "plan_version": "1.0",
@@ -561,6 +579,9 @@ def test_run_groups_child_lineage_and_evidence_into_step_row(
         "agentRunId": "550e8400-e29b-41d4-a716-446655440000",
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
     assert step["artifacts"] == {
         "outputSummary": "art_summary_1",
@@ -615,6 +636,9 @@ def test_run_waiting_state_captures_child_workflow_lineage(
         "agentRunId": None,
         "latestStepExecutionManifestRef": None,
         "stepExecutionManifestRefs": [],
+        "latestStepExecutionCheckpointRef": None,
+        "stepExecutionCheckpointRefs": [],
+        "checkpointRefsByBoundary": {},
     }
 
 
@@ -1440,9 +1464,130 @@ async def test_run_routes_step_checkpoint_create_through_activity_boundary(
     step = workflow.get_step_ledger()["steps"][0]
     assert step["stepCheckpointRef"] == "artifact://checkpoint/created"
     assert step.get("stateCheckpointRef") is None
+    assert step["refs"]["latestStepExecutionCheckpointRef"] == (
+        "artifact://checkpoint/created"
+    )
+    assert step["refs"]["stepExecutionCheckpointRefs"] == [
+        "artifact://checkpoint/created"
+    ]
+    assert step["refs"]["checkpointRefsByBoundary"] == {
+        "after_execution": "artifact://checkpoint/created"
+    }
+    assert workflow._step_checkpoint_refs_by_boundary["implement"] == {
+        "after_execution": "artifact://checkpoint/created"
+    }
     assert "implement" not in workflow._step_checkpoint_refs
     assert "workspacePath" not in captured["payload"]
     assert "diff" not in json.dumps(captured["payload"], sort_keys=True)
+
+
+@pytest.mark.asyncio
+async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    workflow._prepared_artifact_refs = ["artifact://prepared"]
+    captured: list[dict[str, Any]] = []
+    manifest_writes: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
+        boundary = payload["boundary"]
+        return {
+            "checkpointRef": f"artifact://checkpoint/{boundary}",
+            "checkpointId": payload["idempotencyKey"],
+            "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+            "workspaceKind": payload["workspace"]["kind"],
+            "diagnosticRefs": [],
+            "idempotencyKey": payload["idempotencyKey"],
+        }
+
+    async def fake_write_json_artifact(
+        *,
+        name: str,
+        payload: dict[str, Any],
+        content_type: str = "application/json",
+        metadata_json: dict[str, Any] | None = None,
+    ) -> str:
+        manifest_writes.append(
+            {
+                "name": name,
+                "payload": payload,
+                "content_type": content_type,
+                "metadata_json": metadata_json,
+            }
+        )
+        return f"artifact://manifest/{len(manifest_writes)}"
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(workflow, "_write_json_artifact", fake_write_json_artifact)
+
+    await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+    await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_execution",
+        updated_at=now,
+        step_outputs={"summaryRef": "artifact://summary"},
+    )
+    await workflow._record_step_execution_manifest(
+        "implement",
+        phase="start",
+        updated_at=now,
+        reason="initial_execution",
+    )
+
+    assert [call["payload"]["boundary"] for call in captured] == [
+        "before_execution",
+        "after_execution",
+    ]
+    assert captured[0]["payload"]["taskInputSnapshotRef"] == "artifact://task-input"
+    assert captured[0]["payload"]["planRef"] == "artifact://plan"
+    assert captured[0]["payload"]["preparedInputRefs"] == ["artifact://prepared"]
+    assert captured[0]["payload"]["workspace"]["kind"] == "ephemeral_workspace_ref"
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["refs"]["latestStepExecutionCheckpointRef"] == (
+        "artifact://checkpoint/after_execution"
+    )
+    assert step["refs"]["stepExecutionCheckpointRefs"] == [
+        "artifact://checkpoint/before_execution",
+        "artifact://checkpoint/after_execution",
+    ]
+    assert step["refs"]["checkpointRefsByBoundary"] == {
+        "before_execution": "artifact://checkpoint/before_execution",
+        "after_execution": "artifact://checkpoint/after_execution",
+    }
+    workspace = manifest_writes[-1]["payload"]["workspace"]
+    assert workspace["checkpointBeforeRef"] == (
+        "artifact://checkpoint/before_execution"
+    )
+    assert workspace["checkpointAfterRef"] == "artifact://checkpoint/after_execution"
+    assert "diff" not in json.dumps(
+        [call["payload"] for call in captured],
+        sort_keys=True,
+    ).lower()
 
 
 def test_run_marks_completed_step_without_checkpoint_ineligible(
@@ -1622,6 +1767,8 @@ async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check
                 "feedback": None,
                 "issues": [],
             }
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -1790,6 +1937,8 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
         if activity_type == "step.review":
             return next(review_verdicts)
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -1952,6 +2101,8 @@ async def test_run_execution_stage_stops_downstream_handoff_when_gate_budget_exh
                 "remainingWorkRef": "art_remaining_work_1",
                 "recommendedNextAction": "needs_human",
             }
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -2106,6 +2257,8 @@ async def test_run_execution_stage_stops_downstream_handoff_when_no_progress_bud
                 "remainingWorkRef": "art_remaining_work_1",
                 "recommendedNextAction": "needs_human",
             }
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -2251,6 +2404,8 @@ async def test_run_execution_stage_continues_independent_nodes_after_gate_stop(
                 "remainingWorkRef": "art_remaining_work_1",
                 "recommendedNextAction": "needs_human",
             }
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_child_workflow(
@@ -2393,6 +2548,8 @@ async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_i
             return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
         if activity_type == "step.review":
             return next(review_verdicts)
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
         raise AssertionError(f"unexpected activity: {activity_type}")
 
     async def fake_execute_typed_activity(


### PR DESCRIPTION
Jira issue key: MM-823

Summary:
- Capture and record canonical Step Execution checkpoint refs at workflow boundaries including after_prepare, before_execution, after_execution, after_gate, before_publication, and before_recovery_restoration where applicable.
- Populate workspace checkpointBeforeRef/checkpointAfterRef from canonical checkpoint artifacts and carry boundary refs into step execution manifests.
- Add ledger ref fields for latestStepExecutionCheckpointRef, stepExecutionCheckpointRefs, and checkpointRefsByBoundary with read-side compatibility for legacy refs.

Tests run:
- pytest tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q (198 passed)
- ./tools/test_unit.sh with the same Python targets: Python tests passed (198 passed), then the wrapper failed during unrelated frontend Vitest path forwarding with module resolution errors.

Remaining risks:
- Full unit suite was not rerun after the wrapper frontend-path issue; verification is limited to the affected Temporal workflow and ledger tests.
- Temporal behavior is covered at unit boundaries here, not by compose-backed integration_ci in this step.