### PR TITLE
[codex] Fix resolver workflow failure recovery

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -76,6 +76,10 @@ _TURN_ITEMS_PAGE_LIMIT = 200
 _TURN_ITEMS_MAX_PAGES = 20
 _EMPTY_ROLLOUT_READ_GRACE_SECONDS = 1.0
 _EMPTY_ROLLOUT_READ_RETRY_SECONDS = 0.1
+_SQLITE_STATE_RUNTIME_FAILURE_MARKERS: tuple[str, ...] = (
+    "failed to initialize sqlite state runtime",
+    "failed to initialize state runtime",
+)
 _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
@@ -563,6 +567,64 @@ class CodexManagedSessionRuntime:
                 notification_timeout_seconds=self._turn_completion_timeout_seconds,
             )
         return self._client
+
+    @staticmethod
+    def _is_sqlite_state_runtime_initialization_failure(error: BaseException) -> bool:
+        message = str(error).lower()
+        return all(
+            marker in message for marker in _SQLITE_STATE_RUNTIME_FAILURE_MARKERS
+        )
+
+    def _recover_sqlite_state_runtime_initialization(self) -> None:
+        """Best-effort recovery for transient Codex SQLite startup failures."""
+
+        self.close()
+        self._ensure_directories()
+        recovery_errors: list[str] = []
+        for sqlite_path in sorted(self._codex_home_path.glob("*.sqlite")):
+            connection: sqlite3.Connection | None = None
+            try:
+                connection = sqlite3.connect(
+                    str(sqlite_path),
+                    timeout=_LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS,
+                )
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchall()
+            except sqlite3.Error as exc:
+                recovery_errors.append(f"{sqlite_path.name}: {exc}")
+            finally:
+                if connection is not None:
+                    connection.close()
+
+            shm_path = sqlite_path.with_name(sqlite_path.name + "-shm")
+            try:
+                shm_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                recovery_errors.append(f"{shm_path.name}: {exc}")
+
+        detail = ""
+        if recovery_errors:
+            detail = " errors=" + "; ".join(recovery_errors[:4])
+        self._append_spool(
+            "stderr",
+            "codex sqlite state runtime recovery: checkpointed sqlite WAL "
+            f"after app-server initialization failure{detail}\n",
+        )
+
+    def _initialized_app_server_client(self) -> CodexAppServerRpcClient:
+        client = self._app_server_client()
+        try:
+            client.initialize()
+            return client
+        except RuntimeError as exc:
+            if not self._is_sqlite_state_runtime_initialization_failure(exc):
+                raise
+            self._recover_sqlite_state_runtime_initialization()
+
+        client = self._app_server_client()
+        client.initialize()
+        return client
 
     def close(self) -> None:
         if self._client is not None:
@@ -2210,8 +2272,7 @@ class CodexManagedSessionRuntime:
         if not active_turn_id:
             return state
 
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         try:
             thread_payload = client.request(
                 "thread/read",
@@ -2310,8 +2371,7 @@ class CodexManagedSessionRuntime:
     ) -> CodexManagedSessionHandle:
         self._ensure_directories()
         self._seed_codex_home_from_auth_volume()
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         started = client.request("thread/start", {"cwd": str(self._workspace_path)})
         thread_payload = started.get("thread")
         if not isinstance(thread_payload, Mapping):
@@ -2361,8 +2421,7 @@ class CodexManagedSessionRuntime:
         request: SendCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
         state = self._validate_locator(request)
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         vendor_thread_id = self._recovery_thread(client=client, state=state)
         rollout_mirror = self._new_rollout_live_mirror(state)
 
@@ -2543,8 +2602,7 @@ class CodexManagedSessionRuntime:
                     "reason": "steer_turn requires the active managed-session turn id"
                 },
             )
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         vendor_thread_id = self._recovery_thread(client=client, state=state)
         steer_params: dict[str, Any] = {
             "threadId": vendor_thread_id,
@@ -2596,8 +2654,7 @@ class CodexManagedSessionRuntime:
                     )
                 },
             )
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         interrupt_params = {
             "threadId": state.vendor_thread_id,
             "turnId": request.turn_id,
@@ -2625,8 +2682,7 @@ class CodexManagedSessionRuntime:
         request: CodexManagedSessionClearRequest,
     ) -> CodexManagedSessionHandle:
         state = self._validate_locator(request)
-        client = self._app_server_client()
-        client.initialize()
+        client = self._initialized_app_server_client()
         started = client.request("thread/start", {"cwd": str(self._workspace_path)})
         thread_payload = started.get("thread")
         if not isinstance(thread_payload, Mapping):

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -571,7 +571,7 @@ class CodexManagedSessionRuntime:
     @staticmethod
     def _is_sqlite_state_runtime_initialization_failure(error: BaseException) -> bool:
         message = str(error).lower()
