### PR TITLE
MM-876 Complete provider-aware execution profile selection

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -1289,6 +1289,11 @@ def _row_to_dict(
     managed_secret_statuses: dict[str, str] | None = None,
     secret_ref_results: dict[str, _SecretRefParseResult] | None = None,
 ) -> dict[str, Any]:
+    readiness = _provider_profile_readiness(
+        row,
+        managed_secret_statuses=managed_secret_statuses,
+        secret_ref_results=secret_ref_results,
+    )
     payload = {
         "profile_id": row.profile_id,
         "runtime_id": row.runtime_id,
@@ -1332,11 +1337,8 @@ def _row_to_dict(
         "last_auth_method": (
             row.last_auth_method.value if row.last_auth_method else None
         ),
-        "readiness": _provider_profile_readiness(
-            row,
-            managed_secret_statuses=managed_secret_statuses,
-            secret_ref_results=secret_ref_results,
-        ),
+        "launch_ready": readiness["launch_ready"],
+        "readiness": readiness,
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
     }

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -241,6 +241,7 @@ class ProviderProfileResponse(BaseModel):
     first_authenticated_at: Optional[str]
     last_validated_at: Optional[str]
     last_auth_method: Optional[str]
+    launch_ready: bool
     readiness: "ProviderProfileReadiness"
     created_at: Optional[str]
     updated_at: Optional[str]
@@ -967,10 +968,18 @@ def _secret_ref_results_for_rows(
     results: dict[str, dict[str, _SecretRefParseResult]] = {}
     for row in rows:
         row_results: dict[str, _SecretRefParseResult] = {}
-        for role, ref in (row.secret_refs or {}).items():
+        if not isinstance(row.secret_refs, dict):
+            results[row.profile_id] = row_results
+            continue
+        for role, ref in row.secret_refs.items():
+            if not isinstance(ref, str) or not ref:
+                row_results[str(role)] = _SecretRefParseResult(
+                    error="SecretRef must be a non-empty string"
+                )
+                continue
             try:
                 row_results[str(role)] = _SecretRefParseResult(
-                    parsed=parse_secret_ref(str(ref))
+                    parsed=parse_secret_ref(ref)
                 )
             except SecretReferenceError as exc:
                 row_results[str(role)] = _SecretRefParseResult(error=str(exc))

--- a/api_service/services/provider_profile_readiness.py
+++ b/api_service/services/provider_profile_readiness.py
@@ -75,10 +75,10 @@ def _credential_bindings_launch_ready(
     if credential_source != ProviderCredentialSource.SECRET_REF:
         return True
 
-    if not row.secret_refs:
+    if not isinstance(row.secret_refs, dict) or not row.secret_refs:
         return False
     for secret_ref in row.secret_refs.values():
-        if not secret_ref:
+        if not isinstance(secret_ref, str) or not secret_ref:
             return False
         try:
             parsed = parse_secret_ref(secret_ref)

--- a/api_service/services/provider_profile_readiness.py
+++ b/api_service/services/provider_profile_readiness.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    ProviderCredentialSource,
+    ProviderProfileAuthState,
+    RuntimeMaterializationMode,
+    SecretStatus,
+)
+from moonmind.auth.secret_refs import SecretBackend, SecretReferenceError, parse_secret_ref
+
+
+def provider_profile_launch_ready(
+    row: ManagedAgentProviderProfile,
+    *,
+    managed_secret_statuses: dict[str, str] | None = None,
+) -> bool:
+    """Return the canonical launch predicate for DB-backed profile routing."""
+
+    if not row.enabled:
+        return False
+    if row.auth_state != ProviderProfileAuthState.CONNECTED:
+        return False
+    if row.disabled_reason is not None:
+        return False
+    if not row.max_parallel_runs or row.max_parallel_runs <= 0:
+        return False
+    if row.cooldown_after_429_seconds is None or row.cooldown_after_429_seconds < 0:
+        return False
+    if not _credential_bindings_launch_ready(
+        row,
+        managed_secret_statuses=managed_secret_statuses or {},
+    ):
+        return False
+    return _provider_validation_launch_ready(row.command_behavior)
+
+
+def provider_profile_launch_ready_from_payload(profile: dict[str, Any]) -> bool:
+    """Return launch readiness for adapter/manager profile payloads."""
+
+    if profile.get("enabled") is False:
+        return False
+    if profile.get("launch_ready") is False or profile.get("launchReady") is False:
+        return False
+
+    readiness = profile.get("readiness")
+    if isinstance(readiness, dict):
+        launch_ready = readiness.get("launch_ready")
+        if launch_ready is None:
+            launch_ready = readiness.get("launchReady")
+        if launch_ready is False:
+            return False
+
+    command_behavior = profile.get("command_behavior")
+    if isinstance(command_behavior, dict):
+        return _provider_validation_launch_ready(command_behavior)
+
+    return True
+
+
+def _credential_bindings_launch_ready(
+    row: ManagedAgentProviderProfile,
+    *,
+    managed_secret_statuses: dict[str, str],
+) -> bool:
+    credential_source = row.credential_source
+    materialization_mode = row.runtime_materialization_mode
+    if credential_source == ProviderCredentialSource.OAUTH_VOLUME or (
+        materialization_mode == RuntimeMaterializationMode.OAUTH_HOME
+    ):
+        return bool(row.volume_ref and row.volume_mount_path)
+
+    if credential_source != ProviderCredentialSource.SECRET_REF:
+        return True
+
+    if not row.secret_refs:
+        return False
+    for secret_ref in row.secret_refs.values():
+        if not secret_ref:
+            return False
+        try:
+            parsed = parse_secret_ref(secret_ref)
+        except SecretReferenceError:
+            return False
+        if parsed.backend == SecretBackend.DB_ENCRYPTED:
+            if managed_secret_statuses.get(parsed.locator) != SecretStatus.ACTIVE.value:
+                return False
+    return True
+
+
+def _provider_validation_launch_ready(command_behavior: Any) -> bool:
+    if not isinstance(command_behavior, dict):
+        return True
+    readiness = command_behavior.get("auth_readiness")
+    if not isinstance(readiness, dict):
+        return True
+    launch_ready = readiness.get("launch_ready")
+    if launch_ready is None:
+        launch_ready = readiness.get("launchReady")
+    return launch_ready is not False

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -5,7 +5,10 @@ from sqlalchemy import case
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from api_service.db.models import ManagedAgentProviderProfile, ProviderProfileAuthState
+from api_service.db.models import ManagedAgentProviderProfile, ManagedSecret
+from api_service.services.provider_profile_readiness import (
+    provider_profile_launch_ready,
+)
 from moonmind.utils.logging import redact_profile_file_templates, redact_sensitive_payload
 
 logger = logging.getLogger(__name__)
@@ -37,10 +40,17 @@ async def normalize_runtime_default_profile(
     if not rows:
         return None
 
+    managed_secret_statuses = await _managed_secret_statuses_for_profiles(
+        session=session,
+        rows=rows,
+    )
     launchable_rows = [
         row
         for row in rows
-        if row.enabled and row.auth_state == ProviderProfileAuthState.CONNECTED
+        if provider_profile_launch_ready(
+            row,
+            managed_secret_statuses=managed_secret_statuses,
+        )
     ]
     if not launchable_rows:
         rows_to_clear = [row for row in rows if row.is_default]
@@ -78,7 +88,11 @@ async def normalize_runtime_default_profile(
 
     return selected_id
 
-def _manager_profile_payload(row: ManagedAgentProviderProfile) -> dict[str, Any]:
+def _manager_profile_payload(
+    row: ManagedAgentProviderProfile,
+    *,
+    managed_secret_statuses: dict[str, str] | None = None,
+) -> dict[str, Any]:
     return {
         "profile_id": row.profile_id,
         "is_default": row.is_default,
@@ -111,6 +125,10 @@ def _manager_profile_payload(row: ManagedAgentProviderProfile) -> dict[str, Any]
         "disabled_reason": (
             row.disabled_reason.value if row.disabled_reason else None
         ),
+        "launch_ready": provider_profile_launch_ready(
+            row,
+            managed_secret_statuses=managed_secret_statuses,
+        ),
         "first_authenticated_at": (
             row.first_authenticated_at.isoformat()
             if row.first_authenticated_at
@@ -135,7 +153,6 @@ async def sync_provider_profile_manager(
         .where(
             ManagedAgentProviderProfile.runtime_id == runtime_id,
             ManagedAgentProviderProfile.enabled.is_(True),
-            ManagedAgentProviderProfile.auth_state == ProviderProfileAuthState.CONNECTED,
         )
         .order_by(
             ManagedAgentProviderProfile.is_default.desc(),
@@ -144,8 +161,22 @@ async def sync_provider_profile_manager(
         )
     )
     result = await session.execute(stmt)
-    rows = result.scalars().all()
-    profiles_payload = [_manager_profile_payload(row) for row in rows]
+    rows = list(result.scalars().all())
+    managed_secret_statuses = await _managed_secret_statuses_for_profiles(
+        session=session,
+        rows=rows,
+    )
+    profiles_payload = [
+        _manager_profile_payload(
+            row,
+            managed_secret_statuses=managed_secret_statuses,
+        )
+        for row in rows
+        if provider_profile_launch_ready(
+            row,
+            managed_secret_statuses=managed_secret_statuses,
+        )
+    ]
 
     try:
         from moonmind.workflows.temporal.client import TemporalClientAdapter
@@ -188,3 +219,27 @@ async def sync_provider_profile_manager(
             exc,
             exc_info=True,
         )
+
+
+async def _managed_secret_statuses_for_profiles(
+    *,
+    session: AsyncSession,
+    rows: list[ManagedAgentProviderProfile],
+) -> dict[str, str]:
+    slugs: set[str] = set()
+    for row in rows:
+        for secret_ref in (row.secret_refs or {}).values():
+            if isinstance(secret_ref, str) and secret_ref.startswith("db://"):
+                slug = secret_ref.removeprefix("db://").strip()
+                if slug:
+                    slugs.add(slug)
+    if not slugs:
+        return {}
+
+    result = await session.execute(
+        select(ManagedSecret).where(ManagedSecret.slug.in_(slugs))
+    )
+    return {
+        row.slug: row.status.value if row.status else ""
+        for row in result.scalars().all()
+    }

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -228,11 +228,14 @@ async def _managed_secret_statuses_for_profiles(
 ) -> dict[str, str]:
     slugs: set[str] = set()
     for row in rows:
-        for secret_ref in (row.secret_refs or {}).values():
-            if isinstance(secret_ref, str) and secret_ref.startswith("db://"):
-                slug = secret_ref.removeprefix("db://").strip()
-                if slug:
-                    slugs.add(slug)
+        if not isinstance(row.secret_refs, dict):
+            continue
+        for secret_ref in row.secret_refs.values():
+            if not isinstance(secret_ref, str) or not secret_ref.startswith("db://"):
+                continue
+            slug = secret_ref.removeprefix("db://").strip()
+            if slug:
+                slugs.add(slug)
     if not slugs:
         return {}
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -9520,11 +9520,13 @@ describe.skip("Task Create Entrypoint", () => {
       {
         profile_id: "profile:codex-default",
         account_label: "Codex Default",
+        provider_id: "openai",
         is_default: true,
       },
       {
         profile_id: "profile:codex-secondary",
         account_label: "Codex Secondary",
+        provider_id: "openrouter",
         is_default: false,
       },
     ];
@@ -9654,6 +9656,12 @@ describe.skip("Task Create Entrypoint", () => {
     expect(presignedUploadIndex).toBeGreaterThanOrEqual(0);
     expect(completeIndex).toBeGreaterThan(presignedUploadIndex);
     expect(executionIndex).toBeGreaterThan(completeIndex);
+    const executionCall = fetchSpy.mock.calls[executionIndex];
+    const executionRequest = JSON.parse(String(executionCall?.[1]?.body));
+    expect(executionRequest.payload.task.runtime).toMatchObject({
+      profileId: "profile:codex-default",
+      profileSelector: { providerId: "openai" },
+    });
   });
 
   it(
@@ -16589,5 +16597,34 @@ describe("resolveDefaultProviderProfileId", () => {
     expect(
       resolveDefaultProviderProfileId(disabled, "claude-anthropic"),
     ).toBe("codex");
+  });
+
+  it("uses priority ordering when no launchable configured or default profile exists", () => {
+    const candidates = [
+      {
+        profile_id: "disabled-default",
+        is_default: true,
+        enabled: true,
+        launch_ready: false,
+        priority: 500,
+      },
+      {
+        profile_id: "low-priority",
+        is_default: false,
+        enabled: true,
+        launch_ready: true,
+        priority: 10,
+      },
+      {
+        profile_id: "high-priority",
+        is_default: false,
+        enabled: true,
+        launch_ready: true,
+        priority: 200,
+      },
+    ];
+    expect(resolveDefaultProviderProfileId(candidates, "disabled-default")).toBe(
+      "high-priority",
+    );
   });
 });

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -450,10 +450,15 @@ interface JiraImportProvenance {
 interface ProviderProfile {
   profile_id: string;
   account_label?: string | null;
+  provider_id?: string | null;
   provider_label?: string | null;
   default_model?: string | null;
   is_default?: boolean;
   enabled?: boolean;
+  launch_ready?: boolean;
+  launchReady?: boolean;
+  priority?: number | null;
+  tags?: string[] | null;
 }
 
 interface BranchOption {
@@ -476,24 +481,39 @@ export function resolveDefaultProviderProfileId(
   profiles: ProviderProfile[],
   configuredDefaultRef?: string | null,
 ): string {
+  const launchableProfiles = profiles.filter(
+    (profile) =>
+      profile.enabled !== false &&
+      profile.launch_ready !== false &&
+      profile.launchReady !== false,
+  );
   const trimmedRef = configuredDefaultRef?.trim?.() || "";
   if (trimmedRef) {
-    const configured = profiles.find(
-      (profile) => profile.profile_id === trimmedRef && profile.enabled !== false,
+    const configured = launchableProfiles.find(
+      (profile) => profile.profile_id === trimmedRef,
     );
     if (configured) {
       return configured.profile_id;
     }
   }
-  const explicitDefault = profiles.find((profile) => profile.is_default);
+  const explicitDefault = launchableProfiles.find((profile) => profile.is_default);
   if (explicitDefault) {
     return explicitDefault.profile_id;
   }
-  const onlyProfile = profiles[0];
-  if (profiles.length === 1 && onlyProfile) {
+  const onlyProfile = launchableProfiles[0];
+  if (launchableProfiles.length === 1 && onlyProfile) {
     return onlyProfile.profile_id;
   }
-  return profiles[0]?.profile_id || "";
+  return (
+    [...launchableProfiles].sort((left, right) => {
+      const leftPriority = Number(left.priority ?? 100);
+      const rightPriority = Number(right.priority ?? 100);
+      if (leftPriority !== rightPriority) {
+        return rightPriority - leftPriority;
+      }
+      return left.profile_id.localeCompare(right.profile_id);
+    })[0]?.profile_id || ""
+  );
 }
 
 interface SkillsResponse {
@@ -8768,6 +8788,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       isMergeAutomationPublishMode(publishMode) &&
       effectivePublishMode === "pr" &&
       !isSelfManagedPublishSkill(effectivePublishSkillId);
+    const selectedProviderProfile = (providerProfilesQuery.data || []).find(
+      (profile) => profile.profile_id === providerProfile,
+    );
+    const selectedProviderId = selectedProviderProfile?.provider_id?.trim?.() || "";
 
     const taskPayload: Record<string, unknown> = {
       instructions: objectiveInstructionsForSubmit,
@@ -8787,6 +8811,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         ...(model.trim() ? { model: model.trim() } : {}),
         ...(effort.trim() ? { effort: effort.trim() } : {}),
         ...(providerProfile ? { profileId: providerProfile } : {}),
+        ...(selectedProviderId
+          ? { profileSelector: { providerId: selectedProviderId } }
+          : {}),
       },
       publish: {
         mode: effectivePublishMode,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6739,6 +6739,8 @@ export interface components {
             last_validated_at: string | null;
             /** Last Auth Method */
             last_auth_method: string | null;
+            /** Launch Ready */
+            launch_ready: boolean;
             readiness: components["schemas"]["ProviderProfileReadiness"];
             /** Created At */
             created_at: string | null;

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -48,6 +48,9 @@ from moonmind.schemas.agent_runtime_models import (
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.executions.runtime_defaults import resolve_runtime_defaults
+from api_service.services.provider_profile_readiness import (
+    provider_profile_launch_ready_from_payload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -944,6 +947,11 @@ class ManagedAgentAdapter:
         if execution_profile_ref is not None:
             for profile in profiles:
                 if profile.get("profile_id") == execution_profile_ref:
+                    if not provider_profile_launch_ready_from_payload(profile):
+                        raise ProfileResolutionError(
+                            f"Provider profile '{execution_profile_ref}' is not "
+                            f"launch-ready for runtime_id='{runtime_id}'"
+                        )
                     return profile
             raise ProfileResolutionError(
                 f"Provider profile '{execution_profile_ref}' not found for "
@@ -954,6 +962,8 @@ class ManagedAgentAdapter:
         eligible_profiles = []
         for profile in profiles:
             if not profile.get("enabled", True):
+                continue
+            if not provider_profile_launch_ready_from_payload(profile):
                 continue
             if normalized_selector:
                 if normalized_selector.get("providerId") and profile.get("provider_id") != normalized_selector.get("providerId"):

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2801,26 +2801,38 @@ class TemporalArtifactActivities:
 
         from api_service.db.models import (
             ManagedAgentProviderProfile,
-            ProviderProfileAuthState,
         )
         from api_service.db.base import get_async_session_context
+        from api_service.services.provider_profile_readiness import (
+            provider_profile_launch_ready,
+        )
+        from api_service.services.provider_profile_service import (
+            _managed_secret_statuses_for_profiles,
+        )
 
         async with get_async_session_context() as session:
             stmt = select(ManagedAgentProviderProfile).where(
                 ManagedAgentProviderProfile.runtime_id == runtime_id,
                 ManagedAgentProviderProfile.enabled.is_(True),
-                ManagedAgentProviderProfile.auth_state
-                == ProviderProfileAuthState.CONNECTED,
             ).order_by(
                 ManagedAgentProviderProfile.is_default.desc(),
                 ManagedAgentProviderProfile.priority.desc(),
                 ManagedAgentProviderProfile.profile_id.asc(),
             )
             result = await session.execute(stmt)
-            rows = result.scalars().all()
+            rows = list(result.scalars().all())
+            managed_secret_statuses = await _managed_secret_statuses_for_profiles(
+                session=session,
+                rows=rows,
+            )
 
         profiles = []
         for row in rows:
+            if not provider_profile_launch_ready(
+                row,
+                managed_secret_statuses=managed_secret_statuses,
+            ):
+                continue
             command_behavior = row.command_behavior or {}
             billing_metadata = (
                 command_behavior.get("billing")
@@ -2860,6 +2872,7 @@ class TemporalArtifactActivities:
                     "rate_limit_policy": row.rate_limit_policy.value,
                     "max_lease_duration_seconds": row.max_lease_duration_seconds,
                     "enabled": row.enabled,
+                    "launch_ready": True,
                     "auth_state": row.auth_state.value if row.auth_state else None,
                     "disabled_reason": (
                         row.disabled_reason.value if row.disabled_reason else None

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -154,6 +154,7 @@ class ProfileSlotState:
     cooldown_after_429_seconds: int
     rate_limit_policy: str
     enabled: bool
+    launch_ready: bool = True
     is_default: bool = False
     max_lease_duration_seconds: int = _MAX_LEASE_DURATION_SECONDS
     current_leases: list[str] = field(default_factory=list)
@@ -169,12 +170,12 @@ class ProfileSlotState:
 
     @property
     def available_slots(self) -> int:
-        if not self.enabled:
+        if not self.enabled or not self.launch_ready:
             return 0
         return max(0, self.max_parallel_runs - len(self.current_leases))
 
     def is_available(self) -> bool:
-        if not self.enabled or self.available_slots <= 0:
+        if not self.enabled or not self.launch_ready or self.available_slots <= 0:
             return False
         if self.cooldown_until is not None:
             return False
@@ -225,6 +226,7 @@ class ProfileSlotState:
             "cooldown_after_429_seconds": self.cooldown_after_429_seconds,
             "rate_limit_policy": self.rate_limit_policy,
             "enabled": self.enabled,
+            "launch_ready": self.launch_ready,
             "is_default": self.is_default,
             "max_lease_duration_seconds": self.max_lease_duration_seconds,
             "current_leases": list(self.current_leases),
@@ -710,6 +712,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 900),
                 rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                 enabled=p.get("enabled", True),
+                launch_ready=p.get("launch_ready", p.get("launchReady", True)),
                 is_default=p.get("is_default", False),
                 max_lease_duration_seconds=p.get(
                     "max_lease_duration_seconds", _MAX_LEASE_DURATION_SECONDS
@@ -746,6 +749,10 @@ class MoonMindProviderProfileManagerWorkflow:
                     "rate_limit_policy", existing.rate_limit_policy
                 )
                 existing.enabled = p.get("enabled", existing.enabled)
+                existing.launch_ready = p.get(
+                    "launch_ready",
+                    p.get("launchReady", existing.launch_ready),
+                )
                 existing.is_default = p.get("is_default", existing.is_default)
                 existing.max_lease_duration_seconds = p.get(
                     "max_lease_duration_seconds", existing.max_lease_duration_seconds
@@ -767,6 +774,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     ),
                     rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                     enabled=p.get("enabled", True),
+                    launch_ready=p.get("launch_ready", p.get("launchReady", True)),
                     is_default=p.get("is_default", False),
                     max_lease_duration_seconds=p.get(
                         "max_lease_duration_seconds", _MAX_LEASE_DURATION_SECONDS
@@ -1216,7 +1224,7 @@ class MoonMindProviderProfileManagerWorkflow:
             configured_default_profiles = [
                 profile
                 for profile in self._profiles.values()
-                if profile.is_default and profile.enabled
+                if profile.is_default and profile.enabled and profile.launch_ready
             ]
             default_profiles = [
                 profile for profile in eligible_profiles if profile.is_default
@@ -1262,9 +1270,6 @@ class MoonMindProviderProfileManagerWorkflow:
             return False
 
     def _sort_profiles_for_selection(self, profiles: list[ProfileSlotState]) -> None:
-        if self._workflow_patch_enabled(BILLING_AWARE_PROFILE_SELECTION_PATCH):
-            profiles.sort(key=self._billing_sort_key)
-            return
         profiles.sort(key=lambda p: (p.priority, p.available_slots), reverse=True)
 
     async def _signal_slot_assigned(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -18,6 +18,9 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
     )
+    from api_service.services.provider_profile_readiness import (
+        provider_profile_launch_ready_from_payload,
+    )
     from moonmind.schemas.agent_skill_models import SkillSelector
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
@@ -11181,6 +11184,11 @@ class MoonMindRunWorkflow:
         snapshot = profile_snapshots.get(profile_id)
         if not isinstance(snapshot, Mapping):
             return profile_id
+        if not provider_profile_launch_ready_from_payload(dict(snapshot)):
+            raise ValueError(
+                "%s execution_profile_ref '%s' is not launch-ready for this "
+                "runtime." % (source_label, profile_id)
+            )
         runtime_id = self._coerce_text(snapshot.get("runtime_id"), max_chars=160)
         if not runtime_id or not agent_id:
             return profile_id

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -11142,15 +11142,15 @@ class MoonMindRunWorkflow:
                     if self._managed_runtime_id(agent_id) != self._managed_runtime_id(
                         source_agent_id
                     ):
-                        self._get_logger().warning(
+                        raise ValueError(
                             "Inherited execution_profile_ref '%s' targets runtime "
-                            "'%s' but child runtime is '%s'; falling back to "
-                            "auto-selection.",
-                            profile_id,
-                            self._managed_runtime_id(source_agent_id),
-                            self._managed_runtime_id(agent_id),
+                            "'%s' but child runtime is '%s'."
+                            % (
+                                profile_id,
+                                self._managed_runtime_id(source_agent_id),
+                                self._managed_runtime_id(agent_id),
+                            )
                         )
-                        return None
                 return self._validated_execution_profile_ref(
                     profile_id,
                     agent_id=agent_id,
@@ -11172,13 +11172,10 @@ class MoonMindRunWorkflow:
         if profile_snapshots is None:
             return profile_id
         if profile_id not in profile_snapshots:
-            self._get_logger().warning(
+            raise ValueError(
                 "%s execution_profile_ref '%s' is not a known profile for this "
-                "runtime; falling back to auto-selection.",
-                source_label,
-                profile_id,
+                "runtime." % (source_label, profile_id)
             )
-            return None
         if not isinstance(profile_snapshots, Mapping):
             return profile_id
         snapshot = profile_snapshots.get(profile_id)
@@ -11189,15 +11186,11 @@ class MoonMindRunWorkflow:
             return profile_id
         child_runtime_id = self._managed_runtime_id(agent_id)
         if runtime_id != child_runtime_id:
-            self._get_logger().warning(
+            raise ValueError(
                 "%s execution_profile_ref '%s' belongs to runtime '%s' but child "
-                "runtime is '%s'; falling back to auto-selection.",
-                source_label,
-                profile_id,
-                runtime_id,
-                child_runtime_id,
+                "runtime is '%s'."
+                % (source_label, profile_id, runtime_id, child_runtime_id)
             )
-            return None
         return profile_id
 
     @staticmethod

--- a/tests/integration/test_multi_profile_openrouter.py
+++ b/tests/integration/test_multi_profile_openrouter.py
@@ -20,6 +20,7 @@ from api_service.db.models import (
     Base,
     ManagedAgentProviderProfile,
     ProviderCredentialSource,
+    ProviderProfileAuthState,
     RuntimeMaterializationMode,
     ManagedAgentRateLimitPolicy,
 )
@@ -89,6 +90,8 @@ async def test_two_openrouter_profiles_independently_resolvable(tmp_path: Path) 
                     credential_source=ProviderCredentialSource.SECRET_REF,
                     runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
                     default_model="qwen/qwen3.6-plus",
+                    secret_refs={"provider_api_key": "env://OPENROUTER_API_KEY"},
+                    auth_state=ProviderProfileAuthState.CONNECTED,
                     priority=100,
                     max_parallel_runs=4,
                     cooldown_after_429_seconds=300,
@@ -105,6 +108,8 @@ async def test_two_openrouter_profiles_independently_resolvable(tmp_path: Path) 
                     credential_source=ProviderCredentialSource.SECRET_REF,
                     runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
                     default_model="anthropic/claude-sonnet-4-20250514",
+                    secret_refs={"provider_api_key": "env://OPENROUTER_API_KEY_ALT"},
+                    auth_state=ProviderProfileAuthState.CONNECTED,
                     priority=50,
                     max_parallel_runs=2,
                     cooldown_after_429_seconds=300,
@@ -269,6 +274,7 @@ async def test_profile_roundtrip_via_provider_profile_list(tmp_path: Path) -> No
                     runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
                     default_model="qwen/qwen3.6-plus",
                     secret_refs={"provider_api_key": "env://OPENROUTER_API_KEY"},
+                    auth_state=ProviderProfileAuthState.CONNECTED,
                     clear_env_keys=["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
                     env_template={
                         "OPENROUTER_API_KEY": {

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -179,11 +179,31 @@ class _TrackedProfile:
         is_default: bool,
         events: list[tuple[object, ...]],
         auth_state: ProviderProfileAuthState = ProviderProfileAuthState.CONNECTED,
+        disabled_reason: ProviderProfileDisabledReason | None = None,
+        credential_source: ProviderCredentialSource = ProviderCredentialSource.NONE,
+        runtime_materialization_mode: RuntimeMaterializationMode = (
+            RuntimeMaterializationMode.COMPOSITE
+        ),
+        max_parallel_runs: int = 1,
+        cooldown_after_429_seconds: int = 900,
+        secret_refs: dict[str, str] | None = None,
+        volume_ref: str | None = None,
+        volume_mount_path: str | None = None,
+        command_behavior: dict | None = None,
     ) -> None:
         self.profile_id = profile_id
         self.runtime_id = runtime_id
         self.enabled = enabled
         self.auth_state = auth_state
+        self.disabled_reason = disabled_reason
+        self.credential_source = credential_source
+        self.runtime_materialization_mode = runtime_materialization_mode
+        self.max_parallel_runs = max_parallel_runs
+        self.cooldown_after_429_seconds = cooldown_after_429_seconds
+        self.secret_refs = secret_refs or {}
+        self.volume_ref = volume_ref
+        self.volume_mount_path = volume_mount_path
+        self.command_behavior = command_behavior or {}
         self.priority = priority
         self._is_default = is_default
         self._events = events
@@ -273,6 +293,41 @@ async def test_runtime_default_switch_flushes_old_default_first():
             {"claude_minimax": False, "claude_anthropic": True},
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_default_normalization_skips_not_launch_ready_profiles():
+    events: list[tuple[object, ...]] = []
+    blocked_default = _TrackedProfile(
+        profile_id="claude_blocked",
+        runtime_id="claude_code",
+        enabled=True,
+        priority=500,
+        is_default=True,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        command_behavior={"auth_readiness": {"launch_ready": False}},
+        events=events,
+    )
+    ready_fallback = _TrackedProfile(
+        profile_id="claude_ready",
+        runtime_id="claude_code",
+        enabled=True,
+        priority=100,
+        is_default=False,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        command_behavior={"auth_readiness": {"launch_ready": True}},
+        events=events,
+    )
+    session = _TrackedDefaultSession([blocked_default, ready_fallback], events)
+
+    selected = await normalize_runtime_default_profile(
+        session=session,
+        runtime_id="claude_code",
+    )
+
+    assert selected == "claude_ready"
+    assert blocked_default.is_default is False
+    assert ready_fallback.is_default is True
 
 async def get_or_create_sample_profile() -> ManagedAgentProviderProfile:
     """Helper to create a baseline profile in the test DB."""

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -1,6 +1,7 @@
 """Unit/Integration tests for ManagedAgentProviderProfile CRUD API."""
 
 from types import SimpleNamespace
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -26,9 +27,11 @@ from api_service.db.models import (
 )
 from api_service.main import app
 from api_service.services.provider_profile_service import (
+    _managed_secret_statuses_for_profiles,
     _manager_profile_payload,
     normalize_runtime_default_profile,
 )
+from api_service.services.provider_profile_readiness import provider_profile_launch_ready
 
 @pytest.fixture(scope="module")
 def _module_db(tmp_path_factory):
@@ -186,7 +189,7 @@ class _TrackedProfile:
         ),
         max_parallel_runs: int = 1,
         cooldown_after_429_seconds: int = 900,
-        secret_refs: dict[str, str] | None = None,
+        secret_refs: Any = None,
         volume_ref: str | None = None,
         volume_mount_path: str | None = None,
         command_behavior: dict | None = None,
@@ -328,6 +331,61 @@ async def test_runtime_default_normalization_skips_not_launch_ready_profiles():
     assert selected == "claude_ready"
     assert blocked_default.is_default is False
     assert ready_fallback.is_default is True
+
+
+def test_launch_ready_rejects_malformed_secret_refs() -> None:
+    profile = _TrackedProfile(
+        profile_id="malformed_secret_refs",
+        runtime_id="codex_cli",
+        enabled=True,
+        priority=100,
+        is_default=False,
+        events=[],
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        credential_source=ProviderCredentialSource.SECRET_REF,
+        secret_refs=["db://not-a-dict"],
+    )
+
+    assert provider_profile_launch_ready(profile) is False
+
+    profile.secret_refs = {"provider_api_key": 123}
+
+    assert provider_profile_launch_ready(profile) is False
+
+
+@pytest.mark.asyncio
+async def test_managed_secret_statuses_ignores_malformed_secret_refs() -> None:
+    class _EmptySecretSession:
+        async def execute(self, _stmt):
+            raise AssertionError("malformed secret_refs should not query secrets")
+
+    rows = [
+        _TrackedProfile(
+            profile_id="malformed_secret_refs",
+            runtime_id="codex_cli",
+            enabled=True,
+            priority=100,
+            is_default=False,
+            events=[],
+            secret_refs=["db://not-a-dict"],
+        ),
+        _TrackedProfile(
+            profile_id="non_string_secret_ref",
+            runtime_id="codex_cli",
+            enabled=True,
+            priority=100,
+            is_default=False,
+            events=[],
+            secret_refs={"provider_api_key": 123},
+        ),
+    ]
+
+    statuses = await _managed_secret_statuses_for_profiles(
+        session=_EmptySecretSession(),
+        rows=rows,
+    )
+
+    assert statuses == {}
 
 async def get_or_create_sample_profile() -> ManagedAgentProviderProfile:
     """Helper to create a baseline profile in the test DB."""
@@ -1025,7 +1083,9 @@ async def test_provider_profile_readiness_reports_managed_secret_status(
         response = await client.get(f"/api/v1/provider-profiles/{profile_id}")
 
     assert response.status_code == 200
-    readiness = response.json()["readiness"]
+    payload = response.json()
+    assert payload["launch_ready"] is False
+    readiness = payload["readiness"]
     assert readiness["status"] == "blocked"
     checks = {check["id"]: check for check in readiness["checks"]}
     assert checks["secret_refs"]["status"] == "error"

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -260,6 +260,36 @@ async def test_resolve_profile_by_id():
     # so the adapter should NOT send a redundant slot request.
     assert ("slot_request", "wf-123", "gemini_cli") not in calls
 
+async def test_resolve_profile_by_id_rejects_not_launch_ready():
+    profiles = [
+        {
+            "profile_id": "prof-disabled",
+            "credential_source": "oauth_volume",
+            "enabled": True,
+            "launch_ready": False,
+        }
+    ]
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles(profiles),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-not-ready",
+    )
+
+    from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="gemini_cli",
+        executionProfileRef="prof-disabled",
+        correlationId="corr-not-ready",
+        idempotencyKey="idem-not-ready",
+    )
+    with pytest.raises(ProfileResolutionError, match="not launch-ready"):
+        await adapter.start(request)
+
 async def test_resolve_profile_auto_picks_runtime_default():
     profiles = [
         {
@@ -293,6 +323,46 @@ async def test_resolve_profile_auto_picks_runtime_default():
     )
     handle = await adapter.start(request)
     assert handle.metadata["profile_id"] == "second"
+
+async def test_resolve_profile_selector_excludes_not_launch_ready_default():
+    profiles = [
+        {
+            "profile_id": "blocked-default",
+            "credential_source": "secret_ref",
+            "is_default": True,
+            "launch_ready": False,
+            "priority": 300,
+            "available_slots": 9,
+        },
+        {
+            "profile_id": "ready-fallback",
+            "credential_source": "oauth_volume",
+            "is_default": False,
+            "launch_ready": True,
+            "priority": 100,
+            "available_slots": 1,
+        },
+    ]
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles(profiles),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-ready-fallback",
+    )
+
+    from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        executionProfileRef="auto",
+        correlationId="corr-ready-fallback",
+        idempotencyKey="idem-ready-fallback",
+    )
+    handle = await adapter.start(request)
+    assert handle.metadata["profile_id"] == "ready-fallback"
 
 async def test_resolve_profile_selector_filters():
     profiles = [
@@ -920,7 +990,7 @@ async def test_provider_profile_list_returns_enabled_profiles(tmp_path: Path):
                     runtime_id="gemini_cli",
                     credential_source=ProviderCredentialSource.OAUTH_VOLUME,
                     runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
-                    volume_ref=None,
+                    volume_ref="oauth-volume://gemini",
                     volume_mount_path="/mnt/auth",
                     account_label="primary",
                     max_parallel_runs=2,
@@ -996,7 +1066,7 @@ async def test_provider_profile_list_filters_by_runtime_id(tmp_path: Path):
                     ManagedAgentProviderProfile(
                         profile_id=pid,
                         runtime_id=runtime,
-                        credential_source=ProviderCredentialSource.SECRET_REF,
+                        credential_source=ProviderCredentialSource.NONE,
                         runtime_materialization_mode=RuntimeMaterializationMode.ENV_BUNDLE,
                         max_parallel_runs=1,
                         cooldown_after_429_seconds=300,
@@ -1038,7 +1108,7 @@ async def test_provider_profile_list_preserves_secret_ref_materialization_fields
                     runtime_id="claude_code",
                     credential_source=ProviderCredentialSource.SECRET_REF,
                     runtime_materialization_mode=RuntimeMaterializationMode.ENV_BUNDLE,
-                    secret_refs={"ANTHROPIC_AUTH_TOKEN": "MINIMAX_API_KEY"},
+                    secret_refs={"ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"},
                     clear_env_keys=["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
                     env_template={
                         "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
@@ -1075,7 +1145,7 @@ async def test_provider_profile_list_preserves_secret_ref_materialization_fields
         assert len(profiles) == 1
         assert profiles[0]["profile_id"] == "claude-minimax"
         assert profiles[0]["secret_refs"] == {
-            "ANTHROPIC_AUTH_TOKEN": "MINIMAX_API_KEY"
+            "ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"
         }
         assert profiles[0]["clear_env_keys"] == [
             "ANTHROPIC_API_KEY",

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -700,7 +700,7 @@ class TestProviderProfileManagerHelpers:
         assert best is not None
         assert best.profile_id == "p2"
 
-    def test_find_available_profile_prefers_lower_cost_when_billing_patch_enabled(self):
+    def test_find_available_profile_keeps_priority_order_when_billing_patch_enabled(self):
         wf = self._make_workflow()
         wf._profiles["expensive"] = ProfileSlotState(
             profile_id="expensive",
@@ -734,7 +734,7 @@ class TestProviderProfileManagerHelpers:
             best = wf._find_available_profile({"providerId": "openai"})
 
         assert best is not None
-        assert best.profile_id == "cheap"
+        assert best.profile_id == "expensive"
 
     def test_find_available_profile_none_available(self):
         wf = self._make_workflow()
@@ -818,6 +818,19 @@ class TestProviderProfileManagerHelpers:
             wf._find_available_profile(execution_profile_ref="missing-profile")
             is None
         )
+
+    def test_find_available_profile_exact_ref_requires_launch_ready_profile(self):
+        wf = self._make_workflow()
+        wf._profiles["not-ready"] = ProfileSlotState(
+            profile_id="not-ready",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            launch_ready=False,
+        )
+
+        assert wf._find_available_profile(execution_profile_ref="not-ready") is None
 
     def test_find_available_profile_sorts_by_priority(self):
         wf = self._make_workflow()

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1187,7 +1187,7 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.execution_profile_ref, "codex_default")
 
-    def test_build_agent_execution_request_does_not_inherit_cross_runtime_profile(self) -> None:
+    def test_build_agent_execution_request_rejects_cross_runtime_profile(self) -> None:
         from unittest.mock import patch
 
         wf = MoonMindRunWorkflow()
@@ -1206,28 +1206,29 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "moonmind.workflows.temporal.workflows.run.workflow.info",
             return_value=MockInfo(),
         ):
-            request = wf._build_agent_execution_request(
-                node_inputs={
-                    "runtime": {
-                        "mode": "claude",
-                    },
-                },
-                node_id="node-cross-runtime-profile",
-                tool_name="pr-resolver",
-                workflow_parameters={
-                    "task": {
+            with self.assertRaisesRegex(
+                ValueError,
+                "targets runtime 'codex_cli' but child runtime is 'claude_code'",
+            ):
+                wf._build_agent_execution_request(
+                    node_inputs={
                         "runtime": {
-                            "mode": "codex",
-                            "executionProfileRef": "codex_default",
+                            "mode": "claude",
                         },
                     },
-                },
-            )
+                    node_id="node-cross-runtime-profile",
+                    tool_name="pr-resolver",
+                    workflow_parameters={
+                        "task": {
+                            "runtime": {
+                                "mode": "codex",
+                                "executionProfileRef": "codex_default",
+                            },
+                        },
+                    },
+                )
 
-        self.assertEqual(request.agent_id, "claude")
-        self.assertIsNone(request.execution_profile_ref)
-
-    def test_build_agent_execution_request_does_not_inherit_unknown_profile(self) -> None:
+    def test_build_agent_execution_request_rejects_unknown_inherited_profile(self) -> None:
         from unittest.mock import patch
 
         wf = MoonMindRunWorkflow()
@@ -1246,26 +1247,24 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "moonmind.workflows.temporal.workflows.run.workflow.info",
             return_value=MockInfo(),
         ):
-            request = wf._build_agent_execution_request(
-                node_inputs={
-                    "runtime": {
-                        "mode": "codex",
-                    },
-                },
-                node_id="node-unknown-inherited-profile",
-                tool_name="pr-resolver",
-                workflow_parameters={
-                    "task": {
+            with self.assertRaisesRegex(ValueError, "not a known profile"):
+                wf._build_agent_execution_request(
+                    node_inputs={
                         "runtime": {
                             "mode": "codex",
-                            "executionProfileRef": "hallucinated-profile",
                         },
                     },
-                },
-            )
-
-        self.assertEqual(request.agent_id, "codex")
-        self.assertIsNone(request.execution_profile_ref)
+                    node_id="node-unknown-inherited-profile",
+                    tool_name="pr-resolver",
+                    workflow_parameters={
+                        "task": {
+                            "runtime": {
+                                "mode": "codex",
+                                "executionProfileRef": "hallucinated-profile",
+                            },
+                        },
+                    },
+                )
 
     def test_build_agent_execution_request_prefers_runtime_block_profile_over_top_level(self) -> None:
         """Runtime planner sets profile fields inside the runtime block; these
@@ -1381,10 +1380,10 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         self.assertEqual(moonmind["queueOrder"], 7)
         self.assertEqual(moonmind["queuedAt"], "2026-06-22T10:00:00+00:00")
 
-    def test_build_agent_execution_request_falls_back_on_invalid_profile_ref(self) -> None:
+    def test_build_agent_execution_request_rejects_invalid_profile_ref(self) -> None:
         """When a plan node carries a profile ID that doesn't match any known
         profile for the runtime (e.g. AI-hallucinated 'default:codex_cli'),
-        the dispatcher should reject it and fall back to auto-selection."""
+        the dispatcher should reject it instead of falling back to auto-selection."""
         from unittest.mock import patch
 
         wf = MoonMindRunWorkflow()
@@ -1399,19 +1398,17 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "moonmind.workflows.temporal.workflows.run.workflow.info",
             return_value=MockInfo(),
         ):
-            request = wf._build_agent_execution_request(
-                node_inputs={
-                    "runtime": {
-                        "mode": "codex",
-                        "profileId": "default:codex_cli",  # Invalid / not in snapshots
+            with self.assertRaisesRegex(ValueError, "not a known profile"):
+                wf._build_agent_execution_request(
+                    node_inputs={
+                        "runtime": {
+                            "mode": "codex",
+                            "profileId": "default:codex_cli",
+                        },
                     },
-                },
-                node_id="node-invalid-profile",
-                tool_name="pr-resolver",
-            )
-
-        self.assertEqual(request.agent_id, "codex")
-        self.assertIsNone(request.execution_profile_ref)
+                    node_id="node-invalid-profile",
+                    tool_name="pr-resolver",
+                )
 
     def test_build_agent_execution_request_accepts_valid_profile_ref(self) -> None:
         """When a plan node carries a profile ID that is in the known snapshots,

--- a/tests/unit/workflows/temporal/workflows/test_run_profile_ref_validation.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_profile_ref_validation.py
@@ -33,6 +33,41 @@ def test_validated_execution_profile_ref_rejects_runtime_mismatch() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        {"profile_id": "codex-disabled", "runtime_id": "codex_cli", "enabled": False},
+        {
+            "profile_id": "codex-disabled",
+            "runtime_id": "codex_cli",
+            "launch_ready": False,
+        },
+        {
+            "profile_id": "codex-disabled",
+            "runtime_id": "codex_cli",
+            "readiness": {"launch_ready": False},
+        },
+        {
+            "profile_id": "codex-disabled",
+            "runtime_id": "codex_cli",
+            "command_behavior": {"auth_readiness": {"launch_ready": False}},
+        },
+    ],
+)
+def test_validated_execution_profile_ref_rejects_non_launchable_profile(
+    snapshot: dict[str, object],
+) -> None:
+    workflow = MoonMindUserWorkflow()
+    workflow._profile_snapshots = {"codex-disabled": snapshot}
+
+    with pytest.raises(ValueError, match="not launch-ready"):
+        workflow._validated_execution_profile_ref(
+            "codex-disabled",
+            agent_id="codex_cli",
+            source_label="Task",
+        )
+
+
 def test_inherited_execution_profile_ref_rejects_runtime_mismatch() -> None:
     workflow = MoonMindUserWorkflow()
     workflow._profile_snapshots = {

--- a/tests/unit/workflows/temporal/workflows/test_run_profile_ref_validation.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_profile_ref_validation.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
+
+
+def test_validated_execution_profile_ref_rejects_unknown_profile() -> None:
+    workflow = MoonMindUserWorkflow()
+    workflow._profile_snapshots = {
+        "codex-ready": {"profile_id": "codex-ready", "runtime_id": "codex_cli"}
+    }
+
+    with pytest.raises(ValueError, match="not a known profile"):
+        workflow._validated_execution_profile_ref(
+            "missing-profile",
+            agent_id="codex_cli",
+            source_label="Task",
+        )
+
+
+def test_validated_execution_profile_ref_rejects_runtime_mismatch() -> None:
+    workflow = MoonMindUserWorkflow()
+    workflow._profile_snapshots = {
+        "claude-ready": {"profile_id": "claude-ready", "runtime_id": "claude_code"}
+    }
+
+    with pytest.raises(ValueError, match="belongs to runtime 'claude_code'"):
+        workflow._validated_execution_profile_ref(
+            "claude-ready",
+            agent_id="codex_cli",
+            source_label="Task",
+        )
+
+
+def test_inherited_execution_profile_ref_rejects_runtime_mismatch() -> None:
+    workflow = MoonMindUserWorkflow()
+    workflow._profile_snapshots = {
+        "claude-ready": {"profile_id": "claude-ready", "runtime_id": "claude_code"}
+    }
+
+    with pytest.raises(ValueError, match="targets runtime 'claude_code'"):
+        workflow._inherited_execution_profile_ref(
+            {
+                "task": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude-ready",
+                    }
+                }
+            },
+            agent_id="codex_cli",
+        )


### PR DESCRIPTION
Issue reference
- MM-876: Complete remaining behavior for Resolve execution requests with provider-aware selection

Summary
- Added shared provider profile readiness evaluation and applied launch-ready semantics to provider profile API/list/default normalization paths.
- Tightened exact execution_profile_ref handling so disabled, not-ready, policy-blocked, runtime-incompatible, or unknown profiles fail instead of falling back to another provider/runtime.
- Updated selector/default Mission Control behavior and expanded unit, workflow, adapter, API, integration, and UI test coverage.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/workflows/test_run_profile_ref_validation.py
- Python subset: 285 passed, 2 subtests passed. UI suite invoked by test runner: 29 files passed, 467 passed, 236 skipped.

Remaining risks
- Full integration suite was not run in this publication step.
- Provider launch readiness depends on persisted auth/capacity metadata quality from existing provider profile records.