### PR TITLE
[codex] Fix preset placeholder expansion

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5536,7 +5536,11 @@ async def _expand_goal_preset_for_workflow_submission(
     runtime_payload = (
         task_payload.get("runtime") if isinstance(task_payload.get("runtime"), Mapping) else {}
     )
-    target_runtime = request_payload.get("targetRuntime") or runtime_payload.get("mode")
+    target_runtime = (
+        request_payload.get("targetRuntime")
+        or runtime_payload.get("mode")
+        or normalize_runtime_id(settings.workflow.default_runtime)
+    )
     if isinstance(target_runtime, str) and target_runtime.strip():
         context["targetRuntime"] = target_runtime.strip()
 

--- a/api_service/data/presets/document-update-orchestrate.yaml
+++ b/api_service/data/presets/document-update-orchestrate.yaml
@@ -39,7 +39,7 @@ steps:
       args:
         directory: "{{ inputs.document_directory }}"
         repository: "{{ context.repository }}"
-        ref: "{{ context.branch }}"
+        ref: "{{ context.branch | default('') }}"
   - title: Create document update tasks
     type: tool
     instructions: |-

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -17,6 +17,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import yaml
+from jinja2 import StrictUndefined, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -612,7 +613,12 @@ def _render_value(
     variables: dict[str, Any],
 ) -> Any:
     if isinstance(value, str):
-        rendered = env.from_string(value).render(**variables)
+        try:
+            rendered = env.from_string(value).render(**variables)
+        except UndefinedError as exc:
+            raise PresetValidationError(
+                f"Template references an unknown variable: {exc}."
+            ) from exc
         stripped = rendered.strip()
         if _NATIVE_BOOLEAN_TEMPLATE_PATTERN.match(value.strip()):
             lowered = stripped.lower()
@@ -1012,7 +1018,10 @@ class PresetCatalogService:
 
     def __init__(self, session: AsyncSession):
         self._session = session
-        self._template_env = SandboxedEnvironment(autoescape=False)
+        self._template_env = SandboxedEnvironment(
+            autoescape=False,
+            undefined=StrictUndefined,
+        )
 
     async def _get_template_for_scope(
         self,
@@ -1766,11 +1775,6 @@ class PresetCatalogService:
                 raise PresetValidationError(
                     f"Expanded step instructions may not be empty at "
                     f"{_format_include_path(path)}."
-                )
-            if _UNRESOLVED_PLACEHOLDER_PATTERN.search(instructions):
-                raise PresetValidationError(
-                    f"Expanded instructions still contain unresolved template "
-                    f"placeholders at {_format_include_path(path)}."
                 )
             step_type = _normalize_step_type(rendered, index=source_index)
             next_index = len(resolved_steps) + 1

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -17,7 +17,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import yaml
-from jinja2 import StrictUndefined, UndefinedError
+from jinja2 import StrictUndefined, TemplateError, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -618,6 +618,10 @@ def _render_value(
         except UndefinedError as exc:
             raise PresetValidationError(
                 f"Template references an unknown variable: {exc}."
+            ) from exc
+        except TemplateError as exc:
+            raise PresetValidationError(
+                f"Template rendering failed: {exc}."
             ) from exc
         stripped = rendered.strip()
         if _NATIVE_BOOLEAN_TEMPLATE_PATTERN.match(value.strip()):

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -6,10 +6,14 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from moonmind.config.settings import settings
 from moonmind.workflows.executions.preset_goal_scheduler import (
     goal_from_payloads,
     schedule_preset_from_goal,
     workflow_is_already_authored,
+)
+from moonmind.workflows.executions.runtime_defaults import (
+    resolve_default_workflow_runtime,
 )
 
 
@@ -133,7 +137,11 @@ async def expand_preset_for_child_run(
         template_context["repository"] = repository.strip()
         template_context["repo"] = repository.strip()
     runtime_payload = _coerce_mapping(task_payload.get("runtime"))
-    target_runtime = parameters.get("targetRuntime") or runtime_payload.get("mode")
+    target_runtime = (
+        parameters.get("targetRuntime")
+        or runtime_payload.get("mode")
+        or resolve_default_workflow_runtime(settings.workflow)
+    )
     if isinstance(target_runtime, str) and target_runtime.strip():
         template_context["targetRuntime"] = target_runtime.strip()
     catalog = PresetCatalogService(session)

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -132,7 +132,8 @@ async def expand_preset_for_child_run(
     if isinstance(repository, str) and repository.strip():
         template_context["repository"] = repository.strip()
         template_context["repo"] = repository.strip()
-    target_runtime = parameters.get("targetRuntime")
+    runtime_payload = _coerce_mapping(task_payload.get("runtime"))
+    target_runtime = parameters.get("targetRuntime") or runtime_payload.get("mode")
     if isinstance(target_runtime, str) and target_runtime.strip():
         template_context["targetRuntime"] = target_runtime.strip()
     catalog = PresetCatalogService(session)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -644,6 +644,39 @@ async def test_goal_preset_submission_expands_before_planner(tmp_path) -> None:
     assert task_payload["appliedStepTemplates"][0]["slug"] == "jira-implement"
 
 
+@pytest.mark.asyncio
+async def test_goal_preset_submission_uses_default_runtime_for_composite_context(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "default_runtime", "gemini_cli")
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/goal_preset_default_runtime.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            task_payload = {
+                "title": "Break down feature",
+                "goal": "Split docs/Design.md into Jira stories.",
+            }
+            await _expand_goal_preset_for_workflow_submission(
+                task_payload=task_payload,
+                request_payload={"repository": "MoonLadderStudios/MoonMind"},
+                session=session,
+                user_id=uuid4(),
+            )
+    finally:
+        await engine.dispose()
+
+    downstream_task = task_payload["steps"][3]["jiraOrchestration"]["task"]
+    assert task_payload["presetSchedule"]["presetSlug"] == "jira-breakdown-orchestrate"
+    assert downstream_task["repository"] == "MoonLadderStudios/MoonMind"
+    assert downstream_task["runtime"] == {"mode": "gemini_cli"}
+
+
 class _QueryHandle:
     def __init__(
         self,

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -210,6 +210,88 @@ async def test_template_serializes_normalized_capability_input_contract(tmp_path
     assert created["uiSchema"]["jira_issue"]["widget"] == "jira.issue-picker"
     assert created["defaults"] == {}
 
+async def test_expand_template_preserves_literal_placeholders_from_user_input(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="literal-placeholder-input",
+                title="Literal Placeholder Input",
+                description="Allows user-provided handlebars content.",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[
+                    {
+                        "name": "feature_request",
+                        "label": "Feature Request",
+                        "type": "markdown",
+                        "required": True,
+                    }
+                ],
+                steps=[
+                    {
+                        "title": "Use request",
+                        "instructions": (
+                            "Implement this request:\n\n{{ inputs.feature_request }}"
+                        ),
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+            expanded = await service.expand_template(
+                slug="literal-placeholder-input",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": (
+                        "Preserve the literal {{ downstream.value }} token."
+                    )
+                },
+                context={},
+            )
+
+    assert "{{ downstream.value }}" in expanded["steps"][0]["instructions"]
+
+async def test_expand_template_rejects_unknown_template_variable(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="unknown-template-variable",
+                title="Unknown Template Variable",
+                description="Rejects template authoring mistakes.",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "title": "Bad template",
+                        "instructions": "Use {{ inputs.missing_value }}.",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+            with pytest.raises(PresetValidationError, match="unknown variable"):
+                await service.expand_template(
+                    slug="unknown-template-variable",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                )
+
 async def test_template_rejects_secret_like_schema_defaults(tmp_path):
     user_id = uuid4()
     async with template_db(tmp_path) as session_maker:
@@ -2541,6 +2623,54 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(tmp_path):
                 "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
+
+async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "presets"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            expanded = await service.expand_template(
+                slug="jira-breakdown-implement",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Story",
+                    "jira_board_id": "84",
+                    "jira_dependency_mode": "linear_blocker_chain",
+                    "publish_mode": "pr_with_merge_automation",
+                    "source_issue_key": "MM-404",
+                },
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+            )
+
+    assert len(expanded["steps"]) == 4
+    assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
+    assert expanded["steps"][1]["skill"]["id"] == "story-reconcile-implementation"
+    assert expanded["steps"][2]["skill"]["id"] == "story.create_jira_issues"
+    downstream = expanded["steps"][3]
+    assert downstream["skill"]["id"] == "story.create_jira_implement_tasks"
+    assert downstream["jiraOrchestration"]["task"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "runtime": {"mode": "codex_cli"},
+        "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+    }
+    assert downstream["jiraOrchestration"]["traceability"] == {
+        "sourceIssueKey": "MM-404"
+    }
 
 async def test_seed_catalog_includes_document_update_orchestrate_preset(tmp_path):
     seed_dir = (

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -292,6 +292,40 @@ async def test_expand_template_rejects_unknown_template_variable(tmp_path):
                     context={},
                 )
 
+async def test_expand_template_reports_malformed_template_as_validation_error(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="malformed-template",
+                title="Malformed Template",
+                description="Rejects malformed Jinja templates.",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "title": "Bad syntax",
+                        "instructions": "Use {{ inputs.missing_value.",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+            with pytest.raises(PresetValidationError, match="Template rendering failed"):
+                await service.expand_template(
+                    slug="malformed-template",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                )
+
 async def test_template_rejects_secret_like_schema_defaults(tmp_path):
     user_id = uuid4()
     async with template_db(tmp_path) as session_maker:

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -422,6 +422,49 @@ async def test_child_run_goal_scheduled_breakdown_preserves_target_runtime(tmp_p
     assert downstream_task["runtime"] == {"mode": "jules"}
 
 
+@pytest.mark.asyncio
+async def test_child_jira_breakdown_implement_expands_workflow_runtime_context(
+    tmp_path,
+):
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "workflow",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "publishMode": "none",
+                    "workflow": {
+                        "title": "Break down and implement docs/Design.md",
+                        "instructions": "Create Jira stories and implement tasks.",
+                        "runtime": {"mode": "codex_cli"},
+                        "inputs": {
+                            "feature_request": "docs/Designs/RuntimeTypes.md",
+                            "jira_project_key": "MM",
+                            "jira_issue_type": "Story",
+                            "jira_board_id": "",
+                            "jira_dependency_mode": "linear_blocker_chain",
+                            "publish_mode": "pr_with_merge_automation",
+                            "source_issue_key": "MM-404",
+                        },
+                        "taskTemplate": {
+                            "slug": "jira-breakdown-implement",
+                            "version": "1.0.0",
+                        },
+                    },
+                },
+            )
+
+    task = expanded_parameters["workflow"]
+    downstream_task = task["steps"][3]["jiraOrchestration"]["task"]
+    assert downstream_task["repository"] == "MoonLadderStudios/MoonMind"
+    assert downstream_task["runtime"] == {"mode": "codex_cli"}
+    assert downstream_task["publish"] == {
+        "mode": "pr",
+        "mergeAutomation": {"enabled": True},
+    }
+
+
 def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -423,6 +423,36 @@ async def test_child_run_goal_scheduled_breakdown_preserves_target_runtime(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_child_run_goal_scheduled_breakdown_uses_default_runtime_context(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        worker_runtime.settings.workflow, "default_runtime", "gemini_cli"
+    )
+    async with _template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            expanded_parameters = await _expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "requestType": "task",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "publishMode": "pr",
+                    "task": {
+                        "title": "Break down feature",
+                        "goal": "Split docs/Design.md into Jira stories.",
+                    },
+                },
+            )
+
+    downstream_task = expanded_parameters["task"]["steps"][3]["jiraOrchestration"][
+        "task"
+    ]
+    assert downstream_task["repository"] == "MoonLadderStudios/MoonMind"
+    assert downstream_task["runtime"] == {"mode": "gemini_cli"}
+
+
+@pytest.mark.asyncio
 async def test_child_jira_breakdown_implement_expands_workflow_runtime_context(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

Fix preset expansion so literal `{{ ... }}` text supplied by a user in preset inputs is preserved instead of being rejected as an unresolved template placeholder.

The catalog renderer now uses Jinja `StrictUndefined` to catch real missing template variables during rendering, rather than scanning the final rendered instructions. Submit-time preset expansion also carries `workflow.runtime.mode` into preset context so composite Jira breakdown presets can populate downstream task runtime metadata.

## Root Cause

The previous unresolved-placeholder check inspected the final rendered instruction text. When a user-provided Jira breakdown/design input contained literal handlebars, the expanded instructions still contained `{{ ... }}` and the preset was rejected even though the template itself had rendered correctly.

## Validation

- `pytest tests/unit/api/test_presets_service.py -q --tb=short` passed: 61 passed
- `pytest tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q --tb=short` passed: 96 passed
- `./tools/test_unit.sh` attempted; interrupted after 24 minutes at 6445 passed, 6 skipped, 1 xpassed before reaching frontend tests
