### PR TITLE
MM-868 preserve provider profile queue order

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1642,6 +1642,8 @@ class MoonMindAgentRun:
             try:
                 payload["queue_order"] = int(raw_queue_order)
             except (TypeError, ValueError):
+                # Queue metadata is best-effort; invalid values should not block
+                # otherwise valid slot requests.
                 pass
         raw_queued_at = moonmind_map.get("queuedAt", moonmind_map.get("queued_at"))
         queued_at = str(raw_queued_at or "").strip()

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1555,6 +1555,7 @@ class MoonMindAgentRun:
         execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Signal the ProviderProfileManager for slot requests; auto-start it on first failure.
 
@@ -1576,6 +1577,8 @@ class MoonMindAgentRun:
         }
         if request_priority is not None:
             signal_payload["priority"] = request_priority
+        if request_queue_metadata:
+            signal_payload.update(request_queue_metadata)
         if workflow.patched(SLOT_HANDOFF_PATCH_ID):
             lease_group_id = self._lease_group_id()
             if lease_group_id:
@@ -1621,6 +1624,31 @@ class MoonMindAgentRun:
         except (TypeError, ValueError):
             return 0
 
+    @staticmethod
+    def _request_queue_metadata(request: AgentExecutionRequest) -> dict[str, Any]:
+        parameters = request.parameters
+        if not isinstance(parameters, Mapping):
+            return {}
+        metadata = parameters.get("metadata")
+        metadata_map = metadata if isinstance(metadata, Mapping) else {}
+        moonmind = metadata_map.get("moonmind")
+        moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+        payload: dict[str, Any] = {}
+        raw_queue_order = moonmind_map.get(
+            "queueOrder",
+            moonmind_map.get("queue_order"),
+        )
+        if raw_queue_order is not None and not isinstance(raw_queue_order, bool):
+            try:
+                payload["queue_order"] = int(raw_queue_order)
+            except (TypeError, ValueError):
+                pass
+        raw_queued_at = moonmind_map.get("queuedAt", moonmind_map.get("queued_at"))
+        queued_at = str(raw_queued_at or "").strip()
+        if queued_at:
+            payload["queued_at"] = queued_at
+        return payload
+
     async def _manager_state_for_slot_wait(
         self,
         *,
@@ -1649,6 +1677,7 @@ class MoonMindAgentRun:
         execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Terminate a stuck manager, start a fresh one, and re-request a slot.
 
@@ -1671,6 +1700,7 @@ class MoonMindAgentRun:
             execution_profile_ref=execution_profile_ref,
             profile_selector=profile_selector,
             request_priority=request_priority,
+            request_queue_metadata=request_queue_metadata,
         )
 
     async def _ensure_manager_started(
@@ -1686,6 +1716,7 @@ class MoonMindAgentRun:
             execution_profile_ref=None,
             profile_selector=None,
             request_priority=None,
+            request_queue_metadata=None,
         )
 
     async def _sync_manager_profiles(
@@ -2233,6 +2264,7 @@ class MoonMindAgentRun:
             execution_profile_ref=request.execution_profile_ref,
             profile_selector=selector_payload,
             request_priority=self._request_priority(request),
+            request_queue_metadata=self._request_queue_metadata(request),
         )
         self._awaiting_slot_reason_override = None
         self._slot_wait_timeout_override_seconds = None
@@ -2512,6 +2544,7 @@ class MoonMindAgentRun:
                             execution_profile_ref=request.execution_profile_ref,
                             profile_selector=selector_payload,
                             request_priority=self._request_priority(request),
