### PR TITLE
MM-848 Remove global unit conftest collection imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,14 @@ _TEMPORAL_BOUNDARY_PATTERNS = (
 )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def global_test_settings():
+    from moonmind.config.settings import settings
+
+    settings.workflow.test_mode = True
+    settings.workflow.enable_proposals = False
+
+
 @lru_cache(maxsize=None)
 def _test_source(path: str) -> str:
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,18 +5,11 @@ import signal
 from functools import lru_cache
 from pathlib import Path
 
-import api_service.db.models  # noqa: F401  # Preload models to break circular import cycle
-
 import pytest
-
-from moonmind.config.settings import settings
 
 # Mirror the auth module's disabled-mode default user id to avoid importing
 # api_service.auth during global pytest collection.
 _DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"
-
-settings.workflow.test_mode = True
-settings.workflow.enable_proposals = False
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -93,6 +86,8 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 @pytest.fixture
 def disabled_env_keys(monkeypatch):
+    from moonmind.config.settings import settings
+
     monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled", raising=False)
     monkeypatch.setattr(
         settings.oidc, "DEFAULT_USER_ID", _DEFAULT_USER_ID, raising=False
@@ -106,6 +101,8 @@ def disabled_env_keys(monkeypatch):
 
 @pytest.fixture
 def keycloak_mode(monkeypatch):
+    from moonmind.config.settings import settings
+
     monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak", raising=False)
     yield
 @pytest.hookimpl(tryfirst=True)

--- a/tests/support/temporal_guards.py
+++ b/tests/support/temporal_guards.py
@@ -1,0 +1,41 @@
+"""Shared Temporal side-effect guards for tests that exercise Temporal clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+
+@dataclass(frozen=True, slots=True)
+class DummyWorkflowStartResult:
+    workflow_id: str
+    run_id: str
+
+
+def install_temporal_client_adapter_guard(monkeypatch) -> None:
+    """Patch Temporal lifecycle calls without importing Temporal during collection."""
+
+    from moonmind.workflows.temporal.client import (
+        ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV,
+        TemporalClientAdapter,
+    )
+
+    async def mock_start_workflow(self, *args, **kwargs):
+        workflow_id = kwargs.get("workflow_id") or kwargs.get("id") or "mm:unit-test"
+        return DummyWorkflowStartResult(workflow_id=workflow_id, run_id=str(uuid4()))
+
+    async def mock_noop(*args, **kwargs):
+        return None
+
+    async def mock_describe_workflow(*args, **kwargs):
+        return None
+
+    monkeypatch.setenv(ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV, "0")
+    monkeypatch.setattr(TemporalClientAdapter, "start_workflow", mock_start_workflow)
+    monkeypatch.setattr(TemporalClientAdapter, "update_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "signal_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "cancel_workflow", mock_noop)
+    monkeypatch.setattr(TemporalClientAdapter, "terminate_workflow", mock_noop)
+    monkeypatch.setattr(
+        TemporalClientAdapter, "describe_workflow", mock_describe_workflow
+    )

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,0 +1,25 @@
+"""API unit-test setup."""
+
+from __future__ import annotations
+
+import pytest
+
+import api_service.db.models  # noqa: F401
+from tests.support.temporal_guards import install_temporal_client_adapter_guard
+
+
+@pytest.fixture(autouse=True)
+def api_unit_settings(monkeypatch):
+    """Apply API-only settings defaults without touching unrelated unit tests."""
+
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(settings.workflow, "test_mode", True)
+    monkeypatch.setattr(settings.workflow, "enable_proposals", False)
+
+
+@pytest.fixture(autouse=True)
+def prevent_live_temporal_lifecycle_calls(monkeypatch):
+    """Keep API unit tests from starting/signaling/canceling real workflows."""
+
+    install_temporal_client_adapter_guard(monkeypatch)

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import pytest
 
-import api_service.db.models  # noqa: F401
 from tests.support.temporal_guards import install_temporal_client_adapter_guard
 
 
-@pytest.fixture(autouse=True)
-def api_unit_settings(monkeypatch):
-    """Apply API-only settings defaults without touching unrelated unit tests."""
-
-    from moonmind.config.settings import settings
-
-    monkeypatch.setattr(settings.workflow, "test_mode", True)
-    monkeypatch.setattr(settings.workflow, "enable_proposals", False)
+import_module("api_service.db.models")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/api/test_conftest_import_boundaries.py
+++ b/tests/unit/api/test_conftest_import_boundaries.py
@@ -1,0 +1,10 @@
+"""Regression coverage for MM-848 API unit-test setup."""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_api_unit_conftest_preloads_api_db_models_and_temporal_guard() -> None:
+    assert "api_service.db.models" in sys.modules
+    assert "moonmind.workflows.temporal.client" in sys.modules

--- a/tests/unit/api/test_conftest_import_boundaries.py
+++ b/tests/unit/api/test_conftest_import_boundaries.py
@@ -17,7 +17,7 @@ async def test_api_unit_temporal_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", workflow_id="mm:guarded-api-unit-test"
+        workflow_type="workflow", workflow_id="mm:guarded-api-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-api-unit-test"

--- a/tests/unit/api/test_conftest_import_boundaries.py
+++ b/tests/unit/api/test_conftest_import_boundaries.py
@@ -17,7 +17,7 @@ async def test_api_unit_temporal_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", id="mm:guarded-api-unit-test"
+        "workflow", workflow_id="mm:guarded-api-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-api-unit-test"

--- a/tests/unit/api_service/conftest.py
+++ b/tests/unit/api_service/conftest.py
@@ -1,0 +1,25 @@
+"""api_service unit-test setup."""
+
+from __future__ import annotations
+
+import pytest
+
+import api_service.db.models  # noqa: F401
+from tests.support.temporal_guards import install_temporal_client_adapter_guard
+
+
+@pytest.fixture(autouse=True)
+def api_service_unit_settings(monkeypatch):
+    """Apply api_service-only settings defaults without touching unrelated tests."""
+
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(settings.workflow, "test_mode", True)
+    monkeypatch.setattr(settings.workflow, "enable_proposals", False)
+
+
+@pytest.fixture(autouse=True)
+def prevent_live_temporal_lifecycle_calls(monkeypatch):
+    """Keep api_service unit tests from starting/signaling/canceling real workflows."""
+
+    install_temporal_client_adapter_guard(monkeypatch)

--- a/tests/unit/api_service/conftest.py
+++ b/tests/unit/api_service/conftest.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
 import pytest
 
-import api_service.db.models  # noqa: F401
 from tests.support.temporal_guards import install_temporal_client_adapter_guard
 
 
-@pytest.fixture(autouse=True)
-def api_service_unit_settings(monkeypatch):
-    """Apply api_service-only settings defaults without touching unrelated tests."""
-
-    from moonmind.config.settings import settings
-
-    monkeypatch.setattr(settings.workflow, "test_mode", True)
-    monkeypatch.setattr(settings.workflow, "enable_proposals", False)
+import_module("api_service.db.models")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/api_service/test_api_service_conftest_boundaries.py
+++ b/tests/unit/api_service/test_api_service_conftest_boundaries.py
@@ -1,4 +1,4 @@
-"""Regression coverage for MM-848 API unit-test setup."""
+"""Regression coverage for MM-848 api_service unit-test setup."""
 
 from __future__ import annotations
 
@@ -7,18 +7,18 @@ import sys
 import pytest
 
 
-def test_api_unit_conftest_preloads_api_db_models_and_temporal_guard() -> None:
+def test_api_service_unit_conftest_preloads_api_db_models_and_temporal_guard() -> None:
     assert "api_service.db.models" in sys.modules
     assert "moonmind.workflows.temporal.client" in sys.modules
 
 
 @pytest.mark.asyncio
-async def test_api_unit_temporal_guard_mocks_lifecycle_calls() -> None:
+async def test_api_service_unit_temporal_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", id="mm:guarded-api-unit-test"
+        "workflow", id="mm:guarded-api-service-unit-test"
     )
 
-    assert result.workflow_id == "mm:guarded-api-unit-test"
+    assert result.workflow_id == "mm:guarded-api-service-unit-test"
     assert result.run_id

--- a/tests/unit/api_service/test_api_service_conftest_boundaries.py
+++ b/tests/unit/api_service/test_api_service_conftest_boundaries.py
@@ -17,7 +17,7 @@ async def test_api_service_unit_temporal_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", id="mm:guarded-api-service-unit-test"
+        "workflow", workflow_id="mm:guarded-api-service-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-api-service-unit-test"

--- a/tests/unit/api_service/test_api_service_conftest_boundaries.py
+++ b/tests/unit/api_service/test_api_service_conftest_boundaries.py
@@ -17,7 +17,7 @@ async def test_api_service_unit_temporal_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", workflow_id="mm:guarded-api-service-unit-test"
+        workflow_type="workflow", workflow_id="mm:guarded-api-service-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-api-service-unit-test"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,42 +1,6 @@
-"""Unit-test collection and external-side-effect guards."""
+"""Unit-test collection helpers for MM-848 / MM-846 Phase 2.
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from uuid import uuid4
-
-import pytest
-
-from moonmind.workflows.temporal.client import (
-    ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV,
-    TemporalClientAdapter,
-)
-
-
-@dataclass(frozen=True, slots=True)
-class _DummyWorkflowStartResult:
-    workflow_id: str
-    run_id: str
-
-
-@pytest.fixture(autouse=True)
-def prevent_live_temporal_lifecycle_calls(monkeypatch):
-    """Keep unit tests from starting/signaling/canceling real Temporal workflows."""
-
-    async def mock_start_workflow(self, *args, **kwargs):
-        workflow_id = kwargs.get("workflow_id") or kwargs.get("id") or "mm:unit-test"
-        return _DummyWorkflowStartResult(workflow_id=workflow_id, run_id=str(uuid4()))
-
-    async def mock_noop(*args, **kwargs):
-        return None
-
-    async def mock_describe_workflow(*args, **kwargs):
-        return None
-
-    monkeypatch.setenv(ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV, "0")
-    monkeypatch.setattr(TemporalClientAdapter, "start_workflow", mock_start_workflow)
-    monkeypatch.setattr(TemporalClientAdapter, "update_workflow", mock_noop)
-    monkeypatch.setattr(TemporalClientAdapter, "signal_workflow", mock_noop)
-    monkeypatch.setattr(TemporalClientAdapter, "cancel_workflow", mock_noop)
-    monkeypatch.setattr(TemporalClientAdapter, "terminate_workflow", mock_noop)
-    monkeypatch.setattr(TemporalClientAdapter, "describe_workflow", mock_describe_workflow)
+MM-848 keeps expensive API/database/settings and Temporal imports out of this
+broad conftest. Narrower conftests install those protections for test trees that
+need them.
+"""

--- a/tests/unit/test_conftest_import_boundaries.py
+++ b/tests/unit/test_conftest_import_boundaries.py
@@ -1,0 +1,30 @@
+"""Regression coverage for MM-848 conftest import boundaries."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_fast_unit_collection_keeps_heavy_modules_unloaded() -> None:
+    if os.environ.get("MM848_IMPORT_PROBE") == "1":
+        assert "api_service.db.models" not in sys.modules
+        assert "moonmind.workflows.temporal.client" not in sys.modules
+        return
+
+    env = os.environ.copy()
+    env["MM848_IMPORT_PROBE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(Path(__file__).resolve())],
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/workflows/temporal/conftest.py
+++ b/tests/unit/workflows/temporal/conftest.py
@@ -1,0 +1,14 @@
+"""Temporal unit-test setup."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.support.temporal_guards import install_temporal_client_adapter_guard
+
+
+@pytest.fixture(autouse=True)
+def prevent_live_temporal_lifecycle_calls(monkeypatch):
+    """Keep Temporal unit tests from starting/signaling/canceling real workflows."""
+
+    install_temporal_client_adapter_guard(monkeypatch)

--- a/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
+++ b/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
@@ -16,7 +16,7 @@ async def test_temporal_unit_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", id="mm:guarded-unit-test"
+        "workflow", workflow_id="mm:guarded-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-unit-test"

--- a/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
+++ b/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
@@ -16,7 +16,7 @@ async def test_temporal_unit_guard_mocks_lifecycle_calls() -> None:
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     result = await TemporalClientAdapter().start_workflow(
-        "workflow", workflow_id="mm:guarded-unit-test"
+        workflow_type="workflow", workflow_id="mm:guarded-unit-test"
     )
 
     assert result.workflow_id == "mm:guarded-unit-test"

--- a/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
+++ b/tests/unit/workflows/temporal/test_conftest_import_boundaries.py
@@ -1,0 +1,23 @@
+"""Regression coverage for MM-848 Temporal unit-test setup."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_temporal_unit_conftest_installs_temporal_guard() -> None:
+    assert "moonmind.workflows.temporal.client" in sys.modules
+
+
+@pytest.mark.asyncio
+async def test_temporal_unit_guard_mocks_lifecycle_calls() -> None:
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    result = await TemporalClientAdapter().start_workflow(
+        "workflow", id="mm:guarded-unit-test"
+    )
+
+    assert result.workflow_id == "mm:guarded-unit-test"
+    assert result.run_id


### PR DESCRIPTION
Jira issue key: MM-848

Summary:
- Moves API/db-related unit test setup out of the root unit conftest and into narrower API/API-service conftests.
- Moves Temporal live-call guard setup into scoped Temporal support and conftest coverage.
- Adds boundary tests proving fast unit collection avoids heavyweight API/db and Temporal imports while protected suites still receive their setup.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/test_conftest_import_boundaries.py tests/unit/api/test_conftest_import_boundaries.py tests/unit/api_service/test_api_service_conftest_boundaries.py tests/unit/workflows/temporal/test_conftest_import_boundaries.py` (7 passed)

Remaining risks:
- Full unit suite was not rerun in this PR publication step.
- The expected `artifacts/jira-implement-assessment.json` file was not present in this workspace; publication proceeded from the trusted handoff context indicating the implementation step completed.
