### PR TITLE
[codex] Classify Claude session limits as rate limits

### DIFF
--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -21,10 +21,12 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
 )
 # Markers for Anthropic Claude Code CLI usage-limit messages.  The shipped CLI
 # prints variations of "You've hit your limit · resets <time>" (account
-# quota) and "You've hit your usage limit ..." (workspace/admin quota); both
-# exit with a non-zero code and otherwise look like a generic execution error.
+# quota), "You've hit your session limit ..." (subscription/session quota), and
+# "You've hit your usage limit ..." (workspace/admin quota); all exit with a
+# non-zero code and otherwise look like a generic execution error.
 _CLAUDE_CODE_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "hit your limit",
+    "session limit",
     "usage limit",
     "status 429",
     "status: 429",

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -26,7 +26,7 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
 # non-zero code and otherwise look like a generic execution error.
 _CLAUDE_CODE_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "hit your limit",
-    "session limit",
+    "hit your session limit",
     "usage limit",
     "status 429",
     "status: 429",

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -96,6 +96,13 @@ class TestDefaultStrategyClassifyExit:
         assert status == "failed"
         assert failure == "integration_error"
 
+    def test_claude_rate_limited_session_limit_variant(self) -> None:
+        s = ClaudeCodeStrategy()
+        stdout = "You've hit your session limit · resets 9:50pm (UTC)"
+        status, failure = s.classify_exit(1, stdout, "")
+        assert status == "failed"
+        assert failure == "integration_error"
+
     def test_codex_success(self) -> None:
         s = CodexCliStrategy()
         status, failure = s.classify_exit(0, "", "")
@@ -228,6 +235,17 @@ class TestClaudeCodeOutputParser:
         assert result.rate_limited
         assert any("usage limit" in message.lower() for message in result.error_messages)
 
+    def test_parse_detects_session_limit_message(self) -> None:
+        parser = ClaudeCodeOutputParser()
+        result = parser.parse(
+            "You've hit your session limit · resets 9:50pm (UTC)\n",
+            "",
+        )
+        assert result.rate_limited
+        assert result.error_messages == [
+            "You've hit your session limit · resets 9:50pm (UTC)"
+        ]
+
     def test_parse_ignores_clean_output(self) -> None:
         parser = ClaudeCodeOutputParser()
         result = parser.parse(
@@ -287,7 +305,7 @@ class TestStrategyClassifyResultRateLimit:
         s = ClaudeCodeStrategy()
         result = s.classify_result(
             exit_code=1,
-            stdout="You've hit your limit · resets 1pm (UTC)\n",
+            stdout="You've hit your session limit · resets 9:50pm (UTC)\n",
             stderr="",
         )
         assert result.status == "failed"

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -246,6 +246,15 @@ class TestClaudeCodeOutputParser:
             "You've hit your session limit · resets 9:50pm (UTC)"
         ]
 
+    def test_parse_ignores_session_limit_prose_without_hit_phrase(self) -> None:
+        parser = ClaudeCodeOutputParser()
+        result = parser.parse(
+            "Updated docs explaining how session limit messages are classified.\n",
+            "",
+        )
+        assert not result.rate_limited
+        assert result.error_messages == []
+
     def test_parse_ignores_clean_output(self) -> None:
         parser = ClaudeCodeOutputParser()
         result = parser.parse(


### PR DESCRIPTION
## Summary
- Recognize Claude Code `session limit` output as a provider rate-limit condition.
- Add parser, exit-classification, and provider cooldown regression coverage for the exact message observed in the failed workflow.

## Root Cause
Claude Code emitted `You've hit your session limit · resets 9:50pm (UTC)`, but MoonMind only recognized older Claude limit wording. The runtime therefore surfaced a generic execution error instead of provider cooldown metadata.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/runtime/test_output_parser.py`
- `./tools/test_unit.sh`
- Restarted `moonmind-temporal-worker-agent-runtime-1` and verified the running worker parses the new message as rate-limited.
