### PR TITLE
MM-875 add provider API key setup

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -541,10 +541,10 @@ async def setup_provider_api_key(
     session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
     current_user: User = Depends(get_current_user()),
 ) -> dict[str, Any]:
+    _require_provider_profile_permission(current_user, "provider_profiles.write")
     profile = await session.get(ManagedAgentProviderProfile, profile_id)
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
-    _require_provider_profile_permission(current_user, "provider_profiles.write")
     _require_profile_management(profile, current_user)
     mapping = _api_key_mapping_for_profile(profile)
 
@@ -560,11 +560,12 @@ async def setup_provider_api_key(
     try:
         await validate_provider_api_key(profile.provider_id, api_key)
     except HTTPException as exc:
-        await _mark_api_key_validation_failed(
-            session=session,
-            profile=profile,
-            reason="API key validation failed.",
-        )
+        if exc.status_code in {401, 403, 422}:
+            await _mark_api_key_validation_failed(
+                session=session,
+                profile=profile,
+                reason="API key validation failed.",
+            )
         raise exc
 
     validated_at = datetime.now(UTC)
@@ -721,7 +722,10 @@ async def commit_claude_manual_auth(
     profile.command_behavior = behavior
 
     await session.flush()
-    await normalize_runtime_default_profile(session=session, runtime_id=profile.runtime_id)
+    await normalize_runtime_default_profile(
+        session=session,
+        runtime_id=profile.runtime_id,
+    )
     await session.commit()
     await session.refresh(profile)
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
@@ -1142,8 +1146,10 @@ async def _mark_api_key_validation_failed(
         }
     )
     profile.command_behavior = behavior
+    await normalize_runtime_default_profile(session=session, runtime_id=profile.runtime_id)
     await session.commit()
     await session.refresh(profile)
+    await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
 
 async def _upsert_managed_secret(
     *,

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -263,6 +263,12 @@ class ClaudeManualAuthCommitRequest(BaseModel):
     token: str = Field(..., min_length=1, max_length=8192)
     account_label: Optional[str] = None
 
+class ProviderApiKeySetupRequest(BaseModel):
+    api_key: str = Field(..., min_length=1, max_length=8192)
+    account_label: Optional[str] = None
+    make_default: bool = False
+    enable_after_validation: bool = True
+
 class ClaudeManualAuthReadiness(BaseModel):
     connected: bool
     last_validated_at: str
@@ -271,6 +277,13 @@ class ClaudeManualAuthReadiness(BaseModel):
     failure_reason: Optional[str] = None
 
 class ClaudeManualAuthCommitResponse(BaseModel):
+    status: str
+    status_label: str
+    readiness: ClaudeManualAuthReadiness
+    profile_id: str
+    secret_ref: str
+
+class ProviderApiKeySetupResponse(BaseModel):
     status: str
     status_label: str
     readiness: ClaudeManualAuthReadiness
@@ -517,6 +530,107 @@ async def update_profile(
         managed_secret_statuses=secret_statuses,
         secret_ref_results=secret_ref_results.get(profile.profile_id),
     )
+
+@router.post(
+    "/{profile_id}/credentials/api-key",
+    response_model=ProviderApiKeySetupResponse,
+)
+async def setup_provider_api_key(
+    profile_id: str,
+    body: ProviderApiKeySetupRequest,
+    session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
+    current_user: User = Depends(get_current_user()),
+) -> dict[str, Any]:
+    profile = await session.get(ManagedAgentProviderProfile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    _require_provider_profile_permission(current_user, "provider_profiles.write")
+    _require_profile_management(profile, current_user)
+    mapping = _api_key_mapping_for_profile(profile)
+
+    api_key = body.api_key.strip()
+    if not _looks_like_provider_api_key(mapping, api_key):
+        await _mark_api_key_validation_failed(
+            session=session,
+            profile=profile,
+            reason="API key validation failed.",
+        )
+        raise HTTPException(status_code=422, detail="API key validation failed.")
+
+    try:
+        await validate_provider_api_key(profile.provider_id, api_key)
+    except HTTPException as exc:
+        await _mark_api_key_validation_failed(
+            session=session,
+            profile=profile,
+            reason="API key validation failed.",
+        )
+        raise exc
+
+    validated_at = datetime.now(UTC)
+    secret_slug = _provider_api_key_secret_slug(
+        profile.profile_id,
+        mapping.secret_role,
+    )
+    secret_ref = f"db://{secret_slug}"
+    await _upsert_managed_secret(
+        session=session,
+        slug=secret_slug,
+        plaintext=api_key,
+        details={
+            "provider_profile_id": profile.profile_id,
+            "runtime_id": profile.runtime_id,
+            "provider_id": profile.provider_id,
+            "auth_strategy": mapping.auth_strategy,
+            "secret_role": mapping.secret_role,
+            "last_validated_at": validated_at.isoformat(),
+        },
+    )
+
+    _apply_api_key_setup_to_profile(
+        profile,
+        mapping=mapping,
+        secret_ref=secret_ref,
+        account_label=body.account_label,
+        validated_at=validated_at,
+        enabled=body.enable_after_validation,
+    )
+
+    await session.flush()
+    secret_ref_results = _secret_ref_results_for_rows([profile])
+    secret_statuses = await _managed_secret_statuses_for_rows(
+        session,
+        [profile],
+        secret_ref_results=secret_ref_results,
+    )
+    if profile.enabled:
+        _require_enabled_profile_launchable(
+            profile,
+            managed_secret_statuses=secret_statuses,
+            secret_ref_results=secret_ref_results.get(profile.profile_id, {}),
+        )
+    await normalize_runtime_default_profile(
+        session=session,
+        runtime_id=profile.runtime_id,
+        preferred_profile_id=profile.profile_id if body.make_default else None,
+    )
+    await session.commit()
+    await session.refresh(profile)
+    await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
+
+    return {
+        "status": "ready",
+        "status_label": mapping.ready_label,
+        "profile_id": profile.profile_id,
+        "secret_ref": secret_ref,
+        "readiness": {
+            "connected": True,
+            "last_validated_at": validated_at.isoformat(),
+            "backing_secret_exists": True,
+            "launch_ready": True,
+            "failure_reason": None,
+        },
+    }
 
 @router.post(
     "/{profile_id}/manual-auth/commit",
@@ -842,6 +956,58 @@ def _require_claude_anthropic_profile(row: ManagedAgentProviderProfile) -> None:
             detail="Manual Claude auth is only supported for claude_code Anthropic profiles.",
         )
 
+@dataclass(frozen=True, slots=True)
+class _ApiKeyMapping:
+    runtime_id: str
+    provider_id: str
+    secret_role: str
+    env_key: str
+    clear_env_keys: tuple[str, ...]
+    auth_strategy: str
+    ready_label: str
+
+_API_KEY_MAPPINGS: dict[tuple[str, str], _ApiKeyMapping] = {
+    ("claude_code", "anthropic"): _ApiKeyMapping(
+        runtime_id="claude_code",
+        provider_id="anthropic",
+        secret_role="anthropic_api_key",
+        env_key="ANTHROPIC_API_KEY",
+        clear_env_keys=("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"),
+        auth_strategy="api_key_env",
+        ready_label="Anthropic API key ready",
+    ),
+    ("codex_cli", "openai"): _ApiKeyMapping(
+        runtime_id="codex_cli",
+        provider_id="openai",
+        secret_role="openai_api_key",
+        env_key="OPENAI_API_KEY",
+        clear_env_keys=("MINIMAX_API_KEY",),
+        auth_strategy="api_key_env",
+        ready_label="OpenAI API key ready",
+    ),
+    ("gemini_cli", "google"): _ApiKeyMapping(
+        runtime_id="gemini_cli",
+        provider_id="google",
+        secret_role="google_api_key",
+        env_key="GEMINI_API_KEY",
+        clear_env_keys=("GOOGLE_APPLICATION_CREDENTIALS",),
+        auth_strategy="api_key_env",
+        ready_label="Google API key ready",
+    ),
+}
+
+def _api_key_mapping_for_profile(row: ManagedAgentProviderProfile) -> _ApiKeyMapping:
+    mapping = _API_KEY_MAPPINGS.get((row.runtime_id, row.provider_id))
+    if mapping is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "API-key setup is only supported for first-party Anthropic, "
+                "OpenAI, and Google profiles."
+            ),
+        )
+    return mapping
+
 def _claude_auth_actions_for_profile(row: ManagedAgentProviderProfile) -> list[str]:
     actions = ["use_api_key"]
     if row.volume_ref or row.volume_mount_path:
@@ -877,6 +1043,107 @@ def _claude_manual_secret_slug(profile_id: str) -> str:
         normalized = "claude-anthropic"
     digest = hashlib.sha256(profile_id.encode("utf-8")).hexdigest()[:16]
     return f"{normalized}-{digest}-token"
+
+def _provider_api_key_secret_slug(profile_id: str, secret_role: str) -> str:
+    normalized_profile = re.sub(r"[^a-z0-9]+", "-", profile_id.lower()).strip("-")
+    normalized_role = re.sub(r"[^a-z0-9]+", "-", secret_role.lower()).strip("-")
+    if not normalized_profile:
+        normalized_profile = "provider-profile"
+    digest = hashlib.sha256(
+        f"{profile_id}:{secret_role}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"{normalized_profile}-{normalized_role}-{digest}"
+
+def _looks_like_provider_api_key(mapping: _ApiKeyMapping, api_key: str) -> bool:
+    if not api_key:
+        return False
+    if mapping.provider_id == "anthropic":
+        return api_key.startswith("sk-ant-") and len(api_key) >= 12
+    if mapping.provider_id == "openai":
+        return api_key.startswith("sk-") and len(api_key) >= 12
+    if mapping.provider_id == "google":
+        return len(api_key) >= 12
+    return False
+
+def _apply_api_key_setup_to_profile(
+    row: ManagedAgentProviderProfile,
+    *,
+    mapping: _ApiKeyMapping,
+    secret_ref: str,
+    account_label: str | None,
+    validated_at: datetime,
+    enabled: bool,
+) -> None:
+    row.credential_source = ProviderCredentialSource.SECRET_REF
+    row.runtime_materialization_mode = RuntimeMaterializationMode.API_KEY_ENV
+    row.secret_refs = {
+        **(row.secret_refs or {}),
+        mapping.secret_role: secret_ref,
+    }
+    clear_env_keys = list(row.clear_env_keys or [])
+    for env_key in mapping.clear_env_keys:
+        if env_key not in clear_env_keys:
+            clear_env_keys.append(env_key)
+    row.clear_env_keys = clear_env_keys
+    row.env_template = {
+        **(row.env_template or {}),
+        mapping.env_key: {"from_secret_ref": mapping.secret_role},
+    }
+    row.account_label = account_label or row.account_label or row.provider_label
+    row.enabled = enabled
+    row.auth_state = ProviderProfileAuthState.CONNECTED
+    row.disabled_reason = (
+        None if enabled else ProviderProfileDisabledReason.USER_DISABLED
+    )
+    if row.first_authenticated_at is None:
+        row.first_authenticated_at = validated_at
+    row.last_validated_at = validated_at
+    row.last_auth_method = ProviderProfileAuthMethod.SECRET_REF
+    behavior = dict(row.command_behavior or {})
+    behavior.update(
+        {
+            "auth_strategy": mapping.auth_strategy,
+            "auth_state": "connected",
+            "auth_actions": ["use_api_key"],
+            "auth_status_label": mapping.ready_label,
+            "auth_readiness": {
+                "connected": True,
+                "last_validated_at": validated_at.isoformat(),
+                "backing_secret_exists": True,
+                "launch_ready": True,
+            },
+        }
+    )
+    row.command_behavior = behavior
+
+async def _mark_api_key_validation_failed(
+    *,
+    session: AsyncSession,
+    profile: ManagedAgentProviderProfile,
+    reason: str,
+) -> None:
+    failed_at = datetime.now(UTC)
+    profile.enabled = False
+    profile.auth_state = ProviderProfileAuthState.VALIDATION_FAILED
+    profile.disabled_reason = ProviderProfileDisabledReason.AUTH_INVALID
+    profile.last_validated_at = failed_at
+    behavior = dict(profile.command_behavior or {})
+    behavior.update(
+        {
+            "auth_state": "validation_failed",
+            "auth_status_label": "API key validation failed",
+            "auth_readiness": {
+                "connected": False,
+                "last_validated_at": failed_at.isoformat(),
+                "backing_secret_exists": False,
+                "launch_ready": False,
+                "failure_reason": redact_sensitive_payload(reason),
+            },
+        }
+    )
+    profile.command_behavior = behavior
+    await session.commit()
+    await session.refresh(profile)
 
 async def _upsert_managed_secret(
     *,
@@ -930,6 +1197,50 @@ async def validate_claude_manual_token(token: str) -> None:
             status_code=502,
             detail="Claude token validation failed.",
         )
+
+async def validate_provider_api_key(provider_id: str, api_key: str) -> None:
+    provider_id = provider_id.strip().lower()
+    if provider_id == "anthropic":
+        await validate_claude_manual_token(api_key)
+        return
+    if provider_id == "openai":
+        await _validate_openai_api_key(api_key)
+        return
+    if provider_id == "google":
+        await _validate_google_api_key(api_key)
+        return
+    raise HTTPException(
+        status_code=422,
+        detail="Unsupported provider API-key setup.",
+    )
+
+async def _validate_openai_api_key(api_key: str) -> None:
+    try:
+        response = await _get_claude_manual_validation_client().get(
+            "https://api.openai.com/v1/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("openai_api_key_validation_failed")
+        raise HTTPException(status_code=502, detail="API key validation failed.") from exc
+    if response.status_code in {401, 403}:
+        raise HTTPException(status_code=401, detail="API key validation failed.")
+    if response.status_code >= 400:
+        raise HTTPException(status_code=502, detail="API key validation failed.")
+
+async def _validate_google_api_key(api_key: str) -> None:
+    try:
+        response = await _get_claude_manual_validation_client().get(
+            "https://generativelanguage.googleapis.com/v1beta/models",
+            params={"key": api_key},
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("google_api_key_validation_failed")
+        raise HTTPException(status_code=502, detail="API key validation failed.") from exc
+    if response.status_code in {400, 401, 403}:
+        raise HTTPException(status_code=401, detail="API key validation failed.")
+    if response.status_code >= 400:
+        raise HTTPException(status_code=502, detail="API key validation failed.")
 
 def _get_claude_manual_validation_client() -> httpx.AsyncClient:
     global _claude_manual_validation_client

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -744,6 +744,23 @@ export interface paths {
         patch: operations["update_profile_api_v1_provider_profiles__profile_id__patch"];
         trace?: never;
     };
+    "/api/v1/provider-profiles/{profile_id}/credentials/api-key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Setup Provider Api Key */
+        post: operations["setup_provider_api_key_api_v1_provider_profiles__profile_id__credentials_api_key_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/provider-profiles/{profile_id}/manual-auth/commit": {
         parameters: {
             query?: never;
@@ -6546,6 +6563,35 @@ export interface components {
                 [key: string]: string;
             };
         };
+        /** ProviderApiKeySetupRequest */
+        ProviderApiKeySetupRequest: {
+            /** Api Key */
+            api_key: string;
+            /** Account Label */
+            account_label?: string | null;
+            /**
+             * Make Default
+             * @default false
+             */
+            make_default: boolean;
+            /**
+             * Enable After Validation
+             * @default true
+             */
+            enable_after_validation: boolean;
+        };
+        /** ProviderApiKeySetupResponse */
+        ProviderApiKeySetupResponse: {
+            /** Status */
+            status: string;
+            /** Status Label */
+            status_label: string;
+            readiness: components["schemas"]["ClaudeManualAuthReadiness"];
+            /** Profile Id */
+            profile_id: string;
+            /** Secret Ref */
+            secret_ref: string;
+        };
         /** ProviderProfileCreate */
         ProviderProfileCreate: {
             /** Profile Id */
@@ -10428,6 +10474,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProviderProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    setup_provider_api_key_api_v1_provider_profiles__profile_id__credentials_api_key_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProviderApiKeySetupRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderApiKeySetupResponse"];
                 };
             };
             /** @description Validation Error */

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -1292,6 +1292,285 @@ def test_claude_manual_auth_secret_slug_is_collision_resistant() -> None:
     assert second.endswith("-token")
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "profile_id",
+        "runtime_id",
+        "provider_id",
+        "api_key",
+        "secret_role",
+        "env_key",
+        "clear_env_key",
+        "status_label",
+    ),
+    [
+        (
+            "mm-875-anthropic-api-key",
+            "claude_code",
+            "anthropic",
+            "sk-ant-mm875-route-token",
+            "anthropic_api_key",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "Anthropic API key ready",
+        ),
+        (
+            "mm-875-openai-api-key",
+            "codex_cli",
+            "openai",
+            "sk-mm875-openai-route-token",
+            "openai_api_key",
+            "OPENAI_API_KEY",
+            "MINIMAX_API_KEY",
+            "OpenAI API key ready",
+        ),
+        (
+            "mm-875-google-api-key",
+            "gemini_cli",
+            "google",
+            "google-mm875-route-token",
+            "google_api_key",
+            "GEMINI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "Google API key ready",
+        ),
+    ],
+)
+async def test_provider_api_key_setup_stores_secret_ref_mappings_only(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+    profile_id: str,
+    runtime_id: str,
+    provider_id: str,
+    api_key: str,
+    secret_role: str,
+    env_key: str,
+    clear_env_key: str,
+    status_label: str,
+) -> None:
+    validated: list[tuple[str, str]] = []
+    synced_runtimes: list[str] = []
+
+    async def _fake_validate(provider: str, key: str) -> None:
+        validated.append((provider, key))
+
+    async def _fake_sync(*, session: AsyncSession, runtime_id: str) -> None:
+        synced_runtimes.append(runtime_id)
+
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.validate_provider_api_key",
+        _fake_validate,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.sync_provider_profile_manager",
+        _fake_sync,
+    )
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id=runtime_id,
+                    provider_id=provider_id,
+                    provider_label=provider_id.title(),
+                    credential_source=ProviderCredentialSource.NONE,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    secret_refs={"custom_tool": "env://CUSTOM_TOOL_SECRET"},
+                    clear_env_keys=["CUSTOM_ENV"],
+                    env_template={
+                        "CUSTOM_ENV": {"from_secret_ref": "custom_tool"},
+                    },
+                    enabled=False,
+                    is_default=False,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/credentials/api-key",
+            json={
+                "api_key": api_key,
+                "account_label": "MM-875 route test",
+                "make_default": True,
+                "enable_after_validation": True,
+            },
+        )
+        profile_response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    assert api_key not in response.text
+    payload = response.json()
+    assert payload["status"] == "ready"
+    assert payload["status_label"] == status_label
+    assert payload["readiness"]["connected"] is True
+    assert payload["readiness"]["launch_ready"] is True
+    expected_secret_slug = provider_profiles_router._provider_api_key_secret_slug(
+        profile_id,
+        secret_role,
+    )
+    expected_secret_ref = f"db://{expected_secret_slug}"
+    assert payload["secret_ref"] == expected_secret_ref
+
+    assert profile_response.status_code == 200
+    profile_payload = profile_response.json()
+    assert api_key not in profile_response.text
+    assert profile_payload["credential_source"] == "secret_ref"
+    assert profile_payload["runtime_materialization_mode"] == "api_key_env"
+    assert profile_payload["secret_refs"] == {
+        "custom_tool": "env://CUSTOM_TOOL_SECRET",
+        secret_role: expected_secret_ref,
+    }
+    assert profile_payload["env_template"] == {
+        "CUSTOM_ENV": {"from_secret_ref": "custom_tool"},
+        env_key: {"from_secret_ref": secret_role},
+    }
+    assert clear_env_key in profile_payload["clear_env_keys"]
+    assert profile_payload["account_label"] == "MM-875 route test"
+    assert profile_payload["enabled"] is True
+    assert profile_payload["is_default"] is True
+    assert profile_payload["auth_state"] == "connected"
+    assert profile_payload["disabled_reason"] is None
+    assert profile_payload["first_authenticated_at"] is not None
+    assert profile_payload["last_validated_at"] is not None
+    assert profile_payload["last_auth_method"] == "secret_ref"
+    assert profile_payload["command_behavior"]["auth_strategy"] == "api_key_env"
+    assert profile_payload["command_behavior"]["auth_status_label"] == status_label
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedSecret).where(ManagedSecret.slug == expected_secret_slug)
+        )
+        secret = result.scalar_one()
+
+    assert secret.ciphertext == api_key
+    assert validated == [(provider_id, api_key)]
+    assert synced_runtimes == [runtime_id]
+
+@pytest.mark.asyncio
+async def test_provider_api_key_setup_failed_validation_updates_state_without_secret(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_id = "mm-875-openai-invalid-api-key"
+    raw_key = "sk-mm875-invalid-token"
+    validated: list[tuple[str, str]] = []
+
+    async def _fake_validate(provider: str, key: str) -> None:
+        validated.append((provider, key))
+        raise provider_profiles_router.HTTPException(
+            status_code=401,
+            detail="API key validation failed.",
+        )
+
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.validate_provider_api_key",
+        _fake_validate,
+    )
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="codex_cli",
+                    provider_id="openai",
+                    provider_label="OpenAI",
+                    credential_source=ProviderCredentialSource.NONE,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/credentials/api-key",
+            json={"api_key": raw_key},
+        )
+        profile_response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 401
+    assert raw_key not in response.text
+    assert response.json()["detail"] == "API key validation failed."
+    profile_payload = profile_response.json()
+    assert raw_key not in profile_response.text
+    assert profile_payload["enabled"] is False
+    assert profile_payload["auth_state"] == "validation_failed"
+    assert profile_payload["disabled_reason"] == "auth_invalid"
+    assert profile_payload["secret_refs"] == {}
+    assert profile_payload["env_template"] == {}
+    assert profile_payload["command_behavior"]["auth_readiness"]["failure_reason"] == (
+        "API key validation failed."
+    )
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(select(ManagedSecret))
+        secrets = result.scalars().all()
+
+    assert all(secret.ciphertext != raw_key for secret in secrets)
+    assert validated == [("openai", raw_key)]
+
+@pytest.mark.asyncio
+async def test_provider_api_key_setup_can_validate_without_enabling(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_id = "mm-875-google-validate-only"
+    raw_key = "google-mm875-validate-only"
+
+    async def _fake_validate(provider: str, key: str) -> None:
+        assert (provider, key) == ("google", raw_key)
+
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.validate_provider_api_key",
+        _fake_validate,
+    )
+
+    async with db_base.async_session_maker() as session:
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="gemini_cli",
+                    provider_id="google",
+                    provider_label="Google",
+                    credential_source=ProviderCredentialSource.NONE,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    enabled=False,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/credentials/api-key",
+            json={
+                "api_key": raw_key,
+                "enable_after_validation": False,
+                "make_default": False,
+            },
+        )
+        profile_response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+
+    assert response.status_code == 200
+    profile_payload = profile_response.json()
+    assert raw_key not in profile_response.text
+    assert profile_payload["credential_source"] == "secret_ref"
+    assert profile_payload["auth_state"] == "connected"
+    assert profile_payload["disabled_reason"] == "user_disabled"
+    assert profile_payload["enabled"] is False
+    assert profile_payload["is_default"] is False
+
+@pytest.mark.asyncio
 async def test_claude_oauth_lifecycle_actions_validate_and_disconnect(
     client_app: AsyncClient,
     _module_db,

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -159,10 +159,15 @@ async def test_provider_profile_write_actions_require_write_permission(
             json={"enabled": False},
         )
         delete_response = await client.delete(f"/api/v1/provider-profiles/{profile_id}")
+        api_key_response = await client.post(
+            "/api/v1/provider-profiles/missing-api-key-profile/credentials/api-key",
+            json={"api_key": "sk-mm875-read-only-token"},
+        )
 
     assert create_response.status_code == 403
     assert update_response.status_code == 403
     assert delete_response.status_code == 403
+    assert api_key_response.status_code == 403
     assert create_response.json()["detail"] == (
         "Missing required provider profile permission: provider_profiles.write."
     )
@@ -1457,8 +1462,11 @@ async def test_provider_api_key_setup_failed_validation_updates_state_without_se
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     profile_id = "mm-875-openai-invalid-api-key"
+    fallback_profile_id = "mm-875-openai-invalid-api-key-fallback"
+    runtime_id = "codex_cli"
     raw_key = "sk-mm875-invalid-token"
     validated: list[tuple[str, str]] = []
+    synced_runtimes: list[str] = []
 
     async def _fake_validate(provider: str, key: str) -> None:
         validated.append((provider, key))
@@ -1467,12 +1475,133 @@ async def test_provider_api_key_setup_failed_validation_updates_state_without_se
             detail="API key validation failed.",
         )
 
