### PR TITLE
MM-831 Render expanded Step Execution history in Mission Control

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -734,6 +734,230 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByText('art-plan-checkpoint')).toBeTruthy();
   });
 
+  it('MM-831 renders expanded Step Execution history from the step-executions list endpoint', async () => {
+    window.history.pushState({}, 'Steps Test', '/workflows/test-123/steps?source=temporal');
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'History task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+    const stepsSnapshot = {
+      workflowId: 'test-123',
+      runId: '02-run',
+      runScope: 'latest',
+      steps: [
+        {
+          logicalStepId: 'apply',
+          order: 1,
+          title: 'Apply patch',
+          tool: { type: 'agent_runtime', name: 'codex_cli', version: '1' },
+          dependsOn: [],
+          status: 'succeeded',
+          waitingReason: null,
+          attentionRequired: false,
+          executionOrdinal: 2,
+          startedAt: '2026-04-09T00:00:03Z',
+          updatedAt: '2026-04-09T00:00:04Z',
+          summary: 'Applied repository changes',
+          checks: [],
+          refs: { childWorkflowId: null, childRunId: null, agentRunId: null },
+          artifacts: {
+            outputSummary: null,
+            outputPrimary: 'art-apply-output',
+            runtimeStdout: null,
+            runtimeStderr: null,
+            runtimeMergedLogs: null,
+            runtimeDiagnostics: null,
+            providerSnapshot: null,
+          },
+          lastError: null,
+        },
+      ],
+    };
+    const stepExecutionsResponse = {
+      workflowId: 'test-123',
+      runId: '02-run',
+      runScope: 'latest',
+      logicalStepId: 'apply',
+      stepExecutions: [
+        {
+          manifestArtifactRef: 'art-exec-1-manifest',
+          stepExecutionId: 'test-123:02-run:apply:1',
+          workflowId: 'test-123',
+          runId: '02-run',
+          logicalStepId: 'apply',
+          executionOrdinal: 1,
+          sourceExecutionOrdinal: null,
+          lineage: null,
+          reason: 'initial_execution',
+          status: 'failed',
+          terminalDisposition: 'retryable',
+          startedAt: '2026-04-09T00:00:01Z',
+          updatedAt: '2026-04-09T00:00:02Z',
+          summary: 'First attempt failed the gate',
+          runtimeChildRefs: { childWorkflowId: 'child-wf-apply-1' },
+          workspacePolicy: 'workspace_required',
+          gitDisposition: 'candidate',
+          qualityGateVerdict: 'ADDITIONAL_WORK_NEEDED',
+          manifestRefs: { manifestArtifactRef: 'art-exec-1-manifest' },
+          outputRefs: { summary: 'art-exec-1-output', diff: 'art-exec-1-diff' },
+          stepEvidence: {
+            logicalStepId: 'apply',
+            executionOrdinal: 1,
+            checkpointRefsByBoundary: {},
+            contextBundleRef: {
+              category: 'context',
+              status: 'available',
+              artifactRef: 'art-exec-1-context',
+            },
+            gateSummary: { verdict: 'ADDITIONAL_WORK_NEEDED', artifactRef: 'art-exec-1-gate' },
+            terminalDisposition: 'retryable',
+            sideEffectSummary: { status: 'skipped', artifactRefs: {} },
+            diagnosticRefs: [
+              {
+                kind: 'environment',
+                status: 'available',
+                diagnosticsRef: 'art-exec-1-diag',
+                reasonCode: 'sidecar_unhealthy',
+                summary: 'Sidecar unhealthy',
+              },
+            ],
+          },
+          recoveryEligibility: null,
+        },
+        {
+          manifestArtifactRef: 'art-exec-2-manifest',
+          stepExecutionId: 'test-123:02-run:apply:2',
+          workflowId: 'test-123',
+          runId: '02-run',
+          logicalStepId: 'apply',
+          executionOrdinal: 2,
+          sourceExecutionOrdinal: 1,
+          lineage: {
+            sourceWorkflowId: 'wf-source',
+            sourceRunId: 'run-source',
+            sourceLogicalStepId: 'apply',
+            sourceExecutionOrdinal: 1,
+            relationship: 'recovered_from',
+          },
+          reason: 'dependency_invalidated',
+          status: 'succeeded',
+          terminalDisposition: 'accepted',
+          startedAt: '2026-04-09T00:00:03Z',
+          updatedAt: '2026-04-09T00:00:04Z',
+          summary: 'Re-ran after the upstream contract changed',
+          runtimeChildRefs: { childWorkflowId: 'child-wf-apply-2' },
+          workspacePolicy: 'workspace_required',
+          gitDisposition: 'accepted',
+          qualityGateVerdict: 'FULLY_IMPLEMENTED',
+          manifestRefs: { manifestArtifactRef: 'art-exec-2-manifest' },
+          outputRefs: { summary: 'art-exec-2-output', diff: 'art-exec-2-diff' },
+          stepEvidence: {
+            logicalStepId: 'apply',
+            executionOrdinal: 2,
+            checkpointRefsByBoundary: {},
+            contextBundleRef: {
+              category: 'context',
+              status: 'available',
+              artifactRef: 'art-exec-2-context',
+            },
+            gateSummary: { verdict: 'FULLY_IMPLEMENTED', artifactRef: 'art-exec-2-gate' },
+            terminalDisposition: 'accepted',
+            sideEffectSummary: {
+              status: 'available',
+              artifactRefs: { publish: 'art-exec-2-sideeffect' },
+            },
+            diagnosticRefs: [],
+          },
+          recoveryEligibility: null,
+        },
+      ],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps/apply/step-executions')) {
+        return Promise.resolve({ ok: true, json: async () => stepExecutionsResponse } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({ ok: true, json: async () => stepsSnapshot } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    // History is not requested or rendered until the row is expanded.
+    await waitFor(() => {
+      expect(screen.getAllByText('Apply patch').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByLabelText('Step Execution history')).toBeNull();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
+
+    // The expanded surface consumes the step-executions LIST endpoint.
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([input]) =>
+          String(input).includes(
+            '/api/executions/test-123/steps/apply/step-executions?source=temporal',
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    const history = await screen.findByLabelText('Step Execution history');
+    expect(screen.getByRole('heading', { name: 'Step Execution history' })).toBeTruthy();
+    expect(screen.getByText('2 step executions')).toBeTruthy();
+
+    // Newest execution renders first.
+    const ordinals = Array.from(
+      (history as HTMLElement).querySelectorAll('.step-execution-pill'),
+    ).map((node) => node.textContent);
+    expect(ordinals).toEqual(['Execution 2', 'Execution 1']);
+
+    // Downstream invalidation status is surfaced in the compact history rows.
+    expect(within(history).getByText('Downstream invalidation')).toBeTruthy();
+
+    // Full enumerated evidence field set is surfaced as refs / typed diagnostics.
+    expect(within(history).getByText('Lineage')).toBeTruthy();
+    expect(within(history).getByText('Source attempt')).toBeTruthy();
+    expect(within(history).getAllByText('Terminal disposition').length).toBe(2);
+    expect(within(history).getAllByText('Workspace policy').length).toBe(2);
+    expect(within(history).getAllByText('Git disposition').length).toBe(2);
+    expect(within(history).getAllByText('Gate verdict').length).toBe(2);
+    expect(within(history).getAllByText('Context bundle').length).toBe(2);
+    expect(within(history).getAllByText('Runtime child refs').length).toBe(2);
+    expect(within(history).getByText('Diagnostics refs')).toBeTruthy();
+    expect(within(history).getAllByText('Side effects').length).toBe(2);
+
+    // Ref-only values, never inlined bodies.
+    expect(within(history).getByText('art-exec-2-context')).toBeTruthy();
+    expect(within(history).getByText('art-exec-1-context')).toBeTruthy();
+    expect(within(history).getByText('art-exec-2-diff')).toBeTruthy();
+    expect(within(history).getByText('art-exec-1-diag')).toBeTruthy();
+    expect(within(history).getByText('art-exec-2-sideeffect')).toBeTruthy();
+    expect(within(history).getByText('child-wf-apply-2')).toBeTruthy();
+    expect(within(history).getByText('wf-source')).toBeTruthy();
+  });
+
   it('MM-801 renders Artifacts as the focused report and artifact route', async () => {
     window.history.pushState({}, 'Artifacts Test', '/workflows/test-123/artifacts?source=temporal');
     mockWorkflowDetailSubrouteFetch();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2852,8 +2852,8 @@ function StepExecutionRefList({ entries }: { entries: Array<[string, string]> })
   if (entries.length === 0) return null;
   return (
     <span className="step-execution-ref-list">
-      {entries.map(([label, ref]) => (
-        <span className="step-execution-ref" key={`${label}-${ref}`}>
+      {entries.map(([label, ref], index) => (
+        <span className="step-execution-ref" key={`${label}-${ref}-${index}`}>
           <span className="small">{formatStatusLabel(label)}:</span>{' '}
           <code className="text-xs break-all">{ref}</code>
         </span>

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -524,6 +524,98 @@ const RecoveryEligibilitySchema = z
   })
   .passthrough();
 
+// MM-831: bounded Step Execution evidence projection consumed by the expanded
+// Step Execution history surface. These mirror the API camelCase ref-only
+// projection models; raw artifact bodies are never inlined.
+const GateSummaryStatusSchema = z
+  .object({
+    verdict: z.string().nullable().optional(),
+    summary: z.string().nullable().optional(),
+    artifactRef: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const SideEffectSummarySchema = z
+  .object({
+    status: z.string().optional(),
+    artifactRefs: z.record(z.string(), z.string()).default({}),
+    summary: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const EnvironmentDiagnosticReferenceSchema = z
+  .object({
+    kind: z.string(),
+    status: z.string(),
+    diagnosticsRef: z.string().nullable().optional(),
+    reasonCode: z.string(),
+    summary: z.string(),
+  })
+  .passthrough();
+
+const StepEvidenceSummarySchema = z
+  .object({
+    logicalStepId: z.string(),
+    executionOrdinal: z.number().nullable().optional(),
+    checkpointRefsByBoundary: z.record(z.string(), EvidenceRefStatusSchema).default({}),
+    contextBundleRef: EvidenceRefStatusSchema.nullable().optional(),
+    retrievalManifestRef: EvidenceRefStatusSchema.nullable().optional(),
+    memoryManifestRef: EvidenceRefStatusSchema.nullable().optional(),
+    gateSummary: GateSummaryStatusSchema.nullable().optional(),
+    terminalDisposition: z.string().nullable().optional(),
+    sideEffectSummary: SideEffectSummarySchema.nullable().optional(),
+    diagnosticRefs: z.array(EnvironmentDiagnosticReferenceSchema).default([]),
+  })
+  .passthrough();
+
+const StepExecutionLineageSchema = z
+  .object({
+    sourceWorkflowId: z.string(),
+    sourceRunId: z.string(),
+    sourceLogicalStepId: z.string(),
+    sourceExecutionOrdinal: z.number(),
+    relationship: z.string().nullable().optional(),
+    lineageExecutionOrdinal: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+const StepExecutionProjectionSchema = z
+  .object({
+    manifestArtifactRef: z.string(),
+    stepExecutionId: z.string(),
+    workflowId: z.string(),
+    runId: z.string(),
+    logicalStepId: z.string(),
+    executionOrdinal: z.number(),
+    sourceExecutionOrdinal: z.number().nullable().optional(),
+    lineage: StepExecutionLineageSchema.nullable().optional(),
+    reason: z.string(),
+    status: z.string(),
+    terminalDisposition: z.string().nullable().optional(),
+    startedAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
+    summary: z.string().nullable().optional(),
+    runtimeChildRefs: z.record(z.string(), z.unknown()).default({}),
+    workspacePolicy: z.string().nullable().optional(),
+    gitDisposition: z.string().nullable().optional(),
+    qualityGateVerdict: z.string().nullable().optional(),
+    manifestRefs: z.record(z.string(), z.unknown()).default({}),
+    outputRefs: z.record(z.string(), z.unknown()).default({}),
+    stepEvidence: StepEvidenceSummarySchema.nullable().optional(),
+    recoveryEligibility: RecoveryEligibilitySchema.nullable().optional(),
+  })
+  .passthrough();
+
+const StepExecutionListSchema = z
+  .object({
+    workflowId: z.string(),
+    runId: z.string(),
+    runScope: z.string().default('latest'),
+    logicalStepId: z.string().default(''),
+    stepExecutions: z.array(StepExecutionProjectionSchema).default([]),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string().optional(),
@@ -2741,13 +2833,249 @@ function StepProvenanceMarker({ row }: { row: z.infer<typeof StepLedgerRowSchema
   );
 }
 
+// MM-831: flatten a ref map into renderable [label, ref] entries. Only string
+// values are surfaced (these are artifact refs, never raw bodies).
+function stepRefEntries(
+  refs: Record<string, unknown> | null | undefined,
+): Array<[string, string]> {
+  if (!refs) return [];
+  const entries: Array<[string, string]> = [];
+  for (const [key, value] of Object.entries(refs)) {
+    if (typeof value === 'string' && value) {
+      entries.push([key, value]);
+    }
+  }
+  return entries;
+}
+
+function StepExecutionRefList({ entries }: { entries: Array<[string, string]> }) {
+  if (entries.length === 0) return null;
+  return (
+    <span className="step-execution-ref-list">
+      {entries.map(([label, ref]) => (
+        <span className="step-execution-ref" key={`${label}-${ref}`}>
+          <span className="small">{formatStatusLabel(label)}:</span>{' '}
+          <code className="text-xs break-all">{ref}</code>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// MM-831: one compact Step Execution row inside the expanded history. Surfaces
+// the full enumerated evidence field set (lineage, reason, source attempt,
+// runtime child refs, context bundle ref, workspace policy, git disposition,
+// gate verdict, output/diagnostic/diff refs, side effects, terminal
+// disposition, downstream invalidation) as refs and typed diagnostics only.
+function StepExecutionHistoryRow({
+  execution,
+}: {
+  execution: z.infer<typeof StepExecutionProjectionSchema>;
+}) {
+  const contextBundleRef = execution.stepEvidence?.contextBundleRef?.artifactRef ?? null;
+  const gateVerdict =
+    execution.qualityGateVerdict ?? execution.stepEvidence?.gateSummary?.verdict ?? null;
+  const diagnosticRefs = (execution.stepEvidence?.diagnosticRefs ?? []).filter(
+    (item) => item.diagnosticsRef,
+  );
+  const sideEffect = execution.stepEvidence?.sideEffectSummary ?? null;
+  const sideEffectRefs = stepRefEntries(sideEffect?.artifactRefs);
+  const outputRefs = stepRefEntries(execution.outputRefs);
+  const runtimeChildRefs = stepRefEntries(execution.runtimeChildRefs);
+  const downstreamInvalidated = execution.reason === 'dependency_invalidated';
+  const lineage = execution.lineage ?? null;
+
+  return (
+    <li className="step-execution-history-item">
+      <div className="step-execution-history-head">
+        <span className="step-execution-pill">Execution {execution.executionOrdinal}</span>
+        <span {...executionStatusPillProps(execution.status)}>
+          {formatStatusLabel(execution.status)}
+        </span>
+        <span className="step-execution-reason">{formatStatusLabel(execution.reason)}</span>
+        {downstreamInvalidated ? (
+          <span
+            className="step-invalidation-marker"
+            title="This step re-ran because a changed upstream output invalidated it."
+          >
+            Downstream invalidation
+          </span>
+        ) : null}
+      </div>
+      <dl className="step-execution-history-facts">
+        {execution.sourceExecutionOrdinal ? (
+          <div className="step-execution-fact">
+            <dt>Source attempt</dt>
+            <dd>Execution {execution.sourceExecutionOrdinal}</dd>
+          </div>
+        ) : null}
+        {lineage ? (
+          <div className="step-execution-fact">
+            <dt>Lineage</dt>
+            <dd>
+              <code className="text-xs break-all">{lineage.sourceWorkflowId}</code> run{' '}
+              <code className="text-xs break-all">{lineage.sourceRunId}</code>{' '}
+              {lineage.sourceLogicalStepId} execution {lineage.sourceExecutionOrdinal}
+              {lineage.relationship ? ` (${formatStatusLabel(lineage.relationship)})` : ''}
+            </dd>
+          </div>
+        ) : null}
+        {execution.terminalDisposition ? (
+          <div className="step-execution-fact">
+            <dt>Terminal disposition</dt>
+            <dd>{formatStatusLabel(execution.terminalDisposition)}</dd>
+          </div>
+        ) : null}
+        {execution.workspacePolicy ? (
+          <div className="step-execution-fact">
+            <dt>Workspace policy</dt>
+            <dd>{formatStatusLabel(execution.workspacePolicy)}</dd>
+          </div>
+        ) : null}
+        {execution.gitDisposition ? (
+          <div className="step-execution-fact">
+            <dt>Git disposition</dt>
+            <dd>{formatStatusLabel(execution.gitDisposition)}</dd>
+          </div>
+        ) : null}
+        {gateVerdict ? (
+          <div className="step-execution-fact">
+            <dt>Gate verdict</dt>
+            <dd>{formatStatusLabel(gateVerdict)}</dd>
+          </div>
+        ) : null}
+        {contextBundleRef ? (
+          <div className="step-execution-fact">
+            <dt>Context bundle</dt>
+            <dd>
+              <code className="text-xs break-all">{contextBundleRef}</code>
+            </dd>
+          </div>
+        ) : null}
+        {runtimeChildRefs.length > 0 ? (
+          <div className="step-execution-fact">
+            <dt>Runtime child refs</dt>
+            <dd>
+              <StepExecutionRefList entries={runtimeChildRefs} />
+            </dd>
+          </div>
+        ) : null}
+        {outputRefs.length > 0 ? (
+          <div className="step-execution-fact">
+            <dt>Output &amp; diff refs</dt>
+            <dd>
+              <StepExecutionRefList entries={outputRefs} />
+            </dd>
+          </div>
+        ) : null}
+        {diagnosticRefs.length > 0 ? (
+          <div className="step-execution-fact">
+            <dt>Diagnostics refs</dt>
+            <dd>
+              <StepExecutionRefList
+                entries={diagnosticRefs.map((item) => [item.kind, item.diagnosticsRef as string])}
+              />
+            </dd>
+          </div>
+        ) : null}
+        {sideEffect ? (
+          <div className="step-execution-fact">
+            <dt>Side effects</dt>
+            <dd>
+              {formatStatusLabel(sideEffect.status || 'skipped')}
+              {sideEffectRefs.length > 0 ? (
+                <>
+                  {' '}
+                  <StepExecutionRefList entries={sideEffectRefs} />
+                </>
+              ) : null}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+      {execution.summary ? <p className="small">{execution.summary}</p> : null}
+    </li>
+  );
+}
+
+// MM-831: expanded Step Execution history. Consumes the step-executions LIST
+// endpoint (keyed by execution_ordinal) and renders newest-first compact rows.
+function StepExecutionHistory({
+  apiBase,
+  workflowId,
+  logicalStepId,
+  sourceTemporal,
+  enabled,
+  pollInterval,
+}: {
+  apiBase: string;
+  workflowId: string;
+  logicalStepId: string;
+  sourceTemporal: boolean;
+  enabled: boolean;
+  pollInterval: number | false;
+}) {
+  const historyQuery = useQuery({
+    queryKey: ['workflow-detail-step-executions', workflowId, logicalStepId, sourceTemporal],
+    queryFn: async () => {
+      const suffix = sourceTemporal ? '?source=temporal' : '';
+      const response = await fetch(
+        `${apiBase}/executions/${encodeURIComponent(workflowId)}/steps/${encodeURIComponent(
+          logicalStepId,
+        )}/step-executions${suffix}`,
+        { credentials: 'include' },
+      );
+      if (!response.ok) {
+        const statusText = response.statusText.trim();
+        const detail = statusText ? ` ${statusText}` : '';
+        throw new Error(`Step executions: ${response.status}${detail}`);
+      }
+      return StepExecutionListSchema.parse(await response.json());
+    },
+    enabled: enabled && Boolean(workflowId) && Boolean(logicalStepId),
+    refetchInterval: enabled ? pollInterval : false,
+  });
+
+  if (!enabled) return null;
+
+  const executions = historyQuery.data?.stepExecutions ?? [];
+  const ordered = [...executions].sort((a, b) => b.executionOrdinal - a.executionOrdinal);
+
+  return (
+    <section className="step-tl-detail-section">
+      <h4>Step Execution history</h4>
+      {historyQuery.isLoading ? (
+        <p className="small">Loading step executions…</p>
+      ) : historyQuery.isError ? (
+        <p className="small step-tl-error">{(historyQuery.error as Error).message}</p>
+      ) : ordered.length > 0 ? (
+        <>
+          <p className="small step-execution-history-count">
+            {ordered.length} step execution{ordered.length === 1 ? '' : 's'}
+          </p>
+          <ol className="step-execution-history" aria-label="Step Execution history">
+            {ordered.map((execution) => (
+              <StepExecutionHistoryRow key={execution.stepExecutionId} execution={execution} />
+            ))}
+          </ol>
+        </>
+      ) : (
+        <p className="small">No step executions recorded for this step yet.</p>
+      )}
+    </section>
+  );
+}
+
 function StepLedgerRowCard({
   apiBase,
   logStreamingEnabled,
   sessionTimelineEnabled,
   structuredHistoryEnabled,
   row,
+  workflowId,
   runId,
+  sourceTemporal,
+  historyPollInterval,
   expanded,
   onToggle,
   isLast,
@@ -2758,7 +3086,10 @@ function StepLedgerRowCard({
   sessionTimelineEnabled: boolean;
   structuredHistoryEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
+  workflowId: string;
   runId: string;
+  sourceTemporal: boolean;
+  historyPollInterval: number | false;
   expanded: boolean;
   onToggle: () => void;
   isLast: boolean;
@@ -2849,6 +3180,14 @@ function StepLedgerRowCard({
               <h4>Artifacts</h4>
               <StepArtifactsList artifacts={row.artifacts} />
             </section>
+            <StepExecutionHistory
+              apiBase={apiBase}
+              workflowId={workflowId}
+              logicalStepId={row.logicalStepId}
+              sourceTemporal={sourceTemporal}
+              enabled={expanded}
+              pollInterval={historyPollInterval}
+            />
             <StepWorkloadDetails workload={row.workload} />
             <section className="step-tl-detail-section">
               <h4>Metadata</h4>
@@ -5668,7 +6007,10 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                         sessionTimelineEnabled={sessionTimelineEnabled}
                         structuredHistoryEnabled={structuredHistoryEnabled}
                         row={row}
+                        workflowId={workflowId}
                         runId={latestRunId}
+                        sourceTemporal={sourceTemporal}
+                        historyPollInterval={liveUpdates && !isTerminalExecution ? detailPoll : false}
                         expanded={Boolean(expandedSteps[row.logicalStepId])}
                         onToggle={() => toggleStep(row.logicalStepId)}
                         isLast={idx === stepsQuery.data.steps.length - 1}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3320,6 +3320,107 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   gap: 0.4rem;
 }
 
+/* MM-831: expanded Step Execution history surface */
+.step-execution-history-count {
+  margin: 0 0 0.4rem;
+  color: rgb(var(--mm-muted));
+}
+
+.step-execution-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.step-execution-history-item {
+  border: 1px solid rgb(var(--mm-border) / 0.4);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  background: rgb(var(--mm-panel) / 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.step-execution-history-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.step-execution-reason {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgb(var(--mm-muted));
+}
+
+/* MM-831: downstream invalidation marker for dependency-invalidated executions */
+.step-invalidation-marker {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.12rem 0.48rem;
+  border: 1px solid rgb(var(--mm-warn) / 0.5);
+  background: rgb(var(--mm-warn) / 0.14);
+  color: rgb(var(--mm-warn));
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.step-execution-history-facts {
+  margin: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.step-execution-fact {
+  display: grid;
+  grid-template-columns: minmax(8.5rem, max-content) 1fr;
+  gap: 0.25rem 0.6rem;
+  align-items: baseline;
+}
+
+.step-execution-fact dt {
+  margin: 0;
+  font-size: 0.66rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgb(var(--mm-muted));
+}
+
+.step-execution-fact dd {
+  margin: 0;
+  font-size: 0.72rem;
+  color: rgb(var(--mm-ink) / 0.82);
+  min-width: 0;
+}
+
+.step-execution-ref-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.55rem;
+}
+
+.step-execution-ref {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  max-width: 100%;
+}
+
+@media (max-width: 640px) {
+  .step-execution-fact {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
+  }
+}
+
 /* Section header for steps */
 .step-tl-section-header {
   display: flex;


### PR DESCRIPTION
## Jira issue

[MM-831](https://moonladder.atlassian.net/browse/MM-831) — Complete remaining behavior for Expose Step Execution evidence in API and Mission Control

## Summary

The API/backend half of MM-831, the default workflow detail surface, recovery actions, and the `step-executions` route vocabulary were already met. The remaining bounded backlog (assessment verdict `PARTIALLY_IMPLEMENTED`) was the **AC2 expanded Step Execution history UI** plus surfacing **downstream invalidation status** in compact rows. This change closes that gap (frontend-only):

- Adds a `StepExecutionHistory` component to `frontend/src/entrypoints/workflow-detail.tsx` that consumes the `GET /{workflow_id}/steps/{logical_step_id}/step-executions` LIST endpoint (keyed by `execution_ordinal`) in the expanded ledger row.
- Renders the full enumerated AC2 evidence field set per execution — execution ordinal, lineage, reason, source attempt, runtime child refs, context bundle ref, workspace policy, git disposition, gate verdict, output/diff refs, diagnostics refs, side effects, terminal disposition — newest-first, as **refs and typed diagnostics only (no raw artifact bodies)**.
- Surfaces a **Downstream invalidation** marker on executions whose `reason` is `dependency_invalidated`.
- Adds ref-only Zod projections mirroring the API camelCase models in `moonmind/schemas/temporal_models.py`, and Mission Control styles consistent with existing `step-tl` conventions.

Files changed: `frontend/src/entrypoints/workflow-detail.tsx`, `frontend/src/entrypoints/workflow-detail.test.tsx`, `frontend/src/styles/mission-control.css` (667 insertions).

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` → **121 passed (1 file)**, including the new `MM-831 renders expanded Step Execution history` test asserting lineage, source attempt, terminal disposition, workspace policy, git disposition, gate verdict, context bundle, runtime child refs, diagnostics refs, side effects, downstream invalidation, ref-only values, and newest-first ordering.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist -- tests/unit/api/routers/test_executions.py -k step_execution` → **10 passed, 1 failed (environmental), 284 deselected**.
- Frontend typecheck: `tsc --noEmit -p frontend/tsconfig.json` → **EXIT=0, no type errors**.

## Remaining risks

- One backend test (`test_describe_execution_surfaces_failed_step_execution_recovery_phase`) fails with a `PermissionError` from a cross-run sandbox file-permission collision (the shared-container `ManagedRunStore` globs root-owned `*.json` from sibling runs). This is **unrelated** to this branch — the diff is frontend-only and that test is unchanged here (last modified in PR #2531).
- This change is UI-only; it depends on the already-merged backend `step-executions` list/detail endpoints. The frontend Zod projections were verified to match the backend Pydantic camelCase aliases exactly, so a future backend alias rename would require a matching frontend update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-831]: https://moonladder.atlassian.net/browse/MM-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