### PR TITLE
Fix managed session retry and remediation targeting

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1254,6 +1254,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     raise
                 refreshed_snapshot = await self._load_snapshot(binding.workflow_id)
                 if not refreshed_snapshot.container_id or not refreshed_snapshot.thread_id:
+                    logger.warning(
+                        "Refreshed managed-session snapshot for session %s has no "
+                        "active container or thread ID; launching a fresh "
+                        "workflow-scoped session.",
+                        binding.session_id,
+                    )
                     snapshot = refreshed_snapshot
                 else:
                     refreshed_locator = self._locator_from_snapshot(refreshed_snapshot)
@@ -1296,6 +1302,16 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 return handle
 
         active_binding = snapshot.binding
+        if active_binding.session_epoch < binding.session_epoch:
+            logger.warning(
+                "Managed-session snapshot for session %s is stale "
+                "(snapshot epoch %s < request epoch %s); launching from the "
+                "request binding.",
+                binding.session_id,
+                active_binding.session_epoch,
+                binding.session_epoch,
+            )
+            active_binding = binding
         turn_completion_timeout_seconds = self._turn_completion_timeout_seconds(
             request=request,
             profile=profile,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1254,24 +1254,46 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     raise
                 refreshed_snapshot = await self._load_snapshot(binding.workflow_id)
                 if not refreshed_snapshot.container_id or not refreshed_snapshot.thread_id:
-                    raise
-                refreshed_locator = self._locator_from_snapshot(refreshed_snapshot)
-                logger.warning(
-                    "Retrying managed-session resume status after locator mismatch "
-                    "using refreshed workflow snapshot for session %s",
-                    refreshed_locator.session_id,
+                    snapshot = refreshed_snapshot
+                else:
+                    refreshed_locator = self._locator_from_snapshot(refreshed_snapshot)
+                    logger.warning(
+                        "Retrying managed-session resume status after locator mismatch "
+                        "using refreshed workflow snapshot for session %s",
+                        refreshed_locator.session_id,
+                    )
+                    try:
+                        handle = await self._coerce_handle(
+                            self._session_status(refreshed_locator)
+                        )
+                    except Exception as retry_exc:
+                        if not _is_session_locator_mismatch_error(retry_exc):
+                            raise
+                        logger.warning(
+                            "Managed-session resume status still mismatched after "
+                            "snapshot refresh for session %s; launching a fresh "
+                            "workflow-scoped session.",
+                            refreshed_locator.session_id,
+                        )
+                        snapshot = refreshed_snapshot
+                    else:
+                        await self._signal_control_action(
+                            action="resume_session",
+                            reason=None,
+                            container_id=handle.session_state.container_id,
+                            thread_id=handle.session_state.thread_id,
+                            active_turn_id=handle.session_state.active_turn_id,
+                        )
+                        return handle
+            else:
+                await self._signal_control_action(
+                    action="resume_session",
+                    reason=None,
+                    container_id=handle.session_state.container_id,
+                    thread_id=handle.session_state.thread_id,
+                    active_turn_id=handle.session_state.active_turn_id,
                 )
-                handle = await self._coerce_handle(
-                    self._session_status(refreshed_locator)
-                )
-            await self._signal_control_action(
-                action="resume_session",
-                reason=None,
-                container_id=handle.session_state.container_id,
-                thread_id=handle.session_state.thread_id,
-                active_turn_id=handle.session_state.active_turn_id,
-            )
-            return handle
+                return handle
 
         active_binding = snapshot.binding
         turn_completion_timeout_seconds = self._turn_completion_timeout_seconds(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -482,6 +482,25 @@ class TemporalExecutionService:
             return True
         return (record.owner_id or None) == owner_id
 
+    def _can_reference_remediation_target(
+        self,
+        record: TemporalExecutionCanonicalRecord,
+        *,
+        owner_id: str | None,
+        owner_type: TemporalExecutionOwnerType,
+        authority_mode: str,
+    ) -> bool:
+        if self._can_reference_dependency_target(
+            record,
+            owner_id=owner_id,
+            owner_type=owner_type,
+        ):
+            return True
+        return (
+            record.owner_type is TemporalExecutionOwnerType.SYSTEM
+            and authority_mode == "observe_only"
+        )
+
     async def _validate_remediation_link(
         self,
         *,
@@ -517,6 +536,18 @@ class TemporalExecutionService:
                 f"Workflow cannot remediate itself: {new_workflow_id}"
             )
 
+        authority_mode = str(
+            remediation.get("authorityMode")
+            or remediation.get("authority_mode")
+            or "observe_only"
+        ).strip() or "observe_only"
+        if authority_mode not in ALLOWED_REMEDIATION_AUTHORITY_MODES:
+            supported = ", ".join(sorted(ALLOWED_REMEDIATION_AUTHORITY_MODES))
+            raise TemporalExecutionValidationError(
+                "Unsupported workflow.remediation.authorityMode "
+                f"'{authority_mode}'. Supported values: {supported}."
+            )
+
         target_record = await self._session.get(
             TemporalExecutionCanonicalRecord, target_workflow_id
         )
@@ -524,10 +555,11 @@ class TemporalExecutionService:
             raise TemporalExecutionValidationError(
                 f"Remediation target not found: {target_workflow_id}"
             )
-        if not self._can_reference_dependency_target(
+        if not self._can_reference_remediation_target(
             target_record,
             owner_id=owner_id,
             owner_type=owner_type,
+            authority_mode=authority_mode,
         ):
             raise TemporalExecutionValidationError(
                 f"Remediation target unauthorized: {target_workflow_id}"
@@ -585,17 +617,6 @@ class TemporalExecutionService:
         trigger_type = None
         if isinstance(trigger, Mapping):
             trigger_type = str(trigger.get("type") or "").strip() or None
-        authority_mode = str(
-            remediation.get("authorityMode")
-            or remediation.get("authority_mode")
-            or "observe_only"
-        ).strip() or "observe_only"
-        if authority_mode not in ALLOWED_REMEDIATION_AUTHORITY_MODES:
-            supported = ", ".join(sorted(ALLOWED_REMEDIATION_AUTHORITY_MODES))
-            raise TemporalExecutionValidationError(
-                "Unsupported workflow.remediation.authorityMode "
-                f"'{authority_mode}'. Supported values: {supported}."
-            )
         action_policy_ref = str(remediation.get("actionPolicyRef") or "").strip()
         if (
             action_policy_ref

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3168,6 +3168,130 @@ async def test_start_retries_existing_session_status_after_locator_mismatch(
         "threadId": "thread-cleared",
     }
 
+async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
+    tmp_path: Path,
+) -> None:
+    binding = _binding().model_copy(update={"session_epoch": 7})
+    load_snapshot_calls: list[str] = []
+    session_status_calls: list[CodexManagedSessionLocator] = []
+    launch_calls: list[Any] = []
+    attach_calls: list[dict[str, Any]] = []
+    send_turn_calls: list[SendCodexManagedSessionTurnRequest] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(workflow_id: str) -> CodexManagedSessionSnapshot:
+        load_snapshot_calls.append(workflow_id)
+        return _snapshot(
+            binding=binding,
+            container_id="container-stale",
+            thread_id="thread-stale",
+        )
+
+    async def _session_status(
+        request: CodexManagedSessionLocator,
+    ) -> CodexManagedSessionHandle:
+        session_status_calls.append(request)
+        _raise_activity_error_from_application_error(
+            ApplicationError(
+                "sessionEpoch does not match the active managed session",
+                type="RuntimeError",
+            )
+        )
+
+    async def _launch_session(request: Any) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-fresh",
+            thread_id="thread-fresh",
+        )
+
+    async def _send_turn(
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _fetch_summary(
+        request: FetchCodexManagedSessionSummaryRequest,
+    ) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _publish_artifacts(
+        request: PublishCodexManagedSessionArtifactsRequest,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+        attach_calls.append(payload)
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_attach_runtime_handles,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding))
+
+    assert handle.status == "completed"
+    assert len(load_snapshot_calls) == 2
+    assert len(session_status_calls) == 2
+    assert len(launch_calls) == 1
+    assert session_status_calls[0].container_id == "container-stale"
+    assert session_status_calls[1].thread_id == "thread-stale"
+    launch_request = launch_calls[0]["request"]
+    assert launch_request["sessionEpoch"] == 7
+    assert launch_request["threadId"] == f"thread:{binding.session_id}:7"
+    assert send_turn_calls[0].container_id == "container-fresh"
+    assert send_turn_calls[0].thread_id == "thread-fresh"
+    assert attach_calls == [
+        {"containerId": "container-fresh", "threadId": "thread-fresh"}
+    ]
+    assert control_calls[0] == {
+        "action": "start_session",
+        "containerId": "container-fresh",
+        "threadId": "thread-fresh",
+    }
+
 async def test_clear_session_rotates_epoch_and_signals_session_workflow(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3172,6 +3172,7 @@ async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
     tmp_path: Path,
 ) -> None:
     binding = _binding().model_copy(update={"session_epoch": 7})
+    stale_snapshot_binding = binding.model_copy(update={"session_epoch": 6})
     load_snapshot_calls: list[str] = []
     session_status_calls: list[CodexManagedSessionLocator] = []
     launch_calls: list[Any] = []
@@ -3182,7 +3183,7 @@ async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
     async def _load_snapshot(workflow_id: str) -> CodexManagedSessionSnapshot:
         load_snapshot_calls.append(workflow_id)
         return _snapshot(
-            binding=binding,
+            binding=stale_snapshot_binding,
             container_id="container-stale",
             thread_id="thread-stale",
         )
@@ -3277,7 +3278,9 @@ async def test_start_relaunches_session_when_refreshed_locator_still_mismatches(
     assert len(session_status_calls) == 2
     assert len(launch_calls) == 1
     assert session_status_calls[0].container_id == "container-stale"
+    assert session_status_calls[0].session_epoch == 6
     assert session_status_calls[1].thread_id == "thread-stale"
+    assert session_status_calls[1].session_epoch == 6
     launch_request = launch_calls[0]["request"]
     assert launch_request["sessionEpoch"] == 7
     assert launch_request["threadId"] == f"thread:{binding.session_id}:7"

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1002,6 +1002,97 @@ async def test_create_execution_persists_supplied_matching_remediation_run_id(
         assert link.authority_mode == "observe_only"
 
 @pytest.mark.asyncio
+async def test_create_execution_allows_observe_only_remediation_of_system_target(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        user_owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=None,
+            owner_type="system",
+            title="System target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        remediation = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=user_owner_id,
+            title="Remediate system target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {
+                    "instructions": "Investigate the target",
+                    "remediation": {
+                        "target": {"workflowId": target.workflow_id},
+                        "authorityMode": "observe_only",
+                    },
+                }
+            },
+            idempotency_key=None,
+        )
+
+        link = await session.get(
+            TemporalExecutionRemediationLink, remediation.workflow_id
+        )
+        assert link is not None
+        assert link.target_workflow_id == target.workflow_id
+        assert link.target_run_id == target.run_id
+        assert link.authority_mode == "observe_only"
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_elevated_user_remediation_of_system_target(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=None,
+            owner_type="system",
+            title="System target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="Remediation target unauthorized",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=uuid4(),
+                title="Remediate system target",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "instructions": "Investigate the target",
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "authorityMode": "admin_auto",
+                        },
+                    }
+                },
+                idempotency_key=None,
+            )
+
+@pytest.mark.asyncio
 async def test_create_execution_rejects_missing_remediation_target_workflow_id(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Summary
- relaunch managed Codex sessions when refreshed resume locators still fail epoch validation
- allow observe-only remediation runs to target system-owned workflow executions while keeping elevated user remediation denied
- add regression coverage for persistent locator mismatch recovery and system-target remediation authorization

## Tests
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_temporal_service.py
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
