### PR TITLE
[codex] fix paused workflow resume action

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4657,6 +4657,14 @@ def _degraded_step_execution_projection_payload(
 def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
     raw_state = str(record.state.value).strip().lower()
     workflow_type_value = _enum_value(getattr(record, "workflow_type", None))
+    memo = dict(getattr(record, "memo", None) or {})
+    waiting_reason = (
+        str(getattr(record, "waiting_reason", "") or "").strip()
+        or str(memo.get("waiting_reason") or "").strip()
+    )
+    is_operator_paused = (
+        bool(getattr(record, "paused", False)) or waiting_reason == "operator_paused"
+    )
     if not settings.temporal_dashboard.actions_enabled:
         return ExecutionActionCapabilityModel(
             disabled_reasons={
@@ -4719,6 +4727,14 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         "timed_out": {"can_edit_for_rerun", "can_rerun"},
     }
     enabled = state_actions.get(raw_state, set())
+    if is_operator_paused and raw_state not in {
+        "completed",
+        "failed",
+        "canceled",
+        "terminated",
+        "timed_out",
+    }:
+        enabled = (enabled - {"can_pause"}) | {"can_resume"}
     has_workflow_input_snapshot = bool(
         _workflow_input_snapshot_ref_from_memo(dict(getattr(record, "memo", None) or {}))
     )
@@ -4784,6 +4800,9 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                 if not has_workflow_input_snapshot:
                     disabled_reasons[alias] = "original_task_input_snapshot_missing"
                     continue
+        if field_name == "can_pause" and is_operator_paused:
+            disabled_reasons[alias] = "already_paused"
+            continue
         disabled_reasons[alias] = "state_not_eligible"
     return ExecutionActionCapabilityModel(
         can_set_title="can_set_title" in enabled,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -9939,6 +9939,39 @@ def test_describe_execution_exposes_dependency_bypass_action(
     assert body["actions"]["canBypassDependencies"] is True
     assert "canBypassDependencies" not in body["actions"]["disabledReasons"]
 
+def test_describe_execution_exposes_lifecycle_resume_for_operator_paused_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.waiting_reason = "operator_paused"
+    record.attention_required = True
+    record.memo = {
+        **record.memo,
+        "waiting_reason": "operator_paused",
+        "attention_required": True,
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "executing"
+    assert body["waitingReason"] == "operator_paused"
+    assert body["attentionRequired"] is True
+    assert body["actions"]["canResume"] is True
+    assert body["actions"]["canPause"] is False
+    assert "canResume" not in body["actions"]["disabledReasons"]
+    assert body["actions"]["disabledReasons"]["canPause"] == "already_paused"
+
 def test_describe_execution_exposes_temporal_workflow_editing_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Treat `operator_paused` waiting metadata and the persisted paused flag as lifecycle-pause evidence when building execution action capabilities.
- Expose lifecycle `Resume` for operator-paused active runs even when the projected workflow state is still `executing`.
- Add API detail regression coverage for the safe-boundary paused case that previously returned `canResume: false`.

## Root Cause
Paused safe-boundary workflows can retain `state=executing` while Temporal memo/projection metadata carries `waiting_reason=operator_paused`. The action capability builder only enabled lifecycle Resume for `state=awaiting_external`, so Mission Control disabled Resume even though the workflow's `Resume` update was valid.

## Validation
- `pytest tests/unit/api/routers/test_executions.py -k 'operator_paused_boundary or includes_actions_and_debug_fields or exposes_dependency_bypass_action' -q` - passed.
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py -k 'operator_paused_boundary or includes_actions_and_debug_fields or exposes_dependency_bypass_action'` - passed; Python selection and Vitest UI phase completed.
- `./tools/test_unit.sh` - attempted, but interrupted after 31m45s due an apparent unrelated hang near the end of the Python phase; it had reported `6658 passed, 6 skipped, 1 xpassed, 150 warnings, 16 subtests passed` before interruption.