### PR TITLE
MM-870 Managed Session Docker Cleanup

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1018,6 +1018,27 @@ async def ensure_provider_profile_managers_started():
     except Exception as e:
         logger.error(f"Error ensuring ProviderProfileManager workflows: {e}", exc_info=True)
 
+async def ensure_managed_session_reconcile_schedule_started() -> None:
+    """Best-effort startup install for the managed-session reconcile schedule."""
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    try:
+        schedule_id = (
+            await TemporalClientAdapter().ensure_managed_session_reconcile_schedule(
+                enabled=True
+            )
+        )
+    except Exception:
+        logger.warning(
+            "Failed to ensure managed session reconcile schedule during API startup",
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "Ensured managed session reconcile schedule during API startup: %s",
+        schedule_id,
+    )
+
 def _register_settings_change_subscribers() -> None:
     """Wire the default SettingsChangePublisher subscribers once per process.
 
@@ -1185,6 +1206,7 @@ async def startup_event():
 
     # Wait for the Temporal client to be available and initialize provider profile managers
     await ensure_provider_profile_managers_started()
+    await ensure_managed_session_reconcile_schedule_started()
     logger.info("Application startup events completed.")
 
 def teardown_providers():

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8204,6 +8204,10 @@ class TemporalAgentRuntimeActivities:
         # fail the reconcile activity, whose reattach/degrade work is primary.
         orphan_containers_reaped = 0
         orphan_reap_skipped_recent = 0
+        orphan_volumes_scanned = 0
+        orphan_volumes_reaped = 0
+        orphan_volume_reap_skipped_active = 0
+        orphan_volume_reap_skipped_recent = 0
         orphan_session_ids_reaped: list[str] = []
         try:
             reap_result = await _await_with_activity_heartbeats(
@@ -8224,6 +8228,18 @@ class TemporalAgentRuntimeActivities:
             orphan_reap_skipped_recent = int(
                 getattr(reap_result, "skipped_recent", 0) or 0
             )
+            orphan_volumes_scanned = int(
+                getattr(reap_result, "scanned_volumes", 0) or 0
+            )
+            orphan_volumes_reaped = int(
+                getattr(reap_result, "reaped_volumes", 0) or 0
+            )
+            orphan_volume_reap_skipped_active = int(
+                getattr(reap_result, "skipped_active_volumes", 0) or 0
+            )
+            orphan_volume_reap_skipped_recent = int(
+                getattr(reap_result, "skipped_recent_volumes", 0) or 0
+            )
             orphan_session_ids_reaped = list(
                 getattr(reap_result, "reaped_session_ids", ()) or ()
             )[:session_id_limit]
@@ -8236,6 +8252,10 @@ class TemporalAgentRuntimeActivities:
             "orphanContainersReaped": orphan_containers_reaped,
             "orphanSessionIdsReaped": orphan_session_ids_reaped,
             "orphanReapSkippedRecent": orphan_reap_skipped_recent,
+            "orphanVolumesScanned": orphan_volumes_scanned,
+            "orphanVolumesReaped": orphan_volumes_reaped,
+            "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,
+            "orphanVolumeReapSkippedRecent": orphan_volume_reap_skipped_recent,
         }
 
     @staticmethod

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -3625,42 +3625,55 @@ class DockerCodexManagedSessionController:
         ]
         if not volume_names:
             return []
-        template = (
-            '{{printf "%s|%s|%s|%s|%s" .Name '
-            '(index .Labels "moonmind.session_id") '
-            '(index .Labels "moonmind.volume_role") '
-            '(index .Labels "moonmind.kind") '
-            ".CreatedAt}}"
-        )
-        # Tolerate partial inspect failures. Legacy deterministic-name volumes
-        # remain discoverable from the volume ls output even if labels are absent.
-        _inspect_rc, inspect_out, _inspect_err = await self._command_runner(
+        inspect_rc, inspect_out, inspect_err = await self._command_runner(
             (
                 self._docker_binary,
                 "volume",
                 "inspect",
-                "--format",
-                template,
                 *volume_names,
             ),
             env=self._docker_env(),
         )
-        inspected: dict[str, _ManagedSessionSidecarVolume] = {}
-        for line in inspect_out.splitlines():
-            parts = line.split("|")
-            if len(parts) != 5:
-                continue
-            name, session_id, role, kind, created_raw = (
-                self._docker_template_empty(part) for part in parts
+        if inspect_rc != 0:
+            details = (
+                inspect_err.strip()
+                or inspect_out.strip()
+                or f"exit code {inspect_rc}"
             )
+            raise RuntimeError(
+                f"failed to inspect managed session sidecar volumes: {details}"
+            )
+
+        inspected: dict[str, _ManagedSessionSidecarVolume] = {}
+        try:
+            volume_inspect_items = json.loads(inspect_out) if inspect_out.strip() else []
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                "failed to parse managed session sidecar volume inspect output"
+            ) from exc
+        if not isinstance(volume_inspect_items, list):
+            raise RuntimeError(
+                "failed to inspect managed session sidecar volumes: expected JSON list"
+            )
+
+        for item in volume_inspect_items:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("Name")
             if not name or name not in volume_names:
                 continue
+            labels = item.get("Labels") or {}
+            if not isinstance(labels, dict):
+                labels = {}
             inspected[name] = _ManagedSessionSidecarVolume(
                 name=name,
-                session_id=session_id,
-                role=role or self._sidecar_volume_role_from_name(name),
-                kind=kind,
-                created_at=_parse_docker_timestamp(created_raw),
+                session_id=str(labels.get("moonmind.session_id") or ""),
+                role=str(
+                    labels.get("moonmind.volume_role")
+                    or self._sidecar_volume_role_from_name(name)
+                ),
+                kind=str(labels.get("moonmind.kind") or ""),
+                created_at=_parse_docker_timestamp(str(item.get("CreatedAt") or "")),
             )
 
         volumes: list[_ManagedSessionSidecarVolume] = []
@@ -3693,7 +3706,7 @@ class DockerCodexManagedSessionController:
         template = (
             '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}'
         )
-        _inspect_rc, inspect_out, _inspect_err = await self._command_runner(
+        inspect_rc, inspect_out, inspect_err = await self._command_runner(
             (
                 self._docker_binary,
                 "inspect",
@@ -3703,6 +3716,13 @@ class DockerCodexManagedSessionController:
             ),
             env=self._docker_env(),
         )
+        if inspect_rc != 0:
+            details = (
+                inspect_err.strip()
+                or inspect_out.strip()
+                or f"exit code {inspect_rc}"
+            )
+            raise RuntimeError(f"failed to inspect active docker containers: {details}")
         return {line.strip() for line in inspect_out.splitlines() if line.strip()}
 
     def _active_sidecar_volume_names(self, active_session_ids: set[str]) -> set[str]:
@@ -3739,10 +3759,10 @@ class DockerCodexManagedSessionController:
             ):
                 skipped_active += 1
                 continue
-            if (
-                volume.created_at is not None
-                and (now - volume.created_at).total_seconds() < grace_seconds
-            ):
+            if volume.created_at is None:
+                skipped_recent += 1
+                continue
+            if (now - volume.created_at).total_seconds() < grace_seconds:
                 skipped_recent += 1
                 continue
             try:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -89,6 +89,10 @@ _SESSION_DOCKER_MODE_DISABLED_VALUES = {"no-docker", "disabled", "none", "off"}
 # (mid-launch) or that is being relaunched.
 _DEFAULT_SESSION_REAP_GRACE_SECONDS = 900.0
 _MANAGED_SESSION_LABEL_KEY = "moonmind.session_id"
+_MANAGED_SESSION_SIDECAR_VOLUME_KIND = "session-docker-sidecar-volume"
+_MANAGED_SESSION_SIDECAR_VOLUME_NAME = re.compile(
+    r"^moonmind-session-.+-docker-(graph|socket)$"
+)
 _FALSEY_ENV_VALUES = {"0", "false", "no", "off", ""}
 logger = logging.getLogger(__name__)
 
@@ -104,6 +108,17 @@ class _ManagedSessionContainer:
 
 
 @dataclass(frozen=True)
+class _ManagedSessionSidecarVolume:
+    """A docker volume created for a managed-session docker sidecar."""
+
+    name: str
+    session_id: str
+    role: str
+    kind: str
+    created_at: datetime | None
+
+
+@dataclass(frozen=True)
 class ManagedSessionReapResult:
     """Outcome of one orphaned managed-session container sweep."""
 
@@ -112,6 +127,10 @@ class ManagedSessionReapResult:
     reaped_containers: int = 0
     skipped_active: int = 0
     skipped_recent: int = 0
+    scanned_volumes: int = 0
+    reaped_volumes: int = 0
+    skipped_active_volumes: int = 0
+    skipped_recent_volumes: int = 0
     disabled: bool = False
 
 
@@ -509,15 +528,42 @@ class DockerCodexManagedSessionController:
         tag = last_segment.rsplit(":", 1)[-1].strip().lower()
         return bool(tag) and tag != "latest"
 
-    async def _create_volume(self, volume_name: str) -> None:
-        await self._run((self._docker_binary, "volume", "create", volume_name))
+    @staticmethod
+    def _sidecar_volume_labels(
+        *,
+        session_id: str,
+        role: str,
+        agent_run_id: str,
+        session_epoch: int,
+    ) -> dict[str, str]:
+        return {
+            "moonmind.session_id": session_id,
+            "moonmind.kind": _MANAGED_SESSION_SIDECAR_VOLUME_KIND,
+            "moonmind.volume_role": role,
+            "moonmind.agent_run_id": agent_run_id,
+            "moonmind.session_epoch": str(session_epoch),
+        }
 
-    async def _remove_volume(self, volume_name: str, *, ignore_failure: bool) -> None:
+    async def _create_volume(
+        self,
+        volume_name: str,
+        *,
+        labels: Mapping[str, str] | None = None,
+    ) -> None:
+        command: list[str] = [self._docker_binary, "volume", "create"]
+        for key, value in (labels or {}).items():
+            command.extend(["--label", f"{key}={value}"])
+        command.append(volume_name)
+        await self._run(tuple(command))
+
+    async def _remove_volume(self, volume_name: str, *, ignore_failure: bool) -> bool:
         try:
             await self._run((self._docker_binary, "volume", "rm", "-f", volume_name))
+            return True
         except RuntimeError:
             if not ignore_failure:
                 raise
+            return False
 
     async def _cleanup_docker_sidecar_resources(
         self,
@@ -558,8 +604,24 @@ class DockerCodexManagedSessionController:
         sidecar_name = self._sidecar_container_name(session_id)
         socket_volume = self._sidecar_socket_volume_name(session_id)
         graph_volume = self._sidecar_graph_volume_name(session_id)
-        await self._create_volume(socket_volume)
-        await self._create_volume(graph_volume)
+        await self._create_volume(
+            socket_volume,
+            labels=self._sidecar_volume_labels(
+                session_id=session_id,
+                role="docker-socket",
+                agent_run_id=agent_run_id,
+                session_epoch=session_epoch,
+            ),
+        )
+        await self._create_volume(
+            graph_volume,
+            labels=self._sidecar_volume_labels(
+                session_id=session_id,
+                role="docker-graph",
+                agent_run_id=agent_run_id,
+                session_epoch=session_epoch,
+            ),
+        )
         command = [
             self._docker_binary,
             "run",
@@ -604,8 +666,19 @@ class DockerCodexManagedSessionController:
         await self._wait_docker_sidecar_ready(sidecar_id)
         return sidecar_id
 
-    async def _prepare_docker_sidecar_socket_volume(self, session_id: str) -> None:
-        await self._create_volume(self._sidecar_socket_volume_name(session_id))
+    async def _prepare_docker_sidecar_socket_volume(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> None:
+        await self._create_volume(
+            self._sidecar_socket_volume_name(request.session_id),
+            labels=self._sidecar_volume_labels(
+                session_id=request.session_id,
+                role="docker-socket",
+                agent_run_id=request.agent_run_id,
+                session_epoch=request.session_epoch,
+            ),
+        )
 
     def _session_docker_config_path(
         self,
@@ -2595,7 +2668,7 @@ class DockerCodexManagedSessionController:
                 request.session_id,
                 ignore_failure=True,
             )
-            await self._prepare_docker_sidecar_socket_volume(request.session_id)
+            await self._prepare_docker_sidecar_socket_volume(request)
         run_command = [
             self._docker_binary,
             "run",
@@ -3508,6 +3581,188 @@ class DockerCodexManagedSessionController:
             )
         return containers
 
+    @staticmethod
+    def _is_managed_session_sidecar_volume_name(volume_name: str) -> bool:
+        return bool(_MANAGED_SESSION_SIDECAR_VOLUME_NAME.match(volume_name))
+
+    @staticmethod
+    def _sidecar_volume_role_from_name(volume_name: str) -> str:
+        if volume_name.endswith("-docker-graph"):
+            return "docker-graph"
+        if volume_name.endswith("-docker-socket"):
+            return "docker-socket"
+        return ""
+
+    @staticmethod
+    def _docker_template_empty(value: str) -> str:
+        normalized = str(value or "").strip()
+        if normalized in {"<no value>", "<nil>", "nil", "None"}:
+            return ""
+        return normalized
+
+    async def _list_managed_session_sidecar_volumes(
+        self,
+    ) -> list[_ManagedSessionSidecarVolume]:
+        returncode, stdout, stderr = await self._command_runner(
+            (
+                self._docker_binary,
+                "volume",
+                "ls",
+                "--format",
+                "{{.Name}}",
+            ),
+            env=self._docker_env(),
+        )
+        if returncode != 0:
+            details = stderr.strip() or stdout.strip() or f"exit code {returncode}"
+            raise RuntimeError(
+                f"failed to list managed session sidecar volumes: {details}"
+            )
+        volume_names = [
+            line.strip()
+            for line in stdout.splitlines()
+            if self._is_managed_session_sidecar_volume_name(line.strip())
+        ]
+        if not volume_names:
+            return []
+        template = (
+            '{{printf "%s|%s|%s|%s|%s" .Name '
+            '(index .Labels "moonmind.session_id") '
+            '(index .Labels "moonmind.volume_role") '
+            '(index .Labels "moonmind.kind") '
+            ".CreatedAt}}"
+        )
+        # Tolerate partial inspect failures. Legacy deterministic-name volumes
+        # remain discoverable from the volume ls output even if labels are absent.
+        _inspect_rc, inspect_out, _inspect_err = await self._command_runner(
+            (
+                self._docker_binary,
+                "volume",
+                "inspect",
+                "--format",
+                template,
+                *volume_names,
+            ),
+            env=self._docker_env(),
+        )
+        inspected: dict[str, _ManagedSessionSidecarVolume] = {}
+        for line in inspect_out.splitlines():
+            parts = line.split("|")
+            if len(parts) != 5:
+                continue
+            name, session_id, role, kind, created_raw = (
+                self._docker_template_empty(part) for part in parts
+            )
+            if not name or name not in volume_names:
+                continue
+            inspected[name] = _ManagedSessionSidecarVolume(
+                name=name,
+                session_id=session_id,
+                role=role or self._sidecar_volume_role_from_name(name),
+                kind=kind,
+                created_at=_parse_docker_timestamp(created_raw),
+            )
+
+        volumes: list[_ManagedSessionSidecarVolume] = []
+        for name in volume_names:
+            volumes.append(
+                inspected.get(
+                    name,
+                    _ManagedSessionSidecarVolume(
+                        name=name,
+                        session_id="",
+                        role=self._sidecar_volume_role_from_name(name),
+                        kind="",
+                        created_at=None,
+                    ),
+                )
+            )
+        return volumes
+
+    async def _list_active_docker_volume_mounts(self) -> set[str]:
+        returncode, stdout, stderr = await self._command_runner(
+            (self._docker_binary, "ps", "-q"),
+            env=self._docker_env(),
+        )
+        if returncode != 0:
+            details = stderr.strip() or stdout.strip() or f"exit code {returncode}"
+            raise RuntimeError(f"failed to list active docker containers: {details}")
+        container_ids = [line.strip() for line in stdout.splitlines() if line.strip()]
+        if not container_ids:
+            return set()
+        template = (
+            '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}'
+        )
+        _inspect_rc, inspect_out, _inspect_err = await self._command_runner(
+            (
+                self._docker_binary,
+                "inspect",
+                "--format",
+                template,
+                *container_ids,
+            ),
+            env=self._docker_env(),
+        )
+        return {line.strip() for line in inspect_out.splitlines() if line.strip()}
+
+    def _active_sidecar_volume_names(self, active_session_ids: set[str]) -> set[str]:
+        names: set[str] = set()
+        for session_id in active_session_ids:
+            names.add(self._sidecar_graph_volume_name(session_id))
+            names.add(self._sidecar_socket_volume_name(session_id))
+        return names
+
+    async def _reap_orphan_sidecar_volumes(
+        self,
+        *,
+        active_session_ids: set[str],
+        grace_seconds: float,
+        now: datetime,
+    ) -> tuple[int, int, int, int]:
+        volumes = await self._list_managed_session_sidecar_volumes()
+        if not volumes:
+            return (0, 0, 0, 0)
+        active_mounts = await self._list_active_docker_volume_mounts()
+        active_volume_names = self._active_sidecar_volume_names(active_session_ids)
+
+        reaped_volumes = 0
+        skipped_active = 0
+        skipped_recent = 0
+        for volume in volumes:
+            if (
+                volume.name in active_mounts
+                or volume.name in active_volume_names
+                or (
+                    volume.session_id
+                    and volume.session_id in active_session_ids
+                )
+            ):
+                skipped_active += 1
+                continue
+            if (
+                volume.created_at is not None
+                and (now - volume.created_at).total_seconds() < grace_seconds
+            ):
+                skipped_recent += 1
+                continue
+            try:
+                removed = await self._remove_volume(volume.name, ignore_failure=True)
+            except Exception:
+                logger.warning(
+                    "Failed to reap orphaned managed session sidecar volume %s",
+                    volume.name,
+                    exc_info=True,
+                )
+                continue
+            if not removed:
+                continue
+            reaped_volumes += 1
+            logger.info(
+                "Reaped orphaned managed session sidecar volume %s",
+                volume.name,
+            )
+        return (len(volumes), reaped_volumes, skipped_active, skipped_recent)
+
     async def reap_orphan_session_containers(self) -> ManagedSessionReapResult:
         """Remove managed-session containers that no longer back a live session.
 
