### PR TITLE
Plan skill-declared required capabilities

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -2,7 +2,7 @@
 name: batch-dependabot-resolver
 description: Discover open Dependabot version-bump PRs and enqueue one `pr-resolver` workflow for each.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - gh
 ---
 

--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: batch-dependabot-resolver
 description: Discover open Dependabot version-bump PRs and enqueue one `pr-resolver` workflow for each.
+metadata:
+  requiredCapabilities:
+    - gh
 ---
 
 # Batch Dependabot Resolver Skill

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -2,7 +2,7 @@
 name: batch-pr-resolver
 description: Discover open PRs in a repository and enqueue one `pr-resolver` task for each.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - gh
 ---
 

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: batch-pr-resolver
 description: Discover open PRs in a repository and enqueue one `pr-resolver` task for each.
+metadata:
+  requiredCapabilities:
+    - gh
 ---
 
 # Batch PR Resolver Skill

--- a/.agents/skills/document-update/SKILL.md
+++ b/.agents/skills/document-update/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: document-update
 description: Align a technical document with the actual code implementation and correct drift. Use when a user asks to update docs to match current behavior, audit a technical document against the repository, or fix stale architecture, API, workflow, or operator documentation.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # Document Update

--- a/.agents/skills/document-update/SKILL.md
+++ b/.agents/skills/document-update/SKILL.md
@@ -2,7 +2,7 @@
 name: document-update
 description: Align a technical document with the actual code implementation and correct drift. Use when a user asks to update docs to match current behavior, audit a technical document against the repository, or fix stale architecture, API, workflow, or operator documentation.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -2,7 +2,7 @@
 name: fix-ci
 description: Fix continuous integration (CI) test or build failures for the current PR branch. Fetch CI failure logs, map them to local commands, reproduce the failures, fix the code, verify locally, and commit and push.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
     - gh
 ---

--- a/.agents/skills/fix-ci/SKILL.md
+++ b/.agents/skills/fix-ci/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: fix-ci
 description: Fix continuous integration (CI) test or build failures for the current PR branch. Fetch CI failure logs, map them to local commands, reproduce the failures, fix the code, verify locally, and commit and push.
+metadata:
+  requiredCapabilities:
+    - git
+    - gh
 ---
 
 # Fix CI

--- a/.agents/skills/fix-comments/SKILL.md
+++ b/.agents/skills/fix-comments/SKILL.md
@@ -2,7 +2,7 @@
 name: fix-comments
 description: Resolve GitHub PR feedback end-to-end for the branch you are on. Use when you need to fetch all comments on the branch PR, evaluate whether each comment still applies, decide whether it should be addressed, implement fixes, run compile/tests with retry-on-failure, then commit and push the result.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
     - gh
 ---

--- a/.agents/skills/fix-comments/SKILL.md
+++ b/.agents/skills/fix-comments/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: fix-comments
 description: Resolve GitHub PR feedback end-to-end for the branch you are on. Use when you need to fetch all comments on the branch PR, evaluate whether each comment still applies, decide whether it should be addressed, implement fixes, run compile/tests with retry-on-failure, then commit and push the result.
+metadata:
+  requiredCapabilities:
+    - git
+    - gh
 ---
 
 # Fix Comments

--- a/.agents/skills/fix-merge-conflicts/SKILL.md
+++ b/.agents/skills/fix-merge-conflicts/SKILL.md
@@ -2,7 +2,7 @@
 name: fix-merge-conflicts
 description: Sync the branch with the latest `origin/main`, merge `origin/main`, resolve conflicts end-to-end, then commit and push the current branch.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/fix-merge-conflicts/SKILL.md
+++ b/.agents/skills/fix-merge-conflicts/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: fix-merge-conflicts
 description: Sync the branch with the latest `origin/main`, merge `origin/main`, resolve conflicts end-to-end, then commit and push the current branch.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # Fix Merge Conflicts

--- a/.agents/skills/github-issue-to-jira/SKILL.md
+++ b/.agents/skills/github-issue-to-jira/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: github-issue-to-jira
 description: Review an open GitHub issue for a selected repository against the current codebase, then either close it as already implemented with an evidence comment, label it needs clarification with an explanatory comment, or create a fleshed-out Jira story in the requested board/project when the remaining work is clear. Use when triaging GitHub issues into Jira backlog work or closing stale implemented GitHub issues.
+metadata:
+  requiredCapabilities:
+    - git
+    - gh
+    - jira
 ---
 
 # GitHub Issue to Jira

--- a/.agents/skills/github-issue-to-jira/SKILL.md
+++ b/.agents/skills/github-issue-to-jira/SKILL.md
@@ -2,7 +2,7 @@
 name: github-issue-to-jira
 description: Review an open GitHub issue for a selected repository against the current codebase, then either close it as already implemented with an evidence comment, label it needs clarification with an explanatory comment, or create a fleshed-out Jira story in the requested board/project when the remaining work is clear. Use when triaging GitHub issues into Jira backlog work or closing stale implemented GitHub issues.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
     - gh
     - jira

--- a/.agents/skills/jira-implement/SKILL.md
+++ b/.agents/skills/jira-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: jira-implement
 description: Implement repository work from a Jira issue. Use when a user gives Codex a Jira issue key or URL and asks it to fetch the issue, pull relevant instructions, comments, linked context, and attachments, implement the requested code/docs/tests, verify the result, and report what changed.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
 ---

--- a/.agents/skills/jira-implement/SKILL.md
+++ b/.agents/skills/jira-implement/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: jira-implement
 description: Implement repository work from a Jira issue. Use when a user gives Codex a Jira issue key or URL and asks it to fetch the issue, pull relevant instructions, comments, linked context, and attachments, implement the requested code/docs/tests, verify the result, and report what changed.
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
 ---
 
 # Jira Implement

--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -2,7 +2,7 @@
 name: jira-issue-creator
 description: Create Jira issues such as tasks, stories, bugs, or subtasks from user intent. Use when a user asks to open, file, draft, or create a Jira ticket and needs fields validated, issue text composed, Jira API or connector calls made, and the created issue link returned.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
 ---
 

--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: jira-issue-creator
 description: Create Jira issues such as tasks, stories, bugs, or subtasks from user intent. Use when a user asks to open, file, draft, or create a Jira ticket and needs fields validated, issue text composed, Jira API or connector calls made, and the created issue link returned.
+metadata:
+  requiredCapabilities:
+    - jira
 ---
 
 # Jira Issue Creator

--- a/.agents/skills/jira-issue-updater/SKILL.md
+++ b/.agents/skills/jira-issue-updater/SKILL.md
@@ -2,7 +2,7 @@
 name: jira-issue-updater
 description: Update Jira issues such as tasks, stories, bugs, or subtasks through MoonMind's trusted Jira tool surface. Use when a user asks to edit Jira fields, move workflow status, update descriptions, or publish completion/status summaries back to any Jira issue type.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
 ---
 

--- a/.agents/skills/jira-issue-updater/SKILL.md
+++ b/.agents/skills/jira-issue-updater/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: jira-issue-updater
 description: Update Jira issues such as tasks, stories, bugs, or subtasks through MoonMind's trusted Jira tool surface. Use when a user asks to edit Jira fields, move workflow status, update descriptions, or publish completion/status summaries back to any Jira issue type.
+metadata:
+  requiredCapabilities:
+    - jira
 ---
 
 # Jira Issue Updater

--- a/.agents/skills/jira-pr-verify/SKILL.md
+++ b/.agents/skills/jira-pr-verify/SKILL.md
@@ -2,7 +2,7 @@
 name: jira-pr-verify
 description: Verify a GitHub pull request against a Jira issue's goals, requirements, and acceptance criteria, then post a PR comment with the findings. Use when a user asks Codex or MoonMind to compare a PR to a Jira story/task/bug, confirm whether a PR satisfies Jira requirements, audit implementation coverage from Jira, or publish a Jira-vs-PR verification summary.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
     - gh

--- a/.agents/skills/jira-pr-verify/SKILL.md
+++ b/.agents/skills/jira-pr-verify/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: jira-pr-verify
 description: Verify a GitHub pull request against a Jira issue's goals, requirements, and acceptance criteria, then post a PR comment with the findings. Use when a user asks Codex or MoonMind to compare a PR to a Jira story/task/bug, confirm whether a PR satisfies Jira requirements, audit implementation coverage from Jira, or publish a Jira-vs-PR verification summary.
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
+    - gh
 ---
 
 # Jira PR Verify

--- a/.agents/skills/jira-verify/SKILL.md
+++ b/.agents/skills/jira-verify/SKILL.md
@@ -8,6 +8,10 @@ description: >-
   current default branch (typical for stories that have already merged). Use
   when a user asks whether a branch or merged change completes a Jira ticket,
   or needs a Jira-visible verification comment.
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
 ---
 
 # Jira Verify

--- a/.agents/skills/jira-verify/SKILL.md
+++ b/.agents/skills/jira-verify/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   when a user asks whether a branch or merged change completes a Jira ticket,
   or needs a Jira-visible verification comment.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
 ---

--- a/.agents/skills/moonspec-align/SKILL.md
+++ b/.agents/skills/moonspec-align/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-align
 description: Analyze and automatically remediate Moon Spec artifact inconsistencies across spec.md, plan.md, tasks.md, and related design files. Use when the user asks to run an automated `/speckit.analyze`-style workflow that identifies uncertainty, weighs tradeoffs in project context, edits artifacts without asking follow-up questions, resolves coverage gaps, or aligns generated Moon Spec documents before implementation.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-align/SKILL.md
+++ b/.agents/skills/moonspec-align/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-align
 description: Analyze and automatically remediate Moon Spec artifact inconsistencies across spec.md, plan.md, tasks.md, and related design files. Use when the user asks to run an automated `/speckit.analyze`-style workflow that identifies uncertainty, weighs tradeoffs in project context, edits artifacts without asking follow-up questions, resolves coverage gaps, or aligns generated Moon Spec documents before implementation.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Align

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-breakdown
 description: Extract coverage-checked, independently testable Moon Spec user stories from a technical or declarative design and write breakdown output under artifacts/story-breakdowns (gitignored). Use when the user asks to run or reproduce `/speckit.breakdown`, split a broad design into one-story candidates, preserve source coverage, or build a coverage matrix before `/speckit.specify`.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-breakdown
 description: Extract coverage-checked, independently testable Moon Spec user stories from a technical or declarative design and write breakdown output under artifacts/story-breakdowns (gitignored). Use when the user asks to run or reproduce `/speckit.breakdown`, split a broad design into one-story candidates, preserve source coverage, or build a coverage matrix before `/speckit.specify`.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Breakdown

--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-doc-reconcile
 description: Reconcile a canonical declarative document under docs/ with verified implementation discoveries after a FULLY_IMPLEMENTED moonspec-verify verdict. Use when an orchestration run must decide whether implementation discoveries definitely require updating the source design document for function, consistency, or best practices, apply the smallest correct doc update, or escalate a misaligned update as a Jira issue instead of editing.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Doc Reconcile

--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-doc-reconcile
 description: Reconcile a canonical declarative document under docs/ with verified implementation discoveries after a FULLY_IMPLEMENTED moonspec-verify verdict. Use when an orchestration run must decide whether implementation discoveries definitely require updating the source design document for function, consistency, or best practices, apply the smallest correct doc update, or escalate a misaligned update as a Jira issue instead of editing.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-implement/SKILL.md
+++ b/.agents/skills/moonspec-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-implement
 description: Implement a single-story Moon Spec task breakdown with test-driven development. Use when the user asks to run or reproduce `/speckit.implement`, execute `tasks.md`, build the story from a Moon Spec plan, write failing unit and integration tests before production code, mark tasks complete, or prepare the implementation for `/speckit.verify`.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-implement/SKILL.md
+++ b/.agents/skills/moonspec-implement/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-implement
 description: Implement a single-story Moon Spec task breakdown with test-driven development. Use when the user asks to run or reproduce `/speckit.implement`, execute `tasks.md`, build the story from a Moon Spec plan, write failing unit and integration tests before production code, mark tasks complete, or prepare the implementation for `/speckit.verify`.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Implement

