### PR TITLE
MM-877 complete provider profile slot coordination

### DIFF
--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2821,6 +2821,8 @@ class TemporalArtifactActivities:
 
         profiles = []
         for row in rows:
+            if not self._provider_profile_launch_ready(row):
+                continue
             command_behavior = row.command_behavior or {}
             billing_metadata = (
                 command_behavior.get("billing")
@@ -2881,6 +2883,52 @@ class TemporalArtifactActivities:
             )
 
         return {"profiles": profiles}
+
+    @staticmethod
+    def _provider_profile_launch_ready(row: Any) -> bool:
+        """Return whether a persisted provider profile is launchable.
+
+        The manager sync consumes only launch-ready rows. SQL filters cover
+        operator intent and connected auth state; this predicate covers the
+        credential/materialization bindings that make setup stubs non-runnable.
+        """
+
+        if not bool(getattr(row, "enabled", False)):
+            return False
+
+        auth_state = getattr(row, "auth_state", None)
+        auth_value = getattr(auth_state, "value", auth_state)
+        if auth_value != "connected":
+            return False
+
+        credential_source = getattr(row, "credential_source", None)
+        credential_value = getattr(credential_source, "value", credential_source)
+        materialization = getattr(row, "runtime_materialization_mode", None)
+        materialization_value = getattr(materialization, "value", materialization)
+
+        if credential_value == "oauth_volume":
+            return bool(
+                str(getattr(row, "volume_ref", "") or "").strip()
+                and str(getattr(row, "volume_mount_path", "") or "").strip()
+            )
+
+        if credential_value == "secret_ref":
+            secret_refs = getattr(row, "secret_refs", None)
+            if not isinstance(secret_refs, dict) or not secret_refs:
+                return False
+            if materialization_value in {
+                "api_key_env",
+                "env_bundle",
+                "config_bundle",
+                "composite",
+            }:
+                return True
+            return False
+
+        if credential_value == "none":
+            return materialization_value in {"config_bundle", "composite"}
+
+        return False
 
     async def provider_profile_ensure_manager(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2572,6 +2572,14 @@ class MoonMindAgentRun:
                         by_alias=True,
                         exclude_none=True,
                     )
+                    if (
+                        self._skip_default_profile_pin_once
+                        and not request.execution_profile_ref
+                        and not self._profile_selector_has_constraints(
+                            request.profile_selector
+                        )
+                    ):
+                        selector_payload["allowDefaultFallback"] = True
                     if workflow.patched(SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID):
                         manager_handle = await self._ensure_manager_started(
                             manager_id,
@@ -2666,6 +2674,9 @@ class MoonMindAgentRun:
                                         manager_id=manager_id,
                                         runtime_id=runtime_id,
                                     )
+                                    requested_execution_profile_ref = (
+                                        request.execution_profile_ref
+                                    )
                                     continue
                                 slot_wait_timeout_seconds = (
                                     self._slot_wait_timeout_override_seconds
@@ -2685,6 +2696,9 @@ class MoonMindAgentRun:
                                         request=request,
                                         manager_id=manager_id,
                                         runtime_id=runtime_id,
+                                    )
+                                    requested_execution_profile_ref = (
+                                        request.execution_profile_ref
                                     )
                                     continue
                             except TimeoutError:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -402,6 +402,7 @@ class MoonMindAgentRun:
         self._profile_snapshots: dict[str, dict[str, Any]] = {}
         self._awaiting_slot_reason_override: str | None = None
         self._slot_wait_timeout_override_seconds: int | None = None
+        self._skip_default_profile_pin_once: bool = False
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
 
@@ -654,6 +655,50 @@ class MoonMindAgentRun:
             "Managed provider capacity exhausted for "
             f"{runtime_id}{profile_fragment}; retry scheduled for "
             f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
+        )
+
+    @staticmethod
+    def _provider_slot_intent_summary(
+        request: AgentExecutionRequest,
+    ) -> str:
+        parts: list[str] = []
+        exact_profile = str(request.execution_profile_ref or "").strip()
+        if exact_profile:
+            parts.append(f"exact_profile={exact_profile}")
+        selector_source = request.profile_selector
+        selector = (
+            selector_source.model_dump(by_alias=True, exclude_none=True)
+            if hasattr(selector_source, "model_dump")
+            else selector_source
+        )
+        if not isinstance(selector, Mapping):
+            selector = {}
+        provider_id = str(selector.get("providerId") or "").strip()
+        if provider_id:
+            parts.append(f"provider={provider_id}")
+        materialization = str(
+            selector.get("runtimeMaterializationMode") or ""
+        ).strip()
+        if materialization:
+            parts.append(f"materialization={materialization}")
+        tags_any = selector.get("tagsAny") or []
+        tags_all = selector.get("tagsAll") or []
+        if tags_any:
+            parts.append(f"tags_any={','.join(str(tag) for tag in tags_any)}")
+        if tags_all:
+            parts.append(f"tags_all={','.join(str(tag) for tag in tags_all)}")
+        return ", ".join(parts) if parts else "selector=auto"
+
+    def _build_provider_slot_waiting_reason(
+        self,
+        *,
+        runtime_id: str,
+        request: AgentExecutionRequest,
+    ) -> str:
+        intent = self._provider_slot_intent_summary(request)
+        return (
+            "Waiting for provider profile slot; "
+            f"runtime={runtime_id}; {intent}; missing_condition=capacity_or_cooldown."
         )
 
     @staticmethod
@@ -2163,8 +2208,11 @@ class MoonMindAgentRun:
         clear_invalid_profile_for_runtime_change: bool = False,
     ) -> None:
         if profile_count == 0:
+            intent = self._provider_slot_intent_summary(request)
             raise ApplicationError(
-                f"No enabled provider profiles found for runtime_id='{runtime_id}'",
+                "No launch-ready provider profiles found; "
+                f"runtime={runtime_id}; {intent}; "
+                "missing_condition=setup_required_or_policy.",
                 type="ProfileResolutionError",
                 non_retryable=True,
             )
@@ -2178,8 +2226,11 @@ class MoonMindAgentRun:
                 if clear_invalid_profile_for_runtime_change:
                     self._clear_runtime_profile_selection(request)
                     return
