### PR TITLE
[codex] Fix pentest workflow envelope dispatch

### DIFF
--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -895,7 +895,7 @@ class TemporalPentestActivities:
                 dict(invocation_inputs) if isinstance(invocation_inputs, Mapping) else {}
             )
             for key in publication_keys | policy_keys:
-                if key in raw_payload and key not in request_payload:
+                if key in raw_payload:
                     request_payload[key] = raw_payload[key]
             context_payload = raw_payload.get("context")
             context = context_payload if isinstance(context_payload, Mapping) else {}
@@ -911,25 +911,23 @@ class TemporalPentestActivities:
                 or invocation_payload.get("id")
                 or ""
             ).strip()
-            if workflow_id:
-                request_payload["agent_run_id"] = workflow_id
-            if node_id:
-                request_payload["step_id"] = node_id
+            request_payload["agent_run_id"] = workflow_id
+            request_payload["step_id"] = node_id
             idempotency_key = str(raw_payload.get("idempotency_key") or "")
             execution_attempt_match = re.search(r":execution:(\d+):", idempotency_key)
-            if execution_attempt_match:
-                request_payload["attempt"] = int(execution_attempt_match.group(1))
-            else:
-                request_payload.setdefault("attempt", 1)
-            if raw_payload.get("principal"):
-                request_payload["principal_id"] = raw_payload["principal"]
-            if (
-                request_payload.get("agent_run_id")
-                and request_payload.get("step_id")
-            ):
+            request_payload["attempt"] = (
+                int(execution_attempt_match.group(1))
+                if execution_attempt_match
+                else 1
+            )
+            request_payload["principal_id"] = raw_payload.get("principal")
+            request_payload.pop("artifacts_dir", None)
+            if workflow_id and node_id:
+                workspace_root = Path(
+                    os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+                ).expanduser()
                 request_payload["artifacts_dir"] = (
-                    f"/work/agent_jobs/{request_payload['agent_run_id']}"
-                    f"/artifacts/{request_payload['step_id']}"
+                    str(workspace_root / workflow_id / "artifacts" / node_id)
                 )
             publication_source = request_payload
         else:

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -873,13 +873,6 @@ class TemporalPentestActivities:
         if self._workflow_docker_mode == "disabled":
             raise _docker_workflows_disabled_failure()
         raw_payload = dict(payload)
-        nested_request = raw_payload.get("request")
-        if nested_request is not None:
-            request_payload = dict(nested_request)
-            publication_source = request_payload
-        else:
-            request_payload = raw_payload
-            publication_source = raw_payload
         publication_keys = {
             "findings",
             "provider_snapshot_available",
@@ -891,6 +884,57 @@ class TemporalPentestActivities:
             "publication_errors",
         }
         policy_keys = {"pentest_enabled", "execution_policy"}
