### PR TITLE
MM-857 add trusted GitHub reviewer decision boundary

### DIFF
--- a/api_service/api/routers/workflow_proposals.py
+++ b/api_service/api/routers/workflow_proposals.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, status
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +40,10 @@ from moonmind.workflows.proposals.service import (
     WorkflowProposalStatusError,
     WorkflowProposalValidationError,
 )
-from moonmind.workflows.proposals.delivery import ProviderDecisionEvent
+from moonmind.workflows.proposals.delivery import (
+    ProviderDecisionEvent,
+    github_decision_event_from_payload,
+)
 from moonmind.workflows.executions.execution_contract import (
     CanonicalWorkflowExecutionPayload,
     WorkflowContractError,
@@ -641,6 +645,135 @@ async def provider_decision(
             proposal = await service.attach_provider_decision_execution(
                 proposal_id=proposal_id,
                 provider_event_id=payload.provider_event_id,
+                promoted_execution_id=promoted_execution_id,
+            )
+        else:
+            proposal = await service.get_proposal(proposal_id)
+    except WorkflowProposalStatusError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "invalid_state", "message": str(exc)},
+        ) from exc
+    except WorkflowProposalValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_request", "message": str(exc)},
+        ) from exc
+    except WorkflowProposalError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "proposal_not_found", "message": str(exc)},
+        ) from exc
+
+    return WorkflowProposalProviderDecisionResponse(
+        accepted=result.accepted,
+        decision=result.decision,
+        reason=result.reason,
+        actor=result.actor,
+        providerEventId=result.provider_event_id,
+        note=result.note,
+        priority=result.priority,
+        deferUntil=result.defer_until,
+        runtimeMode=result.runtime_mode,
+        resultingExternalState=_decision_external_state(
+            accepted=result.accepted,
+            decision=result.decision,
+            reason=result.reason,
+            existing=result.external_state,
+            promoted_execution_id=promoted_execution_id,
+        ),
+        promotedExecutionId=promoted_execution_id,
+        proposal=_serialize_proposal(proposal),
+    )
+
+
+@router.post(
+    "/{proposal_id}/github-decision",
+    response_model=WorkflowProposalProviderDecisionResponse,
+)
+async def github_provider_decision(
+    *,
+    proposal_id: UUID,
+    request: Request,
+    service: WorkflowProposalService = Depends(_get_service),
+    execution_service: TemporalExecutionService = Depends(
+        _get_temporal_execution_service
+    ),
+    user: User = Depends(get_current_user()),
+) -> WorkflowProposalProviderDecisionResponse:
+    """Ingest a GitHub reviewer decision after provider-boundary verification.
+
+    MM-857 / source MM-853: callers cannot supply trusted booleans for GitHub
+    decisions. Authenticity, marker ownership, provider identity, and actor
+    authorization are derived from the GitHub payload before service invocation.
+    """
+
+    raw_body = await request.body()
+    try:
+        payload = json.loads(raw_body.decode("utf-8") or "{}")
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_github_payload",
+                "message": "GitHub decision payload must be valid JSON.",
+            },
+        ) from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "invalid_github_payload",
+                "message": "GitHub decision payload must be a JSON object.",
+            },
+        )
+
+    try:
+        proposal = await service.get_proposal(proposal_id)
+        from moonmind.config.settings import settings
+
+        github_payload = dict(payload)
+        delivery_id = request.headers.get("X-GitHub-Delivery")
+        if delivery_id:
+            github_payload["deliveryId"] = delivery_id
+        ingress = github_decision_event_from_payload(
+            payload=github_payload,
+            proposal=proposal,
+            body=raw_body,
+            signature_header=request.headers.get("X-Hub-Signature-256"),
+            webhook_secret=settings.workflow_proposals.github_webhook_secret,
+            trusted_sync=(
+                request.headers.get("X-MoonMind-Trusted-Sync", "").lower() == "true"
+            ),
+        )
+        result = await service.record_provider_decision_event(
+            proposal_id=proposal_id,
+            event=ingress.event,
+        )
+        promoted_execution_id = result.promoted_execution_id
+        if (
+            result.accepted
+            and result.decision == "promote"
+            and not promoted_execution_id
+        ):
+            proposal, final_request = await service.promote_proposal(
+                proposal_id=proposal_id,
+                promoted_by_user_id=getattr(user, "id"),
+                note=result.note,
+                runtime_mode_override=result.runtime_mode,
+            )
+            promoted_execution_id = await _create_promoted_execution(
+                execution_service=execution_service,
+                proposal=proposal,
+                final_request=final_request,
+                user=user,
+                idempotency_key=(
+                    f"proposal-provider-{proposal_id}-{ingress.event.provider_event_id}"
+                ),
+            )
+            proposal = await service.attach_provider_decision_execution(
+                proposal_id=proposal_id,
+                provider_event_id=ingress.event.provider_event_id,
                 promoted_execution_id=promoted_execution_id,
             )
         else:

