### PR TITLE
[codex] Reject empty user workflow starts

### DIFF
--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -4,7 +4,7 @@
 **Doc type:** API contract 
 **Status:** Draft 
 **Owner:** MoonMind Platform 
-**Last updated:** 2026-04-04 (UTC) 
+**Last updated:** 2026-06-23 (UTC) 
 **Audience:** backend, dashboard, integrations
 
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
@@ -331,6 +331,9 @@ Current implementation always returns `countMode = "exact"`.
 
 - `workflowType` must be one of the supported values.
 - `manifestArtifactRef` is required for `MoonMind.ManifestIngest`.
+- `MoonMind.UserWorkflow` create requests must include at least one planning
+  source before an execution is persisted or started: non-empty instructions,
+  a selected skill, `inputArtifactRef`, or `planArtifactRef`.
 - `initialParameters` should remain small and JSON-serializable.
 - Artifact refs are references, not embedded blobs.
 

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1575,7 +1575,19 @@ def _has_text(value: Any) -> bool:
 
 
 def _as_dict(value: Any) -> dict[str, Any] | None:
-    return value if isinstance(value, dict) else None
+    if isinstance(value, dict):
+        return value
+    for method_name in ("model_dump", "dict"):
+        method = getattr(value, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            dumped = method()
+        except TypeError:
+            continue
+        if isinstance(dumped, dict):
+            return dumped
+    return None
 
 
 def _has_artifact_ref(value: Any) -> bool:
@@ -1590,6 +1602,8 @@ def _has_artifact_ref(value: Any) -> bool:
 def _has_skill_selector(value: Any) -> bool:
     if _has_text(value):
         return True
+    if isinstance(value, list):
+        return any(_has_skill_selector(item) for item in value)
     selector = _as_dict(value)
     if selector is None:
         return False
@@ -1598,7 +1612,29 @@ def _has_skill_selector(value: Any) -> bool:
         or _has_text(selector.get("id"))
         or _has_text(selector.get("skill"))
         or _has_text(selector.get("skillName"))
+        or _has_skill_selector(selector.get("include"))
+        or _has_skill_selector(selector.get("sets"))
     )
+
+
+def _has_nonempty_sequence(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if item is None:
+            continue
+        if isinstance(item, str) and not item.strip():
+            continue
+        return True
+    return False
+
+
+def _has_structured_workflow_source(mapping: dict[str, Any]) -> bool:
+    if "remediation" in mapping and mapping.get("remediation") is not None:
+        return True
+    if _has_nonempty_sequence(mapping.get("dependsOn")):
+        return True
+    return False
 
 
 def _mapping_has_skill_or_step_source(mapping: dict[str, Any]) -> bool:
@@ -1608,9 +1644,15 @@ def _mapping_has_skill_or_step_source(mapping: dict[str, Any]) -> bool:
         "selected_skill",
         "targetSkill",
         "target_skill",
+        "skills",
+        "skillSelection",
+        "skill_selection",
     ):
         if _has_skill_selector(mapping.get(key)):
             return True
+
+    if _has_structured_workflow_source(mapping):
+        return True
 
     tool = _as_dict(mapping.get("tool"))
     if tool is not None:

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1564,6 +1564,101 @@ class ScheduleParameters(BaseModel):
             )
         return self
 