+        nested_request = raw_payload.get("request")
+        if nested_request is not None:
+            request_payload = dict(nested_request)
+            publication_source = request_payload
+        elif isinstance(raw_payload.get("invocation_payload"), Mapping):
+            invocation_payload = raw_payload["invocation_payload"]
+            invocation_inputs = invocation_payload.get("inputs")
+            request_payload = (
+                dict(invocation_inputs) if isinstance(invocation_inputs, Mapping) else {}
+            )
+            for key in publication_keys | policy_keys:
+                if key in raw_payload and key not in request_payload:
+                    request_payload[key] = raw_payload[key]
+            context_payload = raw_payload.get("context")
+            context = context_payload if isinstance(context_payload, Mapping) else {}
+            workflow_id = str(
+                context.get("workflow_id")
+                or context.get("run_id")
+                or raw_payload.get("workflow_id")
+                or ""
+            ).strip()
+            node_id = str(
+                context.get("node_id")
+                or context.get("step_id")
+                or invocation_payload.get("id")
+                or ""
+            ).strip()
+            if workflow_id:
+                request_payload["agent_run_id"] = workflow_id
+            if node_id:
+                request_payload["step_id"] = node_id
+            idempotency_key = str(raw_payload.get("idempotency_key") or "")
+            execution_attempt_match = re.search(r":execution:(\d+):", idempotency_key)
+            if execution_attempt_match:
+                request_payload["attempt"] = int(execution_attempt_match.group(1))
+            else:
+                request_payload.setdefault("attempt", 1)
+            if raw_payload.get("principal"):
+                request_payload["principal_id"] = raw_payload["principal"]
+            if (
+                request_payload.get("agent_run_id")
+                and request_payload.get("step_id")
+            ):
+                request_payload["artifacts_dir"] = (
+                    f"/work/agent_jobs/{request_payload['agent_run_id']}"
+                    f"/artifacts/{request_payload['step_id']}"
+                )
+            publication_source = request_payload
+        else:
+            request_payload = raw_payload
+            publication_source = raw_payload
         publication_payload = {
             key: publication_source[key]
             for key in publication_keys

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1641,6 +1641,84 @@ async def test_security_pentest_execute_loads_scope_artifact_before_launch_plan(
     assert result["status"] == "completed"
     assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
 
+async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    artifact_service = _FakePentestArtifactService(
+        {"art_scope_valid": _scope_artifact_bytes()}
+    )
+    launcher = _FakePentestLauncher()
+    materialized_requests: list[object] = []
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=artifact_service,
+        workload_launcher=launcher,
+        workload_registry=_RecordingPentestRegistry(),
+    )
+
+    def _record_materialization(**kwargs):
+        materialized_requests.append(kwargs["request"])
+        return {}
+
+    monkeypatch.setattr(
+        activities._pentest_activities,
+        "_materialize_pentest_input_files",
+        _record_materialization,
+    )
+
+    result = await activities.security_pentest_execute(
+        {
+            "registry_snapshot_ref": "art_registry",
+            "principal": "user-security",
+            "invocation_payload": {
+                "id": "step-pentest",
+                "tool": {
+                    "type": "skill",
+                    "name": "security.pentest.run",
+                    "version": "1.0.0",
+                },
+                "inputs": {
+                    "pentest_enabled": True,
+                    "target": "https://lab.example.test",
+                    "operation_mode": "validate_hypothesis",
+                    "scope_artifact_ref": "art_scope_valid",
+                    "runner_profile_id": "pentestgpt-safe",
+                    "execution_profile_ref": "pentestgpt_anthropic_api_team",
+                    "time_budget_minutes": 60,
+                    "evidence_level": "standard",
+                    "agent_run_id": "caller-supplied-run",
+                    "step_id": "caller-supplied-step",
+                    "attempt": 99,
+                    "principal_id": "caller-supplied-principal",
+                    "artifacts_dir": "/tmp/caller-supplied-artifacts",
+                },
+                "options": {},
+            },
+            "context": {
+                "namespace": "default",
+                "workflow_id": "mm:workflow-123",
+                "run_id": "run-123",
+                "node_id": "step-pentest",
+            },
+            "idempotency_key": (
+                "mm:workflow-123:run-123:step-pentest:execution:1:execute"
+            ),
+        }
+    )
+
+    assert artifact_service.reads == [("art_scope_valid", "user-security")]
+    assert result["status"] == "completed"
+    assert result["launch_plan"]["profile_id"] == "pentestgpt-safe"
+    assert len(launcher.requests) == 1
+    assert len(materialized_requests) == 1
+    request = materialized_requests[0]
+    assert request.agent_run_id == "mm:workflow-123"
+    assert request.step_id == "step-pentest"
+    assert request.attempt == 1
+    assert (
+        request.artifacts_dir
+        == "/work/agent_jobs/mm:workflow-123/artifacts/step-pentest"
+    )
+
 @pytest.mark.parametrize(
     ("artifact_id", "artifact_payload", "message"),
     [

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1644,6 +1644,7 @@ async def test_security_pentest_execute_loads_scope_artifact_before_launch_plan(
 async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", "/custom/agent_jobs")
     artifact_service = _FakePentestArtifactService(
         {"art_scope_valid": _scope_artifact_bytes()}
     )
@@ -1669,6 +1670,7 @@ async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
         {
             "registry_snapshot_ref": "art_registry",
             "principal": "user-security",
+            "pentest_enabled": True,
             "invocation_payload": {
                 "id": "step-pentest",
                 "tool": {
@@ -1677,7 +1679,7 @@ async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
                     "version": "1.0.0",
                 },
                 "inputs": {
-                    "pentest_enabled": True,
+                    "pentest_enabled": False,
                     "target": "https://lab.example.test",
                     "operation_mode": "validate_hypothesis",
                     "scope_artifact_ref": "art_scope_valid",
@@ -1714,9 +1716,10 @@ async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
     assert request.agent_run_id == "mm:workflow-123"
     assert request.step_id == "step-pentest"
     assert request.attempt == 1
+    assert request.principal_id == "user-security"
     assert (
         request.artifacts_dir
-        == "/work/agent_jobs/mm:workflow-123/artifacts/step-pentest"
+        == "/custom/agent_jobs/mm:workflow-123/artifacts/step-pentest"
     )
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Fix `security.pentest.execute` so it accepts the actual workflow invocation envelope used by `MoonMind.UserWorkflow`.
- Normalize `invocation_payload.inputs` into the pentest request and derive workflow-owned metadata from the Temporal envelope.
- Add regression coverage for envelope dispatch and for preventing caller-supplied internal fields from overriding workflow metadata.

## Root Cause

The failed workflow scheduled `security.pentest.execute` with `scope_artifact_ref` under `invocation_payload.inputs`, but the activity only handled flat payloads or `{request: ...}`. The scope artifact reference was lost during validation, causing `VALIDATION_FAILED` with `scope_artifact_ref_required`.

## Validation

- Passed: `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py -k 'security_pentest_execute_accepts_workflow_invocation_envelope or security_pentest_execute_loads_scope_artifact_before_launch_plan'`
- Failed, unrelated to this change: `./tools/test_unit.sh`
  - `tests/unit/api/test_presets_service.py::test_seed_catalog_includes_jira_breakdown_orchestrate_preset`
  - `tests/unit/api/test_presets_service.py::test_jira_breakdown_orchestrate_can_create_source_subtasks`
  - Both failures expect Jira project `MM` but the local configured default resolves to `KANDY`.