### PR TITLE
MM-855 Finish deterministic routing and fail-closed delivery records

### DIFF
--- a/api_service/config.template.toml
+++ b/api_service/config.template.toml
@@ -14,7 +14,7 @@ artifact_root = "var/artifacts/workflows"
 [workflow_proposals]
 # Proposal routing defaults shared by the API and workers. These map to
 # MOONMIND_PROPOSAL_TARGETS/MOONMIND_CI_REPOSITORY when sourced from env.
-proposal_targets_default = "project"
+proposal_targets_default = "workflow_repo"
 moonmind_ci_repository = "MoonLadderStudios/MoonMind"
 max_items_project_default = 3
 max_items_moonmind_default = 2

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -268,7 +268,7 @@ All items shipped: per-step runtime/model/effort selection, cost tracking and bi
 - Bounded-evidence remediation context — remediation reads a target run's durable evidence under redaction.
 - Canonical remediation submissions via `execution_remediation_links`.
 - Remediation lifecycle repair prevention — locks/ledger prevent duplicate or conflicting repairs.
-- Durable step ledger and checkpoints — step state, attempts, evidence refs, and latest-attempt evidence refs surfaced in the default ledger row.
+- Durable step ledger & checkpoints — step state, attempts, evidence refs, and latest-attempt evidence refs surfaced in the default ledger row.
 - Resume foundations — distinct full-retry vs recovery actions, checkpoint-evidence gating, editable full retry, and resume-from-last-failed-step.
 - Step Execution evidence manifests and checkpoint contracts are documented as the canonical substrate for semantic re-execution, checkpointed side effects, gated iteration, failed-step recovery, and autonomous story loops.
 - Step Execution history is now visible in expanded Mission Control step rows (MM-831 / PR #2541).

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -12164,7 +12164,7 @@ class CodexWorker:
                             level="warn",
                             message="task.proposalSubmission.rejected",
                             payload={
-                                "target": "project",
+                                "target": "workflow_repo",
                                 "error": str(exc),
                             },
                         )

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -12070,7 +12070,7 @@ class CodexWorker:
         effective_policy = build_effective_proposal_policy(
             policy=task_policy,
             default_targets=defaults.proposal_targets_default,
-            default_max_items_project=defaults.proposal_max_items_project,
+            default_max_items_workflow_repo=defaults.proposal_max_items_workflow_repo,
             default_max_items_moonmind=defaults.proposal_max_items_moonmind,
             default_moonmind_severity_floor=defaults.proposal_moonmind_severity_floor,
             severity_vocabulary=settings.workflow_proposals.severity_vocabulary,
@@ -12131,7 +12131,7 @@ class CodexWorker:
                 errors.append("proposal missing workflowCreateRequest")
                 continue
 
-            if effective_policy.has_project_capacity():
+            if effective_policy.has_workflow_repo_capacity():
                 project_payload = copy.deepcopy(payload)
                 if _ensure_task_request_repository(
                     project_payload,
@@ -12147,7 +12147,7 @@ class CodexWorker:
                         external_links.extend(outcome["external_links"])
                         dedup_updates.extend(outcome["dedup_updates"])
                         delivery_failures.extend(outcome["delivery_failures"])
-                        effective_policy.consume_project_slot()
+                        effective_policy.consume_workflow_repo_slot()
                         submitted += 1
                     except Exception as exc:
                         logger.exception(

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -18,7 +18,7 @@ from moonmind.jules.runtime import (
 )
 from moonmind.workflow_docker_mode import normalize_workflow_docker_mode
 
-_ALLOWED_TARGET_DEFAULTS = ("project", "moonmind", "both")
+_ALLOWED_TARGET_DEFAULTS = ("workflow_repo", "moonmind", "both")
 _ALLOWED_PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _PENTEST_ALLOWED_OPERATION_MODES = (
     "recon_only",
@@ -1025,16 +1025,16 @@ class WorkflowSettings(BaseSettings):
         description="Enable worker-side workflow proposal submission after successful runs.",
     )
     proposal_targets_default: str = Field(
-        "project",
+        "workflow_repo",
         validation_alias=AliasChoices(
             "MOONMIND_PROPOSAL_TARGETS"
         ),
-        description="Default proposal targets when workflows omit proposalPolicy (project|moonmind|both).",
+        description="Default proposal targets when workflows omit proposalPolicy (workflow_repo|moonmind|both).",
     )
     proposal_max_items_project: int = Field(
         3,
         validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT"),
-        description="Default per-run project proposal cap applied when workflow policy omits maxItems.project.",
+        description="Default per-run workflow-repo proposal cap applied when workflow policy omits maxItems.workflowRepo.",
         ge=1,
     )
     proposal_max_items_moonmind: int = Field(
@@ -1125,7 +1125,7 @@ class WorkflowSettings(BaseSettings):
     def _normalize_proposal_targets_default(cls, value: object) -> str:
         text = str(value or "").strip().lower()
         if not text:
-            return "project"
+            return "workflow_repo"
         if text not in _ALLOWED_TARGET_DEFAULTS:
             allowed = ", ".join(_ALLOWED_TARGET_DEFAULTS)
             raise ValueError(
@@ -2287,11 +2287,11 @@ class WorkflowProposalSettings(BaseSettings):
     """Workflow proposal queue runtime knobs."""
 
     proposal_targets_default: str = Field(
-        "project",
+        "workflow_repo",
         validation_alias=AliasChoices(
             "MOONMIND_PROPOSAL_TARGETS"
         ),
-        description="Default proposal targets when policy overrides are absent (project|moonmind|both).",
+        description="Default proposal targets when policy overrides are absent (workflow_repo|moonmind|both).",
     )
     moonmind_ci_repository: str = Field(
         "MoonLadderStudios/MoonMind",
@@ -2303,7 +2303,7 @@ class WorkflowProposalSettings(BaseSettings):
     max_items_project_default: int = Field(
         3,
         validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT"),
-        description="Default per-run cap for project-targeted proposals when unspecified.",
+        description="Default per-run cap for workflow-repo proposals when unspecified.",
         ge=1,
     )
     max_items_moonmind_default: int = Field(
@@ -2369,7 +2369,7 @@ class WorkflowProposalSettings(BaseSettings):
     def _normalize_setting_targets_default(cls, value: object) -> str:
         text = str(value or "").strip().lower()
         if not text:
-            return "project"
+            return "workflow_repo"
         if text not in _ALLOWED_TARGET_DEFAULTS:
             allowed = ", ".join(_ALLOWED_TARGET_DEFAULTS)
             raise ValueError(

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1031,9 +1031,9 @@ class WorkflowSettings(BaseSettings):
         ),
         description="Default proposal targets when workflows omit proposalPolicy (workflow_repo|moonmind|both).",
     )
-    proposal_max_items_project: int = Field(
+    proposal_max_items_workflow_repo: int = Field(
         3,
-        validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT"),
+        validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_WORKFLOW_REPO"),
         description="Default per-run workflow-repo proposal cap applied when workflow policy omits maxItems.workflowRepo.",
         ge=1,
     )
@@ -2300,9 +2300,9 @@ class WorkflowProposalSettings(BaseSettings):
         ),
         description="MoonMind CI repository used whenever proposals target run-quality improvements.",
     )
-    max_items_project_default: int = Field(
+    max_items_workflow_repo_default: int = Field(
         3,
-        validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT"),
+        validation_alias=AliasChoices("WORKFLOW_PROPOSALS_MAX_ITEMS_WORKFLOW_REPO"),
         description="Default per-run cap for workflow-repo proposals when unspecified.",
         ge=1,
     )

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -54,7 +54,7 @@ _SECRET_REF_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
 _SECRET_REF_FIELD_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
 _CONTAINER_VOLUME_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"})
-_PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
+_PROPOSAL_POLICY_TARGETS = ("workflow_repo", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _SELF_MANAGED_PUBLISH_SKILLS = frozenset(
     {
@@ -1241,7 +1241,7 @@ class WorkflowProposalPolicy(BaseModel):
             lowered = target.lower()
             if lowered not in _PROPOSAL_POLICY_TARGETS:
                 raise WorkflowContractError(
-                    "workflow.proposalPolicy.targets entries must be 'project' or 'moonmind'"
+                    "workflow.proposalPolicy.targets entries must be 'workflow_repo' or 'moonmind'"
                 )
             if lowered in seen:
                 continue
@@ -2396,17 +2396,17 @@ def build_effective_proposal_policy(
     elif default_targets_normalized in _PROPOSAL_POLICY_TARGETS:
         default_target_list = [default_targets_normalized]
     else:
-        default_target_list = ["project"]
+        default_target_list = ["workflow_repo"]
     configured_targets = (
         list(policy.targets) if policy and policy.targets else default_target_list
     )
-    allow_project = "project" in configured_targets
+    allow_project = "workflow_repo" in configured_targets
     allow_moonmind = "moonmind" in configured_targets
     if not allow_project and not allow_moonmind:
         allow_project = True
 
     max_items = dict(policy.max_items or {}) if policy and policy.max_items else {}
-    max_items_project = int(max_items.get("project") or 0)
+    max_items_project = int(max_items.get("workflow_repo") or 0)
     if max_items_project <= 0:
         max_items_project = max(1, int(default_max_items_project or 1))
     max_items_moonmind = int(max_items.get("moonmind") or 0)

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -1257,8 +1257,16 @@ class WorkflowProposalPolicy(BaseModel):
         if not isinstance(value, Mapping):
             raise WorkflowContractError("workflow.proposalPolicy.maxItems must be an object")
         normalized: dict[str, int] = {}
+        key_aliases = {
+            "workflow_repo": ("workflowRepo", "workflow_repo"),
+            "moonmind": ("moonmind",),
+        }
         for key in _PROPOSAL_POLICY_TARGETS:
-            raw = value.get(key)
+            raw = None
+            for source_key in key_aliases[key]:
+                if source_key in value:
+                    raw = value.get(source_key)
+                    break
             if raw is None:
                 continue
             try:
@@ -1899,29 +1907,29 @@ class WorkflowExecutionSpec(BaseModel):
 class EffectiveProposalPolicy:
     """Resolved proposal policy derived from config and optional overrides."""
 
-    allow_project: bool
+    allow_workflow_repo: bool
     allow_moonmind: bool
-    max_items_project: int
+    max_items_workflow_repo: int
     max_items_moonmind: int
     min_severity_for_moonmind: str
     severity_rank: dict[str, int]
     delivery_provider: str
     provider_metadata: dict[str, Any] = field(default_factory=dict)
-    remaining_project_slots: int = field(init=False)
+    remaining_workflow_repo_slots: int = field(init=False)
     remaining_moonmind_slots: int = field(init=False)
 
     def __post_init__(self) -> None:
-        self.remaining_project_slots = (
-            self.max_items_project if self.allow_project else 0
+        self.remaining_workflow_repo_slots = (
+            self.max_items_workflow_repo if self.allow_workflow_repo else 0
         )
         self.remaining_moonmind_slots = (
             self.max_items_moonmind if self.allow_moonmind else 0
         )
 
-    def consume_project_slot(self) -> bool:
-        if not self.allow_project or self.remaining_project_slots <= 0:
+    def consume_workflow_repo_slot(self) -> bool:
+        if not self.allow_workflow_repo or self.remaining_workflow_repo_slots <= 0:
             return False
-        self.remaining_project_slots -= 1
+        self.remaining_workflow_repo_slots -= 1
         return True
 
     def consume_moonmind_slot(self) -> bool:
@@ -1930,8 +1938,8 @@ class EffectiveProposalPolicy:
         self.remaining_moonmind_slots -= 1
         return True
 
-    def has_project_capacity(self) -> bool:
-        return self.allow_project and self.remaining_project_slots > 0
+    def has_workflow_repo_capacity(self) -> bool:
+        return self.allow_workflow_repo and self.remaining_workflow_repo_slots > 0
 
     def has_moonmind_capacity(self) -> bool:
         return self.allow_moonmind and self.remaining_moonmind_slots > 0
@@ -2370,7 +2378,7 @@ def build_effective_proposal_policy(
     *,
     policy: WorkflowProposalPolicy | None,
     default_targets: str,
-    default_max_items_project: int,
+    default_max_items_workflow_repo: int,
     default_max_items_moonmind: int,
     default_moonmind_severity_floor: str,
     severity_vocabulary: Sequence[str] | None = None,
@@ -2400,15 +2408,15 @@ def build_effective_proposal_policy(
     configured_targets = (
         list(policy.targets) if policy and policy.targets else default_target_list
     )
-    allow_project = "workflow_repo" in configured_targets
+    allow_workflow_repo = "workflow_repo" in configured_targets
     allow_moonmind = "moonmind" in configured_targets
-    if not allow_project and not allow_moonmind:
-        allow_project = True
+    if not allow_workflow_repo and not allow_moonmind:
+        allow_workflow_repo = True
 
     max_items = dict(policy.max_items or {}) if policy and policy.max_items else {}
-    max_items_project = int(max_items.get("workflow_repo") or 0)
-    if max_items_project <= 0:
-        max_items_project = max(1, int(default_max_items_project or 1))
+    max_items_workflow_repo = int(max_items.get("workflow_repo") or 0)
+    if max_items_workflow_repo <= 0:
+        max_items_workflow_repo = max(1, int(default_max_items_workflow_repo or 1))
     max_items_moonmind = int(max_items.get("moonmind") or 0)
     if max_items_moonmind <= 0:
         max_items_moonmind = max(1, int(default_max_items_moonmind or 1))
@@ -2427,9 +2435,9 @@ def build_effective_proposal_policy(
             severity_floor = filtered_vocab[-1]
 
     return EffectiveProposalPolicy(
-        allow_project=allow_project,
+        allow_workflow_repo=allow_workflow_repo,
         allow_moonmind=allow_moonmind,
-        max_items_project=max_items_project,
+        max_items_workflow_repo=max_items_workflow_repo,
         max_items_moonmind=max_items_moonmind,
         min_severity_for_moonmind=severity_floor,
         severity_rank=severity_rank,

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -1141,7 +1141,7 @@ class WorkflowProposalService:
             error = delivery.get("error")
             if isinstance(error, dict):
                 error["deliveryRecordId"] = str(proposal.id)
-        proposal.provider_metadata = base_provider_metadata
+        proposal.provider_metadata = deepcopy(base_provider_metadata)
         await self._repository.commit()
         return proposal
 

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -61,6 +61,7 @@ _MOONMIND_SIGNAL_TAGS = frozenset(
         "artifact_gap",
     }
 )
+_UNRESOLVED_WORKFLOW_REPO_DESTINATION = "unresolved-workflow-repo"
 _PROPOSAL_RUNTIME_MODE_ALIASES = {
     "codex_cli": "codex",
     "claude_code": "claude",
@@ -999,6 +1000,149 @@ class WorkflowProposalService:
             repository,
             normalized_category or "-",
         )
+        return proposal
+
+    async def record_delivery_failure(
+        self,
+        *,
+        title: str,
+        summary: str,
+        category: str | None,
+        tags: list[str] | None,
+        workflow_create_request: dict[str, Any],
+        origin_source: object,
+        origin_id: UUID | None,
+        origin_metadata: dict[str, Any] | None,
+        origin_external_id: str | None = None,
+        proposed_by_worker_id: str | None,
+        proposed_by_user_id: UUID | None,
+        provider: str,
+        target_class: str,
+        reason: str,
+        recoverable_next_action: str,
+        retryable: bool = True,
+        repository: str | None = None,
+        provider_metadata: dict[str, Any] | None = None,
+        resolved_policy: dict[str, Any] | None = None,
+    ) -> WorkflowProposal:
+        """Persist a sanitized fail-closed delivery record without provider I/O."""
+
+        if not proposed_by_worker_id and not proposed_by_user_id:
+            raise WorkflowProposalValidationError(
+                "one of proposed_by_worker_id or proposed_by_user_id is required"
+            )
+        cleaned_title = self._scrub_text(self._clean_str(title))
+        if not cleaned_title:
+            raise WorkflowProposalValidationError("title is required")
+        if len(cleaned_title) > 256:
+            raise WorkflowProposalValidationError("title exceeds max length")
+
+        cleaned_summary = self._scrub_text(self._clean_str(summary))
+        if not cleaned_summary:
+            raise WorkflowProposalValidationError("summary is required")
+        if len(cleaned_summary) > 10000:
+            raise WorkflowProposalValidationError("summary exceeds max length")
+
+        normalized_provider = self._clean_str(provider).lower() or "github"
+        if normalized_provider not in {"github", "jira"}:
+            raise WorkflowProposalValidationError("provider must be github or jira")
+        normalized_target = self._clean_str(target_class).lower()
+        if normalized_target not in {"workflow_repo", "moonmind"}:
+            raise WorkflowProposalValidationError(
+                "target_class must be workflow_repo or moonmind"
+            )
+
+        normalized_category = self._normalize_category(category)
+        normalized_tags = self._normalize_tags(tags)
+        origin = self._normalize_origin_source(origin_source)
+        metadata = origin_metadata if isinstance(origin_metadata, dict) else {}
+        cleaned_origin_external_id = (
+            self._scrub_text(self._clean_str(origin_external_id)) or None
+        )
+        if (
+            origin is WorkflowProposalOriginSource.WORKFLOW
+            and cleaned_origin_external_id is None
+        ):
+            cleaned_origin_external_id = (
+                self._scrub_text(self._clean_str(metadata.get("workflow_id")))
+                or None
+            )
+
+        destination = self._scrub_text(
+            self._clean_str(repository) or _UNRESOLVED_WORKFLOW_REPO_DESTINATION
+        )
+        request_snapshot = self._scrub_json(dict(workflow_create_request or {}))
+        scrubbed_reason = self._scrub_text(self._clean_str(reason)) or (
+            "proposal delivery failed"
+        )
+        scrubbed_next_action = self._scrub_text(
+            self._clean_str(recoverable_next_action)
+        ) or "Review proposal routing configuration."
+        base_provider_metadata = self._scrub_json(dict(provider_metadata or {}))
+        base_provider_metadata["delivery"] = self._scrub_json(
+            {
+                "status": "failed",
+                "error": {
+                    "provider": normalized_provider,
+                    "destination": destination,
+                    "targetClass": normalized_target,
+                    "sanitizedReason": scrubbed_reason,
+                    "recoverableNextAction": scrubbed_next_action,
+                    "retryable": bool(retryable),
+                },
+            }
+        )
+        base_policy = self._scrub_json(
+            {
+                **dict(resolved_policy or {}),
+                "provider": normalized_provider,
+                "target": normalized_target,
+                "repository": destination,
+                "delivery": {
+                    "status": "failed",
+                    "reason": scrubbed_reason,
+                    "recoverableNextAction": scrubbed_next_action,
+                    "retryable": bool(retryable),
+                },
+            }
+        )
+
+        dedup_key, dedup_hash = self._compute_dedup_fields(
+            repository=destination, title=cleaned_title
+        )
+        proposal = await self._repository.create_proposal(
+            title=cleaned_title,
+            summary=cleaned_summary,
+            category=normalized_category,
+            tags=normalized_tags,
+            repository=destination,
+            workflow_create_request=request_snapshot,
+            proposed_by_worker_id=proposed_by_worker_id,
+            proposed_by_user_id=proposed_by_user_id,
+            origin_source=origin,
+            origin_id=origin_id,
+            origin_external_id=cleaned_origin_external_id,
+            origin_metadata=metadata,
+            dedup_key=dedup_key,
+            dedup_hash=dedup_hash,
+            review_priority=WorkflowProposalReviewPriority.NORMAL,
+            priority_override_reason=None,
+            provider=normalized_provider,
+            external_key=None,
+            external_url=None,
+            delivered_at=None,
+            last_synced_at=datetime.now(UTC),
+            workflow_snapshot_ref=None,
+            provider_metadata=base_provider_metadata,
+            resolved_policy=base_policy,
+        )
+        delivery = base_provider_metadata.get("delivery")
+        if isinstance(delivery, dict):
+            error = delivery.get("error")
+            if isinstance(error, dict):
+                error["deliveryRecordId"] = str(proposal.id)
+        proposal.provider_metadata = base_provider_metadata
+        await self._repository.commit()
         return proposal
 
     async def list_proposals(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5083,7 +5083,7 @@ class TemporalProposalActivities:
             default_targets=getattr(
                 settings.workflow_proposals,
                 "proposal_targets_default",
-                "project",
+                "workflow_repo",
             ),
             default_max_items_project=getattr(
                 settings.workflow_proposals,
@@ -5150,6 +5150,29 @@ class TemporalProposalActivities:
             for key, value in provider_metadata.items()
             if key in {"github", "jira"} and isinstance(value, Mapping)
         }
+        delivery_policy_constraints: dict[str, Any] = {}
+        github_policy = provider_payload.get("github")
+        if isinstance(github_policy, Mapping):
+            for source_key, target_key in (
+                ("allowedRepositories", "allowedRepositories"),
+                ("allowed_repositories", "allowedRepositories"),
+                ("allowedOrganizations", "allowedOrganizations"),
+                ("allowed_organizations", "allowedOrganizations"),
+                ("allowedActions", "allowedActions"),
+                ("allowed_actions", "allowedActions"),
+            ):
+                if source_key in github_policy:
+                    delivery_policy_constraints[target_key] = github_policy[source_key]
+        jira_policy = provider_payload.get("jira")
+        if isinstance(jira_policy, Mapping):
+            for source_key, target_key in (
+                ("allowedProjects", "allowedProjects"),
+                ("allowed_projects", "allowedProjects"),
+                ("allowedActions", "allowedActions"),
+                ("allowed_actions", "allowedActions"),
+            ):
+                if source_key in jira_policy:
+                    delivery_policy_constraints[target_key] = jira_policy[source_key]
 
         service_or_ctx = None
         if self._proposal_service_factory is not None:
@@ -5209,9 +5232,28 @@ class TemporalProposalActivities:
                     errors.append(f"skipped malformed candidate: {title!r}")
                     continue
 
+                original_payload_node = workflow_create_request.get("payload")
+                original_target_repo = ""
+                if isinstance(original_payload_node, Mapping):
+                    original_target_repo = str(
+                        original_payload_node.get("repository") or ""
+                    ).strip()
+                missing_workflow_repo_destination = not original_target_repo
+                request_for_validation: Mapping[str, Any] = workflow_create_request
+                if missing_workflow_repo_destination:
+                    request_copy = deepcopy(dict(workflow_create_request))
+                    payload_copy = (
+                        dict(original_payload_node)
+                        if isinstance(original_payload_node, Mapping)
+                        else {}
+                    )
+                    payload_copy["repository"] = "unresolved-workflow-repo"
+                    request_copy["payload"] = payload_copy
+                    request_for_validation = request_copy
+
                 try:
                     stamped_request = self._validate_candidate_workflow_create_request(
-                        workflow_create_request,
+                        request_for_validation,
                         default_runtime=(
                             default_runtime if isinstance(default_runtime, str) else None
                         ),
@@ -5221,6 +5263,123 @@ class TemporalProposalActivities:
                     errors.append(
                         f"invalid workflowCreateRequest for {title!r}: {redacted_error}"
                     )
+                    continue
+
+                if missing_workflow_repo_destination:
+                    if not effective_policy.allow_project:
+                        delivery_decisions.append(
+                            {
+                                "title": title,
+                                "target": "workflow_repo",
+                                "accepted": False,
+                                "reason": "target_disabled",
+                            }
+                        )
+                        continue
+                    if not effective_policy.consume_project_slot():
+                        delivery_decisions.append(
+                            {
+                                "title": title,
+                                "target": "workflow_repo",
+                                "accepted": False,
+                                "reason": "capacity",
+                            }
+                        )
+                        continue
+
+                    decision = {
+                        "title": title,
+                        "target": "workflow_repo",
+                        "repository": "",
+                        "provider": delivery_provider,
+                        "accepted": True,
+                        "deliveryStatus": "failed",
+                    }
+                    reason = (
+                        "workflowCreateRequest.payload.repository is required for "
+                        "workflow_repo proposal delivery"
+                    )
+                    next_action = (
+                        "Set workflowCreateRequest.payload.repository to the workflow "
+                        "repository before retrying delivery."
+                    )
+                    try:
+                        if service is not None and hasattr(
+                            service, "record_delivery_failure"
+                        ):
+                            from moonmind.workflows.proposals.models import (
+                                WorkflowProposalOriginSource,
+                            )
+
+                            origin_metadata = {
+                                "source": "workflow",
+                                "id": workflow_id,
+                                "workflow_id": workflow_id,
+                                "temporal_run_id": run_id,
+                                "trigger_repo": trigger_repo,
+                                "trigger_job_id": trigger_job_id,
+                            }
+                            proposal = await service.record_delivery_failure(
+                                title=title,
+                                summary=summary,
+                                category=candidate.get("category"),
+                                tags=candidate.get("tags"),
+                                workflow_create_request=dict(workflow_create_request),
+                                origin_source=WorkflowProposalOriginSource.WORKFLOW,
+                                origin_id=None,
+                                origin_external_id=workflow_id,
+                                origin_metadata=origin_metadata,
+                                proposed_by_worker_id=f"temporal:{workflow_id}",
+                                proposed_by_user_id=None,
+                                provider=delivery_provider,
+                                target_class="workflow_repo",
+                                reason=reason,
+                                recoverable_next_action=next_action,
+                                retryable=True,
+                                repository=None,
+                                provider_metadata=provider_payload,
+                                resolved_policy={
+                                    **delivery_policy_constraints,
+                                    "provider": delivery_provider,
+                                    "target": "workflow_repo",
+                                    "repository": "",
+                                    "workflow_id": workflow_id,
+                                    "delivery": {
+                                        "status": "failed",
+                                        "reason": reason,
+                                        "recoverableNextAction": next_action,
+                                    },
+                                },
+                            )
+                            delivery_metadata = getattr(
+                                proposal, "provider_metadata", {}
+                            )
+                            if isinstance(delivery_metadata, Mapping):
+                                delivery_node = delivery_metadata.get("delivery")
+                                if isinstance(delivery_node, Mapping):
+                                    decision["deliveryStatus"] = delivery_node.get(
+                                        "status", "failed"
+                                    )
+                                    if "error" in delivery_node:
+                                        decision["error"] = delivery_node["error"]
+                            submitted_count += 1
+                        else:
+                            decision["error"] = {
+                                "provider": delivery_provider,
+                                "destination": "",
+                                "targetClass": "workflow_repo",
+                                "sanitizedReason": reason,
+                                "recoverableNextAction": next_action,
+                                "retryable": True,
+                            }
+                    except Exception as exc:
+                        redacted_error = self._redactor.scrub(str(exc))[:200]
+                        errors.append(
+                            f"submission failed for {title!r}: {redacted_error}"
+                        )
+                        decision["accepted"] = False
+                        decision["reason"] = "submission_failed"
+                    delivery_decisions.append(decision)
                     continue
 
                 payload_node = stamped_request.get("payload")
@@ -5267,7 +5426,7 @@ class TemporalProposalActivities:
                     and moonmind_severity_qualified
                 )
 
-                target = "project"
+                target = "workflow_repo"
                 if wants_moonmind:
                     if not effective_policy.consume_moonmind_slot():
                         delivery_decisions.append(
@@ -5289,7 +5448,7 @@ class TemporalProposalActivities:
                         delivery_decisions.append(
                             {
                                 "title": title,
-                                "target": "project",
+                                "target": "workflow_repo",
                                 "accepted": False,
                                 "reason": "capacity",
                             }
@@ -5347,6 +5506,7 @@ class TemporalProposalActivities:
                             provider=delivery_provider,
                             provider_metadata=provider_payload,
                             resolved_policy={
+                                **delivery_policy_constraints,
                                 "provider": delivery_provider,
                                 "target": target,
                                 "repository": target_repo,
@@ -5354,7 +5514,7 @@ class TemporalProposalActivities:
                                 "default_runtime": default_runtime_value,
                                 "default_runtime_applied": default_runtime_applied,
                                 "capacity": {
-                                    "project": {
+                                    "workflow_repo": {
                                         "allowed": effective_policy.allow_project,
                                         "limit": effective_policy.max_items_project,
                                         "remaining": (

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5085,9 +5085,9 @@ class TemporalProposalActivities:
                 "proposal_targets_default",
                 "workflow_repo",
             ),
-            default_max_items_project=getattr(
+            default_max_items_workflow_repo=getattr(
                 settings.workflow_proposals,
-                "max_items_project_default",
+                "max_items_workflow_repo_default",
                 3,
             ),
             default_max_items_moonmind=getattr(
@@ -5151,7 +5151,10 @@ class TemporalProposalActivities:
             if key in {"github", "jira"} and isinstance(value, Mapping)
         }
         delivery_policy_constraints: dict[str, Any] = {}
-        github_policy = provider_payload.get("github")
+        if delivery_provider == "github":
+            github_policy = provider_payload.get("github")
+        else:
+            github_policy = None
         if isinstance(github_policy, Mapping):
             for source_key, target_key in (
                 ("allowedRepositories", "allowedRepositories"),
@@ -5163,7 +5166,10 @@ class TemporalProposalActivities:
             ):
                 if source_key in github_policy:
                     delivery_policy_constraints[target_key] = github_policy[source_key]
-        jira_policy = provider_payload.get("jira")
+        if delivery_provider == "jira":
+            jira_policy = provider_payload.get("jira")
+        else:
+            jira_policy = None
         if isinstance(jira_policy, Mapping):
             for source_key, target_key in (
                 ("allowedProjects", "allowedProjects"),
@@ -5242,13 +5248,18 @@ class TemporalProposalActivities:
                 request_for_validation: Mapping[str, Any] = workflow_create_request
                 if missing_workflow_repo_destination:
                     request_copy = deepcopy(dict(workflow_create_request))
-                    payload_copy = (
-                        dict(original_payload_node)
-                        if isinstance(original_payload_node, Mapping)
-                        else {}
-                    )
-                    payload_copy["repository"] = "unresolved-workflow-repo"
-                    request_copy["payload"] = payload_copy
+                    payload_node = request_copy.get("payload")
+                    if isinstance(payload_node, Mapping) and not isinstance(
+                        payload_node, dict
+                    ):
+                        payload_node = dict(payload_node)
+                        request_copy["payload"] = payload_node
+                    if isinstance(payload_node, dict):
+                        payload_node["repository"] = "unresolved-workflow-repo"
+                    else:
+                        request_copy["payload"] = {
+                            "repository": "unresolved-workflow-repo"
+                        }
                     request_for_validation = request_copy
 
                 try:
@@ -5266,7 +5277,7 @@ class TemporalProposalActivities:
                     continue
 
                 if missing_workflow_repo_destination:
-                    if not effective_policy.allow_project:
+                    if not effective_policy.allow_workflow_repo:
                         delivery_decisions.append(
                             {
                                 "title": title,
@@ -5276,7 +5287,7 @@ class TemporalProposalActivities:
                             }
                         )
                         continue
-                    if not effective_policy.consume_project_slot():
+                    if not effective_policy.consume_workflow_repo_slot():
                         delivery_decisions.append(
                             {
                                 "title": title,
@@ -5417,7 +5428,7 @@ class TemporalProposalActivities:
                     bool(moonmind_repo)
                     and effective_policy.allow_moonmind
                     and (
-                        not effective_policy.allow_project
+                        not effective_policy.allow_workflow_repo
                         or target_repo.lower() == moonmind_repo.lower()
                         or category in {"run_quality", "moonmind_ci"}
                     )
@@ -5444,7 +5455,7 @@ class TemporalProposalActivities:
                         stamped_request["payload"] = payload_node
                     target_repo = moonmind_repo
                 else:
-                    if not effective_policy.consume_project_slot():
+                    if not effective_policy.consume_workflow_repo_slot():
                         delivery_decisions.append(
                             {
                                 "title": title,
@@ -5515,14 +5526,14 @@ class TemporalProposalActivities:
                                 "default_runtime_applied": default_runtime_applied,
                                 "capacity": {
                                     "workflow_repo": {
-                                        "allowed": effective_policy.allow_project,
-                                        "limit": effective_policy.max_items_project,
+                                        "allowed": effective_policy.allow_workflow_repo,
+                                        "limit": effective_policy.max_items_workflow_repo,
                                         "remaining": (
-                                            effective_policy.remaining_project_slots
+                                            effective_policy.remaining_workflow_repo_slots
                                         ),
                                         "accepted": (
-                                            effective_policy.max_items_project
-                                            - effective_policy.remaining_project_slots
+                                            effective_policy.max_items_workflow_repo
+                                            - effective_policy.remaining_workflow_repo_slots
                                         ),
                                     },
                                     "moonmind": {

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -217,9 +217,9 @@ async def test_proposal_submit_persists_external_delivery_result() -> None:
     assert delivery.requests[0].origin_metadata["workflow_id"] == "wf-1"
     assert delivery.requests[0].origin_metadata["source"] == "workflow"
     assert delivery.requests[0].origin_metadata["id"] == "wf-1"
-    assert record.resolved_policy["target"] == "project"
+    assert record.resolved_policy["target"] == "workflow_repo"
     assert record.resolved_policy["provider"] == "github"
-    assert record.resolved_policy["capacity"]["project"]["accepted"] == 1
+    assert record.resolved_policy["capacity"]["workflow_repo"]["accepted"] == 1
     assert record.resolved_policy["delivery"]["provider"] == "github"
 
 

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -363,10 +363,11 @@ async def test_provider_approval_creates_one_run_from_stored_snapshot() -> None:
     assert len(executions) == 1
     payload = executions[0]["initialParameters"]
     assert payload["targetRuntime"] == "codex"
-    assert payload["task"]["authoredPresets"] == [
+    workflow = payload["workflow"]
+    assert workflow["authoredPresets"] == [
         {"presetId": "runtime-quality-followup"}
     ]
-    assert payload["task"]["steps"][0]["source"] == {"kind": "preset-derived"}
+    assert workflow["steps"][0]["source"] == {"kind": "preset-derived"}
     assert "unsafe edited text" not in str(payload)
 
     duplicate = await _promote_provider_event(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3585,8 +3585,8 @@ def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
                     "runtime": {"mode": "codex"},
                     "proposeTasks": True,
                     "proposalPolicy": {
-                        "targets": ["project", "moonmind"],
-                        "maxItems": {"project": 2, "moonmind": 1},
+                        "targets": ["workflow_repo", "moonmind"],
+                        "maxItems": {"workflow_repo": 2, "moonmind": 1},
                         "minSeverityForMoonMind": "medium",
                         "defaultRuntime": "gemini_cli",
                     },
@@ -3622,8 +3622,8 @@ def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
     assert "proposalPolicy" not in initial_parameters
     assert initial_parameters["workflow"]["proposeTasks"] is True
     assert initial_parameters["workflow"]["proposalPolicy"] == {
-        "targets": ["project", "moonmind"],
-        "maxItems": {"project": 2, "moonmind": 1},
+        "targets": ["workflow_repo", "moonmind"],
+        "maxItems": {"workflow_repo": 2, "moonmind": 1},
         "minSeverityForMoonMind": "medium",
         "defaultRuntime": "gemini_cli",
     }
@@ -5869,7 +5869,7 @@ def test_create_task_shaped_recurring_schedule_normalizes_proposal_intent(
                         "instructions": "Run this on a schedule",
                         "proposeTasks": True,
                         "proposalPolicy": {
-                            "targets": ["project"],
+                            "targets": ["workflow_repo"],
                             "defaultRuntime": "gemini_cli",
                         },
                     },
@@ -5886,7 +5886,7 @@ def test_create_task_shaped_recurring_schedule_normalizes_proposal_intent(
     assert "proposalPolicy" not in stored_payload
     assert stored_payload["workflow"]["proposeTasks"] is True
     assert stored_payload["workflow"]["proposalPolicy"] == {
-        "targets": ["project"],
+        "targets": ["workflow_repo"],
         "defaultRuntime": "gemini_cli",
     }
 

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -203,7 +203,7 @@ def test_list_proposals_serializes_delivery_record_fields(
     proposal.last_synced_at = datetime(2026, 5, 7, 12, 45, tzinfo=UTC)
     proposal.workflow_snapshot_ref = "artifact://proposals/MM-901.json"
     proposal.provider_metadata = {"jira": {"project_key": "MM", "labels": ["moonmind"]}}
-    proposal.resolved_policy = {"provider": "jira", "target": "project"}
+    proposal.resolved_policy = {"provider": "jira", "target": "workflow_repo"}
     service.list_proposals.return_value = ([proposal], None)
 
     response = test_client.get("/api/proposals")
@@ -217,7 +217,7 @@ def test_list_proposals_serializes_delivery_record_fields(
     assert item["providerMetadata"] == {
         "jira": {"project_key": "MM", "labels": ["moonmind"]}
     }
-    assert item["resolvedPolicy"] == {"provider": "jira", "target": "project"}
+    assert item["resolvedPolicy"] == {"provider": "jira", "target": "workflow_repo"}
     assert item["deliveredAt"] == "2026-05-07T12:30:00Z"
     assert item["lastSyncedAt"] == "2026-05-07T12:45:00Z"
 
@@ -240,7 +240,7 @@ def test_list_proposals_serializes_review_delivery_state(
             "created": True,
         }
     }
-    proposal.resolved_policy = {"provider": "github", "target": "project"}
+    proposal.resolved_policy = {"provider": "github", "target": "workflow_repo"}
     service.list_proposals.return_value = ([proposal], None)
 
     response = test_client.get("/api/proposals")

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -1011,8 +1011,8 @@ def test_workflow_proposal_policy_settings_defaults(app_settings_defaults):
     settings = AppSettings(_env_file=None, **app_settings_defaults)
     assert settings.workflow_proposals.proposal_targets_default == "workflow_repo"
     assert settings.workflow.proposal_targets_default == "workflow_repo"
-    assert settings.workflow_proposals.max_items_project_default == 3
-    assert settings.workflow.proposal_max_items_project == 3
+    assert settings.workflow_proposals.max_items_workflow_repo_default == 3
+    assert settings.workflow.proposal_max_items_workflow_repo == 3
     assert settings.workflow_proposals.moonmind_severity_floor_default == "high"
     assert settings.workflow.proposal_moonmind_severity_floor == "high"
 
@@ -1020,7 +1020,7 @@ def test_workflow_proposal_policy_env_overrides(app_settings_defaults, monkeypat
     """Environment variables should override policy defaults everywhere."""
 
     monkeypatch.setenv("MOONMIND_PROPOSAL_TARGETS", "both")
-    monkeypatch.setenv("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT", "5")
+    monkeypatch.setenv("WORKFLOW_PROPOSALS_MAX_ITEMS_WORKFLOW_REPO", "5")
     monkeypatch.setenv("WORKFLOW_PROPOSALS_MAX_ITEMS_MOONMIND", "4")
     monkeypatch.setenv("MOONMIND_MIN_SEVERITY_FOR_MOONMIND", "medium")
 
@@ -1028,15 +1028,15 @@ def test_workflow_proposal_policy_env_overrides(app_settings_defaults, monkeypat
 
     assert settings.workflow_proposals.proposal_targets_default == "both"
     assert settings.workflow.proposal_targets_default == "both"
-    assert settings.workflow_proposals.max_items_project_default == 5
-    assert settings.workflow.proposal_max_items_project == 5
+    assert settings.workflow_proposals.max_items_workflow_repo_default == 5
+    assert settings.workflow.proposal_max_items_workflow_repo == 5
     assert settings.workflow_proposals.max_items_moonmind_default == 4
     assert settings.workflow.proposal_max_items_moonmind == 4
     assert settings.workflow_proposals.moonmind_severity_floor_default == "medium"
     assert settings.workflow.proposal_moonmind_severity_floor == "medium"
 
     monkeypatch.delenv("MOONMIND_PROPOSAL_TARGETS", raising=False)
-    monkeypatch.delenv("WORKFLOW_PROPOSALS_MAX_ITEMS_PROJECT", raising=False)
+    monkeypatch.delenv("WORKFLOW_PROPOSALS_MAX_ITEMS_WORKFLOW_REPO", raising=False)
     monkeypatch.delenv("WORKFLOW_PROPOSALS_MAX_ITEMS_MOONMIND", raising=False)
     monkeypatch.delenv("MOONMIND_MIN_SEVERITY_FOR_MOONMIND", raising=False)
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -1009,8 +1009,8 @@ def test_workflow_proposal_policy_settings_defaults(app_settings_defaults):
     """Workflow proposal defaults should expose policy knobs on both settings."""
 
     settings = AppSettings(_env_file=None, **app_settings_defaults)
-    assert settings.workflow_proposals.proposal_targets_default == "project"
-    assert settings.workflow.proposal_targets_default == "project"
+    assert settings.workflow_proposals.proposal_targets_default == "workflow_repo"
+    assert settings.workflow.proposal_targets_default == "workflow_repo"
     assert settings.workflow_proposals.max_items_project_default == 3
     assert settings.workflow.proposal_max_items_project == 3
     assert settings.workflow_proposals.moonmind_severity_floor_default == "high"

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -816,7 +816,7 @@ async def test_promote_proposal_preserves_canonical_proposal_intent() -> None:
                 "workflow": {
                     "instructions": "Add regression coverage",
                     "proposalPolicy": {
-                        "targets": ["project"],
+                        "targets": ["workflow_repo"],
                     },
                 },
             }
@@ -835,7 +835,7 @@ async def test_promote_proposal_preserves_canonical_proposal_intent() -> None:
     assert "proposeTasks" not in final_request["payload"]
     task = final_request["payload"]["workflow"]
     assert task["proposeTasks"] is False
-    assert task["proposalPolicy"] == {"targets": ["project"]}
+    assert task["proposalPolicy"] == {"targets": ["workflow_repo"]}
 
 
 @pytest.mark.asyncio
@@ -1053,7 +1053,7 @@ async def test_create_proposal_merges_duplicate_delivery_metadata() -> None:
         last_synced_at=last_synced_at,
         workflow_snapshot_ref="artifact://task-snapshot",
         provider_metadata={"jira": {"issueType": "Task"}},
-        resolved_policy={"target": "project"},
+        resolved_policy={"target": "workflow_repo"},
     )
 
     assert proposal is existing
@@ -1064,7 +1064,7 @@ async def test_create_proposal_merges_duplicate_delivery_metadata() -> None:
     assert existing.resolved_policy == {
         "provider": "jira",
         "decision": "kept",
-        "target": "project",
+        "target": "workflow_repo",
         "duplicate": True,
         "duplicate_record_id": str(existing_id),
     }

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -1440,13 +1440,81 @@ async def test_create_proposal_records_sanitized_delivery_failure() -> None:
     assert proposal.provider_metadata["delivery"]["error"]["sanitizedReason"] == (
         "provider rejected request"
     )
-    persisted_metadata = repo.create_proposal.await_args.kwargs["provider_metadata"]
-    assert proposal.provider_metadata is not persisted_metadata
-    assert proposal.provider_metadata["delivery"] is not persisted_metadata["delivery"]
+
+
+@pytest.mark.asyncio
+async def test_record_delivery_failure_assigns_fresh_metadata_with_record_id() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=WorkflowProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="hash",
+        review_priority=WorkflowProposalReviewPriority.NORMAL,
+        priority_override_reason=None,
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=WorkflowProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_metadata={"workflow_id": "wf-1"},
+        origin_external_id="wf-1",
+        provider="github",
+        external_key=None,
+        external_url=None,
+        delivered_at=None,
+        last_synced_at=None,
+        workflow_snapshot_ref=None,
+        provider_metadata={},
+        resolved_policy={"provider": "github"},
+        workflow_create_request={"payload": {"repository": "Moon/Repo"}},
+    )
+    repo.create_proposal.return_value = record
+    service = WorkflowProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    proposal = await service.record_delivery_failure(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["tests"],
+        workflow_create_request={
+            "type": "workflow",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {"repository": "Moon/Repo"},
+        },
+        origin_source=WorkflowProposalOriginSource.WORKFLOW,
+        origin_id=None,
+        origin_external_id="wf-1",
+        origin_metadata={"workflow_id": "wf-1"},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        provider="github",
+        target_class="workflow_repo",
+        reason="provider rejected request",
+        recoverable_next_action="Check provider configuration.",
+        retryable=True,
+        repository="Moon/Repo",
+        resolved_policy={"provider": "github"},
+    )
+
+    initial_metadata = repo.create_proposal.await_args.kwargs["provider_metadata"]
+    assert proposal.provider_metadata is not initial_metadata
+    assert proposal.provider_metadata["delivery"] is not initial_metadata["delivery"]
     assert proposal.provider_metadata["delivery"]["error"]["deliveryRecordId"] == str(
         record.id
     )
-    assert persisted_metadata["delivery"]["error"]["deliveryRecordId"] == str(record.id)
+    assert initial_metadata["delivery"]["error"]["deliveryRecordId"] == str(record.id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -1440,6 +1440,13 @@ async def test_create_proposal_records_sanitized_delivery_failure() -> None:
     assert proposal.provider_metadata["delivery"]["error"]["sanitizedReason"] == (
         "provider rejected request"
     )
+    persisted_metadata = repo.create_proposal.await_args.kwargs["provider_metadata"]
+    assert proposal.provider_metadata is not persisted_metadata
+    assert proposal.provider_metadata["delivery"] is not persisted_metadata["delivery"]
+    assert proposal.provider_metadata["delivery"]["error"]["deliveryRecordId"] == str(
+        record.id
+    )
+    assert persisted_metadata["delivery"]["error"]["deliveryRecordId"] == str(record.id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -20,6 +20,10 @@ from moonmind.workflows.proposals.models import (
     WorkflowProposalStatus,
 )
 from moonmind.workflows.proposals.service import WorkflowProposalService
+from moonmind.workflows.proposals.delivery import (
+    ProposalDeliveryError,
+    ProposalDeliveryService,
+)
 
 class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
     async def test_returns_empty_list_stub(self) -> None:
@@ -517,7 +521,7 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         result = await activities.proposal_submit(
             {
                 "candidates": candidates,
-                "policy": {"maxItems": {"project": 2}},
+                "policy": {"maxItems": {"workflow_repo": 2}},
                 "origin": {},
             }
         )
@@ -571,8 +575,8 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
             {
                 "candidates": candidates,
                 "policy": {
-                    "targets": ["project", "moonmind"],
-                    "maxItems": {"project": 1, "moonmind": 2},
+                    "targets": ["workflow_repo", "moonmind"],
+                    "maxItems": {"workflow_repo": 1, "moonmind": 2},
                     "minSeverityForMoonMind": "medium",
                 },
                 "origin": {},
@@ -627,7 +631,7 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         candidates = [
             {
                 "title": "[run_quality] Follow-up: Fix proposal routing",
-                "summary": "Proposal should remain project-targeted for MoonMind repo runs.",
+                "summary": "Proposal should remain workflow-repo-targeted for MoonMind repo runs.",
                 "category": "run_quality",
                 "tags": ["artifact_gap"],
                 "workflowCreateRequest": {
@@ -885,6 +889,183 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["validationErrors"][0]["code"], "proposal_validation_error")
         self.assertIn("workflow_id", result["validationErrors"][0]["message"])
         mock_service.create_proposal.assert_not_called()
+
+    async def test_missing_workflow_repo_records_recoverable_delivery_failure(
+        self,
+    ) -> None:
+        """MM-855/MM-853: unresolved workflow_repo routing is an auditable failure."""
+
+        repo = AsyncMock()
+
+        async def create_record(**kwargs: Any) -> SimpleNamespace:
+            return SimpleNamespace(id=uuid4(), **kwargs)
+
+        repo.create_proposal.side_effect = create_record
+        service = WorkflowProposalService(repo, redactor=SecretRedactor([], "***"))
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Record unresolved repository",
+                        "summary": "Missing workflow repository should be audited.",
+                        "workflowCreateRequest": {
+                            "payload": {
+                                "workflow": {"instructions": "Fix missing routing"}
+                            }
+                        },
+                    }
+                ],
+                "policy": {"targets": ["workflow_repo"]},
+                "origin": {"workflow_id": "wf-mm-855", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        repo.create_proposal.assert_awaited_once()
+        kwargs = repo.create_proposal.await_args.kwargs
+        self.assertEqual(kwargs["repository"], "unresolved-workflow-repo")
+        self.assertEqual(kwargs["resolved_policy"]["target"], "workflow_repo")
+        failure = result["deliveryFailures"][0]
+        self.assertEqual(failure["targetClass"], "workflow_repo")
+        self.assertIn("repository is required", failure["sanitizedReason"])
+        self.assertIn("recoverableNextAction", failure)
+
+    async def test_missing_github_credentials_records_recoverable_delivery_failure(
+        self,
+    ) -> None:
+        """MM-855/MM-853: credential authorization failures stay recoverable."""
+
+        class MissingCredentialDelivery:
+            async def deliver(self, request):
+                raise ProposalDeliveryError(
+                    "GitHub credentials do not cover repository",
+                    provider="github",
+                    destination=request.destination,
+                    retryable=True,
+                    next_action="Authorize GitHub delivery credentials for this repository.",
+                )
+
+        repo = AsyncMock()
+
+        async def create_record(**kwargs: Any) -> SimpleNamespace:
+            values = dict(kwargs)
+            values.setdefault("external_key", None)
+            values.setdefault("external_url", None)
+            values.setdefault("delivered_at", None)
+            values.setdefault("last_synced_at", None)
+            values.setdefault("provider_metadata", {})
+            values.setdefault("resolved_policy", {})
+            return SimpleNamespace(id=uuid4(), **values)
+
+        repo.create_proposal.side_effect = create_record
+        service = WorkflowProposalService(
+            repo,
+            redactor=SecretRedactor([], "***"),
+            delivery_service=MissingCredentialDelivery(),
+        )
+        service._emit_notification = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Deliver with missing credentials",
+                        "summary": "Credential failures should be audited.",
+                        "workflowCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {"targets": ["workflow_repo"]},
+                "origin": {"workflow_id": "wf-mm-855", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        self.assertEqual(result["deliveredCount"], 0)
+        failure = result["deliveryFailures"][0]
+        self.assertEqual(failure["provider"], "github")
+        self.assertEqual(failure["destination"], "org/repo")
+        self.assertIn("credentials", failure["sanitizedReason"])
+        self.assertEqual(
+            failure["recoverableNextAction"],
+            "Authorize GitHub delivery credentials for this repository.",
+        )
+
+    async def test_disallowed_repository_records_delivery_failure(self) -> None:
+        """MM-855/MM-853: unauthorized repositories fail closed before provider I/O."""
+
+        class NoopGitHubProvider:
+            async def search_issue(self, request):
+                raise AssertionError("disallowed repository should fail before provider I/O")
+
+            async def create_issue(self, request, rendered):
+                raise AssertionError("disallowed repository should fail before provider I/O")
+
+            async def update_issue(self, request, rendered, issue):
+                raise AssertionError("disallowed repository should fail before provider I/O")
+
+        repo = AsyncMock()
+
+        async def create_record(**kwargs: Any) -> SimpleNamespace:
+            values = dict(kwargs)
+            values.setdefault("external_key", None)
+            values.setdefault("external_url", None)
+            values.setdefault("delivered_at", None)
+            values.setdefault("last_synced_at", None)
+            values.setdefault("provider_metadata", {})
+            values.setdefault("resolved_policy", {})
+            return SimpleNamespace(id=uuid4(), **values)
+
+        repo.create_proposal.side_effect = create_record
+        service = WorkflowProposalService(
+            repo,
+            redactor=SecretRedactor([], "***"),
+            delivery_service=ProposalDeliveryService(github=NoopGitHubProvider()),
+        )
+        service._emit_notification = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Disallowed repository",
+                        "summary": "Policy should block delivery.",
+                        "workflowCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {
+                    "targets": ["workflow_repo"],
+                    "delivery": {
+                        "provider": "github",
+                        "github": {"allowedRepositories": ["org/allowed"]},
+                    },
+                },
+                "origin": {"workflow_id": "wf-mm-855", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        failure = result["deliveryFailures"][0]
+        self.assertEqual(
+            failure["sanitizedReason"],
+            "GitHub repository is not allowed by proposal delivery policy",
+        )
+        self.assertEqual(failure["destination"], "org/repo")
 
 class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
     async def test_default_runtime_stamped_into_candidate(self) -> None:
@@ -1337,7 +1518,7 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
                     }
                 ],
                 "policy": {
-                    "targets": ["project", "moonmind"],
+                    "targets": ["workflow_repo", "moonmind"],
                     "minSeverityForMoonMind": "medium",
                 },
                 "origin": {"workflow_id": "wf-1", "temporal_run_id": "run-1"},
@@ -1350,8 +1531,8 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
             call_kwargs["workflow_create_request"]["payload"]["repository"],
             "org/repo",
         )
-        self.assertEqual(call_kwargs["resolved_policy"]["target"], "project")
-        self.assertEqual(result["delivery_decisions"][0]["target"], "project")
+        self.assertEqual(call_kwargs["resolved_policy"]["target"], "workflow_repo")
+        self.assertEqual(result["delivery_decisions"][0]["target"], "workflow_repo")
 
     async def test_resolved_policy_records_capacity_gates_and_runtime_decision(
         self,

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -528,6 +528,28 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["generated_count"], 5)
         self.assertEqual(result["submitted_count"], 2)
 
+    async def test_max_items_workflow_repo_camel_case_policy_respected(self) -> None:
+        activities = TemporalProposalActivities()
+        candidates = [
+            {
+                "title": f"Proposal {i}",
+                "summary": f"Summary {i}",
+                "workflowCreateRequest": {"payload": {"repository": "org/repo"}},
+            }
+            for i in range(5)
+        ]
+
+        result = await activities.proposal_submit(
+            {
+                "candidates": candidates,
+                "policy": {"maxItems": {"workflowRepo": 1}},
+                "origin": {},
+            }
+        )
+
+        self.assertEqual(result["generated_count"], 5)
+        self.assertEqual(result["submitted_count"], 1)
+
     async def test_raw_task_policy_uses_per_target_caps(self) -> None:
         mock_service = AsyncMock()
 
@@ -936,6 +958,58 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertIn("repository is required", failure["sanitizedReason"])
         self.assertIn("recoverableNextAction", failure)
 
+    async def test_missing_workflow_repo_validation_uses_isolated_payload_copy(
+        self,
+    ) -> None:
+        """Validation stamping must not share nested payload objects with input."""
+
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        original_request = {
+            "payload": {
+                "workflow": {
+                    "instructions": "original",
+                    "metadata": {"marker": "keep"},
+                }
+            }
+        }
+        captured_validation_request = {}
+
+        def mutate_during_validation(request, **kwargs):
+            request["payload"]["workflow"]["instructions"] = "mutated"
+            captured_validation_request.update(request)
+            return request
+
+        activities._validate_candidate_workflow_create_request = mutate_during_validation
+
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Record unresolved repository",
+                        "summary": "Missing workflow repository should be audited.",
+                        "workflowCreateRequest": original_request,
+                    }
+                ],
+                "policy": {"targets": ["workflow_repo"]},
+                "origin": {"workflow_id": "wf-mm-855", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        self.assertEqual(
+            original_request["payload"]["workflow"]["instructions"], "original"
+        )
+        self.assertEqual(
+            captured_validation_request["payload"]["workflow"]["instructions"],
+            "mutated",
+        )
+
     async def test_missing_github_credentials_records_recoverable_delivery_failure(
         self,
     ) -> None:
@@ -1066,6 +1140,50 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
             "GitHub repository is not allowed by proposal delivery policy",
         )
         self.assertEqual(failure["destination"], "org/repo")
+
+    async def test_delivery_policy_constraints_use_active_provider_only(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Create Jira follow-up",
+                        "summary": "Policy should use Jira constraints only.",
+                        "workflowCreateRequest": {"payload": {"repository": "MM"}},
+                    }
+                ],
+                "policy": {
+                    "targets": ["workflow_repo"],
+                    "delivery": {
+                        "provider": "jira",
+                        "github": {
+                            "allowedRepositories": ["org/repo"],
+                            "allowedActions": ["open_pr"],
+                        },
+                        "jira": {
+                            "allowedProjects": ["MM"],
+                            "allowedActions": ["create_issue"],
+                        },
+                    },
+                },
+                "origin": {"workflow_id": "wf-mm-855", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        resolved_policy = mock_service.create_proposal.await_args.kwargs[
+            "resolved_policy"
+        ]
+        self.assertEqual(resolved_policy["provider"], "jira")
+        self.assertEqual(resolved_policy["allowedActions"], ["create_issue"])
+        self.assertEqual(resolved_policy["allowedProjects"], ["MM"])
+        self.assertNotIn("allowedRepositories", resolved_policy)
 
 class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
     async def test_default_runtime_stamped_into_candidate(self) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -5174,8 +5174,8 @@ async def test_run_proposals_stage_uses_workflow_proposal_policy(
             "workflow": {
                 "proposeTasks": True,
                 "proposalPolicy": {
-                    "maxItems": {"project": 12},
-                    "targets": ["project"],
+                    "maxItems": {"workflow_repo": 12},
+                    "targets": ["workflow_repo"],
                     "defaultRuntime": "gemini_cli",
                 }
             }
@@ -5183,8 +5183,8 @@ async def test_run_proposals_stage_uses_workflow_proposal_policy(
     )
     
     assert captured_policy is not None
-    assert captured_policy["maxItems"] == {"project": 12}
-    assert captured_policy["targets"] == ["project"]
+    assert captured_policy["maxItems"] == {"workflow_repo": 12}
+    assert captured_policy["targets"] == ["workflow_repo"]
     assert captured_policy["defaultRuntime"] == "gemini_cli"
     
     # Also verify origin format DOC-REQ-005

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -71,8 +71,8 @@ async def test_run_proposals_stage_propagates_policy(
         "task": {
             "proposeTasks": True,
             "proposalPolicy": {
-                "max_items": {"project": 5},
-                "targets": ["project"],
+                "max_items": {"workflow_repo": 5},
+                "targets": ["workflow_repo"],
                 "default_runtime": "claude",
             }
         }
@@ -86,8 +86,8 @@ async def test_run_proposals_stage_propagates_policy(
     
     submit_payload = captured[1][1]
     policy_payload = submit_payload["policy"]
-    assert policy_payload["maxItems"] == {"project": 5}
-    assert policy_payload["targets"] == ["project"]
+    assert policy_payload["maxItems"] == {"workflow_repo": 5}
+    assert policy_payload["targets"] == ["workflow_repo"]
     assert policy_payload["defaultRuntime"] == "claude"
 
     assert mock_run_workflow._proposals_generated == 1


### PR DESCRIPTION
Jira issue key: MM-855

Summary:
- Finalizes deterministic proposal routing for workflow repository and MoonMind proposal targets.
- Adds fail-closed delivery behavior for missing or unauthorized destinations with sanitized, recoverable failure records.
- Expands proposal delivery audit metadata and end-to-end proposal.submit coverage for routing, missing repository, disallowed repository, missing evidence, and missing credential paths.

Tests run:
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_proposal_activities.py tests/unit/workflows/proposals/test_service.py tests/unit/api/routers/test_workflow_proposals.py tests/unit/config/test_settings.py

Remaining risks:
- Full unit suite and compose-backed integration_ci suite were not run in this publication step.
- GitHub reported existing default-branch Dependabot vulnerabilities during push; they are unrelated to this branch diff.
