### PR TITLE
MM-856 Align proposal issue contract

### DIFF
--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -366,11 +366,39 @@ def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     return safe
 
 
+def _label_token(value: object, fallback: str) -> str:
+    token = re.sub(r"[^a-z0-9]+", "-", _clean(value).lower()).strip("-")
+    return token or fallback
+
+
+def _target_class(request: ProposalDeliveryRequest) -> str:
+    target = _clean(request.resolved_policy.get("target")).lower()
+    if target == "moonmind":
+        return "moonmind"
+    if request.dedup_key.startswith("moonmind:"):
+        return "moonmind"
+    return "workflow-repo"
+
+
+def _canonical_github_labels(request: ProposalDeliveryRequest) -> tuple[str, ...]:
+    short_hash = (request.dedup_hash or "unknown")[:12] or "unknown"
+    labels = (
+        "moonmind:proposal",
+        "moonmind:state:open",
+        f"moonmind:target:{_target_class(request)}",
+        f"moonmind:category:{_label_token(request.category, 'uncategorized')}",
+        f"moonmind:priority:{_label_token(request.priority, 'normal')}",
+        f"moonmind:dedup:{short_hash}",
+    )
+    return labels
+
+
 def _marker(request: ProposalDeliveryRequest) -> str:
     snapshot = request.workflow_snapshot_ref or "stored-proposal-snapshot"
     return (
         "<!-- moonmind-proposal "
-        f"record={request.record_id} dedup={request.dedup_hash} "
+        f"record={request.record_id} target={_target_class(request)} "
+        f"dedup={request.dedup_hash} "
         f"snapshot={snapshot} -->"
     )
 
