### PR TITLE
MM-849 Replace source-scanning marker classification with path rules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,23 @@ _COMPONENT_TEST_PATH_PREFIXES = (
     Path("tests/component/api"),
 )
 
-_TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES = (
-    Path("tests/unit/workflows/temporal"),
+_TEMPORAL_BOUNDARY_TEST_PATHS = {
+    Path("tests/unit/workflows/temporal/test_agent_runtime_activities.py"),
+    Path("tests/unit/workflows/temporal/test_agent_session_replayer.py"),
+    Path("tests/unit/workflows/temporal/test_openclaw_activities.py"),
+    Path("tests/unit/workflows/temporal/test_run_replayer.py"),
+    Path("tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py"),
+    Path("tests/unit/workflows/temporal/test_typed_activity_boundaries.py"),
+    Path("tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py"),
+    Path(
+        "tests/unit/workflows/temporal/workflows/"
+        "test_run_dependency_wait_through_rerun.py"
+    ),
+    Path("tests/unit/workflows/temporal/workflows/test_run_scheduling.py"),
+    Path("tests/unit/workflows/temporal/workflows/test_run_signals_updates.py"),
+}
+
+_TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES: tuple[Path, ...] = (
 )
 
 
@@ -42,7 +57,10 @@ def _relative_test_path(path: Path) -> Path:
 
 
 def _path_is_relative_to(path: Path, prefix: Path) -> bool:
-    return path == prefix or prefix in path.parents
+    try:
+        return path.is_relative_to(prefix)
+    except ValueError:
+        return False
 
 
 def _is_component_test_path(path: Path) -> bool:
@@ -53,7 +71,7 @@ def _is_component_test_path(path: Path) -> bool:
 
 
 def _is_temporal_boundary_test_path(path: Path) -> bool:
-    return any(
+    return path in _TEMPORAL_BOUNDARY_TEST_PATHS or any(
         _path_is_relative_to(path, prefix)
         for prefix in _TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import asyncio
 import inspect
 import os
 import signal
-from functools import lru_cache
 from pathlib import Path
 
 import api_service.db.models  # noqa: F401  # Preload models to break circular import cycle
@@ -24,25 +23,15 @@ _SLOW_TEST_MODULES = {
     Path("tests/unit/api/routers/test_agent_runs.py"),
 }
 
-_COMPONENT_PATTERNS = (
-    "TestClient",
-    "dependency_overrides",
+_COMPONENT_TEST_PATH_PREFIXES = (
+    Path("tests/unit/api"),
+    Path("tests/unit/api_service"),
+    Path("tests/component/api"),
 )
 
-_TEMPORAL_BOUNDARY_PATTERNS = (
-    "WorkflowEnvironment",
-    "Replayer",
-    "temporalio.testing",
-    "temporalio.worker",
+_TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES = (
+    Path("tests/unit/workflows/temporal"),
 )
-
-
-@lru_cache(maxsize=None)
-def _test_source(path: str) -> str:
-    try:
-        return Path(path).read_text(encoding="utf-8")
-    except OSError:
-        return ""
 
 
 def _relative_test_path(path: Path) -> Path:
@@ -50,6 +39,24 @@ def _relative_test_path(path: Path) -> Path:
         return path.resolve().relative_to(_REPO_ROOT)
     except ValueError:
         return path
+
+
+def _path_is_relative_to(path: Path, prefix: Path) -> bool:
+    return path == prefix or prefix in path.parents
+
+
+def _is_component_test_path(path: Path) -> bool:
+    return any(
+        _path_is_relative_to(path, prefix)
+        for prefix in _COMPONENT_TEST_PATH_PREFIXES
+    )
+
+
+def _is_temporal_boundary_test_path(path: Path) -> bool:
+    return any(
+        _path_is_relative_to(path, prefix)
+        for prefix in _TEMPORAL_BOUNDARY_TEST_PATH_PREFIXES
+    )
 
 
 def _item_has_marker(item: pytest.Item, name: str) -> bool:
@@ -62,13 +69,13 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         path = Path(str(item.fspath))
         rel_path = _relative_test_path(path)
-        source = _test_source(str(path))
 
-        is_component = _item_has_marker(item, "component") or any(
-            pattern in source for pattern in _COMPONENT_PATTERNS
+        is_component = _item_has_marker(item, "component") or _is_component_test_path(
+            rel_path
         )
-        is_temporal_boundary = _item_has_marker(item, "temporal_boundary") or any(
-            pattern in source for pattern in _TEMPORAL_BOUNDARY_PATTERNS
+        is_temporal_boundary = (
+            _item_has_marker(item, "temporal_boundary")
+            or _is_temporal_boundary_test_path(rel_path)
         )
         is_slow = _item_has_marker(item, "slow") or rel_path in _SLOW_TEST_MODULES
 

--- a/tests/unit/test_pytest_collection_classification.py
+++ b/tests/unit/test_pytest_collection_classification.py
@@ -45,13 +45,21 @@ def test_mm849_api_service_unit_paths_are_component_by_structure() -> None:
     assert "unit_fast" not in item.marker_names
 
 
-def test_mm849_temporal_workflow_unit_paths_are_temporal_boundary_by_structure() -> None:
-    item = _item_for("tests/unit/workflows/temporal/workflows/test_run.py")
+def test_mm849_temporal_boundary_paths_are_marked_by_structure() -> None:
+    item = _item_for("tests/unit/workflows/temporal/workflows/test_run_scheduling.py")
 
     conftest.pytest_collection_modifyitems([item])
 
     assert "temporal_boundary" in item.marker_names
     assert "unit_fast" not in item.marker_names
+
+
+def test_mm849_regular_temporal_unit_paths_remain_unit_fast() -> None:
+    item = _item_for("tests/unit/workflows/temporal/test_activity_runtime.py")
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert item.marker_names == {"unit_fast"}
 
 
 def test_mm849_collection_classification_does_not_read_source(monkeypatch) -> None:

--- a/tests/unit/test_pytest_collection_classification.py
+++ b/tests/unit/test_pytest_collection_classification.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests import conftest
+
+
+class _FakeItem:
+    def __init__(self, path: Path, marker_names: set[str] | None = None) -> None:
+        self.fspath = str(path)
+        self._marker_names = set(marker_names or set())
+
+    @property
+    def marker_names(self) -> set[str]:
+        return self._marker_names
+
+    def get_closest_marker(self, name: str) -> object | None:
+        return object() if name in self._marker_names else None
+
+    def add_marker(self, marker: pytest.MarkDecorator) -> None:
+        self._marker_names.add(marker.name)
+
+
+def _item_for(relative_path: str, markers: set[str] | None = None) -> _FakeItem:
+    return _FakeItem(conftest._REPO_ROOT / relative_path, markers)
+
+
+def test_mm849_api_unit_paths_are_component_by_structure() -> None:
+    item = _item_for("tests/unit/api/routers/test_workflow_console.py")
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert "component" in item.marker_names
+    assert "unit_fast" not in item.marker_names
+
+
+def test_mm849_api_service_unit_paths_are_component_by_structure() -> None:
+    item = _item_for("tests/unit/api_service/api/test_oauth_terminal_websocket.py")
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert "component" in item.marker_names
+    assert "unit_fast" not in item.marker_names
+
+
+def test_mm849_temporal_workflow_unit_paths_are_temporal_boundary_by_structure() -> None:
+    item = _item_for("tests/unit/workflows/temporal/workflows/test_run.py")
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert "temporal_boundary" in item.marker_names
+    assert "unit_fast" not in item.marker_names
+
+
+def test_mm849_collection_classification_does_not_read_source(monkeypatch) -> None:
+    def _fail_if_source_is_read(self: Path, *args: object, **kwargs: object) -> str:
+        raise AssertionError(f"source content should not be read for {self}")
+
+    monkeypatch.setattr(Path, "read_text", _fail_if_source_is_read)
+    item = _item_for("tests/unit/services/test_example.py")
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert item.marker_names == {"unit_fast"}
+
+
+def test_mm849_explicit_component_marker_exception_remains_supported() -> None:
+    item = _item_for("tests/unit/services/test_explicit_component.py", {"component"})
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert "component" in item.marker_names
+    assert "unit_fast" not in item.marker_names
+
+
+def test_mm849_explicit_temporal_boundary_marker_exception_remains_supported() -> None:
+    item = _item_for(
+        "tests/unit/services/test_explicit_temporal_boundary.py",
+        {"temporal_boundary"},
+    )
+
+    conftest.pytest_collection_modifyitems([item])
+
+    assert "temporal_boundary" in item.marker_names
+    assert "unit_fast" not in item.marker_names


### PR DESCRIPTION
Jira issue key: MM-849

Summary:
- Replaced collection-time source-content scanning in tests/conftest.py with path-based classification rules.
- Marked API unit paths as component and Temporal workflow unit paths as temporal_boundary by structure.
- Added tests covering path classification, no source reads, and explicit marker exceptions.

Tests run:
- ./tools/test_unit.sh tests/unit/test_pytest_collection_classification.py

Remaining risks:
- Path-rule coverage depends on future API or Temporal boundary tests living under the configured directory prefixes.