@@ -3527,16 +3782,13 @@ class DockerCodexManagedSessionController:
             # so refuse to remove anything rather than guess.
             return ManagedSessionReapResult(disabled=True)
 
-        containers = await self._list_managed_session_containers()
-        if not containers:
-            return ManagedSessionReapResult()
-
         active_session_ids = {
             record.session_id for record in self._session_store.list_active()
         }
         grace_seconds = self._reap_grace_seconds()
         now = datetime.now(tz=UTC)
 
+        containers = await self._list_managed_session_containers()
         by_session: dict[str, list[_ManagedSessionContainer]] = {}
         for container in containers:
             by_session.setdefault(container.session_id, []).append(container)
@@ -3581,10 +3833,25 @@ class DockerCodexManagedSessionController:
                     session_id,
                 )
 
+        (
+            scanned_volumes,
+            reaped_volumes,
+            skipped_active_volumes,
+            skipped_recent_volumes,
+        ) = await self._reap_orphan_sidecar_volumes(
+            active_session_ids=active_session_ids,
+            grace_seconds=grace_seconds,
+            now=now,
+        )
+
         return ManagedSessionReapResult(
             scanned_containers=len(containers),
             reaped_session_ids=tuple(reaped_session_ids),
             reaped_containers=reaped_containers,
             skipped_active=skipped_active,
             skipped_recent=skipped_recent,
+            scanned_volumes=scanned_volumes,
+            reaped_volumes=reaped_volumes,
+            skipped_active_volumes=skipped_active_volumes,
+            skipped_recent_volumes=skipped_recent_volumes,
         )

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2156,6 +2156,25 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                     "Reconciled %d managed session records during startup",
                     len(session_reconciled),
                 )
