### PR TITLE
MM-878 complete provider profile materialization

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -563,6 +563,36 @@ def _codex_openrouter_qwen36_plus_file_templates(
         }
     ]
 
+def _codex_minimax_m27_file_templates() -> list[dict[str, object]]:
+    return [
+        {
+            "path": "{{runtime_support_dir}}/codex-home/config.toml",
+            "format": "toml",
+            "merge_strategy": "deep_merge",
+            "content_template": {
+                "model_providers": {
+                    "minimax": {
+                        "name": "MiniMax Chat Completions API",
+                        "base_url": "https://api.minimax.io/v1",
+                        "env_key": "MINIMAX_API_KEY",
+                        "wire_api": "chat",
+                        "requires_openai_auth": False,
+                        "request_max_retries": 4,
+                        "stream_max_retries": 10,
+                        "stream_idle_timeout_ms": 300000,
+                    },
+                },
+                "profiles": {
+                    "m27": {
+                        "model": "codex-MiniMax-M2.7",
+                        "model_provider": "minimax",
+                    }
+                },
+            },
+            "permissions": "0600",
+        }
+    ]
+
 def _legacy_codex_openrouter_qwen36_plus_file_templates() -> list[dict[str, object]]:
     return [
         {
@@ -657,6 +687,11 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
             "volume_ref": None,
             "volume_mount_path": None,
+            "clear_env_keys": [
+                "GEMINI_API_KEY",
+                "GOOGLE_API_KEY",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+            ],
             "account_label": "Gemini CLI (auto-seeded)",
             "enabled": False,
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
@@ -674,6 +709,13 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
             "volume_ref": None,
             "volume_mount_path": None,
+            "clear_env_keys": [
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "OPENAI_ORG_ID",
+                "OPENAI_PROJECT",
+                "MINIMAX_API_KEY",
+            ],
             "account_label": "Codex CLI (auto-seeded)",
             "enabled": False,
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
@@ -693,6 +735,8 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "volume_mount_path": None,
             "clear_env_keys": [
                 "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+                "ANTHROPIC_BASE_URL",
                 "CLAUDE_API_KEY",
                 "OPENAI_API_KEY",
             ],
@@ -717,14 +761,18 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "credential_source": ProviderCredentialSource.SECRET_REF,
             "runtime_materialization_mode": RuntimeMaterializationMode.ENV_BUNDLE,
             "secret_refs": {
-                "ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"
+                "provider_api_key": "env://MINIMAX_API_KEY"
             },
             "clear_env_keys": [
                 "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
                 "OPENAI_API_KEY",
             ],
             "env_template": {
                 "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+                "ANTHROPIC_AUTH_TOKEN": {
+                    "from_secret_ref": "provider_api_key",
+                },
                 "ANTHROPIC_MODEL": "MiniMax-M2.7",
                 "ANTHROPIC_SMALL_FAST_MODEL": "MiniMax-M2.7",
                 "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
@@ -736,6 +784,51 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "volume_ref": None,
             "volume_mount_path": None,
             "account_label": "Claude Code via MiniMax (auto-seeded)",
+            "enabled": True,
+            "auth_state": ProviderProfileAuthState.CONNECTED,
+            "disabled_reason": None,
+            "last_auth_method": ProviderProfileAuthMethod.SECRET_REF,
+        })
+        _DEFAULT_PROFILES.append({
+            "profile_id": "codex_minimax_m27",
+            "runtime_id": "codex_cli",
+            "is_default": False,
+            "provider_id": "minimax",
+            "provider_label": "MiniMax",
+            "default_model": "codex-MiniMax-M2.7",
+            "model_overrides": {
+                "codex_profile_name": "m27",
+            },
+            "credential_source": ProviderCredentialSource.SECRET_REF,
+            "runtime_materialization_mode": RuntimeMaterializationMode.COMPOSITE,
+            "secret_refs": {
+                "provider_api_key": "env://MINIMAX_API_KEY",
+            },
+            "clear_env_keys": [
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "OPENAI_ORG_ID",
+                "OPENAI_PROJECT",
+            ],
+            "env_template": {
+                "MINIMAX_API_KEY": {
+                    "from_secret_ref": "provider_api_key",
+                },
+            },
+            "file_templates": _codex_minimax_m27_file_templates(),
+            "home_path_overrides": {
+                "CODEX_HOME": "{{runtime_support_dir}}/codex-home",
+            },
+            "command_behavior": {
+                "suppress_default_model_flag": True,
+            },
+            "max_parallel_runs": 4,
+            "cooldown_after_429_seconds": 600,
+            "rate_limit_policy": ManagedAgentRateLimitPolicy.BACKOFF,
+            "max_lease_duration_seconds": 7200,
+            "volume_ref": None,
+            "volume_mount_path": None,
+            "account_label": "Codex CLI via MiniMax (auto-seeded)",
             "enabled": True,
             "auth_state": ProviderProfileAuthState.CONNECTED,
             "disabled_reason": None,
@@ -883,7 +976,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         await session.execute(stmt)
                         needs_commit = True
                     desired_clear_env_keys = profile_def.get("clear_env_keys")
-                    if profile_id == "claude_anthropic" and desired_clear_env_keys:
+                    if desired_clear_env_keys:
                         current_clear_env_keys = list(
                             existing_by_id[profile_id]["clear_env_keys"] or []
                         )
@@ -934,6 +1027,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                     provider_id=profile_def["provider_id"],
                     provider_label=profile_def.get("provider_label"),
                     default_model=profile_def.get("default_model"),
+                    model_overrides=profile_def.get("model_overrides"),
                     credential_source=profile_def["credential_source"],
                     runtime_materialization_mode=profile_def["runtime_materialization_mode"],
                     volume_ref=profile_def.get("volume_ref"),

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -570,6 +570,7 @@ def _codex_minimax_m27_file_templates() -> list[dict[str, object]]:
             "format": "toml",
             "merge_strategy": "deep_merge",
             "content_template": {
+                "profile": "m27",
                 "model_providers": {
                     "minimax": {
                         "name": "MiniMax Chat Completions API",

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1511,9 +1511,9 @@ class RuntimeFileTemplate(BaseModel):
         self.format = normalized_format
 
         normalized_merge = str(self.merge_strategy or "replace").strip().lower()
-        if normalized_merge != "replace":
+        if normalized_merge not in {"replace", "deep_merge", "append"}:
             raise ValueError(
-                "fileTemplates[].mergeStrategy must be 'replace'"
+                "fileTemplates[].mergeStrategy must be one of: replace, deep_merge, append"
             )
         self.merge_strategy = normalized_merge
         return self
@@ -1530,6 +1530,12 @@ class ManagedRuntimeProfile(BaseModel):
     auth_mode: str | None = Field(None, alias="authMode")
     credential_source: str | None = Field(None, alias="credentialSource")
     runtime_materialization_mode: str | None = Field(None, alias="runtimeMaterializationMode")
+    enabled: bool | None = Field(None, alias="enabled")
+    auth_state: ProviderProfileAuthState | None = Field(None, alias="authState")
+    disabled_reason: ProviderProfileDisabledReason | None = Field(
+        None, alias="disabledReason"
+    )
+    launch_ready: bool | None = Field(None, alias="launchReady")
     command_behavior: dict[str, Any] = Field(default_factory=dict, alias="commandBehavior")
     command_template: list[str] = Field(default_factory=list, alias="commandTemplate")
     default_model: str | None = Field(None, alias="defaultModel")

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -671,6 +671,10 @@ class ManagedAgentAdapter:
                 runtime_materialization_mode=profile.get(
                     "runtime_materialization_mode"
                 ),
+                enabled=profile.get("enabled"),
+                auth_state=profile.get("auth_state"),
+                disabled_reason=profile.get("disabled_reason"),
+                launch_ready=profile.get("launch_ready"),
                 # Use delta_env_overrides (profile-specific additions only), NOT
                 # shaped_env (which contains the full base environment).  The
                 # launcher already starts from os.environ and overlays

--- a/moonmind/workflows/adapters/materializer.py
+++ b/moonmind/workflows/adapters/materializer.py
@@ -304,9 +304,10 @@ class ProviderProfileMaterializer:
         raw = file_path.read_text(encoding="utf-8")
         if not raw.strip():
             return {}
-        if file_format == "json":
+        normalized_format = str(file_format).strip().lower()
+        if normalized_format == "json":
             parsed = json.loads(raw)
-        elif file_format == "toml":
+        elif normalized_format == "toml":
             parsed = tomllib.loads(raw)
         else:
             raise ValueError("deep_merge is supported only for json and toml fileTemplates")

--- a/moonmind/workflows/adapters/materializer.py
+++ b/moonmind/workflows/adapters/materializer.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import tempfile
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -245,13 +246,87 @@ class ProviderProfileMaterializer:
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
         rendered_content = self._render_value(file_template.content_template, context)
-        content = self._serialize_file_content(
-            rendered_content,
-            file_format=file_template.format,
-        )
+        content = self._render_file_content(file_template, file_path, rendered_content)
         file_path.write_text(content, encoding="utf-8")
         os.chmod(file_path, self._parse_permissions(file_template.permissions))
         self.generated_files.append(str(file_path))
+
+    def _render_file_content(
+        self,
+        file_template: RuntimeFileTemplate,
+        file_path: Path,
+        rendered_content: Any,
+    ) -> str:
+        merge_strategy = str(file_template.merge_strategy or "replace").strip().lower()
+        if merge_strategy == "replace" or not file_path.exists():
+            return self._serialize_file_content(
+                rendered_content,
+                file_format=file_template.format,
+            )
+        if merge_strategy == "deep_merge":
+            return self._render_deep_merged_file_content(
+                file_path=file_path,
+                rendered_content=rendered_content,
+                file_format=file_template.format,
+            )
+        if merge_strategy == "append":
+            existing = file_path.read_text(encoding="utf-8")
+            addition = self._serialize_file_content(
+                rendered_content,
+                file_format=file_template.format,
+            )
+            separator = "" if not existing or existing.endswith("\n") else "\n"
+            return f"{existing}{separator}{addition}"
+        raise ValueError(
+            "fileTemplates[].mergeStrategy must be one of: replace, deep_merge, append"
+        )
+
+    def _render_deep_merged_file_content(
+        self,
+        *,
+        file_path: Path,
+        rendered_content: Any,
+        file_format: str,
+    ) -> str:
+        if not isinstance(rendered_content, dict):
+            raise ValueError("deep_merge fileTemplates require object content_template")
+
+        existing = self._parse_existing_structured_file(file_path, file_format=file_format)
+        merged = self._deep_merge_dicts(existing, rendered_content)
+        return self._serialize_file_content(merged, file_format=file_format)
+
+    def _parse_existing_structured_file(
+        self,
+        file_path: Path,
+        *,
+        file_format: str,
+    ) -> dict[str, Any]:
+        raw = file_path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return {}
+        if file_format == "json":
+            parsed = json.loads(raw)
+        elif file_format == "toml":
+            parsed = tomllib.loads(raw)
+        else:
+            raise ValueError("deep_merge is supported only for json and toml fileTemplates")
+        if not isinstance(parsed, dict):
+            raise ValueError("deep_merge existing file content must be an object")
+        return parsed
+
+    def _deep_merge_dicts(
+        self,
+        base: dict[str, Any],
+        overlay: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged = dict(base)
+        for key, value in overlay.items():
+            existing = merged.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                merged[key] = self._deep_merge_dicts(existing, value)
+            else:
+                merged[key] = value
+        return merged
 
     @staticmethod
     def _parse_permissions(value: str | int | None) -> int:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2006,16 +2006,24 @@ def _provider_profile_prefers_proxy_first(profile: Mapping[str, Any]) -> bool:
         .strip()
         .lower()
     )
-    credential_source = str(
+    credential_source_raw = (
         profile.get("credential_source") or profile.get("credentialSource") or ""
-    ).strip()
-    materialization_mode = str(
+    )
+    credential_source = str(
+        getattr(credential_source_raw, "value", credential_source_raw)
+    ).strip().lower()
+    materialization_mode_raw = (
         profile.get("runtime_materialization_mode")
         or profile.get("runtimeMaterializationMode")
         or ""
-    ).strip()
+    )
+    materialization_mode = str(
+        getattr(materialization_mode_raw, "value", materialization_mode_raw)
+    ).strip().lower()
+    if provider == "minimax":
+        return False
     return (
-        provider in {"anthropic", "minimax", "openai"}
+        provider in {"anthropic", "openai"}
         and credential_source == "secret_ref"
         and materialization_mode in {"api_key_env", "env_bundle"}
     )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1985,6 +1985,41 @@ def _coerce_activity_payload_input(
         request = kwargs
     return _coerce_activity_request(request, activity_type=activity_type)
 
+def _provider_profile_prefers_proxy_first(profile: Mapping[str, Any]) -> bool:
+    tags = {str(tag).strip().lower() for tag in profile.get("tags") or []}
+    if "proxy-first" in tags:
+        return True
+    if "direct-credentials-required" in tags:
+        return False
+
+    command_behavior = profile.get("command_behavior")
+    if not isinstance(command_behavior, Mapping):
+        command_behavior = profile.get("commandBehavior")
+    if isinstance(command_behavior, Mapping) and bool(
+        command_behavior.get("requires_direct_credentials")
+        or command_behavior.get("requiresDirectCredentials")
+    ):
+        return False
+
+    provider = (
+        str(profile.get("provider_id") or profile.get("providerId") or "")
+        .strip()
+        .lower()
+    )
+    credential_source = str(
+        profile.get("credential_source") or profile.get("credentialSource") or ""
+    ).strip()
+    materialization_mode = str(
+        profile.get("runtime_materialization_mode")
+        or profile.get("runtimeMaterializationMode")
+        or ""
+    ).strip()
+    return (
+        provider in {"anthropic", "minimax", "openai"}
+        and credential_source == "secret_ref"
+        and materialization_mode in {"api_key_env", "env_bundle"}
+    )
+
 def _redacted_webhook_target(webhook_url: str) -> str:
     if not webhook_url:
         return ""
@@ -6235,8 +6270,7 @@ class TemporalAgentRuntimeActivities:
             default_credential_source=default_credential_source,
         )
         delta_env_overrides = dict(context.delta_env_overrides)
-        tags = profile.get("tags") or []
-        if "proxy-first" in tags:
+        if _provider_profile_prefers_proxy_first(profile):
             from cryptography.fernet import Fernet
 
             from api_service.core.encryption import get_encryption_key

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -965,6 +965,41 @@ class ManagedRuntimeLauncher:
         ):
             request.instruction_ref = result.rendered_instruction
 
+    @staticmethod
+    def _assert_profile_launch_ready(profile: ManagedRuntimeProfile) -> None:
+        """Re-check compact Provider Profile readiness at the launch boundary."""
+
+        profile_ref = str(profile.profile_id or profile.runtime_id or "profile").strip()
+        if profile.enabled is False:
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: disabled"
+            )
+        if profile.auth_state is not None and profile.auth_state != "connected":
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: "
+                f"auth_state={profile.auth_state!r}"
+            )
+        if profile.disabled_reason is not None:
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: "
+                f"disabled_reason={profile.disabled_reason!r}"
+            )
+        if profile.launch_ready is False:
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: "
+                "launch_ready=False"
+            )
+        readiness = profile.command_behavior.get("auth_readiness")
+        if isinstance(readiness, Mapping):
+            launch_ready = readiness.get("launch_ready")
+            if launch_ready is None:
+                launch_ready = readiness.get("launchReady")
+            if launch_ready is False:
+                raise RuntimeError(
+                    f"Provider profile {profile_ref!r} is not launch-ready: "
+                    "command_behavior.auth_readiness.launch_ready=False"
+                )
+
     async def _project_run_skill_snapshot(
         self,
         *,
@@ -1107,6 +1142,7 @@ class ManagedRuntimeLauncher:
             assert_managed_secret_refs_active_for_launch,
             resolve_managed_api_key_reference,
         )
