### PR TITLE
Allow Claude runs to inherit GitHub auth

### DIFF
--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -611,12 +611,12 @@ class ManagedRuntimeLauncher:
     def _runtime_requires_direct_github_env(runtime_id: str | None) -> bool:
         """Return whether a managed runtime needs token env in addition to broker helpers.
 
-        Codex CLI shell-tool execution can bypass the workspace-local ``gh`` wrapper
-        during nested ``bash -lc`` command execution, so direct ``GITHUB_TOKEN``
-        env remains necessary for reliable GitHub CLI auth.
+        Some runtime shell-tool execution can bypass the workspace-local ``gh``
+        wrapper during nested shell execution, so direct ``GITHUB_TOKEN`` env
+        remains necessary for reliable GitHub CLI auth.
         """
 
-        return str(runtime_id or "").strip() == "codex_cli"
+        return str(runtime_id or "").strip() in {"claude_code", "codex_cli"}
 
     @staticmethod
     def _write_executable_script(path: Path, content: str) -> str:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -616,7 +616,7 @@ class ManagedRuntimeLauncher:
         remains necessary for reliable GitHub CLI auth.
         """
 
-        return str(runtime_id or "").strip() in {"claude_code", "codex_cli"}
+        return (runtime_id or "").strip() in {"claude_code", "codex_cli"}
 
     @staticmethod
     def _write_executable_script(path: Path, content: str) -> str:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1995,7 +1995,7 @@ async def test_launch_resolves_github_token_from_secret_ref_setting(
 
     run_root = store.store_root.parent / "workspaces" / "run-github-secret-ref-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
-    assert "GITHUB_TOKEN" not in captured_env
+    assert captured_env["GITHUB_TOKEN"] == "resolved-github-token"
     assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     gitconfig = Path(captured_env["GIT_CONFIG_GLOBAL"])
     assert gitconfig.exists()
@@ -2072,7 +2072,7 @@ async def test_launch_resolves_github_token_from_managed_secrets_store_without_p
 
     run_root = store.store_root.parent / "workspaces" / "run-github-managed-store-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
-    assert "GITHUB_TOKEN" not in captured_env
+    assert captured_env["GITHUB_TOKEN"] == "resolved-from-managed-secrets-table"
     assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     assert (run_root / ".moonmind" / "bin" / "gh").exists()
 
@@ -2407,7 +2407,7 @@ async def test_launch_privilege_drop_chowns_github_broker_socket_for_claude_code
     )
     assert ("chown", "-R", "app:app", str(workspace_root.parent)) in chown_calls
     assert str(socket_path.parent) in deferred_cleanup
-    assert "GITHUB_TOKEN" not in captured_launch_env
+    assert captured_launch_env["GITHUB_TOKEN"] == "ghp_testtoken123"
     assert captured_launch_env["PATH"].startswith(
         str(workspace_root.parent / ".moonmind" / "bin")
     )


### PR DESCRIPTION
## Summary
- Pass direct `GITHUB_TOKEN` to `claude_code` managed runtime launches, matching the existing Codex CLI behavior.
- Keep brokered `gh` wrapper setup in place while allowing nested shell execution to authenticate reliably.
- Update launcher tests to assert Claude Code receives the resolved token without writing it into gitconfig.

## Root Cause
Workflow `mm:4b3c55aa-21ee-430d-98d1-a0a6f61c3913` failed because the child agent run completed with `publish_unavailable`: Claude Code could not authenticate GitHub CLI calls. The runtime only passed direct GitHub token env to `codex_cli`, but Claude Code shell execution can also bypass the workspace-local `gh` wrapper during nested shell commands.

## Impact
Claude Code managed runs can now publish PRs/comments when a resolved GitHub token is available through the managed runtime secret/profile path.

## Verification
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py -k 'github_token_from_secret_ref_setting or github_token_from_managed_secrets_store_without_profile_ref or direct_github_env_for_codex_cli_managed_runs or chowns_github_broker_socket_for_claude_code'`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py -k test_agent_runtime_status_temporal_boundary --no-xdist`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` was run; the full run had one unrelated Temporal ephemeral server startup failure, and the failing boundary test passed on isolated rerun.
- `git diff --check`