+USER_WORKFLOW_PLAN_SOURCE_ERROR = (
+    "MoonMind.UserWorkflow requires non-empty instructions, a selected skill, "
+    "inputArtifactRef, or planArtifactRef before a workflow can be started"
+)
+
+
+def _has_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _has_artifact_ref(value: Any) -> bool:
+    if _has_text(value):
+        return True
+    ref = _as_dict(value)
+    if ref is None:
+        return False
+    return _has_text(ref.get("artifact_id")) or _has_text(ref.get("artifactId"))
+
+
+def _has_skill_selector(value: Any) -> bool:
+    if _has_text(value):
+        return True
+    selector = _as_dict(value)
+    if selector is None:
+        return False
+    return (
+        _has_text(selector.get("name"))
+        or _has_text(selector.get("id"))
+        or _has_text(selector.get("skill"))
+        or _has_text(selector.get("skillName"))
+    )
+
+
+def _mapping_has_skill_or_step_source(mapping: dict[str, Any]) -> bool:
+    for key in (
+        "skill",
+        "selectedSkill",
+        "selected_skill",
+        "targetSkill",
+        "target_skill",
+    ):
+        if _has_skill_selector(mapping.get(key)):
+            return True
+
+    tool = _as_dict(mapping.get("tool"))
+    if tool is not None:
+        if str(tool.get("type") or "").strip().lower() == "skill":
+            if _has_skill_selector(tool) or _has_skill_selector(tool.get("skill")):
+                return True
+
+    steps = mapping.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            step_mapping = _as_dict(step)
+            if step_mapping is None:
+                continue
+            if _has_text(step_mapping.get("instructions")):
+                return True
+            if _mapping_has_skill_or_step_source(step_mapping):
+                return True
+
+    return False
+
+
+def has_user_workflow_plan_source(
+    *,
+    initial_parameters: dict[str, Any] | None,
+    input_artifact_ref: Any,
+    plan_artifact_ref: Any,
+) -> bool:
+    """Return whether a UserWorkflow start has enough planning input to run."""
+
+    if _has_artifact_ref(input_artifact_ref) or _has_artifact_ref(plan_artifact_ref):
+        return True
+
+    params = _as_dict(initial_parameters) or {}
+    payloads: list[dict[str, Any]] = [params]
+    for key in ("workflow", "task", "inputs", "parameters"):
+        payload = _as_dict(params.get(key))
+        if payload is not None:
+            payloads.append(payload)
+
+    for payload in payloads:
+        if _has_text(payload.get("instructions")):
+            return True
+        if _mapping_has_skill_or_step_source(payload):
+            return True
+
+    return False
+
+
 class CreateExecutionRequest(BaseModel):
     """Request payload for starting a workflow execution."""
 
@@ -1599,6 +1694,15 @@ class CreateExecutionRequest(BaseModel):
                 "manifestArtifactRef is required when workflowType is "
                 "MoonMind.ManifestIngest"
             )
+        if (
+            self.workflow_type == "MoonMind.UserWorkflow"
+            and not has_user_workflow_plan_source(
+                initial_parameters=self.initial_parameters,
+                input_artifact_ref=self.input_artifact_ref,
+                plan_artifact_ref=self.plan_artifact_ref,
+            )
+        ):
+            raise ValueError(USER_WORKFLOW_PLAN_SOURCE_ERROR)
         return self
 
 class UpdateExecutionRequest(BaseModel):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -47,12 +47,14 @@ from moonmind.schemas.temporal_models import (
     SUPPORTED_FAILURE_POLICIES,
     SUPPORTED_SIGNAL_NAMES,
     SUPPORTED_UPDATE_NAMES,
+    USER_WORKFLOW_PLAN_SOURCE_ERROR,
     DependencyResolvedSignalPayload,
     AGENT_RUN_ID_MEMO_KEYS,
     AGENT_RUN_ID_PARAM_KEYS,
     AGENT_RUN_ID_SEARCH_ATTR_KEYS,
     RecoveryCheckpointModel,
     RecoverySourceModel,
+    has_user_workflow_plan_source,
 )
 from moonmind.security.outbound_scan import scan_outbound_text
 from moonmind.workflows.temporal.client import TemporalClientAdapter
