### PR TITLE
[codex] Retry managed session status after locator mismatch

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -279,7 +279,9 @@ def _is_session_locator_mismatch_error(exc: BaseException) -> bool:
         message = str(getattr(current, "message", "") or current).strip().lower()
         if any(marker in message for marker in _SESSION_LOCATOR_MISMATCH_MARKERS):
             return True
-        current = getattr(current, "cause", None) or current.__cause__
+        current = getattr(current, "cause", None) or getattr(current, "__cause__", None)
+        if not isinstance(current, BaseException):
+            current = None
     return False
 
 def _reset_thread_id_for_empty_turn(locator: CodexManagedSessionLocator) -> str:
@@ -1453,8 +1455,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self, binding: CodexManagedSessionBinding
     ) -> CodexManagedSessionLocator:
         snapshot = await self._load_snapshot(binding.workflow_id)
-        if not snapshot.container_id or not snapshot.thread_id:
-            raise ValueError("Workflow-scoped managed session has no runtime handles yet")
         return self._locator_from_snapshot(snapshot)
 
     @staticmethod

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -262,6 +262,26 @@ def _is_empty_assistant_turn_failure(metadata: Mapping[str, Any] | None) -> bool
         "codex app-server turn/completed produced no assistant output",
     }
 
+
+_SESSION_LOCATOR_MISMATCH_MARKERS = (
+    "sessionid does not match the active managed session",
+    "sessionepoch does not match the active managed session",
+    "containerid does not match the active managed session",
+    "threadid does not match the active managed session",
+)
+
+
+def _is_session_locator_mismatch_error(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(getattr(current, "message", "") or current).strip().lower()
+        if any(marker in message for marker in _SESSION_LOCATOR_MISMATCH_MARKERS):
+            return True
+        current = getattr(current, "cause", None) or current.__cause__
+    return False
+
 def _reset_thread_id_for_empty_turn(locator: CodexManagedSessionLocator) -> str:
     return f"{locator.thread_id}:empty-output-reset"
 
@@ -1224,16 +1244,24 @@ class CodexSessionAdapter(ManagedAgentAdapter):
     ) -> CodexManagedSessionHandle:
         snapshot = await self._load_snapshot(binding.workflow_id)
         if snapshot.container_id and snapshot.thread_id:
-            handle = await self._coerce_handle(
-                self._session_status(
-                    CodexManagedSessionLocator(
-                        sessionId=binding.session_id,
-                        sessionEpoch=snapshot.binding.session_epoch,
-                        containerId=snapshot.container_id,
-                        threadId=snapshot.thread_id,
-                    )
+            locator = self._locator_from_snapshot(snapshot)
+            try:
+                handle = await self._coerce_handle(self._session_status(locator))
+            except Exception as exc:
+                if not _is_session_locator_mismatch_error(exc):
+                    raise
+                refreshed_snapshot = await self._load_snapshot(binding.workflow_id)
+                if not refreshed_snapshot.container_id or not refreshed_snapshot.thread_id:
+                    raise
+                refreshed_locator = self._locator_from_snapshot(refreshed_snapshot)
+                logger.warning(
+                    "Retrying managed-session resume status after locator mismatch "
+                    "using refreshed workflow snapshot for session %s",
+                    refreshed_locator.session_id,
                 )
-            )
+                handle = await self._coerce_handle(
+                    self._session_status(refreshed_locator)
+                )
             await self._signal_control_action(
                 action="resume_session",
                 reason=None,
@@ -1427,8 +1455,16 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         snapshot = await self._load_snapshot(binding.workflow_id)
         if not snapshot.container_id or not snapshot.thread_id:
             raise ValueError("Workflow-scoped managed session has no runtime handles yet")
+        return self._locator_from_snapshot(snapshot)
+
+    @staticmethod
+    def _locator_from_snapshot(
+        snapshot: CodexManagedSessionSnapshot,
+    ) -> CodexManagedSessionLocator:
+        if not snapshot.container_id or not snapshot.thread_id:
+            raise ValueError("Workflow-scoped managed session has no runtime handles yet")
         return CodexManagedSessionLocator(
-            sessionId=binding.session_id,
+            sessionId=snapshot.binding.session_id,
             sessionEpoch=snapshot.binding.session_epoch,
             containerId=snapshot.container_id,
             threadId=snapshot.thread_id,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -37,6 +37,7 @@ from moonmind.workflows.codex_session_timeouts import (
 from moonmind.workflows.adapters.codex_session_adapter import (
     CodexSessionAdapter,
     CodexSessionRunFailedError,
+    _is_session_locator_mismatch_error,
     _jira_skill_blocker_summary,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
@@ -65,6 +66,14 @@ async def _prepare_turn_instructions(payload: dict[str, Any]) -> str:
             if inline:
                 return f"{inline}\n\nManaged Codex CLI note:"
     return f"{instruction_ref}\n\nManaged Codex CLI note:"
+
+
+async def test_session_locator_mismatch_error_ignores_non_exception_cause() -> None:
+    class MetadataCauseError(Exception):
+        cause = {"message": "metadata"}
+
+    assert not _is_session_locator_mismatch_error(MetadataCauseError("wrapper"))
+
 
 def _raise_activity_error_from_application_error(error: ApplicationError) -> None:
     try:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -26,6 +26,9 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionSnapshot,
     CodexManagedSessionSummary,
     CodexManagedSessionTurnResponse,
+    FetchCodexManagedSessionSummaryRequest,
+    PublishCodexManagedSessionArtifactsRequest,
+    SendCodexManagedSessionTurnRequest,
 )
 from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
@@ -3040,6 +3043,120 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
         "action": "resume_session",
         "containerId": "container-existing",
         "threadId": "thread-existing",
+    }
+
+
+async def test_start_retries_existing_session_status_after_locator_mismatch(
+    tmp_path: Path,
+) -> None:
+    binding = _binding().model_copy(update={"session_epoch": 3})
+    load_snapshot_calls: list[str] = []
+    session_status_calls: list[CodexManagedSessionLocator] = []
+    send_turn_calls: list[SendCodexManagedSessionTurnRequest] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(workflow_id: str) -> CodexManagedSessionSnapshot:
+        load_snapshot_calls.append(workflow_id)
+        return _snapshot(
+            binding=binding,
+            container_id="container-cleared",
+            thread_id="thread-cleared",
+        )
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        raise AssertionError("launch_session should not be called for a ready session")
+
+    async def _session_status(
+        request: CodexManagedSessionLocator,
+    ) -> CodexManagedSessionHandle:
+        session_status_calls.append(request)
+        if len(session_status_calls) == 1:
+            _raise_activity_error_from_application_error(
+                ApplicationError(
+                    "sessionEpoch does not match the active managed session",
+                    type="RuntimeError",
+                )
+            )
+        return _session_handle(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _send_turn(
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _fetch_summary(
+        request: FetchCodexManagedSessionSummaryRequest,
+    ) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _publish_artifacts(
+        request: PublishCodexManagedSessionArtifactsRequest,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding))
+
+    assert handle.status == "completed"
+    assert len(load_snapshot_calls) == 2
+    assert len(session_status_calls) == 2
+    assert session_status_calls[0].session_epoch == 3
+    assert session_status_calls[1].session_epoch == 3
+    assert send_turn_calls[0].session_epoch == 3
+    assert send_turn_calls[0].thread_id == "thread-cleared"
+    assert control_calls[0] == {
+        "action": "resume_session",
+        "containerId": "container-cleared",
+        "threadId": "thread-cleared",
     }
 
 async def test_clear_session_rotates_epoch_and_signals_session_workflow(


### PR DESCRIPTION
## Summary
- Retry managed-session resume status once after an explicit active-session locator mismatch by reloading the session workflow snapshot.
- Share snapshot-to-locator construction so resume probes use refreshed binding metadata.
- Add a regression test covering stale `session_status` failure after a cleared workflow-scoped Codex session.

## Root Cause
Workflow `mm:041822ee-2146-4dd0-91fe-4a96e0c70d3c` failed in child step 04 before `send_turn`: after waiting for a provider slot, the adapter resumed a cleared Codex session and `agent_runtime.session_status` returned `sessionEpoch does not match the active managed session`. Activity retry repeated the same locator payload instead of refreshing the session workflow snapshot.

## Verification
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `./tools/test_unit.sh`