### PR TITLE
[codex] Fix runtime switch provider profile cleanup

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -149,6 +149,9 @@ SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
 PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID = (
     "agent-run-pin-provider-profile-before-slot-request-v1"
 )
+RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
+    "agent-run-runtime-selection-profile-clear-v1"
+)
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
 AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
     "agent-run-managed-no-progress-reconciliation-v1"
@@ -1789,6 +1792,13 @@ class MoonMindAgentRun:
     def update_runtime_selection(self, payload: dict[str, Any] | None = None) -> None:
         payload = payload or {}
         update_payload: dict[str, Any] = {}
+        profile_ref_source_keys = {
+            "executionProfileRef",
+            "execution_profile_ref",
+            "profileId",
+            "profile_id",
+            "providerProfile",
+        }
         for source_key, target_key in (
             ("executionProfileRef", "executionProfileRef"),
             ("execution_profile_ref", "executionProfileRef"),
@@ -1808,6 +1818,12 @@ class MoonMindAgentRun:
             if isinstance(value, str):
                 value = value.strip()
                 if not value:
+                    if (
+                        target_key == "executionProfileRef"
+                        and source_key in profile_ref_source_keys
+                        and workflow.patched(RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID)
+                    ):
+                        update_payload[target_key] = ""
                     continue
             update_payload[target_key] = value
         parameters_patch = payload.get("parametersPatch") or payload.get(
@@ -1857,6 +1873,43 @@ class MoonMindAgentRun:
         for key in ("profileSelector", "profile_selector"):
             runtime_payload.pop(key, None)
 
+    @staticmethod
+    def _has_runtime_profile_field(runtime_payload: Mapping[str, Any]) -> bool:
+        return any(
+            key in runtime_payload
+            for key in (
+                "executionProfileRef",
+                "execution_profile_ref",
+                "profileId",
+                "profile_id",
+                "providerProfile",
+                "provider_profile",
+            )
+        )
+
+    def _has_profile_selection_update(
+        self,
+        *,
+        payload: Mapping[str, Any],
+        parameters_patch: Any,
+    ) -> bool:
+        if self._has_runtime_profile_field(payload):
+            return True
+        if not isinstance(parameters_patch, Mapping):
+            return False
+        if self._has_runtime_profile_field(parameters_patch):
+            return True
+        for key in ("task", "authoredTaskInput", "workflow"):
+            nested_payload = parameters_patch.get(key)
+            if not isinstance(nested_payload, Mapping):
+                continue
+            runtime_payload = nested_payload.get("runtime")
+            if isinstance(runtime_payload, Mapping) and self._has_runtime_profile_field(
+                runtime_payload
+            ):
+                return True
+        return False
+
     def _profile_ref_targets_different_runtime(
         self,
         *,
@@ -1879,10 +1932,9 @@ class MoonMindAgentRun:
     def _clear_runtime_profile_selection(
         self,
         request: AgentExecutionRequest,
-        params: dict[str, Any] | None = None,
     ) -> None:
         request.execution_profile_ref = None
-        params = dict(params if params is not None else request.parameters or {})
+        params = dict(request.parameters or {})
         self._drop_runtime_profile_fields(params)
         for key in ("task", "authoredTaskInput", "workflow"):
             payload = self._mapping_copy(params.get(key))
@@ -1927,6 +1979,12 @@ class MoonMindAgentRun:
         workflow_runtime = self._mapping_copy(workflow_payload.get("runtime"))
 
         profile_id = str(payload.get("executionProfileRef") or "").strip()
+        explicit_profile_selection_update = self._has_profile_selection_update(
+            payload=payload,
+            parameters_patch=parameters_patch,
+        )
+        if profile_id.lower() == "auto":
+            profile_id = ""
 
         model = str(payload.get("model") or "").strip()
         if model:
@@ -1975,18 +2033,22 @@ class MoonMindAgentRun:
             self._drop_runtime_profile_fields(task_runtime)
             self._drop_runtime_profile_fields(authored_runtime)
             self._drop_runtime_profile_fields(workflow_runtime)
+        elif explicit_profile_selection_update:
+            request.execution_profile_ref = None
+            self._drop_runtime_profile_fields(params)
+            self._drop_runtime_profile_fields(task_runtime)
+            self._drop_runtime_profile_fields(authored_runtime)
+            self._drop_runtime_profile_fields(workflow_runtime)
 
         profile_selector_payload = payload.get("profileSelector")
-        if not isinstance(profile_selector_payload, Mapping):
-            candidate_selector = (
-                parameters_patch.get("profileSelector")
-                or parameters_patch.get("profile_selector")
-                if isinstance(parameters_patch, Mapping)
-                else None
-            )
-            if isinstance(candidate_selector, Mapping):
-                profile_selector_payload = candidate_selector
-        if not isinstance(profile_selector_payload, Mapping):
+        if not isinstance(profile_selector_payload, Mapping) and not runtime_changed:
+            if isinstance(parameters_patch, Mapping):
+                candidate_selector = parameters_patch.get("profileSelector")
+                if not isinstance(candidate_selector, Mapping):
+                    candidate_selector = parameters_patch.get("profile_selector")
+                if isinstance(candidate_selector, Mapping):
+                    profile_selector_payload = candidate_selector
+        if not isinstance(profile_selector_payload, Mapping) and not runtime_changed:
             task_patch = (
                 parameters_patch.get("task")
                 if isinstance(parameters_patch, Mapping)
@@ -1995,15 +2057,13 @@ class MoonMindAgentRun:
             task_runtime_patch = (
                 task_patch.get("runtime") if isinstance(task_patch, Mapping) else None
             )
-            task_selector = (
-                task_runtime_patch.get("profileSelector")
-                or task_runtime_patch.get("profile_selector")
-                if isinstance(task_runtime_patch, Mapping)
-                else None
-            )
-            if isinstance(task_selector, Mapping):
-                profile_selector_payload = task_selector
-        if not isinstance(profile_selector_payload, Mapping):
+            if isinstance(task_runtime_patch, Mapping):
+                task_selector = task_runtime_patch.get("profileSelector")
+                if not isinstance(task_selector, Mapping):
+                    task_selector = task_runtime_patch.get("profile_selector")
+                if isinstance(task_selector, Mapping):
+                    profile_selector_payload = task_selector
+        if not isinstance(profile_selector_payload, Mapping) and not runtime_changed:
             authored_patch = (
                 parameters_patch.get("authoredTaskInput")
                 if isinstance(parameters_patch, Mapping)
@@ -2014,14 +2074,12 @@ class MoonMindAgentRun:
                 if isinstance(authored_patch, Mapping)
                 else None
             )
-            authored_selector = (
-                authored_runtime_patch.get("profileSelector")
-                or authored_runtime_patch.get("profile_selector")
-                if isinstance(authored_runtime_patch, Mapping)
-                else None
-            )
-            if isinstance(authored_selector, Mapping):
-                profile_selector_payload = authored_selector
+            if isinstance(authored_runtime_patch, Mapping):
+                authored_selector = authored_runtime_patch.get("profileSelector")
+                if not isinstance(authored_selector, Mapping):
+                    authored_selector = authored_runtime_patch.get("profile_selector")
+                if isinstance(authored_selector, Mapping):
+                    profile_selector_payload = authored_selector
 
         if isinstance(profile_selector_payload, Mapping):
             request.profile_selector = ProfileSelector.model_validate(
@@ -2045,20 +2103,20 @@ class MoonMindAgentRun:
             authored_runtime.pop("profile_selector", None)
             workflow_runtime.pop("profileSelector", None)
             workflow_runtime.pop("profile_selector", None)
-        elif runtime_changed:
+        elif runtime_changed or explicit_profile_selection_update:
             request.profile_selector = ProfileSelector()
             self._drop_runtime_profile_selector_fields(params)
             self._drop_runtime_profile_selector_fields(task_runtime)
             self._drop_runtime_profile_selector_fields(authored_runtime)
             self._drop_runtime_profile_selector_fields(workflow_runtime)
 
-        if task_runtime:
+        if task_runtime or "runtime" in task_payload:
             task_payload["runtime"] = task_runtime
             params["task"] = task_payload
-        if authored_runtime:
+        if authored_runtime or "runtime" in authored_payload:
             authored_payload["runtime"] = authored_runtime
             params["authoredTaskInput"] = authored_payload
-        if workflow_runtime:
+        if workflow_runtime or "runtime" in workflow_payload:
             workflow_payload["runtime"] = workflow_runtime
             params["workflow"] = workflow_payload
         request.parameters = params

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1840,11 +1840,65 @@ class MoonMindAgentRun:
     def _mapping_copy(value: Any) -> dict[str, Any]:
         return dict(value) if isinstance(value, Mapping) else {}
 
+    @staticmethod
+    def _drop_runtime_profile_fields(runtime_payload: dict[str, Any]) -> None:
+        for key in (
+            "executionProfileRef",
+            "execution_profile_ref",
+            "profileId",
+            "profile_id",
+            "providerProfile",
+            "provider_profile",
+        ):
+            runtime_payload.pop(key, None)
+
+    @staticmethod
+    def _drop_runtime_profile_selector_fields(runtime_payload: dict[str, Any]) -> None:
+        for key in ("profileSelector", "profile_selector"):
+            runtime_payload.pop(key, None)
+
+    def _profile_ref_targets_different_runtime(
+        self,
+        *,
+        profile_id: str,
+        runtime_id: str,
+    ) -> bool:
+        snapshots = self._profile_snapshots
+        if not isinstance(snapshots, Mapping):
+            return False
+        snapshot = snapshots.get(profile_id)
+        if not isinstance(snapshot, Mapping):
+            return False
+        snapshot_runtime_id = str(snapshot.get("runtime_id") or "").strip()
+        if not snapshot_runtime_id:
+            return False
+        return self._managed_runtime_id(snapshot_runtime_id) != self._managed_runtime_id(
+            runtime_id
+        )
+
+    def _clear_runtime_profile_selection(
+        self,
+        request: AgentExecutionRequest,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        request.execution_profile_ref = None
+        params = dict(params if params is not None else request.parameters or {})
+        self._drop_runtime_profile_fields(params)
+        for key in ("task", "authoredTaskInput", "workflow"):
+            payload = self._mapping_copy(params.get(key))
+            runtime_payload = self._mapping_copy(payload.get("runtime"))
+            if runtime_payload:
+                self._drop_runtime_profile_fields(runtime_payload)
+                payload["runtime"] = runtime_payload
+                params[key] = payload
+        request.parameters = params
+
     def _apply_runtime_selection_update(
         self,
         request: AgentExecutionRequest,
         payload: Mapping[str, Any],
     ) -> None:
+        previous_runtime_id = self._managed_runtime_id(request.agent_id)
         params = dict(request.parameters or {})
         parameters_patch = payload.get("parametersPatch")
         if isinstance(parameters_patch, Mapping):
@@ -1869,13 +1923,10 @@ class MoonMindAgentRun:
         task_runtime = self._mapping_copy(task_payload.get("runtime"))
         authored_payload = self._mapping_copy(params.get("authoredTaskInput"))
         authored_runtime = self._mapping_copy(authored_payload.get("runtime"))
+        workflow_payload = self._mapping_copy(params.get("workflow"))
+        workflow_runtime = self._mapping_copy(workflow_payload.get("runtime"))
 
         profile_id = str(payload.get("executionProfileRef") or "").strip()
-        if profile_id:
-            request.execution_profile_ref = profile_id
-            params["profileId"] = profile_id
-            task_runtime["profileId"] = profile_id
-            authored_runtime["profileId"] = profile_id
 
         model = str(payload.get("model") or "").strip()
         if model:
@@ -1883,12 +1934,14 @@ class MoonMindAgentRun:
             params["requestedModel"] = model
             task_runtime["model"] = model
             authored_runtime["model"] = model
+            workflow_runtime["model"] = model
 
         effort = str(payload.get("effort") or "").strip()
         if effort:
             params["effort"] = effort
             task_runtime["effort"] = effort
             authored_runtime["effort"] = effort
+            workflow_runtime["effort"] = effort
 
         target_runtime = str(payload.get("targetRuntime") or "").strip()
         if target_runtime:
@@ -1896,6 +1949,32 @@ class MoonMindAgentRun:
             params["targetRuntime"] = target_runtime
             task_runtime["mode"] = target_runtime
             authored_runtime["mode"] = target_runtime
+            workflow_runtime["mode"] = target_runtime
+        current_runtime_id = self._managed_runtime_id(request.agent_id)
+        runtime_changed = current_runtime_id != previous_runtime_id
+
+        if (
+            profile_id
+            and runtime_changed
+            and self._profile_ref_targets_different_runtime(
+                profile_id=profile_id,
+                runtime_id=current_runtime_id,
+            )
+        ):
+            profile_id = ""
+
+        if profile_id:
+            request.execution_profile_ref = profile_id
+            params["profileId"] = profile_id
+            task_runtime["profileId"] = profile_id
+            authored_runtime["profileId"] = profile_id
+            workflow_runtime["profileId"] = profile_id
+        elif runtime_changed:
+            request.execution_profile_ref = None
+            self._drop_runtime_profile_fields(params)
+            self._drop_runtime_profile_fields(task_runtime)
+            self._drop_runtime_profile_fields(authored_runtime)
+            self._drop_runtime_profile_fields(workflow_runtime)
 
         profile_selector_payload = payload.get("profileSelector")
         if not isinstance(profile_selector_payload, Mapping):
@@ -1955,6 +2034,7 @@ class MoonMindAgentRun:
             params["profileSelector"] = selector_params
             task_runtime["profileSelector"] = selector_params
             authored_runtime["profileSelector"] = selector_params
+            workflow_runtime["profileSelector"] = selector_params
         elif profile_id:
             request.profile_selector = ProfileSelector()
             params.pop("profileSelector", None)
@@ -1963,6 +2043,14 @@ class MoonMindAgentRun:
             task_runtime.pop("profile_selector", None)
             authored_runtime.pop("profileSelector", None)
             authored_runtime.pop("profile_selector", None)
+            workflow_runtime.pop("profileSelector", None)
+            workflow_runtime.pop("profile_selector", None)
+        elif runtime_changed:
+            request.profile_selector = ProfileSelector()
+            self._drop_runtime_profile_selector_fields(params)
+            self._drop_runtime_profile_selector_fields(task_runtime)
+            self._drop_runtime_profile_selector_fields(authored_runtime)
+            self._drop_runtime_profile_selector_fields(workflow_runtime)
 
         if task_runtime:
             task_payload["runtime"] = task_runtime
@@ -1970,6 +2058,9 @@ class MoonMindAgentRun:
         if authored_runtime:
             authored_payload["runtime"] = authored_runtime
             params["authoredTaskInput"] = authored_payload
+        if workflow_runtime:
+            workflow_payload["runtime"] = workflow_runtime
+            params["workflow"] = workflow_payload
         request.parameters = params
 
     def _validate_synced_profile_selection(
@@ -1978,6 +2069,7 @@ class MoonMindAgentRun:
         profile_count: int,
         runtime_id: str,
         request: AgentExecutionRequest,
+        clear_invalid_profile_for_runtime_change: bool = False,
     ) -> None:
         if profile_count == 0:
             raise ApplicationError(
@@ -1992,6 +2084,9 @@ class MoonMindAgentRun:
                 and self._profile_snapshots
                 and requested_profile_id not in self._profile_snapshots
             ):
+                if clear_invalid_profile_for_runtime_change:
+                    self._clear_runtime_profile_selection(request)
+                    return
                 raise ApplicationError(
                     f"Provider profile '{requested_profile_id}' not found for runtime_id='{runtime_id}'",
                     type="ProfileResolutionError",
@@ -2069,6 +2164,9 @@ class MoonMindAgentRun:
             profile_count=profile_count,
             runtime_id=runtime_id,
             request=request,
+            clear_invalid_profile_for_runtime_change=(
+                manager_id != previous_manager_id
+            ),
         )
         manager_handle = await self._ensure_manager_and_signal(
             manager_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -368,6 +368,7 @@ RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH = (
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = "run-workflow-child-task-queue-v2"
+RUN_RUNTIME_PROFILE_CLEAR_FORWARDING_PATCH = "run-runtime-profile-clear-forwarding-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 # Replay-stable patch id for unified wait-through-rerun dependency behavior.
 # Under this patch, a non-success prerequisite terminal outcome (failed,
@@ -12099,6 +12100,26 @@ class MoonMindRunWorkflow:
             selection[target_key] = value
         return selection
 
+    @staticmethod
+    def _source_requests_runtime_profile_clear(
+        source: Mapping[str, Any] | None,
+    ) -> bool:
+        if not isinstance(source, Mapping):
+            return False
+        for source_key in (
+            "executionProfileRef",
+            "execution_profile_ref",
+            "profileId",
+            "profile_id",
+            "providerProfile",
+        ):
+            if source_key not in source:
+                continue
+            value = source.get(source_key)
+            if isinstance(value, str) and value.strip().lower() in {"", "auto"}:
+                return True
+        return False
+
     def _runtime_selection_update_payload(
         self, payload: Mapping[str, Any] | None
     ) -> dict[str, Any] | None:
@@ -12110,26 +12131,51 @@ class MoonMindRunWorkflow:
         if not isinstance(parameters_patch, Mapping):
             return None
 
+        preserve_profile_clear = workflow.patched(
+            RUN_RUNTIME_PROFILE_CLEAR_FORWARDING_PATCH
+        )
+        profile_clear_requested = False
         selection: dict[str, Any] = {}
         for source in (parameters_patch,):
+            if preserve_profile_clear and self._source_requests_runtime_profile_clear(
+                source
+            ):
+                profile_clear_requested = True
             selection.update(self._runtime_selection_from_source(source))
 
         runtime_block = parameters_patch.get("runtime")
         if isinstance(runtime_block, Mapping):
+            if (
+                preserve_profile_clear
+                and self._source_requests_runtime_profile_clear(runtime_block)
+            ):
+                profile_clear_requested = True
             selection.update(self._runtime_selection_from_source(runtime_block))
 
         workflow_payload = parameters_patch.get("workflow")
         if isinstance(workflow_payload, Mapping):
             workflow_runtime = workflow_payload.get("runtime")
             if isinstance(workflow_runtime, Mapping):
+                if (
+                    preserve_profile_clear
+                    and self._source_requests_runtime_profile_clear(workflow_runtime)
+                ):
+                    profile_clear_requested = True
                 selection.update(self._runtime_selection_from_source(workflow_runtime))
 
         authored_payload = parameters_patch.get("authoredTaskInput")
         if isinstance(authored_payload, Mapping):
             authored_runtime = authored_payload.get("runtime")
             if isinstance(authored_runtime, Mapping):
+                if (
+                    preserve_profile_clear
+                    and self._source_requests_runtime_profile_clear(authored_runtime)
+                ):
+                    profile_clear_requested = True
                 selection.update(self._runtime_selection_from_source(authored_runtime))
 
+        if profile_clear_requested:
+            selection["executionProfileRef"] = ""
         if not selection:
             return None
         selection["parametersPatch"] = dict(parameters_patch)

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -377,6 +377,106 @@ class TestEnsureManagerAutoStart:
         )
         assert "profileSelector" not in request.parameters["workflow"]["runtime"]
 
+    def test_runtime_selection_update_clears_profile_when_profile_patch_is_empty(
+        self,
+    ):
+        """Explicit profile clears must reset exact refs and stale selectors."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            parameters={
+                "targetRuntime": "codex_cli",
+                "profileId": "codex-openrouter",
+                "profileSelector": {"providerId": "openrouter"},
+                "task": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "codex-openrouter",
+                        "profileSelector": {"providerId": "openrouter"},
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "codex-openrouter",
+                        "profileSelector": {"providerId": "openrouter"},
+                    }
+                },
+                "workflow": {
+                    "runtime": {
+                        "profileId": "codex-openrouter",
+                        "profileSelector": {"providerId": "openrouter"},
+                    }
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "parametersPatch": {
+                    "profileId": "",
+                    "workflow": {"runtime": {"profileId": ""}},
+                },
+            },
+        )
+
+        assert request.agent_id == "codex_cli"
+        assert request.execution_profile_ref is None
+        assert request.profile_selector.provider_id is None
+        assert "profileId" not in request.parameters
+        assert "profileSelector" not in request.parameters
+        assert "profileId" not in request.parameters["task"]["runtime"]
+        assert "profileSelector" not in request.parameters["task"]["runtime"]
+        assert "profileId" not in request.parameters["authoredTaskInput"]["runtime"]
+        assert (
+            "profileSelector"
+            not in request.parameters["authoredTaskInput"]["runtime"]
+        )
+        assert "profileId" not in request.parameters["workflow"]["runtime"]
+        assert "profileSelector" not in request.parameters["workflow"]["runtime"]
+
+    def test_runtime_selection_update_treats_auto_profile_as_clear(self):
+        """The edit form's automatic profile value must not become a literal ID."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            parameters={
+                "targetRuntime": "codex_cli",
+                "profileId": "codex-openrouter",
+                "profileSelector": {"providerId": "openrouter"},
+                "task": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "codex-openrouter",
+                        "profileSelector": {"providerId": "openrouter"},
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "codex-openrouter",
+                        "profileSelector": {"providerId": "openrouter"},
+                    }
+                },
+            },
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {"executionProfileRef": "auto"},
+        )
+
+        assert request.execution_profile_ref is None
+        assert request.profile_selector.provider_id is None
+        assert "profileId" not in request.parameters
+        assert "profileSelector" not in request.parameters
+        assert "profileId" not in request.parameters["task"]["runtime"]
+        assert "profileSelector" not in request.parameters["task"]["runtime"]
+        assert "profileId" not in request.parameters["authoredTaskInput"]["runtime"]
+        assert (
+            "profileSelector"
+            not in request.parameters["authoredTaskInput"]["runtime"]
+        )
+
     def test_runtime_selection_update_clears_profile_known_to_previous_runtime(self):
         """A stale profile echoed by the edit form must not fail the new slot request."""
         workflow_instance = MoonMindAgentRun()
@@ -451,6 +551,73 @@ class TestEnsureManagerAutoStart:
         )
         assert "profileSelector" not in request.parameters["workflow"]["runtime"]
 
+    def test_runtime_selection_update_honors_top_level_selector_on_runtime_change(
+        self,
+    ):
+        """Only an explicit top-level selector should survive a runtime switch."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request(
+            agentId="claude_code",
+            executionProfileRef="claude_anthropic",
+            parameters={
+                "targetRuntime": "claude_code",
+                "profileId": "claude_anthropic",
+                "profileSelector": {"providerId": "anthropic"},
+                "task": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude_anthropic",
+                        "profileSelector": {"providerId": "anthropic"},
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude_anthropic",
+                        "profileSelector": {"providerId": "anthropic"},
+                    }
+                },
+            },
+            profileSelector={"providerId": "anthropic"},
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "codex_cli",
+                "profileSelector": {"providerId": "openai"},
+                "parametersPatch": {
+                    "task": {
+                        "runtime": {
+                            "profileSelector": {"providerId": "anthropic"},
+                        }
+                    },
+                    "authoredTaskInput": {
+                        "runtime": {
+                            "profileSelector": {"providerId": "anthropic"},
+                        }
+                    },
+                },
+            },
+        )
+
+        assert request.agent_id == "codex_cli"
+        assert request.execution_profile_ref is None
+        assert request.profile_selector.provider_id == "openai"
+        assert request.parameters["profileSelector"]["providerId"] == "openai"
+        assert request.parameters["task"]["runtime"]["profileSelector"] == {
+            "providerId": "openai",
+            "tagsAny": [],
+            "tagsAll": [],
+        }
+        assert request.parameters["authoredTaskInput"]["runtime"][
+            "profileSelector"
+        ] == {
+            "providerId": "openai",
+            "tagsAny": [],
+            "tagsAll": [],
+        }
+
     def test_runtime_change_validation_clears_profile_missing_from_new_snapshot(self):
         """Runtime-switch edits may clear stale profiles after syncing the new runtime."""
         workflow_instance = MoonMindAgentRun()
@@ -516,6 +683,21 @@ class TestEnsureManagerAutoStart:
             "tagsAny": [],
             "tagsAll": [],
         }
+
+    def test_runtime_selection_signal_preserves_empty_profile_clear(self, monkeypatch):
+        """The signal payload must preserve an explicit top-level profile clear."""
+        monkeypatch.setattr(
+            "moonmind.workflows.temporal.workflows.agent_run.workflow.patched",
+            lambda _patch_id: True,
+        )
+        workflow_instance = MoonMindAgentRun()
+
+        workflow_instance.update_runtime_selection({"executionProfileRef": ""})
+
+        assert workflow_instance._pending_runtime_selection_update == {
+            "executionProfileRef": ""
+        }
+        assert workflow_instance.runtime_selection_updated_event.is_set()
 
     def test_slot_wait_runtime_update_returns_refreshed_manager_and_runtime_ids(self):
         """The slot-wait caller must update local manager/runtime identifiers."""

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -331,6 +331,168 @@ class TestEnsureManagerAutoStart:
         assert "profileSelector" not in request.parameters
         assert "profileSelector" not in request.parameters["task"]["runtime"]
 
+    def test_runtime_selection_update_clears_profile_when_runtime_changes_without_new_profile(
+        self,
+    ):
+        """Runtime edits must not carry an old exact provider profile into the new runtime."""
+        workflow_instance = MoonMindAgentRun()
+        request = _agent_request()
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "claude_code",
+                "model": "claude-opus-4-7",
+                "parametersPatch": {
+                    "workflow": {
+                        "runtime": {
+                            "mode": "claude_code",
+                            "profileId": "codex-openrouter",
+                            "profileSelector": {"providerId": "openrouter"},
+                        }
+                    }
+                },
+            },
+        )
+
+        assert request.agent_id == "claude_code"
+        assert request.execution_profile_ref is None
+        assert request.profile_selector.provider_id is None
+        assert request.parameters["targetRuntime"] == "claude_code"
+        assert request.parameters["task"]["runtime"]["mode"] == "claude_code"
+        assert (
+            request.parameters["authoredTaskInput"]["runtime"]["mode"]
+            == "claude_code"
+        )
+        assert request.parameters["workflow"]["runtime"]["mode"] == "claude_code"
+        assert "profileId" not in request.parameters
+        assert "profileId" not in request.parameters["task"]["runtime"]
+        assert "profileId" not in request.parameters["authoredTaskInput"]["runtime"]
+        assert "profileId" not in request.parameters["workflow"]["runtime"]
+        assert "profileSelector" not in request.parameters
+        assert "profileSelector" not in request.parameters["task"]["runtime"]
+        assert (
+            "profileSelector"
+            not in request.parameters["authoredTaskInput"]["runtime"]
+        )
+        assert "profileSelector" not in request.parameters["workflow"]["runtime"]
+
+    def test_runtime_selection_update_clears_profile_known_to_previous_runtime(self):
+        """A stale profile echoed by the edit form must not fail the new slot request."""
+        workflow_instance = MoonMindAgentRun()
+        workflow_instance._profile_snapshots = {
+            "claude_anthropic": {
+                "profile_id": "claude_anthropic",
+                "runtime_id": "claude_code",
+            }
+        }
+        request = _agent_request(
+            agentId="claude_code",
+            executionProfileRef="claude_anthropic",
+            parameters={
+                "targetRuntime": "claude_code",
+                "profileId": "claude_anthropic",
+                "profileSelector": {"providerId": "anthropic"},
+                "task": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude_anthropic",
+                        "profileSelector": {"providerId": "anthropic"},
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude_anthropic",
+                        "profileSelector": {"providerId": "anthropic"},
+                    }
+                },
+            },
+            profileSelector={"providerId": "anthropic"},
+        )
+
+        workflow_instance._apply_runtime_selection_update(
+            request,
+            {
+                "targetRuntime": "codex_cli",
+                "executionProfileRef": "claude_anthropic",
+                "model": "gpt-5.5",
+                "parametersPatch": {
+                    "workflow": {
+                        "runtime": {
+                            "mode": "codex_cli",
+                            "profileId": "claude_anthropic",
+                            "profileSelector": {"providerId": "anthropic"},
+                        }
+                    }
+                },
+            },
+        )
+
+        assert request.agent_id == "codex_cli"
+        assert request.execution_profile_ref is None
+        assert request.profile_selector.provider_id is None
+        assert request.parameters["targetRuntime"] == "codex_cli"
+        assert request.parameters["task"]["runtime"]["mode"] == "codex_cli"
+        assert (
+            request.parameters["authoredTaskInput"]["runtime"]["mode"]
+            == "codex_cli"
+        )
+        assert request.parameters["workflow"]["runtime"]["mode"] == "codex_cli"
+        assert "profileId" not in request.parameters
+        assert "profileId" not in request.parameters["task"]["runtime"]
+        assert "profileId" not in request.parameters["authoredTaskInput"]["runtime"]
+        assert "profileId" not in request.parameters["workflow"]["runtime"]
+        assert "profileSelector" not in request.parameters
+        assert "profileSelector" not in request.parameters["task"]["runtime"]
+        assert (
+            "profileSelector"
+            not in request.parameters["authoredTaskInput"]["runtime"]
+        )
+        assert "profileSelector" not in request.parameters["workflow"]["runtime"]
+
+    def test_runtime_change_validation_clears_profile_missing_from_new_snapshot(self):
+        """Runtime-switch edits may clear stale profiles after syncing the new runtime."""
+        workflow_instance = MoonMindAgentRun()
+        workflow_instance._profile_snapshots = {
+            "codex_default": {
+                "profile_id": "codex_default",
+                "runtime_id": "codex_cli",
+            }
+        }
+        request = _agent_request(
+            agentId="codex_cli",
+            executionProfileRef="claude_anthropic",
+            parameters={
+                "targetRuntime": "codex_cli",
+                "profileId": "claude_anthropic",
+                "task": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "claude_anthropic",
+                    }
+                },
+                "authoredTaskInput": {
+                    "runtime": {
+                        "mode": "codex_cli",
+                        "profileId": "claude_anthropic",
+                    }
+                },
+            },
+        )
+
+        workflow_instance._validate_synced_profile_selection(
+            profile_count=1,
+            runtime_id="codex_cli",
+            request=request,
+            clear_invalid_profile_for_runtime_change=True,
+        )
+
+        assert request.execution_profile_ref is None
+        assert "profileId" not in request.parameters
+        assert "profileId" not in request.parameters["task"]["runtime"]
+        assert "profileId" not in request.parameters["authoredTaskInput"]["runtime"]
+
     def test_runtime_selection_update_uses_explicit_profile_selector_patch(self):
         """A supplied selector must replace stale criteria for the new slot request."""
         workflow_instance = MoonMindAgentRun()

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -458,6 +458,7 @@ async def test_update_inputs_forwards_runtime_selection_to_active_managed_child(
         "get_external_workflow_handle",
         lambda workflow_id: mock_handle,
     )
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
 
     result = await workflow_instance.update_inputs(
@@ -512,6 +513,7 @@ async def test_update_inputs_forwards_runtime_selection_from_canonical_workflow_
         "get_external_workflow_handle",
         lambda workflow_id: mock_handle,
     )
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
 
     result = await workflow_instance.update_inputs(
@@ -543,6 +545,54 @@ async def test_update_inputs_forwards_runtime_selection_from_canonical_workflow_
                         "model": "claude-opus-4-7",
                         "profileId": "claude_anthropic",
                         "effort": "high",
+                    }
+                }
+            },
+        },
+    )
+    assert result["forwardedRuntimeSelectionUpdate"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_inputs_forwards_runtime_profile_clear_to_active_managed_child(
+    monkeypatch,
+):
+    workflow_instance = MoonMindUserWorkflow()
+    workflow_instance._active_agent_child_workflow_id = "wf:child"
+    workflow_instance._active_agent_id = "claude_code"
+
+    mock_handle = type("MockHandle", (), {"signal": AsyncMock()})()
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: mock_handle,
+    )
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+
+    result = await workflow_instance.update_inputs(
+        {
+            "parametersPatch": {
+                "workflow": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "",
+                    }
+                }
+            }
+        }
+    )
+
+    mock_handle.signal.assert_awaited_once_with(
+        "update_runtime_selection",
+        {
+            "targetRuntime": "claude_code",
+            "executionProfileRef": "",
+            "parametersPatch": {
+                "workflow": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "",
                     }
                 }
             },


### PR DESCRIPTION
## Summary
- Clear stale exact provider-profile refs and selectors when an in-flight runtime selection update changes managed runtime families.
- Preserve fail-fast behavior for same-runtime invalid profile selections while allowing runtime-switch updates to fall back to the new runtime profile manager selection.
- Add workflow-boundary regression coverage for omitted stale profiles, echoed stale profiles, and post-sync invalid profile cleanup.

## Root Cause
Editing a workflow could send `targetRuntime=codex_cli` while the active child `AgentRun` still carried an exact Claude provider profile such as `claude_anthropic`. The child then correctly rejected that stale exact profile against the Codex profile snapshot, causing the first edited run to fail before a later rerun rebuilt the payload cleanly.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py` passed: Python `18 passed`; frontend `30 passed`.
- `./tools/test_unit.sh` passed: Python `6475 passed, 6 skipped, 1 xpassed`; frontend `30 passed`, `455 passed | 235 skipped`.

Existing suite warnings include jsdom canvas warnings and unawaited AsyncMock RuntimeWarnings; they did not fail the verified runs.