### PR TITLE
Implement this skill improvement:

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -6444,12 +6444,17 @@ describe.skip("Task Create Entrypoint", () => {
     const skillSelect = within(primaryStep as HTMLElement).getByLabelText(
       /Skill \(optional\)/,
     );
+    const publishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
     for (const skillId of ["fix-comments", "fix-ci", "fix-merge-conflicts"]) {
+      // Reset the publish mode to "pr" before each iteration so every skill is
+      // independently verified to force the mode back to "none"; otherwise a
+      // bug in a later skill would be masked by the value set by an earlier one.
+      fireEvent.change(publishSelect, { target: { value: "pr" } });
       fireEvent.change(skillSelect, { target: { value: skillId } });
       await waitFor(() => {
-        expect(
-          (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-        ).toBe("none");
+        expect(publishSelect.value).toBe("none");
       });
     }
   });

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -6410,6 +6410,50 @@ describe.skip("Task Create Entrypoint", () => {
     });
   });
 
+  it("defaults publish mode to none when selecting self-publishing fix skills", async () => {
+    type MockInitialData = {
+      dashboardConfig: {
+        system: {
+          defaultPublishMode: string;
+        };
+      };
+    };
+
+    const payload: BootPayload = {
+      ...mockPayload,
+      initialData: {
+        ...(mockPayload.initialData as MockInitialData),
+        dashboardConfig: {
+          ...(mockPayload.initialData as MockInitialData).dashboardConfig,
+          system: {
+            ...(mockPayload.initialData as MockInitialData).dashboardConfig
+              .system,
+            defaultPublishMode: "pr",
+          },
+        },
+      },
+    };
+
+    renderWithClient(<WorkflowStartPage payload={payload} />);
+
+    const primaryStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+
+    const skillSelect = within(primaryStep as HTMLElement).getByLabelText(
+      /Skill \(optional\)/,
+    );
+    for (const skillId of ["fix-comments", "fix-ci", "fix-merge-conflicts"]) {
+      fireEvent.change(skillSelect, { target: { value: skillId } });
+      await waitFor(() => {
+        expect(
+          (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+        ).toBe("none");
+      });
+    }
+  });
+
   it("defaults publish mode to none when selecting jira-verify or jira-pr-verify skills", async () => {
     type MockInitialData = {
       dashboardConfig: {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -34,6 +34,9 @@ const JIRA_ORCHESTRATE_PRESET_SLUG = "jira-orchestrate";
 const JIRA_IMPLEMENT_PRESET_SLUG = "jira-implement";
 const SELF_MANAGED_PUBLISH_SKILLS = new Set([
   ...PR_RESOLVER_SKILLS,
+  "fix-comments",
+  "fix-ci",
+  "fix-merge-conflicts",
   JIRA_BREAKDOWN_PRESET_SLUG,
   JIRA_BREAKDOWN_ORCHESTRATE_PRESET_SLUG,
   JIRA_BREAKDOWN_IMPLEMENT_PRESET_SLUG,

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2059,7 +2059,14 @@ def _build_spec_from_codex_skill_payload(payload: Mapping[str, Any]) -> dict[str
         payload.get("ref")
     )
     publish_payload = {
-        "mode": _normalize_publish_mode(publish_mode),
+        # Preserve an omitted publish mode as ``None`` so the self-managed skill
+        # resolver applies the correct per-skill default (e.g. ``none`` for
+        # fix-comments/fix-ci/fix-merge-conflicts). Materializing the default
+        # ``pr`` here would make ``resolve_publish_mode_for_skill`` treat the
+        # absent mode as an explicit forbidden mode and reject the request.
+        "mode": _normalize_publish_mode(publish_mode)
+        if publish_mode is not None
+        else None,
         "prBaseBranch": publish_base,
         "commitMessage": None,
         "prTitle": None,

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -50,7 +50,14 @@ _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _SELF_MANAGED_PUBLISH_SKILLS = frozenset(
-    {"pr-resolver", "batch-pr-resolver", "batch-dependabot-resolver"}
+    {
+        "pr-resolver",
+        "batch-pr-resolver",
+        "batch-dependabot-resolver",
+        "fix-comments",
+        "fix-ci",
+        "fix-merge-conflicts",
+    }
 )
 _NON_REPOSITORY_SIDE_EFFECT_SKILLS = frozenset(
     {"jira-issue-creator", "jira-issue-updater", "jira-pr-verify", "jira-verify"}

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1009,7 +1009,14 @@ def test_jira_side_effect_skills_reject_repository_publish_modes(
 
 @pytest.mark.parametrize(
     "skill_id",
-    ["pr-resolver", "batch-pr-resolver", "batch-dependabot-resolver"],
+    [
+        "pr-resolver",
+        "batch-pr-resolver",
+        "batch-dependabot-resolver",
+        "fix-comments",
+        "fix-ci",
+        "fix-merge-conflicts",
+    ],
 )
 def test_self_managed_publish_skills_force_none(skill_id: str) -> None:
     assert resolve_publish_mode_for_skill(skill_id, None) == "none"

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1025,6 +1025,34 @@ def test_self_managed_publish_skills_force_none(skill_id: str) -> None:
         resolve_publish_mode_for_skill(skill_id, "pr")
 
 
+@pytest.mark.parametrize(
+    "skill_id",
+    ["fix-comments", "fix-ci", "fix-merge-conflicts"],
+)
+def test_codex_skill_payload_defaults_self_managed_publish_to_none(
+    skill_id: str,
+) -> None:
+    """codex_skill submissions that omit publishMode must default to ``none``.
+
+    Regression for the legacy payload path materializing the default ``pr`` mode
+    before the self-managed resolver runs, which incorrectly rejected the
+    request even though the omitted mode should resolve to ``none``.
+    """
+
+    result = build_canonical_workflow_view(
+        job_type="codex_skill",
+        payload={
+            "skillId": skill_id,
+            "inputs": {
+                "repo": "MoonLadderStudios/MoonMind",
+                "instruction": f"Run {skill_id}.",
+            },
+        },
+    )
+
+    assert result["workflow"]["publish"]["mode"] == "none"
+
+
 def test_jira_issue_updater_allows_explicit_repository_publish_modes() -> None:
     assert resolve_publish_mode_for_skill("jira-issue-updater", "pr") == "pr"
     assert resolve_publish_mode_for_skill("jira-issue-updater", "branch") == "branch"


### PR DESCRIPTION
Implement this skill improvement:

Yes — **`fix-comments` should switch publish mode to `none`, not `branch`, under the current skill contract.**

The reason is that `fix-comments` is already a **self-publishing PR-branch remediation skill**. Its description says it resolves PR feedback, then “commit and push the result,” and the workflow explicitly ends with “Commit with a clear message” and “Push the current branch.”

`branch` would only be right if the skill were rewritten to **commit only** and let MoonMind’s publisher push. That is not the current contract. The publishing docs say `branch` mode performs the infrastructure push after the agent completes, and agents are instructed to commit but **not** push.

`pr` is clearly wrong for `fix-comments`, because `pr` mode creates or updates a runtime work branch and creates a PR back to the selected base branch. `fix-comments` is supposed to update the **existing active PR branch**, not create a second PR.

The current gap appears to be that the UI/backend self-managed-publish lists include `pr-resolver` but not `fix-comments`. In the Start Workflow UI, `SELF_MANAGED_PUBLISH_SKILLS` contains `pr-resolver` / `batch-pr-resolver` and several Jira entries, but not `fix-comments`; the later effect only forces `publishMode` to `none` when the selected/effective skill is in that set.   The backend similarly only marks `pr-resolver`, `batch-pr-resolver`, and `batch-dependabot-resolver` as self-managed publish skills, then enforces `publish.mode == none` for those skills.

I would update the design as:

```text
fix-comments publish mode default: none
fix-ci publish mode default: none
fix-merge-conflicts publish mode default: none
pr-resolver publish mode default: none
```

`fix-ci` and `fix-merge-conflicts` should probably be included too, because their skill files also explicitly say they commit and push the current PR branch.

Longer-term, this should not live as duplicated hardcoded frontend/backend skill-name sets. It should be declarative skill metadata, for example:

```yaml
publish:
  mode: self_managed
  requiredWorkflowPublishMode: none
  sideEffects:
    - git.commit
    - git.push
```

But the immediate product behavior should be: **selecting `fix-comments` forces publish mode to `none`, the same way `pr-resolver` does.**