### PR TITLE
When I first change the runtime dropdown selector to something like "Claude Code", it temporarily spans the full width of the desktop view container a

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16753,4 +16753,56 @@ describe("Task Create runtime switch layout stability", () => {
     });
     expect(screen.getByLabelText("Provider profile")).toBeTruthy();
   });
+
+  it("withholds the previous runtime's profiles while a runtime switch refetches", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    // The initial runtime exposes its (Codex) profiles as selectable options.
+    await screen.findByLabelText("Provider profile");
+    expect(
+      (screen.getByLabelText("Provider profile") as HTMLSelectElement).disabled,
+    ).toBe(false);
+    expect(screen.getByRole("option", { name: /Codex Default/ })).toBeTruthy();
+
+    // Switch to a runtime whose provider profiles are still in-flight.
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Runtime"), {
+        target: { value: "claude_code" },
+      });
+    });
+
+    // Regression (codex r3463139233): keepPreviousData keeps the previous
+    // runtime's profiles in `data` only to stabilize layout. The control must
+    // not expose those stale profiles as selectable/submittable while the new
+    // runtime's profiles are still loading.
+    const switchingSelect = screen.getByLabelText(
+      "Provider profile",
+    ) as HTMLSelectElement;
+    expect(switchingSelect.disabled).toBe(true);
+    expect(screen.queryByRole("option", { name: /Codex Default/ })).toBeNull();
+    expect(
+      screen.queryByRole("option", { name: /Codex Secondary/ }),
+    ).toBeNull();
+
+    // Once the new runtime's profiles arrive, the control re-enables with its
+    // own options.
+    await act(async () => {
+      resolveClaudeProfiles?.([
+        {
+          profile_id: "profile:claude-default",
+          account_label: "Claude Default",
+          is_default: true,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Provider profile") as HTMLSelectElement)
+          .disabled,
+      ).toBe(false);
+    });
+    expect(screen.getByRole("option", { name: /Claude Default/ })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /Codex Default/ })).toBeNull();
+  });
 });

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16628,3 +16628,129 @@ describe("resolveDefaultProviderProfileId", () => {
     );
   });
 });
+
+describe("Task Create runtime switch layout stability", () => {
+  let fetchSpy: MockInstance;
+  let resolveClaudeProfiles:
+    | ((profiles: Array<Record<string, unknown>>) => void)
+    | null;
+
+  // The Runtime/Provider-profile row container is the parent of the wrapping
+  // <label> around the Runtime <select>. Its class toggles between "grid-2"
+  // (two columns / half width) and "stack" (single column / full width).
+  function runtimeRowContainer(): HTMLElement {
+    const container = screen.getByLabelText("Runtime").closest("label")
+      ?.parentElement;
+    expect(container).not.toBeNull();
+    return container as HTMLElement;
+  }
+
+  beforeEach(() => {
+    window.history.pushState({}, "Task Create", "/workflows/new");
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    vi.mocked(navigateTo).mockReset();
+    resolveClaudeProfiles = null;
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          const runtimeId = new URL(`http://localhost${url}`).searchParams.get(
+            "runtime_id",
+          );
+          if (runtimeId === "claude_code") {
+            // Hold the switched-to runtime's profiles in-flight so the test
+            // can observe the layout while the refetch is still pending.
+            return new Promise<Response>((resolve) => {
+              resolveClaudeProfiles = (profiles) =>
+                resolve({
+                  ok: true,
+                  json: async () => profiles,
+                } as Response);
+            });
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => [
+              {
+                profile_id: "profile:codex-default",
+                account_label: "Codex Default",
+                is_default: true,
+              },
+              {
+                profile_id: "profile:codex-secondary",
+                account_label: "Codex Secondary",
+                is_default: false,
+              },
+            ],
+          } as Response);
+        }
+        if (url.startsWith("/api/workflows/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: { worker: [] } }),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [{ value: "main", label: "main", source: "github" }],
+              defaultBranch: "main",
+              error: null,
+            }),
+          } as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [] }),
+        } as Response);
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("keeps the Runtime/Provider-profile row at half width while a runtime switch refetches profiles", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    // The initial runtime (codex_cli) loads two provider profiles, so the row
+    // renders as the two-column grid (half width each).
+    await screen.findByLabelText("Provider profile");
+    expect(runtimeRowContainer().className).toContain("grid-2");
+
+    // Switch to a runtime whose provider profiles are still in-flight.
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Runtime"), {
+        target: { value: "claude_code" },
+      });
+    });
+
+    // Regression (MM runtime-dropdown width flicker): the row must stay
+    // grid-2 during the refetch instead of collapsing to the full-width
+    // "stack" layout that hid the Provider profile field until the new
+    // profiles arrived.
+    expect(runtimeRowContainer().className).toContain("grid-2");
+    expect(runtimeRowContainer().className).not.toContain("stack");
+    expect(screen.getByLabelText("Provider profile")).toBeTruthy();
+
+    // Resolving the in-flight fetch swaps in the new runtime's profiles while
+    // the row stays at half width throughout.
+    await act(async () => {
+      resolveClaudeProfiles?.([
+        {
+          profile_id: "profile:claude-default",
+          account_label: "Claude Default",
+          is_default: true,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(runtimeRowContainer().className).toContain("grid-2");
+    });
+    expect(screen.getByLabelText("Provider profile")).toBeTruthy();
+  });
+});

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8793,9 +8793,14 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       isMergeAutomationPublishMode(publishMode) &&
       effectivePublishMode === "pr" &&
       !isSelfManagedPublishSkill(effectivePublishSkillId);
