### PR TITLE
MM-838 expand PentestGPT findings normalizer

### DIFF
--- a/docker/pentestgpt-runner/moonmind-pentestgpt-run
+++ b/docker/pentestgpt-runner/moonmind-pentestgpt-run
@@ -399,10 +399,6 @@ MD
 ARTIFACT_WRITE_RC=0
 tar -C "$PENTEST_ROOT" --zstd -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
 if [[ "$ARTIFACT_WRITE_RC" -ne 0 ]]; then
-  ARTIFACT_WRITE_RC=0
-  tar -C "$PENTEST_ROOT" -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
-fi
-if [[ "$ARTIFACT_WRITE_RC" -ne 0 ]]; then
   echo "evidence bundle artifact write failed with code $ARTIFACT_WRITE_RC" | redact >> "$STDERR_FILE"
   EXIT_CODE="$EXIT_ARTIFACT_WRITE"
 fi

--- a/docker/pentestgpt-runner/moonmind-pentestgpt-run
+++ b/docker/pentestgpt-runner/moonmind-pentestgpt-run
@@ -2,6 +2,16 @@
 set -Eeuo pipefail
 
 VERSION="moonmind-pentestgpt-runner 1.0"
+RUNNER_CONTRACT_V=1
+EXIT_CONFIG_INPUT=10
+EXIT_ARGS=20
+EXIT_MISSING_EXECUTABLE=30
+EXIT_AUTH=31
+EXIT_QUOTA=32
+EXIT_UPSTREAM_RUNTIME=33
+EXIT_NORMALIZATION=34
+EXIT_ARTIFACT_WRITE=35
+EXIT_TIMEOUT_CANCELLATION=36
 
 redact() {
   sed -E 's/([A-Za-z0-9_-]*(token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])[[:space:]]*[^[:space:],;]+/\1[REDACTED]/Ig'
@@ -21,6 +31,31 @@ path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="
 PY
 }
 
+classify_exit_code() {
+  local code="$1"
+  local norm_status="${2:-}"
+  case "$code" in
+    0) echo "success" ;;
+    "$EXIT_CONFIG_INPUT") echo "config_input" ;;
+    "$EXIT_ARGS") echo "args" ;;
+    "$EXIT_MISSING_EXECUTABLE") echo "missing_executable" ;;
+    "$EXIT_AUTH") echo "auth" ;;
+    "$EXIT_QUOTA") echo "quota" ;;
+    "$EXIT_UPSTREAM_RUNTIME") echo "upstream_runtime" ;;
+    "$EXIT_NORMALIZATION") echo "normalization" ;;
+    "$EXIT_ARTIFACT_WRITE") echo "artifact_write" ;;
+    "$EXIT_TIMEOUT_CANCELLATION"|124|130|143) echo "timeout_cancellation" ;;
+    *)
+      case "$norm_status" in
+        provider_failed) echo "auth" ;;
+        normalizer_error) echo "normalization" ;;
+        runner_failed) echo "upstream_runtime" ;;
+        *) echo "upstream_runtime" ;;
+      esac
+      ;;
+  esac
+}
+
 usage() {
   cat <<'USAGE'
 moonmind-pentestgpt-run [--target TARGET] [--instruction-file PATH] [--non-interactive] [--no-telemetry] [--version] [--self-test] [--check-upstream]
@@ -28,17 +63,12 @@ USAGE
 }
 
 # Verify the runner image contract: telemetry default, wrapper redaction, and