+        self._assert_profile_launch_ready(profile)
         profile_secret_refs = getattr(profile, "secret_refs", None) or {}
         # Refuse to materialize the runtime when any managed SecretRef is
         # disabled, revoked, or missing. Plaintext is never read or surfaced.

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -974,7 +974,13 @@ class ManagedRuntimeLauncher:
             raise RuntimeError(
                 f"Provider profile {profile_ref!r} is not launch-ready: disabled"
             )
-        if profile.auth_state is not None and profile.auth_state != "connected":
+        auth_state = profile.auth_state
+        if auth_state is not None:
+            auth_state_value = getattr(auth_state, "value", auth_state)
+            auth_state_normalized = str(auth_state_value).strip().lower()
+        else:
+            auth_state_normalized = None
+        if auth_state_normalized is not None and auth_state_normalized != "connected":
             raise RuntimeError(
                 f"Provider profile {profile_ref!r} is not launch-ready: "
                 f"auth_state={profile.auth_state!r}"

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -216,6 +216,7 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
     ]
     assert codex_mm_profile.file_templates[0]["merge_strategy"] == "deep_merge"
     assert codex_mm_profile.file_templates[0]["permissions"] == "0600"
+    assert codex_mm_profile.file_templates[0]["content_template"]["profile"] == "m27"
     assert codex_mm_profile.model_overrides == {"codex_profile_name": "m27"}
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -95,8 +95,23 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert claude_profile.volume_mount_path is None
     assert claude_profile.clear_env_keys == [
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
         "CLAUDE_API_KEY",
         "OPENAI_API_KEY",
+    ]
+    first_party_clear_keys = {p.profile_id: p.clear_env_keys for p in profiles}
+    assert first_party_clear_keys["gemini_default"] == [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ]
+    assert first_party_clear_keys["codex_default"] == [
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_ORG_ID",
+        "OPENAI_PROJECT",
+        "MINIMAX_API_KEY",
     ]
 
 @pytest.mark.asyncio
