### PR TITLE
[codex] fix recurring schedule datetime search attr

### DIFF
--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -566,7 +566,6 @@ class TemporalClientAdapter:
             k: v if isinstance(v, list) else [v]
             for k, v in (search_attributes or {}).items()
         }
-        formatted_sa["mm_scheduled_for"] = ["{{.ScheduleTime}}"]
         typed_search_attributes = _build_typed_search_attributes(formatted_sa)
 
         try:

--- a/moonmind/workflows/temporal/manifest_ingest.py
+++ b/moonmind/workflows/temporal/manifest_ingest.py
@@ -756,7 +756,14 @@ def _apply_manifest_node_update(
 import asyncio
 from datetime import timedelta
 
-from temporalio.common import RetryPolicy
+from temporalio.common import RetryPolicy, SearchAttributeKey, SearchAttributePair
+
+from moonmind.workflows.temporal.scheduled_start import (
+    MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE,
+    temporal_scheduled_start_time,
+)
+
+MANIFEST_RECURRING_SCHEDULED_START_PATCH = "manifest-recurring-scheduled-start-v1"
 
 with workflow.unsafe.imports_passed_through():
     pass
@@ -784,6 +791,35 @@ class ManifestIngestWorkflow:
         self._running_tasks: dict[str, asyncio.Task[Any]] = {}
         self._workflow_id: str = info.workflow_id
         self._run_id: str = info.run_id
+
+    def _upsert_scheduled_for_search_attribute(self) -> None:
+        if not self._scheduled_start_patch_enabled():
+            return
+        scheduled_start = temporal_scheduled_start_time(workflow.info())
+        if scheduled_start is None:
+            return
+        try:
+            workflow.upsert_search_attributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_datetime(
+                            MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE
+                        ),
+                        scheduled_start,
+                    )
+                ]
+            )
+        except Exception as exc:
+            self._get_logger().warning(
+                "Failed to upsert manifest scheduled_for search attribute",
+                extra={"error": str(exc)},
+            )
+
+    def _scheduled_start_patch_enabled(self) -> bool:
+        try:
+            return workflow.patched(MANIFEST_RECURRING_SCHEDULED_START_PATCH)
+        except Exception:
+            return False
 
     async def _compile_manifest(
         self,
@@ -846,6 +882,7 @@ class ManifestIngestWorkflow:
         self._manifest_ref = parameters.get("manifestArtifactRef")
         if not self._manifest_ref:
             raise ValueError("manifestArtifactRef is required")
+        self._upsert_scheduled_for_search_attribute()
 
         requested_by = _resolve_workflow_requested_by(
             parameters,

--- a/moonmind/workflows/temporal/scheduled_start.py
+++ b/moonmind/workflows/temporal/scheduled_start.py
@@ -1,0 +1,63 @@
+"""Helpers for copying Temporal schedule metadata into MoonMind visibility."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+from temporalio.common import SearchAttributeKey
+
+TEMPORAL_SCHEDULED_START_TIME_SEARCH_ATTRIBUTE = "TemporalScheduledStartTime"
+MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE = "mm_scheduled_for"
+
+
+def temporal_scheduled_start_time(info: Any) -> datetime | None:
+    """Return Temporal's scheduled start timestamp from workflow info."""
+
+    scheduled_start_key = SearchAttributeKey.for_datetime(
+        TEMPORAL_SCHEDULED_START_TIME_SEARCH_ATTRIBUTE
+    )
+    typed_search_attributes = getattr(info, "typed_search_attributes", None)
+    if typed_search_attributes is not None:
+        scheduled_start = _coerce_datetime(
+            typed_search_attributes.get(scheduled_start_key)
+        )
+        if scheduled_start is not None:
+            return scheduled_start
+
+    search_attributes = getattr(info, "search_attributes", {}) or {}
+    if not isinstance(search_attributes, Mapping):
+        return None
+    return _coerce_search_attribute_datetime(
+        search_attributes.get(TEMPORAL_SCHEDULED_START_TIME_SEARCH_ATTRIBUTE)
+    )
+
+
+def _coerce_search_attribute_datetime(value: Any) -> datetime | None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if not value:
+            return None
+        value = value[0]
+    return _coerce_datetime(value)
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return None
+        try:
+            return datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = [
+    "MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE",
+    "TEMPORAL_SCHEDULED_START_TIME_SEARCH_ATTRIBUTE",
+    "temporal_scheduled_start_time",
+]

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5384,6 +5384,8 @@ class MoonMindRunWorkflow:
             "scheduledFor",
             "scheduled_for",
         )
+        if not scheduled_for and self._has_recurrence_metadata(parameters):
+            scheduled_for = self._temporal_scheduled_start_time()
 
         if input_ref:
             self._input_ref = input_ref
@@ -5393,6 +5395,36 @@ class MoonMindRunWorkflow:
             self._scheduled_for = scheduled_for
 
         return workflow_type, parameters, input_ref, plan_ref, scheduled_for
+
+    def _has_recurrence_metadata(self, parameters: Mapping[str, Any]) -> bool:
+        system_payload = parameters.get("system")
+        if not isinstance(system_payload, Mapping):
+            return False
+        recurrence_payload = system_payload.get("recurrence")
+        return isinstance(recurrence_payload, Mapping) and bool(recurrence_payload)
+
+    def _temporal_scheduled_start_time(self) -> Optional[str]:
+        info = workflow.info()
+        scheduled_start_key = SearchAttributeKey.for_datetime(
+            "TemporalScheduledStartTime"
+        )
+        typed_search_attributes = getattr(info, "typed_search_attributes", None)
+        if typed_search_attributes is not None:
+            scheduled_start = typed_search_attributes.get(scheduled_start_key)
+            if isinstance(scheduled_start, datetime):
+                return scheduled_start.isoformat()
+
+        search_attributes = getattr(info, "search_attributes", {}) or {}
+        values = search_attributes.get("TemporalScheduledStartTime") or []
+        if not values:
+            return None
+        scheduled_start = values[0]
+        if isinstance(scheduled_start, datetime):
+            return scheduled_start.isoformat()
+        if isinstance(scheduled_start, str):
+            normalized = scheduled_start.strip()
+            return normalized or None
+        return None
 
     def _record_bounded_story_loop_context(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -133,6 +133,7 @@ from moonmind.workflows.temporal.completion_summary import (
     is_generic_completion_summary,
 )
 from moonmind.workflows.temporal.title_search import tokenize_title
+from moonmind.workflows.temporal.scheduled_start import temporal_scheduled_start_time
 from moonmind.workflows.temporal.activity_catalog import (
     INTEGRATIONS_TASK_QUEUE,
     WORKFLOW_TASK_QUEUE,
@@ -376,6 +377,7 @@ RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = "run-workflow-child-task-queue-v2"
 RUN_RUNTIME_PROFILE_CLEAR_FORWARDING_PATCH = "run-runtime-profile-clear-forwarding-v1"
+RUN_RECURRING_SCHEDULED_START_PATCH = "run-recurring-scheduled-start-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 # Replay-stable patch id for unified wait-through-rerun dependency behavior.
 # Under this patch, a non-success prerequisite terminal outcome (failed,
@@ -5384,8 +5386,14 @@ class MoonMindRunWorkflow:
             "scheduledFor",
             "scheduled_for",
         )
-        if not scheduled_for and self._has_recurrence_metadata(parameters):
-            scheduled_for = self._temporal_scheduled_start_time()
+        if (
+            not scheduled_for
+            and self._has_recurrence_metadata(parameters)
+            and workflow.patched(RUN_RECURRING_SCHEDULED_START_PATCH)
+        ):
+            temporal_scheduled_for = temporal_scheduled_start_time(workflow.info())
+            if temporal_scheduled_for is not None:
+                scheduled_for = temporal_scheduled_for.isoformat()
 
         if input_ref:
             self._input_ref = input_ref
@@ -5402,29 +5410,6 @@ class MoonMindRunWorkflow:
             return False
         recurrence_payload = system_payload.get("recurrence")
         return isinstance(recurrence_payload, Mapping) and bool(recurrence_payload)
-
-    def _temporal_scheduled_start_time(self) -> Optional[str]:
-        info = workflow.info()
-        scheduled_start_key = SearchAttributeKey.for_datetime(
-            "TemporalScheduledStartTime"
-        )
-        typed_search_attributes = getattr(info, "typed_search_attributes", None)
-        if typed_search_attributes is not None:
-            scheduled_start = typed_search_attributes.get(scheduled_start_key)
-            if isinstance(scheduled_start, datetime):
-                return scheduled_start.isoformat()
-
-        search_attributes = getattr(info, "search_attributes", {}) or {}
-        values = search_attributes.get("TemporalScheduledStartTime") or []
-        if not values:
-            return None
-        scheduled_start = values[0]
-        if isinstance(scheduled_start, datetime):
-            return scheduled_start.isoformat()
-        if isinstance(scheduled_start, str):
-            normalized = scheduled_start.strip()
-            return normalized or None
-        return None
 
     def _record_bounded_story_loop_context(
         self,

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import pytest
 from temporalio.client import ScheduleOverlapPolicy, ScheduleUpdate
+from temporalio.common import SearchAttributeKey
 
 from moonmind.workflows.temporal.client import (
     MANAGED_SESSION_RECONCILE_SCHEDULE_ID,
@@ -78,6 +79,35 @@ class TestCreateSchedule:
         
         schedule_arg = call_args[0][1]
         assert schedule_arg.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
+
+    @pytest.mark.asyncio
+    async def test_does_not_template_scheduled_for_search_attribute(self) -> None:
+        mock_handle = MagicMock()
+        mock_handle.id = _SCHEDULE_ID
+        mock_client = MagicMock()
+        mock_client.create_schedule = AsyncMock(return_value=mock_handle)
+
+        adapter = _make_adapter(mock_client)
+        await adapter.create_schedule(
+            definition_id=_TEST_UUID,
+            cron_expression="0 0 * * *",
+            workflow_type="MoonMind.UserWorkflow",
+            search_attributes={"mm_owner_id": "user-1"},
+        )
+
+        schedule_arg = mock_client.create_schedule.call_args[0][1]
+        typed_search_attributes = schedule_arg.action.typed_search_attributes
+        assert typed_search_attributes is not None
+        assert (
+            typed_search_attributes.get(SearchAttributeKey.for_keyword("mm_owner_id"))
+            == "user-1"
+        )
+        assert (
+            typed_search_attributes.get(
+                SearchAttributeKey.for_datetime("mm_scheduled_for")
+            )
+            is None
+        )
 
     @pytest.mark.asyncio
     async def test_overlap_policy_passed_through(self) -> None:

--- a/tests/unit/workflows/temporal/test_manifest_ingest.py
+++ b/tests/unit/workflows/temporal/test_manifest_ingest.py
@@ -13,6 +13,11 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+)
 
 import moonmind.workflows.temporal.manifest_ingest as manifest_ingest_module
 from api_service.db.models import Base, MoonMindWorkflowState, TemporalWorkflowType
@@ -372,6 +377,8 @@ def test_manifest_workflow_run_uses_owner_principal_and_child_owner_id(
 ) -> None:
     activity_calls: list[tuple[str, dict[str, object]]] = []
     child_calls: list[dict[str, object]] = []
+    search_attribute_upserts: list[list[SearchAttributePair]] = []
+    scheduled_start = datetime(2026, 6, 22, 9, 30, tzinfo=UTC)
 
     monkeypatch.setattr(
         manifest_ingest_module.workflow,
@@ -380,7 +387,27 @@ def test_manifest_workflow_run_uses_owner_principal_and_child_owner_id(
             workflow_id="mm:manifest-1",
             run_id="run-1",
             search_attributes={"mm_owner_id": "user-1"},
+            typed_search_attributes=TypedSearchAttributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_datetime(
+                            "TemporalScheduledStartTime"
+                        ),
+                        scheduled_start,
+                    )
+                ]
+            ),
         ),
+    )
+    monkeypatch.setattr(
+        manifest_ingest_module.workflow,
+        "patched",
+        lambda _patch_id: True,
+    )
+    monkeypatch.setattr(
+        manifest_ingest_module.workflow,
+        "upsert_search_attributes",
+        lambda pairs: search_attribute_upserts.append(list(pairs)),
     )
 
     async def fake_execute_activity(name: str, *, args, **_kwargs):
