### PR TITLE
[codex] Fix Jira preset edit reconstruction

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1769,7 +1769,8 @@ def _serialize_execution(
     skill_params = (
         task_params.get("skill") if isinstance(task_params.get("skill"), dict) else {}
     )
-    target_skill = (
+    preset_primary_skill = _preset_primary_skill_name(task_params)
+    target_skill = preset_primary_skill or (
         str(
             tool_params.get("name")
             or tool_params.get("id")
@@ -1779,8 +1780,6 @@ def _serialize_execution(
         ).strip()
         or None
     )
-    if not target_skill:
-        target_skill = _preset_primary_skill_name(task_params)
     if not target_skill:
         target_skill = (
             _coerce_temporal_scalar(params.get("targetSkill"))
@@ -1900,9 +1899,8 @@ def _serialize_execution(
 
     task_skills = _skill_selector_names(task_payload.get("skills"))
     if task_skills is None:
-        template_primary_skill = _preset_primary_skill_name(task_payload)
-        if template_primary_skill:
-            task_skills = [template_primary_skill]
+        if preset_primary_skill:
+            task_skills = [preset_primary_skill]
     skill_runtime = _skill_runtime_evidence(
         params=params,
         task_payload=task_payload,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1899,8 +1899,9 @@ def _serialize_execution(
 
     task_skills = _skill_selector_names(task_payload.get("skills"))
     if task_skills is None:
-        if preset_primary_skill:
-            task_skills = [preset_primary_skill]
+        template_primary_skill = _preset_primary_skill_name(task_payload)
+        if template_primary_skill:
+            task_skills = [template_primary_skill]
     skill_runtime = _skill_runtime_evidence(
         params=params,
         task_payload=task_payload,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -13944,6 +13944,70 @@ describe("Task Create MM-578 Preset expansion", () => {
         }),
       } as Response);
     }
+    if (
+      url ===
+      "/api/executions/mm%3Acanonical-preset-edit?source=temporal"
+    ) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          workflowId: "mm:canonical-preset-edit",
+          workflowType: "MoonMind.UserWorkflow",
+          state: "executing",
+          targetRuntime: "codex_cli",
+          repository: "MoonLadderStudios/MoonMind",
+          publishMode: "pr",
+          inputParameters: {
+            targetRuntime: "codex_cli",
+            repository: "MoonLadderStudios/MoonMind",
+            workflow: {
+              instructions: "Run Jira Implement for MM-901.",
+              runtime: { mode: "codex_cli" },
+              publish: { mode: "pr" },
+              taskTemplate: {
+                slug: "jira-implement",
+                version: "1.0.0",
+              },
+              appliedStepTemplates: [
+                {
+                  slug: "jira-implement",
+                  version: "1.0.0",
+                  stepIds: [
+                    "tpl:jira-implement:1.0.0:01",
+                    "tpl:jira-implement:1.0.0:02",
+                  ],
+                },
+              ],
+              steps: [
+                {
+                  id: "tpl:jira-implement:1.0.0:01",
+                  title: "Fetch Jira issue",
+                  instructions: "Fetch MM-901.",
+                  tool: {
+                    type: "tool",
+                    id: "jira.get_issue",
+                    inputs: { issueKey: "MM-901" },
+                  },
+                },
+                {
+                  id: "tpl:jira-implement:1.0.0:02",
+                  title: "Implement preset story",
+                  instructions: "Implement MM-901.",
+                  skill: {
+                    id: "moonspec-orchestrate",
+                    args: { issueKey: "MM-901" },
+                  },
+                },
+              ],
+            },
+          },
+          actions: {
+            canUpdateInputs: true,
+            canRerun: false,
+          },
+        }),
+      } as Response);
+    }
     if (url === "/api/executions") {
       return Promise.resolve({
         ok: true,
@@ -13954,6 +14018,14 @@ describe("Task Create MM-578 Preset expansion", () => {
       return Promise.resolve({
         ok: true,
         json: async () => ({ execution: { workflowId: "mm:auto-preset-edit" } }),
+      } as Response);
+    }
+    if (url === "/api/executions/mm%3Acanonical-preset-edit/update") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          execution: { workflowId: "mm:canonical-preset-edit" },
+        }),
       } as Response);
     }
     return Promise.resolve({
@@ -14843,6 +14915,61 @@ describe("Task Create MM-578 Preset expansion", () => {
         (entry) => entry.type === "preset",
       ),
     ).toBe(false);
+  });
+
+  it("saves canonical workflow edit patches without dropping expanded preset steps", async () => {
+    window.history.pushState(
+      {},
+      "Task Edit",
+      "/workflows/new?editExecutionId=mm%3Acanonical-preset-edit",
+    );
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Edit Workflow" })).toBeTruthy();
+    const firstStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    expect(await screen.findByText("Step 2")).toBeTruthy();
+    expect(await screen.findByDisplayValue("Implement MM-901.")).toBeTruthy();
+
+    fireEvent.change(within(firstStep).getByLabelText("Step 1 Instructions"), {
+      target: { value: "Fetch edited MM-901." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Acanonical-preset-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) =>
+          String(url) === "/api/executions/mm%3Acanonical-preset-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body || "{}")) as {
+      updateName?: string;
+      parametersPatch?: {
+        task?: unknown;
+        workflow?: {
+          appliedStepTemplates?: Array<Record<string, unknown>>;
+          steps?: Array<Record<string, unknown>>;
+        };
+      };
+    };
+    expect(request.updateName).toBe("UpdateInputs");
+    expect(request.parametersPatch?.task).toBeUndefined();
+    expect(
+      request.parametersPatch?.workflow?.steps?.map((entry) => entry.title),
+    ).toEqual(["Fetch Jira issue", "Implement preset story"]);
+    expect(request.parametersPatch?.workflow?.steps?.[0]?.instructions).toBe(
+      "Fetch edited MM-901.",
+    );
+    expect(
+      request.parametersPatch?.workflow?.appliedStepTemplates?.[0]?.slug,
+    ).toBe("jira-implement");
   });
 
   it("does not auto-expand or submit on non-submit Preset interactions", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -9352,7 +9352,7 @@ describe.skip("Task Create Entrypoint", () => {
     );
     expect(JSON.parse(String(uploadCall?.[1]?.body))).toMatchObject({
       repository: "MoonLadderStudios/MoonMind",
-      task: {
+      workflow: {
         instructions: expect.stringContaining(
           "Large instructions Large instructions",
         ),
@@ -9684,7 +9684,7 @@ describe.skip("Task Create Entrypoint", () => {
       .at(-1);
     expect(JSON.parse(String(uploadCall?.[1]?.body))).toMatchObject({
       repository: "MoonLadderStudios/MoonMind",
-      task: {
+      workflow: {
         instructions: "Primary objective",
         steps: expect.arrayContaining([
           expect.objectContaining({
@@ -13917,7 +13917,7 @@ describe("Task Create MM-578 Preset expansion", () => {
           inputParameters: {
             targetRuntime: "codex_cli",
             repository: "MoonLadderStudios/MoonMind",
-            task: {
+            workflow: {
               instructions: "Edit a trusted preset draft.",
               runtime: { mode: "codex_cli" },
               publish: { mode: "pr" },
@@ -14903,15 +14903,19 @@ describe("Task Create MM-578 Preset expansion", () => {
       .at(-1);
     const request = JSON.parse(String(updateCall?.[1]?.body || "{}")) as {
       updateName?: string;
-      parametersPatch?: { task?: { steps?: Array<Record<string, unknown>> } };
+      parametersPatch?: {
+        task?: unknown;
+        workflow?: { steps?: Array<Record<string, unknown>> };
+      };
     };
     expect(request.updateName).toBe("UpdateInputs");
-    expect(request.parametersPatch?.task?.steps?.map((entry) => entry.type)).toEqual([
+    expect(request.parametersPatch?.task).toBeUndefined();
+    expect(request.parametersPatch?.workflow?.steps?.map((entry) => entry.type)).toEqual([
       "tool",
       "skill",
     ]);
     expect(
-      request.parametersPatch?.task?.steps?.some(
+      request.parametersPatch?.workflow?.steps?.some(
         (entry) => entry.type === "preset",
       ),
     ).toBe(false);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -866,13 +866,30 @@ function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown
   return structuredClone(value) as Record<string, unknown>;
 }
 
+function workflowPayloadKey(
+  source: Record<string, unknown>,
+): "workflow" | "task" | null {
+  if (Object.keys(recordValue(source.workflow)).length > 0) {
+    return "workflow";
+  }
+  if (Object.keys(recordValue(source.task)).length > 0) {
+    return "task";
+  }
+  return null;
+}
+
+function workflowTaskRecord(source: Record<string, unknown>): Record<string, unknown> {
+  const key = workflowPayloadKey(source);
+  return key ? recordValue(source[key]) : {};
+}
+
 function artifactInputTaskRecord(
   artifactInput: Record<string, unknown>,
 ): Record<string, unknown> {
   const snapshotDraft = recordValue(artifactInput.draft);
   const source =
     Object.keys(snapshotDraft).length > 0 ? snapshotDraft : artifactInput;
-  return recordValue(source.task);
+  return workflowTaskRecord(source);
 }
 
 function artifactInputHasStepInstructionGaps(
@@ -933,7 +950,8 @@ function mergeMissingTaskInstructionsFromArtifact(
   const mergedDraft = recordValue(merged.draft);
   const mergedSource =
     Object.keys(mergedDraft).length > 0 ? mergedDraft : merged;
-  const mergedTask = recordValue(mergedSource.task);
+  const mergedTaskKey = workflowPayloadKey(mergedSource);
+  const mergedTask = mergedTaskKey ? recordValue(mergedSource[mergedTaskKey]) : {};
   const mergedSteps = Array.isArray(mergedTask.steps) ? mergedTask.steps : [];
   if (mergedSteps.length === 0) {
     return artifactInput;
@@ -980,7 +998,9 @@ function mergeMissingTaskInstructionsFromArtifact(
       instructions: String(sourceStep?.instructions),
     };
   });
-  mergedSource.task = mergedTask;
+  if (mergedTaskKey) {
+    mergedSource[mergedTaskKey] = mergedTask;
+  }
   return changed ? merged : artifactInput;
 }
 
@@ -1037,14 +1057,14 @@ function buildEditParametersPatch({
       ? artifactBase.parameters
       : executionParameters,
   );
-  const submittedTask = recordValue(submittedPayload.task);
-  const artifactBaseTask = recordValue(artifactBase.parameters.task);
-  const executionTask = recordValue(executionParameters.task);
+  const submittedTask = workflowTaskRecord(submittedPayload);
+  const artifactBaseTask = workflowTaskRecord(artifactBase.parameters);
+  const executionTask = workflowTaskRecord(executionParameters);
   const baseTask = mergeRecordValues(
     artifactBase.fromAuthoritativeDraft
       ? executionTask
       : artifactBaseTask,
-    recordValue(baseParameters.task),
+    workflowTaskRecord(baseParameters),
   );
   const editTask = { ...submittedTask };
 
@@ -1076,11 +1096,18 @@ function buildEditParametersPatch({
     delete mergedTask.git;
   }
 
+  const usesCanonicalWorkflowPayload =
+    Object.keys(recordValue(baseParameters.workflow)).length > 0 ||
+    Object.keys(recordValue(executionParameters.workflow)).length > 0 ||
+    Object.keys(recordValue(artifactBase.parameters.workflow)).length > 0 ||
+    Object.keys(recordValue(submittedPayload.workflow)).length > 0;
+  const workflowPatchKey = usesCanonicalWorkflowPayload ? "workflow" : "task";
   const parametersPatch: Record<string, unknown> = {
     ...baseParameters,
     ...submittedPayload,
-    task: mergedTask,
+    [workflowPatchKey]: mergedTask,
   };
+  delete parametersPatch[workflowPatchKey === "workflow" ? "task" : "workflow"];
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;
   }
@@ -3989,7 +4016,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           execution.taskInputSnapshot?.artifactRef || "",
         ).trim();
         const inputArtifactRef = String(execution.inputArtifactRef || "").trim();
-        const inlineTask = execution.inputParameters?.task;
+        const inlineTask = workflowTaskRecord(recordValue(execution.inputParameters));
         if (
           execution.taskInputSnapshot?.reconstructionMode === "authoritative" &&
           snapshotArtifactRef

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -866,43 +866,30 @@ function cloneJsonRecord(value: Record<string, unknown>): Record<string, unknown
   return structuredClone(value) as Record<string, unknown>;
 }
 
-function workflowPayloadKey(
-  source: Record<string, unknown>,
-): "workflow" | "task" | null {
-  if (Object.keys(recordValue(source.workflow)).length > 0) {
-    return "workflow";
-  }
-  if (Object.keys(recordValue(source.task)).length > 0) {
-    return "task";
-  }
-  return null;
+function workflowRecord(source: Record<string, unknown>): Record<string, unknown> {
+  return recordValue(source.workflow);
 }
 
-function workflowTaskRecord(source: Record<string, unknown>): Record<string, unknown> {
-  const key = workflowPayloadKey(source);
-  return key ? recordValue(source[key]) : {};
-}
-
-function artifactInputTaskRecord(
+function artifactInputWorkflowRecord(
   artifactInput: Record<string, unknown>,
 ): Record<string, unknown> {
   const snapshotDraft = recordValue(artifactInput.draft);
   const source =
     Object.keys(snapshotDraft).length > 0 ? snapshotDraft : artifactInput;
-  return workflowTaskRecord(source);
+  return workflowRecord(source);
 }
 
 function artifactInputHasStepInstructionGaps(
   artifactInput: Record<string, unknown>,
 ): boolean {
-  const task = artifactInputTaskRecord(artifactInput);
-  const steps = task.steps;
+  const workflow = artifactInputWorkflowRecord(artifactInput);
+  const steps = workflow.steps;
   if (!Array.isArray(steps)) {
     return false;
   }
   const appliedStepIds = new Set<string>();
-  const appliedTemplates = Array.isArray(task.appliedStepTemplates)
-    ? task.appliedStepTemplates
+  const appliedTemplates = Array.isArray(workflow.appliedStepTemplates)
+    ? workflow.appliedStepTemplates
     : [];
   appliedTemplates.forEach((template) => {
     const templateRecord = recordValue(template);
@@ -940,8 +927,10 @@ function mergeMissingTaskInstructionsFromArtifact(
   artifactInput: Record<string, unknown>,
   sourceArtifactInput: Record<string, unknown>,
 ): Record<string, unknown> {
-  const sourceTask = artifactInputTaskRecord(sourceArtifactInput);
-  const sourceSteps = Array.isArray(sourceTask.steps) ? sourceTask.steps : [];
+  const sourceWorkflow = artifactInputWorkflowRecord(sourceArtifactInput);
+  const sourceSteps = Array.isArray(sourceWorkflow.steps)
+    ? sourceWorkflow.steps
+    : [];
   if (sourceSteps.length === 0) {
     return artifactInput;
   }
@@ -950,9 +939,10 @@ function mergeMissingTaskInstructionsFromArtifact(
   const mergedDraft = recordValue(merged.draft);
   const mergedSource =
     Object.keys(mergedDraft).length > 0 ? mergedDraft : merged;
-  const mergedTaskKey = workflowPayloadKey(mergedSource);
-  const mergedTask = mergedTaskKey ? recordValue(mergedSource[mergedTaskKey]) : {};
-  const mergedSteps = Array.isArray(mergedTask.steps) ? mergedTask.steps : [];
+  const mergedWorkflow = workflowRecord(mergedSource);
+  const mergedSteps = Array.isArray(mergedWorkflow.steps)
+    ? mergedWorkflow.steps
+    : [];
   if (mergedSteps.length === 0) {
     return artifactInput;
   }
@@ -967,16 +957,18 @@ function mergeMissingTaskInstructionsFromArtifact(
     }
   });
 
-  const sourceTaskInstructions = String(sourceTask.instructions || "").trim();
+  const sourceWorkflowInstructions = String(
+    sourceWorkflow.instructions || "",
+  ).trim();
   if (
-    sourceTaskInstructions &&
-    !String(mergedTask.instructions || "").trim()
+    sourceWorkflowInstructions &&
+    !String(mergedWorkflow.instructions || "").trim()
   ) {
-    mergedTask.instructions = sourceTask.instructions;
+    mergedWorkflow.instructions = sourceWorkflow.instructions;
     changed = true;
   }
 
-  mergedTask.steps = mergedSteps.map((step, index) => {
+  mergedWorkflow.steps = mergedSteps.map((step, index) => {
     const stepRecord = recordValue(step);
     if (Object.keys(stepRecord).length === 0) {
       return step;
@@ -998,9 +990,7 @@ function mergeMissingTaskInstructionsFromArtifact(
       instructions: String(sourceStep?.instructions),
     };
   });
-  if (mergedTaskKey) {
-    mergedSource[mergedTaskKey] = mergedTask;
-  }
+  mergedSource.workflow = mergedWorkflow;
   return changed ? merged : artifactInput;
 }
 
@@ -1042,10 +1032,12 @@ function buildEditParametersPatch({
   execution,
   artifactInput,
   submittedPayload,
+  submittedWorkflow,
 }: {
   execution: TemporalTaskEditingExecutionContract;
   artifactInput?: Record<string, unknown> | undefined;
   submittedPayload: Record<string, unknown>;
+  submittedWorkflow: Record<string, unknown>;
 }): Record<string, unknown> {
   const artifactBase = artifactInputParametersForPatch(execution, artifactInput);
   const executionParameters = recordValue(execution.inputParameters);
@@ -1057,57 +1049,53 @@ function buildEditParametersPatch({
       ? artifactBase.parameters
       : executionParameters,
   );
-  const submittedTask = workflowTaskRecord(submittedPayload);
-  const artifactBaseTask = workflowTaskRecord(artifactBase.parameters);
-  const executionTask = workflowTaskRecord(executionParameters);
-  const baseTask = mergeRecordValues(
+  const artifactBaseWorkflow = workflowRecord(artifactBase.parameters);
+  const executionWorkflow = workflowRecord(executionParameters);
+  const baseWorkflow = mergeRecordValues(
     artifactBase.fromAuthoritativeDraft
-      ? executionTask
-      : artifactBaseTask,
-    workflowTaskRecord(baseParameters),
+      ? executionWorkflow
+      : artifactBaseWorkflow,
+    workflowRecord(baseParameters),
   );
-  const editTask = { ...submittedTask };
+  const editWorkflow = { ...submittedWorkflow };
 
   // This field is not reconstructed into the edit form yet. Preserve the
   // existing value instead of letting the create-form default overwrite it.
-  if ("proposeTasks" in editTask) {
-    delete editTask.proposeTasks;
+  if ("proposeTasks" in editWorkflow) {
+    delete editWorkflow.proposeTasks;
   }
 
-  const mergedTask: Record<string, unknown> = {
-    ...baseTask,
-    ...editTask,
+  const mergedWorkflow: Record<string, unknown> = {
+    ...baseWorkflow,
+    ...editWorkflow,
     runtime: mergeRecordValues(
-      recordValue(baseTask.runtime),
-      recordValue(editTask.runtime),
+      recordValue(baseWorkflow.runtime),
+      recordValue(editWorkflow.runtime),
     ),
-    git: mergeRecordValues(recordValue(baseTask.git), recordValue(editTask.git)),
+    git: mergeRecordValues(
+      recordValue(baseWorkflow.git),
+      recordValue(editWorkflow.git),
+    ),
     publish: mergeRecordValues(
-      recordValue(baseTask.publish),
-      recordValue(editTask.publish),
+      recordValue(baseWorkflow.publish),
+      recordValue(editWorkflow.publish),
     ),
   };
-  const mergedGit = recordValue(mergedTask.git);
+  const mergedGit = recordValue(mergedWorkflow.git);
   delete mergedGit.startingBranch;
   delete mergedGit.targetBranch;
   if (Object.keys(mergedGit).length > 0) {
-    mergedTask.git = mergedGit;
+    mergedWorkflow.git = mergedGit;
   } else {
-    delete mergedTask.git;
+    delete mergedWorkflow.git;
   }
 
-  const usesCanonicalWorkflowPayload =
-    Object.keys(recordValue(baseParameters.workflow)).length > 0 ||
-    Object.keys(recordValue(executionParameters.workflow)).length > 0 ||
-    Object.keys(recordValue(artifactBase.parameters.workflow)).length > 0 ||
-    Object.keys(recordValue(submittedPayload.workflow)).length > 0;
-  const workflowPatchKey = usesCanonicalWorkflowPayload ? "workflow" : "task";
   const parametersPatch: Record<string, unknown> = {
     ...baseParameters,
     ...submittedPayload,
-    [workflowPatchKey]: mergedTask,
+    workflow: mergedWorkflow,
   };
-  delete parametersPatch[workflowPatchKey === "workflow" ? "task" : "workflow"];
+  delete parametersPatch.task;
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;
   }
@@ -3383,13 +3371,22 @@ function stripOversizedInlineInstructions(
   }
 
   const payloadRecord = payload as Record<string, unknown>;
-  const task = payloadRecord.task;
-  if (!task || typeof task !== "object" || Array.isArray(task)) {
+  const workflow = payloadRecord.workflow;
+  const createTask = payloadRecord.task;
+  const workflowInput =
+    workflow && typeof workflow === "object" && !Array.isArray(workflow)
+      ? workflow
+      : createTask && typeof createTask === "object" && !Array.isArray(createTask)
+        ? createTask
+        : null;
+  if (!workflowInput) {
     return;
   }
 
-  const taskRecord = task as Record<string, unknown>;
-  const steps = Array.isArray(taskRecord.steps) ? taskRecord.steps : [];
+  const workflowInputRecord = workflowInput as Record<string, unknown>;
+  const steps = Array.isArray(workflowInputRecord.steps)
+    ? workflowInputRecord.steps
+    : [];
 
   const fitsInlineLimit = () =>
     utf8ByteLength(JSON.stringify(requestBody)) <=
@@ -3436,8 +3433,8 @@ function stripOversizedInlineInstructions(
     }
   }
 
-  if ("instructions" in taskRecord) {
-    delete taskRecord.instructions;
+  if ("instructions" in workflowInputRecord) {
+    delete workflowInputRecord.instructions;
     if (fitsInlineLimit()) {
       return;
     }
@@ -4016,7 +4013,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           execution.taskInputSnapshot?.artifactRef || "",
         ).trim();
         const inputArtifactRef = String(execution.inputArtifactRef || "").trim();
-        const inlineTask = workflowTaskRecord(recordValue(execution.inputParameters));
+        const inlineTask = workflowRecord(recordValue(execution.inputParameters));
         if (
           execution.taskInputSnapshot?.reconstructionMode === "authoritative" &&
           snapshotArtifactRef
@@ -7913,12 +7910,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       }
       const editParametersPatch =
         temporalDraftData && pageMode.intent !== "comparison"
-          ? buildEditParametersPatch({
-              execution: temporalDraftData.execution,
-              artifactInput: temporalDraftData.artifactInput,
-              submittedPayload,
-            })
-          : null;
+      ? buildEditParametersPatch({
+          execution: temporalDraftData.execution,
+          artifactInput: temporalDraftData.artifactInput,
+          submittedPayload,
+          submittedWorkflow: taskPayload,
+        })
+      : null;
       const artifactPayload = editParametersPatch ?? submittedPayload;
       const isExactRerunRequest =
         pageMode.mode === "rerun" && pageMode.intent === "rerun";
@@ -7938,16 +7936,17 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             "Cannot request edited retry because the source execution identity is missing.",
           );
         }
-        const editedTaskPayload: Record<string, unknown> = {
-          ...recordValue(artifactPayload.task ?? taskPayload),
+        const editedWorkflowPayload: Record<string, unknown> = {
+          ...mergeRecordValues(taskPayload, workflowRecord(artifactPayload)),
           recovery: {
             kind: "edited_full_retry",
             sourceWorkflowId,
             sourceRunId,
           },
         };
-        delete editedTaskPayload.resume;
-        artifactPayload.task = editedTaskPayload;
+        delete editedWorkflowPayload.resume;
+        artifactPayload.workflow = editedWorkflowPayload;
+        delete artifactPayload.task;
       }
       if (
         pageMode.intent === "comparison" &&
@@ -8012,9 +8011,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             JSON.stringify(rerunDraft.inputAttachments)
         : false;
       const isExactRerun = isExactRerunRequest && !rerunFormChanged;
+      const artifactWorkflowPayload = mergeRecordValues(
+        taskPayload,
+        workflowRecord(artifactPayload),
+      );
       const taskInputArtifactBody = JSON.stringify({
         repository: artifactPayload.repository ?? normalizedRepository,
-        task: artifactPayload.task ?? taskPayload,
+        workflow: artifactWorkflowPayload,
       });
       const taskInputArtifactBytes = utf8ByteLength(taskInputArtifactBody);
       const existingInputArtifactRef = String(

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -211,4 +211,141 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
       effort: "low",
     });
   });
+
+  it("reconstructs canonical workflow steps from execution parameters", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:canonical-workflow",
+      workflowType: "MoonMind.UserWorkflow",
+      targetRuntime: "codex_cli",
+      inputParameters: {
+        workflow: {
+          instructions: "Run Jira Implement for MM-901.",
+          runtime: { mode: "codex_cli", model: "gpt-5.4" },
+          appliedStepTemplates: [
+            {
+              slug: "jira-implement",
+              version: "1.0.0",
+              stepIds: [
+                "tpl:jira-implement:1.0.0:01",
+                "tpl:jira-implement:1.0.0:02",
+              ],
+            },
+          ],
+          steps: [
+            {
+              id: "tpl:jira-implement:1.0.0:01",
+              title: "Load Jira preset brief",
+              type: "tool",
+              instructions: "Load MM-901.",
+              tool: { id: "jira.load_preset_brief", inputs: { issueKey: "MM-901" } },
+            },
+            {
+              id: "tpl:jira-implement:1.0.0:02",
+              title: "Assess existing implementation state",
+              type: "skill",
+              instructions: "Assess MM-901.",
+              skill: { id: "auto", args: {} },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.taskInstructions).toBe(
+      "Run Jira Implement for MM-901.\n\nLoad MM-901.\n\nAssess MM-901.",
+    );
+    expect(draft.steps.map((step) => step.title)).toEqual([
+      "Load Jira preset brief",
+      "Assess existing implementation state",
+    ]);
+    expect(draft.appliedTemplates).toEqual([
+      {
+        slug: "jira-implement",
+        version: "1.0.0",
+        inputs: {},
+        stepIds: [
+          "tpl:jira-implement:1.0.0:01",
+          "tpl:jira-implement:1.0.0:02",
+        ],
+        appliedAt: "",
+        capabilities: [],
+      },
+    ]);
+  });
+
+  it("prefers authoritative draft.workflow when it carries the full preset expansion", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:canonical-workflow-snapshot",
+        workflowType: "MoonMind.UserWorkflow",
+        taskInputSnapshot: {
+          available: true,
+          artifactRef: "art-snapshot",
+          snapshotVersion: 1,
+          sourceKind: "create",
+          reconstructionMode: "authoritative",
+          disabledReasons: {},
+          fallbackEvidenceRefs: [],
+        },
+        inputParameters: {
+          workflow: {
+            instructions: "Run Jira Implement for MM-902.",
+            steps: [
+              {
+                id: "tpl:jira-implement:1.0.0:01",
+                title: "Load Jira preset brief",
+                instructions: "Load MM-902.",
+              },
+            ],
+          },
+        },
+      },
+      {
+        snapshotVersion: 1,
+        source: { kind: "create" },
+        draft: {
+          workflowShape: "multi_step",
+          workflow: {
+            instructions: "Run Jira Implement for MM-902.",
+            appliedStepTemplates: [
+              {
+                slug: "jira-implement",
+                version: "1.0.0",
+                stepIds: [
+                  "tpl:jira-implement:1.0.0:01",
+                  "tpl:jira-implement:1.0.0:02",
+                  "tpl:jira-implement:1.0.0:03",
+                ],
+              },
+            ],
+            steps: [
+              {
+                id: "tpl:jira-implement:1.0.0:01",
+                title: "Load Jira preset brief",
+                instructions: "Load MM-902.",
+              },
+              {
+                id: "tpl:jira-implement:1.0.0:02",
+                title: "Assess existing implementation state",
+                instructions: "Assess MM-902.",
+              },
+              {
+                id: "tpl:jira-implement:1.0.0:03",
+                title: "Finalize Jira status",
+                instructions: "Finalize MM-902.",
+                skill: { id: "jira-issue-updater", args: {} },
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(draft.steps.map((step) => step.title)).toEqual([
+      "Load Jira preset brief",
+      "Assess existing implementation state",
+      "Finalize Jira status",
+    ]);
+    expect(draft.appliedTemplates[0]?.slug).toBe("jira-implement");
+  });
 });

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -26,14 +26,14 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
         workflowType: "MoonMind.UserWorkflow",
         targetRuntime: "codex_cli",
         inputParameters: {
-          task: {
+          workflow: {
             instructions: "/review\nCheck the branch.",
             runtime: { mode: "codex_cli" },
           },
         },
       },
       {
-        task: {
+        workflow: {
           instructions: "/review\nCheck the branch.",
           runtimeCommand: {
             kind: "slash_command",
@@ -81,8 +81,8 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
         workflowType: "MoonMind.UserWorkflow",
         targetRuntime: "codex_cli",
         inputParameters: {
-          task: {
-            instructions: "Inline fallback should not win.",
+          workflow: {
+            instructions: "Inline workflow should not win.",
             runtime: { mode: "codex_cli" },
           },
         },
@@ -136,8 +136,8 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
         workflowType: "MoonMind.UserWorkflow",
         targetRuntime: "codex_cli",
         inputParameters: {
-          task: {
-            instructions: "Inline fallback should not replace history.",
+          workflow: {
+            instructions: "Inline workflow should not replace history.",
             runtime: { mode: "codex_cli" },
           },
         },
@@ -164,7 +164,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
       workflowType: "MoonMind.UserWorkflow",
       targetRuntime: "codex_cli",
       inputParameters: {
-        task: {
+        workflow: {
           instructions: "Review the overall branch.",
           steps: [
             {
@@ -187,7 +187,7 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
       workflowType: "MoonMind.UserWorkflow",
       targetRuntime: "codex_cli",
       inputParameters: {
-        task: {
+        workflow: {
           instructions: "Coordinate portable steps.",
           runtime: { mode: "codex_cli", model: "gpt-5.4", effort: "medium" },
           steps: [

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -701,21 +701,8 @@ function normalizeAppliedTemplates(
     .filter((entry) => entry.slug);
 }
 
-function workflowPayloadKey(
-  source: Record<string, unknown>,
-): 'workflow' | 'task' | null {
-  if (Object.keys(objectValue(source.workflow)).length > 0) {
-    return 'workflow';
-  }
-  if (Object.keys(objectValue(source.task)).length > 0) {
-    return 'task';
-  }
-  return null;
-}
-
-function workflowTaskRecord(source: Record<string, unknown>): Record<string, unknown> {
-  const key = workflowPayloadKey(source);
-  return key ? objectValue(source[key]) : {};
+function workflowRecord(source: Record<string, unknown>): Record<string, unknown> {
+  return objectValue(source.workflow);
 }
 
 function assertSnapshotAttachmentBindings(
@@ -764,10 +751,6 @@ function snapshotDraftTask(
   const nestedWorkflow = objectValue(snapshotDraft.workflow);
   if (Object.keys(nestedWorkflow).length > 0) {
     return nestedWorkflow;
-  }
-  const nestedTask = objectValue(snapshotDraft.task);
-  if (Object.keys(nestedTask).length > 0) {
-    return nestedTask;
   }
   const primarySkill = objectValue(snapshotDraft.primarySkill);
   const publish = objectValue(snapshotDraft.publish);
@@ -873,10 +856,10 @@ export function buildTemporalSubmissionDraftFromExecution(
   const params = objectValue(execution.inputParameters);
   const artifactParams = objectValue(artifactInput);
   const snapshotDraft = objectValue(artifactParams.draft);
-  const task = workflowTaskRecord(params);
+  const task = workflowRecord(params);
   const artifactTask = Object.keys(snapshotDraft).length > 0
     ? snapshotDraftTask(snapshotDraft)
-    : workflowTaskRecord(artifactParams);
+    : workflowRecord(artifactParams);
   const runtime = objectValue(task.runtime);
   const artifactRuntime = objectValue(artifactTask.runtime);
   const git = objectValue(task.git);

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -701,6 +701,23 @@ function normalizeAppliedTemplates(
     .filter((entry) => entry.slug);
 }
 
+function workflowPayloadKey(
+  source: Record<string, unknown>,
+): 'workflow' | 'task' | null {
+  if (Object.keys(objectValue(source.workflow)).length > 0) {
+    return 'workflow';
+  }
+  if (Object.keys(objectValue(source.task)).length > 0) {
+    return 'task';
+  }
+  return null;
+}
+
+function workflowTaskRecord(source: Record<string, unknown>): Record<string, unknown> {
+  const key = workflowPayloadKey(source);
+  return key ? objectValue(source[key]) : {};
+}
+
 function assertSnapshotAttachmentBindings(
   artifactParams: Record<string, unknown>,
   artifactTask: Record<string, unknown>,
@@ -744,6 +761,10 @@ function assertSnapshotAttachmentBindings(
 function snapshotDraftTask(
   snapshotDraft: Record<string, unknown>,
 ): Record<string, unknown> {
+  const nestedWorkflow = objectValue(snapshotDraft.workflow);
+  if (Object.keys(nestedWorkflow).length > 0) {
+    return nestedWorkflow;
+  }
   const nestedTask = objectValue(snapshotDraft.task);
   if (Object.keys(nestedTask).length > 0) {
     return nestedTask;
@@ -852,10 +873,10 @@ export function buildTemporalSubmissionDraftFromExecution(
   const params = objectValue(execution.inputParameters);
   const artifactParams = objectValue(artifactInput);
   const snapshotDraft = objectValue(artifactParams.draft);
-  const task = objectValue(params.task);
+  const task = workflowTaskRecord(params);
   const artifactTask = Object.keys(snapshotDraft).length > 0
     ? snapshotDraftTask(snapshotDraft)
-    : objectValue(artifactParams.task);
+    : workflowTaskRecord(artifactParams);
   const runtime = objectValue(task.runtime);
   const artifactRuntime = objectValue(artifactTask.runtime);
   const git = objectValue(task.git);

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -12031,13 +12031,11 @@ class MoonMindRunWorkflow:
         if isinstance(runtime_block, Mapping):
             selection.update(self._runtime_selection_from_source(runtime_block))
 
-        task_payload = parameters_patch.get("workflow")
-        if not isinstance(task_payload, Mapping):
-            task_payload = parameters_patch.get("task")
-        if isinstance(task_payload, Mapping):
-            task_runtime = task_payload.get("runtime")
-            if isinstance(task_runtime, Mapping):
-                selection.update(self._runtime_selection_from_source(task_runtime))
+        workflow_payload = parameters_patch.get("workflow")
+        if isinstance(workflow_payload, Mapping):
+            workflow_runtime = workflow_payload.get("runtime")
+            if isinstance(workflow_runtime, Mapping):
+                selection.update(self._runtime_selection_from_source(workflow_runtime))
 
         authored_payload = parameters_patch.get("authoredTaskInput")
         if isinstance(authored_payload, Mapping):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -12031,7 +12031,9 @@ class MoonMindRunWorkflow:
         if isinstance(runtime_block, Mapping):
             selection.update(self._runtime_selection_from_source(runtime_block))
 
-        task_payload = parameters_patch.get("task")
+        task_payload = parameters_patch.get("workflow")
+        if not isinstance(task_payload, Mapping):
+            task_payload = parameters_patch.get("task")
         if isinstance(task_payload, Mapping):
             task_runtime = task_payload.get("runtime")
             if isinstance(task_runtime, Mapping):

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6928,6 +6928,53 @@ def test_serialize_execution_surfaces_task_template_slug_as_primary_skill() -> N
     assert dumped["taskSkills"] == ["jira-orchestrate"]
     assert dumped["skillRuntime"]["selectedSkills"] == ["jira-orchestrate"]
 
+def test_serialize_execution_prefers_preset_slug_over_child_skill_display() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "targetRuntime": "codex_cli",
+        "workflow": {
+            "instructions": "Run Jira Implement for MM-901.",
+            "taskTemplate": {
+                "slug": "jira-implement",
+                "version": "1.0.0",
+            },
+            "tool": {
+                "type": "skill",
+                "name": "jira-issue-updater",
+                "version": "1.0.0",
+            },
+            "skill": {
+                "id": "jira-issue-updater",
+                "args": {},
+            },
+            "appliedStepTemplates": [
+                {
+                    "slug": "jira-implement",
+                    "version": "1.0.0",
+                    "stepIds": ["tpl:jira-implement:1.0.0:08"],
+                }
+            ],
+            "steps": [
+                {
+                    "id": "tpl:jira-implement:1.0.0:08",
+                    "title": "Finalize Jira status",
+                    "instructions": "Update Jira with implementation status.",
+                    "skill": {
+                        "id": "jira-issue-updater",
+                        "args": {},
+                    },
+                }
+            ],
+        },
+    }
+
+    payload = _serialize_execution(record)
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["targetSkill"] == "jira-implement"
+    assert dumped["taskSkills"] == ["jira-implement"]
+    assert dumped["skillRuntime"]["selectedSkills"] == ["jira-implement"]
+
 def test_serialize_execution_surfaces_applied_template_slug_as_primary_skill() -> None:
     record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
     record.parameters = {

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -497,6 +497,60 @@ async def test_update_inputs_forwards_runtime_selection_to_active_managed_child(
     )
     assert result["forwardedRuntimeSelectionUpdate"] is True
 
+
+@pytest.mark.asyncio
+async def test_update_inputs_forwards_runtime_selection_from_canonical_workflow_patch(
+    monkeypatch,
+):
+    workflow_instance = MoonMindUserWorkflow()
+    workflow_instance._active_agent_child_workflow_id = "wf:child"
+    workflow_instance._active_agent_id = "claude_code"
+
+    mock_handle = type("MockHandle", (), {"signal": AsyncMock()})()
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: mock_handle,
+    )
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+
+    result = await workflow_instance.update_inputs(
+        {
+            "parametersPatch": {
+                "workflow": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "model": "claude-opus-4-7",
+                        "profileId": "claude_anthropic",
+                        "effort": "high",
+                    }
+                }
+            }
+        }
+    )
+
+    mock_handle.signal.assert_awaited_once_with(
+        "update_runtime_selection",
+        {
+            "model": "claude-opus-4-7",
+            "executionProfileRef": "claude_anthropic",
+            "effort": "high",
+            "targetRuntime": "claude_code",
+            "parametersPatch": {
+                "workflow": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "model": "claude-opus-4-7",
+                        "profileId": "claude_anthropic",
+                        "effort": "high",
+                    }
+                }
+            },
+        },
+    )
+    assert result["forwardedRuntimeSelectionUpdate"] is True
+
+
 @pytest.mark.asyncio
 async def test_run_workflow_send_message_update_uses_temporal_boundary(
     mock_run_environment, monkeypatch

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -465,7 +465,7 @@ async def test_update_inputs_forwards_runtime_selection_to_active_managed_child(
             "parametersPatch": {
                 "model": "claude-opus-4-7",
                 "profileId": "claude_anthropic",
-                "task": {
+                "workflow": {
                     "runtime": {
                         "mode": "claude_code",
                         "model": "claude-opus-4-7",
@@ -485,7 +485,7 @@ async def test_update_inputs_forwards_runtime_selection_to_active_managed_child(
             "parametersPatch": {
                 "model": "claude-opus-4-7",
                 "profileId": "claude_anthropic",
-                "task": {
+                "workflow": {
                     "runtime": {
                         "mode": "claude_code",
                         "model": "claude-opus-4-7",


### PR DESCRIPTION
## Summary
- Reconstruct edit drafts from canonical `workflow` payloads, with legacy `task` fallback, so expanded Jira Implement preset steps remain visible in the edit form.
- Save canonical edit patches back under `parametersPatch.workflow` to avoid leaving stale canonical workflow data behind.
- Prefer preset provenance for execution skill display so the workflow table shows the preset slug instead of an inner child skill like `jira-issue-updater`.
- Forward runtime updates from canonical `workflow.runtime` patches to active managed child workflows.

## Root Cause
Newer preset submissions persist the expanded task body under the canonical `workflow` key, but the edit reconstruction and save paths still assumed the legacy `task` key. For preset-derived runs, execution serialization also preferred executable child tool/skill metadata before preset provenance.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/lib/temporalTaskEditing.test.ts frontend/src/entrypoints/workflow-start.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:lint`