### PR TITLE
MM-869 honor scheduled queue order for equal-priority provider slots

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -643,6 +643,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="provider_profile.pending_request_order",
+            family="provider_profile",
+            capability_class="artifacts",
+            task_queue=cfg.activity_artifacts_task_queue,
+            fleet=ARTIFACTS_FLEET,
+            timeouts=TemporalActivityTimeouts(30, 60),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="oauth_session.ensure_volume",
             family="oauth_session",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1136,6 +1136,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "artifacts",
         "provider_profile_sync_slot_leases",
     ),
+    "provider_profile.pending_request_order": (
+        "artifacts",
+        "provider_profile_pending_request_order",
+    ),
     "oauth_session.ensure_volume": ("agent_runtime", "oauth_session_ensure_volume"),
     "oauth_session.start_auth_runner": ("agent_runtime", "oauth_session_start_auth_runner"),
     "oauth_session.update_terminal_session": ("artifacts", "oauth_session_update_terminal_session"),

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3092,6 +3092,63 @@ class TemporalArtifactActivities:
 
         return results
 
+    async def provider_profile_pending_request_order(
+        self,
+        *,
+        workflow_ids: list[str],
+    ) -> dict[str, Any]:
+        """Resolve scheduled queue ordering for pending provider-profile requests.
+
+        Looks up the ``scheduled_for`` / ``created_at`` timestamps for a bounded
+        list of workflow ids from the canonical execution projection so the
+        ProviderProfileManager can use existing queue order as the tie-breaker
+        for equal-priority slot requests (MM-869).
+
+        Returns ``{"orders": {workflow_id: {"scheduled_for": ISO, "created_at":
+        ISO}}}`` with compact UTC ISO-8601 timestamp strings. Only ordering
+        timestamps are returned; no other execution data is exposed. Workflow
+        ids without a matching execution record are simply omitted, and the
+        manager applies a deterministic fallback for them. Safe to call
+        repeatedly from the long-lived manager workflow.
+        """
+        from sqlalchemy import select
+
+        from api_service.db.models import TemporalExecutionRecord
+        from api_service.db.base import get_async_session_context
+
+        unique_ids = list(
+            dict.fromkeys(
+                str(wf_id).strip()
+                for wf_id in (workflow_ids or [])
+                if str(wf_id or "").strip()
+            )
+        )
+        orders: dict[str, dict[str, str]] = {}
+        if not unique_ids:
+            return {"orders": orders}
+
+        def _iso_utc(value: datetime) -> str:
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=UTC)
+            return value.astimezone(UTC).isoformat()
+
+        async with get_async_session_context() as session:
+            stmt = select(
+                TemporalExecutionRecord.workflow_id,
+                TemporalExecutionRecord.scheduled_for,
+                TemporalExecutionRecord.created_at,
+            ).where(TemporalExecutionRecord.workflow_id.in_(unique_ids))
+            result = await session.execute(stmt)
+            for workflow_id, scheduled_for, created_at in result.all():
+                entry: dict[str, str] = {}
+                if scheduled_for is not None:
+                    entry["scheduled_for"] = _iso_utc(scheduled_for)
+                if created_at is not None:
+                    entry["created_at"] = _iso_utc(created_at)
+                orders[workflow_id] = entry
+
+        return {"orders": orders}
+
     async def provider_profile_sync_slot_leases(
         self,
         *,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -318,6 +318,12 @@ class MoonMindProviderProfileManagerWorkflow:
         self._has_new_events: bool = False
         self._profile_refresh_requested: bool = False
         self._has_db_profile_snapshot: bool = False
+        # Cache of resolved scheduled/created ordering keyed by queue-order
+        # workflow id. Workflow creation/scheduled times are immutable, so a
+        # resolved entry never has to be re-queried; this keeps the
+        # ``provider_profile.pending_request_order`` activity from re-hitting the
+        # database for the same ids on every drain cycle.
+        self._resolved_orders: dict[str, dict[str, Any]] = {}
 
     # -- Signals ---------------------------------------------------------------
 
@@ -1032,15 +1038,38 @@ class MoonMindProviderProfileManagerWorkflow:
         If the ordering lookup activity fails, this logs enough context to
         diagnose the failure and falls back to the deterministic queue-order /
         priority sort so slot assignment is never blocked for that drain cycle.
+
+        Resolved orders are cached per queue-order workflow id (their scheduled
+        and created timestamps are immutable), so each id is only looked up
+        once; subsequent drain cycles reuse the cache instead of re-querying the
+        database. The lookup is also bounded with a ``schedule_to_start_timeout``
+        so that a starved activity task queue cannot leave available
+        provider-profile slots idle indefinitely waiting on this best-effort,
+        non-critical ordering call -- it times out and falls back to the
+        deterministic queue-order drain instead.
         """
         lookup_ids = self._pending_request_order_lookup_ids()
-        order_by_workflow_id: dict[str, dict[str, Any]] = {}
-        if lookup_ids:
+        # Drop cached entries for ids that are no longer pending so the cache
+        # stays bounded over the lifetime of this long-lived workflow.
+        if self._resolved_orders:
+            lookup_set = set(lookup_ids)
+            self._resolved_orders = {
+                workflow_id: order
+                for workflow_id, order in self._resolved_orders.items()
+                if workflow_id in lookup_set
+            }
+        uncached_ids = [
+            workflow_id
+            for workflow_id in lookup_ids
+            if workflow_id not in self._resolved_orders
+        ]
+        if uncached_ids:
             try:
                 result = await workflow.execute_activity(
                     "provider_profile.pending_request_order",
-                    {"workflow_ids": lookup_ids},
+                    {"workflow_ids": uncached_ids},
                     task_queue=ACTIVITY_TASK_QUEUE,
+                    schedule_to_start_timeout=timedelta(seconds=30),
                     start_to_close_timeout=timedelta(seconds=30),
                     retry_policy=RetryPolicy(
                         initial_interval=timedelta(seconds=2),
@@ -1051,7 +1080,11 @@ class MoonMindProviderProfileManagerWorkflow:
                 )
                 orders = (result or {}).get("orders")
                 if isinstance(orders, dict):
-                    order_by_workflow_id = orders
+                    for workflow_id in uncached_ids:
+                        resolved = orders.get(workflow_id)
+                        self._resolved_orders[workflow_id] = (
+                            resolved if isinstance(resolved, dict) else {}
+                        )
             except Exception:
                 self._get_logger().warning(
                     "pending_request_order activity failed; falling back to "
@@ -1066,7 +1099,7 @@ class MoonMindProviderProfileManagerWorkflow:
         return sorted(
             self._pending_requests,
             key=lambda request: self._scheduled_pending_request_sort_key(
-                request, order_by_workflow_id
+                request, self._resolved_orders
             ),
         )
 

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -52,6 +52,14 @@ PRIORITY_PENDING_REQUESTS_PATCH = (
 QUEUE_ORDER_PENDING_REQUESTS_PATCH = (
     "provider-profile-manager-queue-order-pending-requests-v1"
 )
+SCHEDULED_PENDING_REQUESTS_PATCH = (
+    "provider-profile-manager-scheduled-pending-requests-v1"
+)
+
+# Deterministic sort sentinel for pending requests whose scheduled queue order
+# cannot be resolved (missing scheduled_for / created_at). ISO-8601 strings sort
+# lexically, so this value sorts after any real UTC timestamp.
+_FAR_FUTURE_ORDER_VALUE = "9999-12-31T23:59:59.999999+00:00"
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -925,6 +933,8 @@ class MoonMindProviderProfileManagerWorkflow:
                 self._pending_requests,
                 key=self._pending_request_sort_key,
             )
+        if workflow.patched(SCHEDULED_PENDING_REQUESTS_PATCH):
+            pending_requests = await self._order_pending_requests_by_schedule()
         for req in pending_requests:
             # Check if this requester already has a lease (e.g. from a retried workflow task)
             existing_profile_id = None
@@ -992,6 +1002,101 @@ class MoonMindProviderProfileManagerWorkflow:
             1,
             request.queue_order,
             queued_at,
+        )
+
+    def _pending_request_order_lookup_ids(self) -> list[str]:
+        """Collect the parent/root queue-order keys for pending slot requests.
+
+        Slot requests originate from ``MoonMind.AgentRun`` child workflows, but
+        the visible queue order belongs to the parent/root workflow. ``lease_group_id``
+        is derived from the parent workflow id when present, so it is the primary
+        lookup key; the requester workflow id is used only as a fallback.
+        """
+        lookup_ids: list[str] = []
+        for request in self._pending_requests:
+            workflow_id = self._normalize_optional_string(
+                request.lease_group_id or request.requester_workflow_id
+            )
+            if workflow_id:
+                lookup_ids.append(workflow_id)
+        return list(dict.fromkeys(lookup_ids))
+
+    async def _order_pending_requests_by_schedule(self) -> list[PendingRequest]:
+        """Order pending requests by existing scheduled queue order (MM-869).
+
+        Resolves ``scheduled_for`` / ``created_at`` for each pending request's
+        parent queue-order key via the ``provider_profile.pending_request_order``
+        activity, then sorts by priority DESC, scheduled_for ASC, created_at ASC,
+        queue-order key ASC, requester_workflow_id ASC.
+
+        If the ordering lookup activity fails, this logs enough context to
+        diagnose the failure and falls back to the deterministic queue-order /
+        priority sort so slot assignment is never blocked for that drain cycle.
+        """
+        lookup_ids = self._pending_request_order_lookup_ids()
+        order_by_workflow_id: dict[str, dict[str, Any]] = {}
+        if lookup_ids:
+            try:
+                result = await workflow.execute_activity(
+                    "provider_profile.pending_request_order",
+                    {"workflow_ids": lookup_ids},
+                    task_queue=ACTIVITY_TASK_QUEUE,
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(
+                        initial_interval=timedelta(seconds=2),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(seconds=30),
+                        maximum_attempts=3,
+                    ),
+                )
+                orders = (result or {}).get("orders")
+                if isinstance(orders, dict):
+                    order_by_workflow_id = orders
+            except Exception:
+                self._get_logger().warning(
+                    "pending_request_order activity failed; falling back to "
+                    "queue-order drain for %d pending request(s) on runtime %s",
+                    len(self._pending_requests),
+                    self._runtime_id,
+                )
+                return sorted(
+                    self._pending_requests,
+                    key=self._pending_request_sort_key,
+                )
+        return sorted(
+            self._pending_requests,
+            key=lambda request: self._scheduled_pending_request_sort_key(
+                request, order_by_workflow_id
+            ),
+        )
+
+    @classmethod
+    def _scheduled_pending_request_sort_key(
+        cls,
+        request: PendingRequest,
+        order_by_workflow_id: dict[str, dict[str, Any]],
+    ) -> tuple[int, str, str, str, str]:
+        workflow_id = (
+            cls._normalize_optional_string(
+                request.lease_group_id or request.requester_workflow_id
+            )
+            or ""
+        )
+        ordering = order_by_workflow_id.get(workflow_id) or {}
+        scheduled_for = (
+            cls._normalize_optional_string(ordering.get("scheduled_for"))
+            or _FAR_FUTURE_ORDER_VALUE
+        )
+        created_at = (
+            cls._normalize_optional_string(ordering.get("created_at"))
+            or _FAR_FUTURE_ORDER_VALUE
+        )
+        return (
+            -request.priority,
+            scheduled_for,
+            created_at,
+            workflow_id,
+            request.requester_workflow_id or "",
         )
 
     @staticmethod

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -16,6 +16,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     PendingRequest,
     PRIORITY_PENDING_REQUESTS_PATCH,
     QUEUE_ORDER_PENDING_REQUESTS_PATCH,
+    SCHEDULED_PENDING_REQUESTS_PATCH,
     SLOT_HANDOFF_RESERVATION_PATCH,
     VERIFY_PENDING_REQUESTS_PATCH,
     WORKFLOW_NAME,
@@ -1168,6 +1169,279 @@ class TestProviderProfileManagerHelpers:
             "wf-newer",
         ]
 
+    # -- MM-869: scheduled-order tie-breaker -------------------------------
+
+    @staticmethod
+    def _single_slot_profile() -> ProfileSlotState:
+        return ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+        )
+
+    def _drain_patches(self, *, scheduled: bool) -> set[str]:
+        patches = {PRIORITY_PENDING_REQUESTS_PATCH, QUEUE_ORDER_PENDING_REQUESTS_PATCH}
+        if scheduled:
+            patches.add(SCHEDULED_PENDING_REQUESTS_PATCH)
+        return patches
+
+    def test_pending_request_order_lookup_ids_prefers_lease_group(self):
+        wf = self._make_workflow()
+        wf._pending_requests = [
+            PendingRequest("wf-1", "codex_cli", lease_group_id="parent-1"),
+            PendingRequest("wf-2", "codex_cli"),
+            PendingRequest("wf-3", "codex_cli", lease_group_id="parent-1"),
+        ]
+
+        assert wf._pending_request_order_lookup_ids() == ["parent-1", "wf-2"]
+
+    @pytest.mark.asyncio
+    async def test_scheduled_order_breaks_equal_priority_ties(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        # Signals arrive in reverse scheduled order.
+        wf._pending_requests = [
+            PendingRequest("wf-newer", "codex_cli", priority=0),
+            PendingRequest("wf-older", "codex_cli", priority=0),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        orders = {
+            "wf-newer": {"scheduled_for": "2026-06-22T10:05:00+00:00"},
+            "wf-older": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": orders})
+            await wf._drain_queue()
+
+        assert assigned == [("wf-older", "p1")]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-newer"
+        ]
+        mock_wf.execute_activity.assert_awaited_once()
+        args, _ = mock_wf.execute_activity.call_args
+        assert args[0] == "provider_profile.pending_request_order"
+        assert set(args[1]["workflow_ids"]) == {"wf-newer", "wf-older"}
+
+    @pytest.mark.asyncio
+    async def test_priority_still_wins_over_scheduled_order(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        wf._pending_requests = [
+            PendingRequest("wf-low-early", "codex_cli", priority=0),
+            PendingRequest("wf-high-late", "codex_cli", priority=10),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        orders = {
+            "wf-low-early": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+            "wf-high-late": {"scheduled_for": "2026-06-22T10:05:00+00:00"},
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": orders})
+            await wf._drain_queue()
+
+        assert assigned == [("wf-high-late", "p1")]
+
+    def test_scheduled_sort_key_falls_back_to_created_at(self):
+        orders = {
+            "wf-a": {"created_at": "2026-06-22T09:59:00+00:00"},
+            "wf-b": {"created_at": "2026-06-22T09:58:00+00:00"},
+        }
+        requests = [
+            PendingRequest("wf-a", "codex_cli", priority=0),
+            PendingRequest("wf-b", "codex_cli", priority=0),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=lambda req: (
+                MoonMindProviderProfileManagerWorkflow._scheduled_pending_request_sort_key(
+                    req, orders
+                )
+            ),
+        )
+
+        assert [req.requester_workflow_id for req in ordered] == ["wf-b", "wf-a"]
+
+    def test_scheduled_sort_key_final_fallback_by_workflow_id(self):
+        # No scheduled_for or created_at for either request.
+        orders: dict[str, dict[str, str]] = {}
+        requests = [
+            PendingRequest("wf-b", "codex_cli", priority=0),
+            PendingRequest("wf-a", "codex_cli", priority=0),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=lambda req: (
+                MoonMindProviderProfileManagerWorkflow._scheduled_pending_request_sort_key(
+                    req, orders
+                )
+            ),
+        )
+
+        assert [req.requester_workflow_id for req in ordered] == ["wf-a", "wf-b"]
+
+    def test_scheduled_sort_key_uses_lease_group_id_for_lookup(self):
+        orders = {
+            "parent-late": {"scheduled_for": "2026-06-22T10:05:00+00:00"},
+            "parent-early": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+        requests = [
+            PendingRequest(
+                "wf-child-a", "codex_cli", priority=0, lease_group_id="parent-late"
+            ),
+            PendingRequest(
+                "wf-child-b", "codex_cli", priority=0, lease_group_id="parent-early"
+            ),
+        ]
+
+        ordered = sorted(
+            requests,
+            key=lambda req: (
+                MoonMindProviderProfileManagerWorkflow._scheduled_pending_request_sort_key(
+                    req, orders
+                )
+            ),
+        )
+
+        assert [req.requester_workflow_id for req in ordered] == [
+            "wf-child-b",
+            "wf-child-a",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ordering_lookup_uses_lease_group_id_as_primary_key(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        wf._pending_requests = [
+            PendingRequest(
+                "wf-child-a", "codex_cli", priority=0, lease_group_id="parent-late"
+            ),
+            PendingRequest(
+                "wf-child-b", "codex_cli", priority=0, lease_group_id="parent-early"
+            ),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        orders = {
+            "parent-late": {"scheduled_for": "2026-06-22T10:05:00+00:00"},
+            "parent-early": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": orders})
+            await wf._drain_queue()
+
+        args, _ = mock_wf.execute_activity.call_args
+        assert set(args[1]["workflow_ids"]) == {"parent-late", "parent-early"}
+        assert assigned == [("wf-child-b", "p1")]
+
+    @pytest.mark.asyncio
+    async def test_ordering_activity_failure_falls_back_without_blocking(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        wf._pending_requests = [
+            PendingRequest("wf-newer", "codex_cli", priority=0, queue_order=200),
+            PendingRequest("wf-older", "codex_cli", priority=0, queue_order=100),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(side_effect=RuntimeError("boom"))
+            # Drain must not raise even though the ordering activity failed.
+            await wf._drain_queue()
+
+        # Fallback to the deterministic queue-order sort: queue_order 100 wins.
+        assert assigned == [("wf-older", "p1")]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-newer"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_scheduled_ordering_gated_behind_patch(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        wf._pending_requests = [
+            PendingRequest("wf-newer", "codex_cli", priority=0, queue_order=200),
+            PendingRequest("wf-older", "codex_cli", priority=0, queue_order=100),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            # Legacy replay path: scheduled patch is NOT enabled.
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=False)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": {}})
+            await wf._drain_queue()
+
+        # Legacy queue-order behavior preserved; no ordering activity call.
+        mock_wf.execute_activity.assert_not_awaited()
+        assert assigned == [("wf-older", "p1")]
+
     @pytest.mark.asyncio
     async def test_acquire_slot_update_reserves_without_callback_signal(self):
         wf = self._make_workflow()
@@ -1701,6 +1975,24 @@ def test_provider_profile_manager_state_runtime_binding():
         "provider_profile_manager_state",
     )
 
+def test_provider_profile_pending_request_order_in_catalog():
+    from moonmind.workflows.temporal.activity_catalog import (
+        build_default_activity_catalog,
+    )
+
+    catalog = build_default_activity_catalog()
+    route = catalog.resolve_activity("provider_profile.pending_request_order")
+    assert route.task_queue == "mm.activity.artifacts"
+    assert route.fleet == "artifacts"
+
+def test_provider_profile_pending_request_order_runtime_binding():
+    from moonmind.workflows.temporal.activity_runtime import _ACTIVITY_HANDLER_ATTRS
+
+    assert _ACTIVITY_HANDLER_ATTRS["provider_profile.pending_request_order"] == (
+        "artifacts",
+        "provider_profile_pending_request_order",
+    )
+
 # ---------------------------------------------------------------------------
 # DB Lease Sync: workflow-side behavior tests
 # ---------------------------------------------------------------------------
@@ -1902,6 +2194,104 @@ class TestProviderProfileSyncSlotLeasesActivity:
         # Load should return granted_at from the DB row
         assert '"granted_at"' in source
         assert "row.granted_at" in source
+
+class TestProviderProfilePendingRequestOrderActivity:
+    """Tests for the provider_profile.pending_request_order activity (MM-869)."""
+
+    @staticmethod
+    def _activities():
+        from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+        return TemporalArtifactActivities(None)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _patch_session(rows: list[tuple]):
+        import contextlib
+
+        class _Result:
+            def all(self) -> list[tuple]:
+                return rows
+
+        class _FakeSession:
+            async def execute(self, _stmt):
+                return _Result()
+
+        @contextlib.asynccontextmanager
+        async def _ctx():
+            yield _FakeSession()
+
+        return patch(
+            "api_service.db.base.get_async_session_context",
+            side_effect=lambda: _ctx(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty_orders(self):
+        activities = self._activities()
+        result = await activities.provider_profile_pending_request_order(
+            workflow_ids=[]
+        )
+        assert result == {"orders": {}}
+
+    @pytest.mark.asyncio
+    async def test_returns_compact_iso_timestamps(self):
+        activities = self._activities()
+        rows = [
+            (
+                "mm:workflow-a",
+                datetime(2026, 6, 22, 10, 0, tzinfo=timezone.utc),
+                datetime(2026, 6, 22, 9, 58, tzinfo=timezone.utc),
+            ),
+            (
+                "mm:workflow-b",
+                None,
+                datetime(2026, 6, 22, 9, 59, tzinfo=timezone.utc),
+            ),
+        ]
+        with self._patch_session(rows):
+            result = await activities.provider_profile_pending_request_order(
+                workflow_ids=["mm:workflow-a", "mm:workflow-b", "mm:workflow-a"]
+            )
+
+        assert result == {
+            "orders": {
+                "mm:workflow-a": {
+                    "scheduled_for": "2026-06-22T10:00:00+00:00",
+                    "created_at": "2026-06-22T09:58:00+00:00",
+                },
+                "mm:workflow-b": {
+                    "created_at": "2026-06-22T09:59:00+00:00",
+                },
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_naive_timestamps_are_normalized_to_utc(self):
+        activities = self._activities()
+        rows = [
+            (
+                "mm:workflow-a",
+                datetime(2026, 6, 22, 10, 0),  # naive -> assume UTC
+                None,
+            ),
+        ]
+        with self._patch_session(rows):
+            result = await activities.provider_profile_pending_request_order(
+                workflow_ids=["mm:workflow-a"]
+            )
+
+        assert result["orders"]["mm:workflow-a"]["scheduled_for"].endswith("+00:00")
+
+    @pytest.mark.asyncio
+    async def test_missing_records_are_omitted(self):
+        activities = self._activities()
+        # DB returns nothing for the requested ids.
+        with self._patch_session([]):
+            result = await activities.provider_profile_pending_request_order(
+                workflow_ids=["mm:unknown"]
+            )
+
+        assert result == {"orders": {}}
 
 def test_verify_lease_holders_exists():
     """Ensure the workflow exposes the expected API."""

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -1443,6 +1443,140 @@ class TestProviderProfileManagerHelpers:
         assert assigned == [("wf-older", "p1")]
 
     @pytest.mark.asyncio
+    async def test_ordering_lookup_bounds_schedule_to_start(self):
+        # The best-effort ordering lookup must bound how long it waits for a
+        # worker so a starved activity task queue cannot leave slots idle.
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._pending_requests = [
+            PendingRequest("wf-older", "codex_cli", priority=0),
+            PendingRequest("wf-newer", "codex_cli", priority=0),
+        ]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": {}})
+            await wf._order_pending_requests_by_schedule()
+
+        _, kwargs = mock_wf.execute_activity.call_args
+        assert kwargs["schedule_to_start_timeout"] == timedelta(seconds=30)
+
+    @pytest.mark.asyncio
+    async def test_resolved_orders_cached_across_drain_cycles(self):
+        # Immutable scheduled/created times are cached, so a second drain cycle
+        # with the same pending ids does not re-query the database.
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profiles["p1"] = self._single_slot_profile()
+        wf._pending_requests = [
+            PendingRequest("wf-newer", "codex_cli", priority=0),
+            PendingRequest("wf-older", "codex_cli", priority=0),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        orders = {
+            "wf-newer": {"scheduled_for": "2026-06-22T10:05:00+00:00"},
+            "wf-older": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": orders})
+            # First cycle assigns the single slot to the earliest-scheduled
+            # request and queries the ordering activity.
+            await wf._drain_queue()
+            assert assigned == [("wf-older", "p1")]
+            mock_wf.execute_activity.assert_awaited_once()
+
+            # Free the slot; the still-pending request is already cached.
+            wf._profiles["p1"] = self._single_slot_profile()
+            await wf._drain_queue()
+
+        # The remaining request drained without a second ordering lookup.
+        assert assigned == [("wf-older", "p1"), ("wf-newer", "p1")]
+        mock_wf.execute_activity.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolved_orders_only_queries_uncached_ids(self):
+        # When a new request joins an already-resolved set, only the new id is
+        # looked up.
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._resolved_orders = {
+            "wf-older": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+        wf._pending_requests = [
+            PendingRequest("wf-older", "codex_cli", priority=0),
+            PendingRequest("wf-newer", "codex_cli", priority=0),
+        ]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(
+                return_value={
+                    "orders": {
+                        "wf-newer": {"scheduled_for": "2026-06-22T10:05:00+00:00"}
+                    }
+                }
+            )
+            ordered = await wf._order_pending_requests_by_schedule()
+
+        args, _ = mock_wf.execute_activity.call_args
+        assert args[1]["workflow_ids"] == ["wf-newer"]
+        assert [req.requester_workflow_id for req in ordered] == [
+            "wf-older",
+            "wf-newer",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_resolved_orders_cache_drops_stale_ids(self):
+        # Cached entries for requests that are no longer pending are pruned so
+        # the cache stays bounded for this long-lived workflow.
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._resolved_orders = {
+            "wf-gone": {"scheduled_for": "2026-06-22T09:00:00+00:00"},
+            "wf-here": {"scheduled_for": "2026-06-22T10:00:00+00:00"},
+        }
+        wf._pending_requests = [
+            PendingRequest("wf-here", "codex_cli", priority=0),
+        ]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = datetime(2026, 6, 22, tzinfo=timezone.utc)
+            mock_wf.patched.side_effect = lambda patch_id: (
+                patch_id in self._drain_patches(scheduled=True)
+            )
+            mock_wf.execute_activity = AsyncMock(return_value={"orders": {}})
+            await wf._order_pending_requests_by_schedule()
+
+        # Nothing new to look up, and the stale id was dropped.
+        mock_wf.execute_activity.assert_not_awaited()
+        assert set(wf._resolved_orders) == {"wf-here"}
+
+    @pytest.mark.asyncio
     async def test_acquire_slot_update_reserves_without_callback_signal(self):
         wf = self._make_workflow()
         wf._runtime_id = "pentestgpt"


### PR DESCRIPTION
## Issue

[MM-869](https://moonladder.atlassian.net/browse/MM-869) — Provider Slot Queue: make the provider-profile slot queue honor existing scheduled workflow order for equal-priority runs.

## Summary

Adds a scheduled-order tie-breaker to `ProviderProfileManager` slot assignment so that equal-priority queued workflows acquire provider-profile slots in their existing scheduled queue order instead of signal-arrival order.

- New `provider_profile.pending_request_order` activity resolves `scheduled_for`/`created_at` for a bounded list of workflow ids from the canonical execution projection (`temporal_executions`), returning compact UTC ISO-8601 timestamps and no other execution data.
- The manager passes `lease_group_id` (parent/root workflow) when present, else `requester_workflow_id`, as the ordering-lookup key.
- New drain ordering is gated behind `SCHEDULED_PENDING_REQUESTS_PATCH` (`provider-profile-manager-scheduled-pending-requests-v1`) so in-flight Temporal histories keep replaying prior behavior while new histories use scheduled order.
- Pending requests are sorted by priority DESC, `scheduled_for` ASC, `created_at` ASC, queue-order key ASC, `requester_workflow_id` ASC. Explicit priority still wins; deterministic final fallback by workflow/requester id.
- On ordering-activity failure, the manager logs context and falls back to the existing deterministic queue-order sort, so slot assignment is never blocked.
- No new durable queue-order database column is introduced.

Touched: `moonmind/workflows/temporal/workflows/provider_profile_manager.py`, `moonmind/workflows/temporal/activity_catalog.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/temporal/artifacts.py`, and the corresponding unit tests.

## Tests run

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_provider_profile_manager.py` — 100 passed (covers equal-priority scheduled order, priority-wins, created-at fallback, deterministic final fallback by workflow id, activity-failure fallback, `lease_group_id` primary lookup, and Temporal patch gating).
- Frontend unit suite (run as part of `test_unit.sh`): 464 passed, 236 skipped.

## Remaining risks

- The ordering-lookup activity reads the `temporal_executions` projection; if projection rows are delayed or missing for a workflow, that request falls back to the far-future ordering sentinel for this drain cycle (deterministic, non-blocking, but may briefly order such a workflow last among equal-priority peers).
- New ordering is gated behind `SCHEDULED_PENDING_REQUESTS_PATCH`; correct replay of long-lived in-flight `ProviderProfileManager` histories depends on the patch marker remaining in place until those histories drain.


[MM-869]: https://moonladder.atlassian.net/browse/MM-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