### PR TITLE
MM-858 Push provider-visible promotion state and cover bounded overrides

### DIFF
--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -743,6 +743,138 @@ class GitHubService:
             summary=f"GitHub issue updated: {data.get('html_url')}",
         )
 
+    async def set_issue_labels(
+        self,
+        *,
+        repo: str,
+        issue_number: str,
+        labels: list[str],
+        github_token: str | None = None,
+    ) -> GitHubIssueResult:
+        """Replace the labels on a GitHub Issue without rewriting title or body.
+
+        Used by proposal review-state transitions so the original issue text is
+        preserved as the human audit trail while MoonMind updates state labels.
+        """
+
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            return GitHubIssueResult(
+                externalKey=issue_number,
+                updated=False,
+                summary=resolution_error
+                or self._missing_auth_summary("update issue labels"),
+            )
+        headers = self._github_headers(token)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.patch(
+                    f"https://api.github.com/repos/{repo}/issues/{issue_number}",
+                    headers=headers,
+                    json={"labels": labels or []},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPStatusError as exc:
+                summary = self._github_permission_summary(exc.response)
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    updated=False,
+                    summary=(
+                        "GitHub set issue labels failed with HTTP "
+                        f"{exc.response.status_code}"
+                        + (
+                            f" for {repo}#{issue_number}. {summary}"
+                            if summary
+                            else f" for {repo}#{issue_number}."
+                        )
+                    ),
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    updated=False,
+                    summary=(
+                        "GitHub set issue labels request failed: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                )
+        return GitHubIssueResult(
+            externalKey=str(data.get("number") or issue_number),
+            externalUrl=data.get("html_url"),
+            updated=True,
+            summary=f"GitHub issue labels updated: {data.get('html_url')}",
+        )
+
+    async def comment_on_issue(
+        self,
+        *,
+        repo: str,
+        issue_number: str,
+        body: str,
+        github_token: str | None = None,
+    ) -> GitHubIssueResult:
+        """Post a comment on a GitHub Issue via REST API.
+
+        Comments are additive review-trail entries (for example a promotion
+        execution link); they never replace the original issue body.
+        """
+
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            return GitHubIssueResult(
+                externalKey=issue_number,
+                created=False,
+                summary=resolution_error
+                or self._missing_auth_summary("comment on an issue"),
+            )
+        headers = self._github_headers(token)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.post(
+                    f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
+                    headers=headers,
+                    json={"body": body},
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPStatusError as exc:
+                summary = self._github_permission_summary(exc.response)
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    created=False,
+                    summary=(
+                        "GitHub issue comment failed with HTTP "
+                        f"{exc.response.status_code}"
+                        + (
+                            f" for {repo}#{issue_number}. {summary}"
+                            if summary
+                            else f" for {repo}#{issue_number}."
+                        )
+                    ),
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                return GitHubIssueResult(
+                    externalKey=issue_number,
+                    created=False,
+                    summary=(
+                        "GitHub issue comment request failed: "
+                        f"{exc.__class__.__name__}"
+                    ),
+                )
+        return GitHubIssueResult(
+            externalKey=issue_number,
+            externalUrl=data.get("html_url"),
+            created=True,
+            summary=f"GitHub issue comment posted: {data.get('html_url')}",
+        )
+
     # -- PR operations ----------------------------------------------------
 
     async def create_pull_request(

--- a/moonmind/workflows/proposals/__init__.py
+++ b/moonmind/workflows/proposals/__init__.py
@@ -3,6 +3,7 @@
 from .models import WorkflowProposal, WorkflowProposalOriginSource, WorkflowProposalStatus
 from .repositories import WorkflowProposalNotFoundError, WorkflowProposalRepository
 from .delivery import (
+    ProposalDecisionStateUpdate,
     ProposalDeliveryError,
     ProposalDeliveryRequest,
     ProposalDeliveryResult,
@@ -30,6 +31,7 @@ __all__ = [
     "WorkflowProposalStatus",
     "WorkflowProposalRepository",
     "WorkflowProposalNotFoundError",
+    "ProposalDecisionStateUpdate",
     "ProposalDeliveryError",
     "ProposalDeliveryRequest",
     "ProposalDeliveryResult",

--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Mapping, Protocol
@@ -176,6 +177,26 @@ class ProviderDecisionResult:
 
 
 @dataclass(frozen=True, slots=True)
+class ProposalDecisionStateUpdate:
+    """Bounded review-state transition pushed back to the provider issue.
+
+    Carries only sanitized state-transition metadata. It never carries an
+    executable payload; promotion always runs the stored proposal snapshot.
+    """
+
+    decision: str | None
+    accepted: bool
+    actor: str
+    provider_event_id: str
+    resulting_state: str
+    reason: str | None = None
+    note: str | None = None
+    priority: str | None = None
+    promoted_execution_id: str | None = None
+    promoted_execution_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class GitHubDecisionIngressResult:
     """Verified GitHub reviewer-decision event at the provider boundary."""
 
@@ -203,6 +224,21 @@ class ProposalIssueProvider(Protocol):
         rendered: RenderedProposalIssue,
         issue: Mapping[str, Any],
     ) -> dict[str, Any]:
+        pass
+
+    async def apply_decision_state(
+        self,
+        request: ProposalDeliveryRequest,
+        issue: Mapping[str, Any],
+        labels: Sequence[str],
+        comment: str | None,
+    ) -> dict[str, Any]:
+        """Update review-state labels and append an audit comment.
+
+        Must not rewrite the original issue title or body; the original issue is
+        preserved as the human audit trail.
+        """
+
         pass
 
 
@@ -251,6 +287,35 @@ class GitHubProposalIssueProvider:
         if hasattr(result, "model_dump"):
             return result.model_dump(by_alias=True)
         return dict(result)
+
+    async def apply_decision_state(
+        self,
+        request: ProposalDeliveryRequest,
+        issue: Mapping[str, Any],
+        labels: Sequence[str],
+        comment: str | None,
+    ) -> dict[str, Any]:
+        issue_number = _clean(issue.get("key") or issue.get("number"))
+        label_result = await self._github.set_issue_labels(
+            repo=request.destination,
+            issue_number=issue_number,
+            labels=list(labels),
+        )
+        applied = {
+            "labelsUpdated": bool(getattr(label_result, "updated", False)),
+            "labels": list(labels),
+        }
+        if comment:
+            comment_result = await self._github.comment_on_issue(
+                repo=request.destination,
+                issue_number=issue_number,
+                body=comment,
+            )
+            applied["commented"] = bool(getattr(comment_result, "created", False))
+            comment_url = _clean(getattr(comment_result, "external_url", ""))
+            if comment_url:
+                applied["commentUrl"] = comment_url
+        return applied
 
 
 class JiraProposalIssueProvider:
@@ -336,6 +401,31 @@ class JiraProposalIssueProvider:
             "external_url": _clean(issue.get("url") or issue.get("self")) or None,
         }
 
+    async def apply_decision_state(
+        self,
+        request: ProposalDeliveryRequest,
+        issue: Mapping[str, Any],
+        labels: Sequence[str],
+        comment: str | None,
+    ) -> dict[str, Any]:
+        from moonmind.integrations.jira.models import AddCommentRequest, EditIssueRequest
+
+        issue_key = _clean(issue.get("key") or issue.get("number"))
+        await self._jira.edit_issue(
+            EditIssueRequest(
+                issueKey=issue_key,
+                fields={"labels": list(labels)},
+                update={},
+            )
+        )
+        applied: dict[str, Any] = {"labelsUpdated": True, "labels": list(labels)}
+        if comment:
+            await self._jira.add_comment(
+                AddCommentRequest(issueKey=issue_key, body=comment)
+            )
+            applied["commented"] = True
+        return applied
+
 
 def _clean(value: object) -> str:
     return str(value or "").strip()
@@ -417,6 +507,88 @@ def _canonical_github_labels(request: ProposalDeliveryRequest) -> tuple[str, ...
         f"moonmind:dedup:{short_hash}",
     )
     return labels
+
+
+def _decision_state_labels(
+    request: ProposalDeliveryRequest,
+    *,
+    resulting_state: str,
+    priority: str | None = None,
+) -> tuple[str, ...]:
+    """Render review-state labels for a decision, preserving canonical labels.
+
+    Only the bounded ``state`` token (and the ``priority`` token when a
+    reviewer reprioritization is applied) is transitioned; the proposal,
+    target, category, and dedup labels are kept stable.
+    """
+
+    state_token = _label_token(resulting_state, "updated", max_length=_MAX_GITHUB_LABEL_LENGTH)
+    priority_token = (
+        _label_token(priority, "normal") if _clean(priority) else None
+    )
+    if request.provider == "jira":
+        provider_cfg = _provider_config(request.provider_metadata, "jira")
+        configured = _iter_strings(provider_cfg.get("labels"))
+        labels = [
+            "moonmind-proposal",
+            "proposal-review",
+            f"moonmind-state-{state_token}",
+            *configured,
+        ]
+        if priority_token:
+            labels.append(f"moonmind-priority-{priority_token}")
+        return tuple(dict.fromkeys(labels))
+
+    provider_cfg = _provider_config(request.provider_metadata, "github")
+    base = [*_canonical_github_labels(request), *_iter_strings(provider_cfg.get("labels"))]
+    transitioned: list[str] = []
+    for label in base:
+        if label.startswith("moonmind:state:"):
+            transitioned.append(f"moonmind:state:{state_token}")
+        elif priority_token and label.startswith("moonmind:priority:"):
+            transitioned.append(f"moonmind:priority:{priority_token}")
+        else:
+            transitioned.append(label)
+    return tuple(dict.fromkeys(transitioned))
+
+
+def _decision_comment(
+    update: ProposalDecisionStateUpdate,
+    *,
+    redactor: SecretRedactor | None = None,
+) -> str | None:
+    """Render a sanitized review-trail comment for an accepted decision."""
+
+    redactor = redactor or SecretRedactor.from_environ(placeholder="[REDACTED]")
+    decision = _clean(update.decision) or "decision"
+    promoted_id = _clean(update.promoted_execution_id)
+    if decision == "promote" and promoted_id:
+        link = _clean(update.promoted_execution_url) or promoted_id
+        body = "\n".join(
+            [
+                "MoonMind promoted this proposal to a new MoonMind.UserWorkflow.",
+                "",
+                f"- Execution ID: `{promoted_id}`",
+                f"- Execution link: {link}",
+                "",
+                (
+                    "MoonMind executed the stored proposal snapshot. This issue is "
+                    "preserved as the human audit trail; edited issue text, comments, "
+                    "labels, or fields were not used as executable input."
+                ),
+            ]
+        )
+        return redactor.scrub(body)
+    actor = _clean(update.actor) or "a reviewer"
+    resulting_state = _clean(update.resulting_state) or decision
+    summary = (
+        f"MoonMind recorded a `{decision}` decision from `{actor}`. "
+        f"Resulting state: `{resulting_state}`."
+    )
+    note = _clean(update.note)
+    if note:
+        summary = f"{summary}\n\n{note}"
+    return redactor.scrub(summary)
 
 
 def _marker(request: ProposalDeliveryRequest) -> str:
@@ -962,12 +1134,70 @@ class ProposalDeliveryService:
             provider_metadata=provider_metadata,
         )
 
+    async def record_decision(
+        self,
+        request: ProposalDeliveryRequest,
+        update: ProposalDecisionStateUpdate,
+    ) -> dict[str, Any]:
+        """Push a bounded review-state transition to the provider issue.
+
+        Updates the issue state labels and appends an audit comment (including
+        the promoted execution link for promotions) through the trusted provider
+        adapter. The original issue title and body are preserved as the human
+        audit trail.
+        """
+
+        self._validate_policy(request)
+        provider = self._provider(request.provider)
+        applier = getattr(provider, "apply_decision_state", None)
+        if not callable(applier):
+            return {
+                "provider": request.provider,
+                "applied": False,
+                "reason": "provider_state_update_unsupported",
+            }
+        external_key = _clean(request.external_key)
+        if not external_key:
+            return {
+                "provider": request.provider,
+                "applied": False,
+                "reason": "missing_external_issue",
+            }
+        issue = {
+            "key": external_key,
+            "number": external_key,
+            "url": _clean(request.external_url),
+        }
+        labels = _decision_state_labels(
+            request,
+            resulting_state=update.resulting_state,
+            priority=update.priority,
+        )
+        comment = _decision_comment(update, redactor=self._redactor)
+        applied = await applier(request, issue, labels, comment)
+        result: dict[str, Any] = {
+            "provider": request.provider,
+            "applied": True,
+            "externalKey": external_key,
+            "resultingExternalState": update.resulting_state,
+            "labels": list(labels),
+            "commented": bool(comment),
+        }
+        if _clean(update.promoted_execution_id):
+            result["promotedExecutionId"] = _clean(update.promoted_execution_id)
+        if _clean(update.promoted_execution_url):
+            result["promotedExecutionUrl"] = _clean(update.promoted_execution_url)
+        if isinstance(applied, Mapping):
+            result["providerResponse"] = _safe_metadata(applied)
+        return _safe_metadata(result)
+
 
 __all__ = [
     "ProposalDeliveryError",
     "ProposalDeliveryRequest",
     "ProposalDeliveryResult",
     "ProposalDeliveryService",
+    "ProposalDecisionStateUpdate",
     "ProposalIssueProvider",
     "GitHubProposalIssueProvider",
     "GitHubDecisionIngressResult",

--- a/moonmind/workflows/proposals/delivery.py
+++ b/moonmind/workflows/proposals/delivery.py
@@ -302,7 +302,7 @@ class GitHubProposalIssueProvider:
             labels=list(labels),
         )
         applied = {
-            "labelsUpdated": bool(getattr(label_result, "updated", False)),
+            "labelsUpdated": label_result.updated,
             "labels": list(labels),
         }
         if comment:
@@ -311,8 +311,8 @@ class GitHubProposalIssueProvider:
                 issue_number=issue_number,
                 body=comment,
             )
-            applied["commented"] = bool(getattr(comment_result, "created", False))
-            comment_url = _clean(getattr(comment_result, "external_url", ""))
+            applied["commented"] = comment_result.created
+            comment_url = _clean(comment_result.external_url)
             if comment_url:
                 applied["commentUrl"] = comment_url
         return applied
@@ -1175,14 +1175,27 @@ class ProposalDeliveryService:
         )
         comment = _decision_comment(update, redactor=self._redactor)
         applied = await applier(request, issue, labels, comment)
+        # Some provider adapters (notably GitHub) report failures by returning a
+        # falsey result flag instead of raising. Derive the applied state from the
+        # adapter response so a missing token or provider error is surfaced as an
+        # unapplied transition rather than a silent success.
+        labels_updated = True
+        comment_posted = bool(comment)
+        if isinstance(applied, Mapping):
+            labels_updated = bool(applied.get("labelsUpdated", True))
+            if comment:
+                comment_posted = bool(applied.get("commented", False))
+        state_applied = labels_updated and (comment_posted if comment else True)
         result: dict[str, Any] = {
             "provider": request.provider,
-            "applied": True,
+            "applied": state_applied,
             "externalKey": external_key,
             "resultingExternalState": update.resulting_state,
             "labels": list(labels),
-            "commented": bool(comment),
+            "commented": bool(comment) and comment_posted,
         }
+        if not state_applied:
+            result["reason"] = "provider_state_update_failed"
         if _clean(update.promoted_execution_id):
             result["promotedExecutionId"] = _clean(update.promoted_execution_id)
         if _clean(update.promoted_execution_url):

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -26,6 +26,7 @@ from moonmind.workflows.proposals.models import (
     WorkflowProposalStatus,
 )
 from moonmind.workflows.proposals.delivery import (
+    ProposalDecisionStateUpdate,
     ProposalDeliveryError,
     ProviderDecisionEvent,
     ProviderDecisionResult,
@@ -1580,6 +1581,15 @@ class WorkflowProposalService:
         await self._repository.refresh(proposal)
         return result
 
+    @staticmethod
+    def _promoted_execution_url(execution_id: str | None) -> str | None:
+        """Render the Mission Control link for a promoted execution id."""
+
+        cleaned = str(execution_id or "").strip()
+        if not cleaned:
+            return None
+        return f"/workflows/{cleaned}?source=temporal"
+
     async def _sync_provider_decision_state_if_configured(
         self,
         *,
@@ -1588,34 +1598,45 @@ class WorkflowProposalService:
         resulting_state: str,
         promoted_execution_id: str | None,
     ) -> None:
-        """Best-effort external review state update through a trusted adapter."""
+        """Push the accepted review-state transition through a trusted adapter.
+
+        Updates the provider issue state labels and appends an audit comment
+        (with the promoted execution link for promotions) while preserving the
+        original issue as the human audit trail. Rejected or unverified events
+        are never pushed to the provider issue. Promotion comments are deferred
+        until the promoted execution id is attached.
+        """
 
         updater = getattr(self._delivery_service, "record_decision", None)
         if not callable(updater):
             return
-        payload = self._scrub_json(
-            {
-                "proposalId": str(getattr(proposal, "id", "")),
-                "provider": getattr(proposal, "provider", None),
-                "externalKey": getattr(proposal, "external_key", None),
-                "decision": result.decision,
-                "accepted": result.accepted,
-                "actor": result.actor,
-                "providerEventId": result.provider_event_id,
-                "reason": result.reason,
-                "note": result.note,
-                "resultingExternalState": resulting_state,
-                "promotedExecutionId": promoted_execution_id,
-            }
+        if not result.accepted:
+            return
+        if result.decision == "promote" and not promoted_execution_id:
+            return
+        if not self._clean_str(getattr(proposal, "external_key", "")):
+            return
+
+        update = ProposalDecisionStateUpdate(
+            decision=result.decision,
+            accepted=result.accepted,
+            actor=result.actor,
+            provider_event_id=result.provider_event_id,
+            resulting_state=resulting_state,
+            reason=result.reason,
+            note=result.note,
+            priority=result.priority,
+            promoted_execution_id=promoted_execution_id,
+            promoted_execution_url=self._promoted_execution_url(promoted_execution_id),
+        )
+        provider_metadata = (
+            dict(getattr(proposal, "provider_metadata", {}))
+            if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
+            else {}
         )
         try:
-            await updater(payload)
+            sync_result = await updater(request_from_proposal(proposal), update)
         except Exception as exc:  # pragma: no cover - adapter-specific
-            provider_metadata = (
-                dict(getattr(proposal, "provider_metadata", {}))
-                if isinstance(getattr(proposal, "provider_metadata", {}), Mapping)
-                else {}
-            )
             warnings = provider_metadata.get("providerDecisionUpdateWarnings")
             warning_rows: list[dict[str, Any]] = (
                 list(warnings) if isinstance(warnings, list) else []
@@ -1629,8 +1650,30 @@ class WorkflowProposalService:
                     }
                 )
             )
-            provider_metadata["providerDecisionUpdateWarnings"] = warning_rows
+            provider_metadata["providerDecisionUpdateWarnings"] = warning_rows[-100:]
             proposal.provider_metadata = provider_metadata
+            return
+
+        sync_rows = provider_metadata.get("providerDecisionStateSyncs")
+        rows: list[dict[str, Any]] = (
+            list(sync_rows) if isinstance(sync_rows, list) else []
+        )
+        rows.append(
+            self._scrub_json(
+                {
+                    "providerEventId": result.provider_event_id,
+                    "decision": result.decision,
+                    "resultingExternalState": resulting_state,
+                    "promotedExecutionId": promoted_execution_id,
+                    "promotedExecutionUrl": update.promoted_execution_url,
+                    "result": dict(sync_result)
+                    if isinstance(sync_result, Mapping)
+                    else None,
+                }
+            )
+        )
+        provider_metadata["providerDecisionStateSyncs"] = rows[-100:]
+        proposal.provider_metadata = provider_metadata
 
     async def attach_provider_decision_execution(
         self,

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -1654,6 +1654,32 @@ class WorkflowProposalService:
             proposal.provider_metadata = provider_metadata
             return
 
+        # A provider adapter can return without raising yet still report that the
+        # promotion state was not applied (for example a missing GitHub token).
+        # Surface those as warnings instead of recording a successful sync.
+        if isinstance(sync_result, Mapping) and not sync_result.get("applied", True):
+            warnings = provider_metadata.get("providerDecisionUpdateWarnings")
+            warning_rows: list[dict[str, Any]] = (
+                list(warnings) if isinstance(warnings, list) else []
+            )
+            warning_rows.append(
+                self._scrub_json(
+                    {
+                        "providerEventId": result.provider_event_id,
+                        "decision": result.decision,
+                        "resultingExternalState": resulting_state,
+                        "promotedExecutionId": promoted_execution_id,
+                        "promotedExecutionUrl": update.promoted_execution_url,
+                        "reason": sync_result.get("reason")
+                        or "provider_state_update_failed",
+                        "result": dict(sync_result),
+                    }
+                )
+            )
+            provider_metadata["providerDecisionUpdateWarnings"] = warning_rows[-100:]
+            proposal.provider_metadata = provider_metadata
+            return
+
         sync_rows = provider_metadata.get("providerDecisionStateSyncs")
         rows: list[dict[str, Any]] = (
             list(sync_rows) if isinstance(sync_rows, list) else []

--- a/tests/integration/temporal/test_proposal_review_delivery.py
+++ b/tests/integration/temporal/test_proposal_review_delivery.py
@@ -22,6 +22,16 @@ class _Delivery:
     def __init__(self, *, external_key: str = "42") -> None:
         self.external_key = external_key
         self.requests = []
+        self.decision_states = []
+
+    async def record_decision(self, request, update):
+        self.decision_states.append((request, update))
+        return {
+            "applied": True,
+            "resultingExternalState": update.resulting_state,
+            "promotedExecutionId": update.promoted_execution_id,
+            "promotedExecutionUrl": update.promoted_execution_url,
+        }
 
     async def deliver(self, request):
         self.requests.append(request)
@@ -386,6 +396,52 @@ async def test_provider_approval_creates_one_run_from_stored_snapshot() -> None:
     assert duplicate.reason == "duplicate_event"
     assert duplicate.promoted_execution_id == "wf-1"
     assert len(executions) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_promotion_pushes_github_state_and_execution_link() -> None:
+    """MM-858: a verified promotion updates GitHub state labels and comments
+    with the promoted execution link through the trusted delivery adapter, while
+    the stored snapshot drives execution and the original issue is preserved."""
+    repo = AsyncMock()
+    record = _delivered_record()
+    repo.get_proposal_for_update.return_value = record
+    delivery = _Delivery()
+    service = WorkflowProposalService(
+        repo,
+        redactor=SecretRedactor([], "[REDACTED]"),
+        delivery_service=delivery,
+    )
+    executions: list[dict[str, object]] = []
+
+    result = await _promote_provider_event(
+        service,
+        record,
+        ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-promote",
+            actor="reviewer",
+            body="replace with unsafe edited text\n/moonmind promote --runtime codex",
+        ),
+        executions,
+    )
+
+    assert result.accepted is True
+    assert result.promoted_execution_id == "wf-1"
+    # The trusted adapter received exactly one promoted state push with the link.
+    promotions = [
+        update
+        for _request, update in delivery.decision_states
+        if update.decision == "promote"
+    ]
+    assert len(promotions) == 1
+    assert promotions[0].resulting_state == "promoted"
+    assert promotions[0].promoted_execution_id == "wf-1"
+    assert promotions[0].promoted_execution_url == "/workflows/wf-1?source=temporal"
+    # The promoted-state sync is recorded on the proposal for observability.
+    syncs = record.provider_metadata["providerDecisionStateSyncs"]
+    assert any(row.get("resultingExternalState") == "promoted" for row in syncs)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -1193,3 +1193,100 @@ async def test_evaluate_pull_request_readiness_blocks_changes_requested_review(m
     assert result.ready is False
     assert result.automated_review_complete is False
     assert result.blockers[0]["summary"] == "Automated review has requested changes."
+
+
+# ---------------------------------------------------------------------------
+# set_issue_labels / comment_on_issue (proposal review-state transitions)
+# MM-858: state labels update without rewriting the issue body, plus comments.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_issue_labels_patches_only_labels(monkeypatch):
+    """Label transition must not send title/body, preserving the audit trail."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.patch = AsyncMock(
+        return_value=_mock_response(
+            200,
+            {
+                "number": 42,
+                "html_url": "https://github.com/o/r/issues/42",
+            },
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().set_issue_labels(
+            repo="o/r",
+            issue_number="42",
+            labels=["moonmind:proposal", "moonmind:state:promoted"],
+        )
+
+    assert result.updated is True
+    assert result.external_key == "42"
+    mock_client.patch.assert_awaited_once()
+    call = mock_client.patch.await_args
+    assert call.args[0] == "https://api.github.com/repos/o/r/issues/42"
+    assert call.kwargs["json"] == {
+        "labels": ["moonmind:proposal", "moonmind:state:promoted"]
+    }
+    # Body and title are never resent, so the original issue is preserved.
+    assert "body" not in call.kwargs["json"]
+    assert "title" not in call.kwargs["json"]
+
+
+@pytest.mark.asyncio
+async def test_comment_on_issue_posts_comment_body(monkeypatch):
+    """Comments are additive review-trail entries on the issue comments API."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_mock_response(
+            201,
+            {"html_url": "https://github.com/o/r/issues/42#issuecomment-1"},
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().comment_on_issue(
+            repo="o/r",
+            issue_number="42",
+            body="Execution link: /workflows/wf-1?source=temporal",
+        )
+
+    assert result.created is True
+    mock_client.post.assert_awaited_once()
+    call = mock_client.post.await_args
+    assert call.args[0] == "https://api.github.com/repos/o/r/issues/42/comments"
+    assert call.kwargs["json"] == {
+        "body": "Execution link: /workflows/wf-1?source=temporal"
+    }
+
+
+@pytest.mark.asyncio
+async def test_set_issue_labels_missing_token_returns_summary(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        GitHubService,
+        "resolve_github_token",
+        AsyncMock(return_value=(None, None)),
+    )
+
+    result = await GitHubService().set_issue_labels(
+        repo="o/r", issue_number="42", labels=["moonmind:state:promoted"]
+    )
+
+    assert result.updated is False
+    assert "GitHub auth is not configured" in result.summary

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -622,6 +622,48 @@ async def test_record_decision_skips_when_no_external_issue() -> None:
 
 
 @pytest.mark.asyncio
+async def test_record_decision_reports_unapplied_when_provider_update_fails() -> None:
+    """A non-raising provider failure (e.g. missing token) must not record applied."""
+
+    @dataclass
+    class FailingProvider(FakeProvider):
+        async def apply_decision_state(self, request, issue, labels, comment):
+            self.decision_states.append(
+                {"issue": issue, "labels": list(labels), "comment": comment}
+            )
+            # GitHubService returns updated=False/created=False instead of raising
+            # when the token is missing or GitHub returns an error.
+            return {"labelsUpdated": False, "commented": False}
+
+    provider = FailingProvider()
+    service = ProposalDeliveryService(
+        github=provider, redactor=SecretRedactor([], "[REDACTED]")
+    )
+
+    result = await service.record_decision(
+        _request(
+            external_key="42",
+            external_url="https://github.example/Moon/Repo/issues/42",
+        ),
+        ProposalDecisionStateUpdate(
+            decision="promote",
+            accepted=True,
+            actor="reviewer",
+            provider_event_id="evt-promote",
+            resulting_state="promoted",
+            promoted_execution_id="wf-promoted-1",
+            promoted_execution_url="/workflows/wf-promoted-1?source=temporal",
+        ),
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "provider_state_update_failed"
+    assert result["commented"] is False
+    assert result["providerResponse"]["labelsUpdated"] is False
+    assert len(provider.decision_states) == 1
+
+
+@pytest.mark.asyncio
 async def test_github_apply_decision_state_updates_labels_and_comments_without_body() -> None:
     class FakeGitHub:
         def __init__(self) -> None:

--- a/tests/unit/workflows/proposals/test_delivery.py
+++ b/tests/unit/workflows/proposals/test_delivery.py
@@ -8,11 +8,15 @@ import pytest
 
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.proposals.delivery import (
+    GitHubProposalIssueProvider,
     JiraProposalIssueProvider,
+    ProposalDecisionStateUpdate,
     ProposalDeliveryError,
     ProposalDeliveryRequest,
     ProposalDeliveryService,
     ProviderDecisionEvent,
+    _decision_comment,
+    _decision_state_labels,
     _safe_metadata,
     github_decision_event_from_payload,
     github_marker_for_proposal,
@@ -73,6 +77,23 @@ class FakeProvider:
         self.searches: list[ProposalDeliveryRequest] = []
         self.creates: list[object] = []
         self.updates: list[tuple[object, dict[str, object]]] = []
+        self.decision_states: list[dict[str, object]] = []
+
+    async def apply_decision_state(
+        self,
+        request: ProposalDeliveryRequest,
+        issue: dict[str, object],
+        labels,
+        comment,
+    ) -> dict[str, object]:
+        self.decision_states.append(
+            {
+                "issue": issue,
+                "labels": list(labels),
+                "comment": comment,
+            }
+        )
+        return {"labelsUpdated": True, "commented": bool(comment)}
 
     async def search_issue(self, request: ProposalDeliveryRequest) -> dict[str, object] | None:
         self.searches.append(request)
@@ -492,3 +513,216 @@ async def test_jira_provider_does_not_use_issue_key_as_external_url() -> None:
 
     assert created == {"external_key": "MM-1", "external_url": None}
     assert updated == {"external_key": "MM-1", "external_url": None}
+
+
+# ---------------------------------------------------------------------------
+# MM-858: provider-visible promotion/decision state updates
+# ---------------------------------------------------------------------------
+
+def test_decision_state_labels_transition_github_state_and_priority() -> None:
+    labels = _decision_state_labels(
+        _request(),
+        resulting_state="promoted",
+        priority="urgent",
+    )
+
+    assert "moonmind:state:promoted" in labels
+    assert "moonmind:state:open" not in labels
+    assert "moonmind:priority:urgent" in labels
+    # Canonical proposal/target/category labels are preserved.
+    assert "moonmind:proposal" in labels
+    assert "moonmind:target:workflow-repo" in labels
+
+
+def test_decision_state_labels_transition_jira_state() -> None:
+    labels = _decision_state_labels(
+        _request(provider="jira", repository="MM"),
+        resulting_state="dismissed",
+    )
+
+    assert "moonmind-proposal" in labels
+    assert "moonmind-state-dismissed" in labels
+
+
+def test_decision_comment_for_promotion_includes_execution_link() -> None:
+    comment = _decision_comment(
+        ProposalDecisionStateUpdate(
+            decision="promote",
+            accepted=True,
+            actor="reviewer",
+            provider_event_id="evt-promote",
+            resulting_state="promoted",
+            promoted_execution_id="wf-promoted-1",
+            promoted_execution_url="/workflows/wf-promoted-1?source=temporal",
+        ),
+        redactor=SecretRedactor([], "[REDACTED]"),
+    )
+
+    assert "wf-promoted-1" in comment
+    assert "/workflows/wf-promoted-1?source=temporal" in comment
+    assert "audit trail" in comment.lower()
+
+
+@pytest.mark.asyncio
+async def test_record_decision_pushes_promoted_state_and_execution_link() -> None:
+    provider = FakeProvider()
+    service = ProposalDeliveryService(
+        github=provider, redactor=SecretRedactor([], "[REDACTED]")
+    )
+    request = _request(
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+    )
+
+    result = await service.record_decision(
+        request,
+        ProposalDecisionStateUpdate(
+            decision="promote",
+            accepted=True,
+            actor="reviewer",
+            provider_event_id="evt-promote",
+            resulting_state="promoted",
+            promoted_execution_id="wf-promoted-1",
+            promoted_execution_url="/workflows/wf-promoted-1?source=temporal",
+        ),
+    )
+
+    assert result["applied"] is True
+    assert result["resultingExternalState"] == "promoted"
+    assert result["promotedExecutionId"] == "wf-promoted-1"
+    assert len(provider.decision_states) == 1
+    pushed = provider.decision_states[0]
+    assert "moonmind:state:promoted" in pushed["labels"]
+    assert pushed["issue"]["key"] == "42"
+    assert "wf-promoted-1" in pushed["comment"]
+    # Original issue body/title are never rewritten by a state transition.
+    assert provider.updates == []
+    assert provider.creates == []
+
+
+@pytest.mark.asyncio
+async def test_record_decision_skips_when_no_external_issue() -> None:
+    provider = FakeProvider()
+    service = ProposalDeliveryService(github=provider)
+
+    result = await service.record_decision(
+        _request(),
+        ProposalDecisionStateUpdate(
+            decision="dismiss",
+            accepted=True,
+            actor="reviewer",
+            provider_event_id="evt-dismiss",
+            resulting_state="dismissed",
+        ),
+    )
+
+    assert result["applied"] is False
+    assert result["reason"] == "missing_external_issue"
+    assert provider.decision_states == []
+
+
+@pytest.mark.asyncio
+async def test_github_apply_decision_state_updates_labels_and_comments_without_body() -> None:
+    class FakeGitHub:
+        def __init__(self) -> None:
+            self.label_calls: list[dict[str, object]] = []
+            self.comment_calls: list[dict[str, object]] = []
+            self.update_calls: list[dict[str, object]] = []
+
+        async def set_issue_labels(self, *, repo, issue_number, labels):
+            self.label_calls.append(
+                {"repo": repo, "issue_number": issue_number, "labels": list(labels)}
+            )
+            return SimpleNamespace(updated=True, external_url=None)
+
+        async def comment_on_issue(self, *, repo, issue_number, body):
+            self.comment_calls.append(
+                {"repo": repo, "issue_number": issue_number, "body": body}
+            )
+            return SimpleNamespace(
+                created=True,
+                external_url="https://github.example/Moon/Repo/issues/42#c1",
+            )
+
+        async def update_issue(self, **kwargs):  # pragma: no cover - guard
+            self.update_calls.append(kwargs)
+            return SimpleNamespace()
+
+    github = FakeGitHub()
+    provider = GitHubProposalIssueProvider(github)
+
+    applied = await provider.apply_decision_state(
+        _request(external_key="42"),
+        {"key": "42", "url": "https://github.example/Moon/Repo/issues/42"},
+        ["moonmind:proposal", "moonmind:state:promoted"],
+        "Execution link: /workflows/wf-1?source=temporal",
+    )
+
+    assert applied["labelsUpdated"] is True
+    assert applied["commented"] is True
+    assert github.label_calls[0]["labels"] == [
+        "moonmind:proposal",
+        "moonmind:state:promoted",
+    ]
+    assert github.comment_calls[0]["issue_number"] == "42"
+    # The issue body is never rewritten via the state-update path.
+    assert github.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_jira_apply_decision_state_sets_labels_and_comments() -> None:
+    class FakeJira:
+        def __init__(self) -> None:
+            self.edits: list[object] = []
+            self.comments: list[object] = []
+
+        async def edit_issue(self, request):
+            self.edits.append(request)
+            return {"updated": True}
+
+        async def add_comment(self, request):
+            self.comments.append(request)
+            return {"commented": True}
+
+    jira = FakeJira()
+    provider = JiraProposalIssueProvider(jira)
+
+    applied = await provider.apply_decision_state(
+        _request(provider="jira", repository="MM", external_key="MM-1"),
+        {"key": "MM-1"},
+        ["moonmind-proposal", "moonmind-state-promoted"],
+        "Execution link: /workflows/wf-1?source=temporal",
+    )
+
+    assert applied["labelsUpdated"] is True
+    assert applied["commented"] is True
+    assert jira.edits[0].fields == {
+        "labels": ["moonmind-proposal", "moonmind-state-promoted"]
+    }
+    assert jira.comments[0].issue_key == "MM-1"
+
+
+def test_provider_decision_parser_ignores_replacement_repository_env_and_tools() -> None:
+    """Only bounded runtime control is honored; injected executable overrides
+    (repository, environment variables, credentials, tool config) are ignored."""
+    result = parse_provider_decision(
+        ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-inject",
+            actor="reviewer",
+            body=(
+                "/moonmind promote --runtime codex --repository Evil/Repo "
+                "--env SECRET=leak --credential ghp_inject --tool shell:rm-rf"
+            ),
+        )
+    )
+
+    assert result.accepted is True
+    assert result.decision == "promote"
+    # The only bounded executable control extracted from issue text is runtime.
+    assert result.runtime_mode == "codex"
+    # ProviderDecisionResult carries no replacement repository/env/credential/tool
+    # fields, so injected executable overrides cannot reach promotion.
+    for forbidden in ("repository", "environment", "env", "credential", "tool"):
+        assert not hasattr(result, forbidden)

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -2348,6 +2348,49 @@ async def test_attach_provider_decision_execution_pushes_promoted_state_through_
     assert syncs[-1]["promotedExecutionId"] == "wf-promoted-1"
 
 
+class _FailingStateDelivery:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, object]] = []
+
+    async def record_decision(self, request, update):
+        self.calls.append((request, update))
+        # Provider adapter returned without raising but did not apply the
+        # promotion state (e.g. missing GitHub token).
+        return {
+            "applied": False,
+            "reason": "provider_state_update_failed",
+            "resultingExternalState": update.resulting_state,
+            "promotedExecutionId": update.promoted_execution_id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_attach_provider_decision_execution_records_warning_when_update_fails() -> None:
+    repo = AsyncMock()
+    proposal = _promotable_proposal_with_decision()
+    repo.get_proposal_for_update.return_value = proposal
+    delivery = _FailingStateDelivery()
+    service = WorkflowProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=delivery,
+    )
+
+    updated = await service.attach_provider_decision_execution(
+        proposal_id=proposal.id,
+        provider_event_id="evt-promote",
+        promoted_execution_id="wf-promoted-1",
+    )
+
+    assert len(delivery.calls) == 1
+    # A non-applied update is surfaced as a warning, not a successful sync.
+    assert "providerDecisionStateSyncs" not in updated.provider_metadata
+    warnings = updated.provider_metadata["providerDecisionUpdateWarnings"]
+    assert warnings[-1]["providerEventId"] == "evt-promote"
+    assert warnings[-1]["reason"] == "provider_state_update_failed"
+    assert warnings[-1]["resultingExternalState"] == "promoted"
+
+
 @pytest.mark.asyncio
 async def test_record_provider_decision_event_does_not_push_rejected_event_to_provider() -> None:
     repo = AsyncMock()

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -2115,3 +2115,283 @@ async def test_record_provider_decision_event_rejects_external_identity_mismatch
     decision_row = proposal.provider_metadata["providerDecisions"][0]
     assert decision_row["accepted"] is False
     assert decision_row["reason"] == "provider_identity_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_promote_proposal_applies_priority_and_max_attempts_overrides() -> None:
+    """DESIGN-REQ-016: priority and maxAttempts are accepted bounded overrides."""
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=WorkflowProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        provider_metadata={},
+        workflow_create_request={
+            "type": "workflow",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {
+                "repository": "Moon/Repo",
+                "workflow": {"instructions": "Implement feature"},
+            },
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = WorkflowProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    updated, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+        priority_override=7,
+        max_attempts_override=5,
+    )
+
+    assert updated.status is WorkflowProposalStatus.PROMOTED
+    assert final_request["priority"] == 7
+    assert final_request["maxAttempts"] == 5
+    # The stored snapshot repository/instructions are preserved unchanged.
+    assert final_request["payload"]["repository"] == "Moon/Repo"
+    assert (
+        final_request["payload"]["workflow"]["instructions"] == "Implement feature"
+    )
+
+
+@pytest.mark.asyncio
+async def test_promote_proposal_rejects_max_attempts_override_below_one() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=WorkflowProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        provider_metadata={},
+        workflow_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "workflow": {"instructions": "Implement feature"},
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = WorkflowProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    with pytest.raises(WorkflowProposalValidationError, match="maxAttempts must be >= 1"):
+        await service.promote_proposal(
+            proposal_id=proposal.id,
+            promoted_by_user_id=uuid4(),
+            max_attempts_override=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_promotion_uses_stored_snapshot_and_ignores_injected_overrides() -> None:
+    """DESIGN-REQ-016: a malicious GitHub command cannot replace repository,
+    instructions, steps, environment variables, credentials, or tool config.
+
+    Only the bounded runtime control is honored; everything else is sourced
+    from the stored proposal snapshot.
+    """
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=WorkflowProposalStatus.ACCEPTED,
+        provider="github",
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        review_priority=WorkflowProposalReviewPriority.NORMAL,
+        provider_metadata={},
+        resolved_policy={
+            "allowedActions": [
+                "promote",
+                "dismiss",
+                "defer",
+                "reprioritize",
+                "request_revision",
+            ],
+            "allowedActors": ["reviewer"],
+        },
+        workflow_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "targetRuntime": "gemini_cli",
+                "workflow": {
+                    "instructions": "Implement the stored snapshot task",
+                    "runtime": {"mode": "gemini_cli"},
+                },
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = WorkflowProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    decision = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-inject",
+            actor="reviewer",
+            body=(
+                "/moonmind promote --runtime codex --repository Evil/Repo "
+                "--env SECRET=leak --credential ghp_inject --tool shell:rm-rf"
+            ),
+        ),
+    )
+
+    assert decision.accepted is True
+    assert decision.decision == "promote"
+    assert decision.runtime_mode == "codex"
+
+    _updated, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+        runtime_mode_override=decision.runtime_mode,
+    )
+
+    # Only the bounded runtime override is applied.
+    assert final_request["payload"]["targetRuntime"] == "codex"
+    assert final_request["payload"]["workflow"]["runtime"]["mode"] == "codex"
+    # The stored repository/instructions win over the injected GitHub text.
+    assert final_request["payload"]["repository"] == "Moon/Repo"
+    assert (
+        final_request["payload"]["workflow"]["instructions"]
+        == "Implement the stored snapshot task"
+    )
+    serialized = str(final_request)
+    for injected in ("Evil/Repo", "SECRET", "ghp_inject", "shell:rm-rf"):
+        assert injected not in serialized
+
+
+class _StateRecordingDelivery:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, object]] = []
+
+    async def record_decision(self, request, update):
+        self.calls.append((request, update))
+        return {
+            "applied": True,
+            "resultingExternalState": update.resulting_state,
+            "promotedExecutionId": update.promoted_execution_id,
+        }
+
+
+def _promotable_proposal_with_decision() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        provider="github",
+        repository="Moon/Repo",
+        title="Add tests",
+        summary="Follow-up",
+        category="tests",
+        tags=["artifact_gap"],
+        review_priority=WorkflowProposalReviewPriority.NORMAL,
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="d" * 64,
+        workflow_snapshot_ref="artifact://snapshot",
+        workflow_create_request={"payload": {"repository": "Moon/Repo"}},
+        origin_metadata={"workflow_id": "wf-1"},
+        resolved_policy={"allowedActions": ["promote"], "allowedActors": ["reviewer"]},
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        provider_metadata={
+            "providerDecisions": [
+                {
+                    "providerEventId": "evt-promote",
+                    "decision": "promote",
+                    "accepted": True,
+                    "actor": "reviewer",
+                }
+            ]
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_attach_provider_decision_execution_pushes_promoted_state_through_adapter() -> None:
+    repo = AsyncMock()
+    proposal = _promotable_proposal_with_decision()
+    repo.get_proposal_for_update.return_value = proposal
+    delivery = _StateRecordingDelivery()
+    service = WorkflowProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=delivery,
+    )
+
+    updated = await service.attach_provider_decision_execution(
+        proposal_id=proposal.id,
+        provider_event_id="evt-promote",
+        promoted_execution_id="wf-promoted-1",
+    )
+
+    assert len(delivery.calls) == 1
+    request, update = delivery.calls[0]
+    assert request.external_key == "42"
+    assert update.decision == "promote"
+    assert update.resulting_state == "promoted"
+    assert update.promoted_execution_id == "wf-promoted-1"
+    assert update.promoted_execution_url == "/workflows/wf-promoted-1?source=temporal"
+    syncs = updated.provider_metadata["providerDecisionStateSyncs"]
+    assert syncs[-1]["resultingExternalState"] == "promoted"
+    assert syncs[-1]["promotedExecutionId"] == "wf-promoted-1"
+
+
+@pytest.mark.asyncio
+async def test_record_provider_decision_event_does_not_push_rejected_event_to_provider() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=WorkflowProposalStatus.OPEN,
+        provider="github",
+        repository="Moon/Repo",
+        title="Add tests",
+        summary="Follow-up",
+        category="tests",
+        tags=["artifact_gap"],
+        review_priority=WorkflowProposalReviewPriority.NORMAL,
+        dedup_key="moon/repo:add-tests",
+        dedup_hash="d" * 64,
+        workflow_snapshot_ref="artifact://snapshot",
+        workflow_create_request={"payload": {"repository": "Moon/Repo"}},
+        origin_metadata={},
+        external_key="42",
+        external_url="https://github.example/Moon/Repo/issues/42",
+        provider_metadata={},
+        resolved_policy={"allowedActions": ["dismiss"], "allowedActors": ["reviewer"]},
+        decision_note=None,
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    delivery = _StateRecordingDelivery()
+    service = WorkflowProposalService(
+        repo,
+        redactor=SecretRedactor([], "***"),
+        delivery_service=delivery,
+    )
+
+    result = await service.record_provider_decision_event(
+        proposal_id=proposal.id,
+        event=ProviderDecisionEvent(
+            provider="github",
+            external_key="42",
+            provider_event_id="evt-promote",
+            actor="reviewer",
+            body="/moonmind promote",
+        ),
+    )
+
+    assert result.accepted is False
+    assert result.reason == "action_not_allowed"
+    # Rejected/unverified decisions are never pushed to the provider issue.
+    assert delivery.calls == []


