### PR TITLE
MM-705 consolidate Step Execution manifest writer

### DIFF
--- a/docs/tmp/StepExecutionsCheckpointingGapPlan.md
+++ b/docs/tmp/StepExecutionsCheckpointingGapPlan.md
@@ -30,8 +30,8 @@ foundations from remaining gaps.
 | --- | --- | --- |
 | Step Execution identity / ordinal increment | Wired | Step rows carry `attempt` / `executionOrdinal`; `_mark_step_running(increment_attempt=True)` increments semantic executions. |
 | Canonical content types | Wired | `STEP_EXECUTION_MANIFEST_CONTENT_TYPE` and `STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE` are canonical. Do not reintroduce `step-checkpoint`, `step-resume-checkpoint`, or API `attempts` vocabulary. |
-| Typed manifest start and terminal models | Partially wired | `_record_step_execution_manifest_start` and `_record_step_execution_manifest_terminal` write `StepExecutionManifestModel` payloads with canonical content type. |
-| Legacy duplicate start manifest path | Still present | `_record_step_execution_manifest_started` plus `build_step_execution_manifest_payload` remain and must be deleted after their unique behavior is folded into the typed writer. |
+| Typed manifest start and terminal models | Wired | `_record_step_execution_manifest` writes `StepExecutionManifestModel` payloads with canonical content type for start, launch-blocked, and terminal evidence. |
+| Legacy duplicate start manifest path | Removed | Manifest creation is folded into `_record_step_execution_manifest`; read-side validation remains separate for persisted/degraded evidence. |
 | Ledger manifest refs | Wired | Latest and historical Step Execution manifest refs are attached to step rows. |
 | Gated reattempt loop | Wired for MoonSpec/remediation presets | `ADDITIONAL_WORK_NEEDED` / `FULLY_IMPLEMENTED` drive bounded reattempt behavior; the broader typed gate model is still missing. |
 | Non-attempt stop dimension | Wired | Consecutive no-progress budget is recorded in Step Execution budget manifests and can stop downstream handoff. |
@@ -46,7 +46,6 @@ foundations from remaining gaps.
 
 | Gap | Current impact | Owning work package |
 | --- | --- | --- |
-| One canonical manifest write path | Two manifest start paths still exist. This violates the design requirement for one manifest write path per identity. | WP1 |
 | Checkpoint artifact creation at canonical boundaries | `step_checkpoints.py` helpers exist, but workflow capture is still mostly ref-ingestion from runtime outputs; canonical boundary checkpoint artifacts are not written by `MoonMind.UserWorkflow`. | WP2, WP3 |
 | Checkpoint-backed workspace policy application | Launch validation can block missing evidence, but policy application/restoration is not backed by validated checkpoint artifacts. | WP4 |
 | Checkpoint-backed Resume as default recovery path | Recovery payloads carry checkpoint evidence, but recovery does not yet validate/apply a checkpoint before new work as the primary operator path. | WP5 |
@@ -72,11 +71,10 @@ post-recovery hardening/alignment work.
 ### 1.4 Phase 12 cleanup decision
 
 Phase 12 evidence review retains this temp plan because the final definition of
-done is still open: `build_step_execution_manifest_payload` remains in the live
-workflow path, checkpoint-backed recovery is not yet the default operator flow,
-retrieval-backed context packs are not injected into Temporal step execution,
-and remediation panels remain partial. The plan is non-canonical temporary
-material and must not be cited as implementation completion evidence.
+done is still open: checkpoint-backed recovery is not yet the default operator
+flow, retrieval-backed context packs are not injected into Temporal step
+execution, and remediation panels remain partial. The plan is non-canonical
+temporary material and must not be cited as implementation completion evidence.
 
 Conditional documentation review:
 
@@ -161,7 +159,7 @@ land.
 
 ---
 