+            try:
+                reap_result = await session_controller.reap_orphan_session_containers()
+            except Exception:
+                logger.warning(
+                    "Managed session orphan sweep failed during agent_runtime startup",
+                    exc_info=True,
+                )
+            else:
+                reaped_containers = int(
+                    getattr(reap_result, "reaped_containers", 0) or 0
+                )
+                reaped_volumes = int(getattr(reap_result, "reaped_volumes", 0) or 0)
+                if reaped_containers or reaped_volumes:
+                    logger.info(
+                        "Reaped managed session orphans during startup: "
+                        "%d container(s), %d volume(s)",
+                        reaped_containers,
+                        reaped_volumes,
+                    )
             agent_runtime_activities = TemporalAgentRuntimeActivities(
                 artifact_service=artifact_service,
                 run_store=run_store,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -8605,14 +8605,24 @@ def test_get_execution_steps_returns_503_for_slow_temporal_query(
         "live_query_timeout_seconds",
         0.01,
     )
+    observed_timeouts: list[float] = []
 
-    with TestClient(app) as test_client:
-        started = time.perf_counter()
+    async def fail_fast_timeout(awaitable, *, timeout: float):
+        observed_timeouts.append(timeout)
+        awaitable.close()
+        raise TimeoutError
+
+    with (
+        patch(
+            "api_service.api.routers.executions.asyncio.wait_for",
+            side_effect=fail_fast_timeout,
+        ),
+        TestClient(app) as test_client,
+    ):
         response = test_client.get("/api/executions/mm:wf-1/steps")
-        elapsed = time.perf_counter() - started
 
     assert response.status_code == 503
-    assert elapsed < 0.15
+    assert observed_timeouts == [0.01]
     assert response.json()["detail"]["code"] == "temporal_unavailable"
 
 def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query_times_out(

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from api_service import main as api_main
+
+
+@pytest.mark.asyncio
+async def test_mm870_api_startup_ensures_managed_session_reconcile_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+
+    class _Adapter:
+        async def ensure_managed_session_reconcile_schedule(
+            self,
+            *,
+            enabled: bool,
+        ) -> str:
+            calls.append(enabled)
+            return "mm-operational:managed-session-reconcile"
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        _Adapter,
+    )
+
+    await api_main.ensure_managed_session_reconcile_schedule_started()
+
+    assert calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_mm870_api_startup_schedule_failure_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _Adapter:
+        async def ensure_managed_session_reconcile_schedule(
+            self,
+            *,
+            enabled: bool,
+        ) -> str:
+            del enabled
+            raise RuntimeError("temporal unavailable")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        _Adapter,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await api_main.ensure_managed_session_reconcile_schedule_started()
+
+    assert "Failed to ensure managed session reconcile schedule" in caplog.text

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4893,22 +4893,53 @@ async def test_mm870_controller_reaps_orphan_sidecar_volumes_and_skips_boundarie
             return 0, "", ""
         if command[:4] == ("docker", "volume", "ls", "--format"):
             return 0, "\n".join([*volume_names, "unrelated-volume"]) + "\n", ""
-        if command[:4] == ("docker", "volume", "inspect", "--format"):
+        if command[:3] == ("docker", "volume", "inspect"):
             return (
                 0,
-                "moonmind-session-sess-active-docker-graph|sess-active|"
-                "docker-graph|session-docker-sidecar-volume|"
-                "2020-01-01T00:00:00Z\n"
-                "moonmind-session-sess-mounted-docker-socket|sess-mounted|"
-                "docker-socket|session-docker-sidecar-volume|"
-                "2020-01-01T00:00:00Z\n"
-                "moonmind-session-sess-orphan-docker-graph|sess-orphan|"
-                "docker-graph|session-docker-sidecar-volume|"
-                "2020-01-01T00:00:00Z\n"
-                "moonmind-session-legacy-orphan-docker-socket|<no value>|"
-                "<no value>|<no value>|2020-01-01T00:00:00Z\n"
-                f"moonmind-session-sess-recent-docker-graph|sess-recent|"
-                f"docker-graph|session-docker-sidecar-volume|{recent}\n",
+                json.dumps(
+                    [
+                        {
+                            "Name": "moonmind-session-sess-active-docker-graph",
+                            "CreatedAt": "2020-01-01T00:00:00Z",
+                            "Labels": {
+                                "moonmind.session_id": "sess-active",
+                                "moonmind.volume_role": "docker-graph",
+                                "moonmind.kind": "session-docker-sidecar-volume",
+                            },
+                        },
+                        {
+                            "Name": "moonmind-session-sess-mounted-docker-socket",
+                            "CreatedAt": "2020-01-01T00:00:00Z",
+                            "Labels": {
+                                "moonmind.session_id": "sess-mounted",
+                                "moonmind.volume_role": "docker-socket",
+                                "moonmind.kind": "session-docker-sidecar-volume",
+                            },
+                        },
+                        {
+                            "Name": "moonmind-session-sess-orphan-docker-graph",
+                            "CreatedAt": "2020-01-01T00:00:00Z",
+                            "Labels": {
+                                "moonmind.session_id": "sess-orphan",
+                                "moonmind.volume_role": "docker-graph",
+                                "moonmind.kind": "session-docker-sidecar-volume",
+                            },
+                        },
+                        {
+                            "Name": "moonmind-session-legacy-orphan-docker-socket",
+                            "CreatedAt": "2020-01-01T00:00:00Z",
+                        },
+                        {
+                            "Name": "moonmind-session-sess-recent-docker-graph",
+                            "CreatedAt": recent,
+                            "Labels": {
+                                "moonmind.session_id": "sess-recent",
+                                "moonmind.volume_role": "docker-graph",
+                                "moonmind.kind": "session-docker-sidecar-volume",
+                            },
+                        },
+                    ]
+                ),
                 "",
             )
         if command == ("docker", "ps", "-q"):

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -448,7 +448,7 @@ async def test_mm866_docker_enabled_session_launches_agent_with_sidecar(
         if command[:4] == ("docker", "volume", "rm", "-f"):
             return 0, "", ""
         if command[:3] == ("docker", "volume", "create"):
-            return 0, command[3] + "\n", ""
+            return 0, command[-1] + "\n", ""
         if command[:2] == ("docker", "run"):
             name = command[command.index("--name") + 1]
             if name.endswith("-docker"):
@@ -485,18 +485,29 @@ async def test_mm866_docker_enabled_session_launches_agent_with_sidecar(
     handle = await controller.launch_session(request)
 
     assert handle.session_state.container_id == "agent-ctr"
-    assert (
-        "docker",
-        "volume",
-        "create",
+    volume_create_commands = [
+        command for command in commands if command[:3] == ("docker", "volume", "create")
+    ]
+    assert {command[-1] for command in volume_create_commands} == {
         "moonmind-session-sess-1-docker-socket",
-    ) in commands
-    assert (
-        "docker",
-        "volume",
-        "create",
         "moonmind-session-sess-1-docker-graph",
-    ) in commands
+    }
+    for command in volume_create_commands:
+        labels = {
+            command[index + 1]
+            for index, value in enumerate(command)
+            if value == "--label"
+        }
+        role = (
+            "docker-socket"
+            if command[-1].endswith("-docker-socket")
+            else "docker-graph"
+        )
+        assert "moonmind.session_id=sess-1" in labels
+        assert "moonmind.kind=session-docker-sidecar-volume" in labels
+        assert f"moonmind.volume_role={role}" in labels
+        assert "moonmind.agent_run_id=task-1" in labels
+        assert "moonmind.session_epoch=1" in labels
     assert any(
         command[:2] == ("docker", "run")
         and "moonmind-session-sess-1-docker" in command
@@ -800,7 +811,7 @@ async def test_mm866_ensure_docker_sidecar_starts_sidecar_on_demand(
             if target == "moonmind-session-sess-1-docker":
                 return 1, "", "No such container"
         if command[:3] == ("docker", "volume", "create"):
-            return 0, command[3] + "\n", ""
+            return 0, command[-1] + "\n", ""
         if command[:2] == ("docker", "run"):
             return 0, "sidecar-ctr\n", ""
         if command[:3] == ("docker", "exec", "-e"):
@@ -1215,7 +1226,7 @@ async def test_mm784_request_unrestricted_mode_uses_sidecar_policy(
         if command[:3] == ("docker", "volume", "rm"):
             return 1, "", "No such volume"
         if command[:3] == ("docker", "volume", "create"):
-            return 0, command[3] + "\n", ""
+            return 0, command[-1] + "\n", ""
         if command[:2] == ("docker", "run"):
             name = command[command.index("--name") + 1]
             if name.endswith("-docker"):
@@ -1300,7 +1311,7 @@ async def test_mm784_env_unrestricted_mode_uses_sidecar_policy(
         if command[:3] == ("docker", "volume", "rm"):
             return 1, "", "No such volume"
         if command[:3] == ("docker", "volume", "create"):
-            return 0, command[3] + "\n", ""
+            return 0, command[-1] + "\n", ""
         if command[:2] == ("docker", "run"):
             name = command[command.index("--name") + 1]
             if name.endswith("-docker"):
@@ -4772,6 +4783,8 @@ async def test_controller_reaps_orphan_session_containers_and_skips_active(
             return 0, "", ""
         if command[:4] == ("docker", "volume", "rm", "-f"):
             return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
         raise AssertionError(f"unexpected command: {command}")
 
     controller = DockerCodexManagedSessionController(
@@ -4825,6 +4838,8 @@ async def test_controller_reap_skips_orphans_within_grace_window(
             return 0, "c-new\n", ""
         if command[:3] == ("docker", "inspect", "--format"):
             return 0, f"c-new|sess-new|managed-session|{recent}\n", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
         raise AssertionError(f"unexpected command: {command}")
 
     controller = DockerCodexManagedSessionController(
@@ -4841,6 +4856,91 @@ async def test_controller_reap_skips_orphans_within_grace_window(
     assert result.reaped_containers == 0
     assert result.reaped_session_ids == ()
     assert not any(cmd[:3] == ("docker", "rm", "-f") for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_mm870_controller_reaps_orphan_sidecar_volumes_and_skips_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(_reap_active_record("sess-active"))
+    recent = datetime.now(tz=UTC).isoformat()
+    volume_names = [
+        "moonmind-session-sess-active-docker-graph",
+        "moonmind-session-sess-mounted-docker-socket",
+        "moonmind-session-sess-orphan-docker-graph",
+        "moonmind-session-legacy-orphan-docker-socket",
+        "moonmind-session-sess-recent-docker-graph",
+    ]
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:4] == (
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+        ):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "\n".join([*volume_names, "unrelated-volume"]) + "\n", ""
+        if command[:4] == ("docker", "volume", "inspect", "--format"):
+            return (
+                0,
+                "moonmind-session-sess-active-docker-graph|sess-active|"
+                "docker-graph|session-docker-sidecar-volume|"
+                "2020-01-01T00:00:00Z\n"
+                "moonmind-session-sess-mounted-docker-socket|sess-mounted|"
+                "docker-socket|session-docker-sidecar-volume|"
+                "2020-01-01T00:00:00Z\n"
+                "moonmind-session-sess-orphan-docker-graph|sess-orphan|"
+                "docker-graph|session-docker-sidecar-volume|"
+                "2020-01-01T00:00:00Z\n"
+                "moonmind-session-legacy-orphan-docker-socket|<no value>|"
+                "<no value>|<no value>|2020-01-01T00:00:00Z\n"
+                f"moonmind-session-sess-recent-docker-graph|sess-recent|"
+                f"docker-graph|session-docker-sidecar-volume|{recent}\n",
+                "",
+            )
+        if command == ("docker", "ps", "-q"):
+            return 0, "running-1\n", ""
+        if command[:3] == ("docker", "inspect", "--format"):
+            return 0, "moonmind-session-sess-mounted-docker-socket\n", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert result.scanned_containers == 0
+    assert result.scanned_volumes == 5
+    assert result.reaped_volumes == 2
+    assert result.skipped_active_volumes == 2
+    assert result.skipped_recent_volumes == 1
+    removed = {
+        cmd[-1] for cmd in commands if cmd[:4] == ("docker", "volume", "rm", "-f")
+    }
+    assert removed == {
+        "moonmind-session-sess-orphan-docker-graph",
+        "moonmind-session-legacy-orphan-docker-socket",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5172,6 +5172,10 @@ async def test_agent_runtime_reconcile_managed_sessions_returns_bounded_summary(
                 reaped_containers=2,
                 skipped_active=1,
                 skipped_recent=1,
+                scanned_volumes=5,
+                reaped_volumes=3,
+                skipped_active_volumes=1,
+                skipped_recent_volumes=1,
             )
 
     activities = TemporalAgentRuntimeActivities(session_controller=_Controller())
@@ -5190,6 +5194,10 @@ async def test_agent_runtime_reconcile_managed_sessions_returns_bounded_summary(
         "orphanContainersReaped": 2,
         "orphanSessionIdsReaped": ["sess-orphaned-container"],
         "orphanReapSkippedRecent": 1,
+        "orphanVolumesScanned": 5,
+        "orphanVolumesReaped": 3,
+        "orphanVolumeReapSkippedActive": 1,
+        "orphanVolumeReapSkippedRecent": 1,
     }
 
 
@@ -5210,6 +5218,8 @@ async def test_agent_runtime_reconcile_orphan_reap_failure_is_best_effort() -> N
     assert result["orphanContainersReaped"] == 0
     assert result["orphanSessionIdsReaped"] == []
     assert result["orphanReapSkippedRecent"] == 0
+    assert result["orphanVolumesScanned"] == 0
+    assert result["orphanVolumesReaped"] == 0
 
 @pytest.mark.asyncio
 async def test_agent_runtime_reconcile_managed_sessions_uses_bounded_heartbeating(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3560,6 +3560,9 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     run_launcher = MagicMock()
     session_controller = MagicMock()
     session_controller.reconcile = AsyncMock(return_value=[])
+    session_controller.reap_orphan_session_containers = AsyncMock(
+        return_value=MagicMock()
+    )
     workload_registry = MagicMock()
     workload_launcher = MagicMock()
     mock_build_deps.return_value = (
@@ -3609,6 +3612,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     mock_build_deps.assert_not_called()
     run_supervisor.reconcile.assert_not_awaited()
     session_controller.reconcile.assert_not_awaited()
+    session_controller.reap_orphan_session_containers.assert_not_awaited()
     mock_dispatcher_cls.assert_called_once_with()
     deployment_handler_calls = [
         call
@@ -3702,6 +3706,9 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
     run_launcher = MagicMock()
     session_controller = MagicMock()
     session_controller.reconcile = AsyncMock(return_value=[])
+    session_controller.reap_orphan_session_containers = AsyncMock(
+        return_value=MagicMock()
+    )
     workload_registry = MagicMock()
     workload_launcher = MagicMock()
     mock_build_deps.return_value = (
@@ -3744,6 +3751,7 @@ async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agen
     mock_build_deps.assert_called_once_with(artifact_service=ANY)
     run_supervisor.reconcile.assert_awaited_once()
     session_controller.reconcile.assert_awaited_once()
+    session_controller.reap_orphan_session_containers.assert_awaited_once()
     deployment_handler_calls = [
         call
         for call in mock_dispatcher_cls.return_value.register_skill.call_args_list

--- a/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
+++ b/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
@@ -88,6 +88,10 @@ async def test_managed_session_reconcile_passes_orphan_reap_summary_through(
             "orphanContainersReaped": 4,
             "orphanSessionIdsReaped": ["sess-orphan-a", "sess-orphan-b"],
             "orphanReapSkippedRecent": 1,
+            "orphanVolumesScanned": 6,
+            "orphanVolumesReaped": 2,
+            "orphanVolumeReapSkippedActive": 3,
+            "orphanVolumeReapSkippedRecent": 1,
         }
 
     monkeypatch.setattr(
@@ -108,6 +112,10 @@ async def test_managed_session_reconcile_passes_orphan_reap_summary_through(
     assert result["orphanContainersReaped"] == 4
     assert result["orphanSessionIdsReaped"] == ["sess-orphan-a", "sess-orphan-b"]
     assert result["orphanReapSkippedRecent"] == 1
+    assert result["orphanVolumesScanned"] == 6
+    assert result["orphanVolumesReaped"] == 2
+    assert result["orphanVolumeReapSkippedActive"] == 3
+    assert result["orphanVolumeReapSkippedRecent"] == 1
     # Reaping orphans does not by itself mark the run degraded.
     assert search_attributes[-1] == {
         "SessionStatus": ["completed"],


### PR DESCRIPTION
Issue reference: MM-870 (https://moonladder.atlassian.net/browse/MM-870)

Summary:
- Ensures the managed-session reconcile schedule is installed best-effort during API startup without blocking startup failures.
- Labels managed-session Docker sidecar volumes and extends orphan reaping to cover labeled and legacy deterministic sidecar volumes.
- Runs a best-effort orphan sweep during agent-runtime worker startup and surfaces volume cleanup counts through reconcile activity/workflow results.
- Adds focused unit coverage for startup schedule wiring, sidecar volume labels, volume orphan safety boundaries, disabled/recent skips, and result visibility.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
  - Python: 6765 passed, 6 skipped, 1 xpassed, 16 subtests passed
  - UI: 29 files passed; 464 passed, 236 skipped

Remaining risks:
- Manual operational checks for the live Temporal schedule and Docker volume cleanup behavior still depend on a deployed environment with Docker and Temporal access.