### PR DESCRIPTION
## Jira issue

[MM-858](https://moonladder.atlassian.net/browse/MM-858) — Complete provider-visible promotion status updates and bounded override contract coverage.

## Summary of implementation

Finishes the two pieces of MM-858 that the design (`docs/Workflows/WorkflowProposalSystem.md` §8.1 Promotion) left open, while keeping stored-snapshot promotion intact.

**Provider-visible promotion state path (DESIGN-REQ, "Remaining Work"):**
- `GitHubService.set_issue_labels()` and `GitHubService.comment_on_issue()` — update review-state labels and post an additive review-trail comment via the GitHub REST API. Labels are replaced with a `PATCH` that sends *only* `labels`; the issue title/body are never resent, so the original issue is preserved as the human audit trail.
- New `apply_decision_state()` on the `ProposalIssueProvider` protocol, implemented for both the GitHub and Jira trusted adapters (Jira uses `edit_issue` for labels + `add_comment`).
- `ProposalDeliveryService.record_decision()` pushes a bounded `ProposalDecisionStateUpdate` (sanitized state-transition metadata only — never an executable payload) through the trusted adapter, transitioning the `state` label (and `priority` label when a reviewer reprioritization applies) while preserving canonical proposal/target/category/dedup labels. Promotion comments include the promoted execution id and Mission Control link.
- `WorkflowProposalService._sync_provider_decision_state_if_configured()` now actually pushes accepted decisions through `record_decision` (previously a no-op `getattr`). Rejected/unverified events are never pushed; promotion comments are deferred until the promoted execution id is attached; successful syncs and warnings are recorded on `provider_metadata` (bounded to the last 100 rows).

**Bounded override / rejection contract coverage (DESIGN-REQ-016):**
- Added service-level tests for priority and maxAttempts reviewer overrides (and rejection of `maxAttempts < 1`).
- Added explicit rejection coverage proving injected GitHub-text overrides — replacement repository, environment variables, credentials, and tool configuration — cannot reach promotion: the provider-decision parser honors only the bounded runtime control, and the stored snapshot (repository/instructions/runtime) wins over edited issue text.

## Tests run

`python -m pytest tests/unit/workflows/adapters/test_github_service.py tests/unit/workflows/proposals/test_delivery.py tests/unit/workflows/proposals/test_service.py` — **115 passed**.

New/updated coverage includes:
- `test_set_issue_labels_patches_only_labels`, `test_comment_on_issue_posts_comment_body`, `test_set_issue_labels_missing_token_returns_summary`
- `test_decision_state_labels_transition_github_state_and_priority`, `test_decision_state_labels_transition_jira_state`, `test_decision_comment_for_promotion_includes_execution_link`
- `test_record_decision_pushes_promoted_state_and_execution_link`, `test_record_decision_skips_when_no_external_issue`, `test_github_apply_decision_state_updates_labels_and_comments_without_body`, `test_jira_apply_decision_state_sets_labels_and_comments`, `test_provider_decision_parser_ignores_replacement_repository_env_and_tools`
- `test_promote_proposal_applies_priority_and_max_attempts_overrides`, `test_promote_proposal_rejects_max_attempts_override_below_one`, `test_promotion_uses_stored_snapshot_and_ignores_injected_overrides`, `test_attach_provider_decision_execution_pushes_promoted_state_through_adapter`, `test_record_provider_decision_event_does_not_push_rejected_event_to_provider`

Also added a Temporal boundary integration test (`tests/integration/temporal/test_proposal_review_delivery.py::test_provider_promotion_pushes_github_state_and_execution_link`); per repo policy the time-skipping Temporal boundary suite is local-only and not part of required CI.

## Remaining risks

- The GitHub/Jira state-update calls are exercised against mocked HTTP clients/adapters in unit tests; live label-set and comment behavior depends on real token scopes and repository permissions at runtime. Adapter failures are caught and recorded as `providerDecisionUpdateWarnings` on the proposal rather than failing promotion, so a misconfigured token degrades silently to a recorded warning.
- The promoted execution link is rendered as a relative Mission Control path (`/workflows/{id}?source=temporal`); rendering it as an absolute URL would require a base-URL setting not introduced here.
- Live provider-verification (real GitHub/Jira credentials) is out of scope for required CI and has not been run.


[MM-858]: https://moonladder.atlassian.net/browse/MM-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