### PR TITLE
I am looking for a number of improvements to the Start Workflow page:

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -5814,7 +5814,7 @@ describe.skip("Task Create Entrypoint", () => {
       <WorkflowStartPage payload={withImageOnlyAttachmentPolicy()} />,
     );
 
-    expect(await screen.findByText("Step 1 Images (optional)")).toBeTruthy();
+    expect(await screen.findByText("Images (optional)")).toBeTruthy();
     expect(
       await screen.findByText(
         "Instructions Images",
@@ -6432,7 +6432,6 @@ describe.skip("Task Create Entrypoint", () => {
     fireEvent.change(screen.getByLabelText("Existing run"), {
       target: { value: "mm:dep-1" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
 
     await waitFor(() => {
       expect(screen.getByText(/Build shared schema/)).toBeTruthy();
@@ -8096,10 +8095,10 @@ describe.skip("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Dependencies",
       "Execution context",
       "Execution controls",
       "Schedule",
+      "Dependencies",
       "Submit",
     ]);
   });
@@ -8111,9 +8110,9 @@ describe.skip("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Dependencies",
       "Execution context",
       "Execution controls",
+      "Dependencies",
       "Submit",
     ]);
     unmount();
@@ -8129,9 +8128,9 @@ describe.skip("Task Create Entrypoint", () => {
     expect(canonicalCreateSections()).toEqual([
       "Header",
       "Steps",
-      "Dependencies",
       "Execution context",
       "Execution controls",
+      "Dependencies",
       "Submit",
     ]);
   });
@@ -10622,11 +10621,10 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "Dependent stage." },
     });
 
-    // Add mm:dep-1 first time.
+    // Add mm:dep-1 first time (selecting the option adds it directly).
     fireEvent.change(screen.getByLabelText("Existing run"), {
       target: { value: "mm:dep-1" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
 
     await waitFor(() => {
       expect(screen.getByText(/Build shared schema/)).toBeTruthy();
@@ -10647,7 +10645,6 @@ describe.skip("Task Create Entrypoint", () => {
     fireEvent.change(screen.getByLabelText("Existing run"), {
       target: { value: "mm:dep-2" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
 
     await waitFor(() => {
       expect(within(list as HTMLElement).getAllByRole("listitem")).toHaveLength(2);
@@ -10661,14 +10658,11 @@ describe.skip("Task Create Entrypoint", () => {
       target: { value: "Dependent stage." },
     });
 
-    // Add 10 dependencies.
+    // Add 10 dependencies (each selection adds the chosen prerequisite).
     for (let i = 1; i <= 10; i += 1) {
       fireEvent.change(screen.getByLabelText("Existing run"), {
         target: { value: `mm:dep-${i}` },
       });
-      fireEvent.click(
-        screen.getByRole("button", { name: "Add dependency" }),
-      );
     }
 
     // Wait for all 10 to appear.
@@ -10682,7 +10676,6 @@ describe.skip("Task Create Entrypoint", () => {
     fireEvent.change(screen.getByLabelText("Existing run"), {
       target: { value: "mm:dep-11" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
 
     // Still 10 items.
     const list = document.getElementById("queue-dependency-list");
@@ -10748,21 +10741,19 @@ describe.skip("Task Create Entrypoint", () => {
     expect(task).not.toHaveProperty("dependsOn");
   });
 
-  it("shows validation message when adding dependency without selection", async () => {
+  it("does not add a dependency when the placeholder option stays selected", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
     fireEvent.change(await screen.findByLabelText("Instructions"), {
       target: { value: "Dependent stage." },
     });
 
-    // Click Add without selecting a run.
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Choose a prerequisite run before adding/),
-      ).toBeTruthy();
+    // Re-selecting the placeholder option is a no-op: nothing is added.
+    fireEvent.change(screen.getByLabelText("Existing run"), {
+      target: { value: "" },
     });
+
+    expect(document.getElementById("queue-dependency-list")).toBeNull();
   });
 
   it("hides Jira browser controls when the runtime config does not enable Jira", async () => {
@@ -13562,10 +13553,11 @@ describe("Task Create MM-641 authoring validation", () => {
       target: { value: "feature/mm-641-create-page" },
     });
     fireEvent.change(publishModeSelect, { target: { value: "branch" } });
+    // Selecting a prerequisite from the dropdown adds it directly; there is no
+    // separate "Add dependency" button.
     fireEvent.change(screen.getByLabelText("Existing run"), {
       target: { value: "mm:dep-641" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add dependency" }));
     await waitFor(() => {
       expect(screen.getByText(/Prepare MM-641 source brief/)).toBeTruthy();
     });

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -450,6 +450,7 @@ interface JiraImportProvenance {
 interface ProviderProfile {
   profile_id: string;
   account_label?: string | null;
+  provider_label?: string | null;
   default_model?: string | null;
   is_default?: boolean;
   enabled?: boolean;
@@ -2267,6 +2268,32 @@ function attachmentFilePickerLabel(
 
 function attachmentLimitMessage(policy: AttachmentPolicy): string {
   return `Up to ${policy.maxCount} files across all steps, ${formatAttachmentBytes(policy.maxBytes)} each, ${formatAttachmentBytes(policy.totalBytes)} total.`;
+}
+
+// Human-friendly display names for agent runtimes. Raw runtime ids such as
+// `claude_code` should never surface to operators in the UI.
+const RUNTIME_DISPLAY_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  codex_cli: "Codex CLI",
+  codex_cloud: "Codex Cloud",
+  gemini_cli: "Gemini CLI",
+};
+
+function formatRuntimeLabel(runtimeId: string): string {
+  const known = RUNTIME_DISPLAY_LABELS[runtimeId];
+  if (known) {
+    return known;
+  }
+  const formatted = runtimeId
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((word) =>
+      word.toLowerCase() === "cli"
+        ? "CLI"
+        : word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join(" ");
+  return formatted || runtimeId;
 }
 
 function validateAttachmentFiles(
@@ -5907,10 +5934,12 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       return;
     }
     if (selectedDependencies.includes(normalizedId)) {
+      setSelectedDependencyWorkflowId("");
       setDependencyMessage("That prerequisite is already selected.");
       return;
     }
     if (selectedDependencies.length >= DEPENDENCY_LIMIT) {
+      setSelectedDependencyWorkflowId("");
       setDependencyMessage(
         `You can add at most ${DEPENDENCY_LIMIT} direct dependencies.`,
       );
@@ -6047,7 +6076,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     })
     .map((profile) => ({
       id: profile.profile_id,
-      label: profile.account_label || profile.profile_id,
+      // Default profiles read better as the provider name (e.g. "Anthropic",
+      // "OpenAI", "Google") than as their auto-seeded account label. The
+      // " (Default)" suffix is appended at render time.
+      label:
+        profile.is_default && profile.provider_label
+          ? profile.provider_label
+          : profile.account_label || profile.profile_id,
       isDefault: Boolean(profile.is_default),
     }));
 
@@ -10294,7 +10329,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           <option value="">Inherit agent runtime</option>
                           {supportedAgentRuntimes.map((runtimeOption) => (
                             <option key={runtimeOption} value={runtimeOption}>
-                              {runtimeOption}
+                              {formatRuntimeLabel(runtimeOption)}
                             </option>
                           ))}
                         </select>
@@ -10397,7 +10432,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                       <div className="queue-step-attachments">
                         <div className="queue-step-attachment-control">
                           <span className="queue-step-attachment-label">
-                            {`Step ${index + 1} ${attachmentLabel} (optional)`}
+                            {`${attachmentLabel} (optional)`}
                           </span>
                           <button
                             type="button"
@@ -10780,45 +10815,47 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           data-canonical-create-section="Execution context"
           aria-label="Execution context"
         >
-        <label>
-          Runtime
-          <select
-            name="runtime"
-            value={runtime}
-            onChange={(event) => setRuntime(event.target.value)}
-          >
-            {supportedAgentRuntimes.map((runtimeOption) => (
-              <option key={runtimeOption} value={runtimeOption}>
-                {runtimeOption}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div
-          id="queue-provider-profile-wrap"
-          className={providerOptions.length > 0 ? "" : "hidden"}
-          hidden={providerOptions.length === 0}
-        >
+        <div className={providerOptions.length > 0 ? "grid-2" : "stack"}>
           <label>
-            Provider profile
+            Runtime
             <select
-              name="providerProfile"
-              value={providerProfile}
-              onChange={(event) => setProviderProfile(event.target.value)}
+              name="runtime"
+              value={runtime}
+              onChange={(event) => setRuntime(event.target.value)}
             >
-              {providerOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.isDefault ? `${option.label} (Default)` : option.label}
+              {supportedAgentRuntimes.map((runtimeOption) => (
+                <option key={runtimeOption} value={runtimeOption}>
+                  {formatRuntimeLabel(runtimeOption)}
                 </option>
               ))}
             </select>
           </label>
-          <p className="small" id="queue-auth-profile-hint">
-            {providerProfilesQuery.isError
-              ? "Failed to load provider profiles."
-              : ""}
-          </p>
+
+          {providerOptions.length > 0 ? (
+            <div id="queue-provider-profile-wrap">
+              <label>
+                Provider profile
+                <select
+                  name="providerProfile"
+                  value={providerProfile}
+                  onChange={(event) => setProviderProfile(event.target.value)}
+                >
+                  {providerOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.isDefault
+                        ? `${option.label} (Default)`
+                        : option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {providerProfilesQuery.isError ? (
+                <p className="small" id="queue-auth-profile-hint">
+                  Failed to load provider profiles.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="grid-2">
@@ -11049,35 +11086,122 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
 
         <section
           className="stack"
+          data-canonical-create-section="Dependencies"
+          aria-label="Dependencies"
+        >
+          <div className="queue-dependencies-heading">
+            <strong>Dependencies</strong>
+            <button
+              type="button"
+              className="queue-step-icon-button queue-info-toggle queue-dependencies-info-toggle"
+              aria-label="Dependencies info"
+              aria-expanded={dependencyInfoOpen}
+              aria-controls="queue-dependencies-info-panel"
+              title="About dependencies"
+              onClick={() => setDependencyInfoOpen((open) => !open)}
+            >
+              <InfoIcon />
+            </button>
+          </div>
+          {dependencyInfoOpen ? (
+            <div
+              id="queue-dependencies-info-panel"
+              className="notice queue-dependencies-info-panel"
+              role="note"
+            >
+              <p className="small">
+                Add up to {DEPENDENCY_LIMIT} existing <code>MoonMind.UserWorkflow</code>{" "}
+                prerequisites. The new run stays blocked until each
+                prerequisite finishes in <code>completed</code> state.
+              </p>
+              <p className="small">
+                Direct dependencies only. The new run stays blocked while a
+                prerequisite is running, failed, canceled, terminated, timed
+                out, or unresolvable, and unblocks once the prerequisite
+                completes successfully. Cancel this run or bypass the
+                dependency to proceed without that prerequisite.
+              </p>
+              <p className="small">
+                {dependencyOptionsQuery.isLoading
+                  ? "Loading recent runs..."
+                  : dependencyOptionsQuery.isError
+                    ? "Failed to load recent runs. You can still create the task without dependencies, or try refreshing."
+                    : `${availableDependencyOptions.length} recent runs available.`}
+              </p>
+            </div>
+          ) : null}
+          <label>
+            Existing run
+            <select
+              id="queue-dependency-picker"
+              value={selectedDependencyWorkflowId}
+              onChange={(event) => {
+                const workflowId = event.target.value;
+                if (workflowId) {
+                  addDependency(workflowId);
+                } else {
+                  setSelectedDependencyWorkflowId("");
+                  setDependencyMessage(null);
+                }
+              }}
+            >
+              <option value="">Select prerequisite to add...</option>
+              {availableDependencyOptions.map((item) => (
+                <option key={dependencyWorkflowId(item)} value={dependencyWorkflowId(item)}>
+                  {`${item.title} (${dependencyWorkflowId(item)})`}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selectedDependencies.length > 0 ? (
+            <ul className="list" id="queue-dependency-list">
+              {selectedDependencies.map((workflowId) => {
+                const match = (dependencyOptionsQuery.data || []).find(
+                  (item) => dependencyWorkflowId(item) === workflowId,
+                );
+                return (
+                  <li key={workflowId}>
+                    <span>
+                      <strong>{match?.title || workflowId}</strong>{" "}
+                      <code>{workflowId}</code>
+                    </span>
+                    <button
+                      type="button"
+                      className="secondary small"
+                      title={`Remove dependency ${workflowId}`}
+                      onClick={() => removeDependency(workflowId)}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+          {dependencyMessage ? (
+            <p className="notice error">{dependencyMessage}</p>
+          ) : null}
+        </section>
+
+        <section
+          className="stack"
           data-canonical-create-section="Submit"
           aria-label="Submit"
         >
-        <p
-          id="queue-submit-message"
-          role={
-            submitMessage
-              ? submitMessageTone === "error"
-                ? "alert"
-                : "status"
-              : undefined
-          }
-          aria-live={
-            submitMessage
-              ? submitMessageTone === "error"
-                ? "assertive"
-                : "polite"
-              : undefined
-          }
-          className={
-            submitMessage
-              ? submitMessageTone === "pending"
+        {submitMessage ? (
+          <p
+            id="queue-submit-message"
+            role={submitMessageTone === "error" ? "alert" : "status"}
+            aria-live={submitMessageTone === "error" ? "assertive" : "polite"}
+            className={
+              submitMessageTone === "pending"
                 ? "queue-submit-message notice pending"
                 : "queue-submit-message notice error"
-              : "queue-submit-message small"
-          }
-        >
-          {submitMessage || ""}
-        </p>
+            }
+          >
+            {submitMessage}
+          </p>
+        ) : null}
         <div
           className="queue-floating-bar queue-floating-bar--liquid-glass queue-step-actions queue-step-submit-actions"
           role="group"
@@ -11240,112 +11364,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
               : null}
           </div>
         </div>
-        </section>
-
-        <section
-          className="stack queue-dependencies-bottom"
-          data-canonical-create-section="Dependencies"
-          aria-label="Dependencies"
-        >
-          <div className="queue-dependencies-heading">
-            <strong>Dependencies</strong>
-            <button
-              type="button"
-              className="queue-step-icon-button queue-info-toggle queue-dependencies-info-toggle"
-              aria-label="Dependencies info"
-              aria-expanded={dependencyInfoOpen}
-              aria-controls="queue-dependencies-info-panel"
-              title="About dependencies"
-              onClick={() => setDependencyInfoOpen((open) => !open)}
-            >
-              <InfoIcon />
-            </button>
-          </div>
-          {dependencyInfoOpen ? (
-            <div
-              id="queue-dependencies-info-panel"
-              className="notice queue-dependencies-info-panel"
-              role="note"
-            >
-              <p className="small">
-                Add up to {DEPENDENCY_LIMIT} existing <code>MoonMind.UserWorkflow</code>{" "}
-                prerequisites. The new run stays blocked until each
-                prerequisite finishes in <code>completed</code> state.
-              </p>
-              <p className="small">
-                Direct dependencies only. The new run stays blocked while a
-                prerequisite is running, failed, canceled, terminated, timed
-                out, or unresolvable, and unblocks once the prerequisite
-                completes successfully. Cancel this run or bypass the
-                dependency to proceed without that prerequisite.
-              </p>
-              <p className="small">
-                {dependencyOptionsQuery.isLoading
-                  ? "Loading recent runs..."
-                  : dependencyOptionsQuery.isError
-                    ? "Failed to load recent runs. You can still create the task without dependencies, or try refreshing."
-                    : `${availableDependencyOptions.length} recent runs available.`}
-              </p>
-            </div>
-          ) : null}
-          <div className="grid-2">
-            <label>
-              Existing run
-              <select
-                id="queue-dependency-picker"
-                value={selectedDependencyWorkflowId}
-                onChange={(event) => {
-                  setSelectedDependencyWorkflowId(event.target.value);
-                  setDependencyMessage(null);
-                }}
-              >
-                <option value="">Select prerequisite...</option>
-                {availableDependencyOptions.map((item) => (
-                  <option key={dependencyWorkflowId(item)} value={dependencyWorkflowId(item)}>
-                    {`${item.title} (${dependencyWorkflowId(item)})`}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <div className="actions" style={{ alignItems: "flex-end" }}>
-              <button
-                type="button"
-                id="queue-dependency-add"
-                title="Add the selected prerequisite run"
-                onClick={() => addDependency(selectedDependencyWorkflowId)}
-              >
-                Add dependency
-              </button>
-            </div>
-          </div>
-          {selectedDependencies.length > 0 ? (
-            <ul className="list" id="queue-dependency-list">
-              {selectedDependencies.map((workflowId) => {
-                const match = (dependencyOptionsQuery.data || []).find(
-                  (item) => dependencyWorkflowId(item) === workflowId,
-                );
-                return (
-                  <li key={workflowId}>
-                    <span>
-                      <strong>{match?.title || workflowId}</strong>{" "}
-                      <code>{workflowId}</code>
-                    </span>
-                    <button
-                      type="button"
-                      className="secondary small"
-                      title={`Remove dependency ${workflowId}`}
-                      onClick={() => removeDependency(workflowId)}
-                    >
-                      Remove
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          ) : null}
-          {dependencyMessage ? (
-            <p className="notice error">{dependencyMessage}</p>
-          ) : null}
         </section>
         </fieldset>
       </form>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -4974,32 +4974,43 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-right: auto;
 }
 
-.queue-dependencies-bottom {
-  margin-top: 1rem;
-}
-
 .queue-dependencies-heading {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
+/* Render the info affordance as a plain icon (no surrounding button chrome),
+   so it reads as a normal icon rather than a circle inside a circle. */
 .queue-info-toggle {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
+  width: 1.5rem;
+  height: 1.5rem;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  background-image: none;
+  box-shadow: none;
   flex-shrink: 0;
   color: rgb(var(--mm-accent));
-  border-color: rgb(var(--mm-accent) / 0.55);
 }
 
 .queue-info-toggle svg {
-  width: 1.15rem;
-  height: 1.15rem;
+  width: 1.25rem;
+  height: 1.25rem;
   stroke-width: 2;
 }
 
-.queue-info-toggle:hover {
+.queue-info-toggle:hover,
+.queue-info-toggle:active,
+.queue-info-toggle.is-clicked {
+  border: none;
+  background: none;
+  background-image: none;
+  box-shadow: none;
+  transform: none;
+  filter: none;
   color: rgb(var(--mm-ink));
 }
 


### PR DESCRIPTION
I am looking for a number of improvements to the Start Workflow page:
1. The + button to add images should have a label that says Images (optional) but does not need to say "Step 1"
2. Runtimes should not display as claude_code, codex_cli, or gemini_cli. They should display as Claude Code, Codex CLI, Gemini CLI.
3. Runtime and provider profile to not need to span the entire width of the page on Desktop view. They can be half width like model and effort and be side-by-side.
4. The spacing after Provider Profile and before Model is weird and the spacing after Schedule before dependencies is weird.
5. The information button looks bad with a circle surrounded by another circle. It should look more like a normal icon. It doesn't need the outer circle.
6. You should be able to select a dependency and it will get added. You shouldn't need an add dependency button separate from the dropdown. 
7. The default Claude Code profile should be displayed as Anthropic (Default). We do not need to display (auto-seeded). The default Codex CLI profile should be displayed as OpenAI (Default). The default Gemini CLI profile should be displayed as Google (Default).