### PR TITLE
MM-879 complete provider profile activation migration

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1947,7 +1947,7 @@ class RuntimeMaterializationMode(str, enum.Enum):
     COMPOSITE = "composite"
 
 class ManagedAgentRateLimitPolicy(str, enum.Enum):
-    """Rate limit handling policy for a managed agent auth profile."""
+    """Rate limit handling policy for a managed agent provider profile."""
 
     BACKOFF = "backoff"
     QUEUE = "queue"

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -647,6 +647,23 @@ async def _auto_seed_provider_profiles() -> list[str]:
     # Well-known runtime defaults matching docker-compose.yaml conventions.
     _DEFAULT_PROFILES = [
         {
+            "profile_id": "gemini_google_default",
+            "runtime_id": "gemini_cli",
+            "is_default": False,
+            "provider_id": "google",
+            "provider_label": "Google",
+            "default_model": None,  # inherits runtime default: gemini-3.1-pro
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
+            "account_label": "Gemini CLI (setup required)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
+        },
+        {
             "profile_id": "gemini_default",
             "runtime_id": "gemini_cli",
             "is_default": False,
@@ -664,6 +681,23 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "tags": ["setup-required", "first-party"],
         },
         {
+            "profile_id": "codex_openai_default",
+            "runtime_id": "codex_cli",
+            "is_default": False,
+            "provider_id": "openai",
+            "provider_label": "OpenAI",
+            "default_model": None,  # inherits runtime default: gpt-5.5
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
+            "account_label": "Codex CLI (setup required)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
+        },
+        {
             "profile_id": "codex_default",
             "runtime_id": "codex_cli",
             "is_default": False,
@@ -675,6 +709,28 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "volume_ref": None,
             "volume_mount_path": None,
             "account_label": "Codex CLI (auto-seeded)",
+            "enabled": False,
+            "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
+            "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
+            "tags": ["setup-required", "first-party"],
+        },
+        {
+            "profile_id": "claude_anthropic_default",
+            "runtime_id": "claude_code",
+            "is_default": False,
+            "provider_id": "anthropic",
+            "provider_label": "Anthropic",
+            "default_model": None,  # inherits runtime default: claude-opus-4-8
+            "credential_source": ProviderCredentialSource.NONE,
+            "runtime_materialization_mode": RuntimeMaterializationMode.API_KEY_ENV,
+            "volume_ref": None,
+            "volume_mount_path": None,
+            "clear_env_keys": [
+                "ANTHROPIC_API_KEY",
+                "CLAUDE_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+            "account_label": "Claude Code (setup required)",
             "enabled": False,
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
@@ -883,7 +939,13 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         await session.execute(stmt)
                         needs_commit = True
                     desired_clear_env_keys = profile_def.get("clear_env_keys")
-                    if profile_id == "claude_anthropic" and desired_clear_env_keys:
+                    if (
+                        profile_id in {
+                            "claude_anthropic",
+                            "claude_anthropic_default",
+                        }
+                        and desired_clear_env_keys
+                    ):
                         current_clear_env_keys = list(
                             existing_by_id[profile_id]["clear_env_keys"] or []
                         )

--- a/api_service/migrations/versions/316_provider_profile_activation_state.py
+++ b/api_service/migrations/versions/316_provider_profile_activation_state.py
@@ -33,6 +33,255 @@ DISABLED_REASONS = (
     "disconnected",
 )
 AUTH_METHODS = ("oauth_volume", "secret_ref", "manual")
+FIRST_PARTY_SETUP_STUBS = (
+    {
+        "profile_id": "claude_anthropic_default",
+        "runtime_id": "claude_code",
+        "provider_id": "anthropic",
+        "provider_label": "Anthropic",
+        "account_label": "Claude Code (setup required)",
+    },
+    {
+        "profile_id": "claude_anthropic",
+        "runtime_id": "claude_code",
+        "provider_id": "anthropic",
+        "provider_label": "Anthropic",
+        "account_label": "Claude Code (setup required)",
+    },
+    {
+        "profile_id": "codex_openai_default",
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "provider_label": "OpenAI",
+        "account_label": "Codex CLI (setup required)",
+    },
+    {
+        "profile_id": "codex_default",
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "provider_label": "OpenAI",
+        "account_label": "Codex CLI (setup required)",
+    },
+    {
+        "profile_id": "gemini_google_default",
+        "runtime_id": "gemini_cli",
+        "provider_id": "google",
+        "provider_label": "Google",
+        "account_label": "Gemini CLI (setup required)",
+    },
+    {
+        "profile_id": "gemini_default",
+        "runtime_id": "gemini_cli",
+        "provider_id": "google",
+        "provider_label": "Google",
+        "account_label": "Gemini CLI (setup required)",
+    },
+)
+
+
+def activation_backfill_for_row(row: dict[str, object]) -> dict[str, object]:
+    """Classify a pre-activation provider profile for migration backfill."""
+
+    enabled = bool(row.get("enabled"))
+    disabled_reason = str(row.get("disabled_reason") or "").strip()
+    credential_source = str(row.get("credential_source") or "").strip()
+    volume_ref = str(row.get("volume_ref") or "").strip()
+    volume_mount_path = str(row.get("volume_mount_path") or "").strip()
+    secret_refs = row.get("secret_refs")
+    has_secret_refs = bool(secret_refs) and secret_refs != {}
+
+    if disabled_reason == "policy_disabled":
+        return {
+            "enabled": False,
+            "auth_state": "not_configured",
+            "disabled_reason": "policy_disabled",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+    if not enabled:
+        return {
+            "enabled": False,
+            "auth_state": "not_configured",
+            "disabled_reason": "user_disabled",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+    if credential_source == "oauth_volume" and volume_ref and volume_mount_path:
+        return {
+            "enabled": True,
+            "auth_state": "connected",
+            "disabled_reason": None,
+            "last_auth_method": "oauth_volume",
+            "stamp_validated": True,
+        }
+    if credential_source == "secret_ref" and has_secret_refs:
+        return {
+            "enabled": True,
+            "auth_state": "connected",
+            "disabled_reason": None,
+            "last_auth_method": "secret_ref",
+            "stamp_validated": True,
+        }
+    if str(row.get("validation_status") or "").strip() in {
+        "invalid",
+        "failed",
+        "validation_failed",
+    }:
+        return {
+            "enabled": False,
+            "auth_state": "validation_failed",
+            "disabled_reason": "auth_invalid",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+    return {
+        "enabled": False,
+        "auth_state": "not_configured",
+        "disabled_reason": "missing_credentials",
+        "last_auth_method": None,
+        "stamp_validated": False,
+    }
+
+
+def _insert_first_party_setup_stubs() -> None:
+    for stub in FIRST_PARTY_SETUP_STUBS:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO managed_agent_provider_profiles (
+                    profile_id,
+                    runtime_id,
+                    provider_id,
+                    provider_label,
+                    credential_source,
+                    runtime_materialization_mode,
+                    account_label,
+                    enabled,
+                    is_default,
+                    tags,
+                    priority,
+                    max_parallel_runs,
+                    cooldown_after_429_seconds,
+                    rate_limit_policy,
+                    max_lease_duration_seconds,
+                    auth_state,
+                    disabled_reason
+                )
+                SELECT
+                    :profile_id,
+                    :runtime_id,
+                    :provider_id,
+                    :provider_label,
+                    'none',
+                    'api_key_env',
+                    :account_label,
+                    false,
+                    false,
+                    NULL,
+                    100,
+                    1,
+                    900,
+                    'backoff',
+                    7200,
+                    'not_configured',
+                    'missing_credentials'
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM managed_agent_provider_profiles
+                    WHERE profile_id = :profile_id
+                )
+                """
+            ).bindparams(
+                profile_id=stub["profile_id"],
+                runtime_id=stub["runtime_id"],
+                provider_id=stub["provider_id"],
+                provider_label=stub["provider_label"],
+                account_label=stub["account_label"],
+            )
+        )
+
+
+def _backfill_activation_state() -> None:
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            auth_state = 'connected',
+            disabled_reason = NULL,
+            first_authenticated_at = COALESCE(first_authenticated_at, CURRENT_TIMESTAMP),
+            last_validated_at = CURRENT_TIMESTAMP,
+            last_auth_method = 'oauth_volume'
+        WHERE enabled = true
+          AND credential_source = 'oauth_volume'
+          AND COALESCE(volume_ref, '') <> ''
+          AND COALESCE(volume_mount_path, '') <> ''
+        """
+    )
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            auth_state = 'connected',
+            disabled_reason = NULL,
+            first_authenticated_at = COALESCE(first_authenticated_at, CURRENT_TIMESTAMP),
+            last_validated_at = CURRENT_TIMESTAMP,
+            last_auth_method = 'secret_ref'
+        WHERE enabled = true
+          AND credential_source = 'secret_ref'
+          AND secret_refs IS NOT NULL
+          AND CAST(secret_refs AS TEXT) NOT IN ('', '{}', 'null')
+        """
+    )
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            enabled = false,
+            auth_state = 'not_configured',
+            disabled_reason = 'missing_credentials',
+            last_auth_method = NULL
+        WHERE enabled = true
+          AND auth_state <> 'connected'
+        """
+    )
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            auth_state = 'not_configured',
+            disabled_reason = 'user_disabled',
+            last_auth_method = NULL
+        WHERE enabled = false
+          AND disabled_reason IS NULL
+          AND profile_id NOT IN (
+              'claude_anthropic_default',
+              'claude_anthropic',
+              'codex_openai_default',
+              'codex_default',
+              'gemini_google_default',
+              'gemini_default'
+          )
+        """
+    )
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            enabled = false,
+            auth_state = 'not_configured',
+            disabled_reason = 'missing_credentials',
+            last_auth_method = NULL
+        WHERE profile_id IN (
+              'claude_anthropic_default',
+              'claude_anthropic',
+              'codex_openai_default',
+              'codex_default',
+              'gemini_google_default',
+              'gemini_default'
+          )
+          AND auth_state <> 'connected'
+        """
+    )
 
 
 def upgrade() -> None:
@@ -78,11 +327,8 @@ def upgrade() -> None:
         "managed_agent_provider_profiles",
         sa.Column("last_auth_method", auth_method_enum, nullable=True),
     )
-    op.execute(
-        "UPDATE managed_agent_provider_profiles "
-        "SET auth_state = 'connected', disabled_reason = NULL "
-        "WHERE enabled = true"
-    )
+    _insert_first_party_setup_stubs()
+    _backfill_activation_state()
 
     op.create_check_constraint(
         "ck_provider_profiles_auth_state",

--- a/api_service/migrations/versions/316_provider_profile_activation_state.py
+++ b/api_service/migrations/versions/316_provider_profile_activation_state.py
@@ -106,6 +106,18 @@ def activation_backfill_for_row(row: dict[str, object]) -> dict[str, object]:
             "last_auth_method": None,
             "stamp_validated": False,
         }
+    if str(row.get("validation_status") or "").strip() in {
+        "invalid",
+        "failed",
+        "validation_failed",
+    }:
+        return {
+            "enabled": False,
+            "auth_state": "validation_failed",
+            "disabled_reason": "auth_invalid",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
     if credential_source == "oauth_volume" and volume_ref and volume_mount_path:
         return {
             "enabled": True,
@@ -121,18 +133,6 @@ def activation_backfill_for_row(row: dict[str, object]) -> dict[str, object]:
             "disabled_reason": None,
             "last_auth_method": "secret_ref",
             "stamp_validated": True,
-        }
-    if str(row.get("validation_status") or "").strip() in {
-        "invalid",
-        "failed",
-        "validation_failed",
-    }:
-        return {
-            "enabled": False,
-            "auth_state": "validation_failed",
-            "disabled_reason": "auth_invalid",
-            "last_auth_method": None,
-            "stamp_validated": False,
         }
     return {
         "enabled": False,
@@ -202,6 +202,29 @@ def _insert_first_party_setup_stubs() -> None:
 
 
 def _backfill_activation_state() -> None:
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            enabled = false,
+            auth_state = 'not_configured',
+            disabled_reason = 'policy_disabled',
+            last_auth_method = NULL
+        WHERE disabled_reason = 'policy_disabled'
+        """
+    )
+    op.execute(
+        """
+        UPDATE managed_agent_provider_profiles
+        SET
+            enabled = false,
+            auth_state = 'validation_failed',
+            disabled_reason = 'auth_invalid',
+            last_auth_method = NULL
+        WHERE enabled = true
+          AND validation_status IN ('invalid', 'failed', 'validation_failed')
+        """
+    )
     op.execute(
         """
         UPDATE managed_agent_provider_profiles

--- a/docs/ManagedAgents/ClaudeCodeMiniMax.md
+++ b/docs/ManagedAgents/ClaudeCodeMiniMax.md
@@ -31,14 +31,14 @@ The simplest path: add one line to your `.env` and `docker compose up`.
 
    Both the `api` and worker services (`temporal-worker-sandbox`, `temporal-worker-agent-runtime`) include `env_file: .env` in `docker-compose.yaml`, so the key is automatically available in every container that needs it.
 
-2. Run `docker compose up` (or restart if already running). On startup, the API service calls `_auto_seed_auth_profiles()` which checks for `MINIMAX_API_KEY` in the environment. If present, it seeds a `claude_minimax` profile alongside the default profiles:
+2. Run `docker compose up` (or restart if already running). On startup, the API service calls `_auto_seed_provider_profiles()` which checks for `MINIMAX_API_KEY` in the environment. If present, it seeds a `claude_minimax` profile alongside the default profiles:
 
    ```
    profile_id:           claude_minimax
    runtime_id:           claude_code
-   auth_mode:            api_key
-   api_key_ref:          MINIMAX_API_KEY
-   api_key_env_var:      ANTHROPIC_AUTH_TOKEN
+   credential_source:    secret_ref
+   secret_refs:
+     ANTHROPIC_AUTH_TOKEN: env://MINIMAX_API_KEY
    ```
 
 3. The auto-seeded profile also injects these runtime environment overrides into every Claude Code subprocess:
@@ -67,13 +67,12 @@ If auto-seeding has already run, create the profile through Mission Control or t
 
 ### Dashboard
 
-1. Open Mission Control and navigate to **Settings → Auth Profiles → Create Profile**.
+1. Open Mission Control and navigate to **Settings → Provider Profiles → Create Profile**.
 2. Fill in:
    - **Profile ID**: `claude_minimax`
    - **Runtime**: `claude_code`
-   - **Auth Mode**: `api_key`
-   - **API Key Ref**: `MINIMAX_API_KEY` — name of the worker env var holding your key
-   - **API Key Env Var (target)**: `ANTHROPIC_AUTH_TOKEN`
+   - **Credential Source**: `secret_ref`
+   - **Secret Ref**: map `ANTHROPIC_AUTH_TOKEN` to `env://MINIMAX_API_KEY`
    - **Runtime Env Overrides** (JSON):
      ```json
      {
@@ -87,15 +86,19 @@ If auto-seeding has already run, create the profile through Mission Control or t
 ### REST API
 
 ```bash
-curl -X POST http://localhost:8000/api/v1/auth-profiles \
+curl -X POST http://localhost:8000/api/v1/provider-profiles \
   -H 'Content-Type: application/json' \
   -d '{
     "profile_id": "claude_minimax",
     "runtime_id": "claude_code",
-    "auth_mode": "api_key",
-    "api_key_ref": "MINIMAX_API_KEY",
-    "api_key_env_var": "ANTHROPIC_AUTH_TOKEN",
-    "runtime_env_overrides": {
+    "provider_id": "minimax",
+    "provider_label": "MiniMax",
+    "credential_source": "secret_ref",
+    "runtime_materialization_mode": "env_bundle",
+    "secret_refs": {
+      "ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"
+    },
+    "env_template": {
       "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
       "ANTHROPIC_MODEL": "MiniMax-M2.7",
       "ANTHROPIC_SMALL_FAST_MODEL": "MiniMax-M2.7",
@@ -106,6 +109,8 @@ curl -X POST http://localhost:8000/api/v1/auth-profiles \
       "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
     },
     "max_parallel_runs": 1,
+    "auth_state": "connected",
+    "last_auth_method": "secret_ref",
     "enabled": true
   }'
 ```
@@ -118,15 +123,15 @@ curl -X POST http://localhost:8000/api/v1/auth-profiles \
 
 When the `ManagedAgentAdapter` launches a Claude Code subprocess using the `claude_minimax` profile:
 
-1. **`api_key_ref`** (`MINIMAX_API_KEY`) is resolved to the actual key value via `resolve_managed_api_key_reference()`. This looks up the worker-side env var `MINIMAX_API_KEY` (or a `vault://` reference).
-2. The resolved key is injected into the subprocess as `ANTHROPIC_AUTH_TOKEN` (the **`api_key_env_var`** target).
-3. All `runtime_env_overrides` are merged into the subprocess environment, pointing the Claude CLI at the MiniMax endpoint.
+1. The `secret_refs` entry `env://MINIMAX_API_KEY` is resolved to the actual key value at the provider-profile materialization boundary.
+2. The resolved key is injected into the subprocess as `ANTHROPIC_AUTH_TOKEN`.
+3. All configured environment template values are merged into the subprocess environment, pointing the Claude CLI at the MiniMax endpoint.
 
 ### Why `ANTHROPIC_AUTH_TOKEN` instead of `ANTHROPIC_API_KEY`?
 
 Claude Code treats `ANTHROPIC_AUTH_TOKEN` as a bearer-style credential for third-party API providers — it is accepted by the CLI for non-Anthropic endpoints. Using this variable avoids conflicting with a real `ANTHROPIC_API_KEY` that may be set elsewhere on the worker for the default `claude_default` profile.
 
-### Auth Profile Manager
+### ProviderProfileManager
 
 The `ProviderProfileManager` Temporal workflow for `claude_code` automatically manages concurrency slots across both the default Claude profile and the MiniMax profile. When a workflow execution requests `claude_code`, the manager selects an available profile based on slot availability and cooldown state.
 

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -55,7 +55,7 @@ Recent main-branch changes since the prior roadmap snapshot:
 - Codex, Gemini, and Claude Temporal activity workers (`codex-worker`, `gemini-worker`, `claude-worker`).
 - Runtime adapter pattern (`moonmind/agents/`, `moonmind/workflows/temporal/runtime/`).
 - Codex CLI workflow-scoped managed sessions with per-session sidecar Docker daemon.
-- Auth profile management UI in Mission Control; auto-seeding of default auth profiles on startup.
+- Provider profile management UI in Mission Control; auto-seeding of default provider profiles on startup.
 - Worker health checks and readiness probes; per-worker shard health view (MM-775).
 - Graceful worker pause/unpause API and Settings Operations surface.
 - MoonMind-native xterm.js OAuth terminal for provider login (spec 306), superseding the older Tmate-based design.

--- a/docs/Temporal/TemporalSignalsResearch.md
+++ b/docs/Temporal/TemporalSignalsResearch.md
@@ -6,7 +6,7 @@ MoonMind’s Temporal implementation is **Python-first**, with `temporalio` pinn
 
 On **Temporal Signals specifically**, MoonMind shows a **mixed level of maturity**:
 
-A substantial, working signal pattern exists around **auth-profile slot allocation**, where `AgentRun` signals an `AuthProfileManager` workflow (`request_slot`, `release_slot`, `report_cooldown`, `sync_profiles`), and the manager signals back (`slot_assigned`). citeturn50view0turn33view0turn49view0 The **OAuth session** workflow also uses simple `finalize`/`cancel` signals in an idiomatic “set flag + `wait_condition`” pattern. citeturn35view0turn35view2
+A substantial, working signal pattern exists around **provider-profile slot allocation**, where `AgentRun` signals an `ProviderProfileManager` workflow (`request_slot`, `release_slot`, `report_cooldown`, `sync_profiles`), and the manager signals back (`slot_assigned`). citeturn50view0turn33view0turn49view0 The **OAuth session** workflow also uses simple `finalize`/`cancel` signals in an idiomatic “set flag + `wait_condition`” pattern. citeturn35view0turn35view2
 
 However, the central **Run** workflow (which appears to be the main “execution orchestration” workflow) uses a mix of update and signal handlers for execution control. It defines **update handlers** for `Pause`, `Resume`, `Approve`, and `Cancel`, and **signal handlers** for asynchronous ingress via `ExternalEvent` and `reschedule`. Meanwhile, some higher layers still attempt to send signals like `"Pause"`, `"Resume"`, `"Approve"`, and `"ExternalEvent"` via `signal_execution`, and the client adapter uses batch `"pause"`/`"resume"`. This highlights a naming and pattern mismatch: the workflow defines acknowledged updates, but external clients sometimes try to trigger them as signals.
 
@@ -16,7 +16,7 @@ There is also a high-impact interaction with `start_delay`: MoonMind’s client 
 
 MoonMind’s Temporal code is concentrated under `moonmind/workflows/temporal/` (client adapter, service layer, worker wiring) and `moonmind/workflows/temporal/workflows/` (workflow implementations). citeturn29view0turn3view0 The orchestration surface includes:
 
-- **Workflow implementations**: `agent_run.py`, `auth_profile_manager.py`, `oauth_session.py`, `run.py`, plus smaller workflow(s). citeturn3view0turn30view0turn30view1turn31view0turn31view1  
+- **Workflow implementations**: `agent_run.py`, `provider_profile_manager.py`, `oauth_session.py`, `run.py`, plus smaller workflow(s). citeturn3view0turn30view0turn30view1turn31view0turn31view1
 - **Client adapter**: `moonmind/workflows/temporal/client.py` provides `start_workflow`, `signal_workflow`, `send_reschedule_signal`, `execute_update`, and batch pause/resume. citeturn39view3turn39view0turn39view1  
 - **Execution service**: `moonmind/workflows/temporal/service.py` implements `signal_execution(...)` and validates signal names against an allowed set, then forwards signals through the adapter. citeturn41view0turn42view0  
 
@@ -34,11 +34,11 @@ The table below inventories **explicit signal handlers** (decorated methods). If
 |---|---|---|---|---|---|---|
 | `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | `completion_signal` | `dict` representing `AgentRunResult(**result_dict)` | Yes citeturn32view0 | No citeturn32view1 | Yes (signals other workflows) citeturn50view0turn32view2 |
 | `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | `slot_assigned` | `dict` with `profile_id` | Yes citeturn32view0 | No citeturn32view1 | Yes citeturn50view0turn32view2 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | `request_slot` | `dict[str, Any]` (documented TypedDicts exist) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes (signals requesters) citeturn49view0 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | `release_slot` | `dict[str, Any]` (async handler) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes citeturn49view0 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | `report_cooldown` | `dict[str, Any]` (`cooldown_seconds` defaulted) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes citeturn49view0 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | `sync_profiles` | `dict[str, Any]` with `profiles: list[dict]` | Yes citeturn33view0 | No citeturn33view1 | Yes citeturn49view0 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | `shutdown` | no payload | Yes citeturn33view0 | No citeturn33view1 | Indirectly (loop termination) citeturn33view3 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | `request_slot` | `dict[str, Any]` (documented TypedDicts exist) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes (signals requesters) citeturn49view0 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | `release_slot` | `dict[str, Any]` (async handler) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes citeturn49view0 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | `report_cooldown` | `dict[str, Any]` (`cooldown_seconds` defaulted) | Yes citeturn33view0turn49view1 | No citeturn33view1 | Yes citeturn49view0 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | `sync_profiles` | `dict[str, Any]` with `profiles: list[dict]` | Yes citeturn33view0 | No citeturn33view1 | Yes citeturn49view0 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | `shutdown` | no payload | Yes citeturn33view0 | No citeturn33view1 | Indirectly (loop termination) citeturn33view3 |
 | `moonmind/workflows/temporal/workflows/oauth_session.py` | OAuthSession workflow | `finalize` | no payload | Yes citeturn35view0 | No citeturn35view1 | No |
 | `moonmind/workflows/temporal/workflows/oauth_session.py` | OAuthSession workflow | `cancel` | no payload | Yes citeturn35view0 | No citeturn35view1 | No |
 | `moonmind/workflows/temporal/workflows/run.py` | Run workflow | `Pause`, `Resume`, `Approve`, `Cancel` | — | **No** | **Yes** (`@workflow.update`) | No |
@@ -53,11 +53,11 @@ This table inventories where code **sends** signals (internal workflow-to-workfl
 
 | File path | Sender component | Target (intended) | Signal name | Payload shape | External handle used? |
 |---|---|---|---|---|---|
-| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | AuthProfileManager | `request_slot` | `{"requester_workflow_id", "runtime_id", "profile_selector"?}` citeturn50view0 | Yes (`workflow.get_external_workflow_handle`) citeturn50view0 |
-| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | AuthProfileManager | `release_slot` | `{"requester_workflow_id", "profile_id"}` citeturn50view2 | Yes citeturn50view2 |
-| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | AuthProfileManager | `report_cooldown` | `{"profile_id", "cooldown_seconds"}` citeturn50view3 | Yes citeturn50view3 |
-| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | AuthProfileManager | `sync_profiles` | `{"profiles": [...]}` citeturn32view0 | Yes citeturn32view0 |
-| `moonmind/workflows/temporal/workflows/auth_profile_manager.py` | AuthProfileManager workflow | AgentRun workflow | `slot_assigned` | `{"profile_id": ...}` citeturn49view0 | Yes citeturn49view0 |
+| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | ProviderProfileManager | `request_slot` | `{"requester_workflow_id", "runtime_id", "profile_selector"?}` citeturn50view0 | Yes (`workflow.get_external_workflow_handle`) citeturn50view0 |
+| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | ProviderProfileManager | `release_slot` | `{"requester_workflow_id", "profile_id"}` citeturn50view2 | Yes citeturn50view2 |
+| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | ProviderProfileManager | `report_cooldown` | `{"profile_id", "cooldown_seconds"}` citeturn50view3 | Yes citeturn50view3 |
+| `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | ProviderProfileManager | `sync_profiles` | `{"profiles": [...]}` citeturn32view0 | Yes citeturn32view0 |
+| `moonmind/workflows/temporal/workflows/provider_profile_manager.py` | ProviderProfileManager workflow | AgentRun workflow | `slot_assigned` | `{"profile_id": ...}` citeturn49view0 | Yes citeturn49view0 |
 | `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | Parent workflow (caller of AgentRun) | `child_state_changed` | `args=[state, message]` citeturn32view2turn50view0 | Yes citeturn32view2 |
 | `moonmind/workflows/temporal/workflows/agent_run.py` | AgentRun workflow | Parent workflow | `profile_assigned` | `{"profile_id", "child_workflow_id", "runtime_id"}` citeturn32view2 | Yes citeturn32view2 |
 | `moonmind/workflows/temporal/service.py` | `TemporalExecutionService.signal_execution` | Execution workflow (likely Run) | `"ExternalEvent"` | wrapper `{"payload": <dict>, "payload_artifact_ref": <str?>}` citeturn41view0turn42view3 | External via client adapter citeturn41view0 |
@@ -72,7 +72,7 @@ This table inventories where code **sends** signals (internal workflow-to-workfl
 MoonMind frequently uses the canonical **“signal flips state; workflow waits on condition”** model, which is explicitly shown in Temporal Python SDK examples. citeturn54search2 Observed call sites include:
 
 - `AgentRun`: waits for `slot_assigned_event` and `completion_event`. citeturn32view2turn32view0  
-- `AuthProfileManager`: waits for `_has_new_events` or shutdown with a periodic wake-up. citeturn33view3  
+- `ProviderProfileManager`: waits for `_has_new_events` or shutdown with a periodic wake-up. citeturn33view3
 - `OAuthSession`: waits for `_finalize_requested` or `_cancel_requested` with a TTL timeout. citeturn35view2  
 - `Run`: waits on `_reschedule_requested/_cancel_requested`, and later on `not self._paused`, relying on explicit `@workflow.update` and `@workflow.signal` handlers to flip those flags.
 
@@ -80,13 +80,13 @@ MoonMind frequently uses the canonical **“signal flips state; workflow waits o
 
 ### What MoonMind is already doing well
 
-MoonMind’s `AuthProfileManager` and `OAuthSession` show recognizable idioms:
+MoonMind’s `ProviderProfileManager` and `OAuthSession` show recognizable idioms:
 
 The **flag + `wait_condition`** approach is a standard and recommended pattern for signals in Temporal’s Python SDK examples. citeturn35view2turn33view3turn54search2 The handlers are mostly lightweight and deterministic (set state, append requests, set booleans), which is generally good practice for signal handlers.
 
 The code also uses **external workflow handles** (`workflow.get_external_workflow_handle(...)`) to coordinate between workflows. citeturn50view0turn49view0 This matches the SDK’s external handle support (the Python SDK exposes `get_external_workflow_handle` and `get_external_workflow_handle_for`). citeturn54search0
 
-Finally, the workflows actively use **versioning markers** (`workflow.patched(...)`) in long-running coordination paths (e.g., AgentRun slot wait behavior; AuthProfileManager lease persistence / verification), which is the right mechanism for evolving workflow behavior without breaking determinism. citeturn32view2turn33view3
+Finally, the workflows actively use **versioning markers** (`workflow.patched(...)`) in long-running coordination paths (e.g., AgentRun slot wait behavior; ProviderProfileManager lease persistence / verification), which is the right mechanism for evolving workflow behavior without breaking determinism. citeturn32view2turn33view3
 
 ### Key gaps and anti-patterns
 
@@ -102,10 +102,10 @@ Start Delay and signals can silently conflict without Signal-With-Start
 The client adapter can start workflows with `start_delay`. citeturn39view3 Temporal’s Start Delay feature explicitly documents that **during the delay, non–Signal-With-Start signals are ignored**. citeturn55search2 MoonMind does not appear to use Signal-With-Start in the adapter. citeturn39view2turn39view3 As a result, even if Run eventually had pause/reschedule handlers, a pause/reschedule sent “immediately after start” could be dropped if the workflow start is delayed.
 
 Signal payloads are mostly dynamically typed dicts; schema evolution risk is high  
-Temporal’s Python SDK docs strongly encourage a **single dataclass/Pydantic argument** for signals and updates, specifically to enable non-breaking addition of defaulted fields over time. citeturn53search2 MoonMind does document some payload shapes as `TypedDict` (e.g., in `auth_profile_manager.py`), but the live handler signatures still accept `dict[str, Any]`, and other flows use raw `dict`. citeturn49view1turn33view0turn32view0 This makes it harder to validate incoming messages, apply authorization consistently, and manage compatibility across clients over time.
+Temporal’s Python SDK docs strongly encourage a **single dataclass/Pydantic argument** for signals and updates, specifically to enable non-breaking addition of defaulted fields over time. citeturn53search2 MoonMind does document some payload shapes as `TypedDict` (e.g., in `provider_profile_manager.py`), but the live handler signatures still accept `dict[str, Any]`, and other flows use raw `dict`. citeturn49view1turn33view0turn32view0 This makes it harder to validate incoming messages, apply authorization consistently, and manage compatibility across clients over time.
 
 Signal concurrency and shared-state mutation is not explicitly guarded  
-Temporal’s Python SDK states that each signal/update handler executes in its own asyncio task, concurrently with other handlers and the main workflow task; it explicitly calls out using `asyncio.Lock`/`Semaphore` when needed. citeturn54search2 In MoonMind, `AuthProfileManager.release_slot` is `async` (yields), but other handlers like `request_slot` mutate shared structures (`_pending_requests`, `_profiles`) without an explicit lock. citeturn33view0 This may be fine if handlers are effectively single-threaded by design, but the SDK’s concurrency model means you should treat handler code as potentially concurrent and protect shared invariants if signals can arrive quickly.
+Temporal’s Python SDK states that each signal/update handler executes in its own asyncio task, concurrently with other handlers and the main workflow task; it explicitly calls out using `asyncio.Lock`/`Semaphore` when needed. citeturn54search2 In MoonMind, `ProviderProfileManager.release_slot` is `async` (yields), but other handlers like `request_slot` mutate shared structures (`_pending_requests`, `_profiles`) without an explicit lock. citeturn33view0 This may be fine if handlers are effectively single-threaded by design, but the SDK’s concurrency model means you should treat handler code as potentially concurrent and protect shared invariants if signals can arrive quickly.
 
 Idempotency/deduplication rules are not explicit  
 Temporal’s API includes a `request_id` field “used to de-dupe sent signals.” citeturn55search5 MoonMind’s signal payloads (and service wrappers) don’t clearly carry a signal command ID/idempotency key, and the manager does not obviously dedupe repeated `request_slot` calls (it appends to `_pending_requests`). citeturn33view0turn33view3 This can lead to duplicated work under client retries, replay of external systems, or repeated UI actions.
@@ -154,7 +154,7 @@ This aligns with Temporal’s explicit support for signal dedupe at the API leve
 
 Below are recommended canonical contracts. Where MoonMind already has a shape, it is preserved and formalized.
 
-**AuthProfileManager**
+**ProviderProfileManager**
 
 ```python
 class SlotRequest(SignalEnvelope):
@@ -323,7 +323,7 @@ Add explicit idempotency keys to signal payloads and enforce dedupe in handlers
 Temporal can dedupe signals when a stable `request_id` is supplied. citeturn55search5 Even if MoonMind doesn’t expose `request_id` directly at the adapter level, the application should carry a `command_id` and treat duplicates as no-ops. This is especially important for `request_slot` where duplicates can create multiple pending requests. citeturn33view0turn50view0
 
 Harden concurrency in workflows that mutate shared state from signals  
-Because signal handlers run as concurrent asyncio tasks, Temporal explicitly recommends locks/semaphores where needed. citeturn54search2 Add a workflow-level `asyncio.Lock` (deterministic) to `AuthProfileManager` around mutations of `_pending_requests` and `_profiles` to prevent interleavings between `release_slot` (async) and other signals.
+Because signal handlers run as concurrent asyncio tasks, Temporal explicitly recommends locks/semaphores where needed. citeturn54search2 Add a workflow-level `asyncio.Lock` (deterministic) to `ProviderProfileManager` around mutations of `_pending_requests` and `_profiles` to prevent interleavings between `release_slot` (async) and other signals.
 
 ### Potentially breaking changes
 
@@ -338,7 +338,7 @@ Temporal Python guidance recommends single dataclass/Pydantic parameters for for
 MoonMind has a docker-compose test harness that runs `pytest` for unit and “integration/orchestrator” suites. citeturn58view0 For Temporal signals, add a dedicated checklist:
 
 1) Unit tests with time-skipping environment  
-Temporal’s Python SDK provides examples of testing signals and timeouts with `WorkflowEnvironment.start_time_skipping()` and `handle.signal(...)`. citeturn54search2 Mirror that approach to test `Run.pause/resume/reschedule`, `OAuthSession.finalize/cancel`, and `AuthProfileManager` slot allocation.
+Temporal’s Python SDK provides examples of testing signals and timeouts with `WorkflowEnvironment.start_time_skipping()` and `handle.signal(...)`. citeturn54search2 Mirror that approach to test `Run.pause/resume/reschedule`, `OAuthSession.finalize/cancel`, and `ProviderProfileManager` slot allocation.
 
 2) Race tests  
 Send bursts of signals (`pause` then `resume`, concurrent `request_slot`, repeated `release_slot`) using `asyncio.gather` to validate idempotency and lock correctness. This directly targets the SDK’s concurrent handler execution model. citeturn54search2
@@ -383,7 +383,7 @@ This diagram reflects the current architecture (service → adapter → workflow
 
 ```mermaid
 flowchart TD
-  AR[AgentRun Workflow] -->|signal: request_slot| APM[AuthProfileManager Workflow]
+  AR[AgentRun Workflow] -->|signal: request_slot| APM[ProviderProfileManager Workflow]
   APM -->|signal: slot_assigned| AR
   AR -->|signal: release_slot| APM
   AR -->|signal: report_cooldown| APM

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5645,7 +5645,7 @@ export interface components {
         };
         /**
          * ManagedAgentRateLimitPolicy
-         * @description Rate limit handling policy for a managed agent auth profile.
+         * @description Rate limit handling policy for a managed agent provider profile.
          * @enum {string}
          */
         ManagedAgentRateLimitPolicy: "backoff" | "queue" | "fail_fast";

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -112,12 +112,17 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert claude_profile.volume_mount_path is None
     assert claude_profile.clear_env_keys == [
         "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+        "OPENAI_API_KEY",
+    ]
+    first_party_clear_keys = {p.profile_id: p.clear_env_keys for p in profiles}
+    assert first_party_clear_keys["claude_anthropic"] == [
+        "ANTHROPIC_API_KEY",
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_BASE_URL",
         "CLAUDE_API_KEY",
         "OPENAI_API_KEY",
     ]
-    first_party_clear_keys = {p.profile_id: p.clear_env_keys for p in profiles}
     assert first_party_clear_keys["gemini_default"] == [
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -17,6 +17,15 @@ from api_service.db.models import (
     RuntimeMaterializationMode,
 )
 
+FIRST_PARTY_SETUP_PROFILE_IDS = {
+    "gemini_google_default",
+    "gemini_default",
+    "codex_openai_default",
+    "codex_default",
+    "claude_anthropic_default",
+    "claude_anthropic",
+}
+
 @pytest.fixture()
 def _module_db(tmp_path):
     """Create a single in-memory SQLite engine and schema for the test."""
@@ -45,7 +54,7 @@ def _module_db(tmp_path):
 
 @pytest.mark.asyncio
 async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
-    """When the table is empty, auto-seeding should create 3 default profiles."""
+    """When the table is empty, auto-seeding should create setup stubs."""
     from api_service.main import _auto_seed_provider_profiles
 
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
@@ -59,27 +68,35 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 3
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS)
     profile_ids = {p.profile_id for p in profiles}
-    assert profile_ids == {"gemini_default", "codex_default", "claude_anthropic"}
+    assert profile_ids == FIRST_PARTY_SETUP_PROFILE_IDS
     # Standard profiles are seeded with default_model=None so they inherit
     # the runtime default (codex_cli→gpt-5.5, gemini_cli→gemini-3.1-pro,
     # claude_code→claude-opus-4-8) rather than storing a duplicate value.
     defaults = {p.profile_id: p.default_model for p in profiles}
-    assert defaults["gemini_default"] is None
-    assert defaults["codex_default"] is None
-    assert defaults["claude_anthropic"] is None
+    assert all(
+        defaults[profile_id] is None
+        for profile_id in FIRST_PARTY_SETUP_PROFILE_IDS
+    )
     runtime_defaults = {p.profile_id: p.is_default for p in profiles}
-    assert runtime_defaults["gemini_default"] is False
-    assert runtime_defaults["codex_default"] is False
-    assert runtime_defaults["claude_anthropic"] is False
+    assert all(
+        runtime_defaults[profile_id] is False
+        for profile_id in FIRST_PARTY_SETUP_PROFILE_IDS
+    )
     provider_ids = {p.profile_id: p.provider_id for p in profiles}
+    assert provider_ids["codex_openai_default"] == "openai"
     assert provider_ids["codex_default"] == "openai"
+    assert provider_ids["claude_anthropic_default"] == "anthropic"
     assert provider_ids["claude_anthropic"] == "anthropic"
     provider_labels = {p.profile_id: p.provider_label for p in profiles}
+    assert provider_labels["codex_openai_default"] == "OpenAI"
     assert provider_labels["codex_default"] == "OpenAI"
+    assert provider_labels["claude_anthropic_default"] == "Anthropic"
     assert provider_labels["claude_anthropic"] == "Anthropic"
-    claude_profile = next(p for p in profiles if p.profile_id == "claude_anthropic")
+    claude_profile = next(
+        p for p in profiles if p.profile_id == "claude_anthropic_default"
+    )
     assert claude_profile.enabled is False
     assert claude_profile.auth_state == ProviderProfileAuthState.NOT_CONFIGURED
     assert (
@@ -108,7 +125,7 @@ async def test_auto_seed_is_idempotent(_module_db, monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
     first = await _auto_seed_provider_profiles()
-    assert len(first) == 3
+    assert len(first) == len(FIRST_PARTY_SETUP_PROFILE_IDS)
 
     second = await _auto_seed_provider_profiles()
     assert second == []
@@ -117,7 +134,7 @@ async def test_auto_seed_is_idempotent(_module_db, monkeypatch):
     async with db_base.async_session_maker() as session:
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
-    assert len(profiles) == 3
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS)
 
 @pytest.mark.asyncio
 async def test_auto_seed_skipped_when_env_set(_module_db, monkeypatch):
@@ -148,7 +165,7 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 4
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS) + 1
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_anthropic" in profile_ids
     assert "claude_minimax" in profile_ids
@@ -182,7 +199,7 @@ async def test_auto_seed_adds_minimax_after_initial_seed(_module_db, monkeypatch
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     first = await _auto_seed_provider_profiles()
-    assert len(first) == 3
+    assert len(first) == len(FIRST_PARTY_SETUP_PROFILE_IDS)
 
     # Now the key becomes available.
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
@@ -193,7 +210,7 @@ async def test_auto_seed_adds_minimax_after_initial_seed(_module_db, monkeypatch
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 4
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS) + 1
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_anthropic" in profile_ids
     assert "claude_minimax" in profile_ids
@@ -309,7 +326,7 @@ async def test_auto_seed_backfills_claude_api_key_clear_env_for_existing_profile
 
 @pytest.mark.asyncio
 async def test_auto_seed_excludes_minimax_when_env_unset(_module_db, monkeypatch):
-    """When MINIMAX_API_KEY is absent, only the 3 default profiles are seeded."""
+    """When MINIMAX_API_KEY is absent, only first-party setup stubs are seeded."""
     from api_service.main import _auto_seed_provider_profiles
 
     monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
@@ -325,7 +342,7 @@ async def test_auto_seed_excludes_minimax_when_env_unset(_module_db, monkeypatch
     profile_ids = {p.profile_id for p in profiles}
     assert "claude_minimax" not in profile_ids
     assert "claude_anthropic" in profile_ids
-    assert len(profiles) == 3
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS)
 
 @pytest.mark.asyncio
 async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
@@ -344,7 +361,7 @@ async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
         result = await session.execute(select(ManagedAgentProviderProfile))
         profiles = result.scalars().all()
 
-    assert len(profiles) == 4
+    assert len(profiles) == len(FIRST_PARTY_SETUP_PROFILE_IDS) + 1
     profile_ids = {p.profile_id for p in profiles}
     assert "codex_openrouter_qwen36_plus" in profile_ids
 

--- a/tests/unit/api_service/test_provider_profile_enums.py
+++ b/tests/unit/api_service/test_provider_profile_enums.py
@@ -9,6 +9,7 @@ These tests verify:
 
 import enum
 import glob
+import importlib
 import os
 import re
 import asyncio
@@ -114,6 +115,132 @@ class TestProviderProfileActivationEnums:
     def test_last_auth_method_values_match_contract(self):
         expected = {"oauth_volume", "secret_ref", "manual"}
         assert {m.value for m in ProviderProfileAuthMethod} == expected
+
+class TestProviderProfileActivationMigrationBackfill:
+    """MM-879 activation backfill must not make unverified profiles launchable."""
+
+    @pytest.fixture()
+    def migration(self):
+        return importlib.import_module(
+            "api_service.migrations.versions.316_provider_profile_activation_state"
+        )
+
+    def test_enabled_oauth_volume_with_volume_binding_becomes_connected(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "oauth_volume",
+                "volume_ref": "claude-oauth",
+                "volume_mount_path": "/home/claude/.claude",
+            }
+        )
+
+        assert result == {
+            "enabled": True,
+            "auth_state": "connected",
+            "disabled_reason": None,
+            "last_auth_method": "oauth_volume",
+            "stamp_validated": True,
+        }
+
+    def test_enabled_secret_ref_with_secret_binding_becomes_connected(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "secret_ref",
+                "secret_refs": {"OPENAI_API_KEY": "db://openai"},
+            }
+        )
+
+        assert result == {
+            "enabled": True,
+            "auth_state": "connected",
+            "disabled_reason": None,
+            "last_auth_method": "secret_ref",
+            "stamp_validated": True,
+        }
+
+    def test_enabled_profile_without_credentials_is_disabled_missing_credentials(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "none",
+                "secret_refs": None,
+            }
+        )
+
+        assert result == {
+            "enabled": False,
+            "auth_state": "not_configured",
+            "disabled_reason": "missing_credentials",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+
+    def test_existing_disabled_profile_preserves_user_disabled_reason(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": False,
+                "credential_source": "secret_ref",
+                "secret_refs": {"OPENAI_API_KEY": "db://openai"},
+            }
+        )
+
+        assert result == {
+            "enabled": False,
+            "auth_state": "not_configured",
+            "disabled_reason": "user_disabled",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+
+    def test_enabled_profile_with_invalid_validation_is_disabled_auth_invalid(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "secret_ref",
+                "secret_refs": None,
+                "validation_status": "validation_failed",
+            }
+        )
+
+        assert result == {
+            "enabled": False,
+            "auth_state": "validation_failed",
+            "disabled_reason": "auth_invalid",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+
+    def test_policy_disabled_profile_is_not_backfilled_launchable(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "secret_ref",
+                "secret_refs": {"OPENAI_API_KEY": "db://openai"},
+                "disabled_reason": "policy_disabled",
+            }
+        )
+
+        assert result == {
+            "enabled": False,
+            "auth_state": "not_configured",
+            "disabled_reason": "policy_disabled",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
 
 # ---------------------------------------------------------------------------
 # 2. Data migration mapping logic

--- a/tests/unit/api_service/test_provider_profile_enums.py
+++ b/tests/unit/api_service/test_provider_profile_enums.py
@@ -202,15 +202,40 @@ class TestProviderProfileActivationMigrationBackfill:
             "stamp_validated": False,
         }
 
+    @pytest.mark.parametrize(
+        "validation_status",
+        ["invalid", "failed", "validation_failed"],
+    )
     def test_enabled_profile_with_invalid_validation_is_disabled_auth_invalid(
-        self, migration
+        self, migration, validation_status
     ):
         result = migration.activation_backfill_for_row(
             {
                 "enabled": True,
                 "credential_source": "secret_ref",
-                "secret_refs": None,
-                "validation_status": "validation_failed",
+                "secret_refs": {"OPENAI_API_KEY": "db://openai"},
+                "validation_status": validation_status,
+            }
+        )
+
+        assert result == {
+            "enabled": False,
+            "auth_state": "validation_failed",
+            "disabled_reason": "auth_invalid",
+            "last_auth_method": None,
+            "stamp_validated": False,
+        }
+
+    def test_enabled_oauth_profile_with_invalid_validation_is_not_connected(
+        self, migration
+    ):
+        result = migration.activation_backfill_for_row(
+            {
+                "enabled": True,
+                "credential_source": "oauth_volume",
+                "volume_ref": "claude-oauth",
+                "volume_mount_path": "/home/claude/.claude",
+                "validation_status": "invalid",
             }
         )
 
@@ -241,6 +266,36 @@ class TestProviderProfileActivationMigrationBackfill:
             "last_auth_method": None,
             "stamp_validated": False,
         }
+
+    def test_sql_backfill_handles_policy_and_validation_before_connecting(
+        self, migration, monkeypatch
+    ):
+        statements: list[str] = []
+
+        class FakeOp:
+            @staticmethod
+            def execute(statement):
+                statements.append(str(statement))
+
+        monkeypatch.setattr(migration, "op", FakeOp)
+
+        migration._backfill_activation_state()
+
+        assert len(statements) >= 4
+        assert "WHERE disabled_reason = 'policy_disabled'" in statements[0]
+        assert "disabled_reason = 'policy_disabled'" in statements[0]
+        assert (
+            "validation_status IN ('invalid', 'failed', 'validation_failed')"
+            in statements[1]
+        )
+        assert "auth_state = 'validation_failed'" in statements[1]
+        connected_statement_indexes = [
+            index
+            for index, statement in enumerate(statements)
+            if "auth_state = 'connected'" in statement
+        ]
+        assert connected_statement_indexes
+        assert min(connected_statement_indexes) > 1
 
 # ---------------------------------------------------------------------------
 # 2. Data migration mapping logic


### PR DESCRIPTION
Issue reference: MM-879

Summary:
- Adds provider profile activation/auth metadata fields and migration/backfill behavior for OAuth, SecretRef, setup-required, and invalid credential states.
- Seeds/backfills first-party setup-required provider profile stubs in disabled state and normalizes runtime defaults to launch-ready profiles only.
- Finishes provider-profile terminology cleanup in touched contracts/docs and adds migration/enum coverage.

Tests run:
- ./tools/test_unit.sh tests/unit/api_service/test_provider_profile_auto_seed.py tests/unit/api_service/test_provider_profile_enums.py

Remaining risks:
- Focused verification passed; full integration coverage was not run in this PR publication step.