+                            request_queue_metadata=self._request_queue_metadata(request),
                         )
                     else:
                         manager_handle = await self._ensure_manager_and_signal(
@@ -2521,6 +2554,7 @@ class MoonMindAgentRun:
                             execution_profile_ref=request.execution_profile_ref,
                             profile_selector=selector_payload,
                             request_priority=self._request_priority(request),
+                            request_queue_metadata=self._request_queue_metadata(request),
                         )
                         profile_count = await self._sync_manager_profiles(
                             manager_id=manager_id,
@@ -2651,6 +2685,7 @@ class MoonMindAgentRun:
                                             execution_profile_ref=request.execution_profile_ref,
                                             profile_selector=selector_payload,
                                             request_priority=self._request_priority(request),
+                                            request_queue_metadata=self._request_queue_metadata(request),
                                         )
                                         await self._sync_manager_profiles(
                                             manager_id=manager_id,
@@ -2665,6 +2700,7 @@ class MoonMindAgentRun:
                                     execution_profile_ref=request.execution_profile_ref,
                                     profile_selector=selector_payload,
                                     request_priority=self._request_priority(request),
+                                    request_queue_metadata=self._request_queue_metadata(request),
                                 )
                                 await self._sync_manager_profiles(
                                     manager_id=manager_id,
@@ -2745,6 +2781,7 @@ class MoonMindAgentRun:
                             "runtime_id": kw.get("runtime_id", runtime_id),
                             "priority": self._request_priority(request),
                         }
