### PR TITLE
MM-851 split generated contract CI gates

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -337,28 +337,45 @@ jobs:
         path: api_service/static/workflow_console/dist/
         if-no-files-found: error
 
-  check-generated-contracts:
+  detect-openapi-contract-impact:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
+    outputs:
+      run_check: ${{ steps.detect.outputs.run_check }}
     steps:
     - name: Check out code
       uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Detect OpenAPI-affecting changes
       id: detect
+      shell: bash
       run: |
         set -euo pipefail
+
+        ensure_commit_available() {
+          local sha="$1"
+
+          if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+            return 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "$sha"
+        }
 
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
-          changed_files="$(git diff --name-only "$base_sha...$head_sha")"
+          ensure_commit_available "$base_sha"
+          ensure_commit_available "$head_sha"
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
         elif [[ -n "${{ github.event.before }}" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
           base_sha="${{ github.event.before }}"
           head_sha="${{ github.sha }}"
+          ensure_commit_available "$base_sha"
+          ensure_commit_available "$head_sha"
           changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
         else
           echo "run_check=true" >> "$GITHUB_OUTPUT"
@@ -370,27 +387,35 @@ jobs:
         else
           echo "run_check=false" >> "$GITHUB_OUTPUT"
         fi
+
+  run-generated-contracts:
+    needs: detect-openapi-contract-impact
+    if: needs.detect-openapi-contract-impact.outputs.run_check == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
     - name: Set up Node.js
-      if: steps.detect.outputs.run_check == 'true'
       uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: npm
     - name: Install Node dependencies
-      if: steps.detect.outputs.run_check == 'true'
       run: npm ci
     - name: Set up Python for OpenAPI generation
-      if: steps.detect.outputs.run_check == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install system dependencies for backend API check
-      if: steps.detect.outputs.run_check == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y libcairo2-dev pkg-config
     - name: Cache pip dependencies
-      if: steps.detect.outputs.run_check == 'true'
       uses: actions/cache@v5
       with:
         path: ~/.cache/pip
@@ -398,13 +423,36 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install backend dependencies via uv
-      if: steps.detect.outputs.run_check == 'true'
       run: |
         python -m pip install --upgrade pip uv
         uv pip install --system -e .[tests]
     - name: Verify generated frontend API types are in sync
-      if: steps.detect.outputs.run_check == 'true'
       run: npm run contracts:check
-    - name: Skip generated contract check
-      if: steps.detect.outputs.run_check != 'true'
-      run: echo "No backend/OpenAPI-affecting files changed; skipping generated contract verification."
+
+  check-generated-contracts:
+    needs:
+      - detect-openapi-contract-impact
+      - run-generated-contracts
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Verify generated contract status
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ "${{ needs.detect-openapi-contract-impact.result }}" != "success" ]]; then
+          echo "::error::detect-openapi-contract-impact ended with result=${{ needs.detect-openapi-contract-impact.result }}"
+          exit 1
+        fi
+
+        if [[ "${{ needs.detect-openapi-contract-impact.outputs.run_check }}" == "true" ]]; then
+          if [[ "${{ needs.run-generated-contracts.result }}" != "success" ]]; then
+            echo "::error::run-generated-contracts was selected but ended with result=${{ needs.run-generated-contracts.result }}"
+            exit 1
+          fi
+          echo "Generated contract verification passed."
+        else
+          echo "No backend/OpenAPI-affecting files changed; generated contract verification skipped intentionally."
+        fi

--- a/tests/unit/test_pytest_integration_ci_workflow.py
+++ b/tests/unit/test_pytest_integration_ci_workflow.py
@@ -75,17 +75,17 @@ def test_generated_contracts_use_cheap_detector_and_stable_required_status() -> 
     detector_steps = detector_job["steps"]
     detector_checkout = detector_steps[0]
     assert detector_checkout["uses"].startswith("actions/checkout@")
-    assert detector_checkout["with"]["fetch-depth"] == 1
+    assert int(detector_checkout["with"]["fetch-depth"]) == 1
     assert any(
-        "tools/check_openapi_affecting_changes.sh" in step.get("run", "")
+        "tools/check_openapi_affecting_changes.sh" in (step.get("run") or "")
         for step in detector_steps
     )
     assert not any(
-        step.get("uses", "").startswith("actions/setup-node@")
-        or step.get("uses", "").startswith("actions/setup-python@")
-        or "npm ci" in step.get("run", "")
-        or "uv pip install" in step.get("run", "")
-        or "apt-get install" in step.get("run", "")
+        (step.get("uses") or "").startswith("actions/setup-node@")
+        or (step.get("uses") or "").startswith("actions/setup-python@")
+        or "npm ci" in (step.get("run") or "")
+        or "uv pip install" in (step.get("run") or "")
+        or "apt-get install" in (step.get("run") or "")
         for step in detector_steps
     )
 
