### PR TITLE
MM-871 hide Tool Version outside Advanced mode

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16149,6 +16149,24 @@ describe("Task Create governed Tool authoring", () => {
       .toBe("github.create_pull_request");
   });
 
+  it("hides Tool Version behind Advanced mode for MM-871", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Tool");
+
+    expect(await within(step).findByLabelText("Tool ID")).toBeTruthy();
+    expect(within(step).queryByLabelText("Tool Version (optional)")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+    expect(within(step).getByLabelText("Tool Version (optional)")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+    expect(within(step).queryByLabelText("Tool Version (optional)")).toBeNull();
+  });
+
   it("submits an authored MM-577 Skill step with agentic controls", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -9726,20 +9726,22 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                       <p className="small">
                         {toolContractSummary(selectedTrustedTool)}
                       </p>
-                      <label>
-                        Tool Version (optional)
-                        <input
-                          data-step-field="toolVersion"
-                          data-step-index={String(index)}
-                          placeholder="1.0"
-                          value={step.toolVersion}
-                          onChange={(event) =>
-                            updateStep(step.localId, {
-                              toolVersion: event.target.value,
-                            })
-                          }
-                        />
-                      </label>
+                      {showAdvancedStepOptions ? (
+                        <label>
+                          Tool Version (optional)
+                          <input
+                            data-step-field="toolVersion"
+                            data-step-index={String(index)}
+                            placeholder="1.0"
+                            value={step.toolVersion}
+                            onChange={(event) =>
+                              updateStep(step.localId, {
+                                toolVersion: event.target.value,
+                              })
+                            }
+                          />
+                        </label>
+                      ) : null}
                       {isPentestTool ? (
                         <div className="notice small">
                           Runs require an approved scope artifact. Inline scope is


### PR DESCRIPTION
Issue reference: MM-871

Summary:
- Hide the Tool Version field on the workflow start Tool step unless Advanced mode is enabled.
- Add frontend coverage that verifies Tool Version appears only while Advanced mode is on.

Tests run:
- npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx (failed: npm script could not resolve vitest)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx (failed: Python pytest is not installed in this container)
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-start.test.tsx (failed: Vitest resolved the test as /frontend/src/entrypoints/workflow-start.test.tsx and could not find that module)

Remaining risks:
- Local test execution is blocked by this container's dependency/config resolution issues, so CI should provide the authoritative verification.