### PR TITLE
Fix deployment updates for one-shot init-db service

### DIFF
--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -43,6 +43,20 @@ _SENSITIVE_VALUE_PATTERN = re.compile(
     r"(?:token|password|passwd|secret)=[^ \t\n\r,;&\"']+)",
     re.IGNORECASE,
 )
+_COMPOSE_OPTION_FLAGS_WITH_VALUES = frozenset(
+    {
+        "--env-file",
+        "--exit-code-from",
+        "--file",
+        "--format",
+        "--policy",
+        "--project-directory",
+        "--project-name",
+        "--wait-timeout",
+        "-f",
+        "-p",
+    }
+)
 
 
 class DesiredStateStore(Protocol):
@@ -1236,6 +1250,7 @@ class DeploymentUpdateExecutor:
                             _compose_up_args_for_services(
                                 command_plan.up_args,
                                 (service,),
+                                one_shot_service=service,
                             )
                         ),
                     }
@@ -1644,16 +1659,42 @@ def _command_plan_without_services(
 def _compose_up_args_for_services(
     up_args: Sequence[str],
     services: Sequence[str],
+    *,
+    one_shot_service: str | None = None,
 ) -> tuple[str, ...]:
-    target_services = {
-        service.lower() for service in _compose_up_target_services(up_args)
-    }
-    without_targets = tuple(
-        part
-        for part in up_args
-        if str(part).strip().lower() not in target_services
+    prefix, _target_services = _split_trailing_service_args(up_args)
+    requested_services = tuple(str(service) for service in services)
+    if one_shot_service is None:
+        return (*prefix, *requested_services)
+    return _compose_one_shot_up_args(
+        prefix,
+        one_shot_service=str(one_shot_service),
     )
-    return (*without_targets, *tuple(str(service) for service in services))
+
+
+def _compose_one_shot_up_args(
+    up_prefix_args: Sequence[str],
+    *,
+    one_shot_service: str,
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    skip_next = False
+    for raw_part in up_prefix_args:
+        part = str(raw_part)
+        if skip_next:
+            skip_next = False
+            continue
+        if part in {"-d", "--detach", "--wait"}:
+            continue
+        if part == "--wait-timeout":
+            skip_next = True
+            continue
+        if part.startswith("--wait-timeout="):
+            continue
+        parts.append(part)
+    if parts and parts[-1] == "--":
+        parts.pop()
+    return (*parts, "--exit-code-from", one_shot_service, one_shot_service)
 
 
 def _remove_services_from_command_args(
@@ -1663,11 +1704,36 @@ def _remove_services_from_command_args(
 ) -> tuple[str, ...]:
     if not excluded_services:
         return tuple(args)
-    return tuple(
-        str(part)
-        for part in args
-        if str(part).strip().lower() not in excluded_services
+    prefix, trailing_services = _split_trailing_service_args(args)
+    return (
+        *prefix,
+        *(
+            service
+            for service in trailing_services
+            if service.strip().lower() not in excluded_services
+        ),
     )
+
+
+def _split_trailing_service_args(
+    args: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    parts = tuple(str(part) for part in args)
+    if len(parts) <= 3:
+        return parts, ()
+    index = 3
+    while index < len(parts):
+        part = parts[index]
+        if part == "--":
+            return parts[: index + 1], parts[index + 1 :]
+        if part.startswith("-"):
+            option_name = part.split("=", 1)[0]
+            index += 1
+            if option_name in _COMPOSE_OPTION_FLAGS_WITH_VALUES and "=" not in part:
+                index += 1
+            continue
+        return parts[:index], parts[index:]
+    return parts, ()
 
 
 def _target_service_names_from_state(

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -26,6 +26,7 @@ DEPLOYMENT_RUNNER_MODES = frozenset(
 DEPLOYMENT_UPDATE_MODES = frozenset({"changed_services", "force_recreate"})
 DEPLOYMENT_UPDATE_STACKS = frozenset({"moonmind"})
 DEPLOYMENT_FINAL_STATUSES = frozenset({"SUCCEEDED", "FAILED", "PARTIALLY_VERIFIED"})
+DEPLOYMENT_ONE_SHOT_SERVICES = frozenset({"init-db"})
 FILE_LOCK_STALE_AFTER_SECONDS = 6 * 60 * 60
 _REDACTED = "[REDACTED]"
 _STACK_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -1169,6 +1170,7 @@ class DeploymentUpdateExecutor:
         command_log: dict[str, Any] = {
             "runnerMode": command_plan.runner_mode,
             "pull": {"command": list(command_plan.pull_args)},
+            "oneShot": [],
             "up": {"command": list(command_plan.up_args)},
         }
 
@@ -1220,8 +1222,25 @@ class DeploymentUpdateExecutor:
                     requested_repository=str(parsed["image"]["repository"]),
                     excluded_services=self.excluded_services,
                 )
+                one_shot_services = _one_shot_services_from_plan(command_plan)
+                service_command_plan = _command_plan_without_services(
+                    command_plan,
+                    excluded_services=one_shot_services,
+                )
                 command_log["pull"]["command"] = list(command_plan.pull_args)
-                command_log["up"]["command"] = list(command_plan.up_args)
+                command_log["up"]["command"] = list(service_command_plan.up_args)
+                command_log["oneShot"] = [
+                    {
+                        "service": service,
+                        "command": list(
+                            _compose_up_args_for_services(
+                                command_plan.up_args,
+                                (service,),
+                            )
+                        ),
+                    }
+                    for service in one_shot_services
+                ]
                 before_ref = await write_evidence("before-state", before_state)
 
                 _add_progress(
@@ -1243,7 +1262,7 @@ class DeploymentUpdateExecutor:
                         target_image=target_image,
                     )
                 _ensure_runner_survives_update(
-                    command_plan=command_plan,
+                    command_plan=service_command_plan,
                     before_state=before_state,
                     target_image=target_image,
                 )
@@ -1265,6 +1284,25 @@ class DeploymentUpdateExecutor:
                 }
                 await self.desired_state_store.persist(desired_payload)
 
+                if one_shot_services:
+                    _add_progress(
+                        progress_events,
+                        "RUNNING_ONE_SHOT_SERVICES",
+                        "Running one-shot deployment services.",
+                    )
+                for one_shot_entry in command_log["oneShot"]:
+                    service_name = str(one_shot_entry["service"])
+                    one_shot_result = await self.runner.up(
+                        stack=parsed["stack"],
+                        command=tuple(one_shot_entry["command"]),
+                        requested_image=requested_image,
+                    )
+                    one_shot_entry["result"] = one_shot_result
+                    _ensure_command_succeeded(
+                        f"one-shot service {service_name}",
+                        one_shot_result,
+                    )
+
                 _add_progress(
                     progress_events,
                     "RECREATING_SERVICES",
@@ -1272,7 +1310,7 @@ class DeploymentUpdateExecutor:
                 )
                 up_result = await self.runner.up(
                     stack=parsed["stack"],
-                    command=command_plan.up_args,
+                    command=service_command_plan.up_args,
                     requested_image=requested_image,
                 )
                 command_log["up"]["result"] = up_result
@@ -1549,6 +1587,86 @@ def _command_plan_targeting_services(
         runner_mode=command_plan.runner_mode,
         pull_args=(*command_plan.pull_args, *services),
         up_args=(*command_plan.up_args, "--no-deps", *services),
+    )
+
+
+def _one_shot_services_from_plan(command_plan: ComposeCommandPlan) -> tuple[str, ...]:
+    one_shot_services = {
+        service.lower() for service in DEPLOYMENT_ONE_SHOT_SERVICES
+    }
+    return tuple(
+        service
+        for service in _compose_up_target_services(command_plan.up_args)
+        if service.lower() in one_shot_services
+    )
+
+
+def _command_plan_without_services(
+    command_plan: ComposeCommandPlan,
+    *,
+    excluded_services: Sequence[str],
+) -> ComposeCommandPlan:
+    excluded = _normalized_service_names(excluded_services)
+    if not excluded:
+        return command_plan
+    target_services = _compose_up_target_services(command_plan.up_args)
+    remaining_targets = tuple(
+        service
+        for service in target_services
+        if service.lower() not in excluded
+    )
+    if target_services and not remaining_targets:
+        raise ToolFailure(
+            error_code="DEPLOYMENT_RUNNER_UNSAFE",
+            message=(
+                "Deployment update has no long-running target services after "
+                "separating one-shot services."
+            ),
+            retryable=False,
+            details={
+                "excludedServices": sorted(excluded),
+                "failureClass": "runner_self_recreation_unsafe",
+            },
+        )
+    return ComposeCommandPlan(
+        runner_mode=command_plan.runner_mode,
+        pull_args=_remove_services_from_command_args(
+            command_plan.pull_args,
+            excluded_services=excluded,
+        ),
+        up_args=_remove_services_from_command_args(
+            command_plan.up_args,
+            excluded_services=excluded,
+        ),
+    )
+
+
+def _compose_up_args_for_services(
+    up_args: Sequence[str],
+    services: Sequence[str],
+) -> tuple[str, ...]:
+    target_services = {
+        service.lower() for service in _compose_up_target_services(up_args)
+    }
+    without_targets = tuple(
+        part
+        for part in up_args
+        if str(part).strip().lower() not in target_services
+    )
+    return (*without_targets, *tuple(str(service) for service in services))
+
+
+def _remove_services_from_command_args(
+    args: Sequence[str],
+    *,
+    excluded_services: set[str],
+) -> tuple[str, ...]:
+    if not excluded_services:
+        return tuple(args)
+    return tuple(
+        str(part)
+        for part in args
+        if str(part).strip().lower() not in excluded_services
     )
 
 
@@ -2159,6 +2277,8 @@ def _command_failure_class(phase: str) -> str:
         return "image_pull_failure"
     if phase == "up":
         return "service_recreation_failure"
+    if phase.startswith("one-shot service "):
+        return "one_shot_service_failure"
     return "compose_config_validation_failure"
 
 

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -20,10 +20,12 @@ from moonmind.workflows.skills.deployment_execution import (
     InMemoryDesiredStateStore,
     TemporalDeploymentEvidenceWriter,
     _command_plan_targeting_services,
+    _compose_up_args_for_services,
     _ensure_command_succeeded,
     _ensure_runner_survives_update,
     _is_host_absolute_path,
     _remap_host_compose_path,
+    _remove_services_from_command_args,
     _service_is_excluded,
     _service_name_matches,
     _tail_text,
@@ -876,6 +878,10 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
     assert "postgres" not in up_command
     assert "docker-proxy" not in up_command
     assert "temporal" not in up_command
+    assert "-d" not in one_shot_command
+    assert "--wait" not in one_shot_command
+    assert "--exit-code-from" in one_shot_command
+    assert one_shot_command[-2:] == ("init-db", "init-db")
     command_payload = next(
         payload for kind, payload in evidence.records if kind == "command-log"
     )
@@ -986,6 +992,90 @@ def test_runner_guard_blocks_when_no_specific_services_targeted(monkeypatch) -> 
         _ensure_runner_survives_update(command_plan=plan, before_state=before_state)
 
     assert exc_info.value.error_code == "DEPLOYMENT_RUNNER_UNSAFE"
+
+
+def test_compose_up_args_for_services_only_removes_trailing_service_args() -> None:
+    args = (
+        "docker",
+        "compose",
+        "up",
+        "-d",
+        "--wait",
+        "--no-deps",
+        "up",
+        "init-db",
+    )
+
+    rewritten = _compose_up_args_for_services(args, ("api",))
+
+    assert rewritten == (
+        "docker",
+        "compose",
+        "up",
+        "-d",
+        "--wait",
+        "--no-deps",
+        "api",
+    )
+
+
+def test_one_shot_up_args_wait_on_exit_code_without_detached_wait() -> None:
+    args = (
+        "docker",
+        "compose",
+        "up",
+        "-d",
+        "--remove-orphans",
+        "--wait",
+        "--no-deps",
+        "api",
+        "init-db",
+    )
+
+    rewritten = _compose_up_args_for_services(
+        args,
+        ("init-db",),
+        one_shot_service="init-db",
+    )
+
+    assert rewritten == (
+        "docker",
+        "compose",
+        "up",
+        "--remove-orphans",
+        "--no-deps",
+        "--exit-code-from",
+        "init-db",
+        "init-db",
+    )
+
+
+def test_remove_services_from_command_args_preserves_option_values() -> None:
+    args = (
+        "docker",
+        "compose",
+        "pull",
+        "--policy",
+        "always",
+        "--ignore-buildable",
+        "api",
+        "init-db",
+    )
+
+    rewritten = _remove_services_from_command_args(
+        args,
+        excluded_services={"always", "init-db"},
+    )
+
+    assert rewritten == (
+        "docker",
+        "compose",
+        "pull",
+        "--policy",
+        "always",
+        "--ignore-buildable",
+        "api",
+    )
 
 
 def test_targeted_update_plan_skips_compose_dependencies() -> None:

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -850,7 +850,7 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
     monkeypatch.setenv("HOSTNAME", "deploy123")
     events: list[str] = []
     runner = DeploymentControlRunner(events)
-    executor, store, _evidence, _runner, _events = _executor(
+    executor, store, evidence, _runner, _events = _executor(
         runner=runner,
         events=events,
         excluded_services=("temporal-worker-deployment-control",),
@@ -861,23 +861,26 @@ async def test_deployment_control_runner_targets_services_except_itself(monkeypa
     assert result.status == "COMPLETED"
     assert len(store.records) == 1
     pull_command = runner.commands[0][1]
-    up_command = runner.commands[1][1]
+    one_shot_command = runner.commands[1][1]
+    up_command = runner.commands[2][1]
     assert pull_command[-4:] == (
         "temporal-worker-agent-runtime",
         "init-db",
         "api",
         "new-worker",
     )
-    assert up_command[-4:] == (
-        "temporal-worker-agent-runtime",
-        "init-db",
-        "api",
-        "new-worker",
-    )
+    assert one_shot_command[-1:] == ("init-db",)
+    assert up_command[-3:] == ("temporal-worker-agent-runtime", "api", "new-worker")
     assert "temporal-worker-deployment-control" not in up_command
+    assert "init-db" not in up_command
     assert "postgres" not in up_command
     assert "docker-proxy" not in up_command
     assert "temporal" not in up_command
+    command_payload = next(
+        payload for kind, payload in evidence.records if kind == "command-log"
+    )
+    assert command_payload["oneShot"][0]["service"] == "init-db"
+    assert command_payload["oneShot"][0]["result"]["exitCode"] == 0
 
 
 @pytest.mark.asyncio
@@ -1124,6 +1127,14 @@ def test_compose_config_validation_failure_has_normalized_class() -> None:
 
     assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
     assert exc_info.value.details["failureClass"] == "compose_config_validation_failure"
+
+
+def test_one_shot_service_failure_has_normalized_class() -> None:
+    with pytest.raises(ToolFailure) as exc_info:
+        _ensure_command_succeeded("one-shot service init-db", {"exitCode": 2})
+
+    assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert exc_info.value.details["failureClass"] == "one_shot_service_failure"
 
 
 def test_tail_text_returns_empty_for_non_positive_limit() -> None:


### PR DESCRIPTION
## Summary
- split init-db out as a one-shot deployment service before recreating long-running services
- keep init-db evidence in command logs while excluding it from the main up --wait group
- classify one-shot service failures separately

## Verification
- pytest tests/unit/workflows/skills/test_deployment_update_execution.py -q
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh