### PR TITLE
Fix dropped legacy task payload in create_execution (deployment update workflow failure)

### DIFF
--- a/api_service/api/routers/deployment_operations.py
+++ b/api_service/api/routers/deployment_operations.py
@@ -232,12 +232,24 @@ def _iso_text(value: object) -> str | None:
     return text or None
 
 
-def _deployment_plan_inputs(record: object) -> dict[str, Any]:
+def _deployment_workflow_payload(record: object) -> dict[str, Any]:
+    """Return the canonical workflow payload for a deployment execution record.
+
+    ``create_execution`` normalizes legacy ``task`` initial parameters into the
+    canonical ``parameters["workflow"]`` key, so deployment action readers must
+    derive plan/operation metadata from ``workflow`` rather than ``task``.
+    """
+
     parameters = getattr(record, "parameters", None)
     if not isinstance(parameters, dict):
         return {}
-    task = parameters.get("task")
-    if not isinstance(task, dict):
+    workflow = parameters.get("workflow")
+    return workflow if isinstance(workflow, dict) else {}
+
+
+def _deployment_plan_inputs(record: object) -> dict[str, Any]:
+    task = _deployment_workflow_payload(record)
+    if not task:
         return {}
     plan = task.get("plan")
     if not isinstance(plan, list):
@@ -256,11 +268,8 @@ def _deployment_plan_inputs(record: object) -> dict[str, Any]:
 
 
 def _deployment_operation(record: object) -> dict[str, Any]:
-    parameters = getattr(record, "parameters", None)
-    if not isinstance(parameters, dict):
-        return {}
-    task = parameters.get("task")
-    if not isinstance(task, dict):
+    task = _deployment_workflow_payload(record)
+    if not task:
         return {}
     operation = task.get("operation")
     return dict(operation) if isinstance(operation, dict) else {}

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1045,6 +1045,13 @@ class TemporalExecutionService:
                 pinned_remediation["target"] = pinned_target
                 task_params["remediation"] = pinned_remediation
                 params["workflow"] = task_params
+        # Re-promote the normalized task payload under the canonical
+        # "workflow" key. The legacy "task" input shape (used by typed
+        # submissions such as the deployment update path) is otherwise
+        # dropped here when neither the dependsOn nor remediation branch
+        # re-attaches it, leaving the workflow with no instructions/plan.
+        if "workflow" not in params and task_params:
+            params["workflow"] = task_params
 
         resolved_title = title or self._default_title_for_type(workflow_type_enum)
         memo = {

--- a/tests/unit/api/routers/test_deployment_operations.py
+++ b/tests/unit/api/routers/test_deployment_operations.py
@@ -484,7 +484,7 @@ def test_deployment_state_projects_recent_actions_from_execution_history(
             state="failed",
             close_status="failed",
             parameters={
-                "task": {
+                "workflow": {
                     "operation": {"kind": "update"},
                     "plan": [
                         {

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -692,6 +692,75 @@ async def test_create_execution_persists_dependency_edges_and_supports_lookups(
         assert snapshot[dep2.workflow_id].workflow_type == "MoonMind.UserWorkflow"
 
 @pytest.mark.asyncio
+async def test_create_execution_promotes_legacy_task_payload_to_workflow(
+    tmp_path, mock_client_adapter
+):
+    """Legacy ``task`` initial parameters must survive as canonical ``workflow``.
+
+    Typed submissions such as the deployment update path build
+    ``initial_parameters={"task": {...}}`` with no dependsOn/remediation. Prior
+    to the fix the ``task`` key was popped and never re-promoted, so the
+    workflow started with only ``{"failurePolicy": ...}`` and the agent_runtime
+    planner failed with "requires non-empty instructions".
+    """
+
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+
+        execution = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Update deployment stack moonmind",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy="fail_fast",
+            initial_parameters={
+                "task": {
+                    "instructions": "Run the policy-gated deployment update operation.",
+                    "steps": [
+                        {
+                            "id": "update-moonmind-deployment",
+                            "type": "tool",
+                            "tool": {
+                                "type": "skill",
+                                "name": "deployment.update_compose_stack",
+                                "version": "1.0.0",
+                                "inputs": {"stack": "moonmind"},
+                            },
+                        }
+                    ],
+                }
+            },
+            idempotency_key=None,
+        )
+
+        record = await session.get(
+            TemporalExecutionCanonicalRecord, execution.workflow_id
+        )
+        assert record is not None
+        assert "task" not in record.parameters
+        assert record.parameters["failurePolicy"] == "fail_fast"
+        workflow_payload = record.parameters["workflow"]
+        assert (
+            workflow_payload["instructions"]
+            == "Run the policy-gated deployment update operation."
+        )
+        assert workflow_payload["steps"][0]["tool"]["name"] == (
+            "deployment.update_compose_stack"
+        )
+
+        start_args = mock_client_adapter.start_workflow.await_args.kwargs["input_args"]
+        promoted = start_args["initial_parameters"]["workflow"]
+        assert (
+            promoted["instructions"]
+            == "Run the policy-gated deployment update operation."
+        )
+        assert "task" not in start_args["initial_parameters"]
+
+
+@pytest.mark.asyncio
 async def test_create_execution_persists_remediation_link_and_supports_lookups(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Problem

Workflow `mm:bff6cbcc-1fc9-44a0-a9ac-d1c0dd02ff8b` ("Update deployment stack moonmind", integration `deployment.update_compose_stack`) failed after ~16s with:

> `RuntimeError: agent_runtime plan requires non-empty instructions in workflow.instructions, inputs.instructions, or parameters.instructions`

## Root cause

`DeploymentOperationsService.queue_update` builds the submission as `initial_parameters={"task": {...}}` (the legacy task key) carrying the instructions, `steps`, and `plan` for the typed `deployment.update_compose_stack` tool, with **no** `dependsOn` and **no** `remediation`.

In `TemporalExecutionService.create_execution` (`moonmind/workflows/temporal/service.py`):

1. `task_params = dict(_workflow_payload(params))` extracts the task payload.
2. `params.pop("task", None)` removes the legacy key.
3. `params["workflow"] = task_params` is only set **inside** the `dependsOn` branch or the `remediation` branch.

With neither branch taken, the normalized task payload was never re-attached. The workflow started with `initial_parameters={"failurePolicy": "fail_fast"}` — no instructions, no plan — so the `agent_runtime` planner raised.

Confirmed against the failed run's decoded start input: `{"initial_parameters":{"failurePolicy":"fail_fast"}, ...}`.

## Fix

Re-promote the normalized task payload to the canonical `workflow` key whenever no branch has already re-attached it:

```python
if "workflow" not in params and task_params:
    params["workflow"] = task_params
```

Minimal and safe: the `dependsOn`/`remediation` branches still take precedence (they set/pop `workflow` first), and canonical `workflow`-key submissions are unaffected (their key is never popped).

## Tests

- New service-boundary regression test `test_create_execution_promotes_legacy_task_payload_to_workflow` covering the legacy `task` shape end-to-end (persisted record + workflow start args).
- Existing `create_execution`, deployment operations, and runtime-planner suites pass (37 + 92 Python tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)