+                intent = self._provider_slot_intent_summary(request)
                 raise ApplicationError(
-                    f"Provider profile '{requested_profile_id}' not found for runtime_id='{runtime_id}'",
+                    "Requested provider profile is not launch-ready; "
+                    f"runtime={runtime_id}; {intent}; "
+                    "missing_condition=setup_required_or_policy.",
                     type="ProfileResolutionError",
                     non_retryable=True,
                 )
@@ -2533,12 +2584,13 @@ class MoonMindAgentRun:
                         )
                         if workflow.patched(
                             PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID
-                        ):
+                        ) and not self._skip_default_profile_pin_once:
                             pinned_profile_id = self._default_execution_profile_ref(
                                 request
                             )
                             if pinned_profile_id:
                                 request.execution_profile_ref = pinned_profile_id
+                        self._skip_default_profile_pin_once = False
                         manager_handle = await self._ensure_manager_and_signal(
                             manager_id,
                             runtime_id,
@@ -2585,7 +2637,10 @@ class MoonMindAgentRun:
                         self.run_status = RunStatus.awaiting_slot
                         waiting_reason = (
                             self._awaiting_slot_reason_override
-                            or f"Waiting for provider profile slot on {runtime_id}"
+                            or self._build_provider_slot_waiting_reason(
+                                runtime_id=runtime_id,
+                                request=request,
+                            )
                         )
                         self._awaiting_slot_reason_override = None
                         await self._signal_parent_child_state_changed(
@@ -3570,10 +3625,10 @@ class MoonMindAgentRun:
                         self.completion_event.clear()
                         self.final_result = None
                         self._assigned_profile_id = None
-                        if not workflow.patched(
-                            PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID
-                        ):
-                            request.execution_profile_ref = requested_execution_profile_ref
+                        request.execution_profile_ref = requested_execution_profile_ref
+                        self._skip_default_profile_pin_once = (
+                            requested_execution_profile_ref is None
+                        )
                         self.run_status = RunStatus.awaiting_slot
                         continue  # Retries loop
                     else:
@@ -3593,10 +3648,11 @@ class MoonMindAgentRun:
                         )
                         self.completion_event.clear()
                         self.final_result = None
-                        if not workflow.patched(
-                            PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID
-                        ):
-                            request.execution_profile_ref = requested_execution_profile_ref
+                        self._assigned_profile_id = None
+                        request.execution_profile_ref = requested_execution_profile_ref
+                        self._skip_default_profile_pin_once = (
+                            requested_execution_profile_ref is None
+                        )
                         continue  # Retries loop
 
                 # Not a 429 or external agent

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -1157,6 +1157,10 @@ class MoonMindProviderProfileManagerWorkflow:
     ) -> Optional[ProfileSlotState]:
         """Find the best available profile matching the selector."""
         selector = self._normalize_selector(selector)
+        allow_default_fallback = False
+        if selector:
+            allow_default_fallback = bool(selector.pop("allowDefaultFallback", False))
+            selector = selector or None
         exact_profile_id = str(execution_profile_ref or "").strip()
         normalized_group_id = self._normalize_optional_string(lease_group_id)
         if normalized_group_id:
@@ -1222,6 +1226,9 @@ class MoonMindProviderProfileManagerWorkflow:
                 profile for profile in eligible_profiles if profile.is_default
             ]
             if workflow.patched(DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH):
+                if allow_default_fallback:
+                    self._sort_profiles_for_selection(eligible_profiles)
+                    return eligible_profiles[0]
                 if default_profiles:
                     eligible_profiles = default_profiles
                 elif configured_default_profiles:

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -274,9 +274,19 @@ class MockProviderProfileManager:
         self._leases: dict[str, str] = {}  # profile_id -> workflow_id
         self.cooldown_reports: list[dict] = []
         self.cooldowns: dict[str, str] = {}
+        self.default_profile_id = "default-managed"
+        self.selector_provider_map: dict[str, str] = {}
+        self.resolved_profiles: list[str] = []
 
     @workflow.signal
     def request_slot(self, payload: dict) -> None:
+        profile_id = payload.get("execution_profile_ref") or payload.get("profile_id")
+        if not profile_id:
+            profile_selector = payload.get("profile_selector") or {}
+            provider_id = profile_selector.get("providerId")
+            profile_id = self.selector_provider_map.get(provider_id)
+        if profile_id:
+            self.resolved_profiles.append(profile_id)
         self.pending_requests.append(payload)
 
     @workflow.signal
@@ -309,11 +319,16 @@ class MockProviderProfileManager:
             "pending_requests": self.pending_requests,
             "cooldown_reports": list(self.cooldown_reports),
             "cooldowns": dict(self.cooldowns),
+            "resolved_profiles": list(self.resolved_profiles),
         }
 
     @workflow.run
     async def run(self, input_payload: dict) -> dict:
         assign_slots = input_payload.get("assign_slots", True)
+        self.default_profile_id = input_payload.get(
+            "default_profile_id", self.default_profile_id
+        )
+        self.selector_provider_map = dict(input_payload.get("selector_provider_map") or {})
         while not self._shutdown:
             await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
             if self._shutdown:
@@ -324,7 +339,10 @@ class MockProviderProfileManager:
                     profile_id = (
                         req.get("execution_profile_ref")
                         or req.get("profile_id")
-                        or "default-managed"
+                        or self.selector_provider_map.get(
+                            (req.get("profile_selector") or {}).get("providerId")
+                        )
+                        or self.default_profile_id
                     )
                     cooldown_until = self.cooldowns.get(profile_id)
                     if cooldown_until is not None:
@@ -565,12 +583,23 @@ async def test_agent_run_workflow_cancellation():
 
 @pytest.mark.asyncio
 async def test_agent_run_reports_managed_429_retry_summary_to_parent():
+    rate_limited_activities = [
+        mock_publish_artifacts,
+        mock_cancel,
+        mock_provider_profile_list,
+        mock_provider_profile_ensure_manager,
+        mock_provider_profile_reset_manager,
+        mock_agent_runtime_launch,
+        mock_agent_runtime_build_launch_context,
+        mock_agent_runtime_status_rate_limited,
+        mock_agent_runtime_fetch_result_rate_limited,
+    ]
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
             task_queue="agent-run-task-queue",
             workflows=[MoonMindAgentRun, MockProviderProfileManager, TestAgentRunParent],
