### PR TITLE
MM-850 Narrow OpenAPI-affecting path detection

### DIFF
--- a/tests/unit/tools/test_check_openapi_affecting_changes.py
+++ b/tests/unit/tools/test_check_openapi_affecting_changes.py
@@ -25,6 +25,7 @@ def _run_script(*paths: str, stdin: str | None = None) -> subprocess.CompletedPr
     [
         "api_service/api/routers/agent_runs.py",
         "api_service/services/temporal_execution_service.py",
+        "moonmind/core/artifacts.py",
         "moonmind/schemas/agent_runtime_models.py",
         "moonmind/schemas/agent_skill_models.py",
         "moonmind/schemas/chat_models.py",
@@ -68,8 +69,10 @@ def test_managed_session_models_is_openapi_affecting_exported_api_schema() -> No
     init_file = REPO_ROOT / "moonmind" / "schemas" / "__init__.py"
     router_file = REPO_ROOT / "api_service" / "api" / "routers" / "agent_runs.py"
 
-    assert "from .managed_session_models import (" in init_file.read_text()
-    assert "from moonmind.schemas.managed_session_models import" in router_file.read_text()
+    assert "from .managed_session_models import (" in init_file.read_text(encoding="utf-8")
+    assert "from moonmind.schemas.managed_session_models import" in router_file.read_text(
+        encoding="utf-8"
+    )
 
     result = _run_script("moonmind/schemas/managed_session_models.py")
 
@@ -81,7 +84,6 @@ def test_managed_session_models_is_openapi_affecting_exported_api_schema() -> No
     [
         "moonmind/workflows/temporal/runtime/codex_session_runtime.py",
         "moonmind/workflows/temporal/activity_runtime.py",
-        "moonmind/core/artifacts.py",
         "moonmind/manifest/interpolation.py",
         "moonmind/schemas/_validation.py",
         "moonmind/schemas/jules_models.py",

--- a/tests/unit/tools/test_check_openapi_affecting_changes.py
+++ b/tests/unit/tools/test_check_openapi_affecting_changes.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = REPO_ROOT / "tools" / "check_openapi_affecting_changes.sh"
+
 
 def _run_script(*paths: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -16,22 +19,61 @@ def _run_script(*paths: str, stdin: str | None = None) -> subprocess.CompletedPr
         check=False,
     )
 
-def test_matches_backend_api_descendants_from_args() -> None:
-    result = _run_script("api_service/api/routers/agent_runs.py")
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "api_service/api/routers/agent_runs.py",
+        "api_service/services/temporal_execution_service.py",
+        "moonmind/schemas/temporal_artifact_models.py",
+        "moonmind/schemas/managed_session_models.py",
+        "moonmind/schemas/__init__.py",
+        "tools/export_openapi.py",
+        "tools/generate_openapi_types.py",
+        "tools/run_repo_python.sh",
+        "frontend/src/generated/openapi.ts",
+        "package.json",
+        "package-lock.json",
+        "pyproject.toml",
+        "uv.lock",
+    ],
+)
+def test_matches_openapi_affecting_paths_from_args(path: str) -> None:
+    result = _run_script(path)
 
     assert result.returncode == 0
 
-def test_matches_backend_schema_descendants_from_stdin() -> None:
+
+def test_matches_schema_descendants_from_stdin() -> None:
     result = _run_script(
         stdin="frontend/src/entrypoints/workflow-detail.tsx\nmoonmind/schemas/temporal_artifact_models.py\n"
     )
 
     assert result.returncode == 0
 
-def test_ignores_unrelated_paths() -> None:
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "moonmind/workflows/temporal/runtime/codex_session_runtime.py",
+        "moonmind/workflows/temporal/activity_runtime.py",
+        "moonmind/core/artifacts.py",
+        "moonmind/manifest/interpolation.py",
+        "frontend/src/entrypoints/workflow-detail.tsx",
+        "docs/UI/WorkflowConsoleArchitecture.md",
+    ],
+)
+def test_ignores_paths_that_do_not_affect_openapi_contracts(path: str) -> None:
+    result = _run_script(path)
+
+    assert result.returncode == 1
+
+
+def test_ignores_multiple_unrelated_paths_from_args() -> None:
     result = _run_script(
         "frontend/src/entrypoints/workflow-detail.tsx",
         "docs/UI/WorkflowConsoleArchitecture.md",
+        "moonmind/workflows/temporal/runtime/codex_session_runtime.py",
     )
 
     assert result.returncode == 1