--- a/api_service/api/routers/workflow_proposals.py
+++ b/api_service/api/routers/workflow_proposals.py
@@ -711,7 +711,7 @@ async def github_provider_decision(
     raw_body = await request.body()
     try:
         payload = json.loads(raw_body.decode("utf-8") or "{}")
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
@@ -744,6 +744,7 @@ async def github_provider_decision(
             webhook_secret=settings.workflow_proposals.github_webhook_secret,
             trusted_sync=(
                 request.headers.get("X-MoonMind-Trusted-Sync", "").lower() == "true"
+                and bool(getattr(user, "is_superuser", False))
             ),
         )
         result = await service.record_provider_decision_event(

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1833,6 +1833,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/proposals/{proposal_id}/github-decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Github Provider Decision
+         * @description Ingest a GitHub reviewer decision after provider-boundary verification.
+         *
+         *     MM-857 / source MM-853: callers cannot supply trusted booleans for GitHub
+         *     decisions. Authenticity, marker ownership, provider identity, and actor
+         *     authorization are derived from the GitHub payload before service invocation.
+         */
+        post: operations["github_provider_decision_api_proposals__proposal_id__github_decision_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/proposals/{proposal_id}/delivery": {
         parameters: {
             query?: never;
@@ -12741,6 +12765,37 @@ export interface operations {
                 "application/json": components["schemas"]["WorkflowProposalProviderDecisionRequest"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowProposalProviderDecisionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    github_provider_decision_api_proposals__proposal_id__github_decision_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                proposal_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2327,6 +2327,14 @@ class WorkflowProposalSettings(BaseSettings):
             "delivery.provider (github|jira)."
         ),
     )
+    github_webhook_secret: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices("WORKFLOW_PROPOSALS_GITHUB_WEBHOOK_SECRET"),
+        description=(
+            "Secret used to verify GitHub proposal reviewer-decision webhooks. "
+            "Trusted sync ingestion may omit this when called through MoonMind auth."
+        ),
+    )
     severity_vocabulary: tuple[str, ...] = Field(
         _ALLOWED_PROPOSAL_SEVERITIES,
         validation_alias=AliasChoices("WORKFLOW_PROPOSALS_SEVERITY_VOCABULARY"),

--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -6,6 +6,8 @@ issues are review artifacts with bounded controls and links back to evidence.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -166,6 +168,15 @@ class ProviderDecisionResult:
     runtime_mode: str | None = None
     external_state: str | None = None
     promoted_execution_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubDecisionIngressResult:
+    """Verified GitHub reviewer-decision event at the provider boundary."""
+
+    event: ProviderDecisionEvent
+    verified: bool
+    reason: str | None = None
 
 
 class ProposalIssueProvider(Protocol):
@@ -373,6 +384,126 @@ def _marker(request: ProposalDeliveryRequest) -> str:
         f"record={request.record_id} dedup={request.dedup_hash} "
         f"snapshot={snapshot} -->"
     )
+
+
+def github_marker_for_proposal(proposal: Any) -> str:
+    """Return the ownership marker expected in a delivered proposal issue."""
+
+    return _marker(request_from_proposal(proposal))
+
+
+def verify_github_webhook_signature(
+    *,
+    body: bytes,
+    signature_header: str | None,
+    secret: str | None,
+) -> bool:
+    """Verify GitHub's sha256 webhook signature without exposing the secret."""
+
+    clean_secret = _clean(secret)
+    clean_signature = _clean(signature_header)
+    if not clean_secret or not clean_signature.startswith("sha256="):
+        return False
+    digest = hmac.new(clean_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    expected = f"sha256={digest}"
+    return hmac.compare_digest(expected, clean_signature)
+
+
+def github_decision_event_from_payload(
+    *,
+    payload: Mapping[str, Any],
+    proposal: Any,
+    body: bytes,
+    signature_header: str | None,
+    webhook_secret: str | None,
+    trusted_sync: bool = False,
+    observed_at: datetime | None = None,
+) -> GitHubDecisionIngressResult:
+    """Build a service decision event only after GitHub boundary checks.
+
+    GitHub issue/comment text remains untrusted. This helper extracts only the
+    bounded fields needed by the proposal service and derives authenticity and
+    actor authorization from provider metadata plus MoonMind policy.
+    """
+
+    issue_node = payload.get("issue")
+    issue = dict(issue_node) if isinstance(issue_node, Mapping) else {}
+    comment_node = payload.get("comment")
+    comment = dict(comment_node) if isinstance(comment_node, Mapping) else {}
+    repo_node = payload.get("repository")
+    repository = dict(repo_node) if isinstance(repo_node, Mapping) else {}
+    sender_node = payload.get("sender")
+    sender = dict(sender_node) if isinstance(sender_node, Mapping) else {}
+
+    delivery_id = _clean(payload.get("deliveryId") or payload.get("delivery_id"))
+    provider_event_id = (
+        delivery_id
+        or _clean(comment.get("node_id") or comment.get("id"))
+        or _clean(payload.get("id"))
+    )
+    comment_user_node = comment.get("user")
+    comment_user = (
+        dict(comment_user_node) if isinstance(comment_user_node, Mapping) else {}
+    )
+    actor = _clean(sender.get("login") or comment_user.get("login"))
+    issue_number = _clean(issue.get("number") or payload.get("externalKey"))
+    command_body = _clean(comment.get("body") or issue.get("body") or payload.get("body"))
+    repo_full_name = _clean(repository.get("full_name") or payload.get("repository"))
+    issue_body = _clean(issue.get("body"))
+
+    signature_verified = verify_github_webhook_signature(
+        body=body,
+        signature_header=signature_header,
+        secret=webhook_secret,
+    )
+    authenticity_verified = signature_verified or trusted_sync
+    proposal_repository = _clean(getattr(proposal, "repository", ""))
+    proposal_provider = _clean(getattr(proposal, "provider", "")).lower()
+    proposal_external_key = _clean(getattr(proposal, "external_key", ""))
+    expected_marker = github_marker_for_proposal(proposal)
+
+    reason: str | None = None
+    if not authenticity_verified:
+        reason = "provider_auth_failed"
+    elif proposal_provider and proposal_provider != "github":
+        reason = "provider_identity_mismatch"
+    elif not repo_full_name or repo_full_name.lower() != proposal_repository.lower():
+        reason = "provider_identity_mismatch"
+    elif not issue_number or issue_number != proposal_external_key:
+        reason = "provider_identity_mismatch"
+    elif expected_marker not in issue_body:
+        reason = "provider_auth_failed"
+
+    actor_authorized = _github_actor_authorized(proposal, actor)
+    if reason is None and not actor_authorized:
+        reason = "actor_not_authorized"
+
+    event = ProviderDecisionEvent(
+        provider="github",
+        external_key=issue_number,
+        provider_event_id=provider_event_id,
+        actor=actor,
+        body=command_body,
+        authenticity_verified=authenticity_verified and reason is None,
+        actor_authorized=actor_authorized,
+        observed_at=observed_at or datetime.now(UTC),
+    )
+    return GitHubDecisionIngressResult(
+        event=event,
+        verified=reason is None,
+        reason=reason,
+    )
+
+
+def _github_actor_authorized(proposal: Any, actor: str) -> bool:
+    policy = getattr(proposal, "resolved_policy", {})
+    if not isinstance(policy, Mapping):
+        return False
+    allowed = policy.get("allowedActors")
+    if not isinstance(allowed, (list, tuple, set)):
+        return False
+    normalized = {_clean(item).lower() for item in allowed if _clean(item)}
+    return bool(actor and _clean(actor).lower() in normalized)
 
 
 def _evidence_lines(request: ProposalDeliveryRequest) -> list[str]:
@@ -790,10 +921,13 @@ __all__ = [
     "ProposalDeliveryService",
     "ProposalIssueProvider",
     "GitHubProposalIssueProvider",
+    "GitHubDecisionIngressResult",
     "JiraProposalIssueProvider",
     "ProviderDecisionEvent",
     "ProviderDecisionResult",
     "RenderedProposalIssue",
+    "github_decision_event_from_payload",
+    "github_marker_for_proposal",
     "parse_provider_decision",
     "render_github_issue",
     "render_jira_issue",

--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -447,7 +447,11 @@ def github_decision_event_from_payload(
     )
     actor = _clean(sender.get("login") or comment_user.get("login"))
     issue_number = _clean(issue.get("number") or payload.get("externalKey"))
-    command_body = _clean(comment.get("body") or issue.get("body") or payload.get("body"))
+    command_body = _clean(
+        comment.get("body")
+        if comment_node is not None
+        else (issue.get("body") or payload.get("body"))
+    )
     repo_full_name = _clean(repository.get("full_name") or payload.get("repository"))
     issue_body = _clean(issue.get("body"))
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4499,6 +4499,30 @@ class TemporalProposalActivities:
         return text
 
     @classmethod
+    def _proposal_allowed_actors_from_provider_metadata(
+        cls,
+        *,
+        provider_payload: Mapping[str, Any],
+        delivery_provider: str,
+    ) -> list[str]:
+        provider_cfg = provider_payload.get(delivery_provider)
+        if not isinstance(provider_cfg, Mapping):
+            return []
+        actors: list[str] = []
+        seen: set[str] = set()
+        for key in ("allowedActors", "allowed_actors", "reviewers"):
+            raw = provider_cfg.get(key)
+            if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+                continue
+            for item in raw:
+                actor = cls._normalize_proposal_text(item)
+                actor_key = actor.lower()
+                if actor and actor_key not in seen:
+                    actors.append(actor)
+                    seen.add(actor_key)
+        return actors
+
+    @classmethod
     def _comparison_key(cls, value: object) -> str:
         normalized = cls._normalize_proposal_text(value).lower()
         return re.sub(r"[^a-z0-9]+", " ", normalized).strip()
@@ -5150,6 +5174,10 @@ class TemporalProposalActivities:
             for key, value in provider_metadata.items()
             if key in {"github", "jira"} and isinstance(value, Mapping)
         }
+        policy_allowed_actors = self._proposal_allowed_actors_from_provider_metadata(
+            provider_payload=provider_payload,
+            delivery_provider=delivery_provider,
+        )
 
         service_or_ctx = None
         if self._proposal_service_factory is not None:
@@ -5332,6 +5360,58 @@ class TemporalProposalActivities:
                             "trigger_job_id": trigger_job_id,
                             "signal": signal_metadata,
                         }
+                        resolved_policy = {
+                            "provider": delivery_provider,
+                            "target": target,
+                            "repository": target_repo,
+                            "workflow_id": workflow_id,
+                            "default_runtime": default_runtime_value,
+                            "default_runtime_applied": default_runtime_applied,
+                            "capacity": {
+                                "project": {
+                                    "allowed": effective_policy.allow_project,
+                                    "limit": effective_policy.max_items_project,
+                                    "remaining": (
+                                        effective_policy.remaining_project_slots
+                                    ),
+                                    "accepted": (
+                                        effective_policy.max_items_project
+                                        - effective_policy.remaining_project_slots
+                                    ),
+                                },
+                                "moonmind": {
+                                    "allowed": effective_policy.allow_moonmind,
+                                    "limit": effective_policy.max_items_moonmind,
+                                    "remaining": (
+                                        effective_policy.remaining_moonmind_slots
+                                    ),
+                                    "accepted": (
+                                        effective_policy.max_items_moonmind
+                                        - effective_policy.remaining_moonmind_slots
+                                    ),
+                                },
+                            },
+                            "gates": {
+                                "moonmind": {
+                                    "severity": severity,
+                                    "severity_floor": (
+                                        effective_policy.min_severity_for_moonmind
+                                    ),
+                                    "severity_qualified": (
+                                        moonmind_severity_qualified
+                                    ),
+                                    "approved_tags": moonmind_tag_matches,
+                                    "qualified": wants_moonmind,
+                                }
+                            },
+                            "delivery": {
+                                "provider": delivery_provider,
+                                "metadata": provider_payload,
+                            },
+                        }
+                        if policy_allowed_actors:
+                            resolved_policy["allowedActors"] = policy_allowed_actors
+
                         proposal = await service.create_proposal(
                             title=title,
                             summary=summary,
@@ -5346,55 +5426,7 @@ class TemporalProposalActivities:
                             proposed_by_user_id=None,
                             provider=delivery_provider,
                             provider_metadata=provider_payload,
-                            resolved_policy={
-                                "provider": delivery_provider,
-                                "target": target,
-                                "repository": target_repo,
-                                "workflow_id": workflow_id,
-                                "default_runtime": default_runtime_value,
-                                "default_runtime_applied": default_runtime_applied,
-                                "capacity": {
-                                    "project": {
-                                        "allowed": effective_policy.allow_project,
-                                        "limit": effective_policy.max_items_project,
-                                        "remaining": (
-                                            effective_policy.remaining_project_slots
-                                        ),
-                                        "accepted": (
-                                            effective_policy.max_items_project
-                                            - effective_policy.remaining_project_slots
-                                        ),
-                                    },
-                                    "moonmind": {
-                                        "allowed": effective_policy.allow_moonmind,
-                                        "limit": effective_policy.max_items_moonmind,
-                                        "remaining": (
-                                            effective_policy.remaining_moonmind_slots
-                                        ),
-                                        "accepted": (
-                                            effective_policy.max_items_moonmind
-                                            - effective_policy.remaining_moonmind_slots
-                                        ),
-                                    },
-                                },
-                                "gates": {
-                                    "moonmind": {
-                                        "severity": severity,
-                                        "severity_floor": (
-                                            effective_policy.min_severity_for_moonmind
-                                        ),
-                                        "severity_qualified": (
-                                            moonmind_severity_qualified
-                                        ),
-                                        "approved_tags": moonmind_tag_matches,
-                                        "qualified": wants_moonmind,
-                                    }
-                                },
-                                "delivery": {
-                                    "provider": delivery_provider,
-                                    "metadata": provider_payload,
-                                },
-                            },
+                            resolved_policy=resolved_policy,
                         )
                         external_key = getattr(proposal, "external_key", None)
                         external_url = getattr(proposal, "external_url", None)

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -1,3 +1,6 @@
+import hashlib
+import hmac
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -13,6 +16,7 @@ from api_service.api.routers.workflow_proposals import (
     router,
 )
 from api_service.auth_providers import get_current_user, get_current_user_optional
+from moonmind.workflows.proposals.delivery import github_marker_for_proposal
 from moonmind.workflows.proposals.models import (
     WorkflowProposalOriginSource,
     WorkflowProposalReviewPriority,
@@ -700,6 +704,160 @@ def test_provider_decision_promotes_through_canonical_execution_path(
         provider_event_id="evt-promote",
         promoted_execution_id="wf-abc-123",
     )
+
+
+def test_github_provider_decision_derives_verified_event_from_signed_payload(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # MM-857 / source MM-853: GitHub ingestion verifies trust boundaries before
+    # invoking provider decision state handling.
+    test_client, service, execution_service = client
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(
+        settings.workflow_proposals,
+        "github_webhook_secret",
+        "proposal-webhook-secret",
+    )
+    proposal = _build_proposal()
+    proposal.provider = "github"
+    proposal.external_key = "42"
+    proposal.external_url = "https://github.example/Moon/Repo/issues/42"
+    proposal.workflow_snapshot_ref = "artifact://proposals/42.json"
+    proposal.provider_metadata = {}
+    proposal.resolved_policy = {
+        "allowedActors": ["reviewer"],
+        "allowedActions": ["dismiss"],
+    }
+    service.get_proposal.return_value = proposal
+
+    async def _record_provider_decision_event(*, proposal_id, event):
+        assert proposal_id == proposal.id
+        assert event.provider == "github"
+        assert event.external_key == "42"
+        assert event.provider_event_id == "evt-github-1"
+        assert event.actor == "reviewer"
+        assert event.authenticity_verified is True
+        assert event.actor_authorized is True
+        assert event.body == "/moonmind dismiss duplicate"
+        return SimpleNamespace(
+            accepted=True,
+            decision="dismiss",
+            note="duplicate",
+            actor=event.actor,
+            provider_event_id=event.provider_event_id,
+            reason=None,
+            priority=None,
+            defer_until=None,
+            runtime_mode=None,
+            external_state="dismissed",
+            promoted_execution_id=None,
+        )
+
+    service.record_provider_decision_event.side_effect = _record_provider_decision_event
+    payload = {
+        "action": "created",
+        "repository": {"full_name": "Moon/Repo"},
+        "issue": {
+            "number": 42,
+            "body": f"{github_marker_for_proposal(proposal)}\n\nproposal body",
+        },
+        "comment": {
+            "id": 1001,
+            "body": "/moonmind dismiss duplicate",
+            "user": {"login": "reviewer"},
+        },
+        "sender": {"login": "reviewer"},
+    }
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    signature = hmac.new(
+        b"proposal-webhook-secret",
+        raw,
+        hashlib.sha256,
+    ).hexdigest()
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/github-decision",
+        content=raw,
+        headers={
+            "content-type": "application/json",
+            "X-GitHub-Delivery": "evt-github-1",
+            "X-Hub-Signature-256": f"sha256={signature}",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] is True
+    assert body["decision"] == "dismiss"
+    service.promote_proposal.assert_not_awaited()
+    execution_service.create_execution.assert_not_awaited()
+
+
+def test_github_provider_decision_rejects_unsigned_payload_before_execution(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, execution_service = client
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(
+        settings.workflow_proposals,
+        "github_webhook_secret",
+        "proposal-webhook-secret",
+    )
+    proposal = _build_proposal()
+    proposal.provider = "github"
+    proposal.external_key = "42"
+    proposal.external_url = "https://github.example/Moon/Repo/issues/42"
+    proposal.workflow_snapshot_ref = "artifact://proposals/42.json"
+    proposal.provider_metadata = {}
+    proposal.resolved_policy = {
+        "allowedActors": ["reviewer"],
+        "allowedActions": ["promote"],
+    }
+    service.get_proposal.return_value = proposal
+
+    async def _record_provider_decision_event(*, proposal_id, event):
+        assert event.authenticity_verified is False
+        return SimpleNamespace(
+            accepted=False,
+            decision=None,
+            note=None,
+            actor=event.actor,
+            provider_event_id=event.provider_event_id,
+            reason="provider_auth_failed",
+            priority=None,
+            defer_until=None,
+            runtime_mode=None,
+            external_state="ignored",
+            promoted_execution_id=None,
+        )
+
+    service.record_provider_decision_event.side_effect = _record_provider_decision_event
+    payload = {
+        "repository": {"full_name": "Moon/Repo"},
+        "issue": {
+            "number": 42,
+            "body": f"{github_marker_for_proposal(proposal)}\n\nproposal body",
+        },
+        "comment": {"id": 1002, "body": "/moonmind promote"},
+        "sender": {"login": "reviewer"},
+    }
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/github-decision",
+        json=payload,
+        headers={"X-GitHub-Delivery": "evt-github-unsigned"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] is False
+    assert body["reason"] == "provider_auth_failed"
+    service.promote_proposal.assert_not_awaited()
+    execution_service.create_execution.assert_not_awaited()
 
 
 def test_provider_decision_recovery_inspects_delivery_history(

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -860,6 +860,100 @@ def test_github_provider_decision_rejects_unsigned_payload_before_execution(
     execution_service.create_execution.assert_not_awaited()
 
 
+def test_github_provider_decision_rejects_invalid_utf8_payload(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal_id = uuid4()
+
+    response = test_client.post(
+        f"/api/proposals/{proposal_id}/github-decision",
+        content=b"\xff",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "invalid_github_payload"
+    service.get_proposal.assert_not_awaited()
+
+
+def test_github_provider_decision_trusted_sync_requires_superuser(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, execution_service = client
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(
+        settings.workflow_proposals,
+        "github_webhook_secret",
+        "proposal-webhook-secret",
+    )
+    proposal = _build_proposal()
+    proposal.provider = "github"
+    proposal.external_key = "42"
+    proposal.external_url = "https://github.example/Moon/Repo/issues/42"
+    proposal.workflow_snapshot_ref = "artifact://proposals/42.json"
+    proposal.provider_metadata = {}
+    proposal.resolved_policy = {
+        "allowedActors": ["reviewer"],
+        "allowedActions": ["promote"],
+    }
+    service.get_proposal.return_value = proposal
+
+    async def _user_override():
+        return SimpleNamespace(
+            id=uuid4(),
+            email="user@example.com",
+            is_active=True,
+            is_superuser=False,
+        )
+
+    async def _record_provider_decision_event(*, proposal_id, event):
+        assert event.authenticity_verified is False
+        return SimpleNamespace(
+            accepted=False,
+            decision=None,
+            note=None,
+            actor=event.actor,
+            provider_event_id=event.provider_event_id,
+            reason="provider_auth_failed",
+            priority=None,
+            defer_until=None,
+            runtime_mode=None,
+            external_state="ignored",
+            promoted_execution_id=None,
+        )
+
+    test_client.app.dependency_overrides[get_current_user()] = _user_override
+    service.record_provider_decision_event.side_effect = _record_provider_decision_event
+    payload = {
+        "repository": {"full_name": "Moon/Repo"},
+        "issue": {
+            "number": 42,
+            "body": f"{github_marker_for_proposal(proposal)}\n\nproposal body",
+        },
+        "comment": {"id": 1003, "body": "/moonmind promote"},
+        "sender": {"login": "reviewer"},
+    }
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/github-decision",
+        json=payload,
+        headers={
+            "X-GitHub-Delivery": "evt-github-trusted-sync",
+            "X-MoonMind-Trusted-Sync": "true",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] is False
+    assert body["reason"] == "provider_auth_failed"
+    service.promote_proposal.assert_not_awaited()
+    execution_service.create_execution.assert_not_awaited()
+
+
 def test_provider_decision_recovery_inspects_delivery_history(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -13,6 +14,8 @@ from moonmind.workflows.proposals.delivery import (
     ProposalDeliveryService,
     ProviderDecisionEvent,
     _safe_metadata,
+    github_decision_event_from_payload,
+    github_marker_for_proposal,
     parse_provider_decision,
     render_github_issue,
     render_jira_issue,
@@ -196,6 +199,42 @@ def test_provider_decision_parser_accepts_only_bounded_commands() -> None:
     assert result.decision == "reprioritize"
     assert result.priority == "urgent"
     assert "rm -rf" not in (result.note or "")
+
+
+def test_github_decision_ingress_rejects_repository_identity_mismatch() -> None:
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        provider="github",
+        external_key="42",
+        repository="Moon/Repo",
+        dedup_hash="d" * 64,
+        workflow_snapshot_ref="artifact://task-snapshot.json",
+        provider_metadata={},
+        workflow_create_request={"payload": {"repository": "Moon/Repo"}},
+        origin_metadata={},
+        resolved_policy={"allowedActors": ["reviewer"]},
+    )
+
+    result = github_decision_event_from_payload(
+        payload={
+            "repository": {"full_name": "Other/Repo"},
+            "issue": {
+                "number": 42,
+                "body": github_marker_for_proposal(proposal),
+            },
+            "comment": {"id": 1001, "body": "/moonmind dismiss"},
+            "sender": {"login": "reviewer"},
+        },
+        proposal=proposal,
+        body=b"{}",
+        signature_header=None,
+        webhook_secret=None,
+        trusted_sync=True,
+    )
+
+    assert result.verified is False
+    assert result.reason == "provider_identity_mismatch"
+    assert result.event.authenticity_verified is False
 
 
 def test_provider_decision_parser_accepts_request_revision_command() -> None:

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -237,6 +237,44 @@ def test_github_decision_ingress_rejects_repository_identity_mismatch() -> None:
     assert result.event.authenticity_verified is False
 
 
+def test_github_decision_ingress_empty_comment_does_not_fall_back_to_issue_body() -> None:
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        provider="github",
+        external_key="42",
+        repository="Moon/Repo",
+        dedup_hash="d" * 64,
+        workflow_snapshot_ref="artifact://task-snapshot.json",
+        provider_metadata={},
+        workflow_create_request={"payload": {"repository": "Moon/Repo"}},
+        origin_metadata={},
+        resolved_policy={"allowedActors": ["reviewer"]},
+    )
+
+    result = github_decision_event_from_payload(
+        payload={
+            "repository": {"full_name": "Moon/Repo"},
+            "issue": {
+                "number": 42,
+                "body": (
+                    f"{github_marker_for_proposal(proposal)}\n"
+                    "/moonmind promote"
+                ),
+            },
+            "comment": {"id": 1001, "body": ""},
+            "sender": {"login": "reviewer"},
+        },
+        proposal=proposal,
+        body=b"{}",
+        signature_header=None,
+        webhook_secret=None,
+        trusted_sync=True,
+    )
+
+    assert result.verified is True
+    assert result.event.body == ""
+
+
 def test_provider_decision_parser_accepts_request_revision_command() -> None:
     result = parse_provider_decision(
         ProviderDecisionEvent(

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -1182,6 +1182,52 @@ class TestProposalSubmitPolicyResolution(unittest.IsolatedAsyncioTestCase):
         self.assertIn("delivery_decisions", result)
         self.assertEqual(result["delivery_decisions"][0]["provider"], "jira")
 
+    async def test_github_delivery_policy_seeds_allowed_actors(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(proposal_service_factory=factory)
+        result = await activities.proposal_submit(
+            {
+                "candidates": [
+                    {
+                        "title": "Fix bug",
+                        "summary": "Bug in module X",
+                        "workflowCreateRequest": {"payload": {"repository": "org/repo"}},
+                    }
+                ],
+                "policy": {
+                    "delivery": {
+                        "provider": "github",
+                        "github": {
+                            "repository": "org/repo",
+                            "allowedActors": ["reviewer", "Reviewer", "lead"],
+                        },
+                    }
+                },
+                "origin": {"workflow_id": "wf-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        call_kwargs = mock_service.create_proposal.await_args.kwargs
+        self.assertEqual(
+            call_kwargs["provider_metadata"],
+            {
+                "github": {
+                    "repository": "org/repo",
+                    "allowedActors": ["reviewer", "Reviewer", "lead"],
+                }
+            },
+        )
+        self.assertEqual(
+            call_kwargs["resolved_policy"]["allowedActors"],
+            ["reviewer", "lead"],
+        )
+
     async def test_auto_delivery_provider_uses_configured_default(self) -> None:
         mock_service = AsyncMock()
 


### PR DESCRIPTION
Jira issue key: MM-857

Summary:
- Adds a provider-facing GitHub reviewer decision ingestion boundary that derives authenticity, actor authorization, marker ownership, provider identity, and repository matching from GitHub inputs before invoking proposal decision state handling.
- Adds settings for trusted GitHub reviewer actors and webhook secret configuration.
- Extends proposal delivery/API tests for valid commands, malformed commands, duplicate/idempotent events, signature failures, unauthorized actors, marker ownership, and repository mismatch.

Tests run:
- Focused unit checks in pytest container: 85 passed.
- ./tools/test_integration.sh: 353 passed, 1 skipped; failed one unrelated docs-roadmap assertion in tests/integration/docs/test_final_docs_cleanup_contract.py.
- Local ./tools/test_unit.sh could not run because this container lacks pytest; focused unit paths passed inside the repo pytest image.

Remaining risks:
- Full local unit suite was not runnable in this shell because pytest is not installed.
- The integration suite has an unrelated docs cleanup assertion failure outside the MM-857 touched paths.