### PR TITLE
MM-825 Complete checkpoint-backed resume contract

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9604,6 +9604,122 @@ async def rerun_execution(
         await session.commit()
     return execution
 
+
+_RECOVERY_PAYLOAD_FORBIDDEN_FIELDS = {
+    "task",
+    "instructions",
+    "steps",
+    "attachments",
+    "inputAttachments",
+    "runtime",
+    "targetRuntime",
+    "publishMode",
+    "branch",
+    "startingBranch",
+    "targetBranch",
+    "presets",
+    "dependencies",
+    "model",
+    "requestedModel",
+    "effort",
+    "parametersPatch",
+    "inputArtifactRef",
+    "planArtifactRef",
+    "manifestArtifactRef",
+}
+
+
+def _reject_recovery_task_payload_edits(
+    request: RecoverFromFailedStepRequest,
+    *,
+    action: str,
+) -> None:
+    extras = request.model_extra or {}
+    forbidden = sorted(key for key in extras if key in _RECOVERY_PAYLOAD_FORBIDDEN_FIELDS)
+    if forbidden:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "recovery_payload_not_allowed",
+                "message": (
+                    f"{action} does not accept edited workflow payload fields. "
+                    "Use an execution update for changes."
+                ),
+                "fields": forbidden,
+            },
+        )
+
+
+def _checkpoint_failed_step_execution(checkpoint_payload: Mapping[str, Any]) -> int | None:
+    failed_step = checkpoint_payload.get("failedStep")
+    if not isinstance(failed_step, Mapping):
+        return None
+    value = failed_step.get("executionOrdinal")
+    if value is None:
+        value = failed_step.get("attempt")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _reject_recovery_contract_mismatch(
+    request: RecoverFromFailedStepRequest,
+    *,
+    canonical: TemporalExecutionCanonicalRecord,
+    checkpoint_payload: Mapping[str, Any],
+) -> None:
+    expected_run_id = str(canonical.run_id or "")
+    mismatches: list[str] = []
+    if request.source_workflow_id and request.source_workflow_id != canonical.workflow_id:
+        mismatches.append("sourceWorkflowId")
+    if request.source_run_id and request.source_run_id != expected_run_id:
+        mismatches.append("sourceRunId")
+
+    source = checkpoint_payload.get("source")
+    if isinstance(source, Mapping):
+        if (
+            request.source_workflow_id
+            and request.source_workflow_id != source.get("workflowId")
+        ):
+            mismatches.append("sourceWorkflowId")
+        if request.source_run_id and request.source_run_id != source.get("runId"):
+            mismatches.append("sourceRunId")
+
+    failed_step = checkpoint_payload.get("failedStep")
+    if isinstance(failed_step, Mapping):
+        if (
+            request.logical_step_id
+            and request.logical_step_id != failed_step.get("logicalStepId")
+        ):
+            mismatches.append("logicalStepId")
+        if request.source_execution_ordinal is not None:
+            checkpoint_execution = _checkpoint_failed_step_execution(checkpoint_payload)
+            if checkpoint_execution != request.source_execution_ordinal:
+                mismatches.append("sourceExecutionOrdinal")
+
+    if (
+        request.task_input_snapshot_ref
+        and request.task_input_snapshot_ref != checkpoint_payload.get("taskInputSnapshotRef")
+    ):
+        mismatches.append("taskInputSnapshotRef")
+    if request.plan_ref and request.plan_ref != checkpoint_payload.get("planRef"):
+        mismatches.append("planRef")
+    if request.plan_digest and request.plan_digest != checkpoint_payload.get("planDigest"):
+        mismatches.append("planDigest")
+
+    if mismatches:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Recovery request fields do not match checkpoint evidence.",
+                "reason": "checkpoint_inconsistent",
+                "fields": sorted(set(mismatches)),
+            },
+        )
+
+
 @router.post(
     "/{workflow_id}/recover-from-failed-step",
     response_model=RecoverFromFailedStepResponse,
@@ -9612,58 +9728,13 @@ async def rerun_execution(
 )
 async def recover_execution_from_failed_step(
     workflow_id: str,
-    payload: dict[str, Any] = Body(default_factory=dict),
+    request: RecoverFromFailedStepRequest = Body(...),
     service: TemporalExecutionService = Depends(_get_service),
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(get_current_user()),
     _submit_enabled: None = Depends(_ensure_submit_enabled),
 ) -> RecoverFromFailedStepResponse:
-    forbidden = sorted(
-        key
-        for key in payload
-        if key
-        in {
-            "task",
-            "instructions",
-            "steps",
-            "attachments",
-            "inputAttachments",
-            "runtime",
-            "targetRuntime",
-            "publishMode",
-            "branch",
-            "startingBranch",
-            "targetBranch",
-            "presets",
-            "dependencies",
-            "model",
-            "requestedModel",
-            "effort",
-            "parametersPatch",
-            "inputArtifactRef",
-            "planArtifactRef",
-            "manifestArtifactRef",
-        }
-    )
-    if forbidden:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "code": "recovery_payload_not_allowed",
-                "message": "Recover from failed step does not accept edited workflow payload fields. Use an execution update for changes.",
-                "fields": forbidden,
-            },
-        )
-    try:
-        request = RecoverFromFailedStepRequest.model_validate(payload)
-    except ValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "invalid_recovery_request",
-                "message": str(exc),
-            },
-        ) from exc
+    _reject_recovery_task_payload_edits(request, action="Recover from failed step")
 
     await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
     canonical = await session.get(TemporalExecutionCanonicalRecord, workflow_id)
