### PR TITLE
MM-867 split PentestGPT runner publishing

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -59,7 +59,7 @@ MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 # allowlisted). Set MOONMIND_PENTEST_ENABLED="false" as the operator disable
 # override in deployments that are not approved for pentest operation.
 MOONMIND_PENTEST_ENABLED="true"
-MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
 MOONMIND_PENTEST_SAFE_PROFILE_ID="pentestgpt-safe"
 MOONMIND_PENTEST_VPN_LAB_PROFILE_ID="pentestgpt-vpn-lab"
 MOONMIND_PENTEST_ALLOWED_RUNNER_PROFILES="pentestgpt-safe"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,21 +3,19 @@ name: Build and Publish Docker Image to GHCR
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - "docker/pentestgpt-runner/**"
+      - ".github/workflows/pentestgpt-runner.yml"
   workflow_dispatch:
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
-  # Configured vulnerability-severity threshold for the curated PentestGPT
-  # runner image. The build fails when the image scan reports a fixable
-  # vulnerability at or above any listed severity.
-  PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD: "CRITICAL,HIGH"
 
 jobs:
   metadata:
     runs-on: ubuntu-latest
     outputs:
       image_name: ${{ steps.meta.outputs.image_name }}
-      pentest_image_name: ${{ steps.meta.outputs.pentest_image_name }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
       - name: Generate image metadata
@@ -28,7 +26,6 @@ jobs:
           IMAGE_NAME="${{ env.REGISTRY_IMAGE }}"
           IMAGE_NAME="$(printf '%s' "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
-          echo "pentest_image_name=${IMAGE_NAME}-pentestgpt" >> "$GITHUB_OUTPUT"
 
   build:
     needs: metadata
@@ -174,236 +171,3 @@ jobs:
         run: |
           IMAGE_NAME="${{ needs.metadata.outputs.image_name }}"
           docker buildx imagetools inspect "${IMAGE_NAME}:latest"
-
-  build-pentestgpt:
-    needs: metadata
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare runner build metadata
-        id: meta
-        run: |
-          platform=${{ matrix.platform }}
-          echo "pair=pentestgpt-${platform//\//-}" >> "$GITHUB_OUTPUT"
-          echo "image_name=${{ needs.metadata.outputs.pentest_image_name }}" >> "$GITHUB_OUTPUT"
-
-      - name: Build runner smoke image
-        if: matrix.platform == 'linux/amd64'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docker/pentestgpt-runner/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.title=MoonMind PentestGPT Runner
-          cache-from: type=gha,scope=${{ steps.meta.outputs.pair }}
-
-      - name: Smoke test runner image
-        if: matrix.platform == 'linux/amd64'
-        run: |
-          docker run --rm moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }} --version
-
-      - name: Validate runner provenance labels
-        if: matrix.platform == 'linux/amd64'
-        run: |
-          IMAGE="moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}"
-          missing=0
-          for label in \
-            org.opencontainers.image.source \
-            org.opencontainers.image.version \
-            org.opencontainers.image.revision \
-            org.opencontainers.image.title; do
-            value="$(docker inspect --format "{{ index .Config.Labels \"${label}\" }}" "${IMAGE}")"
-            if [ -z "${value}" ] || [ "${value}" = "<no value>" ]; then
-              echo "::error::Runner image is missing required provenance label: ${label}" >&2
-              missing=1
-            else
-              echo "provenance ${label}=${value}"
-            fi
-          done
-          if [ "${missing}" -ne 0 ]; then
-            echo "::error::Runner image provenance labels are incomplete; failing build" >&2
-            exit 1
-          fi
-
-      - name: Validate runner self-test report output
-        if: matrix.platform == 'linux/amd64'
-        run: |
-          IMAGE="moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}"
-          # The runner --self-test validates its own report artifacts and emits
-          # a machine-readable report line. Re-validate that report content here
-          # so CI explicitly fails on invalid self-test report output.
-          selftest_out="$(docker run --rm "${IMAGE}" --self-test)"
-          printf '%s\n' "${selftest_out}"
-          report_line="$(printf '%s\n' "${selftest_out}" | grep '"self_test"' | tail -n1)"
-          if [ -z "${report_line}" ]; then
-            echo "::error::Runner self-test did not emit a machine-readable report" >&2
-            exit 1
-          fi
-          # Pass the report JSON via the environment instead of a pipe: a heredoc
-          # is the program source on stdin for `python3 -`, so a piped stdin would
-          # be consumed as the script and json.loads would see an empty string.
-          REPORT_LINE="${report_line}" python3 <<'PY'
-          import json
-          import os
-          import sys
-
-          report = json.loads(os.environ["REPORT_LINE"])
-          problems = []
-          if report.get("self_test") != "ok":
-              problems.append(f"self_test status is {report.get('self_test')!r}")
-          if report.get("runner_contract_v") != 1:
-              problems.append(f"runner_contract_v drift: {report.get('runner_contract_v')!r}")
-          required = {"report.primary", "report.summary", "report.structured", "report.evidence"}
-          present = set(report.get("report_artifacts") or [])
-          missing = required - present
-          if missing:
-              problems.append(f"missing report artifacts: {sorted(missing)}")
-          if not report.get("redaction_ok"):
-              problems.append("redaction not verified in normalized findings")
-          if not report.get("no_canary_leak"):
-              problems.append("redaction canary leaked into report output")
-          if report.get("failure_category") != "success":
-              problems.append(f"failure_category is {report.get('failure_category')!r}")
-          if int(report.get("findings_count") or 0) < 1:
-              problems.append("self-test produced no findings")
-          if problems:
-              print("::error::Invalid self-test report output: " + "; ".join(problems), file=sys.stderr)
-              raise SystemExit(1)
-          print("self-test report output validated")
-          PY
-
-      - name: Scan runner image for vulnerabilities
-        if: matrix.platform == 'linux/amd64'
-        uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          image-ref: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
-          format: table
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: ${{ env.PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD }}
-
-      - name: Validate upstream PentestGPT CLI compatibility
-        if: matrix.platform == 'linux/amd64'
-        run: |
-          # Verifies the installed upstream PentestGPT CLI contract (executable
-          # present, --help parses, telemetry default off, wrapper redaction).
-          # Distinct exit codes (30-33) classify upstream-CLI breakage apart
-          # from wrapper/config failures.
-          docker run --rm moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }} --check-upstream
-
-      - name: Build and push runner by digest
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docker/pentestgpt-runner/Dockerfile
-          platforms: ${{ matrix.platform }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.title=MoonMind PentestGPT Runner
-          outputs: type=image,name=${{ steps.meta.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ steps.meta.outputs.pair }}
-          cache-to: type=gha,scope=${{ steps.meta.outputs.pair }},mode=max
-
-      - name: Export runner digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload runner digest
-        uses: actions/upload-artifact@v7
-        with:
-          name: digests-${{ steps.meta.outputs.pair }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-pentestgpt:
-    runs-on: ubuntu-latest
-    needs:
-      - metadata
-      - build-pentestgpt
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Download runner digests
-        uses: actions/download-artifact@v8
-        with:
-          path: /tmp/digests
-          pattern: digests-pentestgpt-*
-          merge-multiple: true
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Create runner manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          IMAGE_NAME="${{ needs.metadata.outputs.pentest_image_name }}"
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" \
-            -t "${IMAGE_NAME}:latest" \
-            -t "${IMAGE_NAME}:1.0" \
-            $(printf "${IMAGE_NAME}@sha256:%s " *)
-
-      - name: Inspect runner image and surface digest
-        run: |
-          IMAGE_NAME="${{ needs.metadata.outputs.pentest_image_name }}"
-          # Fail if the default configured runner image tag (1.0) was not
-          # published by this workflow. Production should digest-pin, but the
-          # default tag must always resolve to a freshly published manifest.
-          DEFAULT_TAG="1.0"
-          docker buildx imagetools inspect "${IMAGE_NAME}:${DEFAULT_TAG}"
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE_NAME}:${DEFAULT_TAG}" --format '{{.Manifest.Digest}}')"
-          if [ -z "${DIGEST}" ]; then
-            echo "::error::Default runner image ${IMAGE_NAME}:${DEFAULT_TAG} is not published" >&2
-            exit 1
-          fi
-          {
-            echo "### PentestGPT runner image published"
-            echo ""
-            echo "- Tag: \`${IMAGE_NAME}:${DEFAULT_TAG}\`"
-            echo "- Digest: \`${DIGEST}\`"
-            echo "- Digest-pinned production reference: \`${IMAGE_NAME}@${DIGEST}\`"
-          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/pentestgpt-runner.yml
+++ b/.github/workflows/pentestgpt-runner.yml
@@ -43,6 +43,8 @@ concurrency:
   group: pentestgpt-runner-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   PENTEST_RUNNER_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-pentestgpt
   PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD: "CRITICAL,HIGH"

--- a/.github/workflows/pentestgpt-runner.yml
+++ b/.github/workflows/pentestgpt-runner.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Scan runner image for vulnerabilities
         if: matrix.platform == 'linux/amd64'
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
           format: table

--- a/.github/workflows/pentestgpt-runner.yml
+++ b/.github/workflows/pentestgpt-runner.yml
@@ -1,0 +1,347 @@
+name: Build and Publish PentestGPT Runner
+
+on:
+  pull_request:
+    paths:
+      - "docker/pentestgpt-runner/**"
+      - ".github/workflows/pentestgpt-runner.yml"
+      - "moonmind/config/settings.py"
+      - "moonmind/integrations/pentest/**"
+      - "moonmind/workflows/temporal/activities/pentest_activities.py"
+      - "config/workloads/default-runner-profiles.yaml"
+      - "tests/unit/test_pentestgpt_runner_workflow.py"
+      - "tests/unit/test_docker_publish_workflow.py"
+
+  push:
+    branches: [main]
+    paths:
+      - "docker/pentestgpt-runner/**"
+      - ".github/workflows/pentestgpt-runner.yml"
+      - "moonmind/config/settings.py"
+      - "moonmind/integrations/pentest/**"
+      - "moonmind/workflows/temporal/activities/pentest_activities.py"
+      - "config/workloads/default-runner-profiles.yaml"
+      - "tests/unit/test_pentestgpt_runner_workflow.py"
+      - "tests/unit/test_docker_publish_workflow.py"
+
+  workflow_dispatch:
+    inputs:
+      pentestgpt_ref:
+        description: "Optional upstream GreyDGL/PentestGPT commit/ref override"
+        required: false
+        type: string
+      publish:
+        description: "Publish image to GHCR"
+        required: true
+        default: true
+        type: boolean
+
+  schedule:
+    - cron: "0 10 * * 1"
+
+concurrency:
+  group: pentestgpt-runner-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PENTEST_RUNNER_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-pentestgpt
+  PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD: "CRITICAL,HIGH"
+  PENTESTGPT_DEFAULT_REF: b9869307d028f26660f4615455d3b14b7d976b2e
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.meta.outputs.image_name }}
+      version_tag: ${{ steps.meta.outputs.version_tag }}
+      should_publish: ${{ steps.meta.outputs.should_publish }}
+      pentestgpt_ref: ${{ steps.meta.outputs.pentestgpt_ref }}
+    steps:
+      - name: Generate runner image metadata
+        id: meta
+        run: |
+          VERSION_TAG="$(date -u +'%Y%m%d').${{ github.run_number }}"
+          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          IMAGE_NAME="${{ env.PENTEST_RUNNER_IMAGE }}"
+          IMAGE_NAME="$(printf '%s' "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          PENTESTGPT_REF="${{ inputs.pentestgpt_ref || env.PENTESTGPT_DEFAULT_REF }}"
+          echo "pentestgpt_ref=${PENTESTGPT_REF}" >> "$GITHUB_OUTPUT"
+          SHOULD_PUBLISH=false
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+            SHOULD_PUBLISH=true
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" = "true" ]; then
+            SHOULD_PUBLISH=true
+          fi
+          echo "should_publish=${SHOULD_PUBLISH}" >> "$GITHUB_OUTPUT"
+
+  build-pentestgpt:
+    needs: metadata
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        if: needs.metadata.outputs.should_publish == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare runner build metadata
+        id: meta
+        run: |
+          platform=${{ matrix.platform }}
+          echo "pair=pentestgpt-${platform//\//-}" >> "$GITHUB_OUTPUT"
+          echo "image_name=${{ needs.metadata.outputs.image_name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build runner smoke image
+        if: matrix.platform == 'linux/amd64'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/pentestgpt-runner/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
+          build-args: |
+            PENTESTGPT_REF=${{ needs.metadata.outputs.pentestgpt_ref }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=MoonMind PentestGPT Runner
+          cache-from: type=gha,scope=${{ steps.meta.outputs.pair }}
+
+      - name: Smoke test runner image
+        if: matrix.platform == 'linux/amd64'
+        run: |
+          docker run --rm moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }} --version
+
+      - name: Validate runner provenance labels
+        if: matrix.platform == 'linux/amd64'
+        run: |
+          IMAGE="moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}"
+          missing=0
+          for label in \
+            org.opencontainers.image.source \
+            org.opencontainers.image.version \
+            org.opencontainers.image.revision \
+            org.opencontainers.image.title; do
+            value="$(docker inspect --format "{{ index .Config.Labels \"${label}\" }}" "${IMAGE}")"
+            if [ -z "${value}" ] || [ "${value}" = "<no value>" ]; then
+              echo "::error::Runner image is missing required provenance label: ${label}" >&2
+              missing=1
+            else
+              echo "provenance ${label}=${value}"
+            fi
+          done
+          if [ "${missing}" -ne 0 ]; then
+            echo "::error::Runner image provenance labels are incomplete; failing build" >&2
+            exit 1
+          fi
+
+      - name: Validate runner self-test report output
+        if: matrix.platform == 'linux/amd64'
+        run: |
+          IMAGE="moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}"
+          # The runner --self-test validates its own report artifacts and emits
+          # a machine-readable report line. Re-validate that report content here
+          # so CI explicitly fails on invalid self-test report output.
+          selftest_out="$(docker run --rm "${IMAGE}" --self-test)"
+          printf '%s\n' "${selftest_out}"
+          report_line="$(printf '%s\n' "${selftest_out}" | grep '"self_test"' | tail -n1)"
+          if [ -z "${report_line}" ]; then
+            echo "::error::Runner self-test did not emit a machine-readable report" >&2
+            exit 1
+          fi
+          # Pass the report JSON via the environment instead of a pipe: a heredoc
+          # is the program source on stdin for `python3 -`, so a piped stdin would
+          # be consumed as the script and json.loads would see an empty string.
+          REPORT_LINE="${report_line}" python3 <<'PY'
+          import json
+          import os
+          import sys
+
+          report = json.loads(os.environ["REPORT_LINE"])
+          problems = []
+          if report.get("self_test") != "ok":
+              problems.append(f"self_test status is {report.get('self_test')!r}")
+          if report.get("runner_contract_v") != 1:
+              problems.append(f"runner_contract_v drift: {report.get('runner_contract_v')!r}")
+          required = {"report.primary", "report.summary", "report.structured", "report.evidence"}
+          present = set(report.get("report_artifacts") or [])
+          missing = required - present
+          if missing:
+              problems.append(f"missing report artifacts: {sorted(missing)}")
+          if not report.get("redaction_ok"):
+              problems.append("redaction not verified in normalized findings")
+          if not report.get("no_canary_leak"):
+              problems.append("redaction canary leaked into report output")
+          if report.get("failure_category") != "success":
+              problems.append(f"failure_category is {report.get('failure_category')!r}")
+          if int(report.get("findings_count") or 0) < 1:
+              problems.append("self-test produced no findings")
+          if problems:
+              print("::error::Invalid self-test report output: " + "; ".join(problems), file=sys.stderr)
+              raise SystemExit(1)
+          print("self-test report output validated")
+          PY
+
+      - name: Scan runner image for vulnerabilities
+        if: matrix.platform == 'linux/amd64'
+        uses: aquasecurity/trivy-action@v0.28.0
+        with:
+          image-ref: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: ${{ env.PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD }}
+
+      - name: Validate upstream PentestGPT CLI compatibility
+        if: matrix.platform == 'linux/amd64'
+        run: |
+          # Verifies the installed upstream PentestGPT CLI contract (executable
+          # present, --help parses, telemetry default off, wrapper redaction).
+          # Distinct exit codes (30-33) classify upstream-CLI breakage apart
+          # from wrapper/config failures.
+          docker run --rm moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }} --check-upstream
+
+      - name: Build and push runner by digest
+        if: needs.metadata.outputs.should_publish == 'true'
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/pentestgpt-runner/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            PENTESTGPT_REF=${{ needs.metadata.outputs.pentestgpt_ref }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=MoonMind PentestGPT Runner
+          outputs: type=image,name=${{ steps.meta.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ steps.meta.outputs.pair }}
+          cache-to: type=gha,scope=${{ steps.meta.outputs.pair }},mode=max
+
+      - name: Export runner digest
+        if: needs.metadata.outputs.should_publish == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload runner digest
+        if: needs.metadata.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ steps.meta.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-pentestgpt:
+    if: needs.metadata.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - build-pentestgpt
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download runner digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-pentestgpt-*
+          merge-multiple: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Create runner manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          IMAGE_NAME="${{ needs.metadata.outputs.image_name }}"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" \
+            -t "${IMAGE_NAME}:1.0" \
+            $(printf "${IMAGE_NAME}@sha256:%s " *)
+
+      - name: Inspect runner image and surface digest
+        id: published
+        run: |
+          IMAGE_NAME="${{ needs.metadata.outputs.image_name }}"
+          CHANNEL_TAG="1.0"
+          docker buildx imagetools inspect "${IMAGE_NAME}:${CHANNEL_TAG}"
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE_NAME}:${CHANNEL_TAG}" --format '{{.Manifest.Digest}}')"
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::Default runner image ${IMAGE_NAME}:${CHANNEL_TAG} is not published" >&2
+            exit 1
+          fi
+          PRODUCTION_IMAGE="${IMAGE_NAME}:${CHANNEL_TAG}@${DIGEST}"
+          export IMAGE_NAME CHANNEL_TAG DIGEST
+          {
+            echo "### PentestGPT runner image published"
+            echo ""
+            echo "- Tag: \`${IMAGE_NAME}:${CHANNEL_TAG}\`"
+            echo "- Digest: \`${DIGEST}\`"
+            echo "- Digest-pinned production reference: \`${PRODUCTION_IMAGE}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          mkdir -p /tmp/pentestgpt-runner-image
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          image_name = os.environ["IMAGE_NAME"]
+          channel_tag = os.environ["CHANNEL_TAG"]
+          digest = os.environ["DIGEST"]
+          payload = {
+              "image": f"{image_name}:{channel_tag}@{digest}",
+              "repository": image_name,
+              "channel_tag": channel_tag,
+              "manifest_digest": digest,
+              "source_revision": os.environ["GITHUB_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "published_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+          }
+          with open("/tmp/pentestgpt-runner-image/pentestgpt-runner-image.json", "w", encoding="utf-8") as handle:
+              json.dump(payload, handle, indent=2)
+              handle.write("\n")
+          PY
+
+      - name: Upload runner image reference
+        uses: actions/upload-artifact@v7
+        with:
+          name: pentestgpt-runner-image.json
+          path: /tmp/pentestgpt-runner-image/pentestgpt-runner-image.json
+          if-no-files-found: error
+          retention-days: 30

--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -1,7 +1,7 @@
 profiles:
   - id: pentestgpt-safe
     kind: one_shot
-    image: ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0
+    image: ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6
     workdirTemplate: /work/agent_jobs/${task_run_id}/repo
     requiredMounts:
       - type: volume

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -30,6 +30,10 @@ _PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY = (
     "ghcr.io/moonladderstudios/moonmind-pentestgpt"
 )
 _PENTEST_APPROVED_RUNNER_IMAGE_TAGS = frozenset(("1.0",))
+_PENTEST_DEFAULT_RUNNER_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
 _PENTEST_RUNNER_IMAGE_PATTERN = re.compile(
     r"^(?P<repository>"
     + re.escape(_PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY)
@@ -1463,9 +1467,9 @@ class PentestSettings(BaseSettings):
         },
     )
     runner_image: str = Field(
-        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+        _PENTEST_DEFAULT_RUNNER_IMAGE,
         validation_alias=AliasChoices("MOONMIND_PENTEST_RUNNER_IMAGE"),
-        description="Curated PentestGPT runner image tag or digest.",
+        description="Curated PentestGPT runner image digest-pinned production reference.",
     )
     unsafe_dev_runner_image_override: bool = Field(
         False,

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -96,7 +96,10 @@ PENTEST_VPN_LAB_PROFILE_ID = "pentestgpt-vpn-lab"
 PENTEST_ANTHROPIC_PROFILE_ID = "pentestgpt_anthropic_api_team"
 PENTEST_OPENROUTER_PROFILE_ID = "pentestgpt_openrouter_default"
 PENTEST_LOCAL_PROFILE_ID = "pentestgpt_local_default"
-_PENTEST_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+_PENTEST_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
 _PENTEST_ENTRYPOINT = ("/usr/local/bin/moonmind-pentestgpt-run",)
 _PENTEST_WORKDIR_TEMPLATE = "/work/agent_jobs/${agent_run_id}/repo"
 _PENTEST_ENV_ALLOWLIST = (

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1941,6 +1941,13 @@ def _positive_int_env(name: str) -> int | None:
         raise RuntimeError(f"{name} must be a positive integer")
     return value
 
+def _pentest_runner_image_overrides() -> dict[str, str]:
+    pentest = settings.pentest
+    return {
+        pentest.safe_profile_id: pentest.runner_image,
+        pentest.vpn_lab_profile_id: pentest.runner_image,
+    }
+
 def _build_agent_runtime_deps(
     *,
     artifact_service: Any | None = None,
@@ -2049,6 +2056,7 @@ def _build_agent_runtime_deps(
             workload_registry_path,
             workspace_root=workspace_root,
             allowed_image_registries=allowed_image_registries or None,
+            profile_image_overrides=_pentest_runner_image_overrides(),
         )
     else:
         default_workload_registry = (
@@ -2061,6 +2069,7 @@ def _build_agent_runtime_deps(
             default_workload_registry,
             workspace_root=workspace_root,
             allowed_image_registries=allowed_image_registries or None,
+            profile_image_overrides=_pentest_runner_image_overrides(),
         )
     workload_fleet_limit = _positive_int_env("MOONMIND_DOCKER_WORKLOAD_FLEET_CONCURRENCY")
     workload_launcher = DockerWorkloadLauncher(

--- a/moonmind/workloads/__init__.py
+++ b/moonmind/workloads/__init__.py
@@ -34,7 +34,9 @@ def __getattr__(name: str) -> object:
     if name in _TOOL_BRIDGE_EXPORTS:
         from moonmind.workloads import tool_bridge
 
-        return getattr(tool_bridge, name)
+        value = getattr(tool_bridge, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [

--- a/moonmind/workloads/__init__.py
+++ b/moonmind/workloads/__init__.py
@@ -16,16 +16,26 @@ from moonmind.workloads.docker_launcher import (
     DockerWorkloadLauncherError,
 )
 from moonmind.workloads.registry import RunnerProfileRegistry, WorkloadPolicyError
-from moonmind.workloads.tool_bridge import (
-    CONTAINER_RUN_WORKLOAD_TOOL,
-    DEFAULT_UNREAL_PROFILE_ID,
-    DOOD_TOOL_NAMES,
-    UNREAL_RUN_TESTS_TOOL,
-    build_dood_tool_definition_payload,
-    build_workload_tool_handler,
-    is_dood_tool,
-    register_workload_tool_handlers,
+
+_TOOL_BRIDGE_EXPORTS = frozenset(
+    {
+        "CONTAINER_RUN_WORKLOAD_TOOL",
+        "DEFAULT_UNREAL_PROFILE_ID",
+        "DOOD_TOOL_NAMES",
+        "UNREAL_RUN_TESTS_TOOL",
+        "build_dood_tool_definition_payload",
+        "build_workload_tool_handler",
+        "is_dood_tool",
+        "register_workload_tool_handlers",
+    }
 )
+
+def __getattr__(name: str) -> object:
+    if name in _TOOL_BRIDGE_EXPORTS:
+        from moonmind.workloads import tool_bridge
+
+        return getattr(tool_bridge, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "CONTAINER_RUN_WORKLOAD_TOOL",

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -92,6 +92,7 @@ class RunnerProfileRegistry:
         *,
         workspace_root: str | Path,
         allowed_image_registries: Iterable[str] | None = None,
+        profile_image_overrides: Mapping[str, str] | None = None,
     ) -> "RunnerProfileRegistry":
         registry_path = Path(path)
         if not registry_path.exists():
@@ -104,6 +105,7 @@ class RunnerProfileRegistry:
             registry_path,
             workspace_root=workspace_root,
             allowed_image_registries=allowed_image_registries,
+            profile_image_overrides=profile_image_overrides,
         )
 
     @classmethod
@@ -113,11 +115,15 @@ class RunnerProfileRegistry:
         *,
         workspace_root: str | Path,
         allowed_image_registries: Iterable[str] | None = None,
+        profile_image_overrides: Mapping[str, str] | None = None,
     ) -> "RunnerProfileRegistry":
         registry_path = Path(path)
         raw_text = registry_path.read_text(encoding="utf-8")
         payload = _load_registry_payload(registry_path, raw_text)
-        profiles = _extract_profiles(payload)
+        profiles = _apply_profile_image_overrides(
+            _extract_profiles(payload),
+            profile_image_overrides or {},
+        )
         return cls(
             profiles,
             workspace_root=workspace_root,
@@ -379,3 +385,17 @@ def _extract_profiles(payload: Any) -> list[RunnerProfile]:
         seen.add(profile.id)
         profiles.append(profile)
     return profiles
+
+def _apply_profile_image_overrides(
+    profiles: Iterable[RunnerProfile],
+    overrides: Mapping[str, str],
+) -> list[RunnerProfile]:
+    if not overrides:
+        return list(profiles)
+    normalized = {str(profile_id): str(image) for profile_id, image in overrides.items()}
+    return [
+        profile.model_copy(update={"image": normalized[profile.id]})
+        if profile.id in normalized
+        else profile
+        for profile in profiles
+    ]

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -394,7 +394,10 @@ def _apply_profile_image_overrides(
         return list(profiles)
     normalized = {str(profile_id): str(image) for profile_id, image in overrides.items()}
     return [
-        profile.model_copy(update={"image": normalized[profile.id]})
+        RunnerProfile.model_validate(
+            profile.model_dump(mode="json", by_alias=True)
+            | {"image": normalized[profile.id]}
+        )
         if profile.id in normalized
         else profile
         for profile in profiles

--- a/tests/integration/temporal/test_pentest_docker_e2e.py
+++ b/tests/integration/temporal/test_pentest_docker_e2e.py
@@ -16,7 +16,7 @@ unless explicitly opted in, so they never run by accident:
 Run locally with, e.g.::
 
     MOONMIND_PENTEST_E2E=1 \
-    MOONMIND_PENTEST_RUNNER_IMAGE=ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0 \
+    MOONMIND_PENTEST_RUNNER_IMAGE=ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6 \
     python -m pytest tests/integration/temporal/test_pentest_docker_e2e.py -m integration
 
 Rather than adding skipped acceptance-test skeletons, the following real-Docker

--- a/tests/integration/temporal/test_pentest_runner_profile_registry.py
+++ b/tests/integration/temporal/test_pentest_runner_profile_registry.py
@@ -18,6 +18,10 @@ import pytest
 from moonmind.workloads.registry import RunnerProfileRegistry
 
 _PROFILES_PATH = Path("config/workloads/default-runner-profiles.yaml")
+_PENTEST_RUNNER_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
 
 
 @pytest.mark.integration
@@ -31,7 +35,7 @@ def test_default_runner_profiles_expose_pentestgpt_safe() -> None:
 
     assert profile is not None
     assert profile.kind == "one_shot"
-    assert profile.image == "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+    assert profile.image == _PENTEST_RUNNER_IMAGE
 
 
 @pytest.mark.integration

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -39,6 +39,11 @@ from moonmind.integrations.pentest.models import (
     validate_authorized_scope_for_request,
 )
 
+PENTEST_RUNNER_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
+
 def _valid_request_payload() -> dict[str, object]:
     return {
         "agent_run_id": "run-123",
@@ -496,7 +501,7 @@ def test_pentest_safe_profile_is_default_and_conservative() -> None:
 
     assert profile.id == "pentestgpt-safe"
     assert profile.kind == "one_shot"
-    assert profile.image == "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+    assert profile.image == PENTEST_RUNNER_IMAGE
     assert profile.entrypoint == ("/usr/local/bin/moonmind-pentestgpt-run",)
     assert profile.network_policy == "bridge_approved_lab"
     assert profile.linux_capabilities == ()

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -11,16 +11,6 @@ def _load_workflow() -> dict:
     assert WORKFLOW_PATH.exists(), f"Missing workflow: {WORKFLOW_PATH}"
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
-
-def _pentest_steps() -> list[dict]:
-    return _load_workflow()["jobs"]["build-pentestgpt"]["steps"]
-
-
-def _pentest_step(name: str) -> dict:
-    step = next((s for s in _pentest_steps() if s.get("name") == name), None)
-    assert step is not None, f"Step {name!r} not found in build-pentestgpt"
-    return step
-
 def test_docker_publish_generates_version_before_platform_builds() -> None:
     workflow = _load_workflow()
 
@@ -71,57 +61,14 @@ def test_docker_publish_passes_manifest_tag_into_image_build_metadata() -> None:
     assert all("date +" not in run and "VERSION_TAG=" not in run for run in merge_run_steps)
 
 
-def test_runner_publish_validates_provenance_labels() -> None:
-    # MM-839: CI must fail when the runner image is missing provenance labels.
-    step = _pentest_step("Validate runner provenance labels")
-    assert "linux/amd64" in step.get("if", "")
-    run = step["run"]
-    for label in (
-        "org.opencontainers.image.source",
-        "org.opencontainers.image.version",
-        "org.opencontainers.image.revision",
-        "org.opencontainers.image.title",
-    ):
-        assert label in run, f"provenance label {label} not validated"
-    # The check must fail the build (not merely warn) when a label is missing.
-    assert "exit 1" in run
-
-
-def test_runner_publish_scans_image_with_configured_vulnerability_threshold() -> None:
-    # MM-839: CI must fail on configured vulnerability-threshold breaches.
+def test_docker_publish_no_longer_builds_pentestgpt_runner() -> None:
+    # MM-867: PentestGPT runner publishing lives in pentestgpt-runner.yml so
+    # runner-only changes do not publish the app image.
     workflow = _load_workflow()
-    assert "PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD" in workflow["env"]
+    jobs = workflow["jobs"]
+    metadata_outputs = jobs["metadata"].get("outputs", {})
 
-    step = _pentest_step("Scan runner image for vulnerabilities")
-    assert "linux/amd64" in step.get("if", "")
-    assert str(step.get("uses", "")).startswith("aquasecurity/trivy-action@")
-    with_inputs = step["with"]
-    # exit-code 1 fails the build on a threshold breach.
-    assert str(with_inputs.get("exit-code")) == "1"
-    assert "PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD" in str(with_inputs.get("severity"))
-    assert with_inputs.get("image-ref")
-
-
-def test_runner_publish_validates_selftest_report_output() -> None:
-    # MM-839: CI must fail on invalid self-test report-output content, not just
-    # on the runner exit code.
-    step = _pentest_step("Validate runner self-test report output")
-    assert "linux/amd64" in step.get("if", "")
-    run = step["run"]
-    assert "--self-test" in run
-    assert '"self_test"' in run
-    for token in ("report.primary", "report.structured", "no_canary_leak", "redaction_ok"):
-        assert token in run, f"self-test validation does not check {token}"
-    assert "exit 1" in run or "SystemExit(1)" in run
-
-
-def test_runner_selftest_report_is_passed_without_clobbering_stdin() -> None:
-    # MM-839 regression: a heredoc is the program source on stdin for python, so
-    # piping the report into `python3 - <<'PY'` discards it and json.loads sees an
-    # empty string. The report must be passed via the environment instead.
-    step = _pentest_step("Validate runner self-test report output")
-    run = step["run"]
-    assert "REPORT_LINE=" in run, "report JSON must be passed via the environment"
-    assert 'os.environ["REPORT_LINE"]' in run
-    assert "sys.stdin.read()" not in run, "report must not be read from clobbered stdin"
-    assert "python3 - <<" not in run, "do not feed the program on stdin while piping data"
+    assert "PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD" not in workflow.get("env", {})
+    assert "pentest_image_name" not in metadata_outputs
+    assert "build-pentestgpt" not in jobs
+    assert "merge-pentestgpt" not in jobs

--- a/tests/unit/test_pentestgpt_runner_workflow.py
+++ b/tests/unit/test_pentestgpt_runner_workflow.py
@@ -61,6 +61,15 @@ def test_runner_workflow_uses_bounded_triggers_and_concurrency() -> None:
         "group": "pentestgpt-runner-${{ github.ref }}",
         "cancel-in-progress": False,
     }
+    assert workflow["permissions"] == {}
+    assert workflow["jobs"]["build-pentestgpt"]["permissions"] == {
+        "contents": "read",
+        "packages": "write",
+    }
+    assert workflow["jobs"]["merge-pentestgpt"]["permissions"] == {
+        "contents": "read",
+        "packages": "write",
+    }
 
 
 def test_runner_publish_validates_provenance_labels() -> None:

--- a/tests/unit/test_pentestgpt_runner_workflow.py
+++ b/tests/unit/test_pentestgpt_runner_workflow.py
@@ -95,7 +95,7 @@ def test_runner_publish_scans_image_with_configured_vulnerability_threshold() ->
 
     step = _pentest_step("Scan runner image for vulnerabilities")
     assert "linux/amd64" in step.get("if", "")
-    assert str(step.get("uses", "")).startswith("aquasecurity/trivy-action@")
+    assert step.get("uses") == "aquasecurity/trivy-action@v0.35.0"
     with_inputs = step["with"]
     # exit-code 1 fails the build on a threshold breach.
     assert str(with_inputs.get("exit-code")) == "1"

--- a/tests/unit/test_pentestgpt_runner_workflow.py
+++ b/tests/unit/test_pentestgpt_runner_workflow.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pentestgpt-runner.yml"
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists(), f"Missing workflow: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _workflow_on(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True)
+
+
+def _pentest_steps() -> list[dict]:
+    return _load_workflow()["jobs"]["build-pentestgpt"]["steps"]
+
+
+def _merge_steps() -> list[dict]:
+    return _load_workflow()["jobs"]["merge-pentestgpt"]["steps"]
+
+
+def _pentest_step(name: str) -> dict:
+    step = next((s for s in _pentest_steps() if s.get("name") == name), None)
+    assert step is not None, f"Step {name!r} not found in build-pentestgpt"
+    return step
+
+
+def _merge_step(name: str) -> dict:
+    step = next((s for s in _merge_steps() if s.get("name") == name), None)
+    assert step is not None, f"Step {name!r} not found in merge-pentestgpt"
+    return step
+
+
+def test_runner_workflow_uses_bounded_triggers_and_concurrency() -> None:
+    # MM-867: app-only changes should not trigger the runner workflow.
+    workflow = _load_workflow()
+    triggers = _workflow_on(workflow)
+
+    expected_paths = {
+        "docker/pentestgpt-runner/**",
+        ".github/workflows/pentestgpt-runner.yml",
+        "moonmind/config/settings.py",
+        "moonmind/integrations/pentest/**",
+        "moonmind/workflows/temporal/activities/pentest_activities.py",
+        "config/workloads/default-runner-profiles.yaml",
+        "tests/unit/test_pentestgpt_runner_workflow.py",
+        "tests/unit/test_docker_publish_workflow.py",
+    }
+    assert set(triggers["pull_request"]["paths"]) == expected_paths
+    assert set(triggers["push"]["paths"]) == expected_paths
+    assert triggers["push"]["branches"] == ["main"]
+    assert "workflow_dispatch" in triggers
+    assert triggers["schedule"] == [{"cron": "0 10 * * 1"}]
+    assert workflow["concurrency"] == {
+        "group": "pentestgpt-runner-${{ github.ref }}",
+        "cancel-in-progress": False,
+    }
+
+
+def test_runner_publish_validates_provenance_labels() -> None:
+    # MM-839: CI must fail when the runner image is missing provenance labels.
+    step = _pentest_step("Validate runner provenance labels")
+    assert "linux/amd64" in step.get("if", "")
+    run = step["run"]
+    for label in (
+        "org.opencontainers.image.source",
+        "org.opencontainers.image.version",
+        "org.opencontainers.image.revision",
+        "org.opencontainers.image.title",
+    ):
+        assert label in run, f"provenance label {label} not validated"
+    # The check must fail the build (not merely warn) when a label is missing.
+    assert "exit 1" in run
+
+
+def test_runner_publish_scans_image_with_configured_vulnerability_threshold() -> None:
+    # MM-839: CI must fail on configured vulnerability-threshold breaches.
+    workflow = _load_workflow()
+    assert "PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD" in workflow["env"]
+
+    step = _pentest_step("Scan runner image for vulnerabilities")
+    assert "linux/amd64" in step.get("if", "")
+    assert str(step.get("uses", "")).startswith("aquasecurity/trivy-action@")
+    with_inputs = step["with"]
+    # exit-code 1 fails the build on a threshold breach.
+    assert str(with_inputs.get("exit-code")) == "1"
+    assert "PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD" in str(with_inputs.get("severity"))
+    assert with_inputs.get("image-ref")
+
+
+def test_runner_publish_validates_selftest_report_output() -> None:
+    # MM-839: CI must fail on invalid self-test report-output content, not just
+    # on the runner exit code.
+    step = _pentest_step("Validate runner self-test report output")
+    assert "linux/amd64" in step.get("if", "")
+    run = step["run"]
+    assert "--self-test" in run
+    assert '"self_test"' in run
+    for token in ("report.primary", "report.structured", "no_canary_leak", "redaction_ok"):
+        assert token in run, f"self-test validation does not check {token}"
+    assert "exit 1" in run or "SystemExit(1)" in run
+
+
+def test_runner_selftest_report_is_passed_without_clobbering_stdin() -> None:
+    # MM-839 regression: a heredoc is the program source on stdin for python, so
+    # piping the report into `python3 - <<'PY'` discards it and json.loads sees an
+    # empty string. The report must be passed via the environment instead.
+    step = _pentest_step("Validate runner self-test report output")
+    run = step["run"]
+    assert "REPORT_LINE=" in run, "report JSON must be passed via the environment"
+    assert 'os.environ["REPORT_LINE"]' in run
+    assert "sys.stdin.read()" not in run, "report must not be read from clobbered stdin"
+    assert "python3 - <<" not in run, "do not feed the program on stdin while piping data"
+
+
+def test_runner_publish_uploads_digest_pinned_image_reference_artifact() -> None:
+    # MM-867: production deployment consumes the digest-pinned reference, while
+    # convenient tags continue to publish.
+    manifest_step = _merge_step("Create runner manifest list and push")
+    manifest_run = manifest_step["run"]
+    assert "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" in manifest_run
+    assert "${IMAGE_NAME}:1.0" in manifest_run
+
+    inspect_step = _merge_step("Inspect runner image and surface digest")
+    inspect_run = inspect_step["run"]
+    for token in (
+        "PRODUCTION_IMAGE=\"${IMAGE_NAME}:${CHANNEL_TAG}@${DIGEST}\"",
+        '"image": f"{image_name}:{channel_tag}@{digest}"',
+        '"repository": image_name',
+        '"channel_tag": channel_tag',
+        '"manifest_digest": digest',
+        '"source_revision": os.environ["GITHUB_SHA"]',
+        '"workflow_run_id": os.environ["GITHUB_RUN_ID"]',
+        '"published_at": datetime.now(timezone.utc)',
+    ):
+        assert token in inspect_run
+
+    upload_step = _merge_step("Upload runner image reference")
+    assert upload_step["with"]["name"] == "pentestgpt-runner-image.json"
+    assert (
+        upload_step["with"]["path"]
+        == "/tmp/pentestgpt-runner-image/pentestgpt-runner-image.json"
+    )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -92,6 +92,11 @@ from moonmind.workflows.temporal.artifacts import (
 from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workloads.registry import RunnerProfileRegistry
 
+PENTEST_RUNNER_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
+
 pytestmark = [pytest.mark.asyncio]
 
 
@@ -2795,7 +2800,7 @@ async def test_pentest_workload_profile_registry_includes_safe_runner():
 
     profile = registry.get("pentestgpt-safe")
     assert profile is not None
-    assert profile.image == "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+    assert profile.image == PENTEST_RUNNER_IMAGE
     assert profile.network_policy == "bridge"
     assert "ANTHROPIC_API_KEY" in profile.env_allowlist
 
@@ -2882,7 +2887,7 @@ async def test_security_pentest_execute_rejects_registered_runner_image_drift(
     monkeypatch.setattr(
         settings.pentest,
         "runner_image",
-        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+        PENTEST_RUNNER_IMAGE,
     )
     monkeypatch.setattr(
         settings.pentest, "allowed_runner_profiles", ("pentestgpt-safe",)
@@ -2906,6 +2911,7 @@ async def test_security_pentest_execute_validates_safe_profile_against_registry(
     registry = RunnerProfileRegistry.load_file(
         Path("config/workloads/default-runner-profiles.yaml"),
         workspace_root=tmp_path,
+        profile_image_overrides={"pentestgpt-safe": PENTEST_RUNNER_IMAGE},
     )
     activities = TemporalAgentRuntimeActivities(
         workload_launcher=launcher,
@@ -2914,7 +2920,7 @@ async def test_security_pentest_execute_validates_safe_profile_against_registry(
     monkeypatch.setattr(
         settings.pentest,
         "runner_image",
-        "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0",
+        PENTEST_RUNNER_IMAGE,
     )
     monkeypatch.setattr(settings.pentest, "safe_profile_id", "pentestgpt-safe")
     monkeypatch.setattr(settings.pentest, "default_runner_profile", "pentestgpt-safe")

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -21,6 +21,10 @@ from moonmind.workloads.registry import (
 )
 
 WORKSPACE_ROOT = Path("/work/agent_jobs")
+PENTEST_RUNNER_IMAGE = (
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
+    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+)
 
 def _profile_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
@@ -421,9 +425,27 @@ def test_pentest_runner_defaults_registry_and_publish_workflow_do_not_drift(
     assert domain_profile.image == settings_image
     assert workload_profile is not None
     assert workload_profile.image == settings_image
-    assert settings_image == "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
-    assert "pentest_image_name=${IMAGE_NAME}-pentestgpt" in publish_workflow
-    assert "./docker/pentestgpt-runner/Dockerfile" in publish_workflow
+    assert settings_image == PENTEST_RUNNER_IMAGE
+    assert "pentest_image_name=${IMAGE_NAME}-pentestgpt" not in publish_workflow
+    assert "./docker/pentestgpt-runner/Dockerfile" not in publish_workflow
+
+
+def test_runner_profile_registry_can_override_pentest_image_from_settings() -> None:
+    settings_image = PENTEST_RUNNER_IMAGE
+    registry = RunnerProfileRegistry.load_file(
+        Path("config/workloads/default-runner-profiles.yaml"),
+        workspace_root=WORKSPACE_ROOT,
+        allowed_image_registries=("ghcr.io",),
+        profile_image_overrides={
+            "pentestgpt-safe": settings_image,
+            "pentestgpt-vpn-lab": settings_image,
+        },
+    )
+
+    workload_profile = registry.get("pentestgpt-safe")
+
+    assert workload_profile is not None
+    assert workload_profile.image == settings_image
 
 @pytest.mark.parametrize(
     ("overrides", "message"),

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -447,6 +447,20 @@ def test_runner_profile_registry_can_override_pentest_image_from_settings() -> N
     assert workload_profile is not None
     assert workload_profile.image == settings_image
 
+
+@pytest.mark.parametrize("unsafe_image", ["python", "python:latest"])
+def test_runner_profile_registry_revalidates_image_overrides(
+    unsafe_image: str,
+) -> None:
+    with pytest.raises(ValidationError, match="tag or digest|latest"):
+        RunnerProfileRegistry.load_file(
+            Path("config/workloads/default-runner-profiles.yaml"),
+            workspace_root=WORKSPACE_ROOT,
+            profile_image_overrides={
+                "pentestgpt-safe": unsafe_image,
+            },
+        )
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [


### PR DESCRIPTION
Issue reference: MM-867

Summary:
- Split PentestGPT runner publishing into `.github/workflows/pentestgpt-runner.yml` with bounded triggers, workflow dispatch inputs, scheduled rebuilds, and non-racing concurrency.
- Simplified `.github/workflows/docker-publish.yml` so it only publishes the normal MoonMind app image.
- Preserved runner gates for smoke/provenance/self-test/Trivy/upstream compatibility/multi-arch publish, and added the digest-pinned `pentestgpt-runner-image.json` artifact.
- Made `settings.pentest.runner_image` the runtime source of truth and updated tests around runner image validation and workload profile materialization.

Tests run:
- `./tools/test_unit.sh tests/unit/test_docker_publish_workflow.py tests/unit/test_pentestgpt_runner_workflow.py`

Remaining risks:
- Docker buildx image publication and digest resolution still need to run in GitHub Actions with registry permissions.
- The production digest placeholder must be replaced with the published manifest digest after the runner workflow publishes an image.