--- a/tests/unit/tools/test_check_openapi_affecting_changes.py
+++ b/tests/unit/tools/test_check_openapi_affecting_changes.py
@@ -25,9 +25,21 @@ def _run_script(*paths: str, stdin: str | None = None) -> subprocess.CompletedPr
     [
         "api_service/api/routers/agent_runs.py",
         "api_service/services/temporal_execution_service.py",
+        "moonmind/schemas/agent_runtime_models.py",
+        "moonmind/schemas/agent_skill_models.py",
+        "moonmind/schemas/chat_models.py",
+        "moonmind/schemas/documents_models.py",
+        "moonmind/schemas/manifest_models.py",
+        "moonmind/schemas/manifest_v0_models.py",
+        "moonmind/schemas/manifest_ingest_models.py",
+        "moonmind/schemas/temporal_activity_models.py",
         "moonmind/schemas/temporal_artifact_models.py",
+        "moonmind/schemas/temporal_models.py",
+        "moonmind/schemas/temporal_signal_contracts.py",
         "moonmind/schemas/managed_session_models.py",
         "moonmind/schemas/__init__.py",
+        "moonmind/schemas/workflow_models.py",
+        "moonmind/schemas/workflow_proposal_models.py",
         "tools/export_openapi.py",
         "tools/generate_openapi_types.py",
         "tools/run_repo_python.sh",
@@ -52,6 +64,18 @@ def test_matches_schema_descendants_from_stdin() -> None:
     assert result.returncode == 0
 
 
+def test_managed_session_models_is_openapi_affecting_exported_api_schema() -> None:
+    init_file = REPO_ROOT / "moonmind" / "schemas" / "__init__.py"
+    router_file = REPO_ROOT / "api_service" / "api" / "routers" / "agent_runs.py"
+
+    assert "from .managed_session_models import (" in init_file.read_text()
+    assert "from moonmind.schemas.managed_session_models import" in router_file.read_text()
+
+    result = _run_script("moonmind/schemas/managed_session_models.py")
+
+    assert result.returncode == 0
+
+
 @pytest.mark.parametrize(
     "path",
     [
@@ -59,6 +83,11 @@ def test_matches_schema_descendants_from_stdin() -> None:
         "moonmind/workflows/temporal/activity_runtime.py",
         "moonmind/core/artifacts.py",
         "moonmind/manifest/interpolation.py",
+        "moonmind/schemas/_validation.py",
+        "moonmind/schemas/jules_models.py",
+        "moonmind/schemas/step_execution_models.py",
+        "moonmind/schemas/temporal_payload_policy.py",
+        "moonmind/schemas/workload_models.py",
         "frontend/src/entrypoints/workflow-detail.tsx",
         "docs/UI/WorkflowConsoleArchitecture.md",
     ],

--- a/tools/check_openapi_affecting_changes.sh
+++ b/tools/check_openapi_affecting_changes.sh
@@ -5,23 +5,35 @@ matches_openapi_affecting_path() {
     local path="$1"
 
     case "$path" in
-        api_service/*|\
-moonmind/schemas/__init__.py|\
-moonmind/schemas/agent_runtime_models.py|\
-moonmind/schemas/agent_skill_models.py|\
-moonmind/schemas/chat_models.py|\
-moonmind/schemas/documents_models.py|\
-moonmind/schemas/managed_session_models.py|\
-moonmind/schemas/manifest_ingest_models.py|\
-moonmind/schemas/manifest_models.py|\
-moonmind/schemas/manifest_v0_models.py|\
-moonmind/schemas/temporal_activity_models.py|\
-moonmind/schemas/temporal_artifact_models.py|\
-moonmind/schemas/temporal_models.py|\
-moonmind/schemas/temporal_signal_contracts.py|\
-moonmind/schemas/workflow_models.py|\
-moonmind/schemas/workflow_proposal_models.py|\
-tools/export_openapi.py|tools/generate_openapi_types.py|tools/run_repo_python.sh|frontend/src/generated/openapi.ts|package.json|package-lock.json|pyproject.toml|uv.lock)
+        api_service/*)
+            return 0
+            ;;
+        moonmind/core/artifacts.py|\
+        moonmind/schemas/__init__.py|\
+        moonmind/schemas/agent_runtime_models.py|\
+        moonmind/schemas/agent_skill_models.py|\
+        moonmind/schemas/chat_models.py|\
+        moonmind/schemas/documents_models.py|\
+        moonmind/schemas/managed_session_models.py|\
+        moonmind/schemas/manifest_ingest_models.py|\
+        moonmind/schemas/manifest_models.py|\
+        moonmind/schemas/manifest_v0_models.py|\
+        moonmind/schemas/temporal_activity_models.py|\
+        moonmind/schemas/temporal_artifact_models.py|\
+        moonmind/schemas/temporal_models.py|\
+        moonmind/schemas/temporal_signal_contracts.py|\
+        moonmind/schemas/workflow_models.py|\
+        moonmind/schemas/workflow_proposal_models.py)
+            return 0
+            ;;
+        tools/export_openapi.py|\
+        tools/generate_openapi_types.py|\
+        tools/run_repo_python.sh|\
+        frontend/src/generated/openapi.ts|\
+        package.json|\
+        package-lock.json|\
+        pyproject.toml|\
+        uv.lock)
             return 0
             ;;
     esac

--- a/tools/check_openapi_affecting_changes.sh
+++ b/tools/check_openapi_affecting_changes.sh
@@ -5,7 +5,7 @@ matches_openapi_affecting_path() {
     local path="$1"
 
     case "$path" in
-        api_service/*|moonmind/*|tools/export_openapi.py|tools/generate_openapi_types.py|tools/run_repo_python.sh|frontend/src/generated/openapi.ts|package.json|package-lock.json|pyproject.toml|uv.lock)
+        api_service/*|moonmind/schemas/*.py|tools/export_openapi.py|tools/generate_openapi_types.py|tools/run_repo_python.sh|frontend/src/generated/openapi.ts|package.json|package-lock.json|pyproject.toml|uv.lock)
             return 0
             ;;
     esac

--- a/tools/check_openapi_affecting_changes.sh
+++ b/tools/check_openapi_affecting_changes.sh
@@ -5,7 +5,23 @@ matches_openapi_affecting_path() {
     local path="$1"
 
     case "$path" in
-        api_service/*|moonmind/schemas/*.py|tools/export_openapi.py|tools/generate_openapi_types.py|tools/run_repo_python.sh|frontend/src/generated/openapi.ts|package.json|package-lock.json|pyproject.toml|uv.lock)
+        api_service/*|\
+moonmind/schemas/__init__.py|\
+moonmind/schemas/agent_runtime_models.py|\
+moonmind/schemas/agent_skill_models.py|\
+moonmind/schemas/chat_models.py|\
+moonmind/schemas/documents_models.py|\
+moonmind/schemas/managed_session_models.py|\
+moonmind/schemas/manifest_ingest_models.py|\
+moonmind/schemas/manifest_models.py|\
+moonmind/schemas/manifest_v0_models.py|\
+moonmind/schemas/temporal_activity_models.py|\
+moonmind/schemas/temporal_artifact_models.py|\
+moonmind/schemas/temporal_models.py|\
+moonmind/schemas/temporal_signal_contracts.py|\
+moonmind/schemas/workflow_models.py|\
+moonmind/schemas/workflow_proposal_models.py|\
+tools/export_openapi.py|tools/generate_openapi_types.py|tools/run_repo_python.sh|frontend/src/generated/openapi.ts|package.json|package-lock.json|pyproject.toml|uv.lock)
             return 0
             ;;
     esac


### PR DESCRIPTION
Jira issue key: MM-850

Summary:
- Replaced broad moonmind/* generated-contract detection with a narrow OpenAPI-affecting allowlist.
- Kept API service, exported schema, OpenAPI generation tooling, generated frontend OpenAPI output, and dependency lock/config paths selected.
- Added regression coverage for selected and skipped paths, including arbitrary moonmind workflow/runtime paths and managed_session_models.py export evidence.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/tools/test_check_openapi_affecting_changes.py

Remaining risks:
- The schema allowlist must be updated when new backend schemas are exported through the public API contract.