+                        payload.update(self._request_queue_metadata(request))
                         if workflow.patched(SLOT_HANDOFF_PATCH_ID):
                             lease_group_id = self._lease_group_id()
                             if lease_group_id:

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -49,6 +49,9 @@ BILLING_AWARE_PROFILE_SELECTION_PATCH = (
 PRIORITY_PENDING_REQUESTS_PATCH = (
     "provider-profile-manager-priority-pending-requests-v1"
 )
+QUEUE_ORDER_PENDING_REQUESTS_PATCH = (
+    "provider-profile-manager-queue-order-pending-requests-v1"
+)
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -93,6 +96,8 @@ class SlotRequestPayload(TypedDict):
     requester_workflow_id: str
     runtime_id: str
     priority: int
+    queue_order: int | None
+    queued_at: str | None
     execution_profile_ref: str | None
     lease_group_id: str | None
 
@@ -239,6 +244,8 @@ class PendingRequest:
     requester_workflow_id: str
     runtime_id: str
     priority: int = 0
+    queue_order: int | None = None
+    queued_at: str | None = None
     execution_profile_ref: str | None = None
     profile_selector: Optional[dict[str, Any]] = None
     lease_group_id: str | None = None
@@ -312,12 +319,16 @@ class MoonMindProviderProfileManagerWorkflow:
         self._event_count += 1
         self._has_new_events = True
         priority = self._normalize_request_priority(payload.get("priority"))
+        queue_order = self._normalize_queue_order(payload.get("queue_order"))
+        queued_at = self._normalize_optional_string(payload.get("queued_at"))
         if not workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
             self._pending_requests.append(
                 PendingRequest(
                     requester_workflow_id=payload["requester_workflow_id"],
                     runtime_id=payload.get("runtime_id", self._runtime_id or ""),
                     priority=priority,
+                    queue_order=queue_order,
+                    queued_at=queued_at,
                     execution_profile_ref=payload.get("execution_profile_ref"),
                     profile_selector=payload.get("profile_selector"),
                 )
@@ -327,6 +338,8 @@ class MoonMindProviderProfileManagerWorkflow:
             requester_workflow_id=payload["requester_workflow_id"],
             runtime_id=payload.get("runtime_id", self._runtime_id or ""),
             priority=priority,
+            queue_order=queue_order,
+            queued_at=queued_at,
             execution_profile_ref=payload.get("execution_profile_ref"),
             profile_selector=payload.get("profile_selector"),
             lease_group_id=self._normalize_optional_string(
@@ -507,6 +520,8 @@ class MoonMindProviderProfileManagerWorkflow:
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
                     "priority": r.priority,
+                    "queue_order": r.queue_order,
+                    "queued_at": r.queued_at,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                     "lease_group_id": r.lease_group_id,
@@ -642,6 +657,8 @@ class MoonMindProviderProfileManagerWorkflow:
                 requester_workflow_id=req.get("requester_workflow_id", ""),
                 runtime_id=req.get("runtime_id", ""),
                 priority=self._normalize_request_priority(req.get("priority")),
+                queue_order=self._normalize_queue_order(req.get("queue_order")),
+                queued_at=self._normalize_optional_string(req.get("queued_at")),
                 execution_profile_ref=req.get("execution_profile_ref"),
                 profile_selector=req.get("profile_selector"),
                 lease_group_id=self._normalize_optional_string(
@@ -793,6 +810,15 @@ class MoonMindProviderProfileManagerWorkflow:
             return 0
 
     @staticmethod
+    def _normalize_queue_order(value: object) -> int | None:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
     def _coerce_handoff_ttl_seconds(value: object) -> int:
         try:
             seconds = int(value or 0)
@@ -894,6 +920,11 @@ class MoonMindProviderProfileManagerWorkflow:
                 self._pending_requests,
                 key=lambda request: -request.priority,
             )
+        if workflow.patched(QUEUE_ORDER_PENDING_REQUESTS_PATCH):
+            pending_requests = sorted(
+                self._pending_requests,
+                key=self._pending_request_sort_key,
+            )
         for req in pending_requests:
             # Check if this requester already has a lease (e.g. from a retried workflow task)
             existing_profile_id = None
@@ -943,6 +974,21 @@ class MoonMindProviderProfileManagerWorkflow:
         # Persist lease changes to DB for crash recovery
         if leases_changed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
             await self._sync_leases_to_db()
+
+    @staticmethod
+    def _pending_request_sort_key(
+        request: PendingRequest,
+    ) -> tuple[int, int, int, str, str]:
+        missing_order = 1 if request.queue_order is None else 0
+        order = request.queue_order if request.queue_order is not None else 0
+        queued_at = request.queued_at or ""
+        return (
+            -request.priority,
+            missing_order,
+            order,
+            queued_at,
+            request.requester_workflow_id,
+        )
 
     @staticmethod
     def _normalize_selector(
@@ -1307,6 +1353,8 @@ class MoonMindProviderProfileManagerWorkflow:
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
                     "priority": r.priority,
+                    "queue_order": r.queue_order,
+                    "queued_at": r.queued_at,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                     "lease_group_id": r.lease_group_id,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -978,16 +978,20 @@ class MoonMindProviderProfileManagerWorkflow:
     @staticmethod
     def _pending_request_sort_key(
         request: PendingRequest,
-    ) -> tuple[int, int, int, str, str]:
-        missing_order = 1 if request.queue_order is None else 0
-        order = request.queue_order if request.queue_order is not None else 0
+    ) -> tuple[int, int, int, str]:
         queued_at = request.queued_at or ""
+        if request.queue_order is None:
+            return (
+                -request.priority,
+                0,
+                0,
+                queued_at,
+            )
         return (
             -request.priority,
-            missing_order,
-            order,
+            1,
+            request.queue_order,
             queued_at,
-            request.requester_workflow_id,
         )
 
     @staticmethod

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5933,6 +5933,7 @@ class MoonMindRunWorkflow:
                                 resolved_skillset_ref=resolved_skillset_ref,
                                 workflow_parameters=parameters,
                                 step_execution=current_step_execution,
+                                queue_order=index,
                                 attempt_reason=attempt_reason,
                             )
                             if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):
@@ -7552,6 +7553,7 @@ class MoonMindRunWorkflow:
                 resolved_skillset_ref=resolved_skillset_ref,
                 workflow_parameters=workflow_parameters,
                 step_execution=self._step_execution_for(node_id) or 1,
+                queue_order=self._step_execution_for(node_id) or 1,
                 attempt_reason="policy_revalidation",
             )
             child_workflow_id = (
@@ -10504,6 +10506,7 @@ class MoonMindRunWorkflow:
         resolved_skillset_ref: str | None = None,
         workflow_parameters: Mapping[str, Any] | None = None,
         step_execution: int | None = None,
+        queue_order: int | None = None,
         attempt_reason: str = "initial_execution",
     ) -> "AgentExecutionRequest":
         """Build an ``AgentExecutionRequest`` from plan-node inputs and workflow context."""