-        return all(
+        return any(
             marker in message for marker in _SQLITE_STATE_RUNTIME_FAILURE_MARKERS
         )
 
@@ -599,6 +599,7 @@ class CodexManagedSessionRuntime:
             try:
                 shm_path.unlink()
             except FileNotFoundError:
+                # Absence is expected when SQLite did not leave shared-memory state.
                 pass
             except OSError as exc:
                 recovery_errors.append(f"{shm_path.name}: {exc}")

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2241,7 +2241,21 @@ class TemporalExecutionService:
                 MoonMindWorkflowState.CANCELED: TemporalExecutionCloseStatus.CANCELED,
             }[target_state]
 
-        record = await self._require_source_execution(workflow_id)
+        source_record = await self._load_source_execution(workflow_id)
+        if source_record is None:
+            projection_record = await self._load_projection_execution(
+                workflow_id,
+                include_orphaned=False,
+            )
+            if projection_record is None:
+                raise TemporalExecutionNotFoundError(
+                    f"Workflow execution {workflow_id} was not found"
+                )
+            record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord = (
+                projection_record
+            )
+        else:
+            record = source_record
         if record.state in TERMINAL_STATES and record.state is not target_state:
             raise TemporalExecutionValidationError(
                 f"Execution already terminal as {record.state.value}."
@@ -2254,9 +2268,12 @@ class TemporalExecutionService:
             )
             if record.close_status is None:
                 self._set_state(record, target_state, close_status=target_close_status)
-                await self._sync_integration_correlation_record(record)
-                await self._session.commit()
-                await self._session.refresh(record)
+                if isinstance(record, TemporalExecutionCanonicalRecord):
+                    await self._sync_integration_correlation_record(record)
+            await self._session.commit()
+            await self._session.refresh(record)
+            if isinstance(record, TemporalExecutionRecord):
+                return record
             await self._fan_out_dependency_resolution(record)
             return await self._sync_projection_best_effort(record)
 
@@ -2279,15 +2296,18 @@ class TemporalExecutionService:
             else:
                 self._update_summary(record, summary)
 
-        await self._sync_integration_correlation_record(record)
+        if isinstance(record, TemporalExecutionCanonicalRecord):
+            await self._sync_integration_correlation_record(record)
         await self._session.commit()
         await self._session.refresh(record)