@@ -441,6 +468,9 @@ def test_manifest_workflow_run_uses_owner_principal_and_child_owner_id(
     )
 
     assert result["status"] == "completed"
+    assert search_attribute_upserts
+    assert search_attribute_upserts[0][0].key.name == "mm_scheduled_for"
+    assert search_attribute_upserts[0][0].value == scheduled_start
     assert activity_calls[0] == (
         "manifest_read",
         {"principal": "user-1", "manifest_ref": "art_manifest_1"},

--- a/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -7,6 +8,11 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+)
 from moonmind.workflows.temporal.workflows.run import (
     DEPENDENCY_GATE_PATCH,
     MoonMindUserWorkflow,
@@ -36,6 +42,50 @@ def mock_run_environment(monkeypatch):
     async def fake_execution_stage(*args, **kwargs): pass
     monkeypatch.setattr(MoonMindUserWorkflow, "_run_planning_stage", fake_planning_stage)
     monkeypatch.setattr(MoonMindUserWorkflow, "_run_execution_stage", fake_execution_stage)
+
+def test_initializes_recurring_run_from_temporal_scheduled_start_time(monkeypatch):
+    scheduled_start = datetime(2026, 6, 22, 9, 30, tzinfo=timezone.utc)
+    workflow_instance = MoonMindUserWorkflow()
+
+    monkeypatch.setattr(
+        MoonMindUserWorkflow,
+        "_trusted_owner_metadata",
+        lambda self: ("user", "user-1"),
+    )
+    monkeypatch.setattr(workflow, "memo", lambda: {})
+    monkeypatch.setattr(
+        workflow,
+        "info",
+        lambda: SimpleNamespace(
+            typed_search_attributes=TypedSearchAttributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_datetime(
+                            "TemporalScheduledStartTime"
+                        ),
+                        scheduled_start,
+                    )
+                ]
+            ),
+            search_attributes={},
+        ),
+    )
+
+    result = workflow_instance._initialize_from_payload(
+        {
+            "workflow_type": "MoonMind.UserWorkflow",
+            "initial_parameters": {
+                "system": {
+                    "recurrence": {
+                        "definitionId": "364cc408-29c9-4745-beae-bad55aacd9b5"
+                    }
+                }
+            },
+        }
+    )
+
+    assert result[-1] == scheduled_start.isoformat()
+    assert workflow_instance._scheduled_for == scheduled_start.isoformat()
 
 @pytest.mark.asyncio
 async def test_run_workflow_scheduled(mock_run_environment):