@@ -10873,6 +10876,11 @@ class MoonMindRunWorkflow:
             self._step_execution_retrieval_manifest_artifacts[
                 (node_id, execution_ordinal)
             ] = dict(retrieval_manifest_artifact)
+        if queue_order is not None:
+            moonmind_payload["queueOrder"] = queue_order
+        workflow_start_time = getattr(wf_info, "start_time", None)
+        if isinstance(workflow_start_time, datetime):
+            moonmind_payload["queuedAt"] = workflow_start_time.isoformat()
         metadata_payload["moonmind"] = moonmind_payload
         parameters["metadata"] = metadata_payload
         projection_context = attempt_context.to_manifest_projection().get("context")

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -1110,7 +1110,7 @@ class TestProviderProfileManagerHelpers:
             "wf-older-low"
         ]
 
-    def test_missing_queue_order_uses_deterministic_fallback(self):
+    def test_missing_queue_order_preserves_arrival_order(self):
         requests = [
             PendingRequest("wf-b", "codex_cli", priority=0),
             PendingRequest("wf-a", "codex_cli", priority=0),
@@ -1122,8 +1122,50 @@ class TestProviderProfileManagerHelpers:
         )
 
         assert [request.requester_workflow_id for request in ordered] == [
-            "wf-a",
             "wf-b",
+            "wf-a",
+        ]
+
+    def test_missing_queue_order_stays_ahead_of_explicit_newer_requests(self):
+        requests = [
+            PendingRequest("wf-legacy", "codex_cli", priority=0),
+            PendingRequest("wf-new", "codex_cli", priority=0, queue_order=1),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=MoonMindProviderProfileManagerWorkflow._pending_request_sort_key,
+        )
+
+        assert [request.requester_workflow_id for request in ordered] == [
+            "wf-legacy",
+            "wf-new",
+        ]
+
+    def test_missing_queue_order_can_use_queued_at_fallback(self):
+        requests = [
+            PendingRequest(
+                "wf-newer",
+                "codex_cli",
+                priority=0,
+                queued_at="2026-06-22T10:02:00+00:00",
+            ),
+            PendingRequest(
+                "wf-older",
+                "codex_cli",
+                priority=0,
+                queued_at="2026-06-22T10:01:00+00:00",
+            ),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=MoonMindProviderProfileManagerWorkflow._pending_request_sort_key,
+        )
+
+        assert [request.requester_workflow_id for request in ordered] == [
+            "wf-older",
+            "wf-newer",
         ]
 
     @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -15,6 +15,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     HandoffReservation,
     PendingRequest,
     PRIORITY_PENDING_REQUESTS_PATCH,
+    QUEUE_ORDER_PENDING_REQUESTS_PATCH,
     SLOT_HANDOFF_RESERVATION_PATCH,
     VERIFY_PENDING_REQUESTS_PATCH,
     WORKFLOW_NAME,
@@ -923,6 +924,55 @@ class TestProviderProfileManagerHelpers:
         assert data["leases"]["p1"] == ["wf1"]
         assert data["cooldowns"]["p1"] == "2099-01-01T00:00:00+00:00"
 