+    async def _fake_sync(*, session: AsyncSession, runtime_id: str) -> None:
+        synced_runtimes.append(runtime_id)
+
     monkeypatch.setattr(
         "api_service.api.routers.provider_profiles.validate_provider_api_key",
         _fake_validate,
     )
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.sync_provider_profile_manager",
+        _fake_sync,
+    )
 
     async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.runtime_id == runtime_id
+            )
+        )
+        for row in result.scalars():
+            row.is_default = False
+        await session.flush()
+        existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        if existing is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id=runtime_id,
+                    provider_id="openai",
+                    provider_label="OpenAI",
+                    credential_source=ProviderCredentialSource.NONE,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    enabled=True,
+                    is_default=True,
+                    priority=10_100,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                )
+            )
+        fallback = await session.get(ManagedAgentProviderProfile, fallback_profile_id)
+        if fallback is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=fallback_profile_id,
+                    runtime_id=runtime_id,
+                    provider_id="openai",
+                    provider_label="OpenAI",
+                    credential_source=ProviderCredentialSource.NONE,
+                    runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                    enabled=True,
+                    is_default=False,
+                    priority=10_000,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/credentials/api-key",
+            json={"api_key": raw_key},
+        )
+        profile_response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
+        fallback_response = await client.get(
+            f"/api/v1/provider-profiles/{fallback_profile_id}"
+        )
+
+    assert response.status_code == 401
+    assert raw_key not in response.text
+    assert response.json()["detail"] == "API key validation failed."
+    profile_payload = profile_response.json()
+    assert raw_key not in profile_response.text
+    assert profile_payload["enabled"] is False
+    assert profile_payload["is_default"] is False
+    assert profile_payload["auth_state"] == "validation_failed"
+    assert profile_payload["disabled_reason"] == "auth_invalid"
+    assert profile_payload["secret_refs"] == {}
+    assert profile_payload["env_template"] == {}
+    assert profile_payload["command_behavior"]["auth_readiness"]["failure_reason"] == (
+        "API key validation failed."
+    )
+    assert fallback_response.json()["is_default"] is True
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(select(ManagedSecret))
+        secrets = result.scalars().all()
+
+    assert all(secret.ciphertext != raw_key for secret in secrets)
+    assert validated == [("openai", raw_key)]
+    assert synced_runtimes == [runtime_id]
+
+@pytest.mark.asyncio
+async def test_provider_api_key_setup_transient_validation_error_preserves_profile(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_id = "mm-875-openai-transient-api-key"
+    raw_key = "sk-mm875-transient-token"
+    synced_runtimes: list[str] = []
+
+    async def _fake_validate(provider: str, key: str) -> None:
+        assert (provider, key) == ("openai", raw_key)
+        raise provider_profiles_router.HTTPException(
+            status_code=502,
+            detail="Provider validation temporarily unavailable.",
+        )
+
+    async def _fake_sync(*, session: AsyncSession, runtime_id: str) -> None:
+        synced_runtimes.append(runtime_id)
+
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.validate_provider_api_key",
+        _fake_validate,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.sync_provider_profile_manager",
+        _fake_sync,
+    )
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.runtime_id == "codex_cli"
+            )
+        )
+        for row in result.scalars():
+            row.is_default = False
+        await session.flush()
         existing = await session.get(ManagedAgentProviderProfile, profile_id)
         if existing is None:
             session.add(
@@ -1484,6 +1613,8 @@ async def test_provider_api_key_setup_failed_validation_updates_state_without_se
                     credential_source=ProviderCredentialSource.NONE,
                     runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
                     enabled=True,
+                    is_default=True,
+                    priority=10_200,
                     auth_state=ProviderProfileAuthState.CONNECTED,
                 )
             )