@@ -439,7 +467,9 @@ def render_github_issue(
     redactor = redactor or SecretRedactor.from_environ(placeholder="[REDACTED]")
     provider_cfg = _provider_config(request.provider_metadata, "github")
     configured_labels = _iter_strings(provider_cfg.get("labels"))
-    labels = tuple(dict.fromkeys(("moonmind-proposal", "proposal-review", *configured_labels)))
+    labels = tuple(
+        dict.fromkeys((*_canonical_github_labels(request), *configured_labels))
+    )
     title = f"[MoonMind proposal] {request.title}".strip()
     body = "\n\n".join(
         [

--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -6,6 +6,7 @@ issues are review artifacts with bounded controls and links back to evidence.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -17,6 +18,11 @@ _GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _SECRET_KEY_RE = re.compile(
     r"(token|password|secret|authorization|cookie|private[_-]?key)",
     re.IGNORECASE,
+)
+_MAX_GITHUB_LABEL_LENGTH = 50
+_CATEGORY_LABEL_PREFIX = "moonmind:category:"
+_MAX_CATEGORY_LABEL_TOKEN_LENGTH = (
+    _MAX_GITHUB_LABEL_LENGTH - len(_CATEGORY_LABEL_PREFIX)
 )
 _COMMAND_RE = re.compile(
     (
@@ -366,9 +372,14 @@ def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     return safe
 
 
-def _label_token(value: object, fallback: str) -> str:
+def _label_token(value: object, fallback: str, *, max_length: int | None = None) -> str:
     token = re.sub(r"[^a-z0-9]+", "-", _clean(value).lower()).strip("-")
-    return token or fallback
+    token = token or fallback
+    if max_length is None or len(token) <= max_length:
+        return token
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:8]
+    prefix_length = max(1, max_length - len(digest) - 1)
+    return f"{token[:prefix_length].rstrip('-')}-{digest}"
 
 
 def _target_class(request: ProposalDeliveryRequest) -> str:
@@ -382,11 +393,16 @@ def _target_class(request: ProposalDeliveryRequest) -> str:
 
 def _canonical_github_labels(request: ProposalDeliveryRequest) -> tuple[str, ...]:
     short_hash = (request.dedup_hash or "unknown")[:12] or "unknown"
+    category_token = _label_token(
+        request.category,
+        "uncategorized",
+        max_length=_MAX_CATEGORY_LABEL_TOKEN_LENGTH,
+    )
     labels = (
         "moonmind:proposal",
         "moonmind:state:open",
         f"moonmind:target:{_target_class(request)}",
-        f"moonmind:category:{_label_token(request.category, 'uncategorized')}",
+        f"moonmind:category:{category_token}",
         f"moonmind:priority:{_label_token(request.priority, 'normal')}",
         f"moonmind:dedup:{short_hash}",
     )
@@ -397,9 +413,9 @@ def _marker(request: ProposalDeliveryRequest) -> str:
     snapshot = request.workflow_snapshot_ref or "stored-proposal-snapshot"
     return (
         "<!-- moonmind-proposal "
-        f"record={request.record_id} target={_target_class(request)} "
+        f"record={request.record_id} "
         f"dedup={request.dedup_hash} "
-        f"snapshot={snapshot} -->"
+        f"snapshot={snapshot} target={_target_class(request)} -->"
     )
 
 

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -188,9 +188,9 @@ class WorkflowProposalService:
             category or "", "uncategorized"
         )
         slug = self._slugify_title(title or "")
-        dedup_key = f"{target}:{repo}:{normalized_category}:{slug}"
+        dedup_key = f"{target}:{repo}:{normalized_category}:{slug}"[:512]
         dedup_hash = hashlib.sha256(dedup_key.encode("utf-8")).hexdigest()
-        return dedup_key[:512], dedup_hash
+        return dedup_key, dedup_hash
 
     def _normalize_category(self, value: object) -> str | None:
         text = self._clean_str(value).lower()

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -162,10 +162,33 @@ class WorkflowProposalService:
         normalized = _DEDUP_SLUG_PATTERN.sub("-", title.lower()).strip("-")
         return normalized or "untitled"
 
-    def _compute_dedup_fields(self, *, repository: str, title: str) -> tuple[str, str]:
+    @staticmethod
+    def _slugify_dedup_component(value: str, fallback: str) -> str:
+        normalized = _DEDUP_SLUG_PATTERN.sub("-", value.lower()).strip("-")
+        return normalized or fallback
+
+    def _target_class_for_repository(self, repository: str) -> str:
+        return (
+            "moonmind"
+            if self._is_moonmind_repository(repository)
+            else "workflow-repo"
+        )
+
+    def _compute_dedup_fields(
+        self,
+        *,
+        target_class: str,
+        repository: str,
+        category: str | None,
+        title: str,
+    ) -> tuple[str, str]:
+        target = self._slugify_dedup_component(target_class or "", "workflow-repo")
         repo = (repository or "").strip().lower() or "unknown"
+        normalized_category = self._slugify_dedup_component(
+            category or "", "uncategorized"
+        )
         slug = self._slugify_title(title or "")
-        dedup_key = f"{repo}:{slug}"
+        dedup_key = f"{target}:{repo}:{normalized_category}:{slug}"
         dedup_hash = hashlib.sha256(dedup_key.encode("utf-8")).hexdigest()
         return dedup_key[:512], dedup_hash
 
@@ -902,8 +925,12 @@ class WorkflowProposalService:
                 requested_priority = derived_priority
                 priority_override_reason = derived_reason
 
+        target_class = self._target_class_for_repository(repository)
         dedup_key, dedup_hash = self._compute_dedup_fields(
-            repository=repository, title=cleaned_title
+            target_class=target_class,
+            repository=repository,
+            category=normalized_category,
+            title=cleaned_title,
         )
 
         duplicate_finder = getattr(self._repository, "find_open_duplicate", None)

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -23,6 +23,7 @@ def _request(
     *,
     provider: str = "github",
     repository: str = "Moon/Repo",
+    category: str | None = "tests",
     provider_metadata: dict[str, object] | None = None,
     resolved_policy: dict[str, object] | None = None,
     external_key: str | None = None,
@@ -34,7 +35,7 @@ def _request(
         repository=repository,
         title="Add regression coverage",
         summary="Follow-up proposal from workflow evidence.",
-        category="tests",
+        category=category,
         tags=("artifact_gap", "moonmind"),
         priority="high",
         dedup_key="moon/repo:add-regression-coverage",
@@ -103,14 +104,33 @@ def test_github_renderer_includes_review_context_and_excludes_raw_payload() -> N
     )
 
     assert rendered.title.startswith("[MoonMind proposal] Add regression coverage")
-    assert "moonmind-proposal" in rendered.labels
+    assert "moonmind:proposal" in rendered.labels
+    assert "moonmind:state:open" in rendered.labels
+    assert "moonmind:target:workflow-repo" in rendered.labels
+    assert "moonmind:category:tests" in rendered.labels
+    assert "moonmind:priority:high" in rendered.labels
+    assert "moonmind:dedup:dddddddddddd" in rendered.labels
     assert "custom" in rendered.labels
     assert "<!-- moonmind-proposal" in rendered.body
+    assert "target=workflow-repo" in rendered.body
     assert "wf-123" in rendered.body
     assert "artifact://task-snapshot.json" in rendered.body
     assert "/moonmind promote" in rendered.body
     assert "stored proposal snapshot" in rendered.body.lower()
     assert "RAW EXECUTABLE PAYLOAD SHOULD NOT APPEAR" not in rendered.body
+
+
+def test_github_renderer_labels_moonmind_target_from_policy() -> None:
+    rendered = render_github_issue(
+        _request(
+            category="run_quality",
+            resolved_policy={"target": "moonmind"},
+        )
+    )
+
+    assert "moonmind:target:moonmind" in rendered.labels
+    assert "moonmind:category:run-quality" in rendered.labels
+    assert "target=moonmind" in rendered.body
 
 
 def test_jira_renderer_emits_adf_description_and_configured_fields() -> None:

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -113,6 +113,9 @@ def test_github_renderer_includes_review_context_and_excludes_raw_payload() -> N
     assert "custom" in rendered.labels
     assert "<!-- moonmind-proposal" in rendered.body
     assert "target=workflow-repo" in rendered.body
+    assert rendered.marker.index("record=") < rendered.marker.index("dedup=")
+    assert rendered.marker.index("dedup=") < rendered.marker.index("snapshot=")
+    assert rendered.marker.index("snapshot=") < rendered.marker.index("target=")
     assert "wf-123" in rendered.body
     assert "artifact://task-snapshot.json" in rendered.body
     assert "/moonmind promote" in rendered.body
@@ -131,6 +134,19 @@ def test_github_renderer_labels_moonmind_target_from_policy() -> None:
     assert "moonmind:target:moonmind" in rendered.labels
     assert "moonmind:category:run-quality" in rendered.labels
     assert "target=moonmind" in rendered.body
+
+
+def test_github_renderer_caps_long_category_labels() -> None:
+    rendered = render_github_issue(
+        _request(category="A category value that is much longer than github allows")
+    )
+
+    category_labels = [
+        label for label in rendered.labels if label.startswith("moonmind:category:")
+    ]
+    assert len(category_labels) == 1
+    assert len(category_labels[0]) <= 50
+    assert category_labels[0].startswith("moonmind:category:a-category-value")
 
 
 def test_jira_renderer_emits_adf_description_and_configured_fields() -> None:

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -93,7 +93,7 @@ async def test_create_proposal_defers_runtime_defaults_until_promotion() -> None
     args, kwargs = repo.create_proposal.await_args
     assert kwargs["repository"] == "Moon/Repo"
     assert kwargs["category"] == "tests"
-    assert kwargs["dedup_key"].startswith("moon/repo")
+    assert kwargs["dedup_key"].startswith("workflow-repo:moon/repo:tests:")
     assert len(kwargs["dedup_hash"]) == 64
     assert kwargs["review_priority"] is WorkflowProposalReviewPriority.NORMAL
     assert kwargs["priority_override_reason"] is None
@@ -1078,23 +1078,48 @@ async def test_create_proposal_merges_duplicate_delivery_metadata() -> None:
     service._emit_notification.assert_not_awaited()
 
 
-def test_compute_dedup_fields_are_repository_aware_and_title_normalized() -> None:
+def test_compute_dedup_fields_include_target_repository_category_and_title() -> None:
     service = WorkflowProposalService(AsyncMock(), redactor=SecretRedactor([], "***"))
 
     first_key, first_hash = service._compute_dedup_fields(
-        repository="Moon/Repo", title="Add   Tests!!"
+        target_class="workflow-repo",
+        repository="Moon/Repo",
+        category="Tests",
+        title="Add   Tests!!",
     )
     second_key, second_hash = service._compute_dedup_fields(
-        repository="moon/repo", title="add-tests"
+        target_class="workflow_repo",
+        repository="moon/repo",
+        category="tests",
+        title="add-tests",
     )
     other_key, other_hash = service._compute_dedup_fields(
-        repository="Other/Repo", title="Add Tests"
+        target_class="workflow-repo",
+        repository="Other/Repo",
+        category="Tests",
+        title="Add Tests",
+    )
+    other_category_key, other_category_hash = service._compute_dedup_fields(
+        target_class="workflow-repo",
+        repository="Moon/Repo",
+        category="Security",
+        title="Add Tests",
+    )
+    moonmind_key, moonmind_hash = service._compute_dedup_fields(
+        target_class="moonmind",
+        repository="Moon/Repo",
+        category="Tests",
+        title="Add Tests",
     )
 
-    assert first_key == second_key == "moon/repo:add-tests"
+    assert first_key == second_key == "workflow-repo:moon/repo:tests:add-tests"
     assert first_hash == second_hash
-    assert other_key == "other/repo:add-tests"
+    assert other_key == "workflow-repo:other/repo:tests:add-tests"
     assert other_hash != first_hash
+    assert other_category_key == "workflow-repo:moon/repo:security:add-tests"
+    assert other_category_hash != first_hash
+    assert moonmind_key == "moonmind:moon/repo:tests:add-tests"
+    assert moonmind_hash != first_hash
 
 @pytest.mark.asyncio
 async def test_create_proposal_persists_provider_metadata_separately() -> None:

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -103,6 +104,21 @@ async def test_create_proposal_defers_runtime_defaults_until_promotion() -> None
     assert kwargs["workflow_create_request"]["payload"].get("targetRuntime") is None
     service._emit_notification.assert_awaited_once()
     assert proposal is record
+
+
+def test_compute_dedup_fields_hashes_stored_truncated_key() -> None:
+    service = WorkflowProposalService(AsyncMock(), redactor=SecretRedactor([], "***"))
+
+    dedup_key, dedup_hash = service._compute_dedup_fields(
+        target_class="workflow-repo",
+        repository="Moon/Repo",
+        category="tests",
+        title="A" * 800,
+    )
+
+    assert len(dedup_key) == 512
+    assert dedup_hash == hashlib.sha256(dedup_key.encode("utf-8")).hexdigest()
+
 
 @pytest.mark.asyncio
 async def test_emit_notification_blocks_secret_payload_before_webhook(


### PR DESCRIPTION
Jira issue key: MM-856

Summary:
- Expanded proposal dedup identity to include target class, destination repository, normalized category, and normalized title.
- Updated GitHub issue rendering to emit canonical proposal state, target, category, priority, and dedup labels while preserving configured labels.
- Added coverage for target/category-sensitive deduping and canonical GitHub labels.

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/proposals/test_service.py tests/unit/workflows/proposals/test_delivery.py

Remaining risks:
- Full unit suite was not run in this publication step; verification focused on the proposal service and delivery surfaces changed by MM-856.