+        if isinstance(record, TemporalExecutionRecord):
+            return record
         await self._fan_out_dependency_resolution(record)
         return await self._sync_projection_best_effort(record)
 
     def _record_finish_summary(
         self,
-        record: TemporalExecutionCanonicalRecord,
+        record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord,
         *,
         finish_outcome_code: str | None,
         finish_summary: dict[str, Any] | None,
@@ -3273,7 +3293,7 @@ class TemporalExecutionService:
 
     def _set_state(
         self,
-        record: TemporalExecutionCanonicalRecord,
+        record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord,
         state: MoonMindWorkflowState,
         *,
         close_status: TemporalExecutionCloseStatus | None = None,
@@ -3298,7 +3318,9 @@ class TemporalExecutionService:
             self._clear_waiting_metadata(record)
         self._touch(record)
 
-    def _touch(self, record: TemporalExecutionCanonicalRecord) -> None:
+    def _touch(
+        self, record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord
+    ) -> None:
         now = _utc_now()
         record.updated_at = now
 
@@ -3319,7 +3341,7 @@ class TemporalExecutionService:
 
     def _update_summary(
         self,
-        record: TemporalExecutionCanonicalRecord,
+        record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord,
         summary: str,
         *,
         error_category: str | None = None,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -117,8 +117,7 @@ if not os.path.exists(MARKER_PATH):
     with open(MARKER_PATH, "w", encoding="utf-8") as marker:
         marker.write("failed once\\n")
     sys.stderr.write(
-        "Error: failed to initialize sqlite state runtime under /tmp/codex-home: "
-        "failed to initialize state runtime at /tmp/codex-home\\n"
+        "Error: failed to initialize sqlite state runtime under /tmp/codex-home\\n"
     )
     sys.stderr.flush()
     sys.exit(1)

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -31,10 +31,12 @@ from tests.helpers.codex_session_runtime import (
     write_fake_app_server,
 )
 
+
 def _iso_timestamp(*, minutes_offset: int) -> str:
     return (
         datetime.now(UTC) + timedelta(minutes=minutes_offset)
     ).isoformat().replace("+00:00", "Z")
+
 
 def _write_fake_codex_logs(
     codex_home_path: str | Path,
@@ -57,6 +59,7 @@ def _write_fake_codex_logs(
     finally:
         connection.close()
     return log_path
+
 
 def _write_fake_codex_logs_with_timestamps(
     codex_home_path: str | Path,
@@ -84,6 +87,7 @@ def _write_fake_codex_logs_with_timestamps(
         connection.close()
     return log_path
 
+
 def _runtime_for_rollout_mirror(tmp_path: Path) -> CodexManagedSessionRuntime:
     request = launch_request(tmp_path)
     return CodexManagedSessionRuntime(
@@ -96,6 +100,78 @@ def _runtime_for_rollout_mirror(tmp_path: Path) -> CodexManagedSessionRuntime:
         container_id="ctr-1",
         app_server_command=("python3", "-c", "pass"),
     )
+
+
+def _write_flaky_sqlite_init_app_server(tmp_path: Path) -> Path:
+    script = tmp_path / "fake_flaky_sqlite_init_app_server.py"
+    marker_path = tmp_path / "sqlite-init-failed-once.marker"
+    script.write_text(
+        f"""
+import json
+import os
+import sys
+
+MARKER_PATH = {str(marker_path)!r}
+
+if not os.path.exists(MARKER_PATH):
+    with open(MARKER_PATH, "w", encoding="utf-8") as marker:
+        marker.write("failed once\\n")
+    sys.stderr.write(
+        "Error: failed to initialize sqlite state runtime under /tmp/codex-home: "
+        "failed to initialize state runtime at /tmp/codex-home\\n"
+    )
+    sys.stderr.flush()
+    sys.exit(1)
+
+for line in sys.stdin:
+    message = json.loads(line)
+    msg_id = message.get("id")
+    method = message.get("method")
+    if method == "initialize":
+        sys.stdout.write(json.dumps({{
+            "id": msg_id,
+            "result": {{
+                "userAgent": "fake/0.1",
+                "codexHome": "/tmp/fake-codex-home",
+                "platformFamily": "unix",
+                "platformOs": "linux",
+            }},
+        }}) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/start":
+        sys.stdout.write(json.dumps({{
+            "id": msg_id,
+            "result": {{
+                "thread": {{
+                    "id": "vendor-thread-recovered",
+                    "preview": "",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 1,
+                    "status": {{"type": "idle"}},
+                    "path": "/tmp/vendor-thread-recovered.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [],
+                }}
+            }},
+        }}) + "\\n")
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(json.dumps({{"id": msg_id, "result": {{}}}}) + "\\n")
+        sys.stdout.flush()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return script
+
 
 def _rollout_state(*, rollout_path: Path) -> CodexSessionRuntimeState:
     return CodexSessionRuntimeState(
@@ -152,6 +228,71 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
     assert state_payload["logicalThreadId"] == "logical-thread-1"
     assert state_payload["vendorThreadId"] == "vendor-thread-1"
     assert state_payload["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
+
+
+def test_runtime_clear_session_recovers_sqlite_state_runtime_init_failure(
+    tmp_path: Path,
+) -> None:
+    launch_script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(launch_script)),
+    )
+    runtime.launch_session(request)
+    runtime.close()
+
+    sqlite_path = Path(request.codex_home_path) / "state_1.sqlite"
+    connection = sqlite3.connect(sqlite_path)
+    try:
+        connection.execute("CREATE TABLE state_probe (id INTEGER PRIMARY KEY)")
+        connection.commit()
+    finally:
+        connection.close()
+    shm_path = sqlite_path.with_name(sqlite_path.name + "-shm")
+    shm_path.write_bytes(b"stale-shm")
+
+    retry_script = _write_flaky_sqlite_init_app_server(tmp_path)
+    retry_runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(retry_script)),
+    )
+
+    try:
+        handle = retry_runtime.clear_session(
+            CodexManagedSessionClearRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                newThreadId="logical-thread-2",
+                reason="retry_after_empty_assistant_output",
+            )
+        )
+
+        assert handle.status == "ready"
+        assert handle.session_state.session_epoch == 2
+        assert handle.session_state.thread_id == "logical-thread-2"
+        assert handle.metadata["vendorThreadId"] == "vendor-thread-recovered"
+        assert not shm_path.exists()
+        stderr_text = (Path(request.artifact_spool_path) / "stderr.log").read_text(
+            encoding="utf-8"
+        )
+        assert "codex sqlite state runtime recovery" in stderr_text
+    finally:
+        retry_runtime.close()
 
 def test_runtime_send_turn_returns_terminal_completed_response(
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1907,6 +1907,83 @@ async def test_record_terminal_state_fans_out_dependency_resolution_signals(
 
 
 @pytest.mark.asyncio
+async def test_record_terminal_state_updates_projection_only_child_workflow(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        owner_id = str(uuid4())
+        workflow_id = "resolver:pr:1919:head:aaedf7f60dc1:h:7db9d8b831520627:1"
+        now = datetime.now(UTC)
+        projection = TemporalExecutionRecord(
+            workflow_id=workflow_id,
+            run_id=str(uuid4()),
+            namespace="default",
+            workflow_type=TemporalWorkflowType.USER_WORKFLOW,
+            owner_id=owner_id,
+            owner_type=TemporalExecutionOwnerType.USER,
+            state=MoonMindWorkflowState.EXECUTING,
+            close_status=None,
+            entry="user_workflow",
+            search_attributes={
+                "mm_owner_type": "user",
+                "mm_owner_id": owner_id,
+                "mm_state": "executing",
+                "mm_updated_at": now.isoformat(),
+                "mm_entry": "user_workflow",
+            },
+            memo={"title": "Resolve PR #1919", "summary": "Executing."},
+            artifact_refs=[],
+            parameters={},
+            paused=False,
+            awaiting_external=False,
+            waiting_reason=None,
+            attention_required=False,
+            projection_version=1,
+            last_synced_at=now,
+            sync_state=TemporalExecutionProjectionSyncState.FRESH,
+            sync_error=None,
+            source_mode=TemporalExecutionProjectionSourceMode.PROJECTION_ONLY,
+            created_at=now,
+            started_at=now,
+            updated_at=now,
+            closed_at=None,
+        )
+        session.add(projection)
+        await session.commit()
+
+        result = await service.record_terminal_state(
+            workflow_id=workflow_id,
+            state="failed",
+            close_status="failed",
+            summary="codex app-server closed unexpectedly",
+            error_category="execution_error",
+            finish_outcome_code="FAILED",
+            finish_summary={"finishOutcome": {"code": "FAILED"}},
+        )
+
+        assert isinstance(result, TemporalExecutionRecord)
+        assert result.workflow_id == workflow_id
+        assert result.state is MoonMindWorkflowState.FAILED
+        assert result.close_status is TemporalExecutionCloseStatus.FAILED
+        assert result.closed_at is not None
+        assert result.finish_outcome_code == "FAILED"
+        assert result.finish_summary_json == {"finishOutcome": {"code": "FAILED"}}
+        assert result.memo["summary"] == (
+            "execution_error: codex app-server closed unexpectedly"
+        )
+        assert result.memo["error_category"] == "execution_error"
+        assert result.search_attributes["mm_state"] == "failed"
+        assert (
+            result.source_mode
+            is TemporalExecutionProjectionSourceMode.PROJECTION_ONLY
+        )
+        source = await session.get(TemporalExecutionCanonicalRecord, workflow_id)
+        assert source is None
+        mock_client_adapter.signal_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_record_terminal_state_preserves_existing_terminal_summary(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Summary

- recover Codex app-server startup once when SQLite state runtime initialization fails by checkpointing Codex-home SQLite WAL files and removing stale SHM files
- allow terminal-state recording to update non-orphan projection-only resolver workflows when no canonical source row exists
- add regressions for the Codex SQLite recovery path and projection-only resolver terminal-state recording

## Root Cause

Workflow `resolver:pr:1919:head:aaedf7f60dc1:h:7db9d8b831520627:1` failed during empty-output retry recovery because `agent_runtime.clear_session` could not initialize `codex app-server` against the run's Codex SQLite state. The later terminal-state recording path then failed because the resolver workflow was present as a Temporal projection row but not as a canonical source execution row.

## Validation

- PASS: `./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/runtime/test_codex_session_runtime.py::test_runtime_clear_session_recovers_sqlite_state_runtime_init_failure tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_updates_projection_only_child_workflow`
- PASS: `./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_fans_out_dependency_resolution_signals tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_preserves_existing_terminal_summary tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_indexes_finish_summary tests/unit/workflows/temporal/test_temporal_service.py::test_record_terminal_state_derives_snake_case_finish_outcome_code tests/unit/workflows/temporal/test_temporal_service.py::test_cancel_execution_accepts_projection_only_child_workflow` (`75 passed`)
- NOTE: after rebasing onto current `origin/main`, an additional local command that included three unrelated `create_execution` plan-source tests failed in those three tests while the two resolver regressions passed. Those failures are in `create_execution` validation fixtures outside this PR's changed behavior.