### PR TITLE
[codex] harden managed session clear recovery

### DIFF
--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1107,6 +1107,7 @@ class CodexManagedSessionClearRequest(CodexManagedSessionLocator):
 
     new_thread_id: NonBlankStr = Field(..., alias="newThreadId")
     reason: NonBlankStr | None = Field(None, alias="reason")
+    request_id: NonBlankStr | None = Field(None, alias="requestId")
 
     @model_validator(mode="after")
     def _require_new_thread(self) -> "CodexManagedSessionClearRequest":

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -70,6 +70,9 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     EMPTY_ASSISTANT_FAILURE_CAUSE,
 )
+from moonmind.workflows.temporal.managed_session_errors import (
+    is_managed_session_locator_mismatch_error,
+)
 from moonmind.workflow_docker_mode import (
     DEFAULT_WORKFLOW_DOCKER_MODE,
     normalize_workflow_docker_mode,
@@ -265,27 +268,6 @@ def _is_empty_assistant_turn_failure(metadata: Mapping[str, Any] | None) -> bool
         "codex app-server turn/completed produced no assistant output",
     }
 
-
-_SESSION_LOCATOR_MISMATCH_MARKERS = (
-    "sessionid does not match the active managed session",
-    "sessionepoch does not match the active managed session",
-    "containerid does not match the active managed session",
-    "threadid does not match the active managed session",
-)
-
-
-def _is_session_locator_mismatch_error(exc: BaseException) -> bool:
-    current: BaseException | None = exc
-    seen: set[int] = set()
-    while current is not None and id(current) not in seen:
-        seen.add(id(current))
-        message = str(getattr(current, "message", "") or current).strip().lower()
-        if any(marker in message for marker in _SESSION_LOCATOR_MISMATCH_MARKERS):
-            return True
-        current = getattr(current, "cause", None) or getattr(current, "__cause__", None)
-        if not isinstance(current, BaseException):
-            current = None
-    return False
 
 def _reset_thread_id_for_empty_turn(locator: CodexManagedSessionLocator) -> str:
     return f"{locator.thread_id}:empty-output-reset"
@@ -1075,7 +1057,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 request_id=request_id,
             )
         except Exception as exc:
-            if not _is_session_locator_mismatch_error(exc):
+            if not is_managed_session_locator_mismatch_error(exc):
                 raise
             refreshed_locator = await self._current_locator(binding)
             if (
@@ -1298,7 +1280,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             try:
                 handle = await self._coerce_handle(self._session_status(locator))
             except Exception as exc:
-                if not _is_session_locator_mismatch_error(exc):
+                if not is_managed_session_locator_mismatch_error(exc):
                     raise
                 refreshed_snapshot = await self._load_snapshot(binding.workflow_id)
                 if not refreshed_snapshot.container_id or not refreshed_snapshot.thread_id:
@@ -1321,7 +1303,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                             self._session_status(refreshed_locator)
                         )
                     except Exception as retry_exc:
-                        if not _is_session_locator_mismatch_error(retry_exc):
+                        if not is_managed_session_locator_mismatch_error(retry_exc):
                             raise
                         logger.warning(
                             "Managed-session resume status still mismatched after "

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -599,6 +599,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         binding=binding,
                         new_thread_id=reset_thread_id,
                         reason="retry_after_empty_assistant_output",
+                        request_id=(
+                            f"{binding.agent_run_id}:empty-assistant-clear:"
+                            f"{previous_locator.session_epoch}:"
+                            f"{previous_locator.thread_id}"
+                        ),
                     )
                     current_locator = self._locator_from_state(
                         session_state=reset_handle.session_state,
@@ -631,6 +636,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         retry_metadata = _turn_failure_metadata_from_activity_error(
                             retry_error
                         )
+                        if _is_empty_assistant_turn_failure(retry_metadata):
+                            retry_metadata["selfHealExhausted"] = True
+                            retry_metadata["selfHealAction"] = "clear_session"
+                            retry_metadata["selfHealAttempts"] = 1
                         retry_metadata["sessionInterventions"] = session_interventions
                         retry_metadata["priorTurnFailure"] = turn_metadata
                         publication = await self._publish_failure_artifacts(
@@ -1055,20 +1064,34 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         binding: CodexManagedSessionBinding,
         new_thread_id: str,
         reason: str | None = None,
+        request_id: str | None = None,
     ) -> CodexManagedSessionHandle:
         locator = await self._current_locator(binding)
-        handle = await self._coerce_handle(
-            self._clear_remote_session(
-                CodexManagedSessionClearRequest(
-                    sessionId=locator.session_id,
-                    sessionEpoch=locator.session_epoch,
-                    containerId=locator.container_id,
-                    threadId=locator.thread_id,
-                    newThreadId=new_thread_id,
-                    reason=reason,
-                )
+        try:
+            handle = await self._clear_session_with_locator(
+                locator=locator,
+                new_thread_id=new_thread_id,
+                reason=reason,
+                request_id=request_id,
             )
-        )
+        except Exception as exc:
+            if not _is_session_locator_mismatch_error(exc):
+                raise
+            refreshed_locator = await self._current_locator(binding)
+            if (
+                refreshed_locator.session_epoch > locator.session_epoch
+                and refreshed_locator.thread_id == new_thread_id
+            ):
+                handle = await self._coerce_handle(
+                    self._session_status(refreshed_locator)
+                )
+            else:
+                handle = await self._clear_session_with_locator(
+                    locator=refreshed_locator,
+                    new_thread_id=new_thread_id,
+                    reason=reason,
+                    request_id=request_id,
+                )
         await self._attach_runtime_handles(
             {
                 "sessionEpoch": handle.session_state.session_epoch,
@@ -1086,6 +1109,28 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
+
+    async def _clear_session_with_locator(
+        self,
+        *,
+        locator: CodexManagedSessionLocator,
+        new_thread_id: str,
+        reason: str | None,
+        request_id: str | None,
+    ) -> CodexManagedSessionHandle:
+        return await self._coerce_handle(
+            self._clear_remote_session(
+                CodexManagedSessionClearRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    newThreadId=new_thread_id,
+                    reason=reason,
+                    requestId=request_id,
+                )
+            )
+        )
 
     async def interrupt_turn(
         self,

--- a/moonmind/workflows/temporal/managed_session_errors.py
+++ b/moonmind/workflows/temporal/managed_session_errors.py
@@ -1,0 +1,32 @@
+"""Shared managed-session error classifiers."""
+
+from __future__ import annotations
+
+_MANAGED_SESSION_LOCATOR_MISMATCH_MARKERS = (
+    "sessionid does not match the active managed session",
+    "sessionepoch does not match the active managed session",
+    "containerid does not match the active managed session",
+    "threadid does not match the active managed session",
+    "sessionepoch does not match the durable managed session record",
+    "containerid does not match the durable managed session record",
+    "threadid does not match the durable managed session record",
+)
+
+
+def is_managed_session_locator_mismatch_error(exc: BaseException) -> bool:
+    """Return True when an exception chain reports a stale managed-session locator."""
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(getattr(current, "message", "") or current).strip().lower()
+        if any(marker in message for marker in _MANAGED_SESSION_LOCATOR_MISMATCH_MARKERS):
+            return True
+        current = getattr(current, "cause", None) or getattr(current, "__cause__", None)
+        if not isinstance(current, BaseException):
+            current = None
+    return False
+
+
+__all__ = ["is_managed_session_locator_mismatch_error"]

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -58,6 +58,9 @@ _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
 _MANAGED_SESSION_CONTAINER_UID = 1000
+_EMPTY_ASSISTANT_FAILURE_CAUSE = "app_server_protocol_empty_turn"
+_CLEAR_REQUEST_METADATA_KEY = "lastClearRequest"
+_EMPTY_ASSISTANT_TURN_METADATA_KEY = "emptyAssistantTurn"
 _MANAGED_SESSION_CONTAINER_GID = 1000
 _MANAGED_SESSION_CONTAINER_USER = (
     f"{_MANAGED_SESSION_CONTAINER_UID}:{_MANAGED_SESSION_CONTAINER_GID}"
@@ -152,6 +155,41 @@ def _last_assistant_text_metadata(value: str) -> dict[str, Any]:
         "lastAssistantText": truncated,
         "lastAssistantTextTruncated": True,
         "lastAssistantTextOriginalChars": len(normalized),
+    }
+
+
+def _is_empty_assistant_turn_response(
+    response: CodexManagedSessionTurnResponse,
+) -> bool:
+    if response.metadata.get("failureCause") == _EMPTY_ASSISTANT_FAILURE_CAUSE:
+        return True
+    retry_action = str(response.metadata.get("retryRecommendedAction") or "").strip()
+    reason = str(response.metadata.get("reason") or "").strip()
+    return retry_action == "clear_session" and "produced no assistant output" in reason
+
+
+def _empty_assistant_turn_metadata(
+    record_metadata: Mapping[str, Any],
+    response: CodexManagedSessionTurnResponse,
+) -> dict[str, Any]:
+    existing = record_metadata.get(_EMPTY_ASSISTANT_TURN_METADATA_KEY)
+    previous_count = 0
+    if isinstance(existing, Mapping):
+        try:
+            previous_count = int(existing.get("consecutiveCount") or 0)
+        except (TypeError, ValueError):
+            previous_count = 0
+    count = max(previous_count, 0) + 1
+    return {
+        "failureCause": _EMPTY_ASSISTANT_FAILURE_CAUSE,
+        "consecutiveCount": count,
+        "lastTurnId": response.turn_id,
+        "lastSessionEpoch": response.session_state.session_epoch,
+        "lastThreadId": response.session_state.thread_id,
+        "retryRecommendedAction": "clear_session",
+        "lastReason": str(response.metadata.get("reason") or "").strip()
+        or "codex app-server turn produced no assistant output",
+        "updatedAt": datetime.now(tz=UTC).isoformat(),
     }
 
 def _managed_session_docker_network(
@@ -2649,6 +2687,17 @@ class DockerCodexManagedSessionController:
                 assistant_text = terminal_response.metadata.get("assistantText")
                 if isinstance(assistant_text, str) and assistant_text.strip():
                     record_metadata.update(_last_assistant_text_metadata(assistant_text))
+                    record_metadata.pop(_EMPTY_ASSISTANT_TURN_METADATA_KEY, None)
+                empty_assistant_turn = _is_empty_assistant_turn_response(
+                    terminal_response
+                )
+                if empty_assistant_turn:
+                    record_metadata[_EMPTY_ASSISTANT_TURN_METADATA_KEY] = (
+                        _empty_assistant_turn_metadata(
+                            record_metadata,
+                            terminal_response,
+                        )
+                    )
                 updated_record = await self._session_store.update(
                     request.session_id,
                     session_epoch=terminal_response.session_state.session_epoch,
@@ -2683,6 +2732,28 @@ class DockerCodexManagedSessionController:
                                 "action": "send_turn",
                                 "assistantText": terminal_response.metadata.get("assistantText"),
                                 "reason": request.reason,
+                            },
+                        )
+                    elif empty_assistant_turn:
+                        await self._emit_session_event(
+                            record=updated_record,
+                            kind="empty_assistant_turn_detected",
+                            text=(
+                                "Codex app-server completed a turn without "
+                                "assistant output; session clear is recommended."
+                            ),
+                            turn_id=terminal_response.turn_id,
+                            active_turn_id=(
+                                terminal_response.session_state.active_turn_id
+                            ),
+                            metadata={
+                                "action": "send_turn",
+                                "failureCause": _EMPTY_ASSISTANT_FAILURE_CAUSE,
+                                "retryRecommendedAction": "clear_session",
+                                "reason": terminal_response.metadata.get("reason"),
+                                "consecutiveCount": record_metadata[
+                                    _EMPTY_ASSISTANT_TURN_METADATA_KEY
+                                ]["consecutiveCount"],
                             },
                         )
         return terminal_response
@@ -2787,6 +2858,35 @@ class DockerCodexManagedSessionController:
         if session_store is not None:
             previous_record = session_store.load(request.session_id)
             if previous_record is not None:
+                last_clear = previous_record.metadata.get(_CLEAR_REQUEST_METADATA_KEY)
+                if (
+                    request.request_id
+                    and isinstance(last_clear, Mapping)
+                    and last_clear.get("requestId") == request.request_id
+                    and last_clear.get("status") == "completed"
+                    and (
+                        previous_record.session_epoch
+                        == last_clear.get("newSessionEpoch")
+                    )
+                    and previous_record.thread_id == last_clear.get("newThreadId")
+                    and previous_record.latest_reset_boundary_ref
+                ):
+                    return CodexManagedSessionHandle(
+                        runtimeFamily=request.runtime_family,
+                        sessionState=previous_record.session_state(),
+                        status=self._handle_status_from_record_status(
+                            previous_record.status
+                        ),
+                        imageRef=previous_record.image_ref,
+                        controlUrl=previous_record.control_url,
+                        metadata={
+                            "idempotentReplay": True,
+                            "requestId": request.request_id,
+                            "latestResetBoundaryRef": (
+                                previous_record.latest_reset_boundary_ref
+                            ),
+                        },
+                    )
                 if (
                     previous_record.session_epoch == request.session_epoch + 1
                     and previous_record.container_id == request.container_id
@@ -2814,6 +2914,17 @@ class DockerCodexManagedSessionController:
         )
         if previous_record is not None:
             assert session_store is not None
+            record_metadata = dict(previous_record.metadata)
+            if request.request_id:
+                record_metadata[_CLEAR_REQUEST_METADATA_KEY] = {
+                    "requestId": request.request_id,
+                    "status": "accepted",
+                    "previousSessionEpoch": previous_record.session_epoch,
+                    "newSessionEpoch": handle.session_state.session_epoch,
+                    "previousThreadId": previous_record.thread_id,
+                    "newThreadId": handle.session_state.thread_id,
+                    "reason": request.reason,
+                }
             updated_record = await session_store.update(
                 request.session_id,
                 session_epoch=handle.session_state.session_epoch,
@@ -2825,13 +2936,44 @@ class DockerCodexManagedSessionController:
                 status=self._record_status_from_handle_status(handle.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=None,
+                metadata=record_metadata,
             )
             if self._session_supervisor is not None:
-                await self._session_supervisor.publish_reset_artifacts(
+                updated_record = await self._session_supervisor.publish_reset_artifacts(
                     previous_record=previous_record,
                     record=updated_record,
                     action="clear_session",
                     reason=request.reason,
+                )
+            if request.request_id:
+                completed_metadata = dict(updated_record.metadata)
+                raw_clear_metadata = completed_metadata.get(_CLEAR_REQUEST_METADATA_KEY)
+                clear_metadata = (
+                    dict(raw_clear_metadata)
+                    if isinstance(raw_clear_metadata, Mapping)
+                    else {}
+                )
+                clear_metadata.update(
+                    {
+                        "requestId": request.request_id,
+                        "status": "completed",
+                        "previousSessionEpoch": previous_record.session_epoch,
+                        "newSessionEpoch": updated_record.session_epoch,
+                        "previousThreadId": previous_record.thread_id,
+                        "newThreadId": updated_record.thread_id,
+                        "latestControlEventRef": (
+                            updated_record.latest_control_event_ref
+                        ),
+                        "latestResetBoundaryRef": (
+                            updated_record.latest_reset_boundary_ref
+                        ),
+                    }
+                )
+                completed_metadata[_CLEAR_REQUEST_METADATA_KEY] = clear_metadata
+                await session_store.update(
+                    request.session_id,
+                    metadata=completed_metadata,
+                    updated_at=datetime.now(tz=UTC),
                 )
         else:
             await self._persist_handle_transition(

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -491,6 +491,8 @@ class MoonMindAgentSessionWorkflow:
             self._thread_id = payload.thread_id
         if payload.active_turn_id is not None:
             self._active_turn_id = payload.active_turn_id
+        elif payload.last_control_action == "clear_session":
+            self._active_turn_id = None
         if payload.session_epoch is not None:
             self._binding = self._binding.model_copy(
                 update={"session_epoch": payload.session_epoch}
@@ -517,6 +519,9 @@ class MoonMindAgentSessionWorkflow:
         container_value = payload.get("containerId") or payload.get("container_id")
         thread_value = payload.get("threadId") or payload.get("thread_id")
         active_turn_value = payload.get("activeTurnId") or payload.get("active_turn_id")
+        session_epoch_value = payload.get("sessionEpoch") or payload.get(
+            "session_epoch"
+        )
 
         reason = str(reason_value).strip() or None if reason_value is not None else None
         container_id = (
@@ -532,6 +537,14 @@ class MoonMindAgentSessionWorkflow:
             if active_turn_value is not None
             else None
         )
+        session_epoch = None
+        if session_epoch_value is not None:
+            try:
+                parsed_epoch = int(session_epoch_value)
+            except (TypeError, ValueError):
+                parsed_epoch = None
+            if parsed_epoch is not None and parsed_epoch >= 1:
+                session_epoch = parsed_epoch
 
         binding = self._require_binding()
         self._last_control_action = action
@@ -540,6 +553,21 @@ class MoonMindAgentSessionWorkflow:
         if action == "clear_session":
             if thread_id is None:
                 raise ValueError("clear_session requires threadId")
+            if session_epoch is not None:
+                if session_epoch < binding.session_epoch:
+                    self._update_operator_visibility("stale clear ignored")
+                    return
+                self._status = AGENT_SESSION_STATUS_CLEARING
+                self._thread_id = thread_id
+                self._active_turn_id = active_turn_id
+                if container_id is not None:
+                    self._container_id = container_id
+                self._binding = binding.model_copy(
+                    update={"session_epoch": session_epoch}
+                )
+                self._status = AGENT_SESSION_STATUS_ACTIVE
+                self._update_operator_visibility("cleared to new epoch")
+                return
             self._status = AGENT_SESSION_STATUS_CLEARING
             if self._container_id and self._thread_id:
                 cleared = CodexManagedSessionState(
@@ -894,6 +922,7 @@ class MoonMindAgentSessionWorkflow:
                             threadId=locator.thread_id,
                             newThreadId=next_thread_id,
                             reason=request.reason,
+                            requestId=request.request_id,
                         ).model_dump(by_alias=True),
                     )
                 )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -82,6 +82,9 @@ with workflow.unsafe.imports_passed_through():
         StepExecutionCheckpointBoundary,
         build_step_checkpoint_id,
     )
+    from moonmind.workflows.temporal.managed_session_errors import (
+        is_managed_session_locator_mismatch_error,
+    )
 
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
 from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot, parse_tool_registry
@@ -8198,7 +8201,7 @@ class MoonMindRunWorkflow:
                 request_id=request_id,
             )
         except Exception as exc:
-            if not self._is_managed_session_locator_mismatch_error(exc):
+            if not is_managed_session_locator_mismatch_error(exc):
                 raise
             refreshed_snapshot = (
                 await self._load_workflow_scoped_session_snapshot_for_clear(
@@ -8257,31 +8260,6 @@ class MoonMindRunWorkflow:
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
             **self._execute_kwargs_for_route(clear_route),
         )
-
-    @staticmethod
-    def _is_managed_session_locator_mismatch_error(exc: BaseException) -> bool:
-        markers = (
-            "sessionid does not match the active managed session",
-            "sessionepoch does not match the active managed session",
-            "containerid does not match the active managed session",
-            "threadid does not match the active managed session",
-            "sessionepoch does not match the durable managed session record",
-            "containerid does not match the durable managed session record",
-            "threadid does not match the durable managed session record",
-        )
-        current: BaseException | None = exc
-        seen: set[int] = set()
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-            message = str(getattr(current, "message", "") or current).strip().lower()
-            if any(marker in message for marker in markers):
-                return True
-            current = getattr(current, "cause", None) or getattr(
-                current, "__cause__", None
-            )
-            if not isinstance(current, BaseException):
-                current = None
-        return False
 
     async def _terminate_workflow_scoped_session_via_activity_then_signal(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -418,6 +418,9 @@ RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH = (
 RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH = (
     "run-task-scoped-session-clear-activity-signal-v1"
 )
+RUN_WORKFLOW_SCOPED_SESSION_CLEAR_UPDATE_AUTHORITATIVE_PATCH = (
+    "run-task-scoped-session-clear-update-authoritative-v1"
+)
 RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH = (
     "run-task-scoped-session-termination-v4"
 )
@@ -7962,7 +7965,30 @@ class MoonMindRunWorkflow:
             execution_ordinal=execution_ordinal,
             operation="clear_session",
         )
-        if workflow.patched(RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH):
+        if workflow.patched(
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_UPDATE_AUTHORITATIVE_PATCH
+        ):
+            try:
+                await self._clear_workflow_scoped_session_via_update(
+                    session_handle=session_handle,
+                    binding=binding,
+                    reason=reason,
+                    request_id=request_id,
+                )
+            except AttributeError as exc:
+                self._get_logger().warning(
+                    "Workflow-scoped managed-session clear update unsupported for %s; "
+                    "falling back to activity and signal: %s",
+                    binding.session_id,
+                    exc,
+                )
+                await self._clear_workflow_scoped_session_via_activity_then_signal(
+                    session_handle=session_handle,
+                    binding=binding,
+                    reason=reason,
+                    request_id=request_id,
+                )
+        elif workflow.patched(RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH):
             await self._clear_workflow_scoped_session_via_activity_then_signal(
                 session_handle=session_handle,
                 binding=binding,
@@ -8009,6 +8035,36 @@ class MoonMindRunWorkflow:
                     request_id=request_id,
                 )
         self._codex_session_cleared_before_step_attempts.add(clear_key)
+
+    async def _clear_workflow_scoped_session_via_update(
+        self,
+        *,
+        session_handle: workflow.ExternalWorkflowHandle,
+        binding: CodexManagedSessionBinding,
+        reason: str,
+        request_id: str,
+    ) -> None:
+        execute_update = getattr(session_handle, "execute_update", None)
+        if execute_update is None:
+            raise AttributeError(
+                "'ExternalWorkflowHandle' object has no attribute 'execute_update'"
+            )
+        result = await execute_update(
+            "ClearSession",
+            {
+                "reason": reason,
+                "requestId": request_id,
+            },
+        )
+        session_state = self._get_from_result(
+            result, "sessionState"
+        ) or self._get_from_result(result, "session_state")
+        if isinstance(session_state, Mapping):
+            session_epoch = self._get_from_result(session_state, "sessionEpoch")
+            if isinstance(session_epoch, int) and session_epoch >= 1:
+                self._codex_session_binding = binding.model_copy(
+                    update={"session_epoch": session_epoch}
+                )
 
     async def _terminate_workflow_scoped_sessions(self, *, reason: str) -> None:
         binding = self._codex_session_binding
@@ -8098,6 +8154,7 @@ class MoonMindRunWorkflow:
         clear_handle = await self._clear_workflow_scoped_session_via_activity(
             binding=binding,
             reason=reason,
+            request_id=request_id,
         )
         session_state = clear_handle.session_state
         self._codex_session_binding = binding.model_copy(
@@ -8119,26 +8176,74 @@ class MoonMindRunWorkflow:
         *,
         binding: CodexManagedSessionBinding,
         reason: str,
+        request_id: str | None = None,
     ) -> CodexManagedSessionHandle:
         snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "agent_runtime.load_session_snapshot"
         )
+        snapshot = await self._load_workflow_scoped_session_snapshot_for_clear(
+            binding=binding,
+            snapshot_route=snapshot_route,
+        )
+        if not snapshot.container_id or not snapshot.thread_id:
+            raise ValueError("Workflow-scoped managed session cannot be cleared before launch")
+        clear_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "agent_runtime.clear_session"
+        )
+        try:
+            clear_payload = await self._execute_workflow_scoped_session_clear_activity(
+                snapshot=snapshot,
+                clear_route=clear_route,
+                reason=reason,
+                request_id=request_id,
+            )
+        except Exception as exc:
+            if not self._is_managed_session_locator_mismatch_error(exc):
+                raise
+            refreshed_snapshot = (
+                await self._load_workflow_scoped_session_snapshot_for_clear(
+                    binding=binding,
+                    snapshot_route=snapshot_route,
+                )
+            )
+            if not refreshed_snapshot.container_id or not refreshed_snapshot.thread_id:
+                raise ValueError(
+                    "Workflow-scoped managed session cannot be cleared before launch"
+                ) from exc
+            clear_payload = await self._execute_workflow_scoped_session_clear_activity(
+                snapshot=refreshed_snapshot,
+                clear_route=clear_route,
+                reason=reason,
+                request_id=request_id,
+            )
+        return CodexManagedSessionHandle.model_validate(clear_payload)
+
+    async def _load_workflow_scoped_session_snapshot_for_clear(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        snapshot_route: Any,
+    ) -> CodexManagedSessionSnapshot:
         snapshot_payload = await workflow.execute_activity(
             snapshot_route.activity_type,
             binding.model_dump(mode="json", by_alias=True),
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
             **self._execute_kwargs_for_route(snapshot_route),
         )
-        snapshot = CodexManagedSessionSnapshot.model_validate(snapshot_payload)
-        if not snapshot.container_id or not snapshot.thread_id:
-            raise ValueError("Workflow-scoped managed session cannot be cleared before launch")
-        clear_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-            "agent_runtime.clear_session"
-        )
+        return CodexManagedSessionSnapshot.model_validate(snapshot_payload)
+
+    async def _execute_workflow_scoped_session_clear_activity(
+        self,
+        *,
+        snapshot: CodexManagedSessionSnapshot,
+        clear_route: Any,
+        reason: str,
+        request_id: str | None,
+    ) -> Any:
         next_thread_id = (
             f"thread:{snapshot.binding.session_id}:{snapshot.binding.session_epoch + 1}"
         )
-        clear_payload = await workflow.execute_activity(
+        return await workflow.execute_activity(
             clear_route.activity_type,
             CodexManagedSessionClearRequest(
                 sessionId=snapshot.binding.session_id,
@@ -8147,11 +8252,36 @@ class MoonMindRunWorkflow:
                 threadId=snapshot.thread_id,
                 newThreadId=next_thread_id,
                 reason=reason,
+                requestId=request_id,
             ).model_dump(mode="json", by_alias=True),
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
             **self._execute_kwargs_for_route(clear_route),
         )
-        return CodexManagedSessionHandle.model_validate(clear_payload)
+
+    @staticmethod
+    def _is_managed_session_locator_mismatch_error(exc: BaseException) -> bool:
+        markers = (
+            "sessionid does not match the active managed session",
+            "sessionepoch does not match the active managed session",
+            "containerid does not match the active managed session",
+            "threadid does not match the active managed session",
+            "sessionepoch does not match the durable managed session record",
+            "containerid does not match the durable managed session record",
+            "threadid does not match the durable managed session record",
+        )
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            message = str(getattr(current, "message", "") or current).strip().lower()
+            if any(marker in message for marker in markers):
+                return True
+            current = getattr(current, "cause", None) or getattr(
+                current, "__cause__", None
+            )
+            if not isinstance(current, BaseException):
+                current = None
+        return False
 
     async def _terminate_workflow_scoped_session_via_activity_then_signal(
         self,

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -68,6 +68,21 @@ def test_managed_session_plane_contract_exposes_canonical_control_actions() -> N
         "terminate_session",
     )
 
+def test_clear_session_request_accepts_compact_request_id() -> None:
+    request = CodexManagedSessionClearRequest(
+        sessionId="sess-1",
+        sessionEpoch=1,
+        containerId="ctr-1",
+        threadId="thread-1",
+        newThreadId="thread-2",
+        requestId="wf:run:step:1:clear_session",
+    )
+
+    assert request.request_id == "wf:run:step:1:clear_session"
+    assert request.model_dump(mode="json", by_alias=True)["requestId"] == (
+        "wf:run:step:1:clear_session"
+    )
+
 def test_managed_session_plane_contract_rejects_non_canonical_overrides() -> None:
     with pytest.raises(ValidationError, match="Input should be False"):
         ManagedSessionPlaneContract(cross_task_reuse=True)

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3791,6 +3791,97 @@ async def test_controller_clear_session_publishes_durable_reset_artifacts(
     assert publication.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert publication.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
 
+
+@pytest.mark.asyncio
+async def test_controller_clear_session_request_id_returns_published_duplicate(
+    tmp_path: Path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    store = ManagedSessionStore(tmp_path / "session-store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/work/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/work/agent_jobs/task-1/session",
+            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            startedAt=datetime(2026, 4, 7, 8, 0, tzinfo=UTC),
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if "clear_session" in command:
+            return (
+                0,
+                json.dumps(
+                    {
+                        "sessionState": {
+                            "sessionId": "sess-1",
+                            "sessionEpoch": 2,
+                            "containerId": "ctr-1",
+                            "threadId": "logical-thread-2",
+                        },
+                        "status": "ready",
+                        "imageRef": "ghcr.io/moonladderstudios/moonmind:latest",
+                        "controlUrl": "docker-exec://mm-codex-session-sess-1",
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=supervisor,
+        command_runner=_fake_runner,
+    )
+
+    request = CodexManagedSessionClearRequest(
+        sessionId="sess-1",
+        sessionEpoch=1,
+        containerId="ctr-1",
+        threadId="logical-thread-1",
+        newThreadId="logical-thread-2",
+        requestId="clear-request-1",
+        reason="reset stale context",
+    )
+    first = await controller.clear_session(request)
+    duplicate = await controller.clear_session(request)
+
+    assert first.session_state.session_epoch == 2
+    assert duplicate.session_state.session_epoch == 2
+    assert duplicate.metadata["idempotentReplay"] is True
+    assert duplicate.metadata["requestId"] == "clear-request-1"
+    assert len([command for command in commands if "clear_session" in command]) == 1
+    stored = store.load("sess-1")
+    assert stored is not None
+    assert stored.metadata["lastClearRequest"]["status"] == "completed"
+    assert stored.metadata["lastClearRequest"]["requestId"] == "clear-request-1"
+
+
 @pytest.mark.asyncio
 async def test_controller_send_turn_tolerates_event_publication_failure(
     tmp_path: Path,
@@ -3860,6 +3951,104 @@ async def test_controller_send_turn_tolerates_event_publication_failure(
     )
 
     assert response.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_records_empty_assistant_metadata(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            agentRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "failed",
+                "metadata": {
+                    "reason": (
+                        "codex app-server turn/completed produced no assistant output"
+                    ),
+                    "failureClass": "transient",
+                    "failureCause": "app_server_protocol_empty_turn",
+                    "retryRecommendedAction": "clear_session",
+                },
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Inspect the workspace",
+        )
+    )
+
+    assert response.status == "failed"
+    stored = store.load("sess-1")
+    assert stored is not None
+    empty_turn = stored.metadata["emptyAssistantTurn"]
+    assert empty_turn["failureCause"] == "app_server_protocol_empty_turn"
+    assert empty_turn["consecutiveCount"] == 1
+    session_supervisor.emit_session_event.assert_any_call(
+        record=stored,
+        text=(
+            "Codex app-server completed a turn without assistant output; "
+            "session clear is recommended."
+        ),
+        kind="empty_assistant_turn_detected",
+        turn_id="vendor-turn-1",
+        active_turn_id=None,
+        metadata={
+            "action": "send_turn",
+            "failureCause": "app_server_protocol_empty_turn",
+            "retryRecommendedAction": "clear_session",
+            "reason": "codex app-server turn/completed produced no assistant output",
+            "consecutiveCount": 1,
+        },
+    )
+
 
 @pytest.mark.asyncio
 async def test_controller_clear_session_preserves_retrieval_metadata_in_durable_outputs(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -37,8 +37,10 @@ from moonmind.workflows.codex_session_timeouts import (
 from moonmind.workflows.adapters.codex_session_adapter import (
     CodexSessionAdapter,
     CodexSessionRunFailedError,
-    _is_session_locator_mismatch_error,
     _jira_skill_blocker_summary,
+)
+from moonmind.workflows.temporal.managed_session_errors import (
+    is_managed_session_locator_mismatch_error,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
@@ -72,7 +74,7 @@ async def test_session_locator_mismatch_error_ignores_non_exception_cause() -> N
     class MetadataCauseError(Exception):
         cause = {"message": "metadata"}
 
-    assert not _is_session_locator_mismatch_error(MetadataCauseError("wrapper"))
+    assert not is_managed_session_locator_mismatch_error(MetadataCauseError("wrapper"))
 
 
 def _raise_activity_error_from_application_error(error: ApplicationError) -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1833,6 +1833,107 @@ async def test_start_resets_session_after_prefixed_empty_assistant_activity_fail
     assert len(clear_calls) == 1
     assert send_turn_calls[1].thread_id == reset_thread_id
 
+
+async def test_start_marks_empty_assistant_retry_exhausted(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
+    reset_thread_id = "thread-1:empty-output-reset"
+    send_turn_calls: list[Any] = []
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        metadata = {
+            "reason": "codex app-server turn/completed produced no assistant output",
+            "failureClass": "transient",
+            "failureCause": "app_server_protocol_empty_turn",
+            "retryRecommendedAction": "clear_session",
+            "turnFailureEvidence": {"schemaVersion": "v1"},
+        }
+        _raise_activity_error_from_application_error(
+            ApplicationError(
+                metadata["reason"],
+                metadata,
+                type="CodexTransientTurnError",
+                non_retryable=True,
+            )
+        )
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        assert request.request_id == (
+            f"{binding.agent_run_id}:empty-assistant-clear:1:thread-1"
+        )
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+        )
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_clear_remote_session,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(CodexSessionRunFailedError) as excinfo:
+        await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    assert len(send_turn_calls) == 2
+    turn_metadata = excinfo.value.agent_run_result.metadata["turnMetadata"]
+    assert turn_metadata["selfHealExhausted"] is True
+    assert turn_metadata["selfHealAction"] == "clear_session"
+    assert turn_metadata["selfHealAttempts"] == 1
+    assert turn_metadata["sessionInterventions"][0]["toSessionEpoch"] == 2
+
+
 async def test_start_classifies_codex_provider_capacity_failure_and_publishes_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -3494,6 +3595,102 @@ async def test_clear_session_rotates_epoch_and_signals_session_workflow(
             "threadId": "thread-2",
         }
     ]
+
+
+async def test_clear_session_refreshes_locator_after_epoch_mismatch(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    refreshed_binding = binding.model_copy(update={"session_epoch": 2})
+    reset_thread_id = "thread-1:empty-output-reset"
+    load_calls = 0
+    clear_calls: list[Any] = []
+    status_calls: list[Any] = []
+    attach_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        nonlocal load_calls
+        load_calls += 1
+        if load_calls == 1:
+            return _snapshot(
+                binding=binding,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        return _snapshot(
+            binding=refreshed_binding,
+            container_id="container-1",
+            thread_id=reset_thread_id,
+        )
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        clear_calls.append(request)
+        assert request.request_id == "clear-request-1"
+        _raise_activity_error_from_application_error(
+            ApplicationError(
+                "sessionEpoch does not match the active managed session",
+                type="RuntimeError",
+            )
+        )
+
+    async def _session_status(request: Any) -> CodexManagedSessionHandle:
+        status_calls.append(request)
+        return _session_handle(
+            session_id=request.session_id,
+            session_epoch=request.session_epoch,
+            container_id=request.container_id,
+            thread_id=request.thread_id,
+        )
+
+    async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+        attach_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_clear_remote_session,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_attach_runtime_handles,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.clear_session(
+        binding=binding,
+        new_thread_id=reset_thread_id,
+        reason="retry_after_empty_assistant_output",
+        request_id="clear-request-1",
+    )
+
+    assert handle.session_state.session_epoch == 2
+    assert handle.session_state.thread_id == reset_thread_id
+    assert len(clear_calls) == 1
+    assert len(status_calls) == 1
+    assert attach_calls == [
+        {
+            "sessionEpoch": 2,
+            "containerId": "container-1",
+            "threadId": reset_thread_id,
+            "activeTurnId": None,
+        }
+    ]
+
 
 async def test_cancel_interrupts_active_turn_and_marks_run_canceled(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_managed_session_errors.py
+++ b/tests/unit/workflows/temporal/test_managed_session_errors.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from moonmind.workflows.temporal.managed_session_errors import (
+    is_managed_session_locator_mismatch_error,
+)
+
+
+def test_managed_session_locator_mismatch_matches_active_session_marker() -> None:
+    assert is_managed_session_locator_mismatch_error(
+        RuntimeError("sessionEpoch does not match the active managed session")
+    )
+
+
+def test_managed_session_locator_mismatch_matches_durable_record_marker() -> None:
+    assert is_managed_session_locator_mismatch_error(
+        RuntimeError("threadId does not match the durable managed session record")
+    )
+
+
+def test_managed_session_locator_mismatch_walks_exception_cause_chain() -> None:
+    cause = RuntimeError("containerId does not match the active managed session")
+    wrapper = RuntimeError("activity failed")
+    wrapper.__cause__ = cause
+
+    assert is_managed_session_locator_mismatch_error(wrapper)

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -1326,6 +1326,77 @@ def test_agent_session_legacy_control_action_signal_replays_clear_session(
     assert status["lastControlAction"] == "clear_session"
     assert status["lastControlReason"] == "Replay old clear event"
 
+
+def test_agent_session_epoch_bearing_clear_signal_applies_exact_snapshot_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindAgentSessionWorkflow(_workflow_input())
+    workflow.attach_runtime_handles(
+        _runtime_handles(
+            {
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": "turn-1",
+            }
+        )
+    )
+
+    clear_payload = {
+        "action": "clear_session",
+        "reason": "Apply exact clear state",
+        "sessionEpoch": 2,
+        "containerId": "container-1",
+        "threadId": "thread-2",
+        "activeTurnId": None,
+    }
+
+    workflow.apply_control_action(clear_payload)
+    workflow.apply_control_action(clear_payload)
+
+    status = workflow.get_status()
+    assert status["status"] == AGENT_SESSION_STATUS_ACTIVE
+    assert status["binding"]["sessionEpoch"] == 2
+    assert status["threadId"] == "thread-2"
+    assert status["activeTurnId"] is None
+    assert status["lastControlAction"] == "clear_session"
+    assert status["lastControlReason"] == "Apply exact clear state"
+
+
+def test_agent_session_attach_clear_handles_clear_stale_active_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindAgentSessionWorkflow(_workflow_input())
+    workflow.attach_runtime_handles(
+        _runtime_handles(
+            {
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": "turn-1",
+            }
+        )
+    )
+
+    workflow.attach_runtime_handles(
+        _runtime_handles(
+            {
+                "sessionEpoch": 2,
+                "containerId": "container-1",
+                "threadId": "thread-2",
+                "activeTurnId": None,
+                "lastControlAction": "clear_session",
+                "lastControlReason": "reset",
+            }
+        )
+    )
+
+    status = workflow.get_status()
+    assert status["binding"]["sessionEpoch"] == 2
+    assert status["threadId"] == "thread-2"
+    assert status["activeTurnId"] is None
+
+
 @pytest.mark.asyncio
 async def test_agent_session_async_mutators_wait_for_workflow_lock(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -13,6 +13,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
+    RUN_WORKFLOW_SCOPED_SESSION_CLEAR_UPDATE_AUTHORITATIVE_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_ACTIVITY_SIGNAL_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_PATCH,
     RUN_WORKFLOW_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
@@ -301,6 +302,195 @@ async def test_run_clears_existing_workflow_scoped_codex_session_before_next_ste
     assert workflow._codex_session_binding is not None
     assert workflow._codex_session_binding.session_epoch == 2
     assert ("step-2", 1) in workflow._codex_session_cleared_before_step_attempts
+
+
+@pytest.mark.asyncio
+async def test_run_routes_workflow_scoped_session_clear_through_update_when_patched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    update_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def execute_update(
+            self,
+            update_name: str,
+            payload: Any = None,
+        ) -> dict[str, Any]:
+            update_calls.append((update_name, payload))
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread:sess:wf-run-1:codex_cli:2",
+                    "activeTurnId": None,
+                },
+                "latestResetBoundaryRef": "sess/reset-2.json",
+            }
+
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("authoritative clear path must not execute raw activities")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_UPDATE_AUTHORITATIVE_PATCH,
+        },
+    )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        agentRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._maybe_clear_workflow_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    assert update_calls == [
+        (
+            "ClearSession",
+            {
+                "reason": "Clearing workflow-scoped context before step step-2",
+                "requestId": "wf-run-1:run-1:step-2:execution:1:clear_session",
+            },
+        )
+    ]
+    assert signal_calls == []
+    assert workflow._codex_session_binding is not None
+    assert workflow._codex_session_binding.session_epoch == 2
+
+
+@pytest.mark.asyncio
+async def test_run_legacy_clear_activity_reloads_snapshot_after_epoch_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    activity_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            clear_attempts = len(
+                [
+                    name
+                    for name, _payload in activity_calls
+                    if name == "agent_runtime.clear_session"
+                ]
+            )
+            epoch = 1 if clear_attempts == 0 else 2
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "agentRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": epoch,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": f"thread-{epoch}",
+                "activeTurnId": None,
+                "lastControlAction": "clear_session" if epoch == 2 else None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.clear_session":
+            if payload["sessionEpoch"] == 1:
+                raise RuntimeError(
+                    "sessionEpoch does not match the active managed session"
+                )
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 3,
+                    "containerId": "container-1",
+                    "threadId": "thread:sess:wf-run-1:codex_cli:3",
+                    "activeTurnId": None,
+                },
+                "status": "ready",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_BETWEEN_STEPS_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_PER_EXECUTION_PATCH,
+            RUN_WORKFLOW_SCOPED_SESSION_CLEAR_ACTIVITY_SIGNAL_PATCH,
+        },
+    )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    _use_external_handle(monkeypatch, _FakeHandle())
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        agentRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._maybe_clear_workflow_scoped_session_before_step(
+        request=_managed_request("codex"),
+        logical_step_id="step-2",
+    )
+
+    clear_payloads = [
+        payload
+        for name, payload in activity_calls
+        if name == "agent_runtime.clear_session"
+    ]
+    assert [payload["sessionEpoch"] for payload in clear_payloads] == [1, 2]
+    assert clear_payloads[1]["requestId"] == (
+        "wf-run-1:run-1:step-2:execution:1:clear_session"
+    )
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "clear_session",
+                "reason": "Clearing workflow-scoped context before step step-2",
+                "requestId": "wf-run-1:run-1:step-2:execution:1:clear_session",
+                "containerId": "container-1",
+                "threadId": "thread:sess:wf-run-1:codex_cli:3",
+            },
+        )
+    ]
+    assert workflow._codex_session_binding is not None
+    assert workflow._codex_session_binding.session_epoch == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route new parent-initiated workflow-scoped Codex clears through the AgentSession `ClearSession` update so epoch changes serialize under the session mutation lock.
- Add `requestId` to managed-session clear requests and controller-side duplicate detection once reset artifacts have been published.
- Refresh stale raw clear locators once, keep legacy replay paths intact, and prevent delayed epoch-bearing clear signals from incrementing the session epoch again.
- Record empty assistant turn metadata/events and mark the retry-after-clear path as exhausted when the post-clear retry also produces no assistant output.

## Root Cause
A parent workflow could load a managed-session snapshot at epoch N, then call `agent_runtime.clear_session` after the active Codex session had already advanced. The raw runtime/controller locators correctly rejected the stale epoch, but the parent path did not serialize through the session workflow or refresh before failing. Repeated Codex app-server empty-turn recovery then made the failure noisy and hard to diagnose.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3 -m py_compile moonmind/workflows/temporal/workflows/run.py moonmind/workflows/temporal/workflows/agent_session.py moonmind/workflows/adapters/codex_session_adapter.py moonmind/workflows/temporal/runtime/managed_session_controller.py moonmind/schemas/managed_session_models.py`
- `./tools/test_unit.sh tests/unit/schemas/test_managed_session_models.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `./tools/test_unit.sh`