### PR TITLE
I want to display years on the Workflows page's Scheduled, Created, and Finished columns with only 2 chars, so 6/21/26 instead of 6/21/2026 to save so

### DIFF
--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -137,6 +137,38 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
+  it('renders workflow table dates with two-digit years', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'task-123',
+            source: 'temporal',
+            title: 'Example task',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            scheduledFor: '2026-06-21T12:00:00Z',
+            createdAt: '2026-06-21T12:01:00Z',
+            closedAt: '2026-06-21T12:02:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    const row = (await screen.findByRole('link', { name: 'Example task' })).closest('tr');
+    expect(row).toBeTruthy();
+    const dateCells = row?.querySelectorAll('.queue-table-cell-date');
+    expect(dateCells).toHaveLength(3);
+    for (const cell of Array.from(dateCells || [])) {
+      expect(cell.textContent).toContain('/26');
+      expect(cell.textContent).not.toContain('2026');
+    }
+  });
+
   it('does not query or render operational metrics on the workflow overview', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -159,14 +159,27 @@ describe('Workflows Entrypoint', () => {
 
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
-    const row = (await screen.findByRole('link', { name: 'Example task' })).closest('tr');
-    expect(row).toBeTruthy();
-    const dateCells = row?.querySelectorAll('.queue-table-cell-date');
+    const row = await screen.findByRole('row', { name: /Example task/ });
+    const dateCells = row.querySelectorAll('.queue-table-cell-date');
     expect(dateCells).toHaveLength(3);
-    for (const cell of Array.from(dateCells || [])) {
-      expect(cell.textContent).toContain('/26');
+    const expectedDates = [
+      '2026-06-21T12:00:00Z',
+      '2026-06-21T12:01:00Z',
+      '2026-06-21T12:02:00Z',
+    ].map((iso) =>
+      new Date(iso).toLocaleString(undefined, {
+        year: '2-digit',
+        month: 'numeric',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+      }),
+    );
+    Array.from(dateCells).forEach((cell, index) => {
+      expect(cell.textContent).toBe(expectedDates[index]);
       expect(cell.textContent).not.toContain('2026');
-    }
+    });
   });
 
   it('does not query or render operational metrics on the workflow overview', async () => {

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -179,7 +179,14 @@ function formatWhen(iso: string | null | undefined): string {
   if (!iso) return '—';
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString();
+  return date.toLocaleString(undefined, {
+    year: '2-digit',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 }
 
 function summarizeRuntime(runtime: string | null | undefined): string {


### PR DESCRIPTION
I want to display years on the Workflows page's Scheduled, Created, and Finished columns with only 2 chars, so 6/21/26 instead of 6/21/2026 to save some space