+    def test_build_continue_as_new_preserves_pending_queue_order(self):
+        wf = self._make_workflow()
+        wf._pending_requests = [
+            PendingRequest(
+                "wf-older",
+                "codex_cli",
+                priority=0,
+                queue_order=100,
+                queued_at="2026-06-22T10:00:00+00:00",
+            )
+        ]
+
+        data = wf._build_continue_as_new_input()
+
+        assert data["pending_requests"] == [
+            {
+                "requester_workflow_id": "wf-older",
+                "runtime_id": "codex_cli",
+                "priority": 0,
+                "queue_order": 100,
+                "queued_at": "2026-06-22T10:00:00+00:00",
+                "execution_profile_ref": None,
+                "profile_selector": None,
+                "lease_group_id": None,
+            }
+        ]
+
+    def test_restore_state_preserves_pending_queue_order(self):
+        wf = self._make_workflow()
+        wf._restore_state(
+            {
+                "runtime_id": "codex_cli",
+                "pending_requests": [
+                    {
+                        "requester_workflow_id": "wf-older",
+                        "runtime_id": "codex_cli",
+                        "priority": "0",
+                        "queue_order": "100",
+                        "queued_at": "2026-06-22T10:00:00+00:00",
+                    }
+                ],
+            }
+        )
+
+        assert len(wf._pending_requests) == 1
+        restored = wf._pending_requests[0]
+        assert restored.queue_order == 100
+        assert restored.queued_at == "2026-06-22T10:00:00+00:00"
+
     def test_build_continue_as_new_preserves_handoff_reservations(self):
         wf = self._make_workflow()
         wf._handoff_reservations["run-1"] = HandoffReservation(
@@ -965,6 +1015,116 @@ class TestProviderProfileManagerHelpers:
         assert len(wf._pending_requests) == 1
         assert wf._pending_requests[0].execution_profile_ref == "p2"
         assert wf._pending_requests[0].lease_group_id == "run-1"
+
+    def test_request_slot_records_queue_metadata(self):
+        wf = self._make_workflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            wf.request_slot(
+                {
+                    "requester_workflow_id": "run-1:agent:step-1",
+                    "runtime_id": "codex_cli",
+                    "priority": "0",
+                    "queue_order": "42",
+                    "queued_at": "2026-06-22T10:00:00+00:00",
+                }
+            )
+
+        assert wf._pending_requests[0].queue_order == 42
+        assert wf._pending_requests[0].queued_at == "2026-06-22T10:00:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_equal_priority_uses_queue_order_not_signal_arrival(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+        )
+        wf._pending_requests = [
+            PendingRequest("wf-newer", "codex_cli", priority=0, queue_order=200),
+            PendingRequest("wf-older", "codex_cli", priority=0, queue_order=100),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: patch_id in {
+                PRIORITY_PENDING_REQUESTS_PATCH,
+                QUEUE_ORDER_PENDING_REQUESTS_PATCH,
+            }
+            await wf._drain_queue()
+
+        assert assigned == [("wf-older", "p1")]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-newer"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_priority_still_wins_over_queue_order(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+        )
+        wf._pending_requests = [
+            PendingRequest("wf-older-low", "codex_cli", priority=0, queue_order=100),
+            PendingRequest("wf-newer-high", "codex_cli", priority=10, queue_order=200),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: patch_id in {
+                PRIORITY_PENDING_REQUESTS_PATCH,
+                QUEUE_ORDER_PENDING_REQUESTS_PATCH,
+            }
+            await wf._drain_queue()
+
+        assert assigned == [("wf-newer-high", "p1")]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-older-low"
+        ]
+
+    def test_missing_queue_order_uses_deterministic_fallback(self):
+        requests = [
+            PendingRequest("wf-b", "codex_cli", priority=0),
+            PendingRequest("wf-a", "codex_cli", priority=0),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=MoonMindProviderProfileManagerWorkflow._pending_request_sort_key,
+        )
+
+        assert [request.requester_workflow_id for request in ordered] == [
+            "wf-a",
+            "wf-b",
+        ]
 
     @pytest.mark.asyncio
     async def test_acquire_slot_update_reserves_without_callback_signal(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -350,6 +350,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -493,6 +494,7 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -617,6 +619,7 @@ async def test_agent_run_starts_deferred_codex_session_only_after_slot_assignmen
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         if request_slot:
             order.append("request_slot")
@@ -811,6 +814,7 @@ async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -944,6 +948,7 @@ async def test_agent_run_managed_session_start_runtime_error_returns_failed_resu
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1054,6 +1059,7 @@ async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1158,6 +1164,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         if request_slot:
             ensure_profile_refs.append(execution_profile_ref)
@@ -1293,6 +1300,7 @@ async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1392,6 +1400,7 @@ async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_hist
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"
@@ -1490,6 +1499,7 @@ async def test_agent_run_preserves_pre_launch_instruction_order_for_pre_defer_hi
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "codex-default"

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -866,3 +866,36 @@ class TestEnsureManagerAutoStart:
         assert MoonMindAgentRun._request_priority(
             SimpleNamespace(parameters={"priority": "bad"})  # type: ignore[arg-type]
         ) == 0
+
+    def test_request_queue_metadata_reads_moonmind_metadata(self):
+        request = SimpleNamespace(
+            parameters={
+                "metadata": {
+                    "moonmind": {
+                        "queueOrder": "17",
+                        "queuedAt": "2026-06-22T10:00:00+00:00",
+                    }
+                }
+            }
+        )
+
+        assert MoonMindAgentRun._request_queue_metadata(request) == {
+            "queue_order": 17,
+            "queued_at": "2026-06-22T10:00:00+00:00",
+        }
+
+    def test_request_queue_metadata_ignores_invalid_order(self):
+        request = SimpleNamespace(
+            parameters={
+                "metadata": {
+                    "moonmind": {
+                        "queueOrder": "bad",
+                        "queuedAt": "2026-06-22T10:00:00+00:00",
+                    }
+                }
+            }
+        )
+
+        assert MoonMindAgentRun._request_queue_metadata(request) == {
+            "queued_at": "2026-06-22T10:00:00+00:00",
+        }

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -519,6 +519,7 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "default-managed"
@@ -660,6 +661,7 @@ async def test_agent_run_managed_preserves_workflow_scoped_session_metadata(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
         request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
     ) -> _FakeManagerHandle:
         run.slot_assigned_event.set()
         run._assigned_profile_id = execution_profile_ref or "default-managed"

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1352,6 +1352,35 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.parameters["priority"], 0)
 
+    def test_build_agent_execution_request_records_queue_metadata(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+            start_time = datetime(2026, 6, 22, 10, 0, tzinfo=UTC)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex",
+                    },
+                },
+                node_id="node-queue-order",
+                tool_name="pr-resolver",
+                queue_order=7,
+            )
+
+        moonmind = request.parameters["metadata"]["moonmind"]
+        self.assertEqual(moonmind["queueOrder"], 7)
+        self.assertEqual(moonmind["queuedAt"], "2026-06-22T10:00:00+00:00")
+
     def test_build_agent_execution_request_falls_back_on_invalid_profile_ref(self) -> None:
         """When a plan node carries a profile ID that doesn't match any known
         profile for the runtime (e.g. AI-hallucinated 'default:codex_cli'),


### PR DESCRIPTION
Issue reference: MM-868

Summary:
- Adds queue_order and queued_at to provider-profile slot requests and pending queue state.
- Sorts pending slot requests by priority descending, explicit queue order ascending, queued_at, and requester workflow ID for deterministic equal-priority dispatch.
- Propagates queue ordering from MoonMind run/agent execution metadata into AgentRun slot request paths.
- Adds unit coverage for equal-priority ordering, priority precedence, continue-as-new preservation, missing-order fallback, and dispatch metadata propagation.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py (172 passed, 2 subtests passed)
- Attempted tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py; failed before MM-868 behavior because MoonMindRunWorkflow is registered as an undecorated base class in this local Temporal SDK path.

Remaining risks:
- Full integration coverage is blocked by the existing Temporal workflow registration issue above; unit-level workflow contract coverage passed for the changed queue-order paths.