### PR TITLE
MM-854 harden proposal generation input references

### DIFF
--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -268,7 +268,7 @@ All items shipped: per-step runtime/model/effort selection, cost tracking and bi
 - Bounded-evidence remediation context — remediation reads a target run's durable evidence under redaction.
 - Canonical remediation submissions via `execution_remediation_links`.
 - Remediation lifecycle repair prevention — locks/ledger prevent duplicate or conflicting repairs.
-- Durable step ledger and checkpoints — step state, attempts, evidence refs, and latest-attempt evidence refs surfaced in the default ledger row.
+- Durable step ledger & checkpoints — step state, attempts, evidence refs, and latest-attempt evidence refs surfaced in the default ledger row.
 - Resume foundations — distinct full-retry vs recovery actions, checkpoint-evidence gating, editable full retry, and resume-from-last-failed-step.
 - Step Execution evidence manifests and checkpoint contracts are documented as the canonical substrate for semantic re-execution, checkpointed side effects, gated iteration, failed-step recovery, and autonomous story loops.
 - Step Execution history is now visible in expanded Mission Control step rows (MM-831 / PR #2541).

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1915,6 +1915,203 @@ class MoonMindRunWorkflow:
                 outputs[target_key] = value.strip()
         return outputs
 
+    def _proposal_step_output_refs(
+        self,
+        logical_step_id: str,
+    ) -> dict[str, Any]:
+        row = self._step_ledger_row_for(logical_step_id)
+        if not isinstance(row, Mapping):
+            return {}
+        artifacts = row.get("artifacts")
+        if not isinstance(artifacts, Mapping):
+            return {}
+        outputs = self._step_execution_compact_output_refs(logical_step_id)
+        for source_key, target_key in (
+            ("runtimeDiagnostics", "diagnosticsRef"),
+            ("providerSnapshot", "providerSnapshotRef"),
+            ("stepExecutionManifestRef", "stepExecutionManifestRef"),
+        ):
+            value = artifacts.get(source_key)
+            if isinstance(value, str) and value.strip():
+                outputs[target_key] = value.strip()
+        refs = row.get("refs")
+        if isinstance(refs, Mapping):
+            manifest_refs = refs.get("stepExecutionManifestRefs")
+            if isinstance(manifest_refs, Sequence) and not isinstance(
+                manifest_refs, (str, bytes)
+            ):
+                compact_manifest_refs = [
+                    item.strip()
+                    for item in manifest_refs
+                    if isinstance(item, str) and item.strip()
+                ]
+                if compact_manifest_refs:
+                    outputs["stepExecutionManifestRefs"] = compact_manifest_refs
+        return outputs
+
+    def _proposal_generation_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Return redacted compact metadata for proposal generation activities."""
+
+        task_node = parameters.get("workflow")
+        if not isinstance(task_node, Mapping):
+            task_node = parameters.get("task")
+        task = task_node if isinstance(task_node, Mapping) else {}
+
+        compact_task: dict[str, Any] = {}
+        for key in (
+            "proposalTitle",
+            "proposalIdea",
+            "suggestedTitle",
+            "titleSuggestion",
+            "recommendedNextAction",
+            "nextAction",
+            "nextStep",
+            "next_step",
+        ):
+            value = self._coerce_text(task.get(key), max_chars=500)
+            if value:
+                compact_task[key] = self._sanitize_operator_summary(value) or value
+
+        compact_sections = {
+            "runtime": (
+                "mode",
+                "model",
+                "effort",
+                "profileId",
+                "providerProfile",
+                "executionProfileRef",
+            ),
+            "git": ("branch", "startingBranch", "targetBranch", "baseBranch"),
+            "publish": ("mode", "enabled", "strategy"),
+        }
+        for key, allowed_keys in compact_sections.items():
+            value = self._proposal_compact_mapping(
+                task.get(key),
+                allowed_keys=allowed_keys,
+                max_chars=200,
+            )
+            if value:
+                compact_task[key] = value
+        for key in ("skill", "tool", "skills"):
+            value = self._proposal_compact_selector_metadata(task.get(key))
+            if value:
+                compact_task[key] = value
+
+        authored_presets = task.get("authoredPresets")
+        if isinstance(authored_presets, Sequence) and not isinstance(
+            authored_presets, (str, bytes)
+        ):
+            compact_presets: list[dict[str, Any]] = []
+            for index, preset in enumerate(authored_presets[:5]):
+                if not isinstance(preset, Mapping):
+                    continue
+                compact_preset: dict[str, Any] = {}
+                for key in ("id", "name", "version", "source", "presetId"):
+                    value = self._coerce_text(preset.get(key), max_chars=160)
+                    if value:
+                        compact_preset[key] = value
+                source_ref = self._coerce_text(
+                    preset.get("sourceRef") or preset.get("artifactRef"),
+                    max_chars=400,
+                )
+                if source_ref:
+                    compact_preset["sourceRef"] = source_ref
+                if compact_preset:
+                    compact_preset["index"] = index
+                    compact_presets.append(compact_preset)
+            if compact_presets:
+                compact_task["authoredPresets"] = compact_presets
+
+        return {"workflow": compact_task} if compact_task else {}
+
+    def _proposal_compact_mapping(
+        self,
+        value: object,
+        *,
+        allowed_keys: Sequence[str],
+        max_chars: int,
+    ) -> dict[str, Any]:
+        if not isinstance(value, Mapping):
+            return {}
+        compact: dict[str, Any] = {}
+        for key in allowed_keys:
+            item = value.get(key)
+            if isinstance(item, bool):
+                compact[key] = item
+                continue
+            text = self._coerce_text(item, max_chars=max_chars)
+            if text:
+                compact[key] = text
+        return compact
+
+    def _proposal_compact_selector_metadata(self, value: object) -> dict[str, Any]:
+        if not isinstance(value, Mapping):
+            return {}
+        compact: dict[str, Any] = {}
+        for key in ("id", "name", "version", "source", "mode"):
+            text = self._coerce_text(value.get(key), max_chars=160)
+            if text:
+                compact[key] = text
+        for key in ("include", "exclude", "sets"):
+            items = value.get(key)
+            if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+                continue
+            compact_items: list[Any] = []
+            for item in items[:20]:
+                if isinstance(item, str):
+                    text = self._coerce_text(item, max_chars=160)
+                    if text:
+                        compact_items.append(text)
+                    continue
+                if not isinstance(item, Mapping):
+                    continue
+                compact_item: dict[str, Any] = {}
+                for item_key in ("id", "name", "version", "source"):
+                    text = self._coerce_text(item.get(item_key), max_chars=160)
+                    if text:
+                        compact_item[item_key] = text
+                if compact_item:
+                    compact_items.append(compact_item)
+            if compact_items:
+                compact[key] = compact_items
+        resolved_ref = self._coerce_text(
+            value.get("resolvedSkillsetRef")
+            or value.get("resolved_skillset_ref")
+            or value.get("manifestRef")
+            or value.get("manifest_ref"),
+            max_chars=400,
+        )
+        if resolved_ref:
+            compact["resolvedSkillsetRef"] = resolved_ref
+        return compact
+
+    def _proposal_generation_evidence_refs(self) -> dict[str, Any]:
+        refs: dict[str, Any] = {
+            "inputRef": self._input_ref,
+            "planRef": self._plan_ref,
+            "logsRef": self._logs_ref,
+            "summaryRef": self._summary_ref,
+            "finishSummaryRef": self._report_ref,
+            "runSummaryPath": "reports/run_summary.json",
+        }
+        if self._last_diagnostics_ref:
+            refs["diagnosticsRef"] = self._last_diagnostics_ref
+        if self._last_step_id:
+            step_refs = self._proposal_step_output_refs(self._last_step_id)
+            if step_refs:
+                refs["lastStep"] = {
+                    "id": self._last_step_id,
+                    "outputRefs": step_refs,
+                }
+        return {
+            key: value
+            for key, value in refs.items()
+            if value is not None and value != {}
+        }
+
     def _step_execution_side_effects(
         self,
         logical_step_id: str,
@@ -11255,7 +11452,8 @@ class MoonMindRunWorkflow:
                 "workflow_id": workflow.info().workflow_id,
                 "run_id": workflow.info().run_id,
                 "repo": self._repo,
-                "parameters": parameters,
+                "parameters": self._proposal_generation_parameters(parameters),
+                "evidenceRefs": self._proposal_generation_evidence_refs(),
                 "observability": {
                     "operatorSummary": self._operator_summary,
                     "lastStep": {

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2000,6 +2000,10 @@ class MoonMindRunWorkflow:
             if value:
                 compact_task[key] = value
 
+        compact_steps = self._proposal_compact_steps(task.get("steps"))
+        if compact_steps:
+            compact_task["steps"] = compact_steps
+
         authored_presets = task.get("authoredPresets")
         if isinstance(authored_presets, Sequence) and not isinstance(
             authored_presets, (str, bytes)
@@ -2039,12 +2043,64 @@ class MoonMindRunWorkflow:
         compact: dict[str, Any] = {}
         for key in allowed_keys:
             item = value.get(key)
-            if isinstance(item, bool):
+            if isinstance(item, (bool, int, float)):
                 compact[key] = item
                 continue
             text = self._coerce_text(item, max_chars=max_chars)
             if text:
                 compact[key] = text
+        return compact
+
+    def _proposal_compact_steps(self, value: object) -> list[dict[str, Any]]:
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+            return []
+        compact_steps: list[dict[str, Any]] = []
+        for step in value[:50]:
+            if not isinstance(step, Mapping):
+                continue
+            compact_step: dict[str, Any] = {}
+            for key in ("id", "title", "type"):
+                text = self._coerce_text(step.get(key), max_chars=160)
+                if text:
+                    compact_step[key] = text
+            for key in ("tool", "skill", "skills"):
+                selector = self._proposal_compact_selector_metadata(step.get(key))
+                if selector:
+                    compact_step[key] = selector
+            source = self._proposal_compact_source_metadata(step.get("source"))
+            if source:
+                compact_step["source"] = source
+            if any(
+                key in compact_step for key in ("tool", "skill", "skills", "source")
+            ):
+                compact_steps.append(compact_step)
+        return compact_steps
+
+    def _proposal_compact_source_metadata(self, value: object) -> dict[str, Any]:
+        if not isinstance(value, Mapping):
+            return {}
+        compact: dict[str, Any] = {}
+        for key in (
+            "kind",
+            "presetId",
+            "presetSlug",
+            "presetVersion",
+            "originalStepId",
+        ):
+            text = self._coerce_text(value.get(key), max_chars=160)
+            if text:
+                compact[key] = text
+        include_path = value.get("includePath")
+        if isinstance(include_path, Sequence) and not isinstance(
+            include_path, (str, bytes)
+        ):
+            compact_include_path = [
+                text
+                for item in include_path[:20]
+                if (text := self._coerce_text(item, max_chars=160))
+            ]
+            if compact_include_path:
+                compact["includePath"] = compact_include_path
         return compact
 
     def _proposal_compact_selector_metadata(self, value: object) -> dict[str, Any]:
@@ -2095,7 +2151,6 @@ class MoonMindRunWorkflow:
             "logsRef": self._logs_ref,
             "summaryRef": self._summary_ref,
             "finishSummaryRef": self._report_ref,
-            "runSummaryPath": "reports/run_summary.json",
         }
         if self._last_diagnostics_ref:
             refs["diagnosticsRef"] = self._last_diagnostics_ref

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -28,7 +28,7 @@ from moonmind.workflows.temporal.activity_catalog import (
     LLM_TASK_QUEUE,
     SANDBOX_TASK_QUEUE,
 )
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 
 PLAN_GENERATE_CALLS: list[Dict[str, Any]] = []
 ARTIFACT_READ_CALLS: list[Dict[str, Any]] = []
@@ -264,7 +264,7 @@ async def mock_proposal_submit(args: Dict[str, Any]) -> Dict[str, Any]:
         "errors": [],
     }
 
-class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
+class TestMoonMindUserWorkflow(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         PLAN_GENERATE_CALLS.clear()
         ARTIFACT_READ_CALLS.clear()
@@ -306,7 +306,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
@@ -321,7 +321,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
 
                 # Start workflow
                 handle = await env.client.start_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     request,
                     id="test-workflow-id",
                     task_queue="test-task-queue",
@@ -362,12 +362,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
                 handle = await env.client.start_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     {
                         "workflowType": "MoonMind.UserWorkflow",
                         "title": "Queryable run",
@@ -414,12 +414,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
                 result = await env.client.execute_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     {
                         "workflowType": "MoonMind.UserWorkflow",
                         "ownerId": "malicious-owner",
@@ -440,7 +440,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
             async with Worker(
                 env.client,
                 task_queue="test-task-queue",
-                workflows=[MoonMindRunWorkflow],
+                workflows=[MoonMindUserWorkflow],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
                 request = {
@@ -450,7 +450,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
 
                 with self.assertRaises(client.WorkflowFailureError) as exc_info:
                     await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         request,
                         id="test-workflow-id-error",
                         task_queue="test-task-queue",
@@ -468,12 +468,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
             async with Worker(
                 env.client,
                 task_queue="test-task-queue",
-                workflows=[MoonMindRunWorkflow],
+                workflows=[MoonMindUserWorkflow],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
                 with self.assertRaises(client.WorkflowFailureError) as exc_info:
                     await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         {"workflowType": "MoonMind.UserWorkflow"},
                         id="test-workflow-id-missing-owner",
                         task_queue="test-task-queue",
@@ -510,13 +510,13 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
                 with self.assertRaises(client.WorkflowFailureError) as exc_info:
                     await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         {"workflowType": "MoonMind.UserWorkflow"},
                         id="test-workflow-id-failed-skill-status",
                         task_queue="test-task-queue",
@@ -561,13 +561,13 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
                 with self.assertRaises(client.WorkflowFailureError) as exc_info:
                     await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         {
                             "workflowType": "MoonMind.UserWorkflow",
                             "initialParameters": {
@@ -631,12 +631,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     Worker(
                         env.client,
                         task_queue="test-task-queue",
-                        workflows=[MoonMindRunWorkflow],
+                        workflows=[MoonMindUserWorkflow],
                         workflow_runner=UnsandboxedWorkflowRunner(),
                     ),
                 ):
                     result = await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         {
                             "workflowType": "MoonMind.UserWorkflow",
                             "initialParameters": {
@@ -718,12 +718,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     Worker(
                         env.client,
                         task_queue="test-task-queue",
-                        workflows=[MoonMindRunWorkflow],
+                        workflows=[MoonMindUserWorkflow],
                         workflow_runner=UnsandboxedWorkflowRunner(),
                     ),
                 ):
                     result = await env.client.execute_workflow(
-                        MoonMindRunWorkflow.run,
+                        MoonMindUserWorkflow.run,
                         {
                             "workflowType": "MoonMind.UserWorkflow",
                             "initialParameters": {
@@ -772,12 +772,12 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(
                     env.client,
                     task_queue="test-task-queue",
-                    workflows=[MoonMindRunWorkflow],
+                    workflows=[MoonMindUserWorkflow],
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
                 result = await env.client.execute_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     {
                         "workflowType": "MoonMind.UserWorkflow",
                         "initialParameters": {
@@ -812,7 +812,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 Worker(env.client, task_queue=ARTIFACTS_TASK_QUEUE, activities=[mock_artifact_read]),
                 Worker(env.client, task_queue=SANDBOX_TASK_QUEUE, activities=[mock_sandbox_command, mock_skill_execute]),
                 Worker(env.client, task_queue=INTEGRATIONS_TASK_QUEUE, activities=[mock_integration_start, mock_integration_status_wait]),
-                Worker(env.client, task_queue="test-task-queue", workflows=[MoonMindRunWorkflow], workflow_runner=UnsandboxedWorkflowRunner()),
+                Worker(env.client, task_queue="test-task-queue", workflows=[MoonMindUserWorkflow], workflow_runner=UnsandboxedWorkflowRunner()),
             ):
                 request = {
                     "workflowType": "MoonMind.UserWorkflow",
@@ -825,7 +825,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
 
                 # Start workflow
                 handle = await env.client.start_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     request,
                     id="test-workflow-signal",
                     task_queue="test-task-queue",
@@ -838,7 +838,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 
                 # Signal the workflow to complete the external stage
                 await handle.signal(
-                    MoonMindRunWorkflow.external_event, 
+                    MoonMindUserWorkflow.external_event, 
                     {
                         "correlation_id": "corr-123",
                         "normalized_status": "completed"
@@ -868,7 +868,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                         mock_integration_merge_pr,
                     ],
                 ),
-                Worker(env.client, task_queue="test-task-queue", workflows=[MoonMindRunWorkflow], workflow_runner=UnsandboxedWorkflowRunner()),
+                Worker(env.client, task_queue="test-task-queue", workflows=[MoonMindUserWorkflow], workflow_runner=UnsandboxedWorkflowRunner()),
             ):
                 request = {
                     "workflowType": "MoonMind.UserWorkflow",
@@ -885,7 +885,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
 
                 # Start workflow
                 handle = await env.client.start_workflow(
-                    MoonMindRunWorkflow.run,
+                    MoonMindUserWorkflow.run,
                     request,
                     id="test-workflow-merge",
                     task_queue="test-task-queue",

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -838,7 +838,7 @@ class TestMoonMindUserWorkflow(unittest.IsolatedAsyncioTestCase):
                 
                 # Signal the workflow to complete the external stage
                 await handle.signal(
-                    MoonMindUserWorkflow.external_event, 
+                    MoonMindUserWorkflow.external_event,
                     {
                         "correlation_id": "corr-123",
                         "normalized_status": "completed"

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -64,7 +64,11 @@ async def test_run_proposals_stage_propagates_policy(
             return {"submitted_count": 1}
         return {}
 
-    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
 
     parameters = {
         "repo": "org/repo",
@@ -117,7 +121,11 @@ async def test_run_proposals_stage_passes_compact_telemetry_signals(
             return []
         return {}
 
-    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
 
     await mock_run_workflow._run_proposals_stage(
         parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
@@ -170,7 +178,11 @@ async def test_run_proposals_stage_does_not_fabricate_signal_from_diagnostics_re
             return []
         return {}
 
-    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
 
     await mock_run_workflow._run_proposals_stage(
         parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
@@ -226,7 +238,11 @@ async def test_run_proposals_stage_records_operator_visible_outcomes(
             }
         return {}
 
-    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
 
     await mock_run_workflow._run_proposals_stage(
         parameters={"repo": "org/repo", "task": {"proposeTasks": True}}
@@ -474,3 +490,200 @@ async def test_run_proposals_stage_skipped_when_globally_disabled(
     await mock_run_workflow._run_proposals_stage(parameters=parameters)
 
     assert len(captured) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_generate_payload: dict[str, Any] = {}
+    mock_run_workflow._input_ref = "artifact://run-input"
+    mock_run_workflow._plan_ref = "artifact://plan"
+    mock_run_workflow._logs_ref = "artifact://logs"
+    mock_run_workflow._summary_ref = "artifact://summary"
+    mock_run_workflow._report_ref = "artifact://reports/run-summary"
+    mock_run_workflow._last_step_id = "agent-step"
+    mock_run_workflow._last_step_summary = "Agent completed with diagnostics."
+    mock_run_workflow._last_diagnostics_ref = "artifact://diag-last"
+    step_row = {
+        "logicalStepId": "agent-step",
+        "refs": {
+            "latestStepExecutionManifestRef": "artifact://step-manifest-latest",
+            "stepExecutionManifestRefs": [
+                "artifact://step-manifest-1",
+                "artifact://step-manifest-latest",
+            ],
+        },
+        "artifacts": {
+            "outputSummary": "artifact://output-summary",
+            "outputPrimary": "artifact://agent-run-result",
+            "runtimeStdout": "artifact://stdout",
+            "runtimeStderr": "artifact://stderr",
+            "runtimeMergedLogs": "artifact://merged-logs",
+            "runtimeDiagnostics": "artifact://diag-step",
+            "providerSnapshot": "artifact://provider-snapshot",
+            "stepExecutionManifestRef": "artifact://step-manifest-latest",
+        },
+    }
+    mock_run_workflow._step_ledger_rows = [step_row]
+    mock_run_workflow._step_ledger_by_id = {"agent-step": step_row}
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "proposal.generate":
+            captured_generate_payload.update(
+                json.loads(json.dumps(payload, default=_to_serializable))
+            )
+            return []
+        return {}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    await mock_run_workflow._run_proposals_stage(
+        parameters={
+            "repo": "org/repo",
+            "task": {
+                "proposeTasks": True,
+                "instructions": "raw secret-bearing task input should stay by ref",
+                "steps": [
+                    {
+                        "id": "agent-step",
+                        "instructions": "raw step prompt should stay by ref",
+                    }
+                ],
+                "runtime": {"mode": "codex"},
+                "skills": {"include": [{"name": "pr-resolver"}]},
+                "authoredPresets": [
+                    {
+                        "id": "preset-1",
+                        "name": "Implementation preset",
+                        "version": "2026-06-21",
+                        "sourceRef": "artifact://preset-source",
+                        "body": "raw preset body should not cross workflow history",
+                    }
+                ],
+                "proposalIdea": "Add missing proposal hardening test coverage",
+            },
+            "logs": "raw logs should stay by artifact ref",
+            "diagnostics": {"raw": "raw diagnostics should stay by ref"},
+        }
+    )
+
+    assert captured_generate_payload["parameters"] == {
+        "workflow": {
+            "proposalIdea": "Add missing proposal hardening test coverage",
+            "runtime": {"mode": "codex"},
+            "skills": {"include": [{"name": "pr-resolver"}]},
+            "authoredPresets": [
+                {
+                    "id": "preset-1",
+                    "name": "Implementation preset",
+                    "version": "2026-06-21",
+                    "sourceRef": "artifact://preset-source",
+                    "index": 0,
+                }
+            ],
+        }
+    }
+    serialized_payload = json.dumps(captured_generate_payload, sort_keys=True)
+    assert "raw secret-bearing task input" not in serialized_payload
+    assert "raw step prompt" not in serialized_payload
+    assert "raw logs should stay" not in serialized_payload
+    assert "raw diagnostics should stay" not in serialized_payload
+    assert "raw preset body" not in serialized_payload
+
+    assert captured_generate_payload["evidenceRefs"] == {
+        "inputRef": "artifact://run-input",
+        "planRef": "artifact://plan",
+        "logsRef": "artifact://logs",
+        "summaryRef": "artifact://summary",
+        "finishSummaryRef": "artifact://reports/run-summary",
+        "runSummaryPath": "reports/run_summary.json",
+        "diagnosticsRef": "artifact://diag-last",
+        "lastStep": {
+            "id": "agent-step",
+            "outputRefs": {
+                "summaryRef": "artifact://output-summary",
+                "primaryRef": "artifact://agent-run-result",
+                "stdoutRef": "artifact://stdout",
+                "stderrRef": "artifact://stderr",
+                "logsRef": "artifact://merged-logs",
+                "diagnosticsRef": "artifact://diag-step",
+                "providerSnapshotRef": "artifact://provider-snapshot",
+                "stepExecutionManifestRef": "artifact://step-manifest-latest",
+                "stepExecutionManifestRefs": [
+                    "artifact://step-manifest-1",
+                    "artifact://step-manifest-latest",
+                ],
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_proposals_stage_passes_resolved_skill_metadata_by_ref(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_generate_payload: dict[str, Any] = {}
+    mock_run_workflow._last_step_id = "agent-step"
+    step_row = {
+        "logicalStepId": "agent-step",
+        "refs": {
+            "latestStepExecutionManifestRef": "artifact://skill-step-manifest",
+            "stepExecutionManifestRefs": ["artifact://skill-step-manifest"],
+        },
+        "artifacts": {
+            "outputPrimary": "artifact://agent-run-result",
+            "runtimeDiagnostics": "artifact://diag-step",
+            "stepExecutionManifestRef": "artifact://skill-step-manifest",
+        },
+    }
+    mock_run_workflow._step_ledger_rows = [step_row]
+    mock_run_workflow._step_ledger_by_id = {"agent-step": step_row}
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "proposal.generate":
+            captured_generate_payload.update(
+                json.loads(json.dumps(payload, default=_to_serializable))
+            )
+            return []
+        return {}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+    await mock_run_workflow._run_proposals_stage(
+        parameters={
+            "repo": "org/repo",
+            "task": {
+                "proposeTasks": True,
+                "skills": {
+                    "include": [{"name": "jira-implement"}],
+                    "metadata": "raw resolved skill metadata must not be embedded",
+                },
+            },
+        }
+    )
+
+    serialized_payload = json.dumps(captured_generate_payload, sort_keys=True)
+    assert "raw resolved skill metadata" not in serialized_payload
+    assert captured_generate_payload["parameters"]["workflow"]["skills"] == {
+        "include": [{"name": "jira-implement"}],
+    }
+    assert captured_generate_payload["evidenceRefs"]["lastStep"]["outputRefs"][
+        "stepExecutionManifestRef"
+    ] == "artifact://skill-step-manifest"
+    assert captured_generate_payload["evidenceRefs"]["lastStep"]["outputRefs"][
+        "primaryRef"
+    ] == "artifact://agent-run-result"
+    assert captured_generate_payload["evidenceRefs"]["lastStep"]["outputRefs"][
+        "diagnosticsRef"
+    ] == "artifact://diag-step"

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -552,10 +552,19 @@ async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
                 "steps": [
                     {
                         "id": "agent-step",
+                        "title": "Agent step",
+                        "type": "skill",
                         "instructions": "raw step prompt should stay by ref",
+                        "skill": {"id": "jira-implement"},
+                        "source": {
+                            "kind": "preset-derived",
+                            "presetId": "preset-1",
+                            "includePath": ["root", "implement"],
+                            "originalStepId": "implement-story",
+                        },
                     }
                 ],
-                "runtime": {"mode": "codex"},
+                "runtime": {"mode": "codex", "effort": 2},
                 "skills": {"include": [{"name": "pr-resolver"}]},
                 "authoredPresets": [
                     {
@@ -576,8 +585,22 @@ async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
     assert captured_generate_payload["parameters"] == {
         "workflow": {
             "proposalIdea": "Add missing proposal hardening test coverage",
-            "runtime": {"mode": "codex"},
+            "runtime": {"mode": "codex", "effort": 2},
             "skills": {"include": [{"name": "pr-resolver"}]},
+            "steps": [
+                {
+                    "id": "agent-step",
+                    "title": "Agent step",
+                    "type": "skill",
+                    "skill": {"id": "jira-implement"},
+                    "source": {
+                        "kind": "preset-derived",
+                        "presetId": "preset-1",
+                        "includePath": ["root", "implement"],
+                        "originalStepId": "implement-story",
+                    },
+                }
+            ],
             "authoredPresets": [
                 {
                     "id": "preset-1",
@@ -602,7 +625,6 @@ async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
         "logsRef": "artifact://logs",
         "summaryRef": "artifact://summary",
         "finishSummaryRef": "artifact://reports/run-summary",
-        "runSummaryPath": "reports/run_summary.json",
         "diagnosticsRef": "artifact://diag-last",
         "lastStep": {
             "id": "agent-step",


### PR DESCRIPTION
Jira issue key: MM-854

Summary:
- Hardens Temporal proposal generation inputs so large or sensitive source data is represented through compact artifact references or redacted metadata.
- Expands proposal-stage evidence coverage for run artifacts, diagnostics, normalized AgentRunResult data, finish-summary signals, resolved skill metadata, and preset provenance.
- Preserves the gated proposal stage behavior and workflow-side side-effect boundaries.

Tests run:
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_proposals.py` passed: 13 Python tests passed; UI portion reported 30 files / 456 tests passed with skips.
- `pytest tests/integration/workflows/temporal/workflows/test_run.py -q --tb=short` attempted, but the local Temporal workflow test command exceeded its 5-minute timeout and was stopped.

Remaining risks:
- The focused Temporal integration command did not complete locally due to timeout; the changed file is in the repo-documented class of workflow-boundary tests that can exceed local/CI timeout thresholds.
- The required assessment artifact `artifacts/jira-implement-assessment.json` was not present in this workspace, so this PR publication proceeded from the existing completed branch changes and trusted Jira handoff context rather than a local assessment JSON file.