@@ -135,33 +150,43 @@ async def test_auto_seed_skipped_when_env_set(_module_db, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
-    """When MINIMAX_API_KEY is set, a 4th 'claude_minimax' profile should be seeded."""
+    """When MINIMAX_API_KEY is set, MiniMax Claude and Codex profiles are seeded."""
     from api_service.main import _auto_seed_provider_profiles
 
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
     seeded = await _auto_seed_provider_profiles()
-    assert "claude_code" in seeded  # seeded twice (default + minimax)
+    assert "claude_code" in seeded
+    assert "codex_cli" in seeded
 
     async with db_base.async_session_maker() as session:
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 4
+    assert len(profiles) == 5
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_anthropic" in profile_ids
     assert "claude_minimax" in profile_ids
+    assert "codex_minimax_m27" in profile_ids
 
     # Verify MiniMax profile details.
     mm_profile = next(p for p in profiles if p.profile_id == "claude_minimax")
     assert mm_profile.runtime_id == "claude_code"
     assert mm_profile.secret_refs is not None
-    assert mm_profile.secret_refs.get("ANTHROPIC_AUTH_TOKEN") == "env://MINIMAX_API_KEY"
+    assert mm_profile.secret_refs.get("provider_api_key") == "env://MINIMAX_API_KEY"
     assert mm_profile.env_template is not None
     assert mm_profile.env_template["ANTHROPIC_BASE_URL"] == "https://api.minimax.io/anthropic"
+    assert mm_profile.env_template["ANTHROPIC_AUTH_TOKEN"] == {
+        "from_secret_ref": "provider_api_key"
+    }
     assert mm_profile.env_template["ANTHROPIC_MODEL"] == "MiniMax-M2.7"
     assert mm_profile.env_template["API_TIMEOUT_MS"] == "3000000"
+    assert mm_profile.clear_env_keys == [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENAI_API_KEY",
+    ]
     assert mm_profile.default_model == "MiniMax-M2.7"
     assert mm_profile.volume_ref is None
     assert mm_profile.volume_mount_path is None
@@ -172,6 +197,26 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
 
     anthropic_profile = next(p for p in profiles if p.profile_id == "claude_anthropic")
     assert anthropic_profile.is_default is False
+
+    codex_mm_profile = next(p for p in profiles if p.profile_id == "codex_minimax_m27")
+    assert codex_mm_profile.runtime_id == "codex_cli"
+    assert (
+        codex_mm_profile.runtime_materialization_mode
+        == RuntimeMaterializationMode.COMPOSITE
+    )
+    assert codex_mm_profile.secret_refs == {"provider_api_key": "env://MINIMAX_API_KEY"}
+    assert codex_mm_profile.env_template == {
+        "MINIMAX_API_KEY": {"from_secret_ref": "provider_api_key"}
+    }
+    assert codex_mm_profile.clear_env_keys == [
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_ORG_ID",
+        "OPENAI_PROJECT",
+    ]
+    assert codex_mm_profile.file_templates[0]["merge_strategy"] == "deep_merge"
+    assert codex_mm_profile.file_templates[0]["permissions"] == "0600"
+    assert codex_mm_profile.model_overrides == {"codex_profile_name": "m27"}
 
 @pytest.mark.asyncio
 async def test_auto_seed_adds_minimax_after_initial_seed(_module_db, monkeypatch):
@@ -193,10 +238,11 @@ async def test_auto_seed_adds_minimax_after_initial_seed(_module_db, monkeypatch
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 4
+    assert len(profiles) == 5
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_anthropic" in profile_ids
     assert "claude_minimax" in profile_ids
+    assert "codex_minimax_m27" in profile_ids
 
 @pytest.mark.asyncio
 async def test_auto_seed_reconcile_does_not_overwrite_user_default_model(_module_db, monkeypatch):
@@ -304,8 +350,51 @@ async def test_auto_seed_backfills_claude_api_key_clear_env_for_existing_profile
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "CUSTOM_ENV",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_BASE_URL",
             "CLAUDE_API_KEY",
         ]
+
+@pytest.mark.asyncio
+async def test_auto_seed_backfills_first_party_clear_env_for_existing_profiles(
+    _module_db, monkeypatch
+):
+    from api_service.main import _auto_seed_provider_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    await _auto_seed_provider_profiles()
+
+    async with db_base.async_session_maker() as session:
+        codex_profile = await session.get(ManagedAgentProviderProfile, "codex_default")
+        gemini_profile = await session.get(ManagedAgentProviderProfile, "gemini_default")
+        assert codex_profile is not None
+        assert gemini_profile is not None
+        codex_profile.clear_env_keys = ["OPENAI_API_KEY", "CUSTOM_CODEX_ENV"]
+        gemini_profile.clear_env_keys = ["GEMINI_API_KEY", "CUSTOM_GEMINI_ENV"]
+        await session.commit()
+
+    seeded = await _auto_seed_provider_profiles()
+    assert seeded == []
+
+    async with db_base.async_session_maker() as session:
+        codex_profile = await session.get(ManagedAgentProviderProfile, "codex_default")
+        gemini_profile = await session.get(ManagedAgentProviderProfile, "gemini_default")
+
+    assert codex_profile.clear_env_keys == [
+        "OPENAI_API_KEY",
+        "CUSTOM_CODEX_ENV",
+        "OPENAI_BASE_URL",
+        "OPENAI_ORG_ID",
+        "OPENAI_PROJECT",
+        "MINIMAX_API_KEY",
+    ]
+    assert gemini_profile.clear_env_keys == [
+        "GEMINI_API_KEY",
+        "CUSTOM_GEMINI_ENV",
+        "GOOGLE_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ]
 
 @pytest.mark.asyncio
 async def test_auto_seed_excludes_minimax_when_env_unset(_module_db, monkeypatch):
@@ -324,6 +413,7 @@ async def test_auto_seed_excludes_minimax_when_env_unset(_module_db, monkeypatch
 
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_minimax" not in profile_ids
+    assert "codex_minimax_m27" not in profile_ids
     assert "claude_anthropic" in profile_ids
     assert len(profiles) == 3
 

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -693,6 +693,30 @@ def test_managed_runtime_profile_roundtrips_file_templates() -> None:
         "model": "qwen/qwen3.6-plus",
     }
 
+def test_managed_runtime_profile_accepts_documented_file_merge_strategies() -> None:
+    profile = ManagedRuntimeProfile(
+        runtimeId="codex_cli",
+        fileTemplates=[
+            {
+                "path": "config.toml",
+                "format": "toml",
+                "mergeStrategy": "deep_merge",
+                "contentTemplate": {},
+            },
+            {
+                "path": "runtime.env",
+                "format": "text",
+                "mergeStrategy": "append",
+                "contentTemplate": "",
+            },
+        ],
+    )
+
+    assert [item.merge_strategy for item in profile.file_templates] == [
+        "deep_merge",
+        "append",
+    ]
+
 
 def test_extract_durable_retrieval_metadata_only_allows_boolean_contract_fields() -> None:
     metadata = extract_durable_retrieval_metadata(

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1923,6 +1923,74 @@ async def test_launch_claude_anthropic_missing_secret_ref_fails_before_process(
     assert "ambient-anthropic-key" not in message
 
 @pytest.mark.asyncio
+async def test_launch_rechecks_profile_readiness_before_secret_resolution(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    profile = _make_profile(
+        profile_id="claude_anthropic",
+        runtime_id="claude_code",
+        provider_id="anthropic",
+        credential_source="secret_ref",
+        runtime_materialization_mode="api_key_env",
+        enabled=True,
+        auth_state="connected",
+        disabled_reason=None,
+        launch_ready=False,
+        command_template=["claude", "-p", "hello"],
+        clear_env_keys=["ANTHROPIC_API_KEY"],
+        secret_refs={"anthropic_api_key": "db://claude-token"},
+        env_template={"ANTHROPIC_API_KEY": {"from_secret_ref": "anthropic_api_key"}},
+        passthrough_env_keys=[],
+    )
+    request = _make_request(execution_profile_ref="claude_anthropic")
+
+    class _FakeGitProcess:
+        def __init__(self) -> None:
+            self.pid = 1007
+            self.returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        if args and args[0] == "git":
+            return _FakeGitProcess()
+        raise AssertionError("runtime process should not start")
+
+    async def _fake_assert_active(_secret_refs):
+        raise AssertionError("secret readiness check should not run")
+
+    async def _fake_resolve(_secret_name: str) -> str:
+        raise AssertionError("secret resolution should not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.assert_managed_secret_refs_active_for_launch",
+        _fake_assert_active,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
+        _fake_resolve,
+    )
+
+    with pytest.raises(RuntimeError, match="launch_ready=False"):
+        await launcher.launch(
+            run_id="run-profile-readiness-recheck",
+            request=request,
+            profile=profile,
+        )
+
+@pytest.mark.asyncio
 async def test_launch_resolves_github_token_from_secret_ref_setting(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -165,6 +165,17 @@ def test_apply_runtime_command_rendering_redacts_diagnostics(monkeypatch):
     assert render_metadata["diagnostics"]["message"] == "saw ***"
     assert "render-secret-value" not in str(render_metadata)
 
+def test_assert_profile_launch_ready_accepts_connected_enum_auth_state():
+    from api_service.db.models import ProviderProfileAuthState
+
+    profile = _make_profile(
+        enabled=True,
+        authState=ProviderProfileAuthState.CONNECTED,
+        disabledReason=None,
+    )
+
+    ManagedRuntimeLauncher._assert_profile_launch_ready(profile)
+
 def test_build_command_per_runtime():
     store = ManagedRunStore("/tmp/test-store")
     launcher = ManagedRuntimeLauncher(store)

--- a/tests/unit/workflows/adapters/test_materializer.py
+++ b/tests/unit/workflows/adapters/test_materializer.py
@@ -261,6 +261,99 @@ async def test_materializer_path_aware_file_templates_written_and_cleanup(tmp_pa
     assert materializer.generated_files == []
 
 @pytest.mark.asyncio
+async def test_materializer_deep_merges_toml_file_templates_without_artifact_linking(tmp_path):
+    materializer = ProviderProfileMaterializer(
+        base_env={"PATH": "/usr/bin"},
+        secret_resolver=StaticSecretResolver({"env://minimax": "resolved-minimax-key"}),
+    )
+    support_dir = tmp_path / ".moonmind"
+    config_path = support_dir / "codex-home" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[model_providers.openai]\nname = "OpenAI"\n\n'
+        '[profiles.default]\nmodel = "gpt-5.5"\nmodel_provider = "openai"\n',
+        encoding="utf-8",
+    )
+    profile = ManagedRuntimeProfile(
+        profile_id="codex_minimax_m27",
+        runtime_id="codex_cli",
+        provider_id="minimax",
+        credential_source="secret_ref",
+        runtime_materialization_mode="composite",
+        secret_refs={"provider_api_key": "env://minimax"},
+        env_template={"MINIMAX_API_KEY": {"from_secret_ref": "provider_api_key"}},
+        file_templates=[
+            {
+                "path": "codex-home/config.toml",
+                "format": "toml",
+                "mergeStrategy": "deep_merge",
+                "permissions": "0600",
+                "contentTemplate": {
+                    "model_providers": {
+                        "minimax": {
+                            "name": "MiniMax Chat Completions API",
+                            "base_url": "https://api.minimax.io/v1",
+                            "env_key": "MINIMAX_API_KEY",
+                            "wire_api": "chat",
+                        }
+                    },
+                    "profiles": {
+                        "m27": {
+                            "model": "codex-MiniMax-M2.7",
+                            "model_provider": "minimax",
+                        }
+                    },
+                },
+            }
+        ],
+        command_template=["codex", "exec"],
+    )
+
+    env, _cmd = await materializer.materialize(
+        profile,
+        runtime_support_dir=str(support_dir),
+    )
+
+    content = config_path.read_text(encoding="utf-8")
+    assert env["MINIMAX_API_KEY"] == "resolved-minimax-key"
+    assert "provider_api_key" not in env
+    assert "[model_providers.openai]" in content
+    assert "[model_providers.minimax]" in content
+    assert "[profiles.default]" in content
+    assert "[profiles.m27]" in content
+    assert "resolved-minimax-key" not in content
+    assert oct(config_path.stat().st_mode & 0o777) == "0o600"
+    assert str(config_path) in materializer.generated_files
+
+@pytest.mark.asyncio
+async def test_materializer_appends_text_file_templates(tmp_path):
+    materializer = ProviderProfileMaterializer(
+        base_env={},
+        secret_resolver=MockSecretResolver(),
+    )
+    support_dir = tmp_path / ".moonmind"
+    notes_path = support_dir / "runtime.env"
+    notes_path.parent.mkdir(parents=True)
+    notes_path.write_text("EXISTING=1\n", encoding="utf-8")
+    profile = ManagedRuntimeProfile(
+        profile_id="append_profile",
+        runtime_id="claude_code",
+        file_templates=[
+            {
+                "path": "runtime.env",
+                "format": "text",
+                "mergeStrategy": "append",
+                "contentTemplate": "ADDED=2\n",
+            }
+        ],
+        command_template=["claude"],
+    )
+
+    await materializer.materialize(profile, runtime_support_dir=str(support_dir))
+
+    assert notes_path.read_text(encoding="utf-8") == "EXISTING=1\nADDED=2\n"
+
+@pytest.mark.asyncio
 async def test_materializer_cleanup_removes_generated_support_dir_tree():
     materializer = ProviderProfileMaterializer(
         base_env={},

--- a/tests/unit/workflows/adapters/test_materializer.py
+++ b/tests/unit/workflows/adapters/test_materializer.py
@@ -285,10 +285,11 @@ async def test_materializer_deep_merges_toml_file_templates_without_artifact_lin
         file_templates=[
             {
                 "path": "codex-home/config.toml",
-                "format": "toml",
+                "format": "TOML",
                 "mergeStrategy": "deep_merge",
                 "permissions": "0600",
                 "contentTemplate": {
+                    "profile": "m27",
                     "model_providers": {
                         "minimax": {
                             "name": "MiniMax Chat Completions API",
@@ -321,6 +322,7 @@ async def test_materializer_deep_merges_toml_file_templates_without_artifact_lin
     assert "[model_providers.minimax]" in content
     assert "[profiles.default]" in content
     assert "[profiles.m27]" in content
+    assert 'profile = "m27"' in content
     assert "resolved-minimax-key" not in content
     assert oct(config_path.stat().st_mode & 0o777) == "0o600"
     assert str(config_path) in materializer.generated_files

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3515,6 +3515,36 @@ async def test_agent_runtime_build_launch_context_temporal_boundary(
 async def test_agent_runtime_build_launch_context_prefers_proxy_for_supported_secret_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from api_service.db.models import ProviderCredentialSource, RuntimeMaterializationMode
+
+    monkeypatch.setenv("MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION", "1")
+    activities_impl = TemporalAgentRuntimeActivities()
+
+    result = await activities_impl.agent_runtime_build_launch_context(
+        {
+            "profile": {
+                "profile_id": "claude-anthropic",
+                "credential_source": ProviderCredentialSource.SECRET_REF,
+                "runtime_materialization_mode": RuntimeMaterializationMode.ENV_BUNDLE,
+                "provider_id": "anthropic",
+                "secret_refs": {"provider_api_key": "db://anthropic"},
+            },
+            "runtime_for_profile": "claude_code",
+            "workflow_id": "wf-proxy-default",
+            "default_credential_source": "secret_ref",
+        }
+    )
+
+    env_overrides = result["delta_env_overrides"]
+    assert "MOONMIND_PROXY_TOKEN" in env_overrides
+    assert "ANTHROPIC_BASE_URL" in env_overrides
+    assert "proxy/anthropic" in env_overrides["ANTHROPIC_BASE_URL"]
+    assert "db://anthropic" not in env_overrides.values()
+
+@pytest.mark.asyncio
+async def test_agent_runtime_build_launch_context_keeps_minimax_direct_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION", "1")
     activities_impl = TemporalAgentRuntimeActivities()
 
@@ -3526,18 +3556,23 @@ async def test_agent_runtime_build_launch_context_prefers_proxy_for_supported_se
                 "runtime_materialization_mode": "env_bundle",
                 "provider_id": "minimax",
                 "secret_refs": {"provider_api_key": "db://minimax"},
+                "env_template": {
+                    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+                    "ANTHROPIC_AUTH_TOKEN": {
+                        "from_secret_ref": "provider_api_key",
+                    },
+                },
             },
             "runtime_for_profile": "claude_code",
-            "workflow_id": "wf-proxy-default",
+            "workflow_id": "wf-minimax-direct",
             "default_credential_source": "secret_ref",
         }
     )
 
     env_overrides = result["delta_env_overrides"]
-    assert "MOONMIND_PROXY_TOKEN" in env_overrides
-    assert "ANTHROPIC_BASE_URL" in env_overrides
-    assert "proxy/minimax" in env_overrides["ANTHROPIC_BASE_URL"]
-    assert "db://minimax" not in env_overrides.values()
+    assert "MOONMIND_PROXY_TOKEN" not in env_overrides
+    assert "ANTHROPIC_BASE_URL" not in env_overrides
+    assert "ANTHROPIC_AUTH_TOKEN" not in env_overrides
 
 @pytest.mark.asyncio
 async def test_agent_runtime_fetch_result_temporal_boundary(tmp_path: Path) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -3512,6 +3512,34 @@ async def test_agent_runtime_build_launch_context_temporal_boundary(
             assert "GITHUB_TOKEN" in result["passthrough_env_keys"]
 
 @pytest.mark.asyncio
+async def test_agent_runtime_build_launch_context_prefers_proxy_for_supported_secret_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION", "1")
+    activities_impl = TemporalAgentRuntimeActivities()
+
+    result = await activities_impl.agent_runtime_build_launch_context(
+        {
+            "profile": {
+                "profile_id": "claude-minimax",
+                "credential_source": "secret_ref",
+                "runtime_materialization_mode": "env_bundle",
+                "provider_id": "minimax",
+                "secret_refs": {"provider_api_key": "db://minimax"},
+            },
+            "runtime_for_profile": "claude_code",
+            "workflow_id": "wf-proxy-default",
+            "default_credential_source": "secret_ref",
+        }
+    )
+
+    env_overrides = result["delta_env_overrides"]
+    assert "MOONMIND_PROXY_TOKEN" in env_overrides
+    assert "ANTHROPIC_BASE_URL" in env_overrides
+    assert "proxy/minimax" in env_overrides["ANTHROPIC_BASE_URL"]
+    assert "db://minimax" not in env_overrides.values()
+
+@pytest.mark.asyncio
 async def test_agent_runtime_fetch_result_temporal_boundary(tmp_path: Path) -> None:
     from unittest.mock import patch
 


### PR DESCRIPTION
Issue reference: MM-878 (https://moonladder.atlassian.net/browse/MM-878)

Summary of implementation:
- Adds launch-boundary provider profile readiness rechecks before runtime materialization.
- Extends provider profile materialization for proxy preference, clear_env_keys, env/config template handling, sensitive generated file cleanup, and runtime strategy handoff.
- Adds first-party and MiniMax provider profile seed coverage plus unit coverage across schema, materializer, launcher, and Temporal activity boundaries.

Tests run:
- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/test_provider_profile_auto_seed.py tests/unit/schemas/test_agent_runtime_models.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/adapters/test_materializer.py tests/unit/workflows/temporal/test_agent_runtime_activities.py
- FAIL: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh (3 failures in tests/unit/workflows/temporal/test_temporal_service.py: test_create_execution_rejects_foreign_remediation_agent_run_ids, test_create_execution_accepts_owned_remediation_agent_run_ids, test_create_execution_removes_empty_normalized_depends_on_from_parameters; failures are from UserWorkflow plan-source validation outside the MM-878 changed files)

Remaining risks:
- Full unit suite is not green in this checkout because of the listed Temporal service validation failures.
- Provider verification and compose-backed integration suites were not run in this handoff step.
