### PR TITLE
Fix Jira downstream issue input payload

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1101,9 +1101,13 @@ def _jira_issue_input_from_mapping(
         mapping.get("browseUrl"),
         nested_issue.get("url"),
         nested_issue.get("browseUrl"),
-        _issue_url({**dict(mapping), "key": resolved_key}),
-        _issue_url({**dict(nested_issue), "key": resolved_key}),
     )
+    if not url:
+        url = (
+            _issue_url({**dict(mapping), "key": resolved_key})
+            or _issue_url({**dict(nested_issue), "key": resolved_key})
+            or ""
+        )
     if url:
         issue["url"] = url
 
@@ -1200,7 +1204,6 @@ def _downstream_task_payload(
         "instructions": instructions,
         "inputs": {
             "jira_issue": jira_issue_input,
-            "jira_issue_key": issue_key,
             "source_design_path": source_design_path,
             "constraints": (
                 f"Preserve source issue {source_issue_key} traceability."

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1046,6 +1046,89 @@ def _stable_idempotency_key(
     return f"{prefix}:{source_issue_key}:{digest}"[:128]
 
 
+def _jira_issue_input_from_mapping(
+    *,
+    mapping: Mapping[str, Any],
+    issue_key: str,
+    summary: str,
+) -> dict[str, Any]:
+    nested_issue = _mapping(
+        mapping.get("jiraIssue")
+        or mapping.get("jira_issue")
+        or mapping.get("issue")
+    )
+    fields = _mapping(nested_issue.get("fields"))
+    raw_field_status = fields.get("status")
+    raw_status = nested_issue.get("status")
+    raw_field_assignee = fields.get("assignee")
+    raw_assignee = nested_issue.get("assignee")
+    status = _mapping(raw_field_status or raw_status)
+    assignee = _mapping(raw_field_assignee or raw_assignee)
+    resolved_key = _first_string(
+        issue_key,
+        nested_issue.get("key"),
+        nested_issue.get("issueKey"),
+        nested_issue.get("issue_key"),
+        mapping.get("key"),
+        mapping.get("issueKey"),
+        mapping.get("issue_key"),
+    )
+    issue: dict[str, Any] = {"key": resolved_key}
+
+    resolved_summary = _first_string(
+        summary,
+        fields.get("summary"),
+        nested_issue.get("summary"),
+        mapping.get("summary"),
+    )
+    if resolved_summary:
+        issue["summary"] = resolved_summary
+
+    description = _normalize_jira_text(
+        fields.get("description")
+        or nested_issue.get("description")
+        or nested_issue.get("descriptionText")
+        or nested_issue.get("description_text")
+        or mapping.get("description")
+    )
+    if description:
+        issue["description"] = description
+
+    url = _first_string(
+        mapping.get("issueUrl"),
+        mapping.get("issue_url"),
+        mapping.get("url"),
+        mapping.get("browseUrl"),
+        nested_issue.get("url"),
+        nested_issue.get("browseUrl"),
+        _issue_url({**dict(mapping), "key": resolved_key}),
+        _issue_url({**dict(nested_issue), "key": resolved_key}),
+    )
+    if url:
+        issue["url"] = url
+
+    status_name = _first_string(
+        status.get("name"),
+        raw_field_status if not isinstance(raw_field_status, Mapping) else None,
+        raw_status if not isinstance(raw_status, Mapping) else None,
+    )
+    if status_name:
+        issue["status"] = status_name
+
+    assignee_name = _first_string(
+        assignee.get("displayName"),
+        assignee.get("name"),
+        raw_field_assignee
+        if not isinstance(raw_field_assignee, Mapping)
+        else None,
+        raw_assignee if not isinstance(raw_assignee, Mapping) else None,
+    )
+    if assignee_name:
+        issue["assignee"] = assignee_name
+
+    return issue
+
+
 def _truthy(value: Any) -> bool:
     if isinstance(value, bool):
         return value
@@ -1107,10 +1190,16 @@ def _downstream_task_payload(
         publish.pop("mergeAutomation", None)
         publish.pop("merge_automation", None)
     repository = _string(task_payload.get("repository") or task_payload.get("repo"))
+    jira_issue_input = _jira_issue_input_from_mapping(
+        mapping=mapping,
+        issue_key=issue_key,
+        summary=summary,
+    )
     task: dict[str, Any] = {
         "title": f"Run {preset_label} for {issue_key}: {summary}",
         "instructions": instructions,
         "inputs": {
+            "jira_issue": jira_issue_input,
             "jira_issue_key": issue_key,
             "source_design_path": source_design_path,
             "constraints": (

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1652,6 +1652,11 @@ async def test_create_jira_orchestrate_tasks_wires_ordered_dependencies_and_trac
         "mode": "pr",
         "mergeAutomation": {"enabled": True},
     }
+    assert first_parameters["workflow"]["inputs"]["jira_issue"] == {
+        "key": "MM-501",
+        "summary": "First",
+    }
+    assert first_parameters["workflow"]["inputs"]["jira_issue_key"] == "MM-501"
     assert "merge_automation" not in first_parameters["workflow"]["publish"]
     assert "MM-404" in first_parameters["workflow"]["instructions"]
 
@@ -1931,6 +1936,7 @@ async def test_create_jira_implement_tasks_targets_jira_implement_preset():
                         "storyIndex": 1,
                         "summary": "First",
                         "issueKey": "MM-501",
+                        "issueUrl": "https://jira.example/browse/MM-501",
                     },
                     {
                         "storyId": "STORY-002",
@@ -1980,6 +1986,11 @@ async def test_create_jira_implement_tasks_targets_jira_implement_preset():
         "Use the existing Jira Implement workflow"
         in first_task["instructions"]
     )
+    assert first_task["inputs"]["jira_issue"] == {
+        "key": "MM-501",
+        "summary": "First",
+        "url": "https://jira.example/browse/MM-501",
+    }
     assert first_task["inputs"]["jira_issue_key"] == "MM-501"
     assert first_task["inputs"]["constraints"] == (
         "Preserve source issue MM-404 traceability."

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1656,7 +1656,7 @@ async def test_create_jira_orchestrate_tasks_wires_ordered_dependencies_and_trac
         "key": "MM-501",
         "summary": "First",
     }
-    assert first_parameters["workflow"]["inputs"]["jira_issue_key"] == "MM-501"
+    assert "jira_issue_key" not in first_parameters["workflow"]["inputs"]
     assert "merge_automation" not in first_parameters["workflow"]["publish"]
     assert "MM-404" in first_parameters["workflow"]["instructions"]
 
@@ -1804,9 +1804,9 @@ async def test_create_jira_orchestrate_tasks_uses_input_previous_outputs_mapping
     assert orchestration["storyCount"] == 1
     assert orchestration["createdTaskCount"] == 1
     assert orchestration["tasks"][0]["jiraIssueKey"] == "MM-810"
-    assert creator.requests[0]["initial_parameters"]["workflow"]["inputs"][
-        "jira_issue_key"
-    ] == "MM-810"
+    inputs = creator.requests[0]["initial_parameters"]["workflow"]["inputs"]
+    assert inputs["jira_issue"] == {"key": "MM-810", "summary": "Remaining work"}
+    assert "jira_issue_key" not in inputs
 
 @pytest.mark.asyncio
 async def test_create_jira_orchestrate_tasks_propagates_source_design_path():
@@ -1991,7 +1991,7 @@ async def test_create_jira_implement_tasks_targets_jira_implement_preset():
         "summary": "First",
         "url": "https://jira.example/browse/MM-501",
     }
-    assert first_task["inputs"]["jira_issue_key"] == "MM-501"
+    assert "jira_issue_key" not in first_task["inputs"]
     assert first_task["inputs"]["constraints"] == (
         "Preserve source issue MM-404 traceability."
     )


### PR DESCRIPTION
Summary:
- Include the required jira_issue object when creating downstream Jira Orchestrate/Implement workflow payloads.
- Preserve jira_issue_key and safe Jira metadata for existing consumers.
- Add regression coverage for generated downstream workflow inputs.

Tests:
- /home/nsticco/MoonMind/.venv/bin/pytest tests/unit/workflows/temporal/test_story_output_tools.py -q