@@ -969,6 +971,15 @@ class TemporalExecutionService:
             if not manifest_artifact_ref:
                 raise TemporalExecutionValidationError(
                     "manifestArtifactRef is required for MoonMind.ManifestIngest"
+                )
+        if workflow_type_enum is TemporalWorkflowType.USER_WORKFLOW:
+            if not has_user_workflow_plan_source(
+                initial_parameters=initial_parameters,
+                input_artifact_ref=input_artifact_ref,
+                plan_artifact_ref=plan_artifact_ref,
+            ):
+                raise TemporalExecutionValidationError(
+                    USER_WORKFLOW_PLAN_SOURCE_ERROR
                 )
 
         await self._validate_readable_temporal_artifact_ref(

--- a/tests/unit/api/routers/test_execution_integrations.py
+++ b/tests/unit/api/routers/test_execution_integrations.py
@@ -114,6 +114,7 @@ async def _create_monitored_execution(
         json={
             "workflowType": "MoonMind.UserWorkflow",
             "title": "Integration callback test",
+            "planArtifactRef": f"execution-integrations-plan-{execution_suffix}",
             "idempotencyKey": f"execution-integrations-create-{execution_suffix}",
         },
     )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6203,6 +6203,25 @@ def test_create_execution_surfaces_domain_validation_errors(
     assert response.status_code == 422
     assert response.json()["detail"]["code"] == "invalid_execution_request"
 
+
+def test_create_execution_rejects_user_workflow_without_plan_source(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "workflowType": "MoonMind.UserWorkflow",
+            "title": "Run",
+            "initialParameters": {},
+        },
+    )
+
+    assert response.status_code == 422
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_execution_routes_directly_to_temporal(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
@@ -6213,7 +6232,13 @@ def test_create_execution_routes_directly_to_temporal(
 
     response = test_client.post(
         "/api/executions",
-        json={"workflowType": "MoonMind.UserWorkflow", "title": "Test direct temporal"},
+        json={
+            "workflowType": "MoonMind.UserWorkflow",
+            "title": "Test direct temporal",
+            "initialParameters": {
+                "workflow": {"instructions": "Test direct temporal"}
+            },
+        },
     )
 
     assert response.status_code == 201
@@ -6379,7 +6404,13 @@ def test_create_execution_enforces_idempotency(
 
     response = test_client.post(
         "/api/executions",
-        json={"workflowType": "MoonMind.UserWorkflow", "idempotencyKey": "idem-123"},
+        json={
+            "workflowType": "MoonMind.UserWorkflow",
+            "idempotencyKey": "idem-123",
+            "initialParameters": {
+                "workflow": {"instructions": "Test idempotent create"}
+            },
+        },
     )
 
     assert response.status_code == 201

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -38,7 +38,9 @@ def _definition(**overrides):
         "scope_ref": None,
         "target": {
             "workflowType": "MoonMind.UserWorkflow",
-            "initialParameters": {},
+            "initialParameters": {
+                "workflow": {"instructions": "Test recurring workflow fixture."}
+            },
         },
         "policy": {},
         "version": 1,

--- a/tests/unit/api/test_temporal_service_pause_guard.py
+++ b/tests/unit/api/test_temporal_service_pause_guard.py
@@ -72,7 +72,9 @@ async def test_create_execution_blocked_when_paused(mock_session, mock_client_ad
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters=None,
+                initial_parameters={
+                    "workflow": {"instructions": "Test workflow fixture."}
+                },
                 idempotency_key=None,
             )
 
@@ -90,7 +92,9 @@ async def test_create_execution_allowed_when_not_paused(mock_session, mock_clien
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters=None,
+                initial_parameters={
+                    "workflow": {"instructions": "Test workflow fixture."}
+                },
                 idempotency_key=None,
             )
         except TemporalExecutionValidationError as exc:

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -63,6 +63,9 @@ from moonmind.workflows.temporal.remediation_tools import (
 )
 from moonmind.workflows.temporal.service import TemporalExecutionService
 
+def _valid_user_workflow_parameters() -> dict[str, object]:
+    return {"workflow": {"instructions": "Test workflow fixture."}}
+
 async def _create_target_and_remediation(
     session: AsyncSession,
     mock_client_adapter,
@@ -87,7 +90,7 @@ async def _create_target_and_remediation(
         plan_artifact_ref=None,
         manifest_artifact_ref=None,
         failure_policy=None,
-        initial_parameters={},
+        initial_parameters=_valid_user_workflow_parameters(),
         idempotency_key=None,
     )
     remediation = await execution_service.create_execution(
@@ -311,7 +314,7 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
             summary="Target summary",
         )
@@ -507,7 +510,7 @@ async def test_remediation_context_builder_enriches_agent_run_evidence_and_live_
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
             summary="Target summary",
         )
@@ -1617,7 +1620,7 @@ async def test_remediation_context_builder_rejects_non_remediation_workflow(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1790,7 +1793,7 @@ async def test_remediation_evidence_tools_read_only_context_declared_evidence(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         target_artifact, _upload = await artifact_service.create(
@@ -1927,7 +1930,7 @@ async def test_remediation_evidence_tools_gate_live_follow_by_context_policy(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         remediation = await execution_service.create_execution(
@@ -2050,7 +2053,7 @@ async def test_remediation_evidence_tools_prepare_action_request_rereads_target_
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
             summary="Initial target summary",
         )
@@ -2565,7 +2568,7 @@ async def test_remediation_context_builder_rejects_missing_target_record(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         session.add(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -46,6 +46,7 @@ from moonmind.workflows.temporal.hard_switch_cutover import RENAMED_USER_WORKFLO
 from moonmind.schemas.temporal_models import (
     CreateExecutionRequest,
     RecoveryCheckpointModel,
+    has_user_workflow_plan_source,
 )
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
@@ -164,6 +165,35 @@ def test_create_execution_request_rejects_user_workflow_without_plan_source():
                 "initialParameters": {},
             }
         )
+
+
+def test_create_execution_request_accepts_workflow_skills_plan_source():
+    request = CreateExecutionRequest.model_validate(
+        {
+            "workflowType": "MoonMind.UserWorkflow",
+            "title": "Run skill",
+            "initialParameters": {
+                "workflow": {
+                    "skills": {
+                        "include": [{"name": "pr-resolver"}],
+                    },
+                },
+            },
+        }
+    )
+
+    assert request.workflow_type == "MoonMind.UserWorkflow"
+
+
+def test_user_workflow_plan_source_accepts_pydantic_artifact_refs():
+    class ArtifactRefModel(BaseModel):
+        artifact_id: str
+
+    assert has_user_workflow_plan_source(
+        initial_parameters={},
+        input_artifact_ref=ArtifactRefModel(artifact_id="art_input"),
+        plan_artifact_ref=None,
+    )
 
 
 @pytest.mark.asyncio
@@ -311,6 +341,7 @@ async def test_create_execution_routes_pr_merge_automation_workflows_to_dedicate
             initial_parameters={
                 "publishMode": "pr",
                 "workflow": {
+                    "instructions": "Test merge automation routing.",
                     "publish": {
                         "mode": "pr",
                         "mergeAutomation": {"enabled": True},
@@ -345,7 +376,10 @@ async def test_create_execution_keeps_default_priority_without_merge_automation(
             failure_policy=None,
             initial_parameters={
                 "publishMode": "pr",
-                "workflow": {"publish": {"mode": "pr"}},
+                "workflow": {
+                    "instructions": "Test default publish priority.",
+                    "publish": {"mode": "pr"},
+                },
             },
             idempotency_key=None,
         )

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -42,9 +43,16 @@ from moonmind.workflows.temporal.service import (
     _get_managed_session_store_root,
 )
 from moonmind.workflows.temporal.hard_switch_cutover import RENAMED_USER_WORKFLOW_TYPE
-from moonmind.schemas.temporal_models import RecoveryCheckpointModel
+from moonmind.schemas.temporal_models import (
+    CreateExecutionRequest,
+    RecoveryCheckpointModel,
+)
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
+
+
+def _valid_user_workflow_parameters() -> dict[str, object]:
+    return {"workflow": {"instructions": "Test workflow fixture."}}
 
 
 def _write_mm730_cutover_files(tmp_path):
@@ -146,6 +154,51 @@ async def _create_temporal_artifact(
     )
     await session.commit()
 
+
+def test_create_execution_request_rejects_user_workflow_without_plan_source():
+    with pytest.raises(ValidationError, match="requires non-empty instructions"):
+        CreateExecutionRequest.model_validate(
+            {
+                "workflowType": "MoonMind.UserWorkflow",
+                "title": "Run",
+                "initialParameters": {},
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_user_workflow_without_plan_source_before_start(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(
+            session,
+            client_adapter=mock_client_adapter,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="requires non-empty instructions",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=uuid4(),
+                title="Run",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={},
+                idempotency_key=None,
+            )
+
+        mock_client_adapter.start_workflow.assert_not_awaited()
+        records = (
+            await session.execute(select(TemporalExecutionCanonicalRecord))
+        ).scalars().all()
+        assert records == []
+
+
 @pytest.mark.asyncio
 async def test_create_execution_initializes_lifecycle_search_attributes(tmp_path):
     async with temporal_db(tmp_path) as session:
@@ -217,7 +270,7 @@ async def test_create_execution_routes_user_workflow_after_mm730_cutover(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -323,7 +376,7 @@ async def test_create_execution_returns_repair_pending_fallback_when_projection_
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="repair-pending-create",
         )
 
@@ -352,7 +405,7 @@ async def test_create_execution_defaults_missing_owner_to_system(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -426,7 +479,7 @@ async def test_create_execution_rejects_pending_upload_temporal_input_artifact_r
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=None,
             )
 
@@ -447,7 +500,7 @@ async def test_create_execution_rejects_unsupported_failure_policy(tmp_path):
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy="explode_loudly",
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=None,
             )
 
@@ -468,7 +521,7 @@ async def test_create_execution_rejects_empty_failure_policy(tmp_path):
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy="",
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=None,
             )
 
@@ -532,7 +585,7 @@ async def test_create_execution_rejects_dependency_run_id_identifier(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -604,7 +657,7 @@ async def test_create_execution_rejects_unauthorized_dependency(tmp_path, mock_c
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -640,7 +693,7 @@ async def test_create_execution_persists_dependency_edges_and_supports_lookups(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         dep2 = await service.create_execution(
@@ -651,7 +704,7 @@ async def test_create_execution_persists_dependency_edges_and_supports_lookups(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -780,7 +833,7 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -868,7 +921,7 @@ async def test_record_remediation_approval_decision_appends_bounded_audit(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         remediation = await service.create_execution(
@@ -935,7 +988,7 @@ async def test_record_remediation_approval_decision_rejects_non_pending_target(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -967,7 +1020,7 @@ async def test_create_execution_persists_supplied_matching_remediation_run_id(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1017,7 +1070,7 @@ async def test_create_execution_allows_observe_only_remediation_of_system_target
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1064,7 +1117,7 @@ async def test_create_execution_rejects_elevated_user_remediation_of_system_targ
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1130,7 +1183,7 @@ async def test_create_execution_rejects_remediation_run_id_identifier(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1237,7 +1290,7 @@ async def test_create_execution_rejects_mismatched_remediation_target_run_id(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1281,7 +1334,7 @@ async def test_create_execution_rejects_unsupported_remediation_authority_mode(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1323,7 +1376,7 @@ async def test_create_execution_rejects_incompatible_remediation_action_policy(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1412,7 +1465,7 @@ async def test_create_execution_rejects_nested_remediation_target(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         first_remediation = await service.create_execution(
@@ -1466,7 +1519,7 @@ async def test_create_execution_rejects_malformed_remediation_agent_run_ids(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -1620,7 +1673,7 @@ async def test_create_execution_normalizes_depends_on_before_limit_and_persisten
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=None,
             )
             for index in range(1, 11)
@@ -1709,7 +1762,7 @@ async def test_mark_execution_succeeded_fans_out_dependency_resolution_signals(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         dependent_one = await service.create_execution(
@@ -1768,7 +1821,7 @@ async def test_record_terminal_state_fans_out_dependency_resolution_signals(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         dependent = await service.create_execution(
@@ -1834,7 +1887,7 @@ async def test_record_terminal_state_preserves_existing_terminal_summary(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         await service.cancel_execution(
@@ -1880,7 +1933,7 @@ async def test_record_terminal_state_indexes_finish_summary(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         finish_summary = {
@@ -1929,7 +1982,7 @@ async def test_record_terminal_state_derives_snake_case_finish_outcome_code(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         finish_summary = {
@@ -1978,7 +2031,7 @@ async def test_dependency_status_snapshot_repairs_stale_terminal_prerequisite(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         dependent = await service.create_execution(
@@ -2058,7 +2111,7 @@ async def test_dependency_status_snapshot_returns_stale_record_when_terminal_syn
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         prerequisite_workflow_id = prerequisite.workflow_id
@@ -2094,7 +2147,7 @@ async def test_mark_execution_failed_fanout_is_best_effort(tmp_path, mock_client
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         dependent_one = await service.create_execution(
@@ -2184,7 +2237,7 @@ async def test_create_execution_returns_existing_record_after_idempotency_race(
                         plan_artifact_ref=None,
                         manifest_artifact_ref=None,
                         failure_policy=None,
-                        initial_parameters={},
+                        initial_parameters=_valid_user_workflow_parameters(),
                         idempotency_key=key,
                     )
                     monkeypatch.setattr(
@@ -2217,7 +2270,7 @@ async def test_create_execution_returns_existing_record_after_idempotency_race(
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=key,
             )
 
@@ -2242,7 +2295,7 @@ async def test_create_execution_scopes_idempotency_by_owner_type(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="shared-idempotency-key",
         )
         service_record = await service.create_execution(
@@ -2254,7 +2307,7 @@ async def test_create_execution_scopes_idempotency_by_owner_type(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="shared-idempotency-key",
         )
         service_retry = await service.create_execution(
@@ -2266,7 +2319,7 @@ async def test_create_execution_scopes_idempotency_by_owner_type(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="shared-idempotency-key",
         )
 
@@ -2289,7 +2342,7 @@ async def test_list_executions_syncs_page_in_single_projection_commit(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         await service.create_execution(
@@ -2300,7 +2353,7 @@ async def test_list_executions_syncs_page_in_single_projection_commit(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -2999,7 +3052,7 @@ async def test_selected_step_recovery_rejects_step_without_checkpoint_evidence(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3044,7 +3097,7 @@ async def test_selected_step_recovery_rejects_step_after_failed_step(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3101,7 +3154,7 @@ async def test_failed_step_recovery_requires_hydrated_checkpoint_payload(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3138,7 +3191,7 @@ async def test_failed_step_recovery_invalid_evidence_does_not_create_execution(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3188,7 +3241,7 @@ async def test_failed_step_recovery_rejects_noncanonical_checkpoint_ref(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3231,7 +3284,7 @@ async def test_failed_step_recovery_rejects_checkpoint_run_mismatch(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3271,7 +3324,7 @@ async def test_failed_step_recovery_rejects_checkpoint_plan_mismatch(
             plan_artifact_ref="artifact://plan/source",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3314,7 +3367,7 @@ async def test_failed_step_recovery_rejects_checkpoint_plan_digest_mismatch(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.FAILED
@@ -3358,7 +3411,7 @@ async def test_request_rerun_bounds_fresh_execution_idempotency_key(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         await service.cancel_execution(
@@ -3417,7 +3470,7 @@ async def test_request_rerun_creates_fresh_execution_when_temporal_reports_compl
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3551,7 +3604,7 @@ async def test_manifest_only_updates_rejected_for_non_manifest_workflow(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3588,7 +3641,7 @@ async def test_request_rerun_clears_pause_flags_when_continuing_as_new(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3632,7 +3685,7 @@ async def test_update_execution_rejects_unknown_update_name(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3666,7 +3719,7 @@ async def test_update_execution_rejects_run_intervention_updates(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3704,7 +3757,7 @@ async def test_signal_pause_recovery_and_external_event_transitions(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3757,7 +3810,7 @@ async def test_signal_resume_forwards_payload_via_workflow_update(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3798,7 +3851,7 @@ async def test_signal_send_message_records_intervention_audit_without_state_chan
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -3951,7 +4004,7 @@ async def test_signal_skip_dependency_wait_routes_update_and_records_audit(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         created.state = MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
@@ -3997,7 +4050,7 @@ async def test_signal_send_message_rejects_noncanonical_payload(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4112,7 +4165,7 @@ async def test_signal_execution_rejects_unknown_signal_name(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4172,7 +4225,7 @@ async def test_cancel_execution_terminal_record_skips_temporal_call(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         completed = await service.mark_execution_succeeded(
@@ -4210,7 +4263,7 @@ async def test_cancel_execution_records_reject_audit_action(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4374,7 +4427,7 @@ async def test_cancel_execution_best_effort_terminates_workflow_scoped_codex_ses
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4432,7 +4485,7 @@ async def test_cancel_execution_prefers_direct_session_record_load_for_codex_tas
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4501,7 +4554,7 @@ async def test_cancel_execution_ignores_best_effort_session_terminate_failure(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4559,7 +4612,7 @@ async def test_forced_cancel_marks_failed_with_terminated_close_status(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4773,7 +4826,7 @@ async def test_record_progress_triggers_continue_as_new_for_run_threshold(tmp_pa
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         original_run_id = created.run_id
@@ -4810,7 +4863,7 @@ async def test_signal_external_event_requires_source_and_event_type(tmp_path):
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4837,7 +4890,7 @@ async def test_configure_integration_monitoring_persists_visibility_and_callback
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4883,7 +4936,7 @@ async def test_configure_integration_monitoring_rejects_blank_external_operation
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -4922,7 +4975,7 @@ async def test_ingest_integration_callback_deduplicates_provider_event_ids(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         configured = await service.configure_integration_monitoring(
@@ -4986,7 +5039,7 @@ async def test_wait_cycle_continue_as_new_preserves_active_integration_monitorin
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         configured = await service.configure_integration_monitoring(
@@ -5037,7 +5090,7 @@ async def test_mark_execution_failed_rejects_unknown_error_category(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -5061,7 +5114,7 @@ async def test_projection_sync_markers_round_trip_between_stale_and_fresh(tmp_pa
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -5096,7 +5149,7 @@ async def test_update_execution_persists_repair_pending_when_projection_refresh_
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         previous_sync_at = created.last_synced_at
@@ -5152,7 +5205,7 @@ async def test_orphaned_projection_rows_are_repaired_from_canonical_lists(tmp_pa
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="visible-row",
         )
         hidden = await service.create_execution(
@@ -5163,7 +5216,7 @@ async def test_orphaned_projection_rows_are_repaired_from_canonical_lists(tmp_pa
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="hidden-row",
         )
 
@@ -5211,7 +5264,7 @@ async def test_orphaned_projection_rows_with_canonical_source_repair_on_read_and
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="hidden-describe-row",
         )
 
@@ -5308,7 +5361,7 @@ async def test_mark_execution_succeeded_rejects_terminal_execution(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
 
@@ -5341,7 +5394,7 @@ async def test_list_executions_filters_owner_and_paginates(tmp_path):
                 plan_artifact_ref=None,
                 manifest_artifact_ref=None,
                 failure_policy=None,
-                initial_parameters={},
+                initial_parameters=_valid_user_workflow_parameters(),
                 idempotency_key=f"owner-a-{idx}",
             )
         await service.create_execution(
@@ -5352,7 +5405,7 @@ async def test_list_executions_filters_owner_and_paginates(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="owner-b-0",
         )
         await service.create_execution(
@@ -5422,7 +5475,7 @@ async def test_list_executions_orders_by_updated_at_then_workflow_id(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="older-row",
         )
         newer = await service.create_execution(
@@ -5433,7 +5486,7 @@ async def test_list_executions_orders_by_updated_at_then_workflow_id(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="newer-row",
         )
         tied_a = await service.create_execution(
@@ -5444,7 +5497,7 @@ async def test_list_executions_orders_by_updated_at_then_workflow_id(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="tied-a-row",
         )
         tied_b = await service.create_execution(
@@ -5455,7 +5508,7 @@ async def test_list_executions_orders_by_updated_at_then_workflow_id(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="tied-b-row",
         )
 
@@ -5517,7 +5570,7 @@ async def test_list_executions_orders_scheduled_rows_by_latest_scheduled_for(tmp
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="late-scheduled-row",
         )
         early = await service.create_execution(
@@ -5528,7 +5581,7 @@ async def test_list_executions_orders_scheduled_rows_by_latest_scheduled_for(tmp
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="early-scheduled-row",
         )
         running = await service.create_execution(
@@ -5539,7 +5592,7 @@ async def test_list_executions_orders_scheduled_rows_by_latest_scheduled_for(tmp
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="running-row",
         )
 
@@ -5594,7 +5647,7 @@ async def test_list_executions_filters_entry_repo_and_integration(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="matching-run",
             repository="Moon/Mind",
             integration="github",
@@ -5607,7 +5660,7 @@ async def test_list_executions_filters_entry_repo_and_integration(tmp_path):
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key="other-repo",
             repository="Other/Repo",
             integration="github",
@@ -5659,7 +5712,7 @@ async def test_polling_backoff_resets_after_status_change_and_updates_visibility
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         configured = await service.configure_integration_monitoring(
@@ -5722,7 +5775,7 @@ async def test_late_non_terminal_callback_is_ignored_after_terminal_completion(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         await service.configure_integration_monitoring(
@@ -5778,7 +5831,7 @@ async def test_failed_poll_marks_integration_error_summary(tmp_path):
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
         await service.configure_integration_monitoring(


### PR DESCRIPTION
## Summary

- Add a shared UserWorkflow plan-source guard for create requests.
- Reject `MoonMind.UserWorkflow` starts without instructions, selected skill, `inputArtifactRef`, or `planArtifactRef` before persistence or Temporal start.
- Update direct-create tests and API contract docs for the new validation rule.

## Root cause

Empty direct UserWorkflow submissions were accepted by the API/service boundary, persisted, and started in Temporal. They only failed later in planner activity execution, which polluted workflow history with durable failed runs.

## Validation

Not run. Per current Codex instructions, I did not run tests without an explicit test request.