### PR TITLE
[codex] Fix workspace publish object store recovery

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9347,12 +9347,20 @@ class TemporalAgentRuntimeActivities:
         candidate_dirs: list[Path] = []
         try:
             candidate_dirs.extend(workspace_parent.iterdir())
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug(
+                "Could not scan workspace sibling object-store candidates for %s: %s",
+                workspace,
+                exc,
+            )
         try:
             candidate_dirs.extend(git_dir.iterdir())
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug(
+                "Could not scan in-git object-store candidates for %s: %s",
+                workspace,
+                exc,
+            )
 
         additions: list[str] = []
         for candidate_dir in candidate_dirs:
@@ -9572,10 +9580,6 @@ class TemporalAgentRuntimeActivities:
                 if repaired:
                     status_returncode, status_stdout, status_stderr = (
                         await _read_status()
-                    )
-                    detail = status_stderr.decode("utf-8", errors="replace").strip() or (
-                        status_stdout.decode("utf-8", errors="replace").strip()
-                        or "(no stderr)"
                     )
 
         if status_returncode != 0:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -9286,17 +9286,17 @@ class TemporalAgentRuntimeActivities:
 
     @staticmethod
     def _recover_orphan_workspace_object_stores(workspace: str) -> None:
-        """Register sibling object-stores as Git alternates before commit.
+        """Register orphan object-stores as Git alternates before commit.
 
         Some managed-runtime images stage loose objects in a directory that
-        sits *next to* the workspace ``.git`` directory (for example
-        ``<workspace_parent>/git-objects``) without writing a corresponding
-        ``.git/objects/info/alternates`` entry. When that happens, ``git
-        commit`` later fails with ``error: invalid object ... Error building
-        trees`` because the index references blobs the object database cannot
-        resolve.
+        sits outside ``.git/objects`` without writing a corresponding
+        ``.git/objects/info/alternates`` entry. Known shapes include sibling
+        directories such as ``<workspace_parent>/git-objects`` and in-git
+        directories such as ``<workspace>/.git/agent-objects``. When that
+        happens, later plain Git commands can fail with missing object errors
+        because refs or the index point at objects Git cannot resolve.
 
-        This helper finds such sibling directories, verifies they look like
+        This helper finds such orphan directories, verifies they look like
         git object stores, and appends them to ``info/alternates`` using a
         path relative to ``.git/objects`` (so that ``:`` characters in
         managed run ids do not break alternate parsing).
@@ -9344,36 +9344,41 @@ class TemporalAgentRuntimeActivities:
             except OSError:
                 continue
 
-        additions: list[str] = []
+        candidate_dirs: list[Path] = []
         try:
-            siblings = workspace_parent.iterdir()
-            for sibling in siblings:
-                try:
-                    sibling_resolved = sibling.resolve()
-                except OSError:
-                    continue
-                if sibling_resolved == workspace_resolved:
-                    continue
-                if sibling_resolved == objects_dir_resolved:
-                    continue
-                if sibling_resolved in registered:
-                    continue
-                if (
-                    not TemporalAgentRuntimeActivities
-                    ._looks_like_git_loose_objects_dir(sibling)
-                ):
-                    continue
-                try:
-                    relative = os.path.relpath(
-                        sibling_resolved,
-                        objects_dir_resolved,
-                    )
-                except ValueError:
-                    relative = str(sibling_resolved)
-                additions.append(relative)
-                registered.add(sibling_resolved)
+            candidate_dirs.extend(workspace_parent.iterdir())
         except OSError:
-            return
+            pass
+        try:
+            candidate_dirs.extend(git_dir.iterdir())
+        except OSError:
+            pass
+
+        additions: list[str] = []
+        for candidate_dir in candidate_dirs:
+            try:
+                candidate_resolved = candidate_dir.resolve()
+            except OSError:
+                continue
+            if candidate_resolved == workspace_resolved:
+                continue
+            if candidate_resolved == objects_dir_resolved:
+                continue
+            if candidate_resolved in registered:
+                continue
+            if not TemporalAgentRuntimeActivities._looks_like_git_loose_objects_dir(
+                candidate_dir
+            ):
+                continue
+            try:
+                relative = os.path.relpath(
+                    candidate_resolved,
+                    objects_dir_resolved,
+                )
+            except ValueError:
+                relative = str(candidate_resolved)
+            additions.append(relative)
+            registered.add(candidate_resolved)
 
         if not additions:
             return