-    const selectedProviderProfile = (providerProfilesQuery.data || []).find(
-      (profile) => profile.profile_id === providerProfile,
-    );
+    // Never resolve a provider profile from placeholder data: during a runtime
+    // switch refetch `data` still holds the previous runtime's profiles, which
+    // must not be submitted under the newly selected runtime.
+    const selectedProviderProfile = providerProfilesQuery.isPlaceholderData
+      ? undefined
+      : (providerProfilesQuery.data || []).find(
+          (profile) => profile.profile_id === providerProfile,
+        );
     const selectedProviderId = selectedProviderProfile?.provider_id?.trim?.() || "";
 
     const taskPayload: Record<string, unknown> = {
@@ -10871,14 +10876,24 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                   name="providerProfile"
                   value={providerProfile}
                   onChange={(event) => setProviderProfile(event.target.value)}
+                  // While a runtime switch refetch is in flight, `keepPreviousData`
+                  // keeps the previous runtime's profiles in `data` only so the row
+                  // layout stays stable. Those profiles do not belong to the newly
+                  // selected runtime, so the control is disabled and the stale
+                  // options are withheld to prevent selecting/submitting them.
+                  disabled={providerProfilesQuery.isPlaceholderData}
                 >
-                  {providerOptions.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.isDefault
-                        ? `${option.label} (Default)`
-                        : option.label}
-                    </option>
-                  ))}
+                  {providerProfilesQuery.isPlaceholderData ? (
+                    <option value="">Loading profiles…</option>
+                  ) : (
+                    providerOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.isDefault
+                          ? `${option.label} (Default)`
+                          : option.label}
+                      </option>
+                    ))
+                  )}
                 </select>
               </label>
               {providerProfilesQuery.isError ? (

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
 import { createPortal } from "react-dom";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import type { BootPayload } from "../boot/parseBootPayload";
 import { SkillCombobox } from "../components/SkillCombobox";
@@ -4791,6 +4791,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       return (await response.json()) as ProviderProfile[];
     },
     enabled: Boolean(runtime),
+    // Keep the previously loaded profiles visible while a runtime switch
+    // refetches. Without this, the query key change empties `data`, which
+    // collapses the Runtime/Provider-profile row from `grid-2` to `stack`
+    // (full width) until the fetch resolves and it snaps back to half width.
+    placeholderData: keepPreviousData,
   });
 
   useEffect(() => {


### PR DESCRIPTION
When I first change the runtime dropdown selector to something like "Claude Code", it temporarily spans the full width of the desktop view container and covers provider profile. Eventually it seems to resize somehow back to half the page width as it should. Fix this bug.