### PR TITLE
[codex] Fix PentestGPT Trivy action tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Scan runner image for vulnerabilities
         if: matrix.platform == 'linux/amd64'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
           format: table


### PR DESCRIPTION
## Summary
- Fix the PentestGPT runner vulnerability scan action reference from `aquasecurity/trivy-action@0.28.0` to `aquasecurity/trivy-action@v0.28.0`.

## Root Cause
The Docker publish workflow referenced a Trivy action tag without the required `v` prefix. GitHub Actions failed during job setup because `0.28.0` does not exist, while `v0.28.0` does.

## Validation
- `gh api repos/aquasecurity/trivy-action/git/ref/tags/v0.28.0`
- `git diff --check`
- `python3` PyYAML parse of `.github/workflows/docker-publish.yml`