@@ -97,14 +97,17 @@ def test_generated_contracts_use_cheap_detector_and_stable_required_status() -> 
     )
     contract_steps = contract_job["steps"]
     assert any(
-        step.get("uses", "").startswith("actions/setup-node@")
+        (step.get("uses") or "").startswith("actions/setup-node@")
         for step in contract_steps
     )
     assert any(
-        step.get("uses", "").startswith("actions/setup-python@")
+        (step.get("uses") or "").startswith("actions/setup-python@")
         for step in contract_steps
     )
-    assert any("npm run contracts:check" in step.get("run", "") for step in contract_steps)
+    assert any(
+        "npm run contracts:check" in (step.get("run") or "")
+        for step in contract_steps
+    )
     assert not any(step.get("if") for step in contract_steps)
 
     required_job = jobs["check-generated-contracts"]
@@ -114,7 +117,7 @@ def test_generated_contracts_use_cheap_detector_and_stable_required_status() -> 
     ]
     assert required_job["if"] == "always()"
     required_script = "\n".join(
-        step.get("run", "") for step in required_job["steps"] if "run" in step
+        (step.get("run") or "") for step in required_job["steps"] if "run" in step
     )
     assert "needs.detect-openapi-contract-impact.result" in required_script
     assert "needs.detect-openapi-contract-impact.outputs.run_check" in required_script

--- a/tests/unit/test_pytest_integration_ci_workflow.py
+++ b/tests/unit/test_pytest_integration_ci_workflow.py
@@ -66,6 +66,63 @@ def test_required_pytest_unit_workflow_selects_integration_ci_for_prs() -> None:
     assert "integration-ci" in required_job["needs"]
 
 
+def test_generated_contracts_use_cheap_detector_and_stable_required_status() -> None:
+    workflow = _load_unit_workflow()
+    jobs = workflow["jobs"]
+
+    detector_job = jobs["detect-openapi-contract-impact"]
+    assert detector_job["outputs"]["run_check"] == "${{ steps.detect.outputs.run_check }}"
+    detector_steps = detector_job["steps"]
+    detector_checkout = detector_steps[0]
+    assert detector_checkout["uses"].startswith("actions/checkout@")
+    assert detector_checkout["with"]["fetch-depth"] == 1
+    assert any(
+        "tools/check_openapi_affecting_changes.sh" in step.get("run", "")
+        for step in detector_steps
+    )
+    assert not any(
+        step.get("uses", "").startswith("actions/setup-node@")
+        or step.get("uses", "").startswith("actions/setup-python@")
+        or "npm ci" in step.get("run", "")
+        or "uv pip install" in step.get("run", "")
+        or "apt-get install" in step.get("run", "")
+        for step in detector_steps
+    )
+
+    contract_job = jobs["run-generated-contracts"]
+    assert contract_job["needs"] == "detect-openapi-contract-impact"
+    assert (
+        contract_job["if"]
+        == "needs.detect-openapi-contract-impact.outputs.run_check == 'true'"
+    )
+    contract_steps = contract_job["steps"]
+    assert any(
+        step.get("uses", "").startswith("actions/setup-node@")
+        for step in contract_steps
+    )
+    assert any(
+        step.get("uses", "").startswith("actions/setup-python@")
+        for step in contract_steps
+    )
+    assert any("npm run contracts:check" in step.get("run", "") for step in contract_steps)
+    assert not any(step.get("if") for step in contract_steps)
+
+    required_job = jobs["check-generated-contracts"]
+    assert required_job["needs"] == [
+        "detect-openapi-contract-impact",
+        "run-generated-contracts",
+    ]
+    assert required_job["if"] == "always()"
+    required_script = "\n".join(
+        step.get("run", "") for step in required_job["steps"] if "run" in step
+    )
+    assert "needs.detect-openapi-contract-impact.result" in required_script
+    assert "needs.detect-openapi-contract-impact.outputs.run_check" in required_script
+    assert "needs.run-generated-contracts.result" in required_script
+    assert "Generated contract verification passed." in required_script
+    assert "skipped intentionally" in required_script
+
+
 def test_required_pytest_integration_ci_workflow_runs_hermetic_runner_and_uploads_failure_diagnostics() -> None:
     workflow = _load_workflow()
 


### PR DESCRIPTION
Jira issue key: MM-851

Summary:
- Split generated contract CI into a cheap OpenAPI impact detector, an expensive contract execution job, and a stable required summary job.
- Kept expensive Node, Python, system dependency, and contract-check setup behind the detector output.
- Replaced full checkout history with fetch-depth 1 plus targeted fetches for the commits needed for changed-file detection.
- Added static workflow validation covering detector-only setup, run gating, and stable skip/run status semantics.

Tests run:
- git diff --check origin/main...HEAD
- ./tools/test_unit.sh tests/unit/test_pytest_integration_ci_workflow.py

Remaining risks:
- GitHub Actions behavior still depends on pull_request and push event SHA availability; the workflow now fetches missing base/head commits on demand.
