### PR TITLE
MM-845: Enable PentestGPT discovery by default with operator disable override

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -53,9 +53,12 @@ MOONMIND_UNREAL_CCACHE_VOLUME_NAME="unreal_ccache_volume"
 MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 
 # Curated PentestGPT tool (`security.pentest.run`)
-# Keep disabled until the agent-runtime worker has Docker-proxy access, artifact
-# storage is configured, and approved-scope/provider-secret policy is in place.
-MOONMIND_PENTEST_ENABLED="false"
+# Discovery is enabled by default; the tool is visible in Mission Control and
+# `/workflows/new`. This does not relax execution guardrails (approved scope is
+# still required, external targets stay disabled, only the safe runner profile is
+# allowlisted). Set MOONMIND_PENTEST_ENABLED="false" as the operator disable
+# override in deployments that are not approved for pentest operation.
+MOONMIND_PENTEST_ENABLED="true"
 MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 MOONMIND_PENTEST_SAFE_PROFILE_ID="pentestgpt-safe"
 MOONMIND_PENTEST_VPN_LAB_PROFILE_ID="pentestgpt-vpn-lab"

--- a/docs/Security/PentestOperations.md
+++ b/docs/Security/PentestOperations.md
@@ -13,13 +13,13 @@ This runbook describes how operators enable and supervise the curated `security.
 
 ## Default Posture
 
-Pentest execution is disabled by default:
+`security.pentest.run` discovery is enabled by default, so the tool is visible in Mission Control and `/workflows/new`. To disable discovery, submission, and execution entirely, set the operator override:
 
 ```dotenv
 MOONMIND_PENTEST_ENABLED=false
 ```
 
-Enable it only in deployments where the agent-runtime worker has Docker-proxy access, artifact storage is configured, provider credentials are available through managed secrets or controlled environment variables, and operators have an approved-scope process.
+Discovery being enabled does not relax any execution guardrail. Real runs still require a deployment where the agent-runtime worker has Docker-proxy access, artifact storage is configured, provider credentials are available through managed secrets or controlled environment variables, and operators have an approved-scope process. Keep `MOONMIND_PENTEST_ENABLED=false` in deployments that are not approved for pentest operation.
 
 The safe defaults are:
 
@@ -238,24 +238,36 @@ Run this checklist when bringing the integration up in a staging environment:
    `MOONMIND_PENTEST_ENABLED_PROVIDER_PROFILES`,
    `PENTESTGPT_ANTHROPIC_SECRET_ID` / `PENTESTGPT_OPENROUTER_SECRET_ID`).
 9. Create a lab-only approved scope artifact (`target_class=lab`).
-10. Set `MOONMIND_PENTEST_ENABLED=true`.
+10. Confirm `MOONMIND_PENTEST_ENABLED` is enabled (it now defaults to `true`; only set it explicitly if a prior override disabled it).
 11. Submit `pentest-recon` with `operation_mode=recon_only`.
 12. Verify report bundle refs (`report.primary`, `report.summary`,
     `report.structured`, `report.evidence`).
 13. Verify no secret leaks in logs, artifacts, workflow history, or UI previews.
 14. Verify cleanup metadata and provider lease release.
-15. Disable again (`MOONMIND_PENTEST_ENABLED=false`) unless the environment is
-    approved for continued operation.
+15. If the environment is not approved for continued operation, disable the tool
+    again with the operator override (`MOONMIND_PENTEST_ENABLED=false`).
 
 ## Rollout Gates
 
 Promote capability in this order; each step is gated on the previous one
 passing and on security review for the escalations:
 
-1. Merge hardening behind `MOONMIND_PENTEST_ENABLED=false`.
+1. Ship with discovery enabled by default (`MOONMIND_PENTEST_ENABLED` defaults to
+   `true`); `MOONMIND_PENTEST_ENABLED=false` remains the operator disable override.
 2. Run local/dev lab tests with the real runner image.
 3. Run staging tests with the real provider profile manager.
 4. Enable `recon_only` for internal lab scopes.
 5. Enable `validate_hypothesis` for internal authorized scopes.
 6. Keep `full_authorized`, VPN profiles, and external targets disabled until a
    separate security review signs off.
+
+## Acceptance Criteria (MM-845)
+
+Default-on discovery and the schema-driven Start Workflow inputs are accepted when:
+
+1. With no override set, `security.pentest.run` is discoverable and `MOONMIND_PENTEST_ENABLED` resolves to `true`.
+2. `MOONMIND_PENTEST_ENABLED=false` still hides the tool from discovery and rejects submissions (operator disable override preserved).
+3. `/workflows/new` renders the required PentestGPT fields after the tool is selected: `target`, `scope_artifact_ref`, `operation_mode`, `runner_profile_id`.
+4. `/workflows/new` renders the optional/advanced fields: `objective`, `execution_profile_ref`, `provider_selector`, `time_budget_minutes`, `repo_dir`, `evidence_level`, `network_attachment_ref`, with raw JSON demoted to an edit-JSON fallback.
+5. Backend safety constraints are unchanged by the default flip: approved scope required, external targets disabled by default, only the safe runner profile allowlisted by default, and inline scope rejected for untrusted submissions.
+6. Backend, frontend, integration, and regression coverage exists, including enable-by-default and disable-override regression tests.

--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -59,7 +59,7 @@ The implementation includes:
 9. a curated runner image definition under `docker/pentestgpt-runner/`,
 10. CI publishing for `ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0`.
 
-The default deployment posture remains conservative: `MOONMIND_PENTEST_ENABLED=false`, approved scope is required, telemetry is disabled, only the safe runner profile is allowlisted, VPN/lab profiles are hidden, and `full_authorized` is not allowlisted unless an operator explicitly enables it.
+`security.pentest.run` discovery is enabled by default: `MOONMIND_PENTEST_ENABLED` defaults to `true`, and `MOONMIND_PENTEST_ENABLED=false` remains the operator disable override that hides the tool and rejects submissions. Discovery being on does not relax execution policy — the rest of the deployment posture stays conservative: approved scope is required, telemetry is disabled, external targets are disabled, only the safe runner profile is allowlisted, VPN/lab profiles are hidden, and `full_authorized` is not allowlisted unless an operator explicitly enables it.
 
 #### Production hardening status
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1438,9 +1438,13 @@ class PentestSettings(BaseSettings):
     """Policy and deployment settings for the curated PentestGPT tool."""
 
     enabled: bool = Field(
-        False,
+        True,
         validation_alias=AliasChoices("MOONMIND_PENTEST_ENABLED"),
-        description="Enable discovery and execution of security.pentest.run.",
+        description=(
+            "Enable discovery and execution of security.pentest.run. Discovery is "
+            "enabled by default; set MOONMIND_PENTEST_ENABLED=false to disable it "
+            "as an operator override."
+        ),
         json_schema_extra={
             "moonmind": {
                 "expose": True,

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -697,7 +697,13 @@ async def test_security_pentest_tool_contract_can_return_terminal_metadata() -> 
     assert result.outputs["terminal_cleanup"]["provider_lease_released"] is True
     assert result.outputs["terminal_cleanup"]["container_removed"] is True
 
-async def test_security_pentest_execute_disabled_policy_denies_before_launcher() -> None:
+async def test_security_pentest_execute_disabled_policy_denies_before_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Discovery/execution defaults to enabled (MM-845); the operator disable
+    # override (MOONMIND_PENTEST_ENABLED=false) must still deny before launch
+    # when the policy flag is omitted and falls back to settings.
+    monkeypatch.setattr(settings.pentest, "enabled", False)
     launcher = _FakeLauncher()
     activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
     payload = _activity_payload()["request"]

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -187,8 +187,9 @@ def test_pentest_settings_accepts_approved_runner_images(runner_image: str) -> N
 
     assert parsed.runner_image == runner_image
 
-def test_pentest_settings_default_disables_tool_until_explicit_opt_in() -> None:
-    assert PentestSettings().enabled is False
+def test_pentest_settings_default_enables_tool_with_disable_override() -> None:
+    assert PentestSettings().enabled is True
+    assert PentestSettings(MOONMIND_PENTEST_ENABLED="false").enabled is False
     assert PentestSettings(MOONMIND_PENTEST_ENABLED="true").enabled is True
 
 @pytest.mark.parametrize(

--- a/tests/unit/mcp/test_executable_tool_registry.py
+++ b/tests/unit/mcp/test_executable_tool_registry.py
@@ -14,9 +14,18 @@ def test_executable_tool_registry_hides_pentest_when_disabled() -> None:
     assert registry.has_tool(PENTEST_TOOL_NAME) is False
 
 
-def test_executable_tool_registry_hides_pentest_by_default() -> None:
+def test_executable_tool_registry_exposes_pentest_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(settings.pentest, "enabled", True)
     registry = ExecutableToolDiscoveryRegistry()
 
+    assert registry.has_tool(PENTEST_TOOL_NAME) is True
+
+
+def test_executable_tool_registry_honors_disable_override(monkeypatch) -> None:
+    monkeypatch.setattr(settings.pentest, "enabled", False)
+    registry = ExecutableToolDiscoveryRegistry()
+
+    assert registry.list_tools() == []
     assert registry.has_tool(PENTEST_TOOL_NAME) is False
 
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1478,7 +1478,13 @@ async def test_pentest_heartbeat_helper_emits_compact_redacted_payload(
     assert "secret-value" not in str(payload)
     assert "raw stdout body" not in str(payload)
 
-async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_default():
+async def test_security_pentest_execute_fails_closed_before_runner_when_disabled_by_operator_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Discovery/execution defaults to enabled (MM-845); the operator disable
+    # override (MOONMIND_PENTEST_ENABLED=false) must still fail closed before
+    # the runner when the policy flag is omitted and falls back to settings.
+    monkeypatch.setattr(settings.pentest, "enabled", False)
     launcher = _FakePentestLauncher()
     activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
 
@@ -1492,6 +1498,25 @@ async def test_security_pentest_execute_fails_closed_before_runner_when_disabled
     assert result["failure_classification"]["failure_kind"] == "policy_denied"
     assert result["failure_classification"]["interaction_state"] == "pre_interaction"
     assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+    assert launcher.requests == []
+
+
+async def test_security_pentest_execute_honors_explicit_disabled_payload_flag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # In-flight payloads that recorded an explicit pentest_enabled=False must
+    # keep failing closed even though discovery now defaults to enabled.
+    monkeypatch.setattr(settings.pentest, "enabled", True)
+    launcher = _FakePentestLauncher()
+    activities = TemporalAgentRuntimeActivities(workload_launcher=launcher)
+
+    payload = _pentest_activity_payload(pentest_enabled=False)["request"]
+
+    result = await activities.security_pentest_execute({"request": payload})
+
+    assert result["status"] == "policy_denied"
+    assert result["failure_classification"]["failure_kind"] == "policy_denied"
+    assert result["failure_classification"]["interaction_state"] == "pre_interaction"
     assert launcher.requests == []
 
 async def test_security_pentest_execute_malformed_attempt_returns_validation_failure():


### PR DESCRIPTION
**Jira issue:** [MM-845](https://moonladder.atlassian.net/browse/MM-845) — Pentest UI Improvements

## Summary

The assess step found MM-845 `PARTIALLY_IMPLEMENTED`: the schema-driven Start Workflow Tool-step UI and all backend safety constraints were already in place, but the decisive requirement — *enable `security.pentest.run` discovery by default while preserving `MOONMIND_PENTEST_ENABLED=false` as the operator disable override* — was not met. This PR closes that gap.

- **Enable discovery by default:** flip `PentestSettings.enabled` default from `False` to `True` (`moonmind/config/settings.py`). `MOONMIND_PENTEST_ENABLED=false` remains the operator disable override via the existing `AliasChoices` env binding.
- **Safety constraints unchanged by the default flip:** approved scope still required, external targets still disabled by default, only the safe runner profile allowlisted by default, and inline scope still rejected for untrusted submissions.
- **In-flight compatibility:** an explicit `pentest_enabled=False` recorded in an in-flight activity payload continues to fail closed even though discovery now defaults on.
- **Docs updated to a default-on posture with MM-845 acceptance criteria:**
  - `docs/Steps/PentestTool.md` — default deployment posture.
  - `docs/Security/PentestOperations.md` — Default Posture, Staging Rollout Checklist, Rollout Gates, and a new Acceptance Criteria (MM-845) section.

Already-implemented requirements (verified during assessment, unchanged here): required and optional/advanced PentestGPT fields render in `/workflows/new` via schema-rendered capability fields with raw JSON demoted to a fallback.

## Tests run

`./tools/test_unit.sh` (with `MOONMIND_FORCE_LOCAL_TESTS=1`) over the changed test files:

- `tests/unit/integrations/pentest/test_pentest_models.py`
- `tests/unit/mcp/test_executable_tool_registry.py`
- `tests/unit/workflows/temporal/test_activity_runtime.py`

Result: **204 passed, 1 failed**. The single failure — `test_mm_tool_execute_preserves_tool_failure_envelope` (a GitHub-token redaction-helper assertion) — is **pre-existing and unrelated** to this change: it fails identically on the base commit `a4db88bec` (main), and this PR touches only pentest settings, docs, and pentest tests. All MM-845-related regression tests pass:
- registry exposes pentest by default and honors the disable override;
- settings default-on with disable/enable override parsing;
- activity boundary fails closed under the operator disable override and honors an explicit `pentest_enabled=False` in-flight payload.

## Remaining risks

- **Security posture change:** the pentest tool is now discoverable/submittable by default. Execution guardrails are unchanged (approved scope, safe runner, external targets off), so discovery-on does not relax execution policy, but deployments not approved for pentest operation should explicitly set `MOONMIND_PENTEST_ENABLED=false`.
- **Frontend/integration coverage** for the schema-rendered fields was not re-run in this step (it was verified as pre-existing during assessment); CI is expected to exercise it.
- **Pre-existing unrelated failure:** `test_mm_tool_execute_preserves_tool_failure_envelope` remains red on main and is out of scope for MM-845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-845]: https://moonladder.atlassian.net/browse/MM-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