--- a/.agents/skills/moonspec-orchestrate/SKILL.md
+++ b/.agents/skills/moonspec-orchestrate/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-orchestrate
 description: Orchestrate the full Moon Spec lifecycle from a preselected single-story feature request or active feature directory through specification, planning, TDD task generation, artifact alignment, implementation, and final verification. Use when the user asks for an end-to-end Moon Spec run and the input has already been routed to one independently testable story, or when Codex needs to coordinate `moonspec-specify`, `moonspec-plan`, `moonspec-tasks`, `moonspec-align`, `moonspec-implement`, and `moonspec-verify` without manual analyze/remediation prompts.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Orchestrate

--- a/.agents/skills/moonspec-orchestrate/SKILL.md
+++ b/.agents/skills/moonspec-orchestrate/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-orchestrate
 description: Orchestrate the full Moon Spec lifecycle from a preselected single-story feature request or active feature directory through specification, planning, TDD task generation, artifact alignment, implementation, and final verification. Use when the user asks for an end-to-end Moon Spec run and the input has already been routed to one independently testable story, or when Codex needs to coordinate `moonspec-specify`, `moonspec-plan`, `moonspec-tasks`, `moonspec-align`, `moonspec-implement`, and `moonspec-verify` without manual analyze/remediation prompts.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-plan
 description: Generate a Moon Spec implementation plan and design artifacts from a single-story spec. Use when the user asks to run or reproduce `/speckit.plan`, create or update `plan.md`, produce `research.md`, `data-model.md`, `contracts/`, or `quickstart.md`, validate constitution gates, define separate unit and integration test strategies, and perform repo-aware gap analysis before `/speckit.tasks`.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Plan

--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-plan
 description: Generate a Moon Spec implementation plan and design artifacts from a single-story spec. Use when the user asks to run or reproduce `/speckit.plan`, create or update `plan.md`, produce `research.md`, `data-model.md`, `contracts/`, or `quickstart.md`, validate constitution gates, define separate unit and integration test strategies, and perform repo-aware gap analysis before `/speckit.tasks`.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-specify/SKILL.md
+++ b/.agents/skills/moonspec-specify/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-specify
 description: Create or update a Moon Spec feature specification from a natural language feature request or referenced declarative design. Use when the user asks to run or reproduce `/speckit.specify`, create a `spec.md`, initialize a feature directory under `specs/`, preserve the original feature request for later verification, map source design requirements, or generate a single-story Moon Spec specification with a requirements quality checklist.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Specify

--- a/.agents/skills/moonspec-specify/SKILL.md
+++ b/.agents/skills/moonspec-specify/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-specify
 description: Create or update a Moon Spec feature specification from a natural language feature request or referenced declarative design. Use when the user asks to run or reproduce `/speckit.specify`, create a `spec.md`, initialize a feature directory under `specs/`, preserve the original feature request for later verification, map source design requirements, or generate a single-story Moon Spec specification with a requirements quality checklist.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-tasks
 description: Generate a one-story, TDD-first Moon Spec `tasks.md` from `spec.md`, `plan.md`, and design artifacts. Use when the user asks to run or reproduce `/speckit.tasks`, create or update an executable task breakdown, map one Moon Spec story to implementation tasks, require unit and integration tests before code, preserve source-design traceability, or include final `/speckit.verify` work.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Tasks

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-tasks
 description: Generate a one-story, TDD-first Moon Spec `tasks.md` from `spec.md`, `plan.md`, and design artifacts. Use when the user asks to run or reproduce `/speckit.tasks`, create or update an executable task breakdown, map one Moon Spec story to implementation tasks, require unit and integration tests before code, preserve source-design traceability, or include final `/speckit.verify` work.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -2,7 +2,7 @@
 name: moonspec-verify
 description: Verify a completed Moon Spec implementation against the original request, one-story `spec.md`, plan, tasks, constitution, source-design mappings, and required tests. Use when the user asks to run or reproduce `/speckit.verify`, perform the final read-only implementation check, audit unit and integration test evidence, classify requirement coverage, or decide whether more code or test work is needed before closing a spec.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: moonspec-verify
 description: Verify a completed Moon Spec implementation against the original request, one-story `spec.md`, plan, tasks, constitution, source-design mappings, and required tests. Use when the user asks to run or reproduce `/speckit.verify`, perform the final read-only implementation check, audit unit and integration test evidence, classify requirement coverage, or decide whether more code or test work is needed before closing a spec.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # MoonSpec Verify

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -3,6 +3,9 @@ name: pr-resolver
 description: Master orchestrator to resolve a PR by diagnosing state and delegating to specialized skills.
 metadata:
   required-skills: "fix-comments fix-ci fix-merge-conflicts"
+  requiredCapabilities:
+    - git
+    - gh
 ---
 
 # PR Resolver Skill

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -3,7 +3,7 @@ name: pr-resolver
 description: Master orchestrator to resolve a PR by diagnosing state and delegating to specialized skills.
 metadata:
   required-skills: "fix-comments fix-ci fix-merge-conflicts"
-  requiredCapabilities:
+  required-capabilities:
     - git
     - gh
 ---

--- a/.agents/skills/story-reconcile-implementation/SKILL.md
+++ b/.agents/skills/story-reconcile-implementation/SKILL.md
@@ -2,7 +2,7 @@
 name: story-reconcile-implementation
 description: Compare MoonSpec story breakdown output against the current repository implementation, preserve fully implemented stories as skipped, narrow partially implemented stories to remaining work, and rewrite the story breakdown handoff before Jira issue creation.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
 ---
 

--- a/.agents/skills/story-reconcile-implementation/SKILL.md
+++ b/.agents/skills/story-reconcile-implementation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: story-reconcile-implementation
 description: Compare MoonSpec story breakdown output against the current repository implementation, preserve fully implemented stories as skipped, narrow partially implemented stories to remaining work, and rewrite the story breakdown handoff before Jira issue creation.
+metadata:
+  requiredCapabilities:
+    - git
 ---
 
 # Story Implementation Reconciliation

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: update-moonmind
 description: Refresh MoonMind services from git by checking out a branch, pulling updates, pulling compose images, then restarting changed containers with optional orchestrator inclusion.
+metadata:
+  requiredCapabilities:
+    - git
+    - docker
 ---
 
 # Update MoonMind Deployment (default: without restarting orchestrator)

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -2,7 +2,7 @@
 name: update-moonmind
 description: Refresh MoonMind services from git by checking out a branch, pulling updates, pulling compose images, then restarting changed containers with optional orchestrator inclusion.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - git
     - docker
 ---

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -41,6 +41,9 @@ from api_service.auth_providers import get_current_user
 from api_service.db.models import User
 from api_service.services.settings_catalog import settings_permissions_for_user
 from moonmind.config.settings import settings