-            activities=_COMMON_AGENT_RUN_ACTIVITIES,
+            activities=rate_limited_activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
                 request = AgentExecutionRequest(
@@ -607,17 +636,8 @@ async def test_agent_run_reports_managed_429_retry_summary_to_parent():
                         break
                     await asyncio.sleep(0.1)
 
-                await child_handle.signal(
-                    MoonMindAgentRun.completion_signal,
-                    {
-                        "summary": "Gemini API rate limit exceeded",
-                        "failureClass": "integration_error",
-                        "providerErrorCode": "429",
-                    },
-                )
-
                 manager_state = {}
-                for _ in range(30):
+                for _ in range(60):
                     parent_state = await parent_handle.query(TestAgentRunParent.get_state)
                     manager_state = await manager_handle.query(MockProviderProfileManager.get_state)
                     if manager_state.get("cooldown_reports") and any(
@@ -1496,89 +1516,22 @@ async def test_openrouter_profile_cooldown_attaches_to_profile():
         test_module.mock_provider_profile_list = mock_provider_profile_list_openrouter
 
         try:
-            @workflow.defn(name="MoonMind.ProviderProfileManager")
-            class MockProviderProfileManagerForOpenRouter:
-                def __init__(self):
-                    self._shutdown = False
-                    self.pending_requests = []
-                    self._leases: dict[str, str] = {}
-                    self.cooldown_reports: list[dict] = []
-                    self.cooldowns: dict[str, str] = {}
-
-                @workflow.signal
-                def request_slot(self, payload: dict) -> None:
-                    self.pending_requests.append(payload)
-
-                @workflow.signal
-                def release_slot(self, payload: dict) -> None:
-                    requester_id = payload.get("requester_workflow_id")
-                    to_remove = [p for p, wf in self._leases.items() if wf == requester_id]
-                    for p in to_remove:
-                        del self._leases[p]
-
-                @workflow.signal
-                def report_cooldown(self, payload: dict) -> None:
-                    self.cooldown_reports.append(dict(payload))
-                    profile_id = payload.get("profile_id", "test-openrouter-high-priority")
-                    cooldown_seconds = int(payload.get("cooldown_seconds", 0))
-                    self.cooldowns[profile_id] = (
-                        workflow.now() + timedelta(seconds=cooldown_seconds)
-                    ).isoformat()
-
-                @workflow.signal
-                def sync_profiles(self, payload: dict) -> None:
-                    pass
-
-                @workflow.query
-                def get_state(self) -> dict:
-                    return {
-                        "leases": dict(self._leases),
-                        "pending_requests": self.pending_requests,
-                        "cooldown_reports": list(self.cooldown_reports),
-                        "cooldowns": dict(self.cooldowns),
-                    }
-
-                @workflow.run
-                async def run(self, input_payload: dict) -> dict:
-                    assign_slots = input_payload.get("assign_slots", True)
-                    while not self._shutdown:
-                        await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
-                        if self._shutdown:
-                            break
-                        while self.pending_requests:
-                            req = self.pending_requests.pop(0)
-                            if assign_slots:
-                                profile_id = (
-                                    req.get("execution_profile_ref")
-                                    or req.get("profile_id")
-                                    or "test-openrouter-high-priority"
-                                )
-                                cooldown_until = self.cooldowns.get(profile_id)
-                                if cooldown_until is not None:
-                                    cooldown_dt = datetime.fromisoformat(cooldown_until)
-                                    if workflow.now() < cooldown_dt:
-                                        self.pending_requests.insert(0, req)
-                                        await workflow.sleep(
-                                            (cooldown_dt - workflow.now()).total_seconds()
-                                        )
-                                        continue
-                                self._leases[profile_id] = req["requester_workflow_id"]
-                                handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
-                                await handle.signal("slot_assigned", {"profile_id": profile_id})
-                    return {}
-
             openrouter_activities = [
                 mock_publish_artifacts,
                 mock_cancel,
                 mock_provider_profile_list_openrouter,
                 mock_provider_profile_ensure_manager,
                 mock_provider_profile_reset_manager,
+                mock_agent_runtime_launch,
+                mock_agent_runtime_build_launch_context,
+                mock_agent_runtime_status,
+                mock_agent_runtime_fetch_result,
             ]
 
             async with Worker(
                 env.client,
                 task_queue="agent-run-task-queue",
-                workflows=[MoonMindAgentRun, MockProviderProfileManagerForOpenRouter],
+                workflows=[MoonMindAgentRun, MockProviderProfileManager],
                 activities=openrouter_activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
@@ -1593,8 +1546,12 @@ async def test_openrouter_profile_cooldown_attaches_to_profile():
                 runtime_id = "codex_cli"
                 manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
-                    MockProviderProfileManagerForOpenRouter.run,
-                    {"runtime_id": request.agent_id, "assign_slots": True},
+                    MockProviderProfileManager.run,
+                    {
+                        "runtime_id": request.agent_id,
+                        "assign_slots": True,
+                        "default_profile_id": "test-openrouter-high-priority",
+                    },
                     id=manager_id,
                     task_queue="agent-run-task-queue",
                 )
@@ -1619,7 +1576,7 @@ async def test_openrouter_profile_cooldown_attaches_to_profile():
 
                 await asyncio.sleep(0.3)
 
-                manager_state = await manager_handle.query(MockProviderProfileManagerForOpenRouter.get_state)
+                manager_state = await manager_handle.query(MockProviderProfileManager.get_state)
 
                 # Assert cooldown report references the openrouter profile specifically
                 assert manager_state["cooldown_reports"], "Expected cooldown report to be recorded"
@@ -1650,89 +1607,22 @@ async def test_openrouter_profile_slot_leasing():
         test_module.mock_provider_profile_list = mock_provider_profile_list_openrouter
 
         try:
-            @workflow.defn(name="MoonMind.ProviderProfileManager")
-            class MockProviderProfileManagerForSlotLeasing:
-                def __init__(self):
-                    self._shutdown = False
-                    self.pending_requests = []
-                    self._leases: dict[str, str] = {}
-                    self.cooldown_reports: list[dict] = []
-                    self.cooldowns: dict[str, str] = {}
-
-                @workflow.signal
-                def request_slot(self, payload: dict) -> None:
-                    self.pending_requests.append(payload)
-
-                @workflow.signal
-                def release_slot(self, payload: dict) -> None:
-                    requester_id = payload.get("requester_workflow_id")
-                    to_remove = [p for p, wf in self._leases.items() if wf == requester_id]
-                    for p in to_remove:
-                        del self._leases[p]
-
-                @workflow.signal
-                def report_cooldown(self, payload: dict) -> None:
-                    self.cooldown_reports.append(dict(payload))
-                    profile_id = payload.get("profile_id", "test-openrouter-high-priority")
-                    cooldown_seconds = int(payload.get("cooldown_seconds", 0))
-                    self.cooldowns[profile_id] = (
-                        workflow.now() + timedelta(seconds=cooldown_seconds)
-                    ).isoformat()
-
-                @workflow.signal
-                def sync_profiles(self, payload: dict) -> None:
-                    pass
-
-                @workflow.query
-                def get_state(self) -> dict:
-                    return {
-                        "leases": dict(self._leases),
-                        "pending_requests": self.pending_requests,
-                        "cooldown_reports": list(self.cooldown_reports),
-                        "cooldowns": dict(self.cooldowns),
-                    }
-
-                @workflow.run
-                async def run(self, input_payload: dict) -> dict:
-                    assign_slots = input_payload.get("assign_slots", True)
-                    while not self._shutdown:
-                        await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
-                        if self._shutdown:
-                            break
-                        while self.pending_requests:
-                            req = self.pending_requests.pop(0)
-                            if assign_slots:
-                                profile_id = (
-                                    req.get("execution_profile_ref")
-                                    or req.get("profile_id")
-                                    or "test-openrouter-high-priority"
-                                )
-                                cooldown_until = self.cooldowns.get(profile_id)
-                                if cooldown_until is not None:
-                                    cooldown_dt = datetime.fromisoformat(cooldown_until)
-                                    if workflow.now() < cooldown_dt:
-                                        self.pending_requests.insert(0, req)
-                                        await workflow.sleep(
-                                            (cooldown_dt - workflow.now()).total_seconds()
-                                        )
-                                        continue
-                                self._leases[profile_id] = req["requester_workflow_id"]
-                                handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
-                                await handle.signal("slot_assigned", {"profile_id": profile_id})
-                    return {}
-
             openrouter_activities = [
                 mock_publish_artifacts,
                 mock_cancel,
                 mock_provider_profile_list_openrouter,
                 mock_provider_profile_ensure_manager,
                 mock_provider_profile_reset_manager,
+                mock_agent_runtime_launch,
+                mock_agent_runtime_build_launch_context,
+                mock_agent_runtime_status,
+                mock_agent_runtime_fetch_result,
             ]
 
             async with Worker(
                 env.client,
                 task_queue="agent-run-task-queue",
-                workflows=[MoonMindAgentRun, MockProviderProfileManagerForSlotLeasing],
+                workflows=[MoonMindAgentRun, MockProviderProfileManager],
                 activities=openrouter_activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
@@ -1747,8 +1637,12 @@ async def test_openrouter_profile_slot_leasing():
                 runtime_id = "codex_cli"
                 manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
-                    MockProviderProfileManagerForSlotLeasing.run,
-                    {"runtime_id": request.agent_id, "assign_slots": True},
+                    MockProviderProfileManager.run,
+                    {
+                        "runtime_id": request.agent_id,
+                        "assign_slots": True,
+                        "default_profile_id": "test-openrouter-high-priority",
+                    },
                     id=manager_id,
                     task_queue="agent-run-task-queue",
                 )
@@ -1764,7 +1658,7 @@ async def test_openrouter_profile_slot_leasing():
 
                 await asyncio.sleep(0.5)
 
-                manager_state = await manager_handle.query(MockProviderProfileManagerForSlotLeasing.get_state)
+                manager_state = await manager_handle.query(MockProviderProfileManager.get_state)
 
                 # Assert slot is leased against the openrouter profile specifically
                 assert "test-openrouter-high-priority" in manager_state["leases"], (
@@ -1778,7 +1672,7 @@ async def test_openrouter_profile_slot_leasing():
                 await manager_handle.signal("release_slot", {"requester_workflow_id": "test-workflow-openrouter-slot"})
                 await asyncio.sleep(0.3)
 
-                manager_state_after = await manager_handle.query(MockProviderProfileManagerForSlotLeasing.get_state)
+                manager_state_after = await manager_handle.query(MockProviderProfileManager.get_state)
 
                 # Slot should be released
                 assert "test-openrouter-high-priority" not in manager_state_after.get("leases", {}), (
@@ -1799,89 +1693,22 @@ async def test_openrouter_profile_cancellation_releases_slot():
         test_module.mock_provider_profile_list = mock_provider_profile_list_openrouter
 
         try:
-            @workflow.defn(name="MoonMind.ProviderProfileManager")
-            class MockProviderProfileManagerForCancel:
-                def __init__(self):
-                    self._shutdown = False
-                    self.pending_requests = []
-                    self._leases: dict[str, str] = {}
-                    self.cooldown_reports: list[dict] = []
-                    self.cooldowns: dict[str, str] = {}
-
-                @workflow.signal
-                def request_slot(self, payload: dict) -> None:
-                    self.pending_requests.append(payload)
-
-                @workflow.signal
-                def release_slot(self, payload: dict) -> None:
-                    requester_id = payload.get("requester_workflow_id")
-                    to_remove = [p for p, wf in self._leases.items() if wf == requester_id]
-                    for p in to_remove:
-                        del self._leases[p]
-
-                @workflow.signal
-                def report_cooldown(self, payload: dict) -> None:
-                    self.cooldown_reports.append(dict(payload))
-                    profile_id = payload.get("profile_id", "test-openrouter-high-priority")
-                    cooldown_seconds = int(payload.get("cooldown_seconds", 0))
-                    self.cooldowns[profile_id] = (
-                        workflow.now() + timedelta(seconds=cooldown_seconds)
-                    ).isoformat()
-
-                @workflow.signal
-                def sync_profiles(self, payload: dict) -> None:
-                    pass
-
-                @workflow.query
-                def get_state(self) -> dict:
-                    return {
-                        "leases": dict(self._leases),
-                        "pending_requests": self.pending_requests,
-                        "cooldown_reports": list(self.cooldown_reports),
-                        "cooldowns": dict(self.cooldowns),
-                    }
-
-                @workflow.run
-                async def run(self, input_payload: dict) -> dict:
-                    assign_slots = input_payload.get("assign_slots", True)
-                    while not self._shutdown:
-                        await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
-                        if self._shutdown:
-                            break
-                        while self.pending_requests:
-                            req = self.pending_requests.pop(0)
-                            if assign_slots:
-                                profile_id = (
-                                    req.get("execution_profile_ref")
-                                    or req.get("profile_id")
-                                    or "test-openrouter-high-priority"
-                                )
-                                cooldown_until = self.cooldowns.get(profile_id)
-                                if cooldown_until is not None:
-                                    cooldown_dt = datetime.fromisoformat(cooldown_until)
-                                    if workflow.now() < cooldown_dt:
-                                        self.pending_requests.insert(0, req)
-                                        await workflow.sleep(
-                                            (cooldown_dt - workflow.now()).total_seconds()
-                                        )
-                                        continue
-                                self._leases[profile_id] = req["requester_workflow_id"]
-                                handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
-                                await handle.signal("slot_assigned", {"profile_id": profile_id})
-                    return {}
-
             openrouter_activities = [
                 mock_publish_artifacts,
                 mock_cancel,
                 mock_provider_profile_list_openrouter,
                 mock_provider_profile_ensure_manager,
                 mock_provider_profile_reset_manager,
+                mock_agent_runtime_launch,
+                mock_agent_runtime_build_launch_context,
+                mock_agent_runtime_status,
+                mock_agent_runtime_fetch_result,
             ]
 
             async with Worker(
                 env.client,
                 task_queue="agent-run-task-queue",
-                workflows=[MoonMindAgentRun, MockProviderProfileManagerForCancel],
+                workflows=[MoonMindAgentRun, MockProviderProfileManager],
                 activities=openrouter_activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
@@ -1896,8 +1723,12 @@ async def test_openrouter_profile_cancellation_releases_slot():
                 runtime_id = "codex_cli"
                 manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
-                    MockProviderProfileManagerForCancel.run,
-                    {"runtime_id": request.agent_id, "assign_slots": True},
+                    MockProviderProfileManager.run,
+                    {
+                        "runtime_id": request.agent_id,
+                        "assign_slots": True,
+                        "default_profile_id": "test-openrouter-high-priority",
+                    },
                     id=manager_id,
                     task_queue="agent-run-task-queue",
                 )
@@ -1914,7 +1745,7 @@ async def test_openrouter_profile_cancellation_releases_slot():
                 await asyncio.sleep(0.5)
 
                 # Verify slot is leased before cancellation
-                manager_state_before = await manager_handle.query(MockProviderProfileManagerForCancel.get_state)
+                manager_state_before = await manager_handle.query(MockProviderProfileManager.get_state)
                 assert "test-openrouter-high-priority" in manager_state_before.get("leases", {}), (
                     f"Expected slot leased before cancellation, leases={manager_state_before['leases']}"
                 )
@@ -1925,7 +1756,7 @@ async def test_openrouter_profile_cancellation_releases_slot():
 
                 # Verify slot is released after cancellation
                 try:
-                    manager_state_after = await manager_handle.query(MockProviderProfileManagerForCancel.get_state)
+                    manager_state_after = await manager_handle.query(MockProviderProfileManager.get_state)
                 except Exception:
                     manager_state_after = {"leases": {}}
 
@@ -1950,97 +1781,22 @@ async def test_profile_selector_provider_id_routes_to_openrouter():
             # This is tested at the mock provider list level — the activity returns the correct profiles.
             # The actual routing logic is tested in unit tests; this verifies the integration boundary.
 
-            @workflow.defn(name="MoonMind.ProviderProfileManager")
-            class MockProviderProfileManagerForRouting:
-                def __init__(self):
-                    self._shutdown = False
-                    self.pending_requests = []
-                    self._leases: dict[str, str] = {}
-                    self.cooldown_reports: list[dict] = []
-                    self.cooldowns: dict[str, str] = {}
-                    self.resolved_profiles = []
-
-                @workflow.signal
-                def request_slot(self, payload: dict) -> None:
-                    self.pending_requests.append(payload)
-                    # Resolve profile: use explicit ref if present, otherwise resolve from profile_selector
-                    profile_id = payload.get("execution_profile_ref") or payload.get("profile_id")
-                    if not profile_id:
-                        profile_selector = payload.get("profile_selector") or {}
-                        provider_id = profile_selector.get("providerId")
-                        if provider_id == "openrouter":
-                            # The mock activity returns profiles sorted by priority (highest first);
-                            # pick the highest-priority enabled openrouter profile.
-                            profile_id = "test-openrouter-high-priority"
-                    if profile_id:
-                        self.resolved_profiles.append(profile_id)
-
-                @workflow.signal
-                def release_slot(self, payload: dict) -> None:
-                    requester_id = payload.get("requester_workflow_id")
-                    to_remove = [p for p, wf in self._leases.items() if wf == requester_id]
-                    for p in to_remove:
-                        del self._leases[p]
-
-                @workflow.signal
-                def report_cooldown(self, payload: dict) -> None:
-                    self.cooldown_reports.append(dict(payload))
-
-                @workflow.signal
-                def sync_profiles(self, payload: dict) -> None:
-                    pass
-
-                @workflow.query
-                def get_state(self) -> dict:
-                    return {
-                        "leases": dict(self._leases),
-                        "pending_requests": self.pending_requests,
-                        "cooldown_reports": list(self.cooldown_reports),
-                        "cooldowns": dict(self.cooldowns),
-                        "resolved_profiles": self.resolved_profiles,
-                    }
-
-                @workflow.run
-                async def run(self, input_payload: dict) -> dict:
-                    assign_slots = input_payload.get("assign_slots", True)
-                    while not self._shutdown:
-                        await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
-                        if self._shutdown:
-                            break
-                        while self.pending_requests:
-                            req = self.pending_requests.pop(0)
-                            if assign_slots:
-                                profile_id = (
-                                    req.get("execution_profile_ref")
-                                    or req.get("profile_id")
-                                    or "test-openrouter-high-priority"
-                                )
-                                cooldown_until = self.cooldowns.get(profile_id)
-                                if cooldown_until is not None:
-                                    cooldown_dt = datetime.fromisoformat(cooldown_until)
-                                    if workflow.now() < cooldown_dt:
-                                        self.pending_requests.insert(0, req)
-                                        await workflow.sleep(
-                                            (cooldown_dt - workflow.now()).total_seconds()
-                                        )
-                                        continue
-                                self._leases[profile_id] = req["requester_workflow_id"]
-                                handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
-                                await handle.signal("slot_assigned", {"profile_id": profile_id})
-                    return {}
-
             openrouter_activities = [
                 mock_publish_artifacts,
                 mock_cancel,
                 mock_provider_profile_list_openrouter,
                 mock_provider_profile_ensure_manager,
                 mock_provider_profile_reset_manager,
+                mock_agent_runtime_launch,
+                mock_agent_runtime_build_launch_context,
+                mock_agent_runtime_status,
+                mock_agent_runtime_fetch_result,
             ]
 
             async with Worker(
                 env.client,
                 task_queue="agent-run-task-queue",
-                workflows=[MoonMindAgentRun, MockProviderProfileManagerForRouting],
+                workflows=[MoonMindAgentRun, MockProviderProfileManager],
                 activities=openrouter_activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
@@ -2057,8 +1813,15 @@ async def test_profile_selector_provider_id_routes_to_openrouter():
                 runtime_id = "codex_cli"
                 manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
-                    MockProviderProfileManagerForRouting.run,
-                    {"runtime_id": request.agent_id, "assign_slots": True},
+                    MockProviderProfileManager.run,
+                    {
+                        "runtime_id": request.agent_id,
+                        "assign_slots": True,
+                        "default_profile_id": "test-openrouter-high-priority",
+                        "selector_provider_map": {
+                            "openrouter": "test-openrouter-high-priority"
+                        },
+                    },
                     id=manager_id,
                     task_queue="agent-run-task-queue",
                 )
@@ -2074,7 +1837,7 @@ async def test_profile_selector_provider_id_routes_to_openrouter():
 
                 await asyncio.sleep(0.5)
 
-                manager_state = await manager_handle.query(MockProviderProfileManagerForRouting.get_state)
+                manager_state = await manager_handle.query(MockProviderProfileManager.get_state)
 
                 # The manager should have resolved to the high-priority openrouter profile
                 assert "test-openrouter-high-priority" in manager_state.get("resolved_profiles", []), (
@@ -2095,96 +1858,22 @@ async def test_profile_selector_falls_back_to_lower_priority_when_high_disabled(
         test_module.mock_provider_profile_list = mock_provider_profile_list_openrouter_disabled_high
 
         try:
-            @workflow.defn(name="MoonMind.ProviderProfileManager")
-            class MockProviderProfileManagerForFallback:
-                def __init__(self):
-                    self._shutdown = False
-                    self.pending_requests = []
-                    self._leases: dict[str, str] = {}
-                    self.cooldown_reports: list[dict] = []
-                    self.cooldowns: dict[str, str] = {}
-                    self.resolved_profiles = []
-
-                @workflow.signal
-                def request_slot(self, payload: dict) -> None:
-                    self.pending_requests.append(payload)
-                    # Resolve profile: use explicit ref if present, otherwise resolve from profile_selector
-                    profile_id = payload.get("execution_profile_ref") or payload.get("profile_id")
-                    if not profile_id:
-                        profile_selector = payload.get("profile_selector") or {}
-                        provider_id = profile_selector.get("providerId")
-                        if provider_id == "openrouter":
-                            # With high-priority disabled, fall back to lower-priority openrouter profile.
-                            profile_id = "test-openrouter-low-priority"
-                    if profile_id:
-                        self.resolved_profiles.append(profile_id)
-
-                @workflow.signal
-                def release_slot(self, payload: dict) -> None:
-                    requester_id = payload.get("requester_workflow_id")
-                    to_remove = [p for p, wf in self._leases.items() if wf == requester_id]
-                    for p in to_remove:
-                        del self._leases[p]
-
-                @workflow.signal
-                def report_cooldown(self, payload: dict) -> None:
-                    self.cooldown_reports.append(dict(payload))
-
-                @workflow.signal
-                def sync_profiles(self, payload: dict) -> None:
-                    pass
-
-                @workflow.query
-                def get_state(self) -> dict:
-                    return {
-                        "leases": dict(self._leases),
-                        "pending_requests": self.pending_requests,
-                        "cooldown_reports": list(self.cooldown_reports),
-                        "cooldowns": dict(self.cooldowns),
-                        "resolved_profiles": self.resolved_profiles,
-                    }
-
-                @workflow.run
-                async def run(self, input_payload: dict) -> dict:
-                    assign_slots = input_payload.get("assign_slots", True)
-                    while not self._shutdown:
-                        await workflow.wait_condition(lambda: len(self.pending_requests) > 0 or self._shutdown)
-                        if self._shutdown:
-                            break
-                        while self.pending_requests:
-                            req = self.pending_requests.pop(0)
-                            if assign_slots:
-                                profile_id = (
-                                    req.get("execution_profile_ref")
-                                    or req.get("profile_id")
-                                    or "test-openrouter-low-priority"
-                                )
-                                cooldown_until = self.cooldowns.get(profile_id)
-                                if cooldown_until is not None:
-                                    cooldown_dt = datetime.fromisoformat(cooldown_until)
-                                    if workflow.now() < cooldown_dt:
-                                        self.pending_requests.insert(0, req)
-                                        await workflow.sleep(
-                                            (cooldown_dt - workflow.now()).total_seconds()
-                                        )
-                                        continue
-                                self._leases[profile_id] = req["requester_workflow_id"]
-                                handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
-                                await handle.signal("slot_assigned", {"profile_id": profile_id})
-                    return {}
-
             openrouter_activities = [
                 mock_publish_artifacts,
                 mock_cancel,
                 mock_provider_profile_list_openrouter_disabled_high,
                 mock_provider_profile_ensure_manager,
                 mock_provider_profile_reset_manager,
+                mock_agent_runtime_launch,
+                mock_agent_runtime_build_launch_context,
+                mock_agent_runtime_status,
+                mock_agent_runtime_fetch_result,
             ]
 
             async with Worker(
                 env.client,
                 task_queue="agent-run-task-queue",
-                workflows=[MoonMindAgentRun, MockProviderProfileManagerForFallback],
+                workflows=[MoonMindAgentRun, MockProviderProfileManager],
                 activities=openrouter_activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ):
@@ -2202,8 +1891,15 @@ async def test_profile_selector_falls_back_to_lower_priority_when_high_disabled(
                 runtime_id = "codex_cli"
                 manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
-                    MockProviderProfileManagerForFallback.run,
-                    {"runtime_id": request.agent_id, "assign_slots": True},
+                    MockProviderProfileManager.run,
+                    {
+                        "runtime_id": request.agent_id,
+                        "assign_slots": True,
+                        "default_profile_id": "test-openrouter-low-priority",
+                        "selector_provider_map": {
+                            "openrouter": "test-openrouter-low-priority"
+                        },
+                    },
                     id=manager_id,
                     task_queue="agent-run-task-queue",
                 )
@@ -2219,7 +1915,7 @@ async def test_profile_selector_falls_back_to_lower_priority_when_high_disabled(
 
                 await asyncio.sleep(0.5)
 
-                manager_state = await manager_handle.query(MockProviderProfileManagerForFallback.get_state)
+                manager_state = await manager_handle.query(MockProviderProfileManager.get_state)
 
                 # The manager should have resolved to the low-priority profile
                 assert "test-openrouter-low-priority" in manager_state.get("resolved_profiles", []), (

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -920,7 +920,7 @@ async def test_provider_profile_list_returns_enabled_profiles(tmp_path: Path):
                     runtime_id="gemini_cli",
                     credential_source=ProviderCredentialSource.OAUTH_VOLUME,
                     runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
-                    volume_ref=None,
+                    volume_ref="oauth-volume:gprofile-1",
                     volume_mount_path="/mnt/auth",
                     account_label="primary",
                     max_parallel_runs=2,
@@ -998,6 +998,7 @@ async def test_provider_profile_list_filters_by_runtime_id(tmp_path: Path):
                         runtime_id=runtime,
                         credential_source=ProviderCredentialSource.SECRET_REF,
                         runtime_materialization_mode=RuntimeMaterializationMode.ENV_BUNDLE,
+                        secret_refs={"provider_api_key": "env://PROVIDER_API_KEY"},
                         max_parallel_runs=1,
                         cooldown_after_429_seconds=300,
                         rate_limit_policy=ManagedAgentRateLimitPolicy.QUEUE,
@@ -1026,6 +1027,88 @@ async def test_provider_profile_list_filters_by_runtime_id(tmp_path: Path):
         profiles = result["profiles"]
         assert len(profiles) == 1
         assert profiles[0]["profile_id"] == "c1"
+
+async def test_provider_profile_list_filters_to_launch_ready_profiles(
+    tmp_path: Path,
+):
+    """MM-877: manager sync must exclude setup stubs and not-ready profiles."""
+    async with _in_memory_db(tmp_path) as session_factory:
+        async with session_factory() as session:
+            session.add_all(
+                [
+                    ManagedAgentProviderProfile(
+                        profile_id="ready-secret",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.SECRET_REF,
+                        runtime_materialization_mode=RuntimeMaterializationMode.ENV_BUNDLE,
+                        secret_refs={"provider_api_key": "env://OPENAI_API_KEY"},
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=True,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
+                    ),
+                    ManagedAgentProviderProfile(
+                        profile_id="disabled-setup-stub",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.NONE,
+                        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=False,
+                        auth_state=ProviderProfileAuthState.NOT_CONFIGURED,
+                    ),
+                    ManagedAgentProviderProfile(
+                        profile_id="connected-secret-without-binding",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.SECRET_REF,
+                        runtime_materialization_mode=RuntimeMaterializationMode.ENV_BUNDLE,
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=True,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
+                    ),
+                    ManagedAgentProviderProfile(
+                        profile_id="connected-oauth-without-volume",
+                        runtime_id="codex_cli",
+                        credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                        runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                        volume_mount_path="/mnt/auth",
+                        max_parallel_runs=1,
+                        cooldown_after_429_seconds=300,
+                        rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                        enabled=True,
+                        auth_state=ProviderProfileAuthState.CONNECTED,
+                        last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
+                    ),
+                ]
+            )
+            await session.commit()
+
+        service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        activities = TemporalArtifactActivities(service)
+
+        import api_service.db.base as _db_base_mod
+
+        orig = _db_base_mod.get_async_session_context
+        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+            session_factory
+        )
+        try:
+            result = await activities.provider_profile_list(runtime_id="codex_cli")
+        finally:
+            _db_base_mod.get_async_session_context = orig
+
+        assert [profile["profile_id"] for profile in result["profiles"]] == [
+            "ready-secret"
+        ]
 
 async def test_provider_profile_list_preserves_secret_ref_materialization_fields(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -570,6 +570,39 @@ class TestProviderProfileManagerHelpers:
             )
             assert wf._find_available_profile() is None
 
+    def test_find_available_profile_allows_explicit_default_fallback_retry(self):
+        wf = self._make_workflow()
+        wf._profiles["fallback"] = ProfileSlotState(
+            profile_id="fallback",
+            max_parallel_runs=3,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=False,
+            priority=200,
+        )
+        wf._profiles["default"] = ProfileSlotState(
+            profile_id="default",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            current_leases=["wf1"],
+            priority=100,
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DEFAULT_PROFILE_EXCLUSIVE_SELECTION_PATCH
+            )
+            best = wf._find_available_profile({"allowDefaultFallback": True})
+
+        assert best is not None
+        assert best.profile_id == "fallback"
+
     def test_find_available_profile_preserves_unpatched_default_fallback(self):
         wf = self._make_workflow()
         wf._profiles["fallback"] = ProfileSlotState(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -79,6 +80,43 @@ async def test_managed_session_request_preserves_explicit_empty_inputs() -> None
 
     assert request.parameters == {}
     assert request.workspace_spec == {}
+
+async def test_profile_resolution_error_summarizes_setup_condition() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request().model_copy(
+        update={"execution_profile_ref": "codex-openai"}
+    )
+
+    with pytest.raises(ApplicationError) as exc_info:
+        run._validate_synced_profile_selection(
+            profile_count=0,
+            runtime_id="codex_cli",
+            request=request,
+        )
+
+    message = str(exc_info.value)
+    assert "No launch-ready provider profiles found" in message
+    assert "runtime=codex_cli" in message
+    assert "exact_profile=codex-openai" in message
+    assert "missing_condition=setup_required_or_policy" in message
+
+async def test_slot_waiting_reason_summarizes_capacity_or_cooldown() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request().model_copy(
+        update={
+            "execution_profile_ref": None,
+            "profile_selector": {"providerId": "openai"},
+        }
+    )
+
+    reason = run._build_provider_slot_waiting_reason(
+        runtime_id="codex_cli",
+        request=request,
+    )
+
+    assert "runtime=codex_cli" in reason
+    assert "provider=openai" in reason
+    assert "missing_condition=capacity_or_cooldown" in reason
 
 async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_head_branch(
     monkeypatch: pytest.MonkeyPatch,
@@ -1223,7 +1261,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
     result = await run.run(request)
 
     assert result.summary == "Recovered on pinned profile."
-    assert ensure_profile_refs == ["codex-default", "codex-default"]
+    assert ensure_profile_refs == ["codex-default", None]
     assert manager_signals[:2] == [
         (
             "report_cooldown",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -1154,6 +1154,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
 ) -> None:
     run = MoonMindAgentRun()
     ensure_profile_refs: list[str | None] = []
+    ensure_profile_selectors: list[dict[str, Any]] = []
     manager_signals: list[tuple[str, dict[str, Any]]] = []
     fetch_results = [
         AgentRunResult(
@@ -1206,6 +1207,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
     ) -> _FakeManagerHandle:
         if request_slot:
             ensure_profile_refs.append(execution_profile_ref)
+            ensure_profile_selectors.append(dict(profile_selector))
             run.slot_assigned_event.set()
             run._assigned_profile_id = execution_profile_ref or "codex-default"
         return _FakeManagerHandle()
@@ -1262,6 +1264,10 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
 
     assert result.summary == "Recovered on pinned profile."
     assert ensure_profile_refs == ["codex-default", None]
+    assert ensure_profile_selectors == [
+        {"tagsAny": [], "tagsAll": []},
+        {"tagsAny": [], "tagsAll": [], "allowDefaultFallback": True},
+    ]
     assert manager_signals[:2] == [
         (
             "report_cooldown",
@@ -1277,6 +1283,120 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
                 "profile_id": "codex-default",
             },
         ),
+    ]
+
+async def test_agent_run_preserves_operator_profile_selection_after_cooldown_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    ensure_profile_refs: list[str | None] = []
+    fetch_results = [
+        AgentRunResult(
+            failureClass="execution_error",
+            providerErrorCode="provider_capacity",
+            retryRecommendation="retry_after_cooldown",
+            summary="provider capacity",
+        ),
+        AgentRunResult(summary="Recovered on operator-selected profile."),
+    ]
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId=f"managed-session-run-{len(ensure_profile_refs)}",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: dict[str, Any]) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+        request_priority: int | None = None,
+        request_queue_metadata: dict[str, Any] | None = None,
+    ) -> _FakeManagerHandle:
+        if request_slot:
+            ensure_profile_refs.append(execution_profile_ref)
+            run.slot_assigned_event.set()
+            run._assigned_profile_id = (
+                execution_profile_ref or "codex_openrouter_qwen36_plus"
+            )
+            if len(ensure_profile_refs) == 1:
+                run.update_runtime_selection(
+                    {"executionProfileRef": "codex_openrouter_qwen36_plus"}
+                )
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_id: str,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        run._profile_snapshots = {
+            "codex_openrouter_qwen36_plus": {
+                "cooldown_after_429_seconds": 0,
+                "enabled": True,
+                "is_default": False,
+            },
+            "codex-default": {
+                "cooldown_after_429_seconds": 0,
+                "enabled": True,
+                "is_default": True,
+            },
+        }
+        return 2
+
+    async def fake_fetch_managed_result(**_kwargs: Any) -> AgentRunResult:
+        return fetch_results.pop(0)
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(run, "_fetch_managed_result", fake_fetch_managed_result)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+
+    result = await run.run(
+        _managed_session_request().model_copy(update={"execution_profile_ref": None})
+    )
+
+    assert result.summary == "Recovered on operator-selected profile."
+    assert ensure_profile_refs == [
+        "codex-default",
+        "codex_openrouter_qwen36_plus",
+        "codex_openrouter_qwen36_plus",
     ]
 
 async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(


### PR DESCRIPTION
Issue reference: MM-877

Summary:
- Filters provider profile manager sync output to canonical launch-ready profiles so disabled setup stubs and connected-but-unbound profiles do not become runnable.
- Adds operator-visible provider slot waiting summaries that include runtime, selector intent, and capacity/cooldown missing-condition detail.
- Updates AgentRun cooldown re-request behavior so provider 429 handling can avoid repinning the exhausted default profile when alternatives are allowed.
- Adds boundary/unit coverage for launch-ready filtering and managed slot/cooldown behavior.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
- Result: 86 targeted Python tests passed; UI unit phase also completed with 29 files passed, 466 passed, 236 skipped.

Remaining risks:
- Full unit suite was not rerun beyond the unit runner's UI phase and the targeted Python paths above.
- Hermetic integration suite was not run in this PR-publication step.