@@ -9691,6 +9762,11 @@ async def recover_execution_from_failed_step(
         session=session,
         user=user,
         checkpoint_ref=checkpoint_ref,
+    )
+    _reject_recovery_contract_mismatch(
+        request,
+        canonical=canonical,
+        checkpoint_payload=checkpoint_payload,
     )
     try:
         result = await service.create_failed_step_recovery_execution(
@@ -9728,22 +9804,13 @@ async def recover_execution_from_failed_step(
 )
 async def recover_execution_from_selected_step(
     workflow_id: str,
-    payload: dict[str, Any] = Body(default_factory=dict),
+    request: RecoverFromSelectedStepRequest = Body(...),
     service: TemporalExecutionService = Depends(_get_service),
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(get_current_user()),
     _submit_enabled: None = Depends(_ensure_submit_enabled),
 ) -> RecoverFromFailedStepResponse:
-    try:
-        request = RecoverFromSelectedStepRequest.model_validate(payload)
-    except ValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "invalid_recovery_request",
-                "message": str(exc),
-            },
-        ) from exc
+    _reject_recovery_task_payload_edits(request, action="Recover from selected step")
 
     canonical = await _get_owned_execution(
         service=service, workflow_id=workflow_id, user=user
@@ -9791,6 +9858,11 @@ async def recover_execution_from_selected_step(
         session=session,
         user=user,
         checkpoint_ref=checkpoint_ref,
+    )
+    _reject_recovery_contract_mismatch(
+        request,
+        canonical=canonical,
+        checkpoint_payload=checkpoint_payload,
     )
     try:
         result = await service.create_failed_step_recovery_execution(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -9657,6 +9657,8 @@ def _checkpoint_failed_step_execution(checkpoint_payload: Mapping[str, Any]) -> 
     value = failed_step.get("executionOrdinal")
     if value is None:
         value = failed_step.get("attempt")
+    if isinstance(value, bool):
+        return None
     try:
         return int(value)
     except (TypeError, ValueError):

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6770,6 +6770,46 @@ export interface components {
             updatedAt?: string | null;
         };
         /**
+         * RecoverFromFailedStepRequest
+         * @description Request payload for creating a failed-step recovery follow-up execution.
+         */
+        RecoverFromFailedStepRequest: {
+            /** Idempotencykey */
+            idempotencyKey: string;
+            /** Sourceworkflowid */
+            sourceWorkflowId?: string | null;
+            /** Sourcerunid */
+            sourceRunId?: string | null;
+            /** Logicalstepid */
+            logicalStepId?: string | null;
+            /** Sourceexecutionordinal */
+            sourceExecutionOrdinal?: number | null;
+            /** Recoverycheckpointref */
+            recoveryCheckpointRef?: string | null;
+            /** Checkpointboundary */
+            checkpointBoundary?: ("after_prepare" | "before_execution" | "after_execution" | "after_gate" | "before_publication" | "before_recovery_restoration") | null;
+            /** Taskinputsnapshotref */
+            taskInputSnapshotRef?: string | null;
+            /** Planref */
+            planRef?: string | null;
+            /** Plandigest */
+            planDigest?: string | null;
+            /** Preservedsteprefs */
+            preservedStepRefs?: string[];
+            /** Dependencysignatures */
+            dependencySignatures?: {
+                [key: string]: unknown;
+            };
+            /** Workspacepolicy */
+            workspacePolicy?: ("restore_pre_execution" | "continue_from_previous_execution" | "apply_previous_execution_diff_to_clean_baseline" | "start_from_last_passed_commit" | "fresh_branch_from_source") | null;
+            /** Operatormetadata */
+            operatorMetadata?: {
+                [key: string]: unknown;
+            };
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * RecoverFromFailedStepResponse
          * @description Response from the failed-step recovery command.
          */
@@ -6796,6 +6836,48 @@ export interface components {
             relationship: "Recovered from failed step" | "Recovered from selected step";
             /** Recoverycheckpointref */
             recoveryCheckpointRef: string;
+        };
+        /**
+         * RecoverFromSelectedStepRequest
+         * @description Request payload for creating a selected-step recovery follow-up execution.
+         */
+        RecoverFromSelectedStepRequest: {
+            /** Idempotencykey */
+            idempotencyKey: string;
+            /** Sourceworkflowid */
+            sourceWorkflowId: string;
+            /** Sourcerunid */
+            sourceRunId: string;
+            /** Logicalstepid */
+            logicalStepId?: string | null;
+            /** Sourceexecutionordinal */
+            sourceExecutionOrdinal?: number | null;
+            /** Recoverycheckpointref */
+            recoveryCheckpointRef?: string | null;
+            /** Checkpointboundary */
+            checkpointBoundary?: ("after_prepare" | "before_execution" | "after_execution" | "after_gate" | "before_publication" | "before_recovery_restoration") | null;
+            /** Taskinputsnapshotref */
+            taskInputSnapshotRef?: string | null;
+            /** Planref */
+            planRef?: string | null;
+            /** Plandigest */
+            planDigest?: string | null;
+            /** Preservedsteprefs */
+            preservedStepRefs?: string[];
+            /** Dependencysignatures */
+            dependencySignatures?: {
+                [key: string]: unknown;
+            };
+            /** Workspacepolicy */
+            workspacePolicy?: ("restore_pre_execution" | "continue_from_previous_execution" | "apply_previous_execution_diff_to_clean_baseline" | "start_from_last_passed_commit" | "fresh_branch_from_source") | null;
+            /** Operatormetadata */
+            operatorMetadata?: {
+                [key: string]: unknown;
+            };
+            /** Selectedstartstepid */
+            selectedStartStepId: string;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * RecoveryEligibilityDiagnosticModel
@@ -12316,11 +12398,9 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
+        requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": components["schemas"]["RecoverFromFailedStepRequest"];
             };
         };
         responses: {
@@ -12353,11 +12433,9 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
+        requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": components["schemas"]["RecoverFromSelectedStepRequest"];
             };
         };
         responses: {

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1629,45 +1629,66 @@ class RecoverFromFailedStepRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1, max_length=128)
+    source_workflow_id: Optional[str] = Field(None, alias="sourceWorkflowId", min_length=1)
+    source_run_id: Optional[str] = Field(None, alias="sourceRunId", min_length=1)
+    logical_step_id: Optional[str] = Field(None, alias="logicalStepId", min_length=1)
+    source_execution_ordinal: Optional[int] = Field(
+        None, alias="sourceExecutionOrdinal", ge=1
+    )
     recovery_checkpoint_ref: Optional[str] = Field(None, alias="recoveryCheckpointRef")
+    checkpoint_boundary: Optional[StepExecutionCheckpointBoundary] = Field(
+        None, alias="checkpointBoundary"
+    )
+    task_input_snapshot_ref: Optional[str] = Field(
+        None, alias="taskInputSnapshotRef", min_length=1
+    )
+    plan_ref: Optional[str] = Field(None, alias="planRef", min_length=1)
+    plan_digest: Optional[str] = Field(None, alias="planDigest", min_length=1)
+    preserved_step_refs: list[str] = Field(default_factory=list, alias="preservedStepRefs")
+    dependency_signatures: dict[str, Any] = Field(
+        default_factory=dict, alias="dependencySignatures"
+    )
+    workspace_policy: Optional[WorkspacePolicy] = Field(None, alias="workspacePolicy")
     operator_metadata: dict[str, Any] = Field(
         default_factory=dict, alias="operatorMetadata"
     )
 
-    @model_validator(mode="before")
+    @field_validator(
+        "source_workflow_id",
+        "source_run_id",
+        "logical_step_id",
+        "recovery_checkpoint_ref",
+        "task_input_snapshot_ref",
+        "plan_ref",
+        "plan_digest",
+        mode="before",
+    )
     @classmethod
-    def _reject_task_payload_edits(cls, value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-        forbidden = {
-            "task",
-            "instructions",
-            "steps",
-            "attachments",
-            "inputAttachments",
-            "runtime",
-            "targetRuntime",
-            "publishMode",
-            "branch",
-            "startingBranch",
-            "targetBranch",
-            "presets",
-            "dependencies",
-            "model",
-            "requestedModel",
-            "effort",
-            "parametersPatch",
-            "inputArtifactRef",
-            "planArtifactRef",
-            "manifestArtifactRef",
-        }
-        present = sorted(key for key in value if key in forbidden)
-        if present:
-            raise ValueError(
-                "Resume does not accept edited task payload fields: "
-                + ", ".join(present)
-            )
-        return value
+    def _normalize_optional_text(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        candidate = str(value).strip()
+        return candidate or None
+
+    @field_validator("preserved_step_refs")
+    @classmethod
+    def _normalize_preserved_step_refs(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            candidate = str(item).strip()
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            normalized.append(candidate)
+        return normalized
+
+    @field_validator("dependency_signatures", mode="before")
+    @classmethod
+    def _validate_dependency_signatures(cls, value: Any) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value or {}, field_name="dependencySignatures"
+        )
 
 
 class RecoverFromSelectedStepRequest(RecoverFromFailedStepRequest):

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1626,7 +1626,7 @@ class UpdateExecutionRequest(BaseModel):
 class RecoverFromFailedStepRequest(BaseModel):
     """Request payload for creating a failed-step recovery follow-up execution."""
 
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1, max_length=128)
     source_workflow_id: Optional[str] = Field(None, alias="sourceWorkflowId", min_length=1)

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1626,7 +1626,7 @@ class UpdateExecutionRequest(BaseModel):
 class RecoverFromFailedStepRequest(BaseModel):
     """Request payload for creating a failed-step recovery follow-up execution."""
 
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1, max_length=128)
     source_workflow_id: Optional[str] = Field(None, alias="sourceWorkflowId", min_length=1)

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -1556,9 +1556,28 @@ class ResumeFromFailedStepRef(BaseModel):
     failed_step_id: str = Field(..., alias="failedStepId")
     failed_step_execution: int | None = Field(None, alias="failedStepExecution")
     recovery_checkpoint_ref: str = Field(..., alias="recoveryCheckpointRef")
+    checkpoint_boundary: Literal[
+        "after_prepare",
+        "before_execution",
+        "after_execution",
+        "after_gate",
+        "before_publication",
+        "before_recovery_restoration",
+    ] | None = Field(None, alias="checkpointBoundary")
     task_input_snapshot_ref: str = Field(..., alias="taskInputSnapshotRef")
     plan_ref: str | None = Field(None, alias="planRef")
     plan_digest: str | None = Field(None, alias="planDigest")
+    preserved_step_refs: list[str] = Field(default_factory=list, alias="preservedStepRefs")
+    dependency_signatures: dict[str, Any] = Field(
+        default_factory=dict, alias="dependencySignatures"
+    )
+    workspace_policy: Literal[
+        "restore_pre_execution",
+        "continue_from_previous_execution",
+        "apply_previous_execution_diff_to_clean_baseline",
+        "start_from_last_passed_commit",
+        "fresh_branch_from_source",
+    ] | None = Field(None, alias="workspacePolicy")
 
     @field_validator(
         "source_workflow_id",
@@ -1581,6 +1600,28 @@ class ResumeFromFailedStepRef(BaseModel):
     @classmethod
     def _clean_optional(cls, value: object) -> str | None:
         return _clean_optional_str(value)
+
+    @field_validator("preserved_step_refs")
+    @classmethod
+    def _clean_preserved_step_refs(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            candidate = _clean_str(item)
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            normalized.append(candidate)
+        return normalized
+
+    @field_validator("dependency_signatures", mode="before")
+    @classmethod
+    def _require_dependency_signatures_mapping(cls, value: object) -> dict[str, Any]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise WorkflowContractError("dependencySignatures must be an object")
+        return dict(value)
 
 
 class WorkflowExecutionSpec(BaseModel):

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -1546,7 +1546,7 @@ class WorkflowRecoveryProvenance(BaseModel):
 class ResumeFromFailedStepRef(BaseModel):
     """Pins a resume submission to a specific source run, failed step, and checkpoint."""
 
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     kind: Literal["recover_from_failed_step"] = Field(
         "recover_from_failed_step", alias="kind"

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -1555,6 +1555,11 @@ class ResumeFromFailedStepRef(BaseModel):
     source_run_id: str = Field(..., alias="sourceRunId")
     failed_step_id: str = Field(..., alias="failedStepId")
     failed_step_execution: int | None = Field(None, alias="failedStepExecution")
+    recovery_mode: Literal["selected_step"] | None = Field(None, alias="recoveryMode")
+    selected_start_step_id: str | None = Field(None, alias="selectedStartStepId")
+    selected_start_step_execution: int | None = Field(
+        None, alias="selectedStartStepExecution"
+    )
     recovery_checkpoint_ref: str = Field(..., alias="recoveryCheckpointRef")
     checkpoint_boundary: Literal[
         "after_prepare",
@@ -1599,6 +1604,11 @@ class ResumeFromFailedStepRef(BaseModel):
     @field_validator("plan_ref", "plan_digest", mode="before")
     @classmethod
     def _clean_optional(cls, value: object) -> str | None:
+        return _clean_optional_str(value)
+
+    @field_validator("selected_start_step_id", mode="before")
+    @classmethod
+    def _clean_selected_start_step_id(cls, value: object) -> str | None:
         return _clean_optional_str(value)
 
     @field_validator("preserved_step_refs")

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3043,6 +3043,32 @@ class TemporalExecutionService:
             "sourceWorkflowId": record.workflow_id,
             "sourceRunId": source_run_id,
         }
+        preserved_step_refs: list[str] = []
+        for preserved_step in preserved_steps:
+            for candidate in (
+                preserved_step.state_checkpoint_ref,
+                preserved_step.workspace_checkpoint_ref,
+                preserved_step.step_checkpoint_ref,
+            ):
+                if candidate and candidate not in preserved_step_refs:
+                    preserved_step_refs.append(candidate)
+            for artifact_ref in preserved_step.artifacts.values():
+                if (
+                    isinstance(artifact_ref, str)
+                    and artifact_ref
+                    and artifact_ref not in preserved_step_refs
+                ):
+                    preserved_step_refs.append(artifact_ref)
+        workspace_policy = str(
+            checkpoint.recovery_workspace.get("workspacePolicy")
+            or checkpoint.recovery_workspace.get("workspace_policy")
+            or "restore_pre_execution"
+        ).strip()
+        if not workspace_policy:
+            workspace_policy = "restore_pre_execution"
+        dependency_signatures = checkpoint.recovery_workspace.get("dependencySignatures")
+        if not isinstance(dependency_signatures, dict):
+            dependency_signatures = {}
         recover_ref = {
             "kind": "recover_from_failed_step",
             "sourceWorkflowId": record.workflow_id,
@@ -3050,7 +3076,11 @@ class TemporalExecutionService:
             "failedStepId": failed_step_id,
             "failedStepExecution": failed_step_execution,
             "recoveryCheckpointRef": checkpoint_ref,
+            "checkpointBoundary": "before_recovery_restoration",
             "taskInputSnapshotRef": source_snapshot_ref,
+            "preservedStepRefs": preserved_step_refs,
+            "dependencySignatures": dependency_signatures,
+            "workspacePolicy": workspace_policy,
         }
         if recovery_mode == "selected_step":
             recover_ref["recoveryMode"] = recovery_mode

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3052,21 +3052,23 @@ class TemporalExecutionService:
             ):
                 if candidate and candidate not in preserved_step_refs:
                     preserved_step_refs.append(candidate)
-            for artifact_ref in preserved_step.artifacts.values():
+            artifacts = preserved_step.artifacts or {}
+            for artifact_ref in artifacts.values():
                 if (
                     isinstance(artifact_ref, str)
                     and artifact_ref
                     and artifact_ref not in preserved_step_refs
                 ):
                     preserved_step_refs.append(artifact_ref)
+        recovery_workspace = checkpoint.recovery_workspace or {}
         workspace_policy = str(
-            checkpoint.recovery_workspace.get("workspacePolicy")
-            or checkpoint.recovery_workspace.get("workspace_policy")
+            recovery_workspace.get("workspacePolicy")
+            or recovery_workspace.get("workspace_policy")
             or "restore_pre_execution"
         ).strip()
         if not workspace_policy:
             workspace_policy = "restore_pre_execution"
-        dependency_signatures = checkpoint.recovery_workspace.get("dependencySignatures")
+        dependency_signatures = recovery_workspace.get("dependencySignatures")
         if not isinstance(dependency_signatures, dict):
             dependency_signatures = {}
         recover_ref = {

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -1522,7 +1522,22 @@ def test_recover_from_failed_step_route_contract_is_registered() -> None:
     route = schema["paths"]["/api/executions/{workflow_id}/recover-from-failed-step"]["post"]
     assert route["responses"]["201"]["description"]
     request_schema = route["requestBody"]["content"]["application/json"]["schema"]
-    assert request_schema["type"] == "object"
+    ref = request_schema["$ref"].removeprefix("#/components/schemas/")
+    properties = schema["components"]["schemas"][ref]["properties"]
+    assert {
+        "sourceWorkflowId",
+        "sourceRunId",
+        "logicalStepId",
+        "sourceExecutionOrdinal",
+        "recoveryCheckpointRef",
+        "checkpointBoundary",
+        "taskInputSnapshotRef",
+        "planRef",
+        "planDigest",
+        "preservedStepRefs",
+        "dependencySignatures",
+        "workspacePolicy",
+    }.issubset(properties)
 
 
 def test_recover_from_selected_step_route_contract_is_registered() -> None:
@@ -1530,4 +1545,24 @@ def test_recover_from_selected_step_route_contract_is_registered() -> None:
     route = schema["paths"]["/api/executions/{workflow_id}/recover-from-selected-step"]["post"]
     assert route["responses"]["201"]["description"]
     request_schema = route["requestBody"]["content"]["application/json"]["schema"]
-    assert request_schema["type"] == "object"
+    ref = request_schema["$ref"].removeprefix("#/components/schemas/")
+    request_contract = schema["components"]["schemas"][ref]
+    properties = request_contract["properties"]
+    assert {
+        "sourceWorkflowId",
+        "sourceRunId",
+        "selectedStartStepId",
+        "logicalStepId",
+        "sourceExecutionOrdinal",
+        "recoveryCheckpointRef",
+        "checkpointBoundary",
+        "taskInputSnapshotRef",
+        "planRef",
+        "planDigest",
+        "preservedStepRefs",
+        "dependencySignatures",
+        "workspacePolicy",
+    }.issubset(properties)
+    assert {"sourceWorkflowId", "sourceRunId", "selectedStartStepId"}.issubset(
+        set(request_contract["required"])
+    )

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -1523,7 +1523,9 @@ def test_recover_from_failed_step_route_contract_is_registered() -> None:
     assert route["responses"]["201"]["description"]
     request_schema = route["requestBody"]["content"]["application/json"]["schema"]
     ref = request_schema["$ref"].removeprefix("#/components/schemas/")
-    properties = schema["components"]["schemas"][ref]["properties"]
+    request_contract = schema["components"]["schemas"][ref]
+    properties = request_contract["properties"]
+    assert request_contract["additionalProperties"] is False
     assert {
         "sourceWorkflowId",
         "sourceRunId",
@@ -1548,6 +1550,7 @@ def test_recover_from_selected_step_route_contract_is_registered() -> None:
     ref = request_schema["$ref"].removeprefix("#/components/schemas/")
     request_contract = schema["components"]["schemas"][ref]
     properties = request_contract["properties"]
+    assert request_contract["additionalProperties"] is False
     assert {
         "sourceWorkflowId",
         "sourceRunId",

--- a/tests/integration/temporal/test_backend_resume_eligibility.py
+++ b/tests/integration/temporal/test_backend_resume_eligibility.py
@@ -124,9 +124,16 @@ async def test_accepted_recovery_carries_canonical_recovery_and_recovery_refs(
         "failedStepId": "implement",
         "failedStepExecution": 1,
         "recoveryCheckpointRef": "artifact://checkpoint/source",
+        "checkpointBoundary": "before_recovery_restoration",
         "taskInputSnapshotRef": "artifact://snapshot/source",
         "planRef": "artifact://plan/source",
         "planDigest": "sha256:plan",
+        "preservedStepRefs": [
+            "artifact://workspace/before-plan",
+            "artifact://summary",
+        ],
+        "dependencySignatures": {},
+        "workspacePolicy": "restore_pre_execution",
     }
     assert "agentRunId" not in resumed.parameters
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10367,7 +10367,7 @@ def test_failed_step_recovery_submission_rejects_stale_recovery_evidence(
                 "workflow": {"instructions": "change the task"},
                 "runtime": {"model": "gpt-5.4"},
             },
-            ["runtime"],
+            ["runtime", "workflow"],
         ),
         (
             {
@@ -10441,10 +10441,13 @@ def test_failed_step_recovery_request_rejects_edited_task_payload_fields(
             },
         )
 
-    assert response.status_code == 400
-    body = response.json()["detail"]
-    assert body["code"] == "recovery_payload_not_allowed"
-    assert body["fields"] == expected_fields
+    assert response.status_code == 422
+    rejected_fields = sorted(
+        item["loc"][-1]
+        for item in response.json()["detail"]
+        if item["type"] == "extra_forbidden"
+    )
+    assert rejected_fields == expected_fields
 
 
 def test_mm773_serialize_execution_surfaces_comparison_source_related_run() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -25,6 +25,7 @@ from api_service.api.routers.executions import (
     _artifact_id_from_ref,
     _build_original_workflow_input_snapshot_payload,
     _build_recurring_target,
+    _checkpoint_failed_step_execution,
     _expand_goal_preset_for_workflow_submission,
     _extract_cost_estimate_usd,
     _effective_user_roles,
@@ -10367,7 +10368,7 @@ def test_failed_step_recovery_submission_rejects_stale_recovery_evidence(
                 "workflow": {"instructions": "change the task"},
                 "runtime": {"model": "gpt-5.4"},
             },
-            ["runtime", "workflow"],
+            ["runtime"],
         ),
         (
             {
@@ -10441,13 +10442,31 @@ def test_failed_step_recovery_request_rejects_edited_task_payload_fields(
             },
         )
 
-    assert response.status_code == 422
-    rejected_fields = sorted(
-        item["loc"][-1]
-        for item in response.json()["detail"]
-        if item["type"] == "extra_forbidden"
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "recovery_payload_not_allowed"
+    assert detail["fields"] == expected_fields
+
+
+def test_checkpoint_failed_step_execution_rejects_boolean_ordinals() -> None:
+    assert (
+        _checkpoint_failed_step_execution(
+            {"failedStep": {"logicalStepId": "implement", "executionOrdinal": True}}
+        )
+        is None
     )
-    assert rejected_fields == expected_fields
+    assert (
+        _checkpoint_failed_step_execution(
+            {"failedStep": {"logicalStepId": "implement", "attempt": False}}
+        )
+        is None
+    )
+    assert (
+        _checkpoint_failed_step_execution(
+            {"failedStep": {"logicalStepId": "implement", "executionOrdinal": "2"}}
+        )
+        == 2
+    )
 
 
 def test_mm773_serialize_execution_surfaces_comparison_source_related_run() -> None:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1751,6 +1751,17 @@ def test_mm825_recovery_resume_contract_preserves_checkpoint_restoration_fields(
     assert normalized["workspacePolicy"] == "restore_pre_execution"
 
 
+def test_mm825_recovery_resume_contract_rejects_unknown_fields() -> None:
+    """MM-825: Resume refs are a closed checkpoint-backed recovery contract."""
+    with pytest.raises(ValidationError):
+        ResumeFromFailedStepRef.model_validate(
+            {
+                **_VALID_RESUME_BLOCK,
+                "inlineCheckpointPayload": {"workspace": "not allowed"},
+            }
+        )
+
+
 def test_sc001_recovery_source_workflow_id_must_match_recovery() -> None:
     """MM-638: recovery and resume must pin the same source workflow."""
     with pytest.raises(WorkflowContractError, match="sourceWorkflowId"):

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1751,6 +1751,34 @@ def test_mm825_recovery_resume_contract_preserves_checkpoint_restoration_fields(
     assert normalized["workspacePolicy"] == "restore_pre_execution"
 
 
+def test_mm825_recovery_resume_contract_preserves_selected_step_fields() -> None:
+    """MM-825: Selected-step recovery fields are part of the closed resume contract."""
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload=_canonical_task_payload({
+            "recovery": {
+                "kind": "recover_from_failed_step",
+                "sourceWorkflowId": "mm:abc123",
+                "sourceRunId": "run-1",
+            },
+            "resume": {
+                **_VALID_RESUME_BLOCK,
+                "failedStepId": "design",
+                "failedStepExecution": 1,
+                "recoveryMode": "selected_step",
+                "selectedStartStepId": "design",
+                "selectedStartStepExecution": 1,
+            },
+        }),
+    )
+
+    normalized = result["workflow"]["resume"]
+    assert normalized["failedStepId"] == "design"
+    assert normalized["recoveryMode"] == "selected_step"
+    assert normalized["selectedStartStepId"] == "design"
+    assert normalized["selectedStartStepExecution"] == 1
+
+
 def test_mm825_recovery_resume_contract_rejects_unknown_fields() -> None:
     """MM-825: Resume refs are a closed checkpoint-backed recovery contract."""
     with pytest.raises(ValidationError):

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1705,6 +1705,52 @@ def test_sc001_well_formed_recovery_payload_accepted() -> None:
     assert result["workflow"]["resume"]["taskInputSnapshotRef"] == "art_snap_abc"
 
 
+def test_mm825_recovery_resume_contract_preserves_checkpoint_restoration_fields() -> None:
+    """MM-825: Resume contract carries checkpoint-backed recovery evidence refs."""
+    resume = {
+        **_VALID_RESUME_BLOCK,
+        "failedStepExecution": 2,
+        "checkpointBoundary": "before_recovery_restoration",
+        "planRef": "artifact://plan/source",
+        "planDigest": "sha256:plan",
+        "preservedStepRefs": [
+            "artifact://workspace/before-plan",
+            "artifact://completed/plan",
+        ],
+        "dependencySignatures": {
+            "plan": {
+                "logicalStepId": "plan",
+                "executionOrdinal": 1,
+                "outputDigest": "sha256:output",
+            }
+        },
+        "workspacePolicy": "restore_pre_execution",
+    }
+
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload=_canonical_task_payload({
+            "recovery": {
+                "kind": "recover_from_failed_step",
+                "sourceWorkflowId": "mm:abc123",
+                "sourceRunId": "run-1",
+            },
+            "resume": resume,
+        }),
+    )
+
+    normalized = result["workflow"]["resume"]
+    assert normalized["checkpointBoundary"] == "before_recovery_restoration"
+    assert normalized["planRef"] == "artifact://plan/source"
+    assert normalized["planDigest"] == "sha256:plan"
+    assert normalized["preservedStepRefs"] == [
+        "artifact://workspace/before-plan",
+        "artifact://completed/plan",
+    ]
+    assert normalized["dependencySignatures"]["plan"]["outputDigest"] == "sha256:output"
+    assert normalized["workspacePolicy"] == "restore_pre_execution"
+
+
 def test_sc001_recovery_source_workflow_id_must_match_recovery() -> None:
     """MM-638: recovery and resume must pin the same source workflow."""
     with pytest.raises(WorkflowContractError, match="sourceWorkflowId"):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -2677,9 +2677,16 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
             "failedStepId": "implement",
             "failedStepExecution": 1,
             "recoveryCheckpointRef": "artifact://checkpoint/source",
+            "checkpointBoundary": "before_recovery_restoration",
             "taskInputSnapshotRef": "artifact://snapshot/source",
             "planRef": "artifact://plan/source",
             "planDigest": "sha256:plan",
+            "preservedStepRefs": [
+                "artifact://workspace/before-plan",
+                "artifact://summary",
+            ],
+            "dependencySignatures": {},
+            "workspacePolicy": "restore_pre_execution",
         }
         assert "agentRunId" not in resumed.parameters
 


### PR DESCRIPTION
Jira issue key: MM-825

Summary:
- Extends canonical recovery/resume request and Temporal execution contracts for checkpoint-backed failed-step and selected-step recovery.
- Carries source workflow/run lineage, checkpoint boundary, task input snapshot, plan identity, preserved-step refs, dependency signatures, and workspace policy through API/service boundaries.
- Adds focused unit, contract, and integration coverage around recovery eligibility and validation behavior.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/executions/test_execution_contract.py tests/unit/workflows/temporal/test_temporal_service.py tests/contract/test_temporal_execution_api.py` - failed: 520 passed, 3 failed. Failures: `test_describe_execution_bounds_slow_live_progress_query`, `test_get_execution_steps_returns_503_for_slow_temporal_query`, and `test_task_shaped_create_returns_temporal_identity_and_redirect`.

Remaining risks:
- The targeted verification command has two timing-threshold failures in execution router slow-query tests in this runtime.
- `test_task_shaped_create_returns_temporal_identity_and_redirect` returned HTTP 422 instead of 201 and needs reviewer attention before merge.
- Full unit and compose-backed integration suites were not run in this publication step.