+from moonmind.services.skill_resolution import (
+    extract_required_capabilities_from_skill_markdown,
+)
 from moonmind.workflows.skills.resolver import (
     SkillResolutionError,
     list_available_skill_names,
@@ -99,6 +102,11 @@ class DashboardSkillOption(BaseModel):
     """Serializable skill option exposed to dashboard clients."""
 
     id: str = Field(description="Skill identifier")
+    required_capabilities: list[str] = Field(
+        default_factory=list,
+        alias="requiredCapabilities",
+        description="Default required capabilities declared by Skill metadata",
+    )
     markdown: str | None = Field(None, description="Markdown content of the skill, if requested")
 
 class DashboardSkillListResponse(BaseModel):
@@ -839,11 +847,27 @@ async def list_dashboard_skills(
 
     async def _get_skill_option(skill_id: str) -> DashboardSkillOption:
         markdown_content = None
-        if include_content:
-            skill_file = resolve_skill_markdown_path(skill_id)
-            if skill_file is not None:
-                markdown_content = await asyncio.to_thread(skill_file.read_text, encoding="utf-8")
-        return DashboardSkillOption(id=skill_id, markdown=markdown_content)
+        required_capabilities: list[str] = []
+        skill_file = resolve_skill_markdown_path(skill_id)
+        if skill_file is not None:
+            skill_markdown = await asyncio.to_thread(
+                skill_file.read_text,
+                encoding="utf-8",
+            )
+            required_capabilities = list(
+                extract_required_capabilities_from_skill_markdown(
+                    skill_markdown,
+                    skill_name=skill_id,
+                    source_label=str(skill_file),
+                )
+            )
+            if include_content:
+                markdown_content = skill_markdown
+        return DashboardSkillOption(
+            id=skill_id,
+            requiredCapabilities=required_capabilities,
+            markdown=markdown_content,
+        )
 
     legacy_items = await asyncio.gather(
         *(_get_skill_option(skill_id) for skill_id in legacy_sorted)

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -10,6 +10,7 @@ tags:
   - implement
 requiredCapabilities:
   - git
+  - jira
 annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-implement
@@ -113,6 +114,8 @@ steps:
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues
+      requiredCapabilities:
+        - jira
       args: {}
   - title: Create dependent Jira Implement tasks
     instructions: |-
@@ -137,4 +140,6 @@ steps:
         sourceIssueKey: "{{ inputs.source_issue_key }}"
     skill:
       id: story.create_jira_implement_tasks
+      requiredCapabilities:
+        - jira
       args: {}

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -10,6 +10,7 @@ tags:
   - orchestration
 requiredCapabilities:
   - git
+  - jira
 annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-orchestrate
@@ -113,6 +114,8 @@ steps:
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues
+      requiredCapabilities:
+        - jira
       args: {}
   - title: Create dependent Jira Orchestrate tasks
     instructions: |-
@@ -138,4 +141,6 @@ steps:
         sourceIssueKey: "{{ inputs.source_issue_key }}"
     skill:
       id: story.create_jira_orchestrate_tasks
+      requiredCapabilities:
+        - jira
       args: {}

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -10,6 +10,7 @@ tags:
   - stories
 requiredCapabilities:
   - git
+  - jira
 annotations:
   sourceSkill: moonspec-breakdown
   output: jira
@@ -78,4 +79,6 @@ steps:
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
       id: story.create_jira_issues
+      requiredCapabilities:
+        - jira
       args: {}

--- a/api_service/data/presets/jira-implement.yaml
+++ b/api_service/data/presets/jira-implement.yaml
@@ -9,6 +9,8 @@ tags:
   - pull-request
 requiredCapabilities:
   - git
+  - jira
+  - gh
 annotations:
   sourceSkill: jira-implement
   jiraWorkflow: implementation-to-code-review
@@ -73,6 +75,8 @@ steps:
       Preserve the issue key in the brief so downstream implementation artifacts and the pull request can reference {{ inputs.jira_issue_key }}.
     tool:
       id: jira.load_preset_brief
+      requiredCapabilities:
+        - jira
       args: {}
       inputs:
         issueKey: "{{ inputs.jira_issue_key }}"
@@ -125,6 +129,8 @@ steps:
       linkType: Blocks
     tool:
       id: jira.check_blockers
+      requiredCapabilities:
+        - jira
       args:
         targetIssueKey: "{{ inputs.jira_issue_key }}"
         blockerPreflight:
@@ -141,6 +147,8 @@ steps:
       Otherwise (PARTIALLY_IMPLEMENTED or NOT_IMPLEMENTED), change Jira issue {{ inputs.jira_issue_key }} to status In Progress before implementation starts. Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
     skill:
       id: jira-issue-updater
+      requiredCapabilities:
+        - jira
       args: {}
   - title: Implement the Jira issue
     instructions: |-
@@ -234,4 +242,6 @@ steps:
       Note: when this task was submitted with PR merge automation enabled and the work followed the Code Review path, the parent workflow will transition Jira issue {{ inputs.jira_issue_key }} to Done automatically after the pull request merges. This in-task step only owns the explicit Done transition for the already-implemented case and the Code Review transition for the freshly-implemented case.
     skill:
       id: jira-issue-updater
+      requiredCapabilities:
+        - jira
       args: {}

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -10,6 +10,8 @@ tags:
   - pull-request
 requiredCapabilities:
   - git
+  - jira
+  - gh
 annotations:
   sourceSkill: moonspec-orchestrate
   jiraWorkflow: implementation-to-code-review
@@ -75,6 +77,8 @@ steps:
       Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
     skill:
       id: jira-issue-updater
+      requiredCapabilities:
+        - jira
       args: {}
   - title: Check Jira blockers before implementation
     type: tool
@@ -96,6 +100,8 @@ steps:
       linkType: Blocks
     tool:
       id: jira.check_blockers
+      requiredCapabilities:
+        - jira
       args:
         targetIssueKey: "{{ inputs.jira_issue_key }}"
         blockerPreflight:
@@ -111,6 +117,8 @@ steps:
       Preserve the issue key in the brief so downstream spec artifacts and the pull request can reference {{ inputs.jira_issue_key }}.
     tool:
       id: jira.load_preset_brief
+      requiredCapabilities:
+        - jira
       args: {}
       inputs:
         issueKey: "{{ inputs.jira_issue_key }}"
@@ -493,4 +501,6 @@ steps:
       Use the trusted Jira issue updater workflow and Jira transition tools. Match Code Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
     skill:
       id: jira-issue-updater
+      requiredCapabilities:
+        - jira
       args: {}

--- a/api_service/services/agent_skills_service.py
+++ b/api_service/services/agent_skills_service.py
@@ -17,6 +17,7 @@ from api_service.db.models import (
     SkillSet,
 )
 from moonmind.services.skill_resolution import (
+    extract_required_capabilities_from_skill_markdown,
     extract_required_skill_names_from_skill_markdown,
 )
 from moonmind.workflows.temporal import TemporalArtifactService
@@ -109,6 +110,11 @@ class AgentSkillsService:
             skill_name=skill_slug,
             source_label=f"deployment skill '{skill_slug}' version '{version_string}'",
         )
+        required_capabilities = extract_required_capabilities_from_skill_markdown(
+            content,
+            skill_name=skill_slug,
+            source_label=f"deployment skill '{skill_slug}' version '{version_string}'",
+        )
 
         # Check for duplicate version early if possible
         stmt = select(AgentSkillVersion).where(
@@ -137,6 +143,7 @@ class AgentSkillsService:
                 "version_string": version_string,
                 "format": format_str,
                 "required_skills": list(required_skills),
+                "required_capabilities": list(required_capabilities),
             },
         )
         artifact = await self._artifact_service.write_complete(

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -4,7 +4,7 @@ Status: Desired State
 Owners: MoonMind Engineering
 Last Updated: 2026-04-29
 Canonical for: agent skills, Skill steps, skill-set resolution, runtime skill materialization, `.agents/skills` path policy
-Related: `docs/Steps/StepTypes.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Workflows/WorkflowArchitecture.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/WorkflowConsoleArchitecture.md`, `AGENTS.md`
+Related: `docs/Steps/StepTypes.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Workflows/WorkflowArchitecture.md`, `docs/Workflows/RequiredCapabilities.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/WorkflowConsoleArchitecture.md`, `AGENTS.md`
 
 ---
 

--- a/docs/Steps/StepTypes.md
+++ b/docs/Steps/StepTypes.md
@@ -3,7 +3,7 @@
 Status: Desired-state architecture
 Owners: MoonMind Engineering (Workflow Platform + UI)
 Last Updated: 2026-05-05
-Related: `docs/Workflows/WorkflowPresetsSystem.md`, `docs/UI/CreatePage.md`, `docs/Steps/SkillSystem.md`, `docs/Steps/JiraIntegration.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Tools/DockerComposeUpdateSystem.md`
+Related: `docs/Workflows/WorkflowPresetsSystem.md`, `docs/Workflows/RequiredCapabilities.md`, `docs/UI/CreatePage.md`, `docs/Steps/SkillSystem.md`, `docs/Steps/JiraIntegration.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Tools/DockerComposeUpdateSystem.md`
 
 ---
 
@@ -72,6 +72,8 @@ Product surfaces may expose friendly shortcuts such as **Instructions**, **Manag
 | **Activity** | A Temporal implementation detail for side-effecting work. It is not a user-facing Step Type. |
 
 The term **Capability** should not be used as the umbrella product label in the step picker. The product-facing label is **Step Type**.
+
+This catalog-selector meaning is separate from `requiredCapabilities`, which are hard execution requirements compiled from selected Tools, Skills, Presets, runtime modes, and publish modes. See `docs/Workflows/RequiredCapabilities.md` for declaration, normalization, readiness checks, and launch-blocking semantics.
 
 ---
 

--- a/docs/Temporal/TemporalAgentExecution.md
+++ b/docs/Temporal/TemporalAgentExecution.md
@@ -18,7 +18,10 @@ relevant activity workers, and back. Open migration gaps are tracked in
 
 For broader architecture context see
 [TemporalArchitecture.md](TemporalArchitecture.md) and
-[RemainingWork.md](RemainingWork.md).
+[RemainingWork.md](RemainingWork.md). Required execution capability semantics
+are canonical in [RequiredCapabilities.md](../Workflows/RequiredCapabilities.md):
+the normalized `requiredCapabilities` list is a hard pre-launch readiness
+contract, not an authorization grant or informational label.
 
 ---
 

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -3,7 +3,7 @@
 **Status:** Proposed  
 **Owner:** MoonMind Platform  
 **Audience:** backend, workflow authors, API, Mission Control  
-**Related:** `docs/Workflows/WorkflowDependencies.md`, `docs/Workflows/WorkflowPublishing.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/TemporalAgentExecution.md`, `docs/ManagedAgents/SkillGithubPrResolver.md`
+**Related:** `docs/Workflows/WorkflowDependencies.md`, `docs/Workflows/WorkflowPublishing.md`, `docs/Workflows/RequiredCapabilities.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`, `docs/Temporal/TemporalAgentExecution.md`, `docs/ManagedAgents/SkillGithubPrResolver.md`
 
 ---
 
@@ -18,6 +18,11 @@ This design covers the case where a workflow execution:
 3. waits for external merge-readiness signals such as GitHub review/check completion and optional Jira state,
 4. invokes `pr-resolver`,
 5. does not allow the parent workflow to complete until merge automation reaches its terminal outcome.
+
+Resolver templates that declare `requiredCapabilities` such as `git` and `gh`
+must be treated as hard readiness requirements for the child resolver launch.
+The canonical declaration, merge, and blocker semantics are defined in
+`docs/Workflows/RequiredCapabilities.md`.
 
 The goal is to let downstream workflow dependencies wait on the **original parent Workflow Execution** rather than forcing operators to depend on a second top-level workflow created later.
 

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -44,7 +44,7 @@ Capability declarations may originate from multiple authoring sources:
 4. step-level Skill selection,
 5. Tool definitions or Tool steps,
 6. preset metadata and preset-expanded child steps,
-7. Skill metadata such as `metadata.requiredCapabilities`,
+7. Skill metadata such as `metadata.required-capabilities`,
 8. explicit advanced authoring fields.
 
 The backend merges all sources into a single normalized, deduplicated, ordered top-level list before launch.
@@ -170,7 +170,7 @@ Agent Skills may declare default capabilities in `SKILL.md` frontmatter:
 name: jira-pr-verify
 description: Verify a GitHub pull request against a Jira issue and post a PR comment.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
     - gh
@@ -373,7 +373,7 @@ Skill selection may require capabilities, but Skill identity and Tool access rem
 
 Rules:
 
-1. Selecting a Skill contributes the Skill's declared `metadata.requiredCapabilities`.
+1. Selecting a Skill contributes the Skill's declared `metadata.required-capabilities`.
 2. Supporting Skills included through Skill resolution contribute their own declared capabilities.
 3. A Skill-declared capability does not automatically allow every Tool in that integration.
 4. Allowed Tools remain governed by Skill policy, runtime policy, user authorization, and approval rules.
@@ -472,7 +472,7 @@ Minimum coverage:
 4. container-enabled execution contributes `docker`;
 5. Tool-declared capabilities contribute to the normalized top-level list;
 6. preset-declared and preset-expanded capabilities contribute to the normalized top-level list;
-7. Skill `metadata.requiredCapabilities` contributes when a Skill is selected directly;
+7. Skill `metadata.required-capabilities` contributes when a Skill is selected directly;
 8. supporting Skills selected through required-Skill closure contribute their capabilities;
 9. frontend omission of Skill metadata capabilities is corrected by backend normalization;
 10. readiness blocks before launch when `jira`, `gh`, `git`, `docker`, or runtime-mode requirements cannot be satisfied;

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -1,0 +1,505 @@
+# Required Capabilities
+
+Status: Desired State
+Owners: MoonMind Engineering
+Last Updated: 2026-06-17
+Canonical for: `requiredCapabilities` declaration, derivation, normalization, readiness checks, and failure semantics
+Related: `docs/Workflows/WorkflowArchitecture.md`, `docs/Steps/StepTypes.md`, `docs/Steps/SkillSystem.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
+
+---
+
+## 1. Purpose
+
+This document defines the declarative design of MoonMind **Required Capabilities**.
+
+Required Capabilities are the normalized execution contract that says what the platform must be able to provide before a workflow, task, step, Tool, Skill, preset-derived step, or managed runtime session may start.
+
+They answer questions such as:
+
+1. Does the run need a repository checkout and `git`?
+2. Does it need authenticated GitHub CLI / PR access through `gh`?
+3. Does it need trusted Jira issue access or prefetched Jira artifacts?
+4. Does it need a specific managed runtime such as `codex_cli`?
+5. Does it need Docker, a sandbox, or another worker-side runtime feature?
+
+Required Capabilities are declarative. They describe requirements. They do not grant authorization, contain credentials, execute tools, or replace policy checks.
+
+---
+
+## 2. Desired-state summary
+
+MoonMind has one Required Capabilities contract:
+
+```ts
+type RequiredCapabilities = string[];
+```
+
+The normalized execution payload carries top-level `requiredCapabilities` after control-plane compilation and backend normalization. Those top-level capabilities are the execution-facing requirements consumed by worker routing, runtime preparation, integration readiness checks, and pre-launch blocking.
+
+Capability declarations may originate from multiple authoring sources:
+
+1. runtime mode,
+2. publish mode,
+3. workflow-level Skill selection,
+4. step-level Skill selection,
+5. Tool definitions or Tool steps,
+6. preset metadata and preset-expanded child steps,
+7. Skill metadata such as `metadata.requiredCapabilities`,
+8. explicit advanced authoring fields.
+
+The backend merges all sources into a single normalized, deduplicated, ordered top-level list before launch.
+
+If any required capability cannot be satisfied under policy and authorization, the workflow or agent step must fail before runtime launch with a structured blocker.
+
+---
+
+## 3. Terminology
+
+| Term | Meaning |
+| --- | --- |
+| **Required Capability** | A declarative token naming a runtime, integration, worker, or materialization requirement that must be satisfied before launch. |
+| **Capability token** | A normalized string such as `git`, `gh`, `jira`, `docker`, or `codex_cli`. |
+| **Capability source** | The authoring or compilation source that contributed a token, such as publish mode, a preset, a selected Skill, or a Tool step. |
+| **Satisfied capability** | A required capability whose readiness check has succeeded for the requested target, policy, and user/deployment authorization. |
+| **Unsatisfied capability** | A required capability that cannot be prepared or verified. Unsatisfied required capabilities block before launch. |
+| **Readiness check** | A pre-launch platform check that proves the capability can be provided safely enough for the run to start. |
+| **Materialization** | The act of preparing concrete runtime-visible state, such as a checkout, sanitized Jira artifacts, a `GH_TOKEN`, a Tool result artifact, or an active Skill bundle. |
+
+The word **Capability** is also used in Step Type docs for selectable catalog items. That usage means "a selectable Tool, Skill, or Preset." `requiredCapabilities` are different: they are execution requirements derived from selected work, not user-facing Step Types.
+
+---
+
+## 4. Non-goals and boundaries
+
+Required Capabilities are not:
+
+1. a new GitHub/Jira access system;
+2. an authorization grant;
+3. a place to store secrets;
+4. a Tool invocation;
+5. a Skill or SkillSet selector;
+6. a runtime command;
+7. a replacement for provider profiles, approval policy, or user permissions;
+8. the only validation a workflow needs.
+
+A run that declares `jira` still needs valid Jira authorization or prefetched trusted Jira artifacts. A run that declares `gh` still needs a GitHub identity/token with appropriate repository permissions. A run that declares `git` still needs a repository target that policy allows the worker to prepare.
+
+---
+
+## 5. Contract surfaces
+
+### 5.1 Top-level execution contract
+
+The normalized execution payload carries the final, flattened list:
+
+```json
+{
+  "requiredCapabilities": ["codex_cli", "git", "gh", "jira"],
+  "task": {
+    "runtime": { "mode": "codex_cli" },
+    "publish": { "mode": "none" }
+  }
+}
+```
+
+This list is execution-facing and authoritative after backend normalization.
+
+### 5.2 Workflow or task Skill field
+
+A selected workflow-level Skill may declare explicit requirements:
+
+```json
+{
+  "task": {
+    "skill": {
+      "id": "jira-pr-verify",
+      "requiredCapabilities": ["jira", "git", "gh"]
+    }
+  }
+}
+```
+
+Explicit authoring fields are additive with Skill metadata defaults.
+
+### 5.3 Step Skill field
+
+A step-level Skill may declare requirements:
+
+```json
+{
+  "id": "verify-pr-against-jira",
+  "type": "skill",
+  "skill": {
+    "id": "jira-pr-verify",
+    "requiredCapabilities": ["jira", "git", "gh"]
+  }
+}
+```
+
+Step-level declarations contribute to the top-level execution payload because worker/runtimes must be prepared for the whole executable workflow.
+
+### 5.4 Tool field
+
+Tool definitions and Tool steps may contribute required worker or integration capabilities:
+
+```json
+{
+  "id": "fetch-jira-issue",
+  "type": "tool",
+  "tool": {
+    "id": "jira.get_issue",
+    "requiredCapabilities": ["jira"]
+  }
+}
+```
+
+Tool capability requirements do not convert a Tool into a Skill. They describe what the execution environment must satisfy to run the Tool.
+
+### 5.5 Preset metadata and expansion
+
+Presets may declare capability requirements directly, and preset expansion may generate Tool or Skill steps that declare additional requirements.
+
+Preset-derived capabilities must be compiled into the resolved workflow payload before runtime execution. Runtime workers must not depend on live preset catalog lookup to discover missing capabilities for an already submitted workflow.
+
+### 5.6 Agent Skill metadata
+
+Agent Skills may declare default capabilities in `SKILL.md` frontmatter:
+
+```yaml
+---
+name: jira-pr-verify
+description: Verify a GitHub pull request against a Jira issue and post a PR comment.
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
+    - gh
+---
+```
+
+Deployment-stored Skill versions should preserve the same data in metadata as:
+
+```json
+{
+  "required_capabilities": ["jira", "git", "gh"]
+}
+```
+
+When a Skill requires supporting Skills through `metadata.required-skills`, the resolved Skill closure contributes the required capabilities of every selected and required Skill.
+
+### 5.7 Runtime and publish derivation
+
+The control plane may derive capabilities from runtime and publish choices:
+
+1. runtime mode `codex_cli` contributes `codex_cli`;
+2. repository-backed execution contributes `git`;
+3. `publish.mode = "pr"` contributes `gh`;
+4. container-enabled execution contributes `docker`.
+
+These derived tokens use the same `requiredCapabilities` list as Skill, Tool, and preset declarations.
+
+---
+
+## 6. Normalization and merge rules
+
+Required Capability normalization is deterministic.
+
+Rules:
+
+1. Capability tokens are strings.
+2. Tokens are trimmed.
+3. Tokens are normalized to lowercase unless a future capability registry explicitly marks a token as case-sensitive.
+4. Blank tokens are invalid.
+5. Non-string tokens are invalid.
+6. Duplicate tokens are removed while preserving first-seen order.
+7. The backend is authoritative. The frontend may derive and preview capabilities, but backend normalization must not trust the browser as the only source of required capabilities.
+8. Capability sources are additive. A user or preset may add requirements, but the authoring UI must not silently remove requirements declared by selected Skills, Tools, runtime mode, or publish mode.
+9. Explicit removal, if ever supported, must be policy-checked and visibly represented as an override with audit provenance.
+
+Representative merge order:
+
+1. incoming top-level `requiredCapabilities`,
+2. runtime-mode-derived capabilities,
+3. publish-mode-derived capabilities,
+4. preset/template-derived capabilities,
+5. selected Skill metadata capabilities,
+6. explicit Skill field capabilities,
+7. selected Tool capabilities,
+8. container/runtime adapter capabilities.
+
+The exact internal order may vary, but the resulting list must be stable, deduplicated, and explainable through source provenance.
+
+---
+
+## 7. Capability semantics
+
+### 7.1 `git`
+
+`git` means the platform must be able to prepare a repository workspace for the run.
+
+Minimum readiness:
+
+1. the target repository is known when required;
+2. repository policy permits checkout or workspace reuse;
+3. `git` is available to the runtime or to the workspace preparation layer;
+4. branch/base/head state required by the workflow can be prepared;
+5. publish mode constraints can be honored.
+
+`git` does not imply permission to push unless the workflow's publish mode, Tool, or Skill requires and authorizes mutation.
+
+### 7.2 `gh`
+
+`gh` means the platform must be able to provide GitHub PR/repository operations through GitHub CLI or an equivalent runtime path.
+
+Minimum readiness:
+
+1. GitHub authentication is available under the selected policy;
+2. target repository access can be verified when a repository is known;
+3. target PR access can be verified when a PR is known;
+4. mutation permissions are verified before mutation-capable work starts;
+5. PR comment permission is verified before Skills that must post PR comments start.
+
+A GitHub connector 404 is not, by itself, proof that runtime `gh` access is unavailable. Readiness should check the canonical runtime GitHub path for the selected execution mode.
+
+### 7.3 `jira`
+
+`jira` means the platform must provide trusted Jira issue/project access or materialized trusted Jira artifacts.
+
+Minimum readiness:
+
+1. trusted Jira Tool/connector access is available in the control plane, or required Jira artifacts are already attached to the run;
+2. requested Jira issue keys or URLs are authorized when known;
+3. sanitized Jira outputs can be materialized into artifacts or prepared workspace paths when a managed runtime needs issue content;
+4. raw Atlassian credentials are not exposed in managed agent shells or Skill files.
+
+For managed agent Skills, Jira readiness should prefer prefetched normalized artifacts or trusted control-plane Tool output over placing Jira credentials into the runtime environment.
+
+### 7.4 `docker`
+
+`docker` means the worker or runtime preparation layer can run containerized operations under policy.
+
+Minimum readiness:
+
+1. Docker or the approved container runtime is available;
+2. container execution is allowed for the deployment, repository, and workflow;
+3. resource and network policy are enforceable;
+4. publishable workspace contents are protected from container-only side effects unless explicitly intended.
+
+### 7.5 Runtime-mode capabilities
+
+Runtime tokens such as `codex_cli`, `claude_code`, or `gemini_cli` mean the selected runtime adapter is available and compatible with the workflow's Skill, Tool, policy, and provider profile requirements.
+
+Minimum readiness:
+
+1. the adapter is enabled;
+2. the target worker can launch it;
+3. required model/provider profile constraints are satisfied;
+4. runtime-specific materialization, prompt, Skill bundle, and artifact contracts can be honored.
+
+### 7.6 Scoped future capabilities
+
+Coarse names remain valid. Future scoped aliases may refine semantics:
+
+| Coarse token | Possible scoped tokens |
+| --- | --- |
+| `jira` | `jira.read`, `jira.issue.read`, `jira.comment.write` |
+| `gh` | `github.repo.read`, `github.pr.read`, `github.pr.comment`, `github.pr.merge` |
+| `git` | `repo.read`, `repo.write`, `repo.branch.write` |
+
+Scoped tokens must map into the same Required Capabilities contract. They must not introduce a parallel integration access model.
+
+---
+
+## 8. Readiness and blocking model
+
+Required Capabilities are hard pre-launch requirements.
+
+Readiness checks happen after:
+
+1. preset expansion;
+2. Skill resolution;
+3. backend execution contract normalization;
+4. repository/runtime/publish target resolution sufficient for the check.
+
+Readiness checks happen before:
+
+1. managed agent launch;
+2. Tool step execution;
+3. runtime session creation;
+4. any action that assumes the capability is present.
+
+If a required capability cannot be satisfied, the platform must block before launch with a structured diagnostic.
+
+Representative diagnostic:
+
+```json
+{
+  "status": "blocked",
+  "capability": "jira",
+  "source": ["skill:jira-pr-verify"],
+  "target": {
+    "issueKey": "KANDY-2558"
+  },
+  "check": "trusted_jira_readiness",
+  "reason": "No trusted Jira connection or prefetched Jira artifact is available for this run.",
+  "remediation": "Connect Jira or add a trusted Jira fetch/import step before the agent Skill step."
+}
+```
+
+Diagnostics must be safe to show in logs and UI. They must not include raw tokens, auth headers, cookies, API keys, environment dumps, or private Jira/GitHub content beyond necessary identifiers.
+
+---
+
+## 9. Authorization and policy boundary
+
+Declaring a capability is necessary but not sufficient.
+
+The platform may satisfy a required capability only when all relevant gates pass:
+
+1. deployment policy permits the capability;
+2. repository/project policy permits the target;
+3. the user or service identity has the required authorization;
+4. approval/autonomy policy permits the action;
+5. the worker or runtime adapter can prepare the capability safely;
+6. secret handling policy can be honored.
+
+A required capability never grants broader access than the user, deployment, or runtime policy allows. It only makes the requirement explicit so the platform can prepare or reject the run deterministically.
+
+---
+
+## 10. Skill interaction rules
+
+Skill selection may require capabilities, but Skill identity and Tool access remain separate.
+
+Rules:
+
+1. Selecting a Skill contributes the Skill's declared `metadata.requiredCapabilities`.
+2. Supporting Skills included through Skill resolution contribute their own declared capabilities.
+3. A Skill-declared capability does not automatically allow every Tool in that integration.
+4. Allowed Tools remain governed by Skill policy, runtime policy, user authorization, and approval rules.
+5. Runtime adapters must not rediscover Skill files after launch to add new capabilities.
+6. If an active Skill requires a capability that cannot be satisfied, Skill resolution or runtime preparation must fail before the agent starts.
+
+Example: `jira-pr-verify` declaring `jira`, `git`, and `gh` means the platform must prepare Jira issue access/artifacts, repository state, and GitHub PR/comment access. It does not grant the Skill arbitrary Jira mutation Tools or GitHub merge permission.
+
+---
+
+## 11. Preset interaction rules
+
+Presets are authoring-time composition objects. They may contribute required capabilities in two ways:
+
+1. direct preset metadata;
+2. generated Tool and Skill steps after expansion.
+
+Rules:
+
+1. Preset expansion must happen before execution by default.
+2. Expanded steps carry their own capability declarations and provenance.
+3. Preset-derived capability metadata is flattened into top-level `requiredCapabilities`.
+4. Submitted execution payloads must not need live preset catalog lookup to discover required capabilities.
+5. Rerun and detail views should preserve enough provenance to explain preset-derived capability requirements.
+
+---
+
+## 12. Replay, rerun, and Resume semantics
+
+Required Capabilities participate in execution durability.
+
+Rules:
+
+1. The normalized `requiredCapabilities` list is part of the execution contract.
+2. Exact rerun reuses the original normalized requirements unless explicit re-resolution is requested.
+3. Edited full retry may recompute requirements from the edited workflow input.
+4. Resume from failed step uses the original workflow input and preserved execution contract unless the Resume design explicitly permits re-resolution in the future.
+5. A Resume attempt must not silently drop a capability required by the original failed step.
+6. If a capability was satisfiable in the source run but is no longer satisfiable for Resume, the Resume attempt must fail explicitly before executing the failed step.
+
+---
+
+## 13. Observability
+
+Mission Control and operator diagnostics should expose Required Capabilities as first-class execution context.
+
+At minimum, detail/debug surfaces should be able to show:
+
+1. normalized top-level `requiredCapabilities`;
+2. source provenance for each token;
+3. readiness status for each token;
+4. materialized artifact refs or safe summaries where applicable;
+5. pre-launch blockers and remediation guidance;
+6. policy denials without leaking secrets;
+7. whether a capability came from runtime mode, publish mode, preset, Skill, Tool, or explicit advanced authoring.
+
+User-facing views may collapse details, but operator/debug views must make capability-driven launch failures explainable without parsing raw workflow history.
+
+---
+
+## 14. Security invariants
+
+1. Required Capabilities do not contain secrets.
+2. Skill files and preset files do not contain secrets.
+3. Capability readiness diagnostics do not print environment variables or token values.
+4. Runtime adapters do not broaden capabilities after launch.
+5. Agents do not receive raw integration credentials merely because a capability is required.
+6. Trusted control-plane Tool output and sanitized artifacts are preferred for private integration data needed by managed agents.
+7. Capability metadata from repo or local Skill sources is untrusted input until parsed, normalized, validated, and policy-checked.
+8. Capability satisfaction must be idempotent or safely retryable because workflow preparation may retry.
+
+---
+
+## 15. Core invariants
+
+1. MoonMind has one Required Capabilities contract: normalized `requiredCapabilities`.
+2. Required Capabilities are declarative launch requirements, not authorization grants.
+3. Backend normalization is authoritative.
+4. Frontend derivation is a preview and submit convenience, not the only enforcement layer.
+5. Presets, Tools, Skills, runtime mode, publish mode, and advanced authoring all contribute to the same top-level list.
+6. Direct Skill selection and preset-backed Skill selection must produce equivalent capability requirements when they select equivalent work.
+7. Unsatisfied required capabilities block before launch.
+8. Runtime adapters must not discover or add undeclared capabilities after launch.
+9. Capability source provenance must be available for diagnostics.
+10. Required Capabilities must remain safe to store in workflow histories, manifests, and logs.
+
+---
+
+## 16. Validation and test requirements
+
+Minimum coverage:
+
+1. top-level `requiredCapabilities` normalization trims, lowercases, deduplicates, and rejects invalid entries;
+2. runtime mode contributes the selected runtime token;
+3. PR publish mode contributes `gh`;
+4. container-enabled execution contributes `docker`;
+5. Tool-declared capabilities contribute to the normalized top-level list;
+6. preset-declared and preset-expanded capabilities contribute to the normalized top-level list;
+7. Skill `metadata.requiredCapabilities` contributes when a Skill is selected directly;
+8. supporting Skills selected through required-Skill closure contribute their capabilities;
+9. frontend omission of Skill metadata capabilities is corrected by backend normalization;
+10. readiness blocks before launch when `jira`, `gh`, `git`, `docker`, or runtime-mode requirements cannot be satisfied;
+11. readiness diagnostics include capability, source, check, reason, and remediation;
+12. readiness diagnostics do not include secrets or raw environment dumps;
+13. exact rerun preserves the original normalized requirements by default.
+
+---
+
+## 17. Documentation boundaries
+
+Use this document for the Required Capabilities system.
+
+Use related documents for adjacent systems:
+
+- `docs/Workflows/WorkflowArchitecture.md` for the broader workflow control-plane contract.
+- `docs/Steps/StepTypes.md` for Tool, Skill, and Preset Step Type taxonomy and selectable capability terminology.
+- `docs/Steps/SkillSystem.md` for Skill resolution, required supporting Skills, and runtime Skill materialization.
+- `docs/Workflows/SkillAndPlanContracts.md` for executable Tool and plan contracts.
+- `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` for managed and external agent runtime execution.
+
+---
+
+## 18. Summary
+
+Required Capabilities are MoonMind's declarative execution requirement layer.
+
+They make hidden runtime and integration prerequisites explicit, merge them into one normalized execution contract, verify them before launch, and block early when the platform cannot safely satisfy them.
+
+The correct design is not a separate GitHub/Jira access system. It is a single `requiredCapabilities` contract used consistently by presets, directly selected Skills, Tools, runtime mode, publish mode, backend normalization, runtime preparation, and operator diagnostics.

--- a/docs/Workflows/WorkflowArchitecture.md
+++ b/docs/Workflows/WorkflowArchitecture.md
@@ -21,6 +21,7 @@ It maps how the control plane translates user intent from Mission Control — in
 into durable execution under Temporal.
 
 This document is architectural and declarative. Detailed page behavior belongs in `docs/UI/CreatePage.md`. Detailed image-input behavior belongs in `docs/Workflows/ImageSystem.md`.
+Required execution capability declaration, normalization, and pre-launch blocking semantics belong in `docs/Workflows/RequiredCapabilities.md`.
 
 ---
 

--- a/docs/tmp/SkillRequiredCapabilitiesHardeningPlan.md
+++ b/docs/tmp/SkillRequiredCapabilitiesHardeningPlan.md
@@ -49,7 +49,7 @@ Repo and built-in Skill Markdown should use frontmatter metadata:
 name: jira-pr-verify
 description: Verify a GitHub pull request against a Jira issue's goals, requirements, and acceptance criteria, then post a PR comment with the findings.
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
     - gh
@@ -58,7 +58,7 @@ metadata:
 
 Rules:
 
-1. `metadata.requiredCapabilities` is a YAML sequence of strings.
+1. `metadata.required-capabilities` is a YAML sequence of strings.
 2. Capability tokens are normalized to lowercase and deduplicated while preserving first-seen order.
 3. Invalid, blank, or non-string tokens fail Skill resolution before runtime launch.
 4. Deployment-stored Skill versions should store the same data in artifact metadata as `required_capabilities: string[]`; the resolver may expose both sources as `ResolvedSkillEntry.required_capabilities`.
@@ -80,7 +80,7 @@ The coarse names should continue to work until the platform has a stable scoped 
 ### Phase 1 — Data model and parsing
 
 - Extend `ResolvedSkillEntry` with `required_capabilities: list[str]`.
-- Parse `metadata.requiredCapabilities` from repo and built-in `SKILL.md` frontmatter alongside `metadata.required-skills`.
+- Parse `metadata.required-capabilities` from repo and built-in `SKILL.md` frontmatter alongside `metadata.required-skills`.
 - Read deployment artifact metadata `required_capabilities` for deployment-stored Skills.
 - Normalize and validate capability tokens in one helper, similar to required-Skill name parsing.
 - Include the final per-Skill capability list in the resolved manifest and source trace so detail/debug views can explain why a run required a capability.
@@ -119,7 +119,7 @@ Treat each normalized capability as a launch preflight requirement.
 
 ### Phase 5 — Seed metadata and audit existing Skills
 
-- Add `metadata.requiredCapabilities: [jira, git, gh]` to `jira-pr-verify`.
+- Add `metadata.required-capabilities: [jira, git, gh]` to `jira-pr-verify`.
 - Audit built-in Skills for hard dependencies implied by their instructions:
   - PR resolvers and comment fixers likely require `git` and `gh`.
   - Jira triage / Jira implementation / Jira verification Skills likely require `jira` and often `git` or `gh`.
@@ -130,7 +130,7 @@ Treat each normalized capability as a launch preflight requirement.
 
 Minimum coverage:
 
-1. Parser accepts `metadata.requiredCapabilities` YAML arrays and rejects invalid shapes.
+1. Parser accepts `metadata.required-capabilities` YAML arrays and rejects invalid shapes.
 2. Resolver exposes Skill-declared capabilities on `ResolvedSkillEntry` and resolved manifests.
 3. Selecting `jira-pr-verify` directly produces top-level `requiredCapabilities` containing `codex_cli`, `git`, `gh`, and `jira`, even when no Jira preset is selected.
 4. Existing Advanced Mode tests for explicit `git`, `jira` remain green.
@@ -154,7 +154,7 @@ Minimum coverage:
 
 ```yaml
 metadata:
-  requiredCapabilities:
+  required-capabilities:
     - jira
     - git
     - gh

--- a/docs/tmp/SkillRequiredCapabilitiesHardeningPlan.md
+++ b/docs/tmp/SkillRequiredCapabilitiesHardeningPlan.md
@@ -1,0 +1,163 @@
+# Skill Required Capabilities Hardening Plan
+
+Status: proposal (2026-06-17). Execution plan — lives in `docs/tmp/` because this is rollout and migration work, not the canonical desired-state Skill System contract.
+
+## Goal
+
+Make selected agent Skills declare, propagate, and enforce the runtime capabilities they need, so a directly selected Skill gets the same access preparation as a preset-backed workflow.
+
+This plan intentionally does **not** introduce a new GitHub/Jira access system. The existing `requiredCapabilities` plumbing remains the control-plane and execution-plane contract; the gap is that Skill selection does not yet reliably declare and enforce those requirements.
+
+## Current-state findings
+
+- Advanced mode can already add per-skill `requiredCapabilities`, such as `git` and `jira`.
+- The Create page already derives top-level `payload.requiredCapabilities` from runtime mode, publish mode, task Skill capabilities, step Skill capabilities, and preset/template capabilities.
+- Existing tests already cover advanced-mode inputs that produce top-level capabilities such as `codex_cli`, `git`, `gh`, and `jira`.
+- Presets can declare and derive capabilities. Jira presets such as `jira-orchestrate.yaml` and `jira-implement.yaml` already carry `jira` capability metadata.
+- The backend execution contract already preserves and derives capabilities from top-level, task Skill, step Skill, and Tool fields.
+- The Skill System already has an adjacent transitive metadata concept for `metadata.required-skills`, which proves Skill frontmatter can drive resolution-time behavior.
+
+## Problem statement
+
+`jira-pr-verify` can fail when it is selected directly rather than through a Jira preset. The preset path supplies capability metadata, but the direct Skill path does not automatically add or enforce `jira`, `git`, or `gh` requirements.
+
+That leaves the managed runtime able to launch without trusted Jira content, without a verified Jira tool path, or without usable GitHub PR/comment access. The agent then discovers the missing access too late and may report a task-specific blocker that the platform could have detected before launch.
+
+## Non-goals
+
+- Do not create a parallel "GitHub/Jira access" feature.
+- Do not put secrets or raw credentials in Skill files, Skill manifests, or prompts.
+- Do not treat Skill-declared capabilities as automatic authorization grants.
+- Do not let frontend capability derivation be the only enforcement layer.
+- Do not make runtimes rediscover or broaden capabilities after launch.
+
+## Decisions
+
+1. Agent Skills may declare default runtime capabilities in Skill metadata.
+2. Direct Skill selection must merge those declared capabilities into the existing `requiredCapabilities` payload, just as presets already contribute capabilities.
+3. Backend normalization must be authoritative. The frontend may derive early for preview and submit payload shape, but backend execution contract and runtime preparation must not trust the browser as the only source of capability requirements.
+4. `requiredCapabilities` are hard launch requirements. They are not only labels for routing or display.
+5. Unsatisfied required capabilities must block before agent launch with actionable diagnostics.
+6. Coarse capability names remain supported now (`git`, `gh`, `jira`). Scoped names are allowed as a future refinement (`jira.read`, `github.pr.read`, `github.pr.comment`) but should map to the same enforcement pipeline instead of a second system.
+
+## Skill metadata contract
+
+Repo and built-in Skill Markdown should use frontmatter metadata:
+
+```yaml
+---
+name: jira-pr-verify
+description: Verify a GitHub pull request against a Jira issue's goals, requirements, and acceptance criteria, then post a PR comment with the findings.
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
+    - gh
+---
+```
+
+Rules:
+
+1. `metadata.requiredCapabilities` is a YAML sequence of strings.
+2. Capability tokens are normalized to lowercase and deduplicated while preserving first-seen order.
+3. Invalid, blank, or non-string tokens fail Skill resolution before runtime launch.
+4. Deployment-stored Skill versions should store the same data in artifact metadata as `required_capabilities: string[]`; the resolver may expose both sources as `ResolvedSkillEntry.required_capabilities`.
+5. Capability metadata is safe declarative metadata. It must not contain credentials, tokens, URLs with credentials, or user-specific secrets.
+6. Capability metadata is additive. A selected Skill's default requirements may be augmented by presets, advanced authoring fields, publish mode, runtime mode, or Tool selections, but they must not be silently removed by the authoring UI.
+
+## Capability semantics
+
+| Capability | Minimum meaning now | Future scoped aliases |
+| --- | --- | --- |
+| `git` | Managed runtime has a repository checkout, `git` is installed, and the requested repo/branch state can be prepared. | `repo.read`, `repo.write` |
+| `gh` | GitHub CLI or equivalent GitHub runtime path is present and authenticated for the target repository. For PR-commenting Skills, comment permission must be verified before launch. | `github.pr.read`, `github.pr.comment` |
+| `jira` | Trusted Jira control-plane/tool access is available, or normalized Jira artifacts are prefetched and materialized for the run. Raw Atlassian credentials are not placed in the managed shell. | `jira.read`, `jira.issue.read` |
+
+The coarse names should continue to work until the platform has a stable scoped vocabulary and compatibility mapping.
+
+## Implementation plan
+
+### Phase 1 — Data model and parsing
+
+- Extend `ResolvedSkillEntry` with `required_capabilities: list[str]`.
+- Parse `metadata.requiredCapabilities` from repo and built-in `SKILL.md` frontmatter alongside `metadata.required-skills`.
+- Read deployment artifact metadata `required_capabilities` for deployment-stored Skills.
+- Normalize and validate capability tokens in one helper, similar to required-Skill name parsing.
+- Include the final per-Skill capability list in the resolved manifest and source trace so detail/debug views can explain why a run required a capability.
+
+### Phase 2 — Direct Skill selection merge
+
+- Expose declared Skill capabilities through the Skill catalog / selector data used by Mission Control.
+- When a user selects a Skill directly at the task level, merge that Skill's declared capabilities into the existing task Skill capability list before calling `deriveRequiredCapabilities`.
+- When a user selects a Skill directly on a step, merge that Skill's declared capabilities into the existing step Skill capability list.
+- Keep Advanced Mode capability entries additive and visible; do not duplicate values when the selected Skill already declares them.
+- Preserve preset-derived capabilities exactly as today.
+
+### Phase 3 — Backend authoritative normalization
+
+- In execution contract normalization, merge capabilities from:
+  - incoming top-level `requiredCapabilities`,
+  - runtime mode,
+  - publish mode,
+  - selected task Skill declaration,
+  - selected step Skill declarations,
+  - explicit task/step Skill `requiredCapabilities`,
+  - step Tool `requiredCapabilities`,
+  - preset/template-derived capabilities.
+- Do not rely on live preset lookup for already compiled presets.
+- If the frontend omitted a directly selected Skill's default capabilities, backend Skill resolution must still derive them before launch.
+- Persist the normalized, deduplicated top-level `requiredCapabilities` list as the execution contract used by runtime preparation.
+
+### Phase 4 — Runtime capability readiness gates
+
+Treat each normalized capability as a launch preflight requirement.
+
+- `git`: verify the checkout exists, `git` is executable, the expected repository is available, and branch state can be prepared for the publish mode.
+- `gh`: verify `gh` or the canonical GitHub runtime path is available, authentication is usable, the target repo/PR can be viewed, and PR comment permission is available when the selected Skill can post comments.
+- `jira`: verify trusted Jira tool readiness or prefetch Jira artifacts before agent launch. If the Skill requires Jira issue content and no issue artifact exists, call the trusted Jira fetch/tool path in the control plane and materialize sanitized artifacts into the run workspace.
+- If any required capability cannot be satisfied, fail before agent launch with a structured blocker that names the capability, target, attempted readiness check, and remediation.
+
+### Phase 5 — Seed metadata and audit existing Skills
+
+- Add `metadata.requiredCapabilities: [jira, git, gh]` to `jira-pr-verify`.
+- Audit built-in Skills for hard dependencies implied by their instructions:
+  - PR resolvers and comment fixers likely require `git` and `gh`.
+  - Jira triage / Jira implementation / Jira verification Skills likely require `jira` and often `git` or `gh`.
+  - Docs-only Skills should avoid declaring external capabilities unless they actually need them.
+- Keep capability declarations minimal. A Skill should not declare `jira` merely because a user might mention Jira; it should declare `jira` when the Skill's normal operation needs trusted Jira access or Jira artifacts.
+
+### Phase 6 — Tests
+
+Minimum coverage:
+
+1. Parser accepts `metadata.requiredCapabilities` YAML arrays and rejects invalid shapes.
+2. Resolver exposes Skill-declared capabilities on `ResolvedSkillEntry` and resolved manifests.
+3. Selecting `jira-pr-verify` directly produces top-level `requiredCapabilities` containing `codex_cli`, `git`, `gh`, and `jira`, even when no Jira preset is selected.
+4. Existing Advanced Mode tests for explicit `git`, `jira` remain green.
+5. Preset-derived capability tests remain green and do not double-add duplicates.
+6. Backend normalization derives Skill-declared capabilities even if the frontend omits them.
+7. Runtime preflight blocks before agent launch when `jira` is required but neither trusted Jira tooling nor prefetched Jira artifacts are available.
+8. Runtime preflight blocks before agent launch when `gh` is required but repo/PR read or comment permission is unavailable.
+9. Failure diagnostics are structured and do not include secrets or environment dumps.
+
+## Acceptance criteria
+
+- Directly selecting `jira-pr-verify` launches only after Jira and GitHub readiness have been verified or required artifacts have been materialized.
+- The submitted execution payload includes normalized top-level capabilities such as `codex_cli`, `git`, `gh`, and `jira` for that direct Skill path.
+- A missing Jira or GitHub prerequisite blocks before the agent starts, not after the agent has already begun reasoning.
+- Preset-backed Jira workflows continue to work through the same `requiredCapabilities` field.
+- The system has one capability contract, not a new per-integration access mechanism.
+
+## Initial exemplar change
+
+`jira-pr-verify` now declares:
+
+```yaml
+metadata:
+  requiredCapabilities:
+    - jira
+    - git
+    - gh
+```
+
+That declaration matches the Skill's documented behavior: it needs trusted Jira issue content, repository/PR inspection, and authenticated GitHub comment access.

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -578,6 +578,7 @@ interface SkillCapabilityDetail {
   inputSchema?: Record<string, unknown>;
   uiSchema?: Record<string, unknown>;
   defaults?: Record<string, unknown>;
+  requiredCapabilities?: string[];
 }
 
 interface SkillCatalogResult {
@@ -1834,6 +1835,17 @@ function parseCapabilitiesCsv(value: string): string[] {
       value
         .split(",")
         .map((item) => item.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function mergeCapabilities(...groups: Array<string[] | undefined | null>): string[] {
+  return Array.from(
+    new Set(
+      groups
+        .flatMap((group) => group || [])
+        .map((item) => String(item || "").trim().toLowerCase())
         .filter(Boolean),
     ),
   );
@@ -4893,6 +4905,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           ...(item.inputSchema ? { inputSchema: item.inputSchema } : {}),
           ...(item.uiSchema ? { uiSchema: item.uiSchema } : {}),
           ...(item.defaults ? { defaults: item.defaults } : {}),
+          ...(Array.isArray(item.requiredCapabilities)
+            ? {
+                requiredCapabilities: item.requiredCapabilities
+                  .map((capability) => String(capability || "").trim().toLowerCase())
+                  .filter(Boolean),
+              }
+            : {}),
         };
       }
       return {
@@ -7842,12 +7861,17 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const primarySkillArgsRaw = primaryStepIsSkill && showAdvancedStepOptions
       ? String(primaryStep?.skillArgs || "").trim()
       : "";
-    const taskSkillRequiredCapabilities = primaryStepIsSkill && showAdvancedStepOptions
-      ? parseCapabilitiesCsv(String(primaryStep?.skillRequiredCapabilities || ""))
-      : [];
     const primarySkillDetail = primaryStepIsSkill
       ? skillsQuery.data?.detailsById[primaryValidation.value.skillId.trim()] || null
       : null;
+    const taskSkillRequiredCapabilities = primaryStepIsSkill
+      ? mergeCapabilities(
+          primarySkillDetail?.requiredCapabilities,
+          showAdvancedStepOptions
+            ? parseCapabilitiesCsv(String(primaryStep?.skillRequiredCapabilities || ""))
+            : [],
+        )
+      : [];
     const primarySchemaInputs = primaryStep
       ? schemaSkillInputs(primarySkillDetail, primaryStep.presetInputValues)
       : { values: {}, errors: {} };
@@ -7974,12 +7998,17 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       const stepSkillArgsRaw = stepIsSkill && showAdvancedStepOptions
         ? step.skillArgs.trim()
         : "";
-      const stepSkillCaps = stepIsSkill && showAdvancedStepOptions
-        ? parseCapabilitiesCsv(step.skillRequiredCapabilities)
-        : [];
       const stepSkillDetail = stepIsSkill
         ? skillsQuery.data?.detailsById[stepSkillId] || null
         : null;
+      const stepSkillCaps = stepIsSkill
+        ? mergeCapabilities(
+            stepSkillDetail?.requiredCapabilities,
+            showAdvancedStepOptions
+              ? parseCapabilitiesCsv(step.skillRequiredCapabilities)
+              : [],
+          )
+        : [];
       const stepToolDefinition =
         stepIsTool
           ? (trustedToolsQuery.data || []).find(

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3907,6 +3907,11 @@ export interface components {
              */
             id: string;
             /**
+             * Requiredcapabilities
+             * @description Default required capabilities declared by Skill metadata
+             */
+            requiredCapabilities?: string[];
+            /**
              * Markdown
              * @description Markdown content of the skill, if requested
              */

--- a/moonmind/schemas/agent_skill_models.py
+++ b/moonmind/schemas/agent_skill_models.py
@@ -64,6 +64,7 @@ class ResolvedSkillEntry(BaseModel):
     content_digest: str | None = None
     provenance: AgentSkillProvenance
     required_skills: list[str] = Field(default_factory=list)
+    required_capabilities: list[str] = Field(default_factory=list)
     selection_reason: str | None = None
     required_by: list[str] = Field(default_factory=list)
     
@@ -181,6 +182,7 @@ class SkillCatalogSearchResult(BaseModel):
     latest_version: str | None = None
     source_kind: AgentSkillSourceKind
     supported_runtimes: list[str] = Field(default_factory=list)
+    required_capabilities: list[str] = Field(default_factory=list)
     eligible: bool
     in_current_snapshot: bool = False
     eligibility_summary: str | None = None

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -22,7 +22,9 @@ from moonmind.schemas.agent_skill_models import (
 )
 
 _REQUIRED_SKILLS_METADATA_KEY = "required-skills"
+_REQUIRED_CAPABILITIES_METADATA_KEY = "requiredCapabilities"
 _AGENT_SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$")
+_CAPABILITY_TOKEN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.:-]{0,126}[a-z0-9])?$")
 
 class SkillResolutionContext:
     """Contextual parameters for skill resolution (e.g. paths, run ID)."""
@@ -175,6 +177,10 @@ class DeploymentSkillLoader(SkillLoader):
                     metadata,
                     owner=definition.slug,
                 )
+                required_capabilities = _required_capabilities_from_artifact_metadata(
+                    metadata,
+                    owner=definition.slug,
+                )
                 results.append(
                     ResolvedSkillEntry(
                         skill_name=definition.slug,
@@ -183,6 +189,7 @@ class DeploymentSkillLoader(SkillLoader):
                         content_ref=latest_version.artifact_ref,
                         content_digest=latest_version.content_digest,
                         required_skills=list(required_skills),
+                        required_capabilities=list(required_capabilities),
                         provenance=AgentSkillProvenance(
                             source_kind=AgentSkillSourceKind.DEPLOYMENT
                         ),
@@ -355,6 +362,70 @@ def _required_skill_names_from_frontmatter(
     )
 
 
+def _validate_required_capability_token(value: str, *, owner: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized or _CAPABILITY_TOKEN_RE.fullmatch(normalized) is None:
+        raise ValueError(
+            f"skill '{owner}' metadata.{_REQUIRED_CAPABILITIES_METADATA_KEY} "
+            f"contains invalid required capability '{value}'"
+        )
+    return normalized
+
+
+def _required_capabilities_from_metadata(
+    raw_required: typing.Any,
+    *,
+    owner: str,
+) -> tuple[str, ...]:
+    if raw_required is None:
+        return ()
+    if not isinstance(raw_required, list) or not all(
+        isinstance(item, str) for item in raw_required
+    ):
+        raise ValueError(
+            f"skill '{owner}' metadata.{_REQUIRED_CAPABILITIES_METADATA_KEY} "
+            "must be a list of strings"
+        )
+    required: list[str] = []
+    seen: set[str] = set()
+    for raw_capability in raw_required:
+        capability = _validate_required_capability_token(raw_capability, owner=owner)
+        if capability in seen:
+            continue
+        seen.add(capability)
+        required.append(capability)
+    return tuple(required)
+
+
+def _required_capabilities_from_frontmatter(
+    frontmatter: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> tuple[str, ...]:
+    metadata = frontmatter.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise ValueError(f"skill '{owner}' metadata must be a mapping")
+    return _required_capabilities_from_metadata(
+        metadata.get(_REQUIRED_CAPABILITIES_METADATA_KEY),
+        owner=owner,
+    )
+
+
+def extract_required_capabilities_from_skill_markdown(
+    markdown: str,
+    *,
+    skill_name: str,
+    source_label: str | None = None,
+) -> tuple[str, ...]:
+    """Return required capability metadata from a skill markdown payload."""
+
+    frontmatter = _load_skill_frontmatter_from_markdown(
+        markdown,
+        source_label=source_label or skill_name,
+    )
+    return _required_capabilities_from_frontmatter(frontmatter, owner=skill_name)
+
+
 async def _required_skill_names_for_entry(entry: ResolvedSkillEntry) -> tuple[str, ...]:
     if entry.required_skills:
         required: list[str] = []
@@ -374,6 +445,28 @@ async def _required_skill_names_for_entry(entry: ResolvedSkillEntry) -> tuple[st
         return ()
     frontmatter = await asyncio.to_thread(_load_skill_frontmatter, Path(source_path))
     return _required_skill_names_from_frontmatter(frontmatter, owner=entry.skill_name)
+
+
+async def _required_capabilities_for_entry(entry: ResolvedSkillEntry) -> tuple[str, ...]:
+    if entry.required_capabilities:
+        capabilities: list[str] = []
+        seen: set[str] = set()
+        for raw_capability in entry.required_capabilities:
+            capability = _validate_required_capability_token(
+                str(raw_capability),
+                owner=entry.skill_name,
+            )
+            if capability in seen:
+                continue
+            seen.add(capability)
+            capabilities.append(capability)
+        return tuple(capabilities)
+
+    source_path = entry.provenance.source_path
+    if not source_path:
+        return ()
+    frontmatter = await asyncio.to_thread(_load_skill_frontmatter, Path(source_path))
+    return _required_capabilities_from_frontmatter(frontmatter, owner=entry.skill_name)
 
 
 def _required_skill_names_from_artifact_metadata(
@@ -401,6 +494,24 @@ def _required_skill_names_from_artifact_metadata(
         seen.add(name)
         required.append(name)
     return tuple(required)
+
+
+def _required_capabilities_from_artifact_metadata(
+    metadata: dict[str, typing.Any],
+    *,
+    owner: str,
+) -> tuple[str, ...]:
+    raw_required = metadata.get("required_capabilities")
+    if raw_required is None:
+        return ()
+    if not isinstance(raw_required, list) or not all(
+        isinstance(item, str) for item in raw_required
+    ):
+        raise ValueError(
+            f"skill '{owner}' artifact metadata.required_capabilities "
+            "must be a list of strings"
+        )
+    return _required_capabilities_from_metadata(raw_required, owner=owner)
 
 
 class RepoSkillLoader(SkillLoader):
@@ -536,9 +647,11 @@ class AgentSkillResolver:
             for name in closure_names:
                 entry = resolved_map[name]
                 reason = "selected" if name in requested_names else "required"
+                required_capabilities = await _required_capabilities_for_entry(entry)
                 final_skills.append(
                     entry.model_copy(
                         update={
+                            "required_capabilities": list(required_capabilities),
                             "selection_reason": reason,
                             "required_by": sorted(required_by.get(name, set())),
                         }
@@ -574,6 +687,14 @@ class AgentSkillResolver:
                     }
                     for entry in final_skills
                     for required_by in entry.required_by
+                ],
+                "requiredCapabilitySources": [
+                    {
+                        "skill": entry.skill_name,
+                        "capabilities": list(entry.required_capabilities),
+                    }
+                    for entry in final_skills
+                    if entry.required_capabilities
                 ],
             },
         )

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -22,7 +22,7 @@ from moonmind.schemas.agent_skill_models import (
 )
 
 _REQUIRED_SKILLS_METADATA_KEY = "required-skills"
-_REQUIRED_CAPABILITIES_METADATA_KEY = "requiredCapabilities"
+_REQUIRED_CAPABILITIES_METADATA_KEY = "required-capabilities"
 _AGENT_SKILL_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$")
 _CAPABILITY_TOKEN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.:-]{0,126}[a-z0-9])?$")
 

--- a/moonmind/services/skills_on_demand.py
+++ b/moonmind/services/skills_on_demand.py
@@ -426,6 +426,7 @@ class SkillsOnDemandService:
             name=entry.skill_name,
             latest_version=entry.version,
             source_kind=entry.provenance.source_kind,
+            required_capabilities=list(entry.required_capabilities),
             eligible=eligible,
             in_current_snapshot=in_current_snapshot,
             eligibility_summary=summary,

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -19,6 +19,13 @@ from pydantic import (
 )
 
 from moonmind.config.settings import settings
+from moonmind.services.skill_resolution import (
+    extract_required_capabilities_from_skill_markdown,
+)
+from moonmind.workflows.skills.resolver import (
+    SkillResolutionError,
+    resolve_skill_markdown_path,
+)
 
 from .job_types import CANONICAL_WORKFLOW_JOB_TYPE, LEGACY_WORKFLOW_JOB_TYPES
 
@@ -108,6 +115,7 @@ _EMBEDDED_ATTACHMENT_DATA_FIELDS = frozenset(
         "rawBytes",
     }
 )
+_SKILL_METADATA_CAPABILITY_CACHE: dict[str, tuple[str, ...]] = {}
 
 class WorkflowContractError(ValueError):
     """Raised when queue payloads violate task contract requirements."""
@@ -126,6 +134,35 @@ def _clean_str(value: object) -> str:
 def _clean_optional_str(value: object) -> str | None:
     cleaned = _clean_str(value)
     return cleaned or None
+
+
+def _skill_metadata_required_capabilities(skill_id: object) -> tuple[str, ...]:
+    normalized = _clean_optional_str(skill_id)
+    if not normalized:
+        return ()
+    cache_key = normalized.strip().lower()
+    cached = _SKILL_METADATA_CAPABILITY_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        skill_file = resolve_skill_markdown_path(normalized)
+    except (SkillResolutionError, OSError, ValueError):
+        _SKILL_METADATA_CAPABILITY_CACHE[cache_key] = ()
+        return ()
+    if skill_file is None:
+        _SKILL_METADATA_CAPABILITY_CACHE[cache_key] = ()
+        return ()
+    try:
+        markdown = skill_file.read_text(encoding="utf-8")
+        required = extract_required_capabilities_from_skill_markdown(
+            markdown,
+            skill_name=normalized,
+            source_label=str(skill_file),
+        )
+    except (OSError, ValueError):
+        required = ()
+    _SKILL_METADATA_CAPABILITY_CACHE[cache_key] = tuple(required)
+    return tuple(required)
 
 
 def _normalize_preset_version_alias(value: object) -> object:
@@ -2233,6 +2270,7 @@ def build_canonical_workflow_view(
         required.append("gh")
 
     skill_caps = skill_node.get("requiredCapabilities")
+    required.extend(_skill_metadata_required_capabilities(skill_id))
     if isinstance(skill_caps, list):
         required.extend(skill_caps)
 
@@ -2244,6 +2282,8 @@ def build_canonical_workflow_view(
                 continue
             step_skill_raw = step_raw.get("skill")
             step_skill = step_skill_raw if isinstance(step_skill_raw, Mapping) else {}
+            step_skill_id = step_skill.get("id") or step_skill.get("name")
+            required.extend(_skill_metadata_required_capabilities(step_skill_id))
             step_skill_caps = step_skill.get("requiredCapabilities")
             if isinstance(step_skill_caps, list):
                 required.extend(step_skill_caps)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 import json
 import logging
 import os
+import shutil
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from pathlib import Path
@@ -768,6 +769,145 @@ _STORY_OUTPUT_TASK_TOOLS = frozenset(
 )
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
+def _normalize_required_capability_tokens(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in value:
+        token = str(raw or "").strip().lower()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        result.append(token)
+    return result
+
+
+def _has_jira_prefetch_context(task_payload: Mapping[str, Any]) -> bool:
+    if task_payload.get("jiraIssueKey") or task_payload.get("jira_issue_key"):
+        return True
+    for key in ("jira", "jiraIssue", "jira_issue", "jiraPresetBrief", "jira_preset_brief"):
+        if isinstance(task_payload.get(key), Mapping):
+            return True
+    steps = task_payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, Mapping):
+                continue
+            tool = _coerce_mapping(step.get("tool")) or _coerce_mapping(step.get("skill"))
+            tool_id = str(tool.get("id") or tool.get("name") or "").strip().lower()
+            if tool_id.startswith("jira.") or tool_id.startswith("story.create_jira"):
+                return True
+    return False
+
+
+def _required_capability_blockers(
+    *,
+    parameters: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    blockers: list[dict[str, str]] = []
+    capabilities = _normalize_required_capability_tokens(
+        parameters.get("requiredCapabilities")
+    )
+    if not capabilities:
+        return blockers
+
+    repository = str(parameters.get("repository") or "").strip()
+
+    def add(
+        capability: str,
+        *,
+        check: str,
+        reason: str,
+        remediation: str,
+        target: str = "workflow",
+    ) -> None:
+        blockers.append(
+            {
+                "capability": capability,
+                "source": "requiredCapabilities",
+                "target": target,
+                "check": check,
+                "reason": reason,
+                "remediation": remediation,
+            }
+        )
+
+    if "git" in capabilities and not repository:
+        add(
+            "git",
+            check="repository_target",
+            reason="A repository target is required before git-backed execution can launch.",
+            remediation="Select an allowed repository for this workflow.",
+        )
+
+    if "gh" in capabilities:
+        has_token = bool(
+            os.getenv("GH_TOKEN")
+            or os.getenv("GITHUB_TOKEN")
+            or os.getenv("MOONMIND_GITHUB_TOKEN_SECRET_REF")
+        )
+        if not has_token and shutil.which("gh") is None:
+            add(
+                "gh",
+                check="github_cli_or_token",
+                reason="GitHub CLI access or a GitHub token reference is required before launch.",
+                remediation="Configure a GitHub token/provider profile with repository and pull-request access.",
+            )
+
+    if "jira" in capabilities:
+        atlassian_settings = getattr(settings, "atlassian", None)
+        jira_settings = getattr(settings, "jira", None) or getattr(
+            atlassian_settings,
+            "jira",
+            None,
+        )
+        jira_ready = bool(
+            getattr(jira_settings, "jira_tool_enabled", False)
+            or getattr(jira_settings, "jira_enabled", False)
+            or getattr(settings, "jira_tool_enabled", False)
+            or getattr(settings, "jira_enabled", False)
+            or _has_jira_prefetch_context(task_payload)
+        )
+        if not jira_ready:
+            add(
+                "jira",
+                check="trusted_jira_readiness",
+                reason="Trusted Jira tool access or prefetched Jira context is required before launch.",
+                remediation="Enable the Jira tool integration or attach a trusted Jira issue artifact.",
+            )
+
+    if "docker" in capabilities:
+        docker_host = os.getenv("DOCKER_HOST")
+        default_socket = Path("/var/run/docker.sock")
+        if not docker_host and not default_socket.exists():
+            add(
+                "docker",
+                check="docker_runtime",
+                reason="Docker capability is required but no Docker endpoint is visible to this worker.",
+                remediation="Run on a Docker-capable worker fleet or disable Docker-required execution.",
+            )
+
+    return blockers
+
+
+def _enforce_required_capability_readiness(
+    *,
+    parameters: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+) -> None:
+    blockers = _required_capability_blockers(
+        parameters=parameters,
+        task_payload=task_payload,
+    )
+    if not blockers:
+        return
+    raise RuntimeError(
+        "requiredCapabilities readiness blocked launch: "
+        + json.dumps({"blockers": blockers}, sort_keys=True)
+    )
+
 def _requires_branch_publish_for_story_output(value: Any) -> bool:
     return str(value or "").strip().lower() not in {"branch", "pr"}
 
@@ -1022,6 +1162,10 @@ def _build_runtime_planner():
             task_payload = _coerce_mapping(
                 parameter_payload.get("workflow") or parameter_payload.get("task")
             )
+        _enforce_required_capability_readiness(
+            parameters=parameter_payload,
+            task_payload=task_payload,
+        )
         git_payload = _coerce_mapping(task_payload.get("git"))
         selected_skill_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
             task_payload.get("skill")

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -507,8 +507,8 @@ def test_skills_api_returns_available_skill_ids(
             "worker": ["speckit", "speckit-orchestrate"],
         },
         "legacyItems": [
-            {"id": "speckit", "markdown": None},
-            {"id": "speckit-orchestrate", "markdown": None},
+            {"id": "speckit", "requiredCapabilities": [], "markdown": None},
+            {"id": "speckit-orchestrate", "requiredCapabilities": [], "markdown": None},
         ],
     }
 
@@ -519,7 +519,15 @@ def test_skills_api_include_content_reads_legacy_skill_markdown(
     legacy_root = tmp_path / "legacy"
     skill_dir = legacy_root / "speckit-orchestrate"
     skill_dir.mkdir(parents=True)
-    skill_markdown = "# Speckit Orchestrate\n\nRun the full Moon Spec lifecycle."
+    skill_markdown = (
+        "---\n"
+        "name: speckit-orchestrate\n"
+        "metadata:\n"
+        "  requiredCapabilities:\n"
+        "    - git\n"
+        "---\n"
+        "# Speckit Orchestrate\n\nRun the full Moon Spec lifecycle."
+    )
     (skill_dir / "SKILL.md").write_text(skill_markdown, encoding="utf-8")
 
     monkeypatch.setattr(
@@ -539,7 +547,11 @@ def test_skills_api_include_content_reads_legacy_skill_markdown(
 
     assert response.status_code == 200
     assert response.json()["legacyItems"] == [
-        {"id": "speckit-orchestrate", "markdown": skill_markdown},
+        {
+            "id": "speckit-orchestrate",
+            "requiredCapabilities": ["git"],
+            "markdown": skill_markdown,
+        },
     ]
 
 def test_create_dashboard_skill_success(

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -523,7 +523,7 @@ def test_skills_api_include_content_reads_legacy_skill_markdown(
         "---\n"
         "name: speckit-orchestrate\n"
         "metadata:\n"
-        "  requiredCapabilities:\n"
+        "  required-capabilities:\n"
         "    - git\n"
         "---\n"
         "# Speckit Orchestrate\n\nRun the full Moon Spec lifecycle."

--- a/tests/unit/mcp/test_skills_on_demand_registry.py
+++ b/tests/unit/mcp/test_skills_on_demand_registry.py
@@ -97,6 +97,7 @@ async def test_enabled_query_returns_metadata_without_skill_body_refs() -> None:
             "latest_version": "1.0.0",
             "source_kind": "built_in",
             "supported_runtimes": [],
+            "required_capabilities": [],
             "eligible": True,
             "in_current_snapshot": True,
             "eligibility_summary": "Eligible for this runtime and deployment policy.",

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -514,7 +514,7 @@ async def test_resolver_expands_required_skills_from_strict_metadata(tmp_path):
         "description: Runs orchestration.\n"
         "metadata:\n"
         "  required-skills: \"helper-skill\"\n"
-        "  requiredCapabilities:\n"
+        "  required-capabilities:\n"
         "    - GH\n"
         "    - jira\n"
         "---\n",
@@ -525,7 +525,7 @@ async def test_resolver_expands_required_skills_from_strict_metadata(tmp_path):
         "name: helper-skill\n"
         "description: Supports orchestration.\n"
         "metadata:\n"
-        "  requiredCapabilities:\n"
+        "  required-capabilities:\n"
         "    - git\n"
         "---\n",
         encoding="utf-8",
@@ -819,7 +819,7 @@ async def test_resolver_rejects_invalid_required_capabilities_metadata(tmp_path)
         "name: orchestrator\n"
         "description: Runs orchestration.\n"
         "metadata:\n"
-        "  requiredCapabilities: jira\n"
+        "  required-capabilities: jira\n"
         "---\n",
         encoding="utf-8",
     )
@@ -834,6 +834,6 @@ async def test_resolver_rejects_invalid_required_capabilities_metadata(tmp_path)
 
     with pytest.raises(
         ValueError,
-        match="metadata.requiredCapabilities must be a list of strings",
+        match="metadata.required-capabilities must be a list of strings",
     ):
         await resolver.resolve(selector, context)

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -514,6 +514,9 @@ async def test_resolver_expands_required_skills_from_strict_metadata(tmp_path):
         "description: Runs orchestration.\n"
         "metadata:\n"
         "  required-skills: \"helper-skill\"\n"
+        "  requiredCapabilities:\n"
+        "    - GH\n"
+        "    - jira\n"
         "---\n",
         encoding="utf-8",
     )
@@ -521,6 +524,9 @@ async def test_resolver_expands_required_skills_from_strict_metadata(tmp_path):
         "---\n"
         "name: helper-skill\n"
         "description: Supports orchestration.\n"
+        "metadata:\n"
+        "  requiredCapabilities:\n"
+        "    - git\n"
         "---\n",
         encoding="utf-8",
     )
@@ -543,8 +549,14 @@ async def test_resolver_expands_required_skills_from_strict_metadata(tmp_path):
     assert by_name["orchestrator"].selection_reason == "selected"
     assert by_name["helper-skill"].selection_reason == "required"
     assert by_name["helper-skill"].required_by == ["orchestrator"]
+    assert by_name["orchestrator"].required_capabilities == ["gh", "jira"]
+    assert by_name["helper-skill"].required_capabilities == ["git"]
     assert result.source_trace["requiredSkillEdges"] == [
         {"requiredBy": "orchestrator", "skill": "helper-skill"}
+    ]
+    assert result.source_trace["requiredCapabilitySources"] == [
+        {"skill": "helper-skill", "capabilities": ["git"]},
+        {"skill": "orchestrator", "capabilities": ["gh", "jira"]},
     ]
 
 async def test_resolver_allows_underscores_in_required_skill_names(tmp_path):
@@ -622,8 +634,11 @@ async def test_resolver_expands_deployment_required_skills_from_artifact_metadat
         "helper_skill": MockDef("helper_skill", "art_helper"),
     }
     artifact_metadata = {
-        "art_primary": {"required_skills": ["helper_skill"]},
-        "art_helper": {"required_skills": []},
+        "art_primary": {
+            "required_skills": ["helper_skill"],
+            "required_capabilities": ["jira"],
+        },
+        "art_helper": {"required_skills": [], "required_capabilities": ["git"]},
     }
     requested_slug_batches: list[set[str]] = []
 
@@ -690,6 +705,8 @@ async def test_resolver_expands_deployment_required_skills_from_artifact_metadat
     assert by_name["primary_skill"].selection_reason == "selected"
     assert by_name["helper_skill"].selection_reason == "required"
     assert by_name["helper_skill"].required_by == ["primary_skill"]
+    assert by_name["primary_skill"].required_capabilities == ["jira"]
+    assert by_name["helper_skill"].required_capabilities == ["git"]
     assert requested_slug_batches == [{"primary_skill"}, {"helper_skill"}]
     assert result.source_trace["requiredSkillEdges"] == [
         {"requiredBy": "primary_skill", "skill": "helper_skill"}
@@ -790,4 +807,33 @@ async def test_resolver_rejects_non_string_required_skills_metadata(tmp_path):
     selector = SkillSelector(include=[{"name": "orchestrator"}])
 
     with pytest.raises(ValueError, match="metadata.required-skills must be a string"):
+        await resolver.resolve(selector, context)
+
+
+async def test_resolver_rejects_invalid_required_capabilities_metadata(tmp_path):
+    skills_dir = tmp_path / ".agents" / "skills"
+    skill_dir = skills_dir / "orchestrator"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: orchestrator\n"
+        "description: Runs orchestration.\n"
+        "metadata:\n"
+        "  requiredCapabilities: jira\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    resolver = AgentSkillResolver(loaders=[RepoSkillLoader()])
+    context = SkillResolutionContext(
+        snapshot_id="snap-123",
+        workspace_root=str(tmp_path),
+        allow_repo_skills=True,
+    )
+    selector = SkillSelector(include=[{"name": "orchestrator"}])
+
+    with pytest.raises(
+        ValueError,
+        match="metadata.requiredCapabilities must be a list of strings",
+    ):
         await resolver.resolve(selector, context)

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -982,6 +982,42 @@ def test_mm569_tool_step_required_capabilities_aggregate_into_canonical_required
     assert "jira" in result["requiredCapabilities"]
 
 
+def test_skill_metadata_required_capabilities_aggregate_into_canonical_required() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "task": {
+                "instructions": "Verify PR against Jira.",
+                "skill": {"id": "jira-pr-verify"},
+            },
+        },
+    )
+
+    assert result["workflow"]["skill"]["id"] == "jira-pr-verify"
+    assert set(result["requiredCapabilities"]) >= {"git", "gh", "jira"}
+
+
+def test_step_skill_metadata_required_capabilities_aggregate_into_canonical_required() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "task": {
+                "instructions": "Run a step skill.",
+                "steps": [
+                    {
+                        "instructions": "Verify PR against Jira.",
+                        "skill": {"id": "jira-pr-verify"},
+                    }
+                ],
+            },
+        },
+    )
+
+    assert set(result["requiredCapabilities"]) >= {"git", "gh", "jira"}
+
+
 def test_mm569_tool_validation_error_identifies_required_field_path() -> None:
     invalid = tool_step()
     invalid["tool"].pop("id")

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -20,6 +20,7 @@ from api_service.db.models import (
     TemporalExecutionRecord,
     TemporalWorkflowType,
 )
+from moonmind.workflows.temporal import worker_runtime
 from moonmind.workflows.temporal.worker_runtime import (
     MoonMindAgentRun,
     MoonMindManifestIngest,
@@ -34,6 +35,7 @@ from moonmind.workflows.temporal.worker_runtime import (
     _build_runtime_planner,
     _build_runtime_activities,
     _configure_worker_logging,
+    _required_capability_blockers,
     main_async,
     resolve_adapter_metadata,
     get_activity_route,
@@ -150,6 +152,68 @@ def test_opentelemetry_logging_filter_injects_bounded_managed_session_fields(
     assert "instructions" not in record.managed_session
     assert "rawLog" not in record.managed_session
     assert "token" not in record.managed_session
+
+
+def test_required_capability_readiness_blocks_missing_jira(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        worker_runtime.settings.atlassian.jira,
+        "jira_tool_enabled",
+        False,
+    )
+    monkeypatch.setattr(
+        worker_runtime.settings.atlassian.jira,
+        "jira_enabled",
+        False,
+    )
+
+    blockers = _required_capability_blockers(
+        parameters={
+            "repository": "MoonLadderStudios/MoonMind",
+            "requiredCapabilities": ["git", "jira"],
+        },
+        task_payload={"instructions": "Verify Jira issue."},
+    )
+
+    assert blockers == [
+        {
+            "capability": "jira",
+            "source": "requiredCapabilities",
+            "target": "workflow",
+            "check": "trusted_jira_readiness",
+            "reason": (
+                "Trusted Jira tool access or prefetched Jira context is required "
+                "before launch."
+            ),
+            "remediation": (
+                "Enable the Jira tool integration or attach a trusted Jira issue artifact."
+            ),
+        }
+    ]
+
+
+def test_required_capability_readiness_accepts_prefetched_jira_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        worker_runtime.settings.atlassian.jira,
+        "jira_tool_enabled",
+        False,
+    )
+    monkeypatch.setattr(
+        worker_runtime.settings.atlassian.jira,
+        "jira_enabled",
+        False,
+    )
+
+    blockers = _required_capability_blockers(
+        parameters={
+            "repository": "MoonLadderStudios/MoonMind",
+            "requiredCapabilities": ["jira"],
+        },
+        task_payload={"jiraIssue": {"key": "MM-1"}},
+    )
+
+    assert blockers == []
 
 
 def test_opentelemetry_logging_filter_caches_default_env_fields(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Adds a `docs/tmp/SkillRequiredCapabilitiesHardeningPlan.md` rollout plan for skill-declared runtime capabilities.
- Documents that direct Skill selection should merge declared capabilities into the existing `requiredCapabilities` contract instead of introducing a new GitHub/Jira access system.
- Seeds `jira-pr-verify` with `metadata.requiredCapabilities: [jira, git, gh]` as the initial exemplar.

## Validation

- Not run; documentation and Skill metadata only.

## Notes

The plan calls out parser/resolver, frontend merge, backend authoritative normalization, runtime readiness gates, and tests for the direct `jira-pr-verify` path.