@@ -1496,26 +1627,16 @@ async def test_provider_api_key_setup_failed_validation_updates_state_without_se
         )
         profile_response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
 
-    assert response.status_code == 401
+    assert response.status_code == 502
     assert raw_key not in response.text
-    assert response.json()["detail"] == "API key validation failed."
     profile_payload = profile_response.json()
-    assert raw_key not in profile_response.text
-    assert profile_payload["enabled"] is False
-    assert profile_payload["auth_state"] == "validation_failed"
-    assert profile_payload["disabled_reason"] == "auth_invalid"
+    assert profile_payload["enabled"] is True
+    assert profile_payload["is_default"] is True
+    assert profile_payload["auth_state"] == "connected"
+    assert profile_payload["disabled_reason"] is None
     assert profile_payload["secret_refs"] == {}
     assert profile_payload["env_template"] == {}
-    assert profile_payload["command_behavior"]["auth_readiness"]["failure_reason"] == (
-        "API key validation failed."
-    )
-
-    async with db_base.async_session_maker() as session:
-        result = await session.execute(select(ManagedSecret))
-        secrets = result.scalars().all()
-
-    assert all(secret.ciphertext != raw_key for secret in secrets)
-    assert validated == [("openai", raw_key)]
+    assert synced_runtimes == []
 
 @pytest.mark.asyncio
 async def test_provider_api_key_setup_can_validate_without_enabling(


### PR DESCRIPTION
Issue: MM-875

Summary:
- Adds a provider-aware `POST /api/v1/provider-profiles/{profile_id}/credentials/api-key` setup path for Anthropic, OpenAI, and Google first-party profiles.
- Stores validated keys through managed secrets and writes SecretRef-backed `secret_refs`, `env_template`, `clear_env_keys`, credential source, materialization mode, auth state, validation metadata, and auth method onto provider profiles.
- Updates failed validation behavior to mark profiles `validation_failed` / `auth_invalid` without creating a managed secret for the candidate key.
- Covers enable-after-validation, make-default, rotation-style overwrite, and unsupported-profile behavior in provider profile router tests.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py` (failed to start: `/usr/local/bin/python: No module named pytest`)

Remaining risks:
- Local verification is blocked in this managed runtime because pytest is not installed; CI should run the provider profile unit tests in the normal test environment.