@@ -9524,26 +9529,56 @@ class TemporalAgentRuntimeActivities:
         run_id: str,
         commit_message: str | None = None,
         env: Mapping[str, str] | None = None,
+        auth_env: Mapping[str, str] | None = None,
+        head_branch: str | None = None,
     ) -> dict[str, Any]:
         """Create one deterministic commit when the workspace is dirty."""
         command_env = dict(env) if env is not None else self._workspace_command_env(workspace)
 
-        status_proc = await asyncio.create_subprocess_exec(
-            *self._workspace_git_command(
-                workspace,
-                "status",
-                "--porcelain=v1",
-                "-z",
-                "--untracked-files=all",
-            ),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=command_env,
-        )
-        status_stdout, status_stderr = await asyncio.wait_for(
-            status_proc.communicate(), timeout=15,
-        )
-        if status_proc.returncode != 0:
+        async def _read_status() -> tuple[int, bytes, bytes]:
+            status_proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(
+                    workspace,
+                    "status",
+                    "--porcelain=v1",
+                    "-z",
+                    "--untracked-files=all",
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=command_env,
+            )
+            status_stdout, status_stderr = await asyncio.wait_for(
+                status_proc.communicate(), timeout=15,
+            )
+            return status_proc.returncode, status_stdout, status_stderr
+
+        status_returncode, status_stdout, status_stderr = await _read_status()
+        if status_returncode != 0:
+            detail = status_stderr.decode("utf-8", errors="replace").strip() or (
+                status_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            if (
+                self._is_missing_head_object_error(detail)
+                and isinstance(head_branch, str)
+                and head_branch.strip()
+            ):
+                repaired = await self._fetch_workspace_branch_for_missing_head(
+                    workspace=workspace,
+                    branch=head_branch,
+                    run_id=run_id,
+                    env=dict(auth_env) if auth_env is not None else command_env,
+                )
+                if repaired:
+                    status_returncode, status_stdout, status_stderr = (
+                        await _read_status()
+                    )
+                    detail = status_stderr.decode("utf-8", errors="replace").strip() or (
+                        status_stdout.decode("utf-8", errors="replace").strip()
+                        or "(no stderr)"
+                    )
+
+        if status_returncode != 0:
             detail = status_stderr.decode("utf-8", errors="replace").strip() or (
                 status_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
             )
@@ -9669,6 +9704,85 @@ class TemporalAgentRuntimeActivities:
             run_id,
         )
         return {"push_commit_message": normalized_message}
+
+    @staticmethod
+    def _is_missing_head_object_error(detail: str) -> bool:
+        normalized = str(detail or "").strip().lower()
+        if not normalized:
+            return False
+        return "bad object head" in normalized or (
+            "head" in normalized and "missing object" in normalized
+        )
+
+    async def _fetch_workspace_branch_for_missing_head(
+        self,
+        *,
+        workspace: str,
+        branch: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> bool:
+        branch_name = str(branch or "").strip()
+        if not branch_name or branch_name == "HEAD" or branch_name.startswith("-"):
+            return False
+
+        fetch_proc = await asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace,
+                "fetch",
+                "origin",
+                f"refs/heads/{branch_name}",
+            ),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=dict(env),
+        )
+        fetch_stdout, fetch_stderr = await asyncio.wait_for(
+            fetch_proc.communicate(), timeout=60,
+        )
+        if fetch_proc.returncode != 0:
+            detail = fetch_stderr.decode("utf-8", errors="replace").strip() or (
+                fetch_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            logger.warning(
+                "Could not repair missing workspace HEAD for run %s "
+                "(branch=%s): %s",
+                run_id,
+                branch_name,
+                detail,
+            )
+            return False
+
+        verify_proc = await asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace,
+                "cat-file",
+                "-e",
+                "HEAD^{commit}",
+            ),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=dict(env),
+        )
+        _, verify_stderr = await asyncio.wait_for(
+            verify_proc.communicate(), timeout=10,
+        )
+        if verify_proc.returncode == 0:
+            logger.info(
+                "Repaired missing workspace HEAD object for run %s by fetching %s.",
+                run_id,
+                branch_name,
+            )
+            return True
+
+        logger.warning(
+            "Workspace HEAD still invalid after fetching %s for run %s: %s",
+            branch_name,
+            run_id,
+            verify_stderr.decode("utf-8", errors="replace").strip()
+            or f"git cat-file exited with {verify_proc.returncode}",
+        )
+        return False
 
     @staticmethod
     def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:
@@ -9826,6 +9940,8 @@ class TemporalAgentRuntimeActivities:
                 run_id=run_id,
                 commit_message=commit_message,
                 env=command_env,
+                auth_env=auth_command_env,
+                head_branch=current_branch,
             )
             if commit_info.get("push_status") == "failed":
                 commit_info.setdefault("push_branch", current_branch)

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -332,6 +332,29 @@ class TestPushWorkspaceBranch:
             == ["../../../shared-objects"]
         )
 
+    def test_recover_orphan_object_stores_registers_git_agent_objects(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "mm:run-1" / "repo"
+        (workspace / ".git" / "objects" / "info").mkdir(parents=True)
+        agent_objects = workspace / ".git" / "agent-objects"
+        (agent_objects / "a5").mkdir(parents=True)
+        (agent_objects / "a5" / "894cc4848aec211f7257dad36030019d13596f").write_bytes(
+            b"x"
+        )
+
+        TemporalAgentRuntimeActivities._recover_orphan_workspace_object_stores(
+            str(workspace)
+        )
+
+        alternates_path = workspace / ".git" / "objects" / "info" / "alternates"
+        assert alternates_path.is_file()
+        assert (
+            alternates_path.read_text(encoding="utf-8").splitlines()
+            == ["../agent-objects"]
+        )
+
     @pytest.mark.asyncio
     async def test_push_recovers_orphan_object_store_before_branch_detection(
         self,
@@ -390,6 +413,71 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
 
         assert result["push_status"] == "protected_branch"
+
+    @pytest.mark.asyncio
+    async def test_commit_fetches_current_branch_after_missing_head_object(self):
+        activities = TemporalAgentRuntimeActivities(run_store=None)
+        workspace = "/work/agent_jobs/mm:run-1/repo"
+        calls: list[tuple[object, ...]] = []
+        envs: list[dict[str, str]] = []
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            calls.append(args)
+            envs.append(dict(kwargs.get("env") or {}))
+            proc = AsyncMock()
+            if call_count == 1:  # initial status --porcelain
+                proc.communicate = AsyncMock(
+                    return_value=(b"", b"fatal: bad object HEAD")
+                )
+                proc.returncode = 128
+            elif call_count == 2:  # fetch current branch to recover the object
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # verify HEAD is now present
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # retry status after repair
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:
+                raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._commit_workspace_changes_if_needed(
+                workspace,
+                run_id="mm:run-1",
+                env={"GIT_CONFIG_GLOBAL": "workspace-gitconfig"},
+                auth_env={
+                    "GIT_CONFIG_GLOBAL": "workspace-gitconfig",
+                    "GITHUB_TOKEN": "fake-token",
+                },
+                head_branch="feature/missing-head-object",
+            )
+
+        assert result == {}
+        assert list(calls[0][-4:]) == [
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ]
+        assert list(calls[1][-3:]) == [
+            "fetch",
+            "origin",
+            "refs/heads/feature/missing-head-object",
+        ]
+        assert envs[1]["GITHUB_TOKEN"] == "fake-token"
+        assert list(calls[2][-3:]) == ["cat-file", "-e", "HEAD^{commit}"]
+        assert list(calls[3][-4:]) == [
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ]
 
     @pytest.mark.asyncio
     async def test_push_protected_branch_main(self):


### PR DESCRIPTION
## Summary
- Register in-git orphan object stores such as `.git/agent-objects` as Git alternates before publish Git operations.
- Preserve the missing-HEAD branch fetch repair path and pass the authenticated Git environment into that recovery step.
- Add regression coverage for `.git/agent-objects` recovery and missing-HEAD publish repair.

## Root Cause
Workflow `mm:1e159b81-11e3-420d-9272-3031d1ed723a` failed during final publication because the branch ref pointed at a commit object stored under `.git/agent-objects`. Plain Git commands in the publish activity only saw `.git/objects`, so `git status` failed with `fatal: bad object HEAD`.

## Validation
- `git diff --cached --check`
- `PYTHONPATH=/tmp/moonmind-pr-fix-agent-object-store-publish /home/nsticco/MoonMind/.venv/bin/pytest tests/unit/services/temporal/test_fetch_result_push.py -q --tb=short` (`72 passed`)
- `./tools/test_unit.sh` in the source checkout after the same fix (`6770 passed, 6 skipped, 1 xpassed`; Vitest `464 passed | 236 skipped`)