### PR TITLE
MM-872 complete provider profile activation state

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -27,6 +27,8 @@ from api_service.db.models import (
     User,
     ManagedAgentProviderProfile,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
     ManagedAgentRateLimitPolicy,
 )
@@ -763,6 +765,7 @@ async def finalize_oauth_session(
             detail="Not authorized to update this profile",
         )
 
+    connected_at = datetime.now(timezone.utc)
     profile_data = {
         "runtime_id": session_obj.runtime_id,
         "provider_id": metadata.get("provider_id")
@@ -779,6 +782,13 @@ async def finalize_oauth_session(
         "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 900),
         "rate_limit_policy": policy_enum,
         "enabled": True,
+        "auth_state": ProviderProfileAuthState.CONNECTED,
+        "disabled_reason": None,
+        "first_authenticated_at": existing_profile.first_authenticated_at
+        if existing_profile and existing_profile.first_authenticated_at
+        else connected_at,
+        "last_validated_at": connected_at,
+        "last_auth_method": ProviderProfileAuthMethod.OAUTH_VOLUME,
     }
     try:
         validate_codex_oauth_profile_refs(

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -17,11 +17,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.auth_providers import get_current_user
 from api_service.db.models import (
-    ProviderCredentialSource,
-    RuntimeMaterializationMode,
     ManagedAgentProviderProfile,
     ManagedAgentRateLimitPolicy,
     ManagedSecret,
+    ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
+    RuntimeMaterializationMode,
     SecretStatus,
     User,
 )
@@ -93,9 +96,23 @@ class ProviderProfileCreate(BaseModel):
     max_parallel_runs: int = Field(default=1, ge=1)
     cooldown_after_429_seconds: int = Field(default=900, ge=0)
     rate_limit_policy: str = Field(default="backoff", pattern="^(backoff|queue|fail_fast)$")
-    enabled: bool = True
+    enabled: bool = False
     is_default: bool = False
     max_lease_duration_seconds: int = Field(default=7200, ge=60)
+    auth_state: str = Field(
+        default="not_configured",
+        pattern="^(not_configured|oauth_pending|api_key_pending|connected|validation_failed|disconnected)$",
+    )
+    disabled_reason: Optional[str] = Field(
+        default="missing_credentials",
+        pattern="^(missing_credentials|auth_invalid|user_disabled|policy_disabled|disconnected)$",
+    )
+    first_authenticated_at: Optional[datetime] = None
+    last_validated_at: Optional[datetime] = None
+    last_auth_method: Optional[str] = Field(
+        default=None,
+        pattern="^(oauth_volume|secret_ref|manual)$",
+    )
 
     @field_validator("env_template", mode="before")
     @classmethod
@@ -115,6 +132,10 @@ class ProviderProfileCreate(BaseModel):
 
     @model_validator(mode="after")
     def _validate_runtime_env(self) -> "ProviderProfileCreate":
+        if self.enabled and self.auth_state != ProviderProfileAuthState.CONNECTED.value:
+            raise ValueError("enabled profiles require auth_state=connected")
+        if self.enabled and self.disabled_reason is not None:
+            raise ValueError("enabled profiles must not set disabled_reason")
         validate_codex_oauth_profile_refs(
             runtime_id=self.runtime_id,
             credential_source=self.credential_source,
@@ -165,6 +186,20 @@ class ProviderProfileUpdate(BaseModel):
     enabled: Optional[bool] = None
     is_default: Optional[bool] = None
     max_lease_duration_seconds: Optional[int] = Field(default=None, ge=60)
+    auth_state: Optional[str] = Field(
+        default=None,
+        pattern="^(not_configured|oauth_pending|api_key_pending|connected|validation_failed|disconnected)$",
+    )
+    disabled_reason: Optional[str] = Field(
+        default=None,
+        pattern="^(missing_credentials|auth_invalid|user_disabled|policy_disabled|disconnected)$",
+    )
+    first_authenticated_at: Optional[datetime] = None
+    last_validated_at: Optional[datetime] = None
+    last_auth_method: Optional[str] = Field(
+        default=None,
+        pattern="^(oauth_volume|secret_ref|manual)$",
+    )
 
     @field_validator("secret_refs", mode="after")
     @classmethod
@@ -201,6 +236,11 @@ class ProviderProfileResponse(BaseModel):
     enabled: bool
     is_default: bool
     max_lease_duration_seconds: int
+    auth_state: str
+    disabled_reason: Optional[str]
+    first_authenticated_at: Optional[str]
+    last_validated_at: Optional[str]
+    last_auth_method: Optional[str]
     readiness: "ProviderProfileReadiness"
     created_at: Optional[str]
     updated_at: Optional[str]
@@ -353,6 +393,19 @@ async def create_profile(
         enabled=body.enabled,
         is_default=False,
         max_lease_duration_seconds=body.max_lease_duration_seconds,
+        auth_state=ProviderProfileAuthState(body.auth_state),
+        disabled_reason=(
+            ProviderProfileDisabledReason(body.disabled_reason)
+            if body.disabled_reason is not None
+            else None
+        ),
+        first_authenticated_at=body.first_authenticated_at,
+        last_validated_at=body.last_validated_at,
+        last_auth_method=(
+            ProviderProfileAuthMethod(body.last_auth_method)
+            if body.last_auth_method is not None
+            else None
+        ),
     )
     _validate_codex_oauth_profile_row(profile)
     session.add(profile)
@@ -401,6 +454,12 @@ async def update_profile(
             value = ProviderCredentialSource(value)
         elif key == "runtime_materialization_mode" and value is not None:
             value = RuntimeMaterializationMode(value)
+        elif key == "auth_state" and value is not None:
+            value = ProviderProfileAuthState(value)
+        elif key == "disabled_reason" and value is not None:
+            value = ProviderProfileDisabledReason(value)
+        elif key == "last_auth_method" and value is not None:
+            value = ProviderProfileAuthMethod(value)
         setattr(profile, key, value)
 
     if requested_is_default is False:
@@ -492,6 +551,13 @@ async def commit_claude_manual_auth(
     profile.account_label = (
         body.account_label or profile.account_label or "Claude Anthropic"
     )
+    profile.enabled = True
+    profile.auth_state = ProviderProfileAuthState.CONNECTED
+    profile.disabled_reason = None
+    if profile.first_authenticated_at is None:
+        profile.first_authenticated_at = validated_at
+    profile.last_validated_at = validated_at
+    profile.last_auth_method = ProviderProfileAuthMethod.SECRET_REF
     behavior = dict(profile.command_behavior or {})
     behavior.update(
         {
@@ -564,6 +630,11 @@ async def validate_claude_oauth_profile(
         ) from exc
 
     if not verification.get("verified", False):
+        failed_at = datetime.now(UTC)
+        profile.enabled = False
+        profile.auth_state = ProviderProfileAuthState.VALIDATION_FAILED
+        profile.disabled_reason = ProviderProfileDisabledReason.AUTH_INVALID
+        profile.last_validated_at = failed_at
         reason = redact_sensitive_payload(str(verification.get("reason") or "unknown"))
         _update_claude_auth_behavior(
             profile,
@@ -571,7 +642,7 @@ async def validate_claude_oauth_profile(
             status_label="Claude OAuth validation failed",
             readiness={
                 "connected": False,
-                "last_validated_at": datetime.now(UTC).isoformat(),
+                "last_validated_at": failed_at.isoformat(),
                 "backing_secret_exists": False,
                 "launch_ready": False,
                 "failure_reason": reason,
@@ -585,6 +656,13 @@ async def validate_claude_oauth_profile(
         )
 
     validated_at = datetime.now(UTC)
+    profile.enabled = True
+    profile.auth_state = ProviderProfileAuthState.CONNECTED
+    profile.disabled_reason = None
+    if profile.first_authenticated_at is None:
+        profile.first_authenticated_at = validated_at
+    profile.last_validated_at = validated_at
+    profile.last_auth_method = ProviderProfileAuthMethod.OAUTH_VOLUME
     _update_claude_auth_behavior(
         profile,
         auth_state="connected",
@@ -626,13 +704,18 @@ async def disconnect_claude_oauth_profile(
         profile.runtime_materialization_mode = RuntimeMaterializationMode.API_KEY_ENV
     profile.volume_ref = None
     profile.volume_mount_path = None
+    disconnected_at = datetime.now(UTC)
+    profile.enabled = False
+    profile.auth_state = ProviderProfileAuthState.DISCONNECTED
+    profile.disabled_reason = ProviderProfileDisabledReason.DISCONNECTED
+    profile.last_validated_at = disconnected_at
     _update_claude_auth_behavior(
         profile,
-        auth_state="not_connected",
+        auth_state="disconnected",
         status_label="Claude OAuth disconnected",
         readiness={
             "connected": False,
-            "last_validated_at": datetime.now(UTC).isoformat(),
+            "last_validated_at": disconnected_at.isoformat(),
             "backing_secret_exists": False,
             "launch_ready": False,
         },
@@ -900,6 +983,7 @@ def _provider_profile_readiness(
     checks = [
         _required_fields_check(row),
         _enabled_check(row),
+        _auth_state_check(row),
         _secret_refs_check(
             row,
             credential_source=credential_source,
@@ -967,6 +1051,30 @@ def _enabled_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
         "Enabled state",
         "pass" if row.enabled else "error",
         "Profile is enabled." if row.enabled else "Profile is disabled.",
+    )
+
+
+def _auth_state_check(row: ManagedAgentProviderProfile) -> dict[str, str]:
+    auth_state = row.auth_state.value if row.auth_state else None
+    disabled_reason = row.disabled_reason.value if row.disabled_reason else None
+    connected = auth_state == ProviderProfileAuthState.CONNECTED.value
+    consistent = not row.enabled or disabled_reason is None
+    if connected and consistent:
+        message = "Profile credentials are connected."
+    elif connected:
+        message = f"Profile is enabled but still has disabled reason {disabled_reason}."
+    elif disabled_reason:
+        message = (
+            f"Profile credentials are {auth_state or 'unknown'} "
+            f"({disabled_reason})."
+        )
+    else:
+        message = f"Profile credentials are {auth_state or 'unknown'}."
+    return _readiness_check(
+        "auth_state",
+        "Activation state",
+        "pass" if connected and consistent else "error",
+        message,
     )
 
 
@@ -1152,6 +1260,21 @@ def _row_to_dict(
         "enabled": row.enabled,
         "is_default": row.is_default,
         "max_lease_duration_seconds": row.max_lease_duration_seconds,
+        "auth_state": row.auth_state.value if row.auth_state else None,
+        "disabled_reason": (
+            row.disabled_reason.value if row.disabled_reason else None
+        ),
+        "first_authenticated_at": (
+            row.first_authenticated_at.isoformat()
+            if row.first_authenticated_at
+            else None
+        ),
+        "last_validated_at": (
+            row.last_validated_at.isoformat() if row.last_validated_at else None
+        ),
+        "last_auth_method": (
+            row.last_auth_method.value if row.last_auth_method else None
+        ),
         "readiness": _provider_profile_readiness(
             row,
             managed_secret_statuses=managed_secret_statuses,

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -134,8 +134,8 @@ class ProviderProfileCreate(BaseModel):
     def _validate_runtime_env(self) -> "ProviderProfileCreate":
         if self.enabled and self.auth_state != ProviderProfileAuthState.CONNECTED.value:
             raise ValueError("enabled profiles require auth_state=connected")
-        if self.enabled and self.disabled_reason is not None:
-            raise ValueError("enabled profiles must not set disabled_reason")
+        if self.enabled:
+            self.disabled_reason = None
         validate_codex_oauth_profile_refs(
             runtime_id=self.runtime_id,
             credential_source=self.credential_source,
@@ -461,6 +461,14 @@ async def update_profile(
         elif key == "last_auth_method" and value is not None:
             value = ProviderProfileAuthMethod(value)
         setattr(profile, key, value)
+
+    if profile.enabled:
+        if profile.auth_state != ProviderProfileAuthState.CONNECTED:
+            raise HTTPException(
+                status_code=422,
+                detail="Enabled profiles require auth_state=connected",
+            )
+        profile.disabled_reason = None
 
     if requested_is_default is False:
         profile.is_default = False

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1953,6 +1953,32 @@ class ManagedAgentRateLimitPolicy(str, enum.Enum):
     QUEUE = "queue"
     FAIL_FAST = "fail_fast"
 
+class ProviderProfileAuthState(str, enum.Enum):
+    """Persisted provider-profile credential activation state."""
+
+    NOT_CONFIGURED = "not_configured"
+    OAUTH_PENDING = "oauth_pending"
+    API_KEY_PENDING = "api_key_pending"
+    CONNECTED = "connected"
+    VALIDATION_FAILED = "validation_failed"
+    DISCONNECTED = "disconnected"
+
+class ProviderProfileDisabledReason(str, enum.Enum):
+    """Persisted reason a provider profile is disabled."""
+
+    MISSING_CREDENTIALS = "missing_credentials"
+    AUTH_INVALID = "auth_invalid"
+    USER_DISABLED = "user_disabled"
+    POLICY_DISABLED = "policy_disabled"
+    DISCONNECTED = "disconnected"
+
+class ProviderProfileAuthMethod(str, enum.Enum):
+    """Last verified auth method for provider-profile activation."""
+
+    OAUTH_VOLUME = "oauth_volume"
+    SECRET_REF = "secret_ref"
+    MANUAL = "manual"
+
 class ManagedAgentProviderProfile(Base):
     """Named provider configuration and execution policy for a managed agent runtime."""
 
@@ -1960,7 +1986,36 @@ class ManagedAgentProviderProfile(Base):
     __table_args__ = (
         Index("ix_provider_profiles_runtime", "runtime_id"),
         Index("ix_provider_profiles_provider", "provider_id"),
+        Index("ix_provider_profiles_runtime_provider", "runtime_id", "provider_id"),
         Index("ix_provider_profiles_enabled", "enabled"),
+        Index("ix_provider_profiles_auth_state", "auth_state"),
+        Index(
+            "ix_provider_profiles_readiness",
+            "runtime_id",
+            "provider_id",
+            "enabled",
+            "auth_state",
+        ),
+        CheckConstraint(
+            "auth_state IN ("
+            "'not_configured', 'oauth_pending', 'api_key_pending', "
+            "'connected', 'validation_failed', 'disconnected'"
+            ")",
+            name="ck_provider_profiles_auth_state",
+        ),
+        CheckConstraint(
+            "disabled_reason IS NULL OR disabled_reason IN ("
+            "'missing_credentials', 'auth_invalid', 'user_disabled', "
+            "'policy_disabled', 'disconnected'"
+            ")",
+            name="ck_provider_profiles_disabled_reason",
+        ),
+        CheckConstraint(
+            "last_auth_method IS NULL OR last_auth_method IN ("
+            "'oauth_volume', 'secret_ref', 'manual'"
+            ")",
+            name="ck_provider_profiles_last_auth_method",
+        ),
         Index(
             "ux_provider_profiles_runtime_default",
             "runtime_id",
@@ -2004,7 +2059,7 @@ class ManagedAgentProviderProfile(Base):
 
     account_label: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=text("true")
+        Boolean, nullable=False, default=False, server_default=text("false")
     )
     is_default: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")
@@ -2012,6 +2067,45 @@ class ManagedAgentProviderProfile(Base):
 
     tags: Mapped[Optional[list[str]]] = mapped_column(JSON, nullable=True)
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100, server_default=text("100"))
+
+    auth_state: Mapped[ProviderProfileAuthState] = mapped_column(
+        Enum(
+            ProviderProfileAuthState,
+            name="providerprofileauthstate",
+            native_enum=True,
+            validate_strings=True,
+            values_callable=_enum_values,
+        ),
+        nullable=False,
+        default=ProviderProfileAuthState.NOT_CONFIGURED,
+        server_default=ProviderProfileAuthState.NOT_CONFIGURED.value,
+    )
+    disabled_reason: Mapped[Optional[ProviderProfileDisabledReason]] = mapped_column(
+        Enum(
+            ProviderProfileDisabledReason,
+            name="providerprofiledisabledreason",
+            native_enum=True,
+            validate_strings=True,
+            values_callable=_enum_values,
+        ),
+        nullable=True,
+    )
+    first_authenticated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_validated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_auth_method: Mapped[Optional[ProviderProfileAuthMethod]] = mapped_column(
+        Enum(
+            ProviderProfileAuthMethod,
+            name="providerprofileauthmethod",
+            native_enum=True,
+            validate_strings=True,
+            values_callable=_enum_values,
+        ),
+        nullable=True,
+    )
 
     volume_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     volume_mount_path: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -627,6 +627,9 @@ async def _auto_seed_provider_profiles() -> list[str]:
     from api_service.db.models import (
         ManagedAgentProviderProfile,
         ProviderCredentialSource,
+        ProviderProfileAuthMethod,
+        ProviderProfileAuthState,
+        ProviderProfileDisabledReason,
         RuntimeMaterializationMode,
         ManagedAgentRateLimitPolicy,
     )
@@ -646,50 +649,58 @@ async def _auto_seed_provider_profiles() -> list[str]:
         {
             "profile_id": "gemini_default",
             "runtime_id": "gemini_cli",
-            "is_default": True,
+            "is_default": False,
             "provider_id": "google",
             "provider_label": "Google",
             "default_model": None,  # inherits runtime default: gemini-3.1-pro
-            "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
-            "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
-            "volume_ref": get_provider_default("gemini_cli", "volume_ref"),
-            "volume_mount_path": get_provider_default(
-                "gemini_cli", "volume_mount_path"
-            ),
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
             "account_label": "Gemini CLI (auto-seeded)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
         },
         {
             "profile_id": "codex_default",
             "runtime_id": "codex_cli",
-            "is_default": True,
+            "is_default": False,
             "provider_id": "openai",
             "provider_label": "OpenAI",
             "default_model": None,  # inherits runtime default: gpt-5.5
-            "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
-            "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
-            "volume_ref": get_provider_default("codex_cli", "volume_ref"),
-            "volume_mount_path": get_provider_default("codex_cli", "volume_mount_path"),
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
             "account_label": "Codex CLI (auto-seeded)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
         },
         {
             "profile_id": "claude_anthropic",
             "runtime_id": "claude_code",
-            "is_default": True,
+            "is_default": False,
             "provider_id": "anthropic",
             "provider_label": "Anthropic",
             "default_model": None,  # inherits runtime default: claude-opus-4-8
-            "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
-            "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
-            "volume_ref": get_provider_default("claude_code", "volume_ref"),
-            "volume_mount_path": get_provider_default(
-                "claude_code", "volume_mount_path"
-            ),
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
             "clear_env_keys": [
                 "ANTHROPIC_API_KEY",
                 "CLAUDE_API_KEY",
                 "OPENAI_API_KEY",
             ],
             "account_label": "Claude Code (auto-seeded)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
         },
 
     ]
@@ -725,6 +736,10 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "volume_ref": None,
             "volume_mount_path": None,
             "account_label": "Claude Code via MiniMax (auto-seeded)",
+            "enabled": True,
+            "auth_state": ProviderProfileAuthState.CONNECTED,
+            "disabled_reason": None,
+            "last_auth_method": ProviderProfileAuthMethod.SECRET_REF,
         })
 
     if os.environ.get("OPENROUTER_API_KEY"):
@@ -768,6 +783,10 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "volume_ref": None,
             "volume_mount_path": None,
             "account_label": "Codex CLI via OpenRouter (auto-seeded)",
+            "enabled": True,
+            "auth_state": ProviderProfileAuthState.CONNECTED,
+            "disabled_reason": None,
+            "last_auth_method": ProviderProfileAuthMethod.SECRET_REF,
         })
 
     seeded: list[str] = []
@@ -934,11 +953,21 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         "rate_limit_policy",
                         ManagedAgentRateLimitPolicy.BACKOFF,
                     ),
-                    enabled=True,
+                    enabled=bool(profile_def.get("enabled", False)),
                     is_default=bool(profile_def.get("is_default", False)),
                     max_lease_duration_seconds=profile_def.get(
                         "max_lease_duration_seconds", 7200
                     ),
+                    auth_state=profile_def.get(
+                        "auth_state", ProviderProfileAuthState.NOT_CONFIGURED
+                    ),
+                    disabled_reason=profile_def.get(
+                        "disabled_reason",
+                        ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+                    ),
+                    first_authenticated_at=profile_def.get("first_authenticated_at"),
+                    last_validated_at=profile_def.get("last_validated_at"),
+                    last_auth_method=profile_def.get("last_auth_method"),
                 )
                 session.add(profile)
                 runtime_id = profile_def["runtime_id"]

--- a/api_service/migrations/versions/316_provider_profile_activation_state.py
+++ b/api_service/migrations/versions/316_provider_profile_activation_state.py
@@ -6,15 +6,13 @@ Create Date: 2026-06-23 00:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "316_provider_profile_activation_state"
 down_revision: Union[str, None] = "315_workflow_type_enum_cutover"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
 
 __all__ = ["revision", "down_revision", "upgrade", "downgrade"]
 
@@ -79,6 +77,11 @@ def upgrade() -> None:
     op.add_column(
         "managed_agent_provider_profiles",
         sa.Column("last_auth_method", auth_method_enum, nullable=True),
+    )
+    op.execute(
+        "UPDATE managed_agent_provider_profiles "
+        "SET auth_state = 'connected', disabled_reason = NULL "
+        "WHERE enabled = true"
     )
 
     op.create_check_constraint(

--- a/api_service/migrations/versions/316_provider_profile_activation_state.py
+++ b/api_service/migrations/versions/316_provider_profile_activation_state.py
@@ -1,0 +1,129 @@
+"""add provider profile activation state
+
+Revision ID: 316_provider_profile_activation_state
+Revises: 315_workflow_type_enum_cutover
+Create Date: 2026-06-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "316_provider_profile_activation_state"
+down_revision: Union[str, None] = "315_workflow_type_enum_cutover"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+
+AUTH_STATES = (
+    "not_configured",
+    "oauth_pending",
+    "api_key_pending",
+    "connected",
+    "validation_failed",
+    "disconnected",
+)
+DISABLED_REASONS = (
+    "missing_credentials",
+    "auth_invalid",
+    "user_disabled",
+    "policy_disabled",
+    "disconnected",
+)
+AUTH_METHODS = ("oauth_volume", "secret_ref", "manual")
+
+
+def upgrade() -> None:
+    auth_state_enum = sa.Enum(*AUTH_STATES, name="providerprofileauthstate")
+    disabled_reason_enum = sa.Enum(
+        *DISABLED_REASONS, name="providerprofiledisabledreason"
+    )
+    auth_method_enum = sa.Enum(*AUTH_METHODS, name="providerprofileauthmethod")
+    bind = op.get_bind()
+    auth_state_enum.create(bind, checkfirst=True)
+    disabled_reason_enum.create(bind, checkfirst=True)
+    auth_method_enum.create(bind, checkfirst=True)
+
+    op.alter_column(
+        "managed_agent_provider_profiles",
+        "enabled",
+        server_default=sa.text("false"),
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "auth_state",
+            auth_state_enum,
+            nullable=False,
+            server_default="not_configured",
+        ),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column("disabled_reason", disabled_reason_enum, nullable=True),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column("first_authenticated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column("last_validated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column("last_auth_method", auth_method_enum, nullable=True),
+    )
+
+    op.create_check_constraint(
+        "ck_provider_profiles_auth_state",
+        "managed_agent_provider_profiles",
+        "auth_state IN ("
+        "'not_configured', 'oauth_pending', 'api_key_pending', "
+        "'connected', 'validation_failed', 'disconnected'"
+        ")",
+    )
+    op.create_check_constraint(
+        "ck_provider_profiles_disabled_reason",
+        "managed_agent_provider_profiles",
+        "disabled_reason IS NULL OR disabled_reason IN ("
+        "'missing_credentials', 'auth_invalid', 'user_disabled', "
+        "'policy_disabled', 'disconnected'"
+        ")",
+    )
+    op.create_check_constraint(
+        "ck_provider_profiles_last_auth_method",
+        "managed_agent_provider_profiles",
+        "last_auth_method IS NULL OR last_auth_method IN ("
+        "'oauth_volume', 'secret_ref', 'manual'"
+        ")",
+    )
+
+    op.create_index(
+        "ix_provider_profiles_runtime_provider",
+        "managed_agent_provider_profiles",
+        ["runtime_id", "provider_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_profiles_auth_state",
+        "managed_agent_provider_profiles",
+        ["auth_state"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_profiles_readiness",
+        "managed_agent_provider_profiles",
+        ["runtime_id", "provider_id", "enabled", "auth_state"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("One-way migration: MM-872 provider profile activation state")

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -5,7 +5,7 @@ from sqlalchemy import case
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from api_service.db.models import ManagedAgentProviderProfile
+from api_service.db.models import ManagedAgentProviderProfile, ProviderProfileAuthState
 from moonmind.utils.logging import redact_profile_file_templates, redact_sensitive_payload
 
 logger = logging.getLogger(__name__)
@@ -37,8 +37,19 @@ async def normalize_runtime_default_profile(
     if not rows:
         return None
 
-    enabled_rows = [row for row in rows if row.enabled]
-    candidates = enabled_rows or rows
+    launchable_rows = [
+        row
+        for row in rows
+        if row.enabled and row.auth_state == ProviderProfileAuthState.CONNECTED
+    ]
+    if not launchable_rows:
+        rows_to_clear = [row for row in rows if row.is_default]
+        for row in rows_to_clear:
+            row.is_default = False
+        if rows_to_clear:
+            await session.flush()
+        return None
+    candidates = launchable_rows
 
     selected = None
     if preferred_profile_id:
@@ -96,6 +107,21 @@ def _manager_profile_payload(row: ManagedAgentProviderProfile) -> dict[str, Any]
         ),
         "enabled": row.enabled,
         "max_lease_duration_seconds": row.max_lease_duration_seconds,
+        "auth_state": row.auth_state.value if row.auth_state else None,
+        "disabled_reason": (
+            row.disabled_reason.value if row.disabled_reason else None
+        ),
+        "first_authenticated_at": (
+            row.first_authenticated_at.isoformat()
+            if row.first_authenticated_at
+            else None
+        ),
+        "last_validated_at": (
+            row.last_validated_at.isoformat() if row.last_validated_at else None
+        ),
+        "last_auth_method": (
+            row.last_auth_method.value if row.last_auth_method else None
+        ),
     }
 
 async def sync_provider_profile_manager(
@@ -109,6 +135,7 @@ async def sync_provider_profile_manager(
         .where(
             ManagedAgentProviderProfile.runtime_id == runtime_id,
             ManagedAgentProviderProfile.enabled.is_(True),
+            ManagedAgentProviderProfile.auth_state == ProviderProfileAuthState.CONNECTED,
         )
         .order_by(
             ManagedAgentProviderProfile.is_default.desc(),

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6621,7 +6621,7 @@ export interface components {
             rate_limit_policy: string;
             /**
              * Enabled
-             * @default true
+             * @default false
              */
             enabled: boolean;
             /**
@@ -6634,6 +6634,22 @@ export interface components {
              * @default 7200
              */
             max_lease_duration_seconds: number;
+            /**
+             * Auth State
+             * @default not_configured
+             */
+            auth_state: string;
+            /**
+             * Disabled Reason
+             * @default missing_credentials
+             */
+            disabled_reason: string | null;
+            /** First Authenticated At */
+            first_authenticated_at?: string | null;
+            /** Last Validated At */
+            last_validated_at?: string | null;
+            /** Last Auth Method */
+            last_auth_method?: string | null;
         };
         /** ProviderProfileReadiness */
         ProviderProfileReadiness: {
@@ -6713,6 +6729,16 @@ export interface components {
             is_default: boolean;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds: number;
+            /** Auth State */
+            auth_state: string;
+            /** Disabled Reason */
+            disabled_reason: string | null;
+            /** First Authenticated At */
+            first_authenticated_at: string | null;
+            /** Last Validated At */
+            last_validated_at: string | null;
+            /** Last Auth Method */
+            last_auth_method: string | null;
             readiness: components["schemas"]["ProviderProfileReadiness"];
             /** Created At */
             created_at: string | null;
@@ -6802,6 +6828,16 @@ export interface components {
             is_default?: boolean | null;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds?: number | null;
+            /** Auth State */
+            auth_state?: string | null;
+            /** Disabled Reason */
+            disabled_reason?: string | null;
+            /** First Authenticated At */
+            first_authenticated_at?: string | null;
+            /** Last Validated At */
+            last_validated_at?: string | null;
+            /** Last Auth Method */
+            last_auth_method?: string | null;
         };
         /** ProviderReadinessCheck */
         ProviderReadinessCheck: {

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -729,10 +729,8 @@ class ManagedAgentProviderProfile(BaseModel):
             raise ValueError(
                 "enabled provider profiles must have authState='connected'"
             )
-        if self.enabled and self.disabled_reason is not None:
-            raise ValueError(
-                "enabled provider profiles must not set disabledReason"
-            )
+        if self.enabled:
+            self.disabled_reason = None
 
         validate_codex_oauth_profile_refs(
             runtime_id=self.runtime_id,

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -61,6 +61,22 @@ RuntimeContextPolicy = Literal[
     "reuse_session_same_epoch",
     "external_provider_continuation",
 ]
+ProviderProfileAuthState = Literal[
+    "not_configured",
+    "oauth_pending",
+    "api_key_pending",
+    "connected",
+    "validation_failed",
+    "disconnected",
+]
+ProviderProfileDisabledReason = Literal[
+    "missing_credentials",
+    "auth_invalid",
+    "user_disabled",
+    "policy_disabled",
+    "disconnected",
+]
+ProviderProfileAuthMethod = Literal["oauth_volume", "secret_ref", "manual"]
 
 
 class AgentRuntimeStepExecutionLaunch(BaseModel):
@@ -622,7 +638,20 @@ class ManagedAgentProviderProfile(BaseModel):
     rate_limit_policy: dict[str, Any] = Field(
         default_factory=dict, alias="rateLimitPolicy"
     )
-    enabled: bool = Field(True, alias="enabled")
+    enabled: bool = Field(False, alias="enabled")
+    auth_state: ProviderProfileAuthState = Field(
+        "not_configured", alias="authState"
+    )
+    disabled_reason: ProviderProfileDisabledReason | None = Field(
+        "missing_credentials", alias="disabledReason"
+    )
+    first_authenticated_at: datetime | None = Field(
+        None, alias="firstAuthenticatedAt"
+    )
+    last_validated_at: datetime | None = Field(None, alias="lastValidatedAt")
+    last_auth_method: ProviderProfileAuthMethod | None = Field(
+        None, alias="lastAuthMethod"
+    )
 
     # -- Volume & account binding (optional) --
     volume_ref: str | None = Field(None, alias="volumeRef")
@@ -694,6 +723,15 @@ class ManagedAgentProviderProfile(BaseModel):
             raise ValueError(
                 f"runtimeMaterializationMode must be one of: {allowed}; "
                 f"got {self.runtime_materialization_mode!r}"
+            )
+
+        if self.enabled and self.auth_state != "connected":
+            raise ValueError(
+                "enabled provider profiles must have authState='connected'"
+            )
+        if self.enabled and self.disabled_reason is not None:
+            raise ValueError(
+                "enabled provider profiles must not set disabledReason"
             )
 
         validate_codex_oauth_profile_refs(

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -342,6 +342,8 @@ async def oauth_session_register_profile(
             ManagedAgentProviderProfile,
             ManagedAgentRateLimitPolicy,
             ProviderCredentialSource,
+            ProviderProfileAuthMethod,
+            ProviderProfileAuthState,
             RuntimeMaterializationMode,
         )
         from api_service.services.provider_profile_service import sync_provider_profile_manager
@@ -377,6 +379,7 @@ async def oauth_session_register_profile(
         except ValueError:
             policy_enum = ManagedAgentRateLimitPolicy.BACKOFF
 
+        connected_at = datetime.now(timezone.utc)
         profile_data = {
             "runtime_id": session_obj.runtime_id,
             "provider_id": metadata.get("provider_id")
@@ -393,6 +396,13 @@ async def oauth_session_register_profile(
             "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 900),
             "rate_limit_policy": policy_enum,
             "enabled": True,
+            "auth_state": ProviderProfileAuthState.CONNECTED,
+            "disabled_reason": None,
+            "first_authenticated_at": existing_profile.first_authenticated_at
+            if existing_profile and existing_profile.first_authenticated_at
+            else connected_at,
+            "last_validated_at": connected_at,
+            "last_auth_method": ProviderProfileAuthMethod.OAUTH_VOLUME,
         }
         validate_codex_oauth_profile_refs(
             runtime_id=session_obj.runtime_id,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2799,13 +2799,18 @@ class TemporalArtifactActivities:
         """
         from sqlalchemy import select
 
-        from api_service.db.models import ManagedAgentProviderProfile
+        from api_service.db.models import (
+            ManagedAgentProviderProfile,
+            ProviderProfileAuthState,
+        )
         from api_service.db.base import get_async_session_context
 
         async with get_async_session_context() as session:
             stmt = select(ManagedAgentProviderProfile).where(
                 ManagedAgentProviderProfile.runtime_id == runtime_id,
                 ManagedAgentProviderProfile.enabled.is_(True),
+                ManagedAgentProviderProfile.auth_state
+                == ProviderProfileAuthState.CONNECTED,
             ).order_by(
                 ManagedAgentProviderProfile.is_default.desc(),
                 ManagedAgentProviderProfile.priority.desc(),
@@ -2855,6 +2860,23 @@ class TemporalArtifactActivities:
                     "rate_limit_policy": row.rate_limit_policy.value,
                     "max_lease_duration_seconds": row.max_lease_duration_seconds,
                     "enabled": row.enabled,
+                    "auth_state": row.auth_state.value if row.auth_state else None,
+                    "disabled_reason": (
+                        row.disabled_reason.value if row.disabled_reason else None
+                    ),
+                    "first_authenticated_at": (
+                        row.first_authenticated_at.isoformat()
+                        if row.first_authenticated_at
+                        else None
+                    ),
+                    "last_validated_at": (
+                        row.last_validated_at.isoformat()
+                        if row.last_validated_at
+                        else None
+                    ),
+                    "last_auth_method": (
+                        row.last_auth_method.value if row.last_auth_method else None
+                    ),
                 }
             )
 

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -19,6 +19,8 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     OAuthSessionStatus,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
 )
 from api_service.main import app
@@ -1126,6 +1128,15 @@ async def test_finalize_oauth_session_returns_projection_after_verifying_and_reg
         OAuthSessionStatus.VERIFYING,
         OAuthSessionStatus.REGISTERING_PROFILE,
     ]
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        assert profile.enabled is True
+        assert profile.auth_state == ProviderProfileAuthState.CONNECTED
+        assert profile.disabled_reason is None
+        assert profile.last_auth_method == ProviderProfileAuthMethod.OAUTH_VOLUME
+        assert profile.first_authenticated_at is not None
+        assert profile.last_validated_at is not None
 
 @pytest.mark.asyncio
 async def test_finalize_oauth_session_is_idempotent_for_succeeded_session(
@@ -1148,6 +1159,9 @@ async def test_finalize_oauth_session_is_idempotent_for_succeeded_session(
                 account_label="codex account",
                 owner_user_id=None,
                 enabled=True,
+                auth_state=ProviderProfileAuthState.CONNECTED,
+                disabled_reason=None,
+                last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
             )
         )
         session.add(

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -515,7 +515,6 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
         "model_overrides": {"smart": "test-model-v3"},
         "enabled": True,
         "auth_state": "connected",
-        "disabled_reason": None,
         "last_auth_method": "secret_ref",
     }
     
@@ -533,6 +532,31 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
     assert data["auth_state"] == "connected"
     assert data["disabled_reason"] is None
     assert data["last_auth_method"] == "secret_ref"
+
+
+@pytest.mark.asyncio
+async def test_create_enabled_provider_profile_clears_default_disabled_reason(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "enabled_profile_clears_disabled_reason",
+        "runtime_id": "enabled_profile_clear_runtime",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://enabled_profile_secret"},
+        "enabled": True,
+        "auth_state": "connected",
+        "last_auth_method": "secret_ref",
+    }
+
+    async with client_app as client:
+        response = await client.post("/api/v1/provider-profiles", json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["enabled"] is True
+    assert data["auth_state"] == "connected"
+    assert data["disabled_reason"] is None
 
 
 @pytest.mark.asyncio
@@ -658,6 +682,62 @@ async def test_update_profile_can_become_runtime_default(
     profiles = {profile["profile_id"]: profile for profile in listed.json()}
     assert profiles["patch_runtime_default_first"]["is_default"] is False
     assert profiles["patch_runtime_default_second"]["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_profile_rejects_enabled_without_connected_auth_state(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    payload = {
+        "profile_id": "patch_enabled_requires_connected_auth",
+        "runtime_id": "patch_enabled_requires_connected",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            "/api/v1/provider-profiles/patch_enabled_requires_connected_auth",
+            json={"enabled": True},
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 422
+    assert update_response.json()["detail"] == (
+        "Enabled profiles require auth_state=connected"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_profile_clears_disabled_reason_when_enabled(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    payload = {
+        "profile_id": "patch_enabled_clears_disabled_reason",
+        "runtime_id": "patch_enabled_clears",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://patch_enabled_secret"},
+        "auth_state": "connected",
+        "disabled_reason": "missing_credentials",
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        update_response = await client.patch(
+            "/api/v1/provider-profiles/patch_enabled_clears_disabled_reason",
+            json={"enabled": True},
+        )
+
+    assert create_response.status_code == 201
+    assert update_response.status_code == 200
+    data = update_response.json()
+    assert data["enabled"] is True
+    assert data["auth_state"] == "connected"
+    assert data["disabled_reason"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -18,6 +18,9 @@ from api_service.db.models import (
     ManagedAgentRateLimitPolicy,
     ManagedSecret,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
     RuntimeMaterializationMode,
 )
 from api_service.main import app
@@ -174,10 +177,12 @@ class _TrackedProfile:
         priority: int,
         is_default: bool,
         events: list[tuple[object, ...]],
+        auth_state: ProviderProfileAuthState = ProviderProfileAuthState.CONNECTED,
     ) -> None:
         self.profile_id = profile_id
         self.runtime_id = runtime_id
         self.enabled = enabled
+        self.auth_state = auth_state
         self.priority = priority
         self._is_default = is_default
         self._events = events
@@ -405,6 +410,8 @@ async def test_create_codex_oauth_profile_requires_volume_ref_and_mount_path(
         "credential_source": "oauth_volume",
         "runtime_materialization_mode": "oauth_home",
         "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
     }
 
     async with client_app as client:
@@ -506,7 +513,10 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
         "rate_limit_policy": "queue",
         "default_model": "test-model-v2",
         "model_overrides": {"smart": "test-model-v3"},
-        "enabled": True
+        "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
+        "last_auth_method": "secret_ref",
     }
     
     async with client_app as client:
@@ -520,6 +530,38 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
     assert data["default_model"] == "test-model-v2"
     assert data["model_overrides"] == {"smart": "test-model-v3"}
     assert data["is_default"] is True
+    assert data["auth_state"] == "connected"
+    assert data["disabled_reason"] is None
+    assert data["last_auth_method"] == "secret_ref"
+
+
+@pytest.mark.asyncio
+async def test_create_provider_profile_defaults_to_unconfigured_not_launchable(
+    client_app: AsyncClient, _module_db
+) -> None:
+    payload = {
+        "profile_id": "unconfigured_custom_profile",
+        "runtime_id": "custom_runtime",
+        "provider_id": "custom",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+    }
+
+    async with client_app as client:
+        response = await client.post("/api/v1/provider-profiles", json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["auth_state"] == "not_configured"
+    assert data["disabled_reason"] == "missing_credentials"
+    assert data["credential_source"] == "none"
+    assert data["is_default"] is False
+    readiness = data["readiness"]
+    assert readiness["launch_ready"] is False
+    checks = {check["id"]: check for check in readiness["checks"]}
+    assert checks["enabled"]["status"] == "error"
+    assert checks["auth_state"]["status"] == "error"
 
 @pytest.mark.asyncio
 async def test_create_second_profile_can_become_runtime_default(
@@ -534,6 +576,9 @@ async def test_create_second_profile_can_become_runtime_default(
         "runtime_materialization_mode": "api_key_env",
         "secret_refs": {"API_KEY": "env://first_secret"},
         "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
+        "last_auth_method": "secret_ref",
     }
     second_payload = {
         "profile_id": "runtime_default_second",
@@ -542,6 +587,9 @@ async def test_create_second_profile_can_become_runtime_default(
         "runtime_materialization_mode": "api_key_env",
         "secret_refs": {"API_KEY": "env://second_secret"},
         "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
+        "last_auth_method": "secret_ref",
         "is_default": True,
     }
 
@@ -572,6 +620,9 @@ async def test_update_profile_can_become_runtime_default(
         "runtime_materialization_mode": "api_key_env",
         "secret_refs": {"API_KEY": "env://patch_first_secret"},
         "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
+        "last_auth_method": "secret_ref",
         "is_default": True,
     }
     second_payload = {
@@ -581,6 +632,9 @@ async def test_update_profile_can_become_runtime_default(
         "runtime_materialization_mode": "api_key_env",
         "secret_refs": {"API_KEY": "env://patch_second_secret"},
         "enabled": True,
+        "auth_state": "connected",
+        "disabled_reason": None,
+        "last_auth_method": "secret_ref",
     }
 
     async with client_app as client:
@@ -639,6 +693,9 @@ async def test_update_claude_anthropic_can_replace_minimax_runtime_default(
                     runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
                     secret_refs={"ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"},
                     enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    disabled_reason=None,
+                    last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
                     is_default=True,
                     priority=200,
                 ),
@@ -652,6 +709,9 @@ async def test_update_claude_anthropic_can_replace_minimax_runtime_default(
                     volume_ref="claude_auth_volume",
                     volume_mount_path="/home/app/.claude",
                     enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    disabled_reason=None,
+                    last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
                     is_default=False,
                     priority=100,
                 ),

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -12,6 +12,8 @@ from api_service.db.models import (
     Base,
     ManagedAgentProviderProfile,
     ProviderCredentialSource,
+    ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
     RuntimeMaterializationMode,
 )
 
@@ -68,9 +70,9 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert defaults["codex_default"] is None
     assert defaults["claude_anthropic"] is None
     runtime_defaults = {p.profile_id: p.is_default for p in profiles}
-    assert runtime_defaults["gemini_default"] is True
-    assert runtime_defaults["codex_default"] is True
-    assert runtime_defaults["claude_anthropic"] is True
+    assert runtime_defaults["gemini_default"] is False
+    assert runtime_defaults["codex_default"] is False
+    assert runtime_defaults["claude_anthropic"] is False
     provider_ids = {p.profile_id: p.provider_id for p in profiles}
     assert provider_ids["codex_default"] == "openai"
     assert provider_ids["claude_anthropic"] == "anthropic"
@@ -78,13 +80,19 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert provider_labels["codex_default"] == "OpenAI"
     assert provider_labels["claude_anthropic"] == "Anthropic"
     claude_profile = next(p for p in profiles if p.profile_id == "claude_anthropic")
-    assert claude_profile.credential_source == ProviderCredentialSource.OAUTH_VOLUME
+    assert claude_profile.enabled is False
+    assert claude_profile.auth_state == ProviderProfileAuthState.NOT_CONFIGURED
+    assert (
+        claude_profile.disabled_reason
+        == ProviderProfileDisabledReason.MISSING_CREDENTIALS
+    )
+    assert claude_profile.credential_source == ProviderCredentialSource.NONE
     assert (
         claude_profile.runtime_materialization_mode
-        == RuntimeMaterializationMode.OAUTH_HOME
+        == RuntimeMaterializationMode.API_KEY_ENV
     )
-    assert claude_profile.volume_ref == "claude_auth_volume"
-    assert claude_profile.volume_mount_path == "/home/app/.claude"
+    assert claude_profile.volume_ref is None
+    assert claude_profile.volume_mount_path is None
     assert claude_profile.clear_env_keys == [
         "ANTHROPIC_API_KEY",
         "CLAUDE_API_KEY",
@@ -157,10 +165,13 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
     assert mm_profile.default_model == "MiniMax-M2.7"
     assert mm_profile.volume_ref is None
     assert mm_profile.volume_mount_path is None
-    assert mm_profile.is_default is False
+    assert mm_profile.is_default is True
+    assert mm_profile.enabled is True
+    assert mm_profile.auth_state == ProviderProfileAuthState.CONNECTED
+    assert mm_profile.disabled_reason is None
 
     anthropic_profile = next(p for p in profiles if p.profile_id == "claude_anthropic")
-    assert anthropic_profile.is_default is True
+    assert anthropic_profile.is_default is False
 
 @pytest.mark.asyncio
 async def test_auto_seed_adds_minimax_after_initial_seed(_module_db, monkeypatch):
@@ -340,7 +351,7 @@ async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
     profile = next(p for p in profiles if p.profile_id == "codex_openrouter_qwen36_plus")
     assert profile.runtime_id == "codex_cli"
     assert profile.provider_id == "openrouter"
-    assert profile.is_default is False
+    assert profile.is_default is True
     assert profile.default_model == "qwen/qwen3.6-plus"
     assert profile.secret_refs == {"provider_api_key": "env://OPENROUTER_API_KEY"}
     assert profile.env_template == {
@@ -382,7 +393,7 @@ async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
     assert profile.cooldown_after_429_seconds == 300
 
     codex_default = next(p for p in profiles if p.profile_id == "codex_default")
-    assert codex_default.is_default is True
+    assert codex_default.is_default is False
 
 @pytest.mark.asyncio
 async def test_auto_seed_reconciles_openrouter_codex_config_template_for_existing_profile(

--- a/tests/unit/api_service/test_provider_profile_enums.py
+++ b/tests/unit/api_service/test_provider_profile_enums.py
@@ -23,6 +23,9 @@ from api_service.db.models import (
     ManagedAgentOAuthSession,
     ManagedAgentProviderProfile,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
     RuntimeMaterializationMode,
 )
 
@@ -83,6 +86,34 @@ class TestRuntimeMaterializationModeEnum:
         expected = {"oauth_home", "api_key_env", "env_bundle", "config_bundle", "composite"}
         actual = {m.value for m in RuntimeMaterializationMode}
         assert actual == expected
+
+class TestProviderProfileActivationEnums:
+    """Provider-profile activation enums must match the DB contract."""
+
+    def test_auth_state_values_match_contract(self):
+        expected = {
+            "not_configured",
+            "oauth_pending",
+            "api_key_pending",
+            "connected",
+            "validation_failed",
+            "disconnected",
+        }
+        assert {m.value for m in ProviderProfileAuthState} == expected
+
+    def test_disabled_reason_values_match_contract(self):
+        expected = {
+            "missing_credentials",
+            "auth_invalid",
+            "user_disabled",
+            "policy_disabled",
+            "disconnected",
+        }
+        assert {m.value for m in ProviderProfileDisabledReason} == expected
+
+    def test_last_auth_method_values_match_contract(self):
+        expected = {"oauth_volume", "secret_ref", "manual"}
+        assert {m.value for m in ProviderProfileAuthMethod} == expected
 
 # ---------------------------------------------------------------------------
 # 2. Data migration mapping logic
@@ -248,7 +279,7 @@ async def test_provider_profile_stores_credential_source_and_materialization_mod
 
 @pytest.mark.asyncio
 async def test_provider_profile_composite_mode_is_default(_sqlite_db):
-    """credential_source defaults to NONE and runtime_materialization_mode defaults to COMPOSITE."""
+    """Provider-profile defaults are safe for unconfigured setup stubs."""
     async with _sqlite_db() as session:
         profile = ManagedAgentProviderProfile(
             profile_id="test-defaults",
@@ -267,6 +298,42 @@ async def test_provider_profile_composite_mode_is_default(_sqlite_db):
         row = result.scalar_one()
         assert row.credential_source == ProviderCredentialSource.NONE
         assert row.runtime_materialization_mode == RuntimeMaterializationMode.COMPOSITE
+        assert row.enabled is False
+        assert row.auth_state == ProviderProfileAuthState.NOT_CONFIGURED
+        assert row.disabled_reason is None
+        assert row.first_authenticated_at is None
+        assert row.last_validated_at is None
+        assert row.last_auth_method is None
+
+@pytest.mark.asyncio
+async def test_provider_profile_roundtrips_activation_fields(_sqlite_db):
+    """ManagedAgentProviderProfile must persist canonical activation metadata."""
+    async with _sqlite_db() as session:
+        profile = ManagedAgentProviderProfile(
+            profile_id="test-activation-fields",
+            runtime_id="claude_code",
+            provider_id="anthropic",
+            credential_source=ProviderCredentialSource.SECRET_REF,
+            runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+            enabled=True,
+            auth_state=ProviderProfileAuthState.CONNECTED,
+            disabled_reason=None,
+            last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
+        )
+        session.add(profile)
+        await session.commit()
+
+    async with _sqlite_db() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.profile_id == "test-activation-fields"
+            )
+        )
+        row = result.scalar_one()
+        assert row.enabled is True
+        assert row.auth_state == ProviderProfileAuthState.CONNECTED
+        assert row.disabled_reason is None
+        assert row.last_auth_method == ProviderProfileAuthMethod.SECRET_REF
 
 # ---------------------------------------------------------------------------
 # 4. Migration graph: exactly one head

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -16,6 +16,8 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     OAuthSessionStatus,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
 )
 from moonmind.workflows.temporal.activities import oauth_session_activities
@@ -179,6 +181,12 @@ async def test_register_profile_activity_persists_oauth_home_codex_profile(
         assert profile.volume_ref == "codex_auth_volume"
         assert profile.volume_mount_path == "/home/app/.codex"
         assert profile.max_parallel_runs == 3
+        assert profile.enabled is True
+        assert profile.auth_state == ProviderProfileAuthState.CONNECTED
+        assert profile.disabled_reason is None
+        assert profile.last_auth_method == ProviderProfileAuthMethod.OAUTH_VOLUME
+        assert profile.first_authenticated_at is not None
+        assert profile.last_validated_at is not None
 
 @pytest.mark.asyncio
 async def test_register_profile_activity_rejects_codex_oauth_profile_without_refs(

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -296,6 +296,18 @@ def test_managed_agent_provider_profile_accepts_valid_per_profile_limits() -> No
     assert profile.max_parallel_runs == 2
     assert profile.cooldown_after_429_seconds == 120
 
+def test_managed_agent_provider_profile_clears_disabled_reason_when_enabled() -> None:
+    profile = ManagedAgentProviderProfile(
+        profileId="enabled-clears-disabled-reason",
+        runtimeId="claude_code",
+        credentialSource="secret_ref",
+        runtimeMaterializationMode="api_key_env",
+        enabled=True,
+        authState="connected",
+    )
+
+    assert profile.disabled_reason is None
+
 def test_codex_oauth_provider_profile_requires_auth_volume_refs() -> None:
     with pytest.raises(ValidationError, match="volumeRef is required"):
         ManagedAgentProviderProfile(

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -289,6 +289,8 @@ def test_managed_agent_provider_profile_accepts_valid_per_profile_limits() -> No
         maxParallelRuns=2,
         cooldownAfter429Seconds=120,
         enabled=True,
+        authState="connected",
+        disabledReason=None,
         rateLimitPolicy={"strategy": "provider_backoff"},
     )
     assert profile.max_parallel_runs == 2
@@ -551,6 +553,10 @@ def test_managed_agent_provider_profile_accepts_full_provider_contract() -> None
         maxLeaseDurationSeconds=3600,
         ownerUserId="user-123",
         maxParallelRuns=4,
+        enabled=True,
+        authState="connected",
+        disabledReason=None,
+        lastAuthMethod="secret_ref",
     )
     # No ValidationError — assert all fields round-trip.
     dump = profile.model_dump(by_alias=True)
@@ -574,6 +580,24 @@ def test_managed_agent_provider_profile_accepts_full_provider_contract() -> None
     assert dump["maxLeaseDurationSeconds"] == 3600
     assert dump["ownerUserId"] == "user-123"
     assert dump["maxParallelRuns"] == 4
+    assert dump["authState"] == "connected"
+    assert dump["disabledReason"] is None
+    assert dump["lastAuthMethod"] == "secret_ref"
+
+def test_managed_agent_provider_profile_rejects_enabled_unconfigured_profile() -> None:
+    """enabled is launch intent; authState must prove credentials are connected."""
+    with pytest.raises(
+        ValidationError,
+        match="enabled provider profiles must have authState='connected'",
+    ):
+        ManagedAgentProviderProfile(
+            profileId="unconfigured-enabled",
+            runtimeId="codex_cli",
+            credentialSource="none",
+            runtimeMaterializationMode="composite",
+            enabled=True,
+            authState="not_configured",
+        )
 
 def test_managed_agent_provider_profile_rejects_invalid_credential_source() -> None:
     """Invalid credentialSource raises ValidationError with allowed values."""

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -23,10 +23,12 @@ from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import (
     Base,
+    ManagedAgentRateLimitPolicy,
     ManagedAgentProviderProfile,
     ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
-    ManagedAgentRateLimitPolicy,
 )
 from moonmind.auth.env_shaping import (
     OAUTH_CLEARED_VARS,
@@ -925,6 +927,8 @@ async def test_provider_profile_list_returns_enabled_profiles(tmp_path: Path):
                     cooldown_after_429_seconds=300,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
                     enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
                 )
             )
             session.add(
@@ -962,6 +966,7 @@ async def test_provider_profile_list_returns_enabled_profiles(tmp_path: Path):
         assert profiles[0]["profile_id"] == "gprofile-1"
         assert profiles[0]["credential_source"] == "oauth_volume"
         assert profiles[0]["enabled"] is True
+        assert profiles[0]["auth_state"] == "connected"
         assert profiles[0]["max_parallel_runs"] == 2
 
 async def test_provider_profile_list_returns_empty_for_unknown_runtime(tmp_path: Path):
@@ -997,6 +1002,8 @@ async def test_provider_profile_list_filters_by_runtime_id(tmp_path: Path):
                         cooldown_after_429_seconds=300,
                         rate_limit_policy=ManagedAgentRateLimitPolicy.QUEUE,
                         enabled=True,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
                     )
                 )
             await session.commit()
@@ -1041,6 +1048,8 @@ async def test_provider_profile_list_preserves_secret_ref_materialization_fields
                     cooldown_after_429_seconds=300,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
                     enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
                 )
             )
             await session.commit()
@@ -1121,6 +1130,8 @@ async def test_provider_profile_list_preserves_path_aware_codex_materialization_
                     cooldown_after_429_seconds=300,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
                     enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
                 )
             )
             await session.commit()


### PR DESCRIPTION
Issue reference
- MM-872: https://moonladder.atlassian.net/browse/MM-872

Summary
- Adds persisted provider profile activation fields for auth state, disabled reason, authentication timestamps, and last auth method.
- Adds constrained validation/defaults and readiness-oriented lookup support for provider profiles.
- Updates provider profile API/schema behavior, startup seeding defaults, adapter handling, and migration coverage.
- Adds tests for activation field persistence, safe unconfigured defaults, launch readiness, and secret-safe provider profile fields.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/api_service/test_provider_profile_auto_seed.py tests/unit/api_service/test_provider_profile_enums.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/adapters/test_managed_agent_adapter.py

Remaining risks
- Full repository unit suite and compose-backed integration suite were not run in this PR publication step.
- Existing default-branch GitHub vulnerability alerts are unrelated to this branch and were not addressed here.