-### WP1 — Consolidate manifest writers (prerequisite)
+### WP1 — Consolidate manifest writers (completed)
 
 **Goal:** Make exactly one Step Execution manifest write path per identity.
 
@@ -175,10 +173,8 @@ land.
    - execution metadata override (`kind`, `toolName`, idempotency key);
    - budget metadata;
    - launch-blocked summary/disposition.
-3. Replace all `_record_step_execution_manifest_started` call sites with the
-   canonical typed method.
-4. Delete `_record_step_execution_manifest_started` and
-   `build_step_execution_manifest_payload` entirely.
+3. Route all manifest call sites through the canonical typed method.
+4. Delete duplicate manifest-start helpers entirely.
 5. Keep replay patch markers only as routing guards, not as alternate payload
    builders.
 
@@ -187,9 +183,9 @@ launch-blocked start manifest uses canonical content type; old raw manifest
 payload validates/degrades at the boundary; grep/contract test proves the legacy
 helper is gone.
 
-**Acceptance:** `grep -R "build_step_execution_manifest_payload"` finds no
-production references. All new manifest writes use
-`STEP_EXECUTION_MANIFEST_CONTENT_TYPE`.
+**Acceptance:** Production manifest writes use `_record_step_execution_manifest`
+and `STEP_EXECUTION_MANIFEST_CONTENT_TYPE`; persisted manifest reads continue to
+validate or fail closed through the boundary validator.
 
 ---
 

--- a/moonmind/workflows/temporal/step_execution_conformance.py
+++ b/moonmind/workflows/temporal/step_execution_conformance.py
@@ -19,13 +19,13 @@ from moonmind.schemas.temporal_models import (
     StepExecutionCheckpointModel,
     StepExecutionIdentityModel,
     StepExecutionManifestModel,
+    build_step_execution_id,
 )
 from moonmind.workflows.temporal.step_checkpoints import (
     build_step_checkpoint_payload,
     validate_step_checkpoint_payload,
 )
 from moonmind.workflows.temporal.step_executions import (
-    build_step_execution_manifest_payload,
     memory_side_effect_summary,
     validate_step_execution_manifest_payload,
 )