--- a/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
@@ -53,6 +53,7 @@ def test_initializes_recurring_run_from_temporal_scheduled_start_time(monkeypatc
         lambda self: ("user", "user-1"),
     )
     monkeypatch.setattr(workflow, "memo", lambda: {})
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
     monkeypatch.setattr(
         workflow,
         "info",
@@ -86,6 +87,44 @@ def test_initializes_recurring_run_from_temporal_scheduled_start_time(monkeypatc
 
     assert result[-1] == scheduled_start.isoformat()
     assert workflow_instance._scheduled_for == scheduled_start.isoformat()
+
+def test_initializes_recurring_run_from_string_temporal_scheduled_start_time(
+    monkeypatch,
+):
+    scheduled_start = "2026-06-22T09:30:00+00:00"
+    workflow_instance = MoonMindUserWorkflow()
+
+    monkeypatch.setattr(
+        MoonMindUserWorkflow,
+        "_trusted_owner_metadata",
+        lambda self: ("user", "user-1"),
+    )
+    monkeypatch.setattr(workflow, "memo", lambda: {})
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        workflow,
+        "info",
+        lambda: SimpleNamespace(
+            typed_search_attributes=None,
+            search_attributes={"TemporalScheduledStartTime": scheduled_start},
+        ),
+    )
+
+    result = workflow_instance._initialize_from_payload(
+        {
+            "workflow_type": "MoonMind.UserWorkflow",
+            "initial_parameters": {
+                "system": {
+                    "recurrence": {
+                        "definitionId": "364cc408-29c9-4745-beae-bad55aacd9b5"
+                    }
+                }
+            },
+        }
+    )
+
+    assert result[-1] == scheduled_start
+    assert workflow_instance._scheduled_for == scheduled_start
 
 @pytest.mark.asyncio
 async def test_run_workflow_scheduled(mock_run_environment):


### PR DESCRIPTION
## Summary

Fix recurring cron schedule creation by no longer sending `{{.ScheduleTime}}` as the custom `mm_scheduled_for` Datetime search attribute when creating a Temporal Schedule.

## Root Cause

Temporal evaluates `{{.ScheduleTime}}` for schedule workflow IDs, but schedule action search attributes are validated at schedule creation time. The adapter was sending the literal template string as `mm_scheduled_for`, so Temporal rejected schedule creation because `mm_scheduled_for` is registered as `Datetime`.

## Changes

- Removed the invalid `mm_scheduled_for = "{{.ScheduleTime}}"` schedule-action search attribute.
- Kept owner search attributes on scheduled workflow starts.
- Derived `mm_scheduled_for` inside `MoonMind.UserWorkflow` from Temporal's built-in `TemporalScheduledStartTime` for recurrence-triggered runs once they actually start.
- Added adapter and workflow regression tests for the schedule boundary.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_client_schedules.py tests/unit/workflows/temporal/workflows/test_run_scheduling.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Real local Temporal smoke: created and deleted a unique schedule through the patched `TemporalClientAdapter` against `localhost:7233`.

Note: an SDK time-skipping test-server smoke was attempted first, but that server returned `CreateSchedule is unimplemented`, so the real local Temporal service was used for the schedule-create smoke.