-# the installed upstream PentestGPT CLI. Distinct exit codes let CI classify
-# upstream-CLI breakage separately from wrapper or configuration failures:
-#   30 = upstream CLI missing
-#   31 = upstream CLI contract probe failed
-#   32 = telemetry default invariant failed
-#   33 = redaction invariant failed
+# the installed upstream PentestGPT CLI.
 check_upstream() {
   # Telemetry must default to disabled before any upstream probing.
   if [[ "${LANGFUSE_ENABLED:-false}" != "false" ]]; then
     echo "LANGFUSE_ENABLED must default to false in the runner image" >&2
-    return 32
+    return "$EXIT_CONFIG_INPUT"
   fi
 
   # Wrapper redaction must drop secret-like values and emit a [REDACTED] marker.
@@ -47,16 +77,16 @@ check_upstream() {
   redacted="$(printf '%s\n' "$sample" | redact)"
   if printf '%s' "$redacted" | grep -Eq "supersecretvalue|anothersecret"; then
     echo "wrapper redaction failed on sample secret" >&2
-    return 33
+    return "$EXIT_CONFIG_INPUT"
   fi
   if ! printf '%s' "$redacted" | grep -q "\[REDACTED\]"; then
     echo "wrapper redaction did not emit [REDACTED]" >&2
-    return 33
+    return "$EXIT_CONFIG_INPUT"
   fi
 
   if ! command -v pentestgpt >/dev/null 2>&1; then
     echo "upstream pentestgpt executable not found" >&2
-    return 30
+    return "$EXIT_MISSING_EXECUTABLE"
   fi
 
   # Probe the CLI contract via --help, falling back to --version when an
@@ -64,7 +94,7 @@ check_upstream() {
   if ! pentestgpt --help >/tmp/moonmind-pentestgpt-upstream-help.out 2>&1; then
     if ! pentestgpt --version >/tmp/moonmind-pentestgpt-upstream-version.out 2>&1; then
       echo "upstream pentestgpt CLI failed contract probe" | redact >&2
-      return 31
+      return "$EXIT_UPSTREAM_RUNTIME"
     fi
   fi
 
@@ -117,7 +147,7 @@ while [[ $# -gt 0 ]]; do
     *)
       echo "unknown argument: $1" >&2
       usage >&2
-      exit 20
+      exit "$EXIT_ARGS"
       ;;
   esac
 done
@@ -136,22 +166,42 @@ if [[ "$SELF_TEST" == "1" ]]; then
   test -s "$TMP_ROOT/pentest/findings/findings.report.md"
   test -s "$TMP_ROOT/pentest/findings/findings.summary.md"
   test -s "$TMP_ROOT/pentest/findings/findings.normalizer-input.json"
+  test -s "$TMP_ROOT/pentest/runtime/diagnostics.json"
   test -f "$TMP_ROOT/pentest/evidence/bundle.tar.zst"
+  python - "$TMP_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+findings = json.loads((root / "pentest/findings/findings.normalizer-input.json").read_text(encoding="utf-8"))
+diagnostics = json.loads((root / "pentest/runtime/diagnostics.json").read_text(encoding="utf-8"))
+report_text = (root / "pentest/findings/findings.report.md").read_text(encoding="utf-8")
+summary_text = (root / "pentest/findings/findings.summary.md").read_text(encoding="utf-8")
+assert diagnostics["runner_contract_v"] == 1
+assert diagnostics["failure_category"] == "success"
+assert "provider_error" in diagnostics
+assert findings["summary"]["findings_count"] >= 1
+assert any(item["confidence"] in {"supported", "confirmed"} for item in findings["findings"])
+assert "selftest-secret" not in json.dumps(findings)
+assert "selftest-secret" not in report_text
+assert "selftest-secret" not in summary_text
+PY
   echo "self-test ok"
   exit 0
 fi
 
 if [[ -z "$TARGET" ]]; then
   echo "MM_PENTEST_TARGET or --target is required" >&2
-  exit 10
+  exit "$EXIT_CONFIG_INPUT"
 fi
 if [[ -z "$INSTRUCTION_FILE" ]]; then
   echo "MM_PENTEST_INSTRUCTION_FILE or --instruction-file is required" >&2
-  exit 10
+  exit "$EXIT_CONFIG_INPUT"
 fi
 if [[ ! -r "$INSTRUCTION_FILE" ]]; then
   echo "instruction file is not readable: $INSTRUCTION_FILE" >&2
-  exit 10
+  exit "$EXIT_CONFIG_INPUT"
 fi
 
 PENTEST_ROOT="$(cd "$(dirname "$INSTRUCTION_FILE")/.." && pwd)"
@@ -213,18 +263,18 @@ PY
   rm -f "$RAW_STDOUT_FILE" "$RAW_STDERR_FILE"
 else
   echo "pentestgpt executable not found in runner image" | redact >> "$STDERR_FILE"
-  UPSTREAM_EXIT_CODE=21
+  UPSTREAM_EXIT_CODE="$EXIT_MISSING_EXECUTABLE"
 fi
 
 if [[ "$UPSTREAM_EXIT_CODE" -ne 0 ]]; then
   EXIT_CODE="$UPSTREAM_EXIT_CODE"
 fi
 
-json_write "$RAW_EVIDENCE_FILE" "$(python - "$TARGET" "$MODE" "$LANGFUSE_ENABLED" "$UPSTREAM_EXIT_CODE" <<'PY'
+json_write "$RAW_EVIDENCE_FILE" "$(python - "$TARGET" "$MODE" "$LANGFUSE_ENABLED" "$UPSTREAM_EXIT_CODE" "${MM_PENTEST_SKIP_UPSTREAM:-0}" <<'PY'
 import json
 import sys
 
-print(json.dumps({
+payload = {
     "target": sys.argv[1],
     "operation_mode": sys.argv[2],
     "non_interactive": True,
@@ -234,7 +284,20 @@ print(json.dumps({
         {"type": "runner_started", "message": "MoonMind wrapper initialized."},
         {"type": "upstream_completed", "exit_code": int(sys.argv[4])},
     ],
-}))
+}
+if sys.argv[5] == "1":
+    payload["findings"] = [
+        {
+            "title": "Self-test deterministic supported finding",
+            "severity": "low",
+            "confidence": "supported",
+            "target": sys.argv[1],
+            "summary": "Deterministic fake finding with api_key=selftest-secret for redaction validation.",
+            "remediation": "Rotate password=selftest-secret and verify the fake issue remains non-production.",
+            "references": ["MM-838-self-test"],
+        }
+    ]
+print(json.dumps(payload))
 PY
 )"
 
@@ -246,7 +309,7 @@ python /usr/local/lib/moonmind-pentestgpt/normalize_findings.py \
   --output "$STRUCTURED_FILE" 2> >(redact >> "$STDERR_FILE") || NORMALIZER_RC=$?
 if [[ "$NORMALIZER_RC" -ne 0 ]]; then
   echo "normalize_findings.py failed with code $NORMALIZER_RC" | redact >> "$STDERR_FILE"
-  EXIT_CODE="$NORMALIZER_RC"
+  EXIT_CODE="$EXIT_NORMALIZATION"
 fi
 
 # Derive an honest, status-aware summary/report from the normalized findings so
@@ -333,30 +396,67 @@ The runner produced the schema-valid normalized findings artifact at \`$STRUCTUR
 Supporting evidence is available in the report evidence bundle and raw runtime artifacts.
 MD
 
-tar -C "$PENTEST_ROOT" --zstd -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || true
+ARTIFACT_WRITE_RC=0
+tar -C "$PENTEST_ROOT" --zstd -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
+if [[ "$ARTIFACT_WRITE_RC" -ne 0 ]]; then
+  ARTIFACT_WRITE_RC=0
+  tar -C "$PENTEST_ROOT" -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
+fi
+if [[ "$ARTIFACT_WRITE_RC" -ne 0 ]]; then
+  echo "evidence bundle artifact write failed with code $ARTIFACT_WRITE_RC" | redact >> "$STDERR_FILE"
+  EXIT_CODE="$EXIT_ARTIFACT_WRITE"
+fi
 
 COMPLETED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-json_write "$DIAGNOSTICS_FILE" "$(python - "$VERSION" "$TARGET" "$MODE" "$STARTED_AT" "$COMPLETED_AT" "$EXIT_CODE" "$LANGFUSE_ENABLED" "$STDOUT_FILE" "$STDERR_FILE" "$DIAGNOSTICS_FILE" "$REPORT_FILE" "$SUMMARY_FILE" "$STRUCTURED_FILE" "$EVIDENCE_BUNDLE" <<'PY'
+FAILURE_CATEGORY="$(classify_exit_code "$EXIT_CODE" "$NORM_STATUS")"
+PROVIDER_ERROR_JSON="$(python - "$STDOUT_FILE" "$STDERR_FILE" "$FAILURE_CATEGORY" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+text = ""
+for path in sys.argv[1:3]:
+    try:
+        text += "\n" + Path(path).read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+category = sys.argv[3]
+provider_error = None
+if category in {"auth", "quota"}:
+    code = "401" if category == "auth" else "429"
+    provider_error = {"code": code, "message": category}
+elif re.search(r"\b(401|unauthori[sz]ed|authentication|invalid api key)\b", text, re.I):
+    provider_error = {"code": "401", "message": "auth"}
+elif re.search(r"\b(429|rate limit|quota|capacity)\b", text, re.I):
+    provider_error = {"code": "429", "message": "quota"}
+print(json.dumps(provider_error))
+PY
+)"
+json_write "$DIAGNOSTICS_FILE" "$(python - "$RUNNER_CONTRACT_V" "$VERSION" "$TARGET" "$MODE" "$STARTED_AT" "$COMPLETED_AT" "$EXIT_CODE" "$FAILURE_CATEGORY" "$PROVIDER_ERROR_JSON" "$LANGFUSE_ENABLED" "$STDOUT_FILE" "$STDERR_FILE" "$DIAGNOSTICS_FILE" "$REPORT_FILE" "$SUMMARY_FILE" "$STRUCTURED_FILE" "$EVIDENCE_BUNDLE" <<'PY'
 import json
 import sys
 
 print(json.dumps({
+    "runner_contract_v": int(sys.argv[1]),
     "runner": "moonmind-pentestgpt-run",
-    "version": sys.argv[1],
-    "target": sys.argv[2],
-    "operation_mode": sys.argv[3],
-    "started_at": sys.argv[4],
-    "completed_at": sys.argv[5],
-    "exit_code": int(sys.argv[6]),
-    "telemetry_enabled": sys.argv[7],
+    "version": sys.argv[2],
+    "target": sys.argv[3],
+    "operation_mode": sys.argv[4],
+    "started_at": sys.argv[5],
+    "completed_at": sys.argv[6],
+    "exit_code": int(sys.argv[7]),
+    "failure_category": sys.argv[8],
+    "provider_error": json.loads(sys.argv[9]),
+    "telemetry_enabled": sys.argv[10],
     "artifacts": {
-        "runtime.stdout": sys.argv[8],
-        "runtime.stderr": sys.argv[9],
-        "runtime.diagnostics": sys.argv[10],
-        "report.primary": sys.argv[11],
-        "report.summary": sys.argv[12],
-        "report.structured": sys.argv[13],
-        "report.evidence": sys.argv[14],
+        "runtime.stdout": sys.argv[11],
+        "runtime.stderr": sys.argv[12],
+        "runtime.diagnostics": sys.argv[13],
+        "report.primary": sys.argv[14],
+        "report.summary": sys.argv[15],
+        "report.structured": sys.argv[16],
+        "report.evidence": sys.argv[17],
     },
 }))
 PY

--- a/docker/pentestgpt-runner/normalize_findings.py
+++ b/docker/pentestgpt-runner/normalize_findings.py
@@ -94,13 +94,17 @@ def _slug(value: str) -> str:
     return slug[:48] or "finding"
 
 
-def _stable_finding_id(record: dict[str, Any], *, target: str) -> str:
-    material = "|".join(
-        str(record.get(key) or "")
-        for key in ("title", "summary", "severity", "target", "category")
-    )
-    digest = hashlib.sha256(f"{target}|{material}".encode("utf-8")).hexdigest()[:12]
-    return f"finding-{_slug(str(record.get('title') or 'pentestgpt'))}-{digest}"
+def _stable_finding_id(
+    *,
+    title: str,
+    summary: str,
+    severity: str,
+    target: str,
+    category: str,
+) -> str:
+    material = f"{title}|{summary}|{severity}|{target}|{category}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+    return f"finding-{_slug(title or 'pentestgpt')}-{digest}"
 
 
 def _as_string_list(value: Any) -> list[str]:
@@ -122,10 +126,17 @@ def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | Non
     summary = _redact_text(record.get("summary") or record.get("description") or title)
     if not title and summary:
         title = summary.splitlines()[0][:96].strip()
+    severity = _normalize_severity(record.get("severity"))
+    category = _redact_text(record.get("category") or "")
     finding_id = _redact_text(record.get("finding_id") or record.get("id") or "").strip()
     if not finding_id and (title or summary):
-        finding_id = _stable_finding_id({**record, "title": title, "summary": summary}, target=finding_target)
-    severity = _normalize_severity(record.get("severity"))
+        finding_id = _stable_finding_id(
+            title=title,
+            summary=summary,
+            severity=severity,
+            target=finding_target,
+            category=category,
+        )
     if not finding_id:
         return None, "finding_id is required"
     if not title:
@@ -150,7 +161,9 @@ def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | Non
         or _as_string_list(record.get("references"))
         or _as_string_list(record.get("reference")),
     }
-    for optional in ("category", "impact", "reproduction_artifact_ref"):
+    if category:
+        normalized["category"] = category
+    for optional in ("impact", "reproduction_artifact_ref"):
         if record.get(optional):
             normalized[optional] = _redact_text(record[optional])
     return normalized, None
@@ -199,6 +212,8 @@ def _collect_raw_records(raw: dict[str, Any]) -> tuple[list[Any], bool]:
         records.extend(direct)
         machine_readable = True
     for key in ("export", "result", "results", "report", "output"):
+        if key in {"results"} and raw.get(key) is direct:
+            continue
         nested = raw.get(key)
         if isinstance(nested, dict) and any(
             list_key in nested
@@ -211,12 +226,12 @@ def _collect_raw_records(raw: dict[str, Any]) -> tuple[list[Any], bool]:
             machine_readable = True
     events = raw.get("events")
     if isinstance(events, list):
-        machine_readable = True
         for event in events:
             if isinstance(event, dict):
                 finding = _event_to_finding(event)
                 if finding is not None:
                     records.append(finding)
+                    machine_readable = True
     text_parts = [
         raw.get(key)
         for key in ("markdown", "report_markdown", "report_text", "stdout", "stderr", "text", "plain_text")

--- a/docker/pentestgpt-runner/normalize_findings.py
+++ b/docker/pentestgpt-runner/normalize_findings.py
@@ -19,19 +19,97 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
+import hashlib
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 _VALID_SEVERITIES = {"info", "low", "medium", "high", "critical"}
 _VALID_CONFIDENCES = {"suspected", "supported", "confirmed"}
+_SECRET_RE = re.compile(
+    r"([A-Za-z0-9_-]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])\s*[^\s,;`]+",
+    re.IGNORECASE,
+)
+_HEADING_RE = re.compile(r"^\s{0,3}(?:#{1,6}\s*)?(?P<name>[A-Za-z][A-Za-z0-9 /_-]{1,80})\s*:?\s*$")
+_FIELD_RE = re.compile(r"^\s{0,3}(?:[-*]\s*)?(?P<name>[A-Za-z][A-Za-z0-9 /_-]{1,40})\s*:\s*(?P<value>.+?)\s*$")
+_FINDING_HEADINGS = {
+    "finding",
+    "findings",
+    "vulnerability",
+    "vulnerabilities",
+    "issue",
+    "issues",
+    "pentestgpt finding",
+    "pentestgpt findings",
+}
+_SECTION_FIELDS = {
+    "severity",
+    "confidence",
+    "target",
+    "affected target",
+    "affected_target",
+    "summary",
+    "description",
+    "impact",
+    "remediation",
+    "recommendation",
+    "references",
+    "reference",
+    "evidence",
+    "category",
+    "title",
+    "finding",
+    "vulnerability",
+}
+
+
+def _redact_text(value: Any) -> str:
+    return _SECRET_RE.sub(r"\1[REDACTED]", str(value or "").strip())
 
 
 def _normalize_confidence(value: Any) -> str:
     normalized = str(value or "").strip().lower()
     if normalized in _VALID_CONFIDENCES and normalized != "suspected":
         return normalized
+    if normalized in {"verified", "exploited", "reproduced"}:
+        return "confirmed"
+    if normalized in {"evidence", "observed", "likely", "validated", "supported"}:
+        return "supported"
     return "suspected"
+
+
+def _normalize_severity(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    aliases = {
+        "informational": "info",
+        "moderate": "medium",
+        "severe": "high",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:48] or "finding"
+
+
+def _stable_finding_id(record: dict[str, Any], *, target: str) -> str:
+    material = "|".join(
+        str(record.get(key) or "")
+        for key in ("title", "summary", "severity", "target", "category")
+    )
+    digest = hashlib.sha256(f"{target}|{material}".encode("utf-8")).hexdigest()[:12]
+    return f"finding-{_slug(str(record.get('title') or 'pentestgpt'))}-{digest}"
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, list):
+        return [_redact_text(item) for item in value if str(item).strip()]
+    text = _redact_text(value)
+    return [item.strip() for item in re.split(r"[,;\n]+", text) if item.strip()]
 
 
 def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | None, str | None]:
@@ -40,10 +118,14 @@ def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | Non
     if not isinstance(record, dict):
         return None, "record must be an object"
     finding_target = str(record.get("target") or "").strip() or target
-    finding_id = str(record.get("finding_id") or "").strip()
-    title = str(record.get("title") or "").strip()
-    summary = str(record.get("summary") or "").strip()
-    severity = str(record.get("severity") or "").strip().lower()
+    title = _redact_text(record.get("title") or record.get("finding") or record.get("vulnerability"))
+    summary = _redact_text(record.get("summary") or record.get("description") or title)
+    if not title and summary:
+        title = summary.splitlines()[0][:96].strip()
+    finding_id = _redact_text(record.get("finding_id") or record.get("id") or "").strip()
+    if not finding_id and (title or summary):
+        finding_id = _stable_finding_id({**record, "title": title, "summary": summary}, target=finding_target)
+    severity = _normalize_severity(record.get("severity"))
     if not finding_id:
         return None, "finding_id is required"
     if not title:
@@ -59,15 +141,194 @@ def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | Non
         "confidence": _normalize_confidence(record.get("confidence")),
         "target": finding_target,
         "summary": summary or "No finding summary provided.",
+        "remediation": _redact_text(record.get("remediation") or record.get("recommendation") or "Review the supporting evidence and validate with an authorized remediation owner."),
+        "evidence_artifact_refs": _as_string_list(record.get("evidence_artifact_refs"))
+        or _as_string_list(record.get("evidence_refs"))
+        or _as_string_list(record.get("evidence"))
+        or [],
+        "related_ids": _as_string_list(record.get("related_ids"))
+        or _as_string_list(record.get("references"))
+        or _as_string_list(record.get("reference")),
     }
-    for optional in ("category", "impact", "remediation", "reproduction_artifact_ref"):
+    for optional in ("category", "impact", "reproduction_artifact_ref"):
         if record.get(optional):
-            normalized[optional] = str(record[optional])
-    for seq in ("evidence_artifact_refs", "related_ids"):
-        value = record.get(seq)
-        if isinstance(value, list):
-            normalized[seq] = [str(item) for item in value if str(item).strip()]
+            normalized[optional] = _redact_text(record[optional])
     return normalized, None
+
+
+def _records_from_container(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        for key in ("findings", "vulnerabilities", "issues", "results", "alerts"):
+            nested = value.get(key)
+            if isinstance(nested, list):
+                return nested
+    return []
+
+
+def _event_to_finding(event: dict[str, Any]) -> dict[str, Any] | None:
+    event_type = str(event.get("type") or event.get("event") or "").strip().lower()
+    payload = event.get("finding") or event.get("vulnerability") or event.get("payload") or event.get("data")
+    if isinstance(payload, dict):
+        if event_type and not payload.get("category"):
+            payload = {**payload, "category": event_type}
+        return payload
+    if event_type in {"finding", "finding_detected", "vulnerability", "issue"}:
+        message = event.get("message") or event.get("summary") or event.get("text")
+        if message:
+            return {
+                "title": str(event.get("title") or "PentestGPT event finding"),
+                "summary": message,
+                "severity": event.get("severity") or "info",
+                "confidence": event.get("confidence") or "suspected",
+                "target": event.get("target"),
+                "remediation": event.get("remediation"),
+                "references": event.get("references"),
+                "evidence": event.get("evidence") or event.get("evidence_artifact_refs"),
+                "category": event_type,
+            }
+    return None
+
+
+def _collect_raw_records(raw: dict[str, Any]) -> tuple[list[Any], bool]:
+    records: list[Any] = []
+    machine_readable = "findings" in raw
+    direct = _records_from_container(raw)
+    if direct:
+        records.extend(direct)
+        machine_readable = True
+    for key in ("export", "result", "results", "report", "output"):
+        nested = raw.get(key)
+        if isinstance(nested, dict) and any(
+            list_key in nested
+            for list_key in ("findings", "vulnerabilities", "issues", "results", "alerts")
+        ):
+            machine_readable = True
+        nested_records = _records_from_container(nested)
+        if nested_records:
+            records.extend(nested_records)
+            machine_readable = True
+    events = raw.get("events")
+    if isinstance(events, list):
+        machine_readable = True
+        for event in events:
+            if isinstance(event, dict):
+                finding = _event_to_finding(event)
+                if finding is not None:
+                    records.append(finding)
+    text_parts = [
+        raw.get(key)
+        for key in ("markdown", "report_markdown", "report_text", "stdout", "stderr", "text", "plain_text")
+        if isinstance(raw.get(key), str)
+    ]
+    for text in text_parts:
+        records.extend(_parse_text_findings(text))
+    return records, machine_readable or bool(text_parts)
+
+
+def _commit_text_record(records: list[dict[str, Any]], record: dict[str, Any]) -> None:
+    if record and (record.get("title") or record.get("summary")):
+        record.setdefault("severity", "info")
+        records.append(record)
+
+
+def _parse_text_findings(text: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    active_field: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            active_field = None
+            continue
+        heading = _HEADING_RE.match(stripped)
+        heading_name = heading.group("name").strip().lower() if heading else ""
+        if heading_name in _FINDING_HEADINGS or heading_name.startswith("finding "):
+            if heading_name in {"findings", "vulnerabilities", "issues", "pentestgpt findings"}:
+                active_field = None
+                continue
+            _commit_text_record(records, current)
+            title = re.sub(r"^(finding|vulnerability|issue)\s*[:#-]*\s*", "", stripped, flags=re.I).strip("#: -")
+            current = {"title": title or "PentestGPT finding"}
+            active_field = "summary"
+            continue
+        content = re.sub(r"^\s{0,3}#{1,6}\s*", "", stripped)
+        field = _FIELD_RE.match(content)
+        if field:
+            name = field.group("name").strip().lower().replace(" ", "_").replace("-", "_")
+            value = field.group("value").strip()
+            if name in {"finding", "vulnerability", "issue", "title"}:
+                _commit_text_record(records, current)
+                current = {"title": value}
+                active_field = "summary"
+                continue
+            if name in _SECTION_FIELDS or name.replace("_", " ") in _SECTION_FIELDS:
+                mapped = {
+                    "affected_target": "target",
+                    "description": "summary",
+                    "recommendation": "remediation",
+                    "reference": "references",
+                }.get(name, name)
+                current[mapped] = value
+                active_field = mapped
+                continue
+        if heading_name in _SECTION_FIELDS:
+            active_field = {
+                "affected target": "target",
+                "description": "summary",
+                "recommendation": "remediation",
+                "reference": "references",
+            }.get(heading_name, heading_name)
+            current.setdefault(active_field, "")
+            continue
+        if not current:
+            current = {"title": "PentestGPT text finding", "summary": stripped}
+            active_field = "summary"
+        elif active_field:
+            previous = str(current.get(active_field) or "").strip()
+            current[active_field] = f"{previous}\n{stripped}".strip()
+        else:
+            previous = str(current.get("summary") or "").strip()
+            current["summary"] = f"{previous}\n{stripped}".strip()
+            active_field = "summary"
+    _commit_text_record(records, current)
+    return records
+
+
+def _provider_error(raw: dict[str, Any]) -> dict[str, Any] | None:
+    candidate = raw.get("provider_error")
+    if isinstance(candidate, dict):
+        code = _redact_text(candidate.get("code") or candidate.get("error_code") or "")
+        message = _redact_text(candidate.get("message") or candidate.get("summary") or "")
+    else:
+        code = _redact_text(raw.get("provider_error_code") or "")
+        message = _redact_text(raw.get("provider_error_message") or raw.get("error") or "")
+    if not code and not message:
+        return None
+    return {"code": code or "provider_error", "message": message}
+
+
+def _load_input(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    events: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except Exception:
+            return {"report_text": text}
+        if isinstance(event, dict):
+            events.append(event)
+    if events:
+        return {"events": events}
+    return {"report_text": text}
 
 
 def normalize_evidence(
@@ -89,23 +350,25 @@ def normalize_evidence(
     except (TypeError, ValueError):
         upstream_exit_code = None
 
-    raw_findings = raw.get("findings")
-    findings_key_present = "findings" in raw
-    findings_is_list = isinstance(raw_findings, list)
+    raw_records, parsed_input_present = _collect_raw_records(raw)
+    provider_error = _provider_error(raw)
 
     valid: list[dict[str, Any]] = []
     quarantined: list[dict[str, Any]] = []
-    if findings_is_list:
-        for index, record in enumerate(raw_findings):
-            finding, reason = _validate_finding(record, target=target)
-            if finding is not None:
-                valid.append(finding)
-            else:
-                quarantined.append({"index": index, "reason": reason})
+    for index, record in enumerate(raw_records):
+        finding, reason = _validate_finding(record, target=target)
+        if finding is not None:
+            if not finding["evidence_artifact_refs"]:
+                finding["evidence_artifact_refs"] = [evidence_ref]
+            valid.append(finding)
+        else:
+            quarantined.append({"index": index, "reason": reason})
 
-    if upstream_exit_code not in (None, 0):
+    if provider_error is not None:
+        status = "provider_failed"
+    elif upstream_exit_code not in (None, 0):
         status = "upstream_failed"
-    elif not findings_key_present or not findings_is_list:
+    elif not parsed_input_present:
         status = "no_machine_readable_findings"
     elif valid:
         status = "ok"
@@ -136,6 +399,7 @@ def normalize_evidence(
         "normalization_status": status,
         "quarantined_findings_count": len(quarantined),
         "evidence_refs": [evidence_ref],
+        "provider_error": provider_error,
     }
 
 
@@ -151,7 +415,7 @@ def main() -> int:
     output_path = Path(args.output)
     evidence_ref = f"file:{input_path}"
     try:
-        raw = json.loads(input_path.read_text(encoding="utf-8"))
+        raw = _load_input(input_path)
     except Exception:
         raw = {}
 

--- a/tests/unit/integrations/pentest/test_runner_normalize_findings.py
+++ b/tests/unit/integrations/pentest/test_runner_normalize_findings.py
@@ -10,6 +10,7 @@ clean result on failure.
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -64,8 +65,13 @@ def test_empty_is_completed_no_findings():
     assert out["normalization_status"] == "completed_no_findings"
 
 
-def test_missing_findings_key_no_machine_readable():
+def test_empty_events_are_completed_no_findings():
     out = _norm({"events": []})
+    assert out["normalization_status"] == "completed_no_findings"
+
+
+def test_missing_machine_readable_sources_no_machine_readable():
+    out = _norm({"metadata": {"run": "r-1"}})
     assert out["normalization_status"] == "no_machine_readable_findings"
 
 
@@ -85,3 +91,158 @@ def test_target_backfilled_when_missing():
     out = _norm({"findings": [record]})
     assert out["summary"]["findings_count"] == 1
     assert out["findings"][0]["target"] == "https://lab.example.test"
+
+
+def test_structured_json_vulnerability_export_normalized_with_stable_fields():
+    out = _norm(
+        {
+            "result": {
+                "vulnerabilities": [
+                    {
+                        "title": "Debug endpoint exposed",
+                        "severity": "medium",
+                        "confidence": "supported",
+                        "description": "The debug endpoint returned stack metadata.",
+                        "affected_target": "https://lab.example.test/debug",
+                        "recommendation": "Disable debug routes in production.",
+                        "references": ["CWE-215"],
+                    }
+                ]
+            }
+        }
+    )
+
+    finding = out["findings"][0]
+    assert out["normalization_status"] == "ok"
+    assert finding["finding_id"].startswith("finding-debug-endpoint-exposed-")
+    assert finding["confidence"] == "supported"
+    assert finding["summary"] == "The debug endpoint returned stack metadata."
+    assert finding["remediation"] == "Disable debug routes in production."
+    assert finding["related_ids"] == ["CWE-215"]
+    assert finding["evidence_artifact_refs"] == ["file:/tmp/evidence.json"]
+
+
+def test_event_json_finding_payload_normalized():
+    out = _norm(
+        {
+            "events": [
+                {"type": "runner_started", "message": "start"},
+                {
+                    "type": "finding_detected",
+                    "finding": {
+                        "title": "Weak TLS version accepted",
+                        "severity": "high",
+                        "confidence": "confirmed",
+                        "summary": "TLS 1.0 handshake succeeded.",
+                        "evidence": ["artifact://tls-log"],
+                    },
+                },
+            ]
+        }
+    )
+
+    assert out["summary"]["findings_count"] == 1
+    assert out["summary"]["confirmed_findings_count"] == 1
+    assert out["findings"][0]["confidence"] == "confirmed"
+    assert out["findings"][0]["evidence_artifact_refs"] == ["artifact://tls-log"]
+
+
+def test_line_delimited_event_json_is_loaded(tmp_path: Path):
+    input_path = tmp_path / "events.jsonl"
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "runner_started", "message": "start"}),
+                json.dumps(
+                    {
+                        "type": "finding",
+                        "message": "Directory listing exposed.",
+                        "severity": "low",
+                        "confidence": "supported",
+                        "target": "https://lab.example.test/files",
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    raw = normalize_findings._load_input(input_path)
+    out = _norm(raw)
+
+    assert out["normalization_status"] == "ok"
+    assert out["findings"][0]["summary"] == "Directory listing exposed."
+    assert out["findings"][0]["confidence"] == "supported"
+
+
+def test_markdown_plaintext_and_pentestgpt_headings_parse_as_suspected_by_default():
+    out = _norm(
+        {
+            "report_markdown": """
+## PentestGPT Findings
+
+### Vulnerability: Reflected parameter appears unsafe
+Severity: High
+Affected Target: https://lab.example.test/search?q=x
+Summary: The response reflected input without clear encoding.
+Remediation: Validate output encoding before reporting this as exploitable.
+References: CWE-79, OWASP-A03
+"""
+        }
+    )
+
+    finding = out["findings"][0]
+    assert finding["title"] == "Reflected parameter appears unsafe"
+    assert finding["severity"] == "high"
+    assert finding["confidence"] == "suspected"
+    assert finding["target"] == "https://lab.example.test/search?q=x"
+    assert finding["related_ids"] == ["CWE-79", "OWASP-A03"]
+
+
+def test_fallback_wrapper_text_finding_is_not_confirmed():
+    out = _norm(
+        {
+            "stdout": "Possible issue: admin panel discovered\nSeverity: info\nEvidence: artifact://stdout"
+        }
+    )
+
+    assert out["normalization_status"] == "ok"
+    assert out["findings"][0]["confidence"] == "suspected"
+    assert out["findings"][0]["evidence_artifact_refs"] == ["artifact://stdout"]
+
+
+def test_provider_error_classifies_provider_failed_without_clean_result():
+    out = _norm(
+        {
+            "provider_error": {
+                "code": "429",
+                "message": "quota exhausted for api_key=secret-value",
+            }
+        }
+    )
+
+    assert out["normalization_status"] == "provider_failed"
+    assert out["summary"]["findings_count"] == 0
+    assert out["provider_error"] == {
+        "code": "429",
+        "message": "quota exhausted for api_key=[REDACTED]",
+    }
+
+
+def test_secret_like_human_fields_are_redacted():
+    out = _norm(
+        {
+            "findings": [
+                dict(
+                    _valid(),
+                    summary="Token leaked: token=super-secret",
+                    remediation="Rotate password=another-secret",
+                )
+            ]
+        }
+    )
+
+    dumped = json.dumps(out)
+    assert "super-secret" not in dumped
+    assert "another-secret" not in dumped
+    assert "token=[REDACTED]" in dumped

--- a/tests/unit/integrations/pentest/test_runner_normalize_findings.py
+++ b/tests/unit/integrations/pentest/test_runner_normalize_findings.py
@@ -67,7 +67,21 @@ def test_empty_is_completed_no_findings():
 
 def test_empty_events_are_completed_no_findings():
     out = _norm({"events": []})
-    assert out["normalization_status"] == "completed_no_findings"
+    assert out["normalization_status"] == "no_machine_readable_findings"
+
+
+def test_lifecycle_only_events_are_no_machine_readable_findings():
+    out = _norm(
+        {
+            "events": [
+                {"type": "runner_started", "message": "start"},
+                {"type": "upstream_completed", "exit_code": 0},
+            ],
+            "upstream_exit_code": 0,
+        }
+    )
+
+    assert out["normalization_status"] == "no_machine_readable_findings"
 
 
 def test_missing_machine_readable_sources_no_machine_readable():
@@ -91,6 +105,55 @@ def test_target_backfilled_when_missing():
     out = _norm({"findings": [record]})
     assert out["summary"]["findings_count"] == 1
     assert out["findings"][0]["target"] == "https://lab.example.test"
+
+
+def test_stable_finding_id_uses_normalized_fields():
+    first = _norm(
+        {
+            "findings": [
+                {
+                    "title": "Debug endpoint exposed",
+                    "severity": "HIGH",
+                    "summary": "Stack metadata leaked.",
+                    "category": " web ",
+                }
+            ]
+        },
+        target="https://lab.example.test",
+    )
+    second = _norm(
+        {
+            "findings": [
+                {
+                    "title": "Debug endpoint exposed",
+                    "severity": "high",
+                    "summary": "Stack metadata leaked.",
+                    "target": "https://lab.example.test",
+                    "category": "web",
+                }
+            ]
+        },
+        target="https://lab.example.test",
+    )
+
+    assert first["findings"][0]["finding_id"] == second["findings"][0]["finding_id"]
+
+
+def test_top_level_results_are_not_collected_twice():
+    out = _norm(
+        {
+            "results": [
+                {
+                    "title": "Debug endpoint exposed",
+                    "severity": "medium",
+                    "summary": "Stack metadata leaked.",
+                }
+            ]
+        }
+    )
+
+    assert out["normalization_status"] == "ok"
+    assert out["summary"]["findings_count"] == 1
 
 
 def test_structured_json_vulnerability_export_normalized_with_stable_fields():


### PR DESCRIPTION
Jira issue key: MM-838

Summary:
- Adds runner_contract_v=1 diagnostics fields, structured failure categories, provider_error reporting, and reserved wrapper exit categories for PentestGPT runner outcomes.
- Expands findings normalization to parse structured vulnerability exports, event JSON/JSONL, markdown/plaintext sections, known PentestGPT headings, fallback wrapper text, and provider-error payloads.
- Ensures normalized findings get stable ids, severity, confidence, target, remediation, references, and evidence refs while preserving suspected/supported/confirmed confidence semantics and redaction.
- Extends the runner self-test and unit fixtures for structured JSON, line-delimited events, markdown/plaintext headings, fallback wrapper findings, provider errors, and secret-like input.

Tests run:
- `pytest tests/unit/integrations/pentest/test_runner_normalize_findings.py -q --tb=short` passed: 16 passed.
- `./tools/test_unit.sh tests/unit/integrations/pentest/test_runner_normalize_findings.py` passed the targeted Python phase: 16 passed, then failed in the unrelated frontend phase with Vitest module resolution errors such as `Cannot find module /vite-config.test.ts`.
- `git diff --check origin/main...HEAD` passed.

Remaining risks:
- Full `./tools/test_unit.sh` did not complete because the frontend test phase failed before running tests due module resolution in this workspace; no frontend files were changed.
- The local repository has root-owned Git metadata from a prior step, so branch publication required a per-command GitHub CLI credential-helper override; the remote branch and PR were still created normally.