### PR TITLE
When opening either filter dropdown menus or workflow action dropdown menus on the Workflows page, the bottom of the table area should not cut off the

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -76,17 +76,18 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
 });
 
 describe('Workflow list table dropdown overflow', () => {
-  it('allows table filter and action popovers to escape the table wrapper while open', () => {
+  it('reserves vertical room for table filter and action popovers without disabling horizontal scroll', () => {
     const wrapperBlock = cssRuleBlock(
       `.workflow-list-data-slab .queue-table-wrapper:has(
         .workflow-list-header-filter-popover,
         .td-workflow-actions-popover
       )`,
     );
-    expect(wrapperBlock).toContain('overflow: visible;');
+    expect(wrapperBlock).toContain('padding-bottom: min(18rem, 45vh);');
+    expect(wrapperBlock).not.toContain('overflow: visible;');
 
     const tableBlock = cssRuleBlock('.queue-table-wrapper table');
-    expect(tableBlock).toContain('overflow: visible;');
+    expect(tableBlock).not.toContain('overflow: visible;');
   });
 });
 

--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -40,6 +40,17 @@ function mobileRuleBlock(selector: string, maxWidth = 767): string {
   return blocks.join('\n');
 }
 
+function cssRuleBlock(selector: string): string {
+  const normalizedSelector = selector.replace(/\s+/g, ' ').trim();
+  const blocks: string[] = [];
+  cssRoot().walkRules((rule: Rule) => {
+    if (rule.selector.replace(/\s+/g, ' ').trim() === normalizedSelector) {
+      blocks.push(rule.nodes.map((node) => `${node.toString()};`).join('\n'));
+    }
+  });
+  return blocks.join('\n');
+}
+
 describe('WorkflowRowActionsMenu responsive layout', () => {
   it('renders the actions menu in-flow beneath the trigger on mobile cards', () => {
     // On mobile the absolutely-positioned, right-anchored popover used to shoot
@@ -61,6 +72,21 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
     const menuBlock = mobileRuleBlock('.queue-card-actions .td-workflow-actions-menu');
     expect(menuBlock).toContain('width: 100%;');
     expect(menuBlock).toContain('flex-direction: column;');
+  });
+});
+
+describe('Workflow list table dropdown overflow', () => {
+  it('allows table filter and action popovers to escape the table wrapper while open', () => {
+    const wrapperBlock = cssRuleBlock(
+      `.workflow-list-data-slab .queue-table-wrapper:has(
+        .workflow-list-header-filter-popover,
+        .td-workflow-actions-popover
+      )`,
+    );
+    expect(wrapperBlock).toContain('overflow: visible;');
+
+    const tableBlock = cssRuleBlock('.queue-table-wrapper table');
+    expect(tableBlock).toContain('overflow: visible;');
   });
 });
 

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1538,7 +1538,7 @@ tbody tr:hover {
   .workflow-list-header-filter-popover,
   .td-workflow-actions-popover
 ) {
-  overflow: visible;
+  padding-bottom: min(18rem, 45vh);
 }
 
 .queue-table-wrapper table {
@@ -1547,7 +1547,6 @@ tbody tr:hover {
   border-spacing: 0;
   border-radius: 0;
   background: transparent;
-  overflow: visible;
   table-layout: fixed;
   max-width: 100%;
   margin: 0;

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1534,12 +1534,20 @@ tbody tr:hover {
   background: transparent;
 }
 
+.workflow-list-data-slab .queue-table-wrapper:has(
+  .workflow-list-header-filter-popover,
+  .td-workflow-actions-popover
+) {
+  overflow: visible;
+}
+
 .queue-table-wrapper table {
   border: 0;
   border-collapse: separate;
   border-spacing: 0;
   border-radius: 0;
   background: transparent;
+  overflow: visible;
   table-layout: fixed;
   max-width: 100%;
   margin: 0;


### PR DESCRIPTION
When opening either filter dropdown menus or workflow action dropdown menus on the Workflows page, the bottom of the table area should not cut off the dropdown menu view. The dropdown menu should spill OVER the outside of the table if needed and not be cut off.