### PR TITLE
I want to move the more commonly used workflow actions to the top of the workflow actions dropdown menu.

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2381,10 +2381,10 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    expect(within(menu).getByRole('menuitem', { name: 'Edit task' }).getAttribute('href')).toBe(
+    expect(within(menu).getByRole('menuitem', { name: 'Edit' }).getAttribute('href')).toBe(
       '/workflows/new?editExecutionId=test-123',
     );
-    const editLink = within(menu).getByRole('menuitem', { name: 'Edit task' });
+    const editLink = within(menu).getByRole('menuitem', { name: 'Edit' });
     editLink.addEventListener('click', (event) => event.preventDefault());
     fireEvent.focus(editLink);
     fireEvent.keyDown(editLink, { key: 'Enter' });
@@ -2516,7 +2516,7 @@ describe('Workflow Detail Entrypoint', () => {
     const menu = screen.getByRole('menu', { name: 'Workflow actions' });
     for (const label of [
       'Rename',
-      'Edit task',
+      'Edit',
       'Compare run',
       'Rerun',
       'Resume from failed step',
@@ -2527,8 +2527,8 @@ describe('Workflow Detail Entrypoint', () => {
       'Reject',
       'Cancel',
       'Send Message',
-      'Bypass Dependency Wait',
-      'Create remediation task',
+      'Bypass Dependencies',
+      'Remediate',
     ]) {
       expect(within(menu).getByRole('menuitem', { name: label })).toBeTruthy();
     }
@@ -2945,7 +2945,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    expect(within(menu).getByRole('menuitem', { name: 'Edit task' }).getAttribute('href')).toBe(
+    expect(within(menu).getByRole('menuitem', { name: 'Edit' }).getAttribute('href')).toBe(
       '/workflows/new?rerunExecutionId=test-123&mode=edit',
     );
     expect(within(menu).getByRole('menuitem', { name: 'Rerun' })).toBeTruthy();
@@ -3001,7 +3001,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    expect(within(menu).getByRole('menuitem', { name: 'Edit task' }).getAttribute('href')).toBe(
+    expect(within(menu).getByRole('menuitem', { name: 'Edit' }).getAttribute('href')).toBe(
       '/workflows/new?editExecutionId=test-123',
     );
     expect(screen.queryByText(/Edit workflow unavailable:/)).toBeNull();
@@ -3057,10 +3057,10 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    expect(screen.queryByRole('link', { name: 'Edit task' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Edit' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Rerun' })).toBeNull();
     expect(
-      within(menu).getByText('Edit task unavailable: original task input snapshot missing'),
+      within(menu).getByText('Edit unavailable: original task input snapshot missing'),
     ).toBeTruthy();
     expect(
       within(menu).getByText('Rerun unavailable: original task input snapshot missing'),
@@ -3345,7 +3345,7 @@ describe('Workflow Detail Entrypoint', () => {
     await waitFor(() => {
       expect(screen.getByText('Flagged off task')).toBeTruthy();
     });
-    expect(screen.queryByRole('link', { name: 'Edit task' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Edit' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Rerun' })).toBeNull();
     expect(screen.queryByRole('heading', { name: 'Workflow Actions' })).toBeNull();
   });
@@ -3948,7 +3948,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    expect(within(menu).getByRole('menuitem', { name: 'Create remediation task' })).toBeTruthy();
+    expect(within(menu).getByRole('menuitem', { name: 'Remediate' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Remediation' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Remediation Tasks' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Remediation Target' })).toBeTruthy();
@@ -3960,7 +3960,7 @@ describe('Workflow Detail Entrypoint', () => {
       '/api/artifacts/art_context/download',
     );
 
-    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Create remediation task' }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Remediate' }));
 
     await waitFor(() => {
       const remediationCreateCall = fetchSpy.mock.calls.find(
@@ -4064,7 +4064,7 @@ describe('Workflow Detail Entrypoint', () => {
       target: { value: 'troubleshooting_only' },
     });
     const menu = await openWorkflowActionsMenu();
-    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Create remediation task' }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Remediate' }));
 
     await waitFor(() => {
       const remediationCreateCall = fetchSpy.mock.calls.find(
@@ -4127,7 +4127,7 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByText('Completed target task')).toBeTruthy();
     });
 
-    expect(screen.queryByRole('button', { name: 'Create remediation task' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Remediate' })).toBeNull();
     expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction=inbound'))).toBe(true);
     expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/remediations?direction=outbound'))).toBe(true);
   });
@@ -4998,7 +4998,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
 
     const menu = await openWorkflowActionsMenu();
-    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Bypass Dependency Wait' }));
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Bypass Dependencies' }));
 
     await waitFor(() => {
       expect(confirmSpy).toHaveBeenCalledWith('Bypass dependency waiting for this task?');
@@ -6034,7 +6034,7 @@ describe('Workflow Detail Entrypoint', () => {
     const menu = await openWorkflowActionsMenu();
     expect(within(menu).getByRole('menuitem', { name: 'Cancel' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Skip Dependency Wait' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Bypass Dependency Wait' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Bypass Dependencies' })).toBeNull();
   });
 
   it('renders a Session Continuity panel for Codex managed-session agent runs', async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -13430,6 +13430,28 @@ describe("Task Create MM-641 authoring validation", () => {
     expect(stepsSection).not.toBeNull();
   });
 
+  it("hides Priority and Max Attempts behind the Advanced mode toggle", async () => {
+    renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
+
+    await screen.findByLabelText("Instructions");
+    const executionControls = document.querySelector<HTMLElement>(
+      '[data-canonical-create-section="Execution controls"]',
+    );
+    expect(executionControls).not.toBeNull();
+    const controls = executionControls as HTMLElement;
+
+    expect(within(controls).queryByLabelText("Priority")).toBeNull();
+    expect(within(controls).queryByLabelText("Max Attempts")).toBeNull();
+
+    fireEvent.click(within(controls).getByLabelText("Advanced mode"));
+    expect(within(controls).getByLabelText("Priority")).toBeTruthy();
+    expect(within(controls).getByLabelText("Max Attempts")).toBeTruthy();
+
+    fireEvent.click(within(controls).getByLabelText("Advanced mode"));
+    expect(within(controls).queryByLabelText("Priority")).toBeNull();
+    expect(within(controls).queryByLabelText("Max Attempts")).toBeNull();
+  });
+
   it("blocks invalid MM-641 authoring drafts before creating executions", async () => {
     renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -13452,6 +13452,57 @@ describe("Task Create MM-641 authoring validation", () => {
     expect(within(controls).queryByLabelText("Max Attempts")).toBeNull();
   });
 
+  it("ignores hidden Priority and Max Attempts values when Advanced mode is off", async () => {
+    renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
+
+    const primaryStep = (await screen.findByText("Step 1")).closest("section");
+    expect(primaryStep).not.toBeNull();
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Run end-to-end regression flow." },
+    });
+    fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
+      target: { value: "MoonLadderStudios/MoonMind" },
+    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      { target: { value: "speckit-orchestrate" } },
+    );
+
+    const controls = document.querySelector<HTMLElement>(
+      '[data-canonical-create-section="Execution controls"]',
+    ) as HTMLElement;
+    expect(controls).not.toBeNull();
+
+    // Reveal the advanced controls, set a non-default Priority and an invalid
+    // Max Attempts, then hide the controls again before submitting.
+    fireEvent.click(within(controls).getByLabelText("Advanced mode"));
+    fireEvent.change(within(controls).getByLabelText("Priority"), {
+      target: { value: "7" },
+    });
+    fireEvent.change(within(controls).getByLabelText("Max Attempts"), {
+      target: { value: "0" },
+    });
+    fireEvent.click(within(controls).getByLabelText("Advanced mode"));
+    expect(within(controls).queryByLabelText("Priority")).toBeNull();
+    expect(within(controls).queryByLabelText("Max Attempts")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    // The hidden non-default Priority is dropped and the hidden invalid Max
+    // Attempts neither blocks submission nor leaks through: defaults are sent.
+    const request = latestCreateRequest();
+    expect(request.priority).toBe(0);
+    expect(request.maxAttempts).toBe(3);
+  });
+
   it("blocks invalid MM-641 authoring drafts before creating executions", async () => {
     renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -10763,32 +10763,34 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           data-canonical-create-section="Execution controls"
           aria-label="Execution controls"
         >
-        <div className="grid-2" data-runtime-visibility="worker">
-          <label>
-            Priority
-            <div className="priority-slider-container">
+        {showAdvancedStepOptions ? (
+          <div className="grid-2" data-runtime-visibility="worker">
+            <label>
+              Priority
+              <div className="priority-slider-container">
+                <input
+                  type="range"
+                  name="priority"
+                  min="-10"
+                  max="10"
+                  value={priority}
+                  onChange={(event) => setPriority(Number(event.target.value))}
+                />
+                <output>{priority}</output>
+              </div>
+            </label>
+            <label>
+              Max Attempts
               <input
-                type="range"
-                name="priority"
-                min="-10"
-                max="10"
-                value={priority}
-                onChange={(event) => setPriority(Number(event.target.value))}
+                type="number"
+                min="1"
+                name="maxAttempts"
+                value={maxAttempts}
+                onChange={(event) => setMaxAttempts(Number(event.target.value))}
               />
-              <output>{priority}</output>
-            </div>
-          </label>
-          <label>
-            Max Attempts
-            <input
-              type="number"
-              min="1"
-              name="maxAttempts"
-              value={maxAttempts}
-              onChange={(event) => setMaxAttempts(Number(event.target.value))}
-            />
-          </label>
-        </div>
+            </label>
+          </div>
+        ) : null}
 
         <label className="checkbox">
           <input

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4227,6 +4227,12 @@ export const LIQUID_GL_OPTIONS = {
   magnify: 1,
 } as const;
 
+// Defaults applied when the advanced execution controls (Priority / Max
+// Attempts) are hidden. Submission uses these so toggling Advanced mode off
+// never silently submits stale values nor blocks on a hidden invalid one.
+const DEFAULT_PRIORITY = 0;
+const DEFAULT_MAX_ATTEMPTS = 3;
+
 export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   useLiquidGL({ options: LIQUID_GL_OPTIONS });
   const dashboardConfig = readDashboardConfig(payload);
@@ -4397,8 +4403,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     normalizePublishModeForSubmit(defaultPublishMode),
   );
   const [produceReport, setProduceReport] = useState(false);
-  const [priority, setPriority] = useState(0);
-  const [maxAttempts, setMaxAttempts] = useState(3);
+  const [priority, setPriority] = useState(DEFAULT_PRIORITY);
+  const [maxAttempts, setMaxAttempts] = useState(DEFAULT_MAX_ATTEMPTS);
   const [proposeTasks, setProposeTasks] = useState(() =>
     readProposeTasksPreference(defaultProposeTasks),
   );
@@ -7789,12 +7795,20 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    if (!Number.isInteger(priority)) {
+    // Priority and Max Attempts live behind the Advanced mode toggle. When that
+    // toggle is off the inputs are unmounted, so fall back to defaults instead
+    // of validating or submitting whatever value the hidden state still holds.
+    const effectivePriority = showAdvancedStepOptions ? priority : DEFAULT_PRIORITY;
+    const effectiveMaxAttempts = showAdvancedStepOptions
+      ? maxAttempts
+      : DEFAULT_MAX_ATTEMPTS;
+
+    if (!Number.isInteger(effectivePriority)) {
       setSubmitMessage("Priority must be an integer.");
       clearSubmitBusy();
       return;
     }
-    if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    if (!Number.isInteger(effectiveMaxAttempts) || effectiveMaxAttempts < 1) {
       setSubmitMessage("Max Attempts must be an integer >= 1.");
       clearSubmitBusy();
       return;
@@ -8700,8 +8714,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
 
     const requestBody: Record<string, unknown> = {
       type: "task",
-      priority,
-      maxAttempts,
+      priority: effectivePriority,
+      maxAttempts: effectiveMaxAttempts,
       payload: {
         repository: normalizedRepository,
         ...(mergedCapabilities.length > 0

--- a/frontend/src/lib/workflowActions.test.ts
+++ b/frontend/src/lib/workflowActions.test.ts
@@ -76,15 +76,15 @@ describe('buildWorkflowActionMenuItems', () => {
       }),
     );
     expect(items.map((item) => item.id)).toEqual([
+      'bypass-dependency-wait',
+      'cancel',
+      'create-remediation-task',
       'rename',
       'pause',
       'resume',
       'approve',
       'reject',
-      'cancel',
       'send-message',
-      'bypass-dependency-wait',
-      'create-remediation-task',
     ]);
     expect(items.find((item) => item.id === 'reject')?.danger).toBe(true);
     expect(items.find((item) => item.id === 'cancel')?.danger).toBe(true);
@@ -108,9 +108,9 @@ describe('buildWorkflowActionMenuItems', () => {
     );
     expect(withEditing.map((item) => item.id)).toEqual([
       'edit-task',
-      'compare-run',
       'rerun',
       'resume-from-failed-step',
+      'compare-run',
     ]);
     expect(withEditing.find((item) => item.id === 'edit-task')?.href).toBe('/tasks/abc/edit');
   });

--- a/frontend/src/lib/workflowActions.ts
+++ b/frontend/src/lib/workflowActions.ts
@@ -181,30 +181,42 @@ export function buildWorkflowActionMenuItems(
     }
   };
 
+  // Commonly used actions are surfaced at the top of the menu so operators can
+  // reach them without scanning the full list.
   addButton({
-    id: 'rename',
-    label: 'Rename',
-    available: Boolean(actions.canSetTitle),
-    disabledReason: disabledReason('canSetTitle'),
-    onSelect: handlers.onRename,
+    id: 'bypass-dependency-wait',
+    label: 'Bypass Dependencies',
+    available: Boolean(actions.canBypassDependencies),
+    disabledReason: disabledReason('canBypassDependencies'),
+    danger: true,
+    onSelect: handlers.onBypassDependencies,
+  });
+  addButton({
+    id: 'cancel',
+    label: 'Cancel',
+    available: Boolean(actions.canCancel),
+    disabledReason: disabledReason('canCancel'),
+    danger: true,
+    onSelect: handlers.onCancel,
   });
   if (taskEditingOn) {
     addLink({
       id: 'edit-task',
-      label: 'Edit task',
+      label: 'Edit',
       href: editHref,
       available: Boolean(canShowEditWorkflow && editHref),
       disabledReason: editTaskDisabledReason,
       onSelect: handlers.onEditTask,
     });
-    addLink({
-      id: 'compare-run',
-      label: 'Compare run',
-      href: compareHref,
-      available: Boolean(compareHref),
-      disabledReason: disabledReason('canEditForRerun'),
-      onSelect: handlers.onCompareRun,
-    });
+  }
+  addButton({
+    id: 'create-remediation-task',
+    label: 'Remediate',
+    available: canCreateRemediation,
+    disabledReason: null,
+    onSelect: handlers.onCreateRemediation,
+  });
+  if (taskEditingOn) {
     addButton({
       id: 'rerun',
       label: 'Rerun',
@@ -228,6 +240,24 @@ export function buildWorkflowActionMenuItems(
         onSelect: handlers.onRecoverFromSelectedStep,
       });
     }
+  }
+  // Remaining, less commonly used actions follow.
+  addButton({
+    id: 'rename',
+    label: 'Rename',
+    available: Boolean(actions.canSetTitle),
+    disabledReason: disabledReason('canSetTitle'),
+    onSelect: handlers.onRename,
+  });
+  if (taskEditingOn) {
+    addLink({
+      id: 'compare-run',
+      label: 'Compare run',
+      href: compareHref,
+      available: Boolean(compareHref),
+      disabledReason: disabledReason('canEditForRerun'),
+      onSelect: handlers.onCompareRun,
+    });
   }
   addButton({
     id: 'pause',
@@ -259,34 +289,11 @@ export function buildWorkflowActionMenuItems(
     onSelect: handlers.onReject,
   });
   addButton({
-    id: 'cancel',
-    label: 'Cancel',
-    available: Boolean(actions.canCancel),
-    disabledReason: disabledReason('canCancel'),
-    danger: true,
-    onSelect: handlers.onCancel,
-  });
-  addButton({
     id: 'send-message',
     label: 'Send Message',
     available: Boolean(actions.canSendMessage),
     disabledReason: disabledReason('canSendMessage'),
     onSelect: handlers.onSendMessage,
-  });
-  addButton({
-    id: 'bypass-dependency-wait',
-    label: 'Bypass Dependency Wait',
-    available: Boolean(actions.canBypassDependencies),
-    disabledReason: disabledReason('canBypassDependencies'),
-    danger: true,
-    onSelect: handlers.onBypassDependencies,
-  });
-  addButton({
-    id: 'create-remediation-task',
-    label: 'Create remediation task',
-    available: canCreateRemediation,
-    disabledReason: null,
-    onSelect: handlers.onCreateRemediation,
   });
   return items;
 }


### PR DESCRIPTION
I want to move the more commonly used workflow actions to the top of the workflow actions dropdown menu.

More commonly used: Bypass Dependency Wait (which I'd like to rename to Bypass Dependencies), Cancel, Edit Task (which I'd like to rename to Edit), Create Remediation Task (which I'd like to rename to Remediate), Rerun, Resume from Failed Step.

Additionally, I want to hide the Priority slider and Max Attempts fields of the start workflow page behind the Advanced checkbox.