@@ -121,15 +121,18 @@ def _decision(
 
 
 def _valid_manifest_payload(**overrides: Any) -> dict[str, Any]:
-    payload = build_step_execution_manifest_payload(
-        workflow_id="workflow-1",
-        run_id="run-1",
-        logical_step_id="implement-story",
-        execution_ordinal=2,
+    identity = _identity()
+    payload = StepExecutionManifestModel(
+        stepExecutionId=build_step_execution_id(identity),
+        workflowId=identity.workflow_id,
+        runId=identity.run_id,
+        logicalStepId=identity.logical_step_id,
+        executionOrdinal=identity.execution_ordinal,
         reason="initial_execution",
         status="succeeded",
-        updated_at=_now(),
-        input_refs=["artifact://input"],
+        startedAt=_now(),
+        updatedAt=_now(),
+        input={"preparedInputRefs": ["artifact://input"]},
         context={"contextBundleRef": "artifact://context"},
         workspace={
             "policy": "continue_from_previous_execution",
@@ -139,11 +142,10 @@ def _valid_manifest_payload(**overrides: Any) -> dict[str, Any]:
         execution={"childWorkflowId": "child-1"},
         outputs={"summaryRef": "artifact://summary", "diffRef": "artifact://diff"},
         checks=[{"kind": "unit", "status": "passed"}],
-        side_effects={"recordsRef": "artifact://side-effects"},
-        dependency_effects={"invalidatedLogicalStepIds": []},
+        sideEffects={"recordsRef": "artifact://side-effects"},
+        dependencyEffects={"invalidatedLogicalStepIds": []},
         budget={"attemptLimit": 3},
-    )
-    payload.pop("contentType", None)
+    ).model_dump(by_alias=True, mode="json")
     payload.update(overrides)
     return payload
 

--- a/moonmind/workflows/temporal/step_executions.py
+++ b/moonmind/workflows/temporal/step_executions.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import datetime
 import posixpath
 import re
 from typing import Any, Literal
@@ -13,10 +12,6 @@ from pydantic import ValidationError
 from moonmind.schemas.step_execution_models import (
     MemorySideEffectSummary,
     StepExecutionIdentityModel,
-    StepExecutionManifestModel,
-    StepExecutionReason,
-    StepExecutionStatus,
-    StepExecutionTerminalDisposition,
 )
 from moonmind.schemas.temporal_models import (
     StepExecutionManifestModel as BoundaryStepExecutionManifestModel,
@@ -577,70 +572,6 @@ def plan_reattempt_compensation(
     if not reattempt_allowed:
         plan["reason"] = "uncompensated_non_idempotent_effects"
     return plan
-
-
-def build_step_execution_manifest_payload(
-    *,
-    workflow_id: str,
-    run_id: str,
-    logical_step_id: str,
-    execution_ordinal: int,
-    reason: StepExecutionReason,
-    status: StepExecutionStatus,
-    terminal_disposition: StepExecutionTerminalDisposition | None = None,
-    updated_at: datetime,
-    started_at: datetime | None = None,
-    summary: str | None = None,
-    lineage: Mapping[str, Any] | None = None,
-    input_refs: Sequence[str] = (),
-    context: Mapping[str, Any] | None = None,
-    workspace: Mapping[str, Any] | None = None,
-    git_effect: Mapping[str, Any] | None = None,
-    execution: Mapping[str, Any] | None = None,
-    outputs: Mapping[str, Any] | None = None,
-    checks: Sequence[Mapping[str, Any]] = (),
-    side_effects: Mapping[str, Any] | None = None,
-    side_effect_records: Sequence[Mapping[str, Any]] = (),
-    dependency_effects: Mapping[str, Any] | None = None,
-    recovery_source: Mapping[str, Any] | None = None,
-    budget: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
-    bounded_outputs = dict(outputs or {})
-    if summary is not None:
-        bounded_outputs.setdefault("summary", summary[:500])
-    prepared_refs = [str(ref).strip() for ref in input_refs if str(ref).strip()]
-    input_payload: dict[str, Any] = {}
-    if prepared_refs:
-        input_payload["preparedInputRefs"] = prepared_refs
-    workspace_payload = dict(workspace or {})
-    if git_effect is not None:
-        workspace_payload["gitEffect"] = dict(git_effect)
-    side_effect_payload = dict(side_effects or {})
-    if side_effect_records:
-        side_effect_payload["records"] = [dict(record) for record in side_effect_records]
-    manifest = StepExecutionManifestModel(
-        workflowId=workflow_id,
-        runId=run_id,
-        logicalStepId=logical_step_id,
-        executionOrdinal=execution_ordinal,
-        lineage=dict(lineage) if lineage is not None else None,
-        reason=reason,
-        status=status,
-        terminalDisposition=terminal_disposition,
-        startedAt=started_at or updated_at,
-        updatedAt=updated_at,
-        input=input_payload,
-        context=dict(context or {}),
-        workspace=workspace_payload,
-        execution=dict(execution or {}),
-        outputs=bounded_outputs,
-        checks=[dict(check) for check in checks],
-        sideEffects=side_effect_payload,
-        dependencyEffects=dict(dependency_effects or {}),
-        recoverySource=dict(recovery_source or {}),
-        budget=dict(budget or {}),
-    )
-    return manifest.model_dump(by_alias=True, mode="json")
 
 
 def validate_step_execution_manifest_payload(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1134,8 +1134,8 @@ class MoonMindRunWorkflow:
             outputs=bounded_outputs,
             checks=checks,
             sideEffects=side_effects_payload,
-            dependency_effects=dependency_effects,
-            recovery_source=self._validate_recovery_source_for_execution(),
+            dependencyEffects=dependency_effects,
+            recoverySource=self._validate_recovery_source_for_execution(),
             budget=budget,
         )
         manifest_ref = await self._write_step_execution_manifest(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -107,7 +107,6 @@ from moonmind.workflows.temporal.step_ledger import (
     validate_preserved_dependency_outputs,
 )
 from moonmind.workflows.temporal.step_executions import (
-    build_step_execution_manifest_payload,
     git_effect_metadata,
     logical_step_success_allowed,
     plan_reattempt_compensation,
@@ -1096,42 +1095,53 @@ class MoonMindRunWorkflow:
                 {"invalidatedLogicalStepIds": []},
             )
 
-        manifest_payload = build_step_execution_manifest_payload(
-            workflow_id=identity.workflow_id,
-            run_id=identity.run_id,
-            logical_step_id=identity.logical_step_id,
-            execution_ordinal=identity.execution_ordinal,
-            reason=reason,  # type: ignore[arg-type]
-            status=resolved_status,  # type: ignore[arg-type]
-            terminal_disposition=resolved_terminal_disposition,  # type: ignore[arg-type]
-            started_at=self._step_execution_started_at(logical_step_id),
-            updated_at=updated_at,
-            summary=resolved_summary,
-            lineage=lineage,
-            input_refs=self._combined_step_execution_input_refs(input_refs),
+        bounded_outputs = dict(outputs or {})
+        if resolved_summary is not None:
+            bounded_outputs.setdefault("summary", resolved_summary[:500])
+        prepared_input_refs = self._combined_step_execution_input_refs(input_refs)
+        input_payload: dict[str, Any] = {}
+        if prepared_input_refs:
+            input_payload["preparedInputRefs"] = prepared_input_refs
+        workspace_payload = dict(workspace)
+        if git_effect is not None:
+            workspace_payload["gitEffect"] = dict(git_effect)
+        if side_effect_records:
+            side_effects_payload["records"] = [
+                dict(record) for record in side_effect_records
+            ]
+
+        manifest = StepExecutionManifestModel(
+            stepExecutionId=step_execution_id,
+            workflowId=identity.workflow_id,
+            runId=identity.run_id,
+            logicalStepId=identity.logical_step_id,
+            executionOrdinal=identity.execution_ordinal,
+            lineage=dict(lineage) if lineage is not None else None,
+            reason=reason,
+            status=resolved_status,
+            terminalDisposition=resolved_terminal_disposition,
+            startedAt=self._step_execution_started_at(logical_step_id) or updated_at,
+            updatedAt=updated_at,
+            input=input_payload,
             context=self._step_execution_manifest_context_projection(
                 logical_step_id,
                 attempt=identity.execution_ordinal,
                 reason=reason,
                 execution=execution_payload,
             ),
-            workspace=workspace,
-            git_effect=git_effect,
+            workspace=workspace_payload,
             execution=execution_payload,
-            outputs=outputs,
+            outputs=bounded_outputs,
             checks=checks,
-            side_effects=side_effects_payload,
-            side_effect_records=side_effect_records,
+            sideEffects=side_effects_payload,
             dependency_effects=dependency_effects,
             recovery_source=self._validate_recovery_source_for_execution(),
             budget=budget,
         )
-        manifest_model_payload = dict(manifest_payload)
-        manifest_model_payload.pop("contentType", None)
         manifest_ref = await self._write_step_execution_manifest(
             logical_step_id,
             attempt=attempt,
-            manifest=StepExecutionManifestModel.model_validate(manifest_model_payload),
+            manifest=manifest,
             step_execution_id=step_execution_id,
             idempotency_key=idempotency_key,
             updated_at=updated_at,

--- a/tests/integration/docs/test_final_docs_cleanup_contract.py
+++ b/tests/integration/docs/test_final_docs_cleanup_contract.py
@@ -36,7 +36,7 @@ def test_canonical_docs_and_runtime_evidence_agree_on_manifest_and_checkpoint_st
     assert "STEP_EXECUTION_MANIFEST_CONTENT_TYPE" in runtime_text
     assert "STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE" in runtime_text
     assert "_record_step_execution_manifest" in runtime_text
-    assert "build_step_execution_manifest_payload" in runtime_text
+    assert "build_step_execution_manifest_payload" not in runtime_text
 
     assert "application/vnd.moonmind.step-execution+json;version=1" in docs_text
     assert "application/vnd.moonmind.step-execution-checkpoint+json;version=1" in docs_text
@@ -48,12 +48,11 @@ def test_temp_plan_state_matches_incomplete_final_definition_of_done() -> None:
     temp_text = _read(TEMP_PLAN)
     roadmap_text = _read(ROADMAP_DOC)
 
-    assert "build_step_execution_manifest_payload" in runtime_text
     assert TEMP_PLAN.exists()
     assert "Status: Execution plan (disposable; not canonical)" in temp_text
-    assert "One canonical manifest write path" in temp_text
+    assert "Consolidate manifest writers (completed)" in temp_text
     assert "- [ ] **13.1** Resume-from-checkpoint as the default recovery path" in roadmap_text
-    assert "deleted in the closing PR" in temp_text
+    assert "build_step_execution_manifest_payload" not in temp_text
 
 
 def test_roadmap_and_implementation_evidence_remain_consistent() -> None:
@@ -61,7 +60,7 @@ def test_roadmap_and_implementation_evidence_remain_consistent() -> None:
     runtime_text = "\n".join(_read(path) for path in (RUN_WORKFLOW, STEP_EXECUTIONS))
 
     assert "_record_step_execution_manifest" in runtime_text
-    assert "build_step_execution_manifest_payload" in runtime_text
+    assert "build_step_execution_manifest_payload" not in runtime_text
     assert "Durable step ledger & checkpoints" in roadmap_text
     assert "Resume foundations" in roadmap_text
     assert "checkpoint restore logic exists but is not yet the primary operator flow" in roadmap_text

--- a/tests/unit/docs/test_final_docs_cleanup_policy.py
+++ b/tests/unit/docs/test_final_docs_cleanup_policy.py
@@ -77,6 +77,7 @@ def test_manifest_consolidation_claims_follow_current_code_evidence() -> None:
         )
     else:
         assert "build_step_execution_manifest_payload" not in temp_text
+        assert "Consolidate manifest writers (completed)" in temp_text
 
 
 def test_roadmap_milestones_are_evidence_aligned_and_gated() -> None:
@@ -101,6 +102,8 @@ def test_temp_plan_cleanup_guard_retains_active_plan_when_final_dod_is_open() ->
     if _manifest_builder_is_live():
         assert "deleted in the closing PR" in text
         assert "build_step_execution_manifest_payload" in text
+    else:
+        assert "build_step_execution_manifest_payload" not in text
 
 
 def test_docs_do_not_inline_secrets_or_raw_evidence() -> None:

--- a/tests/unit/workflows/temporal/test_step_executions.py
+++ b/tests/unit/workflows/temporal/test_step_executions.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from moonmind.schemas.step_execution_models import STEP_EXECUTION_CONTENT_TYPE
+from moonmind.schemas.step_execution_models import (
+    STEP_EXECUTION_CONTENT_TYPE,
+    StepExecutionManifestModel,
+)
 from moonmind.workflows.temporal.step_executions import (
     already_occurred_non_idempotent_effects,
-    build_step_execution_manifest_payload,
     compensation_subject_key,
     git_effect_metadata,
     logical_step_success_allowed,
@@ -58,21 +60,23 @@ def test_operation_idempotency_key_includes_execution_ordinal_and_operation() ->
 
 def test_manifest_payload_is_compact_boundary_contract() -> None:
     now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
-    payload = build_step_execution_manifest_payload(
-        workflow_id="wf-1",
-        run_id="run-1",
-        logical_step_id="implement",
-        execution_ordinal=1,
+    manifest = StepExecutionManifestModel(
+        workflowId="wf-1",
+        runId="run-1",
+        logicalStepId="implement",
+        executionOrdinal=1,
         reason="initial_execution",
         status="running",
-        updated_at=now,
-        summary="Executing plan step",
+        startedAt=now,
+        updatedAt=now,
         execution={
             "kind": "skill",
             "idempotencyKey": "wf-1:run-1:implement:execution:1:execute",
         },
-        input_refs=["artifact://input"],
+        input={"preparedInputRefs": ["artifact://input"]},
+        outputs={"summary": "Executing plan step"},
     )
+    payload = manifest.model_dump(by_alias=True, mode="json")
 
     assert payload["contentType"] == STEP_EXECUTION_CONTENT_TYPE
     assert payload["stepExecutionId"] == "wf-1:run-1:implement:execution:1"
@@ -83,23 +87,23 @@ def test_manifest_payload_is_compact_boundary_contract() -> None:
 
 def test_manifest_payload_accepts_terminal_disposition_and_effect_matrices() -> None:
     now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
-    payload = build_step_execution_manifest_payload(
-        workflow_id="wf-1",
-        run_id="run-1",
-        logical_step_id="implement",
-        execution_ordinal=1,
+    manifest = StepExecutionManifestModel(
+        workflowId="wf-1",
+        runId="run-1",
+        logicalStepId="implement",
+        executionOrdinal=1,
         reason="initial_execution",
         status="succeeded",
-        terminal_disposition="accepted",
-        updated_at=now,
-        input_refs=["artifact://input"],
+        terminalDisposition="accepted",
+        startedAt=now,
+        updatedAt=now,
+        input={"preparedInputRefs": ["artifact://input"]},
         context={"bundleRef": "artifact://context"},
         workspace={"policy": "fresh_branch_from_source"},
-        git_effect={"disposition": "accepted", "acceptedOutputPresent": True},
         execution={"kind": "agent_runtime"},
         outputs={"summaryRef": "artifact://summary"},
         checks=[{"kind": "approval_policy", "status": "passed"}],
-        side_effects={
+        sideEffects={
             "summary": {
                 "categories": {
                     "git": 1,
@@ -111,20 +115,33 @@ def test_manifest_payload_accepts_terminal_disposition_and_effect_matrices() -> 
                     "retrieval": 1,
                     "record": 7,
                 }
-            }
+            },
+            "records": [
+                {"class": "external_idempotent", "kind": "normal", "operation": "jira"},
+                {"class": "artifact_write", "kind": "normal", "operation": "artifact"},
+                {"class": "publication", "kind": "normal", "operation": "publish"},
+                {
+                    "class": "external_non_idempotent",
+                    "kind": "compensation",
+                    "operation": "compensate",
+                },
+                {"class": "memory_update", "kind": "normal", "operation": "memory"},
+                {
+                    "class": "retrieval_index_update",
+                    "kind": "normal",
+                    "operation": "retrieval",
+                },
+                {"class": "workspace_mutation", "kind": "normal", "operation": "record"},
+            ],
         },
-        side_effect_records=[
-            {"class": "external_idempotent", "kind": "normal", "operation": "jira"},
-            {"class": "artifact_write", "kind": "normal", "operation": "artifact"},
-            {"class": "publication", "kind": "normal", "operation": "publish"},
-            {"class": "external_non_idempotent", "kind": "compensation", "operation": "compensate"},
-            {"class": "memory_update", "kind": "normal", "operation": "memory"},
-            {"class": "retrieval_index_update", "kind": "normal", "operation": "retrieval"},
-            {"class": "workspace_mutation", "kind": "normal", "operation": "record"},
-        ],
-        dependency_effects={"invalidatedLogicalStepIds": ["verify"]},
+        dependencyEffects={"invalidatedLogicalStepIds": ["verify"]},
         budget={"maxReviewAttempts": 2},
     )
+    manifest.workspace["gitEffect"] = {
+        "disposition": "accepted",
+        "acceptedOutputPresent": True,
+    }
+    payload = manifest.model_dump(by_alias=True, mode="json")
 
     assert payload["terminalDisposition"] == "accepted"
     assert payload["workspace"]["gitEffect"]["disposition"] == "accepted"
@@ -437,33 +454,38 @@ def test_plan_reattempt_compensation_noop_without_prior_effects() -> None:
 
 def test_manifest_payload_embeds_policy_git_effect_and_side_effect_records() -> None:
     now = datetime(2026, 5, 17, 12, 0, tzinfo=UTC)
-    payload = build_step_execution_manifest_payload(
-        workflow_id="wf-1",
-        run_id="run-1",
-        logical_step_id="implement",
-        execution_ordinal=2,
+    workspace = workspace_policy_metadata(
+        policy="continue_from_previous_execution",
+        checkpoint_ref="artifact://checkpoint",
+        checkpoint_valid=True,
+    )
+    workspace["gitEffect"] = git_effect_metadata(
+        disposition="candidate",
+        working_tree_diff_ref="artifact://diff",
+        patch_ref="artifact://patch",
+        workspace_checkpoint_ref="artifact://checkpoint",
+    )
+    manifest = StepExecutionManifestModel(
+        workflowId="wf-1",
+        runId="run-1",
+        logicalStepId="implement",
+        executionOrdinal=2,
         reason="tests_failed",
         status="failed",
-        updated_at=now,
-        workspace=workspace_policy_metadata(
-            policy="continue_from_previous_execution",
-            checkpoint_ref="artifact://checkpoint",
-            checkpoint_valid=True,
-        ),
-        git_effect=git_effect_metadata(
-            disposition="candidate",
-            working_tree_diff_ref="artifact://diff",
-            patch_ref="artifact://patch",
-            workspace_checkpoint_ref="artifact://checkpoint",
-        ),
-        side_effect_records=[
-            side_effect_record(
-                effect_class="publication",
-                operation="repo.merge_pr",
-                workflow_state_accepted=False,
-            )
-        ],
+        startedAt=now,
+        updatedAt=now,
+        workspace=workspace,
+        sideEffects={
+            "records": [
+                side_effect_record(
+                    effect_class="publication",
+                    operation="repo.merge_pr",
+                    workflow_state_accepted=False,
+                )
+            ],
+        },
     )
+    payload = manifest.model_dump(by_alias=True, mode="json")
 
     assert payload["workspace"]["policy"] == "continue_from_previous_execution"
     assert payload["workspace"]["gitEffect"]["disposition"] == "candidate"


### PR DESCRIPTION
Jira issue key: MM-705

Summary:
- Consolidates Step Execution manifest creation into the canonical typed writer path.
- Removes the legacy `build_step_execution_manifest_payload` production path and routes manifest writes through `StepExecutionManifestModel`.
- Updates conformance/docs cleanup tests and the temporary checkpointing gap plan to reflect that the duplicate manifest writer gap is closed.

Tests run:
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_step_executions.py tests/unit/docs/test_final_docs_cleanup_policy.py tests/integration/docs/test_final_docs_cleanup_contract.py` (24 passed)

Remaining risks:
- The assessment still records MM-705 as partially implemented overall: checkpoint-backed recovery defaults, retrieval-backed context injection, remediation panels, and broader universal Step Execution consumer coverage remain future work.
- The branch push retry in this publication step hit a local Git credential-helper import error, but the branch was already present on `origin/mm-705-a8d13dcb` and `gh` authentication is available for PR creation.
