### PR TITLE
MM-885: Add Batch Workflows orchestration preset

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: batch-workflows
+description: Resolve Jira board-column or GitHub repository issue targets and enqueue one child MoonMind workflow per target using a selected child preset, inherited runtime, and a shared publish policy.
+metadata:
+  required-capabilities:
+    - git
+    - jira
+    - gh
+---
+
+# Batch Workflows Skill
+
+## Purpose
+
+Resolve a set of issue-like targets, then queue one child MoonMind workflow per
+target running a selected child preset (for example `jira-implement` or
+`github-issue-implement`). Every child inherits the parent runtime
+(`runtimeInheritance="caller"`) and a single shared publish policy. The parent
+records a summary artifact that links every queued child workflow.
+
+This replaces one-off prompts like "Queue a Jira Implement preset for every issue
+in the In Progress column of the THOR board" with a single batch run.
+
+## Inputs (preset inputs / skill args)
+
+- `source_kind` (string, required): `jira_board_column` or `github_repo_issues`.
+- Jira board-column source: `jira_board_id`, `jira_column`, optional
+  `jira_label_filter`, `jira_issue_type_filter`, `jira_assignee_filter`, and
+  `repository` (target repo for implementation children; defaults to the parent
+  workflow repository when available).
+- GitHub repo issues source: `github_repository`, `github_issue_state`
+  (default `open`), optional `github_label_filter`, `github_assignee_filter`,
+  `github_milestone_filter`, `github_search_query`.
+- `target_preset_slug` / `target_preset_version` / `target_preset_scope`
+  (default `global`) / `target_preset_scope_ref`: the child preset to run per
+  target. Known issue presets (`jira-implement`, `github-issue-implement`) are
+  auto-bound; other presets must be mapped explicitly.
+- `constraints` (string, optional): shared input copied to every child.
+- `publish_mode` (string, required): `none`, `branch`, or `pr`.
+- `max_workflows` (number, optional): hard cap on queued children. Default `25`.
+- `sort` (string, optional): target ordering.
+
+## Workflow
+
+1. **Resolve targets** into the canonical resolved-target shape and write them to
+   `artifacts/batch-workflows-targets.json`, then preview the list before queueing.
+   - `jira_board_column`: use the deterministic trusted Jira tool surface to list
+     the issues in the selected column of the selected board, apply the optional
+     label/issue-type/assignee filters, sort, and cap at `max_workflows`. Each
+     target is:
+
+     ```json
+     {
+       "provider": "jira",
+       "ref": "THOR-123",
+       "jiraIssue": {"key": "THOR-123", "summary": "...", "description": "...",
+                      "url": "...", "status": "In Progress", "assignee": "..."},
+       "repository": "MoonLadderStudios/MoonMind"
+     }
+     ```
+
+   - `github_repo_issues`: use the trusted GitHub tool surface (`gh issue list`)
+     on the selected repository with the chosen state and optional
+     label/assignee/milestone/search filters, sort, and cap at `max_workflows`.
+     Each target is:
+
+     ```json
+     {
+       "provider": "github",
+       "ref": "MoonLadderStudios/MoonMind#123",
+       "githubIssue": {"repository": "MoonLadderStudios/MoonMind", "number": 123,
+                        "title": "...", "body": "...", "url": "...",
+                        "state": "open", "labels": ["..."]},
+       "repository": "MoonLadderStudios/MoonMind"
+     }
+     ```
+
+   Never use raw Jira/GitHub credentials, web scraping, or guessed issue content to
+   build the target list.
+
+2. **Queue child workflows** by running the helper:
+
+   ```bash
+   python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
+     --targets artifacts/batch-workflows-targets.json \
+     --target-preset-slug <slug> \
+     --target-preset-version <version> \
+     --target-preset-scope <global|personal> \
+     --publish-mode <none|branch|pr> \
+     --constraints-file <optional path to shared constraints> \
+     --max-workflows <cap>
+   ```
+
+   For each resolved target the helper:
+   - Auto-binds the issue target into the child preset's issue input
+     (`jira_issue` + `jira_issue_key` for `jira-implement`; `github_issue` +
+     `github_issue_ref` for `github-issue-implement`) and copies the shared
+     `constraints` into every child.
+   - Stamps `runtimeInheritance="caller"` plus a fallback copy of the parent's
+     effective runtime (mode/model/effort/provider profile) so children reuse the
+     caller runtime even on deployments that do not honour the inheritance
+     contract.
+   - Applies the chosen `publish.mode` once to every child.
+   - Assigns a stable idempotency key per `(batch scope, target ref)` so rerunning
+     the same batch does not create duplicate child workflows.
+   - Submits via the internal Temporal execution API (`POST /api/executions`);
+     `MOONMIND_URL` must point at the MoonMind API from the managed session.
+
+3. **Record the summary**: the helper writes `artifacts/batch-workflows-result.json`
+   linking every queued child workflow id together with the resolved targets,
+   skips, and errors, and prints a short `queued/skipped/errors` count summary.
+
+## Safety constraints
+
+- Require `MOONMIND_URL` to reach the MoonMind API; the legacy direct-DB queue is
+  not supported.
+- Never re-select provider/model/effort in the batch form — children inherit the
+  caller runtime.
+- Cap the resolved list at `max_workflows`.
+- Targets whose selected preset is not auto-bindable and has no explicit mapping
+  are skipped with a clear `unsupported_preset` reason rather than queued blindly.

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -1,0 +1,713 @@
+#!/usr/bin/env python3
+"""Queue one child MoonMind workflow per resolved issue target.
+
+The agent resolves Jira board-column or GitHub repository issue targets into the
+canonical resolved-target shape (see SKILL.md) and writes them to a JSON file.
+This helper reads that file plus the selected child preset / publish policy and
+submits one child execution per target through the internal Temporal execution
+API. Every child inherits the parent runtime via ``runtimeInheritance="caller"``
+(with a fallback copy of the effective runtime fields) and shares a single
+publish policy. A summary artifact links every queued child workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from moonmind.workflows.executions.execution_contract import SUPPORTED_PUBLISH_MODES
+from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
+
+logger = logging.getLogger(__name__)
+
+API_EXECUTIONS_ENDPOINT = "/api/executions"
+IDEMPOTENCY_KEY_MAX_LENGTH = 128
+
+# Presets whose issue input the batch form auto-binds. The resolved target is
+# mapped into these presets' issue inputs and the server goal scheduler expands
+# the matching preset from the queued child goal.
+AUTO_BINDABLE_PRESETS = frozenset({"jira-implement", "github-issue-implement"})
+
+
+@dataclass
+class ChildSubmission:
+    queue_request: dict[str, Any]
+    provider: str
+    ref: str
+
+
+@dataclass
+class SkippedTarget:
+    ref: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RuntimeSelection:
+    mode: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    provider_profile: str | None = None
+
+
+@dataclass
+class TargetConfig:
+    preset_slug: str
+    preset_version: str
+    preset_scope: str = "global"
+    preset_scope_ref: str | None = None
+    publish_mode: str = "pr"
+    constraints: str = ""
+    required_capabilities: list[str] = field(default_factory=list)
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    return candidate or None
+
+
+def _normalize_publish_mode(value: str | None) -> str:
+    candidate = str(value or "").strip().lower()
+    if candidate not in SUPPORTED_PUBLISH_MODES:
+        return "pr"
+    return candidate
+
+
+def _required_capabilities_for(provider: str) -> list[str]:
+    base = ["git"]
+    if provider == "jira":
+        base += ["jira", "gh"]
+    elif provider == "github":
+        base += ["gh"]
+    return base
+
+
+def child_goal_for_target(target: dict[str, Any], preset_slug: str) -> str | None:
+    """Return the goal text that routes the server scheduler to ``preset_slug``.
+
+    Returns ``None`` when the target cannot be auto-bound to the selected preset.
+    """
+
+    provider = str(target.get("provider") or "").strip().lower()
+    if preset_slug == "jira-implement" and provider == "jira":
+        issue = (
+            target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
+        )
+        key = _text(issue.get("key")) or _text(target.get("ref"))
+        if key:
+            return f"Implement Jira issue {key}."
+        return None
+    if preset_slug == "github-issue-implement" and provider == "github":
+        issue = (
+            target.get("githubIssue")
+            if isinstance(target.get("githubIssue"), dict)
+            else {}
+        )
+        repository = _text(issue.get("repository")) or _text(target.get("repository"))
+        number = issue.get("number")
+        ref = _text(target.get("ref"))
+        if repository and number is not None:
+            return f"Implement GitHub issue {repository}#{number}."
+        if ref:
+            return f"Implement GitHub issue {ref}."
+        return None
+    return None
+
+
+def bind_child_inputs(
+    target: dict[str, Any], preset_slug: str, constraints: str
+) -> dict[str, Any] | None:
+    """Apply the default issue bindings for the selected child preset.
+
+    Mirrors the ``annotations.bindings`` declared by the ``batch-workflows``
+    preset. Returns ``None`` when the preset is not auto-bindable for the target.
+    """
+
+    provider = str(target.get("provider") or "").strip().lower()
+    shared = _text(constraints)
+    if preset_slug == "jira-implement" and provider == "jira":
+        issue = (
+            target.get("jiraIssue") if isinstance(target.get("jiraIssue"), dict) else {}
+        )
+        key = _text(issue.get("key")) or _text(target.get("ref"))
+        if not key:
+            return None
+        inputs: dict[str, Any] = {
+            "jira_issue": dict(issue) if issue else {"key": key},
+            "jira_issue_key": key,
+            "constraints": shared or "",
+        }
+        return inputs
+    if preset_slug == "github-issue-implement" and provider == "github":
+        issue = (
+            target.get("githubIssue")
+            if isinstance(target.get("githubIssue"), dict)
+            else {}
+        )
+        repository = _text(issue.get("repository")) or _text(target.get("repository"))
+        number = issue.get("number")
+        if not repository or number is None:
+            return None
+        inputs = {
+            "github_issue": dict(issue),
+            "github_issue_ref": f"{repository}#{number}",
+            "constraints": shared or "",
+        }
+        return inputs
+    return None
+
+
+def _child_idempotency_key(
+    *, batch_scope: str | None, provider: str, ref: str, preset_slug: str
+) -> str | None:
+    scope = _text(batch_scope)
+    if not scope:
+        return None
+    components = {
+        "scope": scope,
+        "provider": provider,
+        "ref": ref,
+        "preset": preset_slug,
+    }
+    canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    safe_ref = re.sub(r"[^A-Za-z0-9_.#/-]+", "_", ref)[:32]
+    key = f"batch-workflows:{provider}:{safe_ref}:sha256:{digest}"
+    if len(key) > IDEMPOTENCY_KEY_MAX_LENGTH:
+        key = f"batch-workflows:sha256:{digest}"
+    if len(key) > IDEMPOTENCY_KEY_MAX_LENGTH:
+        raise RuntimeError("generated child idempotency key exceeds storage limit")
+    return key
+
+
+def build_child_request(
+    target: dict[str, Any],
+    *,
+    config: TargetConfig,
+    runtime: RuntimeSelection,
+    batch_scope: str | None = None,
+    inherit_runtime_from_caller: bool = False,
+) -> dict[str, Any] | None:
+    """Build a single ``POST /api/executions`` request for one resolved target.
+
+    Returns ``None`` when the target cannot be auto-bound to the selected preset.
+    """
+
+    provider = str(target.get("provider") or "").strip().lower()
+    ref = _text(target.get("ref")) or ""
+    repository = _text(target.get("repository"))
+    if not ref:
+        return None
+
+    goal = child_goal_for_target(target, config.preset_slug)
+    inputs = bind_child_inputs(target, config.preset_slug, config.constraints)
+    if goal is None or inputs is None:
+        return None
+
+    publish_mode = _normalize_publish_mode(config.publish_mode)
+    required_capabilities = config.required_capabilities or _required_capabilities_for(
+        provider
+    )
+
+    task_payload: dict[str, Any] = {
+        "goal": goal,
+        "instructions": goal,
+        "inputs": inputs,
+        "publish": {"mode": publish_mode},
+        "batchTargetPreset": {
+            "slug": config.preset_slug,
+            "version": config.preset_version,
+            "scope": config.preset_scope,
+            **(
+                {"scopeRef": config.preset_scope_ref}
+                if _text(config.preset_scope_ref)
+                else {}
+            ),
+        },
+    }
+
+    payload_dict: dict[str, Any] = {
+        "requiredCapabilities": required_capabilities,
+        "task": task_payload,
+    }
+    if repository:
+        payload_dict["repository"] = repository
+
+    # Server-side inheritance contract: when running inside a workflow with a
+    # workflow-scoped credential, opt into runtimeInheritance="caller" so the API
+    # copies the parent's effective runtime/provider profile. The explicit
+    # targetRuntime/task.runtime fallback is preserved for deployments that do
+    # not yet honour the inheritance contract.
+    if inherit_runtime_from_caller:
+        payload_dict["runtimeInheritance"] = "caller"
+
+    runtime_payload: dict[str, Any] = {}
+    if runtime.mode:
+        runtime_payload["mode"] = runtime.mode
+        payload_dict["targetRuntime"] = runtime.mode
+    if runtime.model:
+        runtime_payload["model"] = runtime.model
+    if runtime.effort:
+        runtime_payload["effort"] = runtime.effort
+    if runtime.provider_profile:
+        runtime_payload["executionProfileRef"] = runtime.provider_profile
+    if runtime_payload:
+        task_payload["runtime"] = runtime_payload
+
+    idempotency_key = _child_idempotency_key(
+        batch_scope=batch_scope,
+        provider=provider,
+        ref=ref,
+        preset_slug=config.preset_slug,
+    )
+    if idempotency_key:
+        payload_dict["idempotencyKey"] = idempotency_key
+
+    return {
+        "type": "task",
+        "priority": 0,
+        "maxAttempts": 3,
+        "payload": payload_dict,
+    }
+
+
+def build_child_requests(
+    targets: list[dict[str, Any]],
+    *,
+    config: TargetConfig,
+    runtime: RuntimeSelection,
+    max_workflows: int,
+    batch_scope: str | None = None,
+    inherit_runtime_from_caller: bool = False,
+) -> tuple[list[ChildSubmission], list[SkippedTarget]]:
+    """Build child requests, capped at ``max_workflows`` resolved targets."""
+
+    submissions: list[ChildSubmission] = []
+    skipped: list[SkippedTarget] = []
+
+    capped = targets[: max(0, int(max_workflows))] if max_workflows else targets
+    if max_workflows and len(targets) > max_workflows:
+        for overflow in targets[max_workflows:]:
+            skipped.append(
+                SkippedTarget(
+                    ref=str(overflow.get("ref") or "(unknown)"),
+                    reason="max_workflows_exceeded",
+                )
+            )
+
+    for target in capped:
+        ref = str(target.get("ref") or "(unknown)")
+        if config.preset_slug not in AUTO_BINDABLE_PRESETS:
+            skipped.append(SkippedTarget(ref=ref, reason="unsupported_preset"))
+            continue
+        request = build_child_request(
+            target,
+            config=config,
+            runtime=runtime,
+            batch_scope=batch_scope,
+            inherit_runtime_from_caller=inherit_runtime_from_caller,
+        )
+        if request is None:
+            skipped.append(SkippedTarget(ref=ref, reason="unbindable_target"))
+            continue
+        submissions.append(
+            ChildSubmission(
+                queue_request=request,
+                provider=str(target.get("provider") or "").strip().lower(),
+                ref=ref,
+            )
+        )
+
+    return submissions, skipped
+
+
+# --------------------------------------------------------------------------- #
+# Runtime inheritance + environment helpers (parallels batch-pr-resolver).
+# --------------------------------------------------------------------------- #
+def _normalize_runtime_mode(value: str | None) -> str | None:
+    candidate = str(value or "").strip().lower()
+    return candidate or None
+
+
+def _runtime_modes_match(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    return normalize_runtime_id(left) == normalize_runtime_id(right)
+
+
+def _task_context_candidates(task_context_path: str | None) -> list[Path]:
+    candidates: list[Path] = []
+    if task_context_path:
+        candidates.append(Path(task_context_path))
+    for env_key in ("MOONMIND_TASK_CONTEXT_PATH", "TASK_CONTEXT_PATH"):
+        env_value = _text(os.getenv(env_key))
+        if env_value:
+            candidates.append(Path(env_value))
+    candidates.extend(
+        [Path("../artifacts/task_context.json"), Path("artifacts/task_context.json")]
+    )
+    return candidates
+
+
+def _load_parent_runtime_selection(
+    task_context_path: str | None = None,
+) -> RuntimeSelection | None:
+    seen: set[str] = set()
+    for candidate in _task_context_candidates(task_context_path):
+        identity = str(candidate.expanduser())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        runtime_config = (
+            payload.get("runtimeConfig")
+            if isinstance(payload.get("runtimeConfig"), dict)
+            else {}
+        )
+        runtime_node = (
+            payload.get("runtime") if isinstance(payload.get("runtime"), dict) else {}
+        )
+        mode = _normalize_runtime_mode(
+            runtime_config.get("mode")
+            or runtime_node.get("mode")
+            or payload.get("runtime")
+        )
+        if not mode:
+            continue
+        return RuntimeSelection(
+            mode=mode,
+            model=_text(runtime_config.get("model") or runtime_node.get("model")),
+            effort=_text(runtime_config.get("effort") or runtime_node.get("effort")),
+            provider_profile=_text(
+                runtime_config.get("providerProfile")
+                or runtime_config.get("profileId")
+                or runtime_node.get("providerProfile")
+                or runtime_node.get("profileId")
+            ),
+        )
+    return None
+
+
+def _resolve_runtime_selection(task_context_path: str | None) -> RuntimeSelection:
+    inherited = _load_parent_runtime_selection(task_context_path)
+    configured_default_mode = _normalize_runtime_mode(
+        os.getenv("MOONMIND_DEFAULT_RUNTIME")
+    )
+    execution_profile_ref = _text(os.getenv("MOONMIND_EXECUTION_PROFILE_REF"))
+    execution_profile_runtime = _text(os.getenv("MOONMIND_EXECUTION_PROFILE_RUNTIME"))
+    execution_profile_mode = (
+        _normalize_runtime_mode(execution_profile_runtime)
+        if execution_profile_ref
+        else None
+    )
+    runtime_mode = (
+        (inherited.mode if inherited else None)
+        or execution_profile_mode
+        or configured_default_mode
+    )
+    runtime_model = inherited.model if inherited else None
+    runtime_effort = inherited.effort if inherited else None
+    runtime_provider_profile = inherited.provider_profile if inherited else None
+    if runtime_provider_profile is None and _runtime_modes_match(
+        runtime_mode, execution_profile_runtime
+    ):
+        runtime_provider_profile = execution_profile_ref
+    return RuntimeSelection(
+        mode=runtime_mode,
+        model=runtime_model,
+        effort=runtime_effort,
+        provider_profile=runtime_provider_profile,
+    )
+
+
+def _task_workflow_id_from_env() -> str | None:
+    for env_key in (
+        "MOONMIND_TASK_WORKFLOW_ID",
+        "MOONMIND_WORKFLOW_ID",
+        "TEMPORAL_WORKFLOW_ID",
+    ):
+        value = _text(os.getenv(env_key))
+        if value:
+            return value
+    return None
+
+
+def _agent_run_id_from_env() -> str | None:
+    for env_key in ("MOONMIND_AGENT_RUN_ID", "MOONMIND_RUN_ID", "AGENT_RUN_ID"):
+        value = _text(os.getenv(env_key))
+        if value:
+            return value
+    return None
+
+
+def _parent_run_scope(task_context_path: str | None) -> str | None:
+    for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
+        value = _text(os.getenv(env_key))
+        if value:
+            return value
+    spool = _text(os.getenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"))
+    if spool:
+        digest = hashlib.sha256(spool.encode("utf-8")).hexdigest()[:24]
+        return f"path:{digest}"
+    return None
+
+
+def _session_artifact_spool_path() -> Path | None:
+    raw = _text(os.getenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"))
+    return Path(raw) if raw else None
+
+
+def _resolve_artifacts_dir(raw_artifacts_dir: str) -> Path:
+    raw = str(raw_artifacts_dir or "").strip()
+    if not raw or raw == "artifacts":
+        spool = _session_artifact_spool_path()
+        if spool is not None:
+            return spool
+    return Path(raw or "artifacts")
+
+
+def _read_targets(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        payload = payload.get("targets")
+    if not isinstance(payload, list):
+        raise RuntimeError('targets file must be a JSON list (or {"targets": [...]}).')
+    targets: list[dict[str, Any]] = []
+    for item in payload:
+        if isinstance(item, dict):
+            targets.append(item)
+    return targets
+
+
+def _read_constraints(args: argparse.Namespace) -> str:
+    if args.constraints is not None:
+        return str(args.constraints)
+    if args.constraints_file:
+        path = Path(args.constraints_file)
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8")
+    return ""
+
+
+def _read_worker_token() -> str | None:
+    token = _text(os.getenv("MOONMIND_WORKER_TOKEN"))
+    if token:
+        return token
+    token_file = _text(os.getenv("MOONMIND_WORKER_TOKEN_FILE"))
+    if token_file:
+        path = Path(token_file)
+        if path.exists():
+            return path.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+async def _submit_jobs_via_http(
+    submissions: list[ChildSubmission],
+    *,
+    moonmind_url: str,
+    worker_token: str | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    created: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if worker_token:
+        headers["X-MoonMind-Worker-Token"] = worker_token
+    task_workflow_id = _task_workflow_id_from_env()
+    if task_workflow_id:
+        headers["X-MoonMind-Task-Workflow-Id"] = task_workflow_id
+    agent_run_id = _agent_run_id_from_env()
+    if agent_run_id:
+        headers["X-MoonMind-Agent-Run-Identifier"] = agent_run_id
+    base = moonmind_url.rstrip("/")
+    async with httpx.AsyncClient(
+        base_url=base, timeout=30.0, headers=headers
+    ) as client:
+        for submission in submissions:
+            request = submission.queue_request
+            body = {
+                "type": str(request["type"]),
+                "payload": request["payload"],
+                "priority": int(request.get("priority", 0)),
+                "maxAttempts": int(request.get("maxAttempts", 3)),
+            }
+            try:
+                response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
+                response.raise_for_status()
+                data = response.json()
+                job_id = (
+                    str(
+                        data.get("workflowId")
+                        or data.get("taskId")
+                        or data.get("id")
+                        or ""
+                    )
+                    or "(unknown)"
+                )
+                created.append(
+                    {
+                        "provider": submission.provider,
+                        "ref": submission.ref,
+                        "workflowId": job_id,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001 - reported per target
+                errors.append(
+                    {
+                        "provider": submission.provider,
+                        "ref": submission.ref,
+                        "error": str(exc),
+                    }
+                )
+    return created, errors
+
+
+async def _submit_jobs(
+    submissions: list[ChildSubmission],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    moonmind_url = _text(os.getenv("MOONMIND_URL"))
+    if moonmind_url:
+        return await _submit_jobs_via_http(
+            submissions,
+            moonmind_url=moonmind_url,
+            worker_token=_read_worker_token(),
+        )
+    message = (
+        "MOONMIND_URL is not set; batch-workflows requires the MoonMind Temporal "
+        "execution API and cannot submit via the removed legacy DB queue."
+    )
+    return [], [
+        {"provider": submission.provider, "ref": submission.ref, "error": message}
+        for submission in submissions
+    ]
+
+
+def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Queue one child MoonMind workflow per resolved issue target."
+    )
+    parser.add_argument(
+        "--targets", required=True, help="Path to resolved targets JSON."
+    )
+    parser.add_argument("--target-preset-slug", required=True)
+    parser.add_argument("--target-preset-version", required=True)
+    parser.add_argument("--target-preset-scope", default="global")
+    parser.add_argument("--target-preset-scope-ref", default=None)
+    parser.add_argument("--publish-mode", default="pr")
+    parser.add_argument("--constraints", default=None)
+    parser.add_argument("--constraints-file", default=None)
+    parser.add_argument("--max-workflows", type=int, default=25)
+    parser.add_argument("--task-context-path", default=None)
+    parser.add_argument("--artifacts-dir", default="artifacts")
+    return parser.parse_args(argv)
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    targets_path = Path(args.targets)
+    if not targets_path.exists():
+        raise RuntimeError(f"targets file not found: {targets_path}")
+    targets = _read_targets(targets_path)
+    constraints = _read_constraints(args)
+    runtime = _resolve_runtime_selection(args.task_context_path)
+    batch_scope = _parent_run_scope(args.task_context_path)
+    inherit_from_caller = _task_workflow_id_from_env() is not None
+
+    config = TargetConfig(
+        preset_slug=str(args.target_preset_slug).strip(),
+        preset_version=str(args.target_preset_version).strip(),
+        preset_scope=str(args.target_preset_scope or "global").strip() or "global",
+        preset_scope_ref=_text(args.target_preset_scope_ref),
+        publish_mode=_normalize_publish_mode(args.publish_mode),
+        constraints=constraints,
+    )
+
+    submissions, skipped = build_child_requests(
+        targets,
+        config=config,
+        runtime=runtime,
+        max_workflows=args.max_workflows,
+        batch_scope=batch_scope,
+        inherit_runtime_from_caller=inherit_from_caller,
+    )
+    created, errors = await _submit_jobs(submissions)
+
+    payload = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "actor": os.getenv("GITHUB_ACTOR") or os.getenv("USER") or "unknown",
+        "targetPreset": {
+            "slug": config.preset_slug,
+            "version": config.preset_version,
+            "scope": config.preset_scope,
+            "scopeRef": config.preset_scope_ref,
+        },
+        "publishMode": config.publish_mode,
+        "runtime": {
+            "inherit": "caller" if inherit_from_caller else None,
+            "mode": runtime.mode,
+            "model": runtime.model,
+            "effort": runtime.effort,
+            "executionProfileRef": runtime.provider_profile,
+        },
+        "requested": len(targets),
+        "created": len(created),
+        "queued": created,
+        "skipped": [{"ref": item.ref, "reason": item.reason} for item in skipped],
+        "errors": errors,
+    }
+    if payload["created"] == 0:
+        payload["message"] = "No child workflows were queued."
+
+    artifacts_dir = _resolve_artifacts_dir(args.artifacts_dir)
+    _write_artifacts(artifacts_dir / "batch-workflows-result.json", payload)
+    if payload["created"] == 0 and not errors:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "no_op",
+                "reason": "no_targets_queued",
+                "evidence": {
+                    "requested": payload["requested"],
+                    "skipped": payload["skipped"],
+                },
+            },
+        )
+
+    print(json.dumps(payload, indent=2))
+    print(
+        f"queued={payload['created']} skipped={len(skipped)} errors={len(errors)} "
+        f"preset={config.preset_slug}@{config.preset_version}"
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except Exception:
+        print("error: batch-workflows failed. See logs for details.", flush=True)
+        raise SystemExit(1)

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -19,6 +19,8 @@ import json
 import logging
 import os
 import re
+import sys
+import traceback
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -226,7 +228,13 @@ def build_child_request(
         "instructions": goal,
         "inputs": inputs,
         "publish": {"mode": publish_mode},
-        "batchTargetPreset": {
+        # Author the child with the selected preset via ``taskTemplate`` so the
+        # execution API expands the exact slug/version/scope/scopeRef (see
+        # expand_preset_for_child_run). Without this the child is goal-only and
+        # the server goal scheduler silently substitutes a hard-coded global
+        # preset version, dropping any non-default version, personal scope, or
+        # scopeRef. ``batchTargetPreset`` has no readers, so it is not emitted.
+        "taskTemplate": {
             "slug": config.preset_slug,
             "version": config.preset_version,
             "scope": config.preset_scope,
@@ -708,6 +716,10 @@ async def main(argv: list[str] | None = None) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(asyncio.run(main()))
-    except Exception:
-        print("error: batch-workflows failed. See logs for details.", flush=True)
+    except Exception as exc:  # noqa: BLE001 - surface root cause before exiting
+        # Print the exception message and full traceback to stderr so runtime
+        # failures (missing files, JSON decode errors, HTTP errors) are
+        # diagnosable instead of being swallowed behind a generic message.
+        print(f"error: batch-workflows failed: {exc}", file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
         raise SystemExit(1)

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -1,0 +1,382 @@
+slug: batch-workflows
+title: Batch Workflows
+description: Resolve a set of Jira board-column or GitHub repository issue targets,
+  then queue one child MoonMind workflow per target using a selected child preset,
+  inherited runtime/provider/model settings, and a shared publish policy. The parent
+  records a summary artifact that links every queued child workflow.
+scope: global
+version: 1.0.0
+tags:
+- batch
+- orchestration
+- jira
+- github
+requiredCapabilities:
+- git
+- jira
+- gh
+annotations:
+  sourceSkill: batch-workflows
+  output: child-workflows
+  runtimeInheritance: caller
+  orchestration:
+    kind: batch-workflows
+    runtimeInheritance: caller
+    summaryArtifact: artifacts/batch-workflows-result.json
+    targetListArtifact: artifacts/batch-workflows-targets.json
+  bindings:
+    jira-implement:
+      jira_issue: '{{ target.jiraIssue }}'
+      jira_issue_key: '{{ target.jiraIssue.key }}'
+      constraints: '{{ shared.constraints }}'
+    github-issue-implement:
+      github_issue: '{{ target.githubIssue }}'
+      github_issue_ref: '{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}'
+      constraints: '{{ shared.constraints }}'
+  inputSchema:
+    type: object
+    required:
+    - source_kind
+    - target_preset_slug
+    - target_preset_version
+    - publish_mode
+    properties:
+      source_kind:
+        type: string
+        title: Batch source
+        description: Top-level discriminator that selects what the batch iterates over.
+        enum:
+        - jira_board_column
+        - github_repo_issues
+      jira_board_id:
+        type: string
+        title: Jira board
+      jira_column:
+        type: string
+        title: Column
+      jira_label_filter:
+        type: string
+        title: Tag / label filter
+      jira_issue_type_filter:
+        type: string
+        title: Issue type filter
+      jira_assignee_filter:
+        type: string
+        title: Assignee filter
+      repository:
+        type: string
+        title: Repository
+        description: Target repository for implementation child workflows. Defaults
+          to the parent workflow repository when available.
+      github_repository:
+        type: string
+        title: GitHub repository
+      github_issue_state:
+        type: string
+        title: Issue state
+        enum:
+        - open
+        - closed
+        - all
+      github_label_filter:
+        type: string
+        title: Label filter
+      github_assignee_filter:
+        type: string
+        title: Assignee filter
+      github_milestone_filter:
+        type: string
+        title: Milestone filter
+      github_search_query:
+        type: string
+        title: Search query
+      target_preset_slug:
+        type: string
+        title: Run this preset for each item
+      target_preset_version:
+        type: string
+        title: Target preset version
+      target_preset_scope:
+        type: string
+        title: Target preset scope
+        enum:
+        - global
+        - personal
+      target_preset_scope_ref:
+        type: string
+        title: Target preset scope reference
+      constraints:
+        type: string
+        title: Constraints
+      publish_mode:
+        type: string
+        title: Publish mode
+        enum:
+        - none
+        - branch
+        - pr
+      max_workflows:
+        type: string
+        title: Max workflows
+      sort:
+        type: string
+        title: Sort
+        enum:
+        - rank
+        - updated_desc
+        - priority_desc
+  uiSchema:
+    source_kind:
+      widget: discriminator
+      discriminates:
+        jira_board_column:
+        - jira_board_id
+        - jira_column
+        - jira_label_filter
+        - jira_issue_type_filter
+        - jira_assignee_filter
+        - repository
+        github_repo_issues:
+        - github_repository
+        - github_issue_state
+        - github_label_filter
+        - github_assignee_filter
+        - github_milestone_filter
+        - github_search_query
+    jira_board_id:
+      widget: jira.board-picker
+    jira_column:
+      widget: jira.board-column-picker
+      dependsOn: jira_board_id
+      allowManualEntryOnApiFailure: true
+    repository:
+      widget: github.repo-picker
+    github_repository:
+      widget: github.repo-picker
+    target_preset_slug:
+      widget: preset.selector
+      highlightCompatible:
+      - jira-implement
+      - github-issue-implement
+    publish_mode:
+      widget: publish.mode-picker
+  defaults:
+    source_kind: jira_board_column
+    github_issue_state: open
+    target_preset_slug: jira-implement
+    target_preset_version: 1.1.0
+    target_preset_scope: global
+    publish_mode: pr
+    max_workflows: '25'
+    sort: rank
+inputs:
+- name: source_kind
+  label: Batch source
+  type: enum
+  required: true
+  default: jira_board_column
+  options:
+  - jira_board_column
+  - github_repo_issues
+- name: jira_board_id
+  label: Jira Board
+  type: jira_board
+  required: false
+  default: ''
+- name: jira_column
+  label: Column
+  type: text
+  required: false
+  default: ''
+- name: jira_label_filter
+  label: Tag / Label Filter
+  type: text
+  required: false
+  default: ''
+- name: jira_issue_type_filter
+  label: Issue Type Filter
+  type: text
+  required: false
+  default: ''
+- name: jira_assignee_filter
+  label: Assignee Filter
+  type: text
+  required: false
+  default: ''
+- name: repository
+  label: Repository
+  type: text
+  required: false
+  default: ''
+- name: github_repository
+  label: GitHub Repository
+  type: text
+  required: false
+  default: ''
+- name: github_issue_state
+  label: GitHub Issue State
+  type: enum
+  required: false
+  default: open
+  options:
+  - open
+  - closed
+  - all
+- name: github_label_filter
+  label: GitHub Label Filter
+  type: text
+  required: false
+  default: ''
+- name: github_assignee_filter
+  label: GitHub Assignee Filter
+  type: text
+  required: false
+  default: ''
+- name: github_milestone_filter
+  label: GitHub Milestone Filter
+  type: text
+  required: false
+  default: ''
+- name: github_search_query
+  label: GitHub Search Query
+  type: text
+  required: false
+  default: ''
+- name: target_preset_slug
+  label: Run This Preset For Each Item
+  type: text
+  required: true
+  default: jira-implement
+- name: target_preset_version
+  label: Target Preset Version
+  type: text
+  required: true
+  default: 1.1.0
+- name: target_preset_scope
+  label: Target Preset Scope
+  type: enum
+  required: false
+  default: global
+  options:
+  - global
+  - personal
+- name: target_preset_scope_ref
+  label: Target Preset Scope Reference
+  type: text
+  required: false
+  default: ''
+- name: constraints
+  label: Constraints
+  type: textarea
+  required: false
+  default: ''
+- name: publish_mode
+  label: Publish Mode
+  type: enum
+  required: true
+  default: pr
+  options:
+  - none
+  - branch
+  - pr
+- name: max_workflows
+  label: Max Workflows
+  type: text
+  required: false
+  default: '25'
+- name: sort
+  label: Sort
+  type: enum
+  required: false
+  default: rank
+  options:
+  - rank
+  - updated_desc
+  - priority_desc
+steps:
+- title: Resolve targets and queue child workflows
+  annotations:
+    batchWorkflowsRole: resolve-and-queue
+  instructions: |-
+    Resolve a set of issue-like targets and queue one child MoonMind workflow per
+    target. Do not re-select provider/model/effort: every child inherits the parent
+    runtime via runtimeInheritance="caller".
+
+    Step 1 — Resolve targets into the canonical resolved-target shape.
+    If source_kind is "jira_board_column", use the deterministic trusted Jira tool
+    surface to list the issues in column "{{ inputs.jira_column }}" of board
+    "{{ inputs.jira_board_id }}". Apply the optional label, issue-type, and assignee
+    filters. Resolve each issue to:
+    {"provider": "jira", "ref": "<KEY>", "jiraIssue": {"key", "summary", "description",
+    "url", "status", "assignee"}, "repository": "<owner/repo>"}.
+    If source_kind is "github_repo_issues", use the trusted GitHub tool surface
+    (gh issue list) on repository "{{ inputs.github_repository }}" with state
+    "{{ inputs.github_issue_state }}" and the optional label, assignee, milestone,
+    and search-query filters. Resolve each issue to:
+    {"provider": "github", "ref": "<owner/repo>#<number>", "githubIssue": {"repository",
+    "number", "title", "body", "url", "state", "labels"}, "repository": "<owner/repo>"}.
+    Apply the requested sort and cap the resolved list at {{ inputs.max_workflows }}
+    targets. Write the resolved target list to artifacts/batch-workflows-targets.json
+    and present it as a preview before queueing anything. Do not use raw Jira/GitHub
+    credentials, web scraping, or guessed issue content to build targets.
+
+    Step 2 — Queue one child workflow per resolved target running preset
+    "{{ inputs.target_preset_slug }}" version "{{ inputs.target_preset_version }}".
+    Auto-bind the resolved issue target into the child preset's issue input
+    (jira_issue/jira_issue_key for jira-implement, github_issue/github_issue_ref for
+    github-issue-implement) and copy the shared constraints into every child. Apply
+    publish mode "{{ inputs.publish_mode }}" once to every child. Run the helper:
+    python3 .agents/skills/batch-workflows/bin/batch_workflows.py
+    --targets artifacts/batch-workflows-targets.json
+    --target-preset-slug {{ inputs.target_preset_slug }}
+    --target-preset-version {{ inputs.target_preset_version }}
+    --target-preset-scope {{ inputs.target_preset_scope }}
+    --publish-mode {{ inputs.publish_mode }}
+    --max-workflows {{ inputs.max_workflows }}
+    The helper stamps runtimeInheritance="caller" plus a fallback copy of the parent
+    runtime on each child and assigns a stable idempotency key so reruns do not
+    duplicate child workflows.
+
+    Step 3 — Record the summary. The helper writes artifacts/batch-workflows-result.json
+    linking every queued child workflow id together with the resolved targets, skips,
+    and errors. Report the queued/skipped/error counts honestly and link the child
+    workflows in the run summary.
+  batchOrchestration:
+    source:
+      kind: '{{ inputs.source_kind }}'
+      jiraBoardColumn:
+        boardId: '{{ inputs.jira_board_id }}'
+        column: '{{ inputs.jira_column }}'
+        labelFilter: '{{ inputs.jira_label_filter }}'
+        issueTypeFilter: '{{ inputs.jira_issue_type_filter }}'
+        assigneeFilter: '{{ inputs.jira_assignee_filter }}'
+        repository: '{{ inputs.repository }}'
+      githubRepoIssues:
+        repository: '{{ inputs.github_repository }}'
+        state: '{{ inputs.github_issue_state }}'
+        labelFilter: '{{ inputs.github_label_filter }}'
+        assigneeFilter: '{{ inputs.github_assignee_filter }}'
+        milestoneFilter: '{{ inputs.github_milestone_filter }}'
+        searchQuery: '{{ inputs.github_search_query }}'
+    targetPreset:
+      slug: '{{ inputs.target_preset_slug }}'
+      version: '{{ inputs.target_preset_version }}'
+      scope: '{{ inputs.target_preset_scope }}'
+      scopeRef: '{{ inputs.target_preset_scope_ref }}'
+    sharedInputs:
+      constraints: '{{ inputs.constraints }}'
+    publish:
+      mode: '{{ inputs.publish_mode }}'
+    runtime:
+      inherit: caller
+    maxWorkflows: '{{ inputs.max_workflows }}'
+    sort: '{{ inputs.sort }}'
+    summaryArtifact: artifacts/batch-workflows-result.json
+    targetListArtifact: artifacts/batch-workflows-targets.json
+  skill:
+    id: batch-workflows
+    requiredCapabilities:
+    - git
+    - jira
+    - gh
+    args: {}

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -13,7 +13,6 @@ tags:
 - github
 requiredCapabilities:
 - git
-- jira
 - gh
 annotations:
   sourceSkill: batch-workflows
@@ -325,14 +324,19 @@ steps:
     Auto-bind the resolved issue target into the child preset's issue input
     (jira_issue/jira_issue_key for jira-implement, github_issue/github_issue_ref for
     github-issue-implement) and copy the shared constraints into every child. Apply
-    publish mode "{{ inputs.publish_mode }}" once to every child. Run the helper:
-    python3 .agents/skills/batch-workflows/bin/batch_workflows.py
-    --targets artifacts/batch-workflows-targets.json
-    --target-preset-slug {{ inputs.target_preset_slug }}
-    --target-preset-version {{ inputs.target_preset_version }}
-    --target-preset-scope {{ inputs.target_preset_scope }}
-    --publish-mode {{ inputs.publish_mode }}
-    --max-workflows {{ inputs.max_workflows }}
+    publish mode "{{ inputs.publish_mode }}" once to every child. Run the helper
+    as a single command (the trailing backslashes join the line-continued
+    arguments; without them the shell would terminate the command after the
+    script name and parse the remaining flags as separate commands):
+    python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
+    --targets artifacts/batch-workflows-targets.json \
+    --target-preset-slug "{{ inputs.target_preset_slug }}" \
+    --target-preset-version "{{ inputs.target_preset_version }}" \
+    --target-preset-scope "{{ inputs.target_preset_scope }}" \
+    --target-preset-scope-ref "{{ inputs.target_preset_scope_ref }}" \
+    --publish-mode "{{ inputs.publish_mode }}" \
+    --max-workflows "{{ inputs.max_workflows }}" \
+    --constraints "{{ inputs.constraints }}"
     The helper stamps runtimeInheritance="caller" plus a fallback copy of the parent
     runtime on each child and assigns a stable idempotency key so reruns do not
     duplicate child workflows.
@@ -377,6 +381,5 @@ steps:
     id: batch-workflows
     requiredCapabilities:
     - git
-    - jira
     - gh
     args: {}

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,1 @@
+- [Pre-existing test_executions failures](pre-existing-test-executions-failures.md) — describe_execution IllegalStateChangeError reproduces on main; not a regression

--- a/memory/pre-existing-test-executions-failures.md
+++ b/memory/pre-existing-test-executions-failures.md
@@ -1,0 +1,23 @@
+---
+name: pre-existing-test-executions-failures
+description: tests/unit/api/routers/test_executions.py describe_execution tests fail with a pre-existing IllegalStateChangeError unrelated to any change
+metadata:
+  type: reference
+---
+
+`tests/unit/api/routers/test_executions.py::test_describe_execution_*` tests fail
+with `sqlalchemy.exc.IllegalStateChangeError: Method 'close()' can't be called here`
+in this managed-agent workspace. Confirmed reproducing on `main` (base commit
+a5a387ba2) in a clean `git worktree`, and the failure count is non-deterministic
+(varies 14–19) — it is an async-session/event-loop fixture/environment artifact,
+NOT caused by feature branches.
+
+**Why:** During verification it looks alarming when a focused run bundles these
+tests, but they are unrelated to most changes (they exercise the untouched
+`describe_execution` recovery-evidence/feature-flag paths).
+
+**How to apply:** Before treating a `test_executions.py` describe_execution
+failure as a regression, reproduce it on `main` in a worktree. If it reproduces
+there too, it is pre-existing and out of scope. Also avoid running two pytest
+processes over the same test files concurrently — shared sqlite/async resources
+amplify these errors.

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -93,6 +93,7 @@ class BuiltInSkillLoader(SkillLoader):
             "pr-resolver",
             "batch-pr-resolver",
             "batch-dependabot-resolver",
+            "batch-workflows",
             "fix-comments",
             "fix-ci",
             "fix-merge-conflicts",

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -61,6 +61,7 @@ _SELF_MANAGED_PUBLISH_SKILLS = frozenset(
         "pr-resolver",
         "batch-pr-resolver",
         "batch-dependabot-resolver",
+        "batch-workflows",
         "fix-comments",
         "fix-ci",
         "fix-merge-conflicts",

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -438,6 +438,38 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "sourceDirectory"
         ] == "{{ inputs.document_directory }}"
 
+        result = await session.execute(
+            select(Preset)
+            .where(
+                Preset.slug == "batch-workflows",
+                Preset.scope_type == PresetScopeType.GLOBAL,
+                Preset.scope_ref.is_(None),
+            )
+            .options(selectinload(Preset.latest_version))
+        )
+        batch_template = result.scalar_one_or_none()
+        assert batch_template is not None
+        assert batch_template.latest_version is not None
+        batch_annotations = batch_template.latest_version.annotations or {}
+        assert batch_annotations["runtimeInheritance"] == "caller"
+        assert batch_annotations["inputSchema"]["properties"]["source_kind"][
+            "enum"
+        ] == ["jira_board_column", "github_repo_issues"]
+        assert batch_annotations["bindings"]["jira-implement"]["jira_issue_key"] == (
+            "{{ target.jiraIssue.key }}"
+        )
+        assert batch_annotations["bindings"]["github-issue-implement"][
+            "github_issue_ref"
+        ] == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
+        batch_steps = batch_template.latest_version.steps
+        assert len(batch_steps) == 1
+        assert batch_steps[0]["skill"]["id"] == "batch-workflows"
+        assert batch_steps[0]["batchOrchestration"]["runtime"]["inherit"] == "caller"
+        assert (
+            batch_steps[0]["batchOrchestration"]["publish"]["mode"]
+            == "{{ inputs.publish_mode }}"
+        )
+
 @pytest.mark.asyncio
 async def test_startup_deactivates_legacy_speckit_orchestrate_template(
     disabled_env_keys, tmp_path

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -161,10 +161,13 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             assert len(version.steps) == 1
             step = version.steps[0]
             assert step["skill"]["id"] == "batch-workflows"
+            # The parent only orchestrates/queues; it must not hard-require the
+            # jira capability or GitHub-only batches would be blocked at launch
+            # in environments without a trusted Jira integration. Per-target
+            # jira readiness is enforced on the child workflows instead.
             assert sorted(step["skill"]["requiredCapabilities"]) == [
                 "gh",
                 "git",
-                "jira",
             ]
 
 
@@ -217,5 +220,7 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert "runtimeInheritance" in step["instructions"]
 
             assert "git" in expanded["capabilities"]
-            assert "jira" in expanded["capabilities"]
             assert "gh" in expanded["capabilities"]
+            # GitHub-only batches must not be gated on Jira readiness, so the
+            # parent preset no longer advertises the jira capability.
+            assert "jira" not in expanded["capabilities"]

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -1,0 +1,221 @@
+"""Catalog-boundary tests for the MM-885 ``batch-workflows`` seed preset.
+
+These exercise the real preset validation + expansion path (the adapter boundary
+for presets): the seed YAML must validate, expose the documented batch contract
+(source discriminator, both source field sets, target-preset selector, default
+issue bindings, runtimeInheritance=caller, and a single shared publish policy),
+and expand into an orchestration step that queues child workflows.
+"""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import selectinload, sessionmaker
+
+from api_service.db.models import Base, Preset, PresetScopeType
+from api_service.services.presets.catalog import PresetCatalogService
+
+pytestmark = [pytest.mark.asyncio]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRESET_PATH = _REPO_ROOT / "api_service" / "data" / "presets" / "batch-workflows.yaml"
+
+
+@asynccontextmanager
+async def _catalog_db(tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/batch_workflows.db"
+    engine = create_async_engine(db_url, future=True)
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield async_session_maker
+    finally:
+        await engine.dispose()
+
+
+def _seed_dir(tmp_path) -> Path:
+    seed_dir = tmp_path / "presets"
+    seed_dir.mkdir()
+    shutil.copy(_PRESET_PATH, seed_dir / "batch-workflows.yaml")
+    return seed_dir
+
+
+async def _load_preset(session) -> Preset:
+    result = await session.execute(
+        select(Preset)
+        .where(
+            Preset.slug == "batch-workflows",
+            Preset.scope_type == PresetScopeType.GLOBAL,
+            Preset.scope_ref.is_(None),
+        )
+        .options(selectinload(Preset.latest_version))
+    )
+    template = result.scalar_one()
+    assert template.latest_version is not None
+    return template
+
+
+async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            template = await _load_preset(session)
+            version = template.latest_version
+            annotations = version.annotations or {}
+
+            assert template.title == "Batch Workflows"
+            assert template.scope_type is PresetScopeType.GLOBAL
+
+            # Source discriminator with both options.
+            schema = annotations["inputSchema"]
+            assert schema["properties"]["source_kind"]["enum"] == [
+                "jira_board_column",
+                "github_repo_issues",
+            ]
+            assert "source_kind" in schema["required"]
+
+            # Jira board-column source field set.
+            for name in (
+                "jira_board_id",
+                "jira_column",
+                "jira_label_filter",
+                "jira_issue_type_filter",
+                "jira_assignee_filter",
+            ):
+                assert name in schema["properties"]
+            # GitHub repo issues source field set.
+            for name in (
+                "github_repository",
+                "github_issue_state",
+                "github_label_filter",
+                "github_assignee_filter",
+                "github_milestone_filter",
+                "github_search_query",
+            ):
+                assert name in schema["properties"]
+
+            # Target preset selector (slug/version/scope/scopeRef).
+            for name in (
+                "target_preset_slug",
+                "target_preset_version",
+                "target_preset_scope",
+                "target_preset_scope_ref",
+            ):
+                assert name in schema["properties"]
+
+            # Single shared publish policy normalized around none/branch/pr.
+            assert schema["properties"]["publish_mode"]["enum"] == [
+                "none",
+                "branch",
+                "pr",
+            ]
+
+            # Cascading board -> column discriminator wiring in the UI schema.
+            ui_schema = annotations["uiSchema"]
+            assert ui_schema["source_kind"]["widget"] == "discriminator"
+            assert ui_schema["jira_column"]["dependsOn"] == "jira_board_id"
+            assert ui_schema["target_preset_slug"]["highlightCompatible"] == [
+                "jira-implement",
+                "github-issue-implement",
+            ]
+
+            # Default issue bindings for the known issue presets.
+            bindings = annotations["bindings"]
+            assert bindings["jira-implement"]["jira_issue"] == "{{ target.jiraIssue }}"
+            assert (
+                bindings["jira-implement"]["jira_issue_key"]
+                == "{{ target.jiraIssue.key }}"
+            )
+            assert (
+                bindings["github-issue-implement"]["github_issue"]
+                == "{{ target.githubIssue }}"
+            )
+            assert (
+                bindings["github-issue-implement"]["github_issue_ref"]
+                == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
+            )
+
+            # Runtime inheritance directive.
+            assert annotations["runtimeInheritance"] == "caller"
+
+            # The board input keeps the existing jira_board input type.
+            board_input = next(
+                item
+                for item in version.inputs_schema
+                if item["name"] == "jira_board_id"
+            )
+            assert board_input["type"] == "jira_board"
+
+            # Orchestration step references the batch-workflows skill.
+            assert len(version.steps) == 1
+            step = version.steps[0]
+            assert step["skill"]["id"] == "batch-workflows"
+            assert sorted(step["skill"]["requiredCapabilities"]) == [
+                "gh",
+                "git",
+                "jira",
+            ]
+
+
+async def test_batch_workflows_expands_orchestration_step(tmp_path):
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="batch-workflows",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "source_kind": "jira_board_column",
+                    "jira_board_id": "42",
+                    "jira_column": "In Progress",
+                    "target_preset_slug": "jira-implement",
+                    "target_preset_version": "1.1.0",
+                    "publish_mode": "pr",
+                    "constraints": "Be careful",
+                    "max_workflows": "10",
+                },
+            )
+
+            steps = expanded["steps"]
+            assert len(steps) == 1
+            step = steps[0]
+            assert step["skill"]["id"] == "batch-workflows"
+
+            orchestration = step["batchOrchestration"]
+            assert orchestration["source"]["kind"] == "jira_board_column"
+            assert orchestration["source"]["jiraBoardColumn"]["boardId"] == "42"
+            assert orchestration["source"]["jiraBoardColumn"]["column"] == "In Progress"
+            assert orchestration["targetPreset"]["slug"] == "jira-implement"
+            assert orchestration["targetPreset"]["version"] == "1.1.0"
+            assert orchestration["publish"]["mode"] == "pr"
+            # Every child inherits the caller runtime.
+            assert orchestration["runtime"]["inherit"] == "caller"
+            assert orchestration["maxWorkflows"] == "10"
+            assert orchestration["sharedInputs"]["constraints"] == "Be careful"
+            assert (
+                orchestration["summaryArtifact"]
+                == "artifacts/batch-workflows-result.json"
+            )
+
+            # Parent records a summary artifact that links child workflows.
+            assert "artifacts/batch-workflows-result.json" in step["instructions"]
+            assert "runtimeInheritance" in step["instructions"]
+
+            assert "git" in expanded["capabilities"]
+            assert "jira" in expanded["capabilities"]
+            assert "gh" in expanded["capabilities"]

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -159,11 +159,53 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     assert payload["task"]["publish"] == {"mode": "pr"}
     assert payload["repository"] == "MoonLadderStudios/MoonMind"
     assert payload["task"]["inputs"]["jira_issue_key"] == "THOR-123"
-    assert payload["task"]["batchTargetPreset"]["slug"] == "jira-implement"
+    # The selected preset is authored as the child taskTemplate (read by the
+    # execution API), not inert batchTargetPreset metadata.
+    assert payload["task"]["taskTemplate"]["slug"] == "jira-implement"
+    assert payload["task"]["taskTemplate"]["version"] == "1.1.0"
+    assert payload["task"]["taskTemplate"]["scope"] == "global"
+    assert "batchTargetPreset" not in payload["task"]
     # Stable, length-bounded idempotency key.
     key = payload["idempotencyKey"]
     assert key.startswith("batch-workflows:jira:THOR-123:sha256:")
     assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
+
+
+def test_build_child_request_authors_selected_preset_version_scope_and_ref():
+    # A non-default preset version / personal scope / scopeRef must be carried
+    # into the child taskTemplate so the execution API expands the exact
+    # selected preset instead of the goal scheduler's hard-coded global version.
+    module = _load_module()
+    request = module["build_child_request"](
+        _JIRA_TARGET,
+        config=_jira_config(
+            module,
+            preset_version="2.3.0",
+            preset_scope="personal",
+            preset_scope_ref="user-123",
+        ),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    template = request["payload"]["task"]["taskTemplate"]
+    assert template["slug"] == "jira-implement"
+    assert template["version"] == "2.3.0"
+    assert template["scope"] == "personal"
+    assert template["scopeRef"] == "user-123"
+    assert "batchTargetPreset" not in request["payload"]["task"]
+
+
+def test_build_child_request_omits_scope_ref_when_blank():
+    module = _load_module()
+    request = module["build_child_request"](
+        _JIRA_TARGET,
+        config=_jira_config(module, preset_scope_ref=None),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert "scopeRef" not in request["payload"]["task"]["taskTemplate"]
 
 
 def test_build_child_request_without_caller_omits_inheritance_directive():

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -1,0 +1,234 @@
+"""Unit tests for the batch-workflows fan-out helper (MM-885).
+
+Covers the deterministic per-target child-request construction: issue bindings,
+runtime inheritance, shared publish policy, idempotency, the max-workflows cap,
+and unsupported-preset skips. The goal text is validated against the real
+server-side goal scheduler so a queued child expands the intended child preset.
+"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.executions.execution_contract import (
+    WorkflowContractError,
+    is_self_managed_publish_skill,
+    resolve_publish_mode_for_skill,
+)
+from moonmind.workflows.executions.preset_goal_scheduler import (
+    schedule_preset_from_goal,
+)
+
+
+def _load_module() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[2]
+    return runpy.run_path(
+        str(
+            repo_root
+            / ".agents"
+            / "skills"
+            / "batch-workflows"
+            / "bin"
+            / "batch_workflows.py"
+        )
+    )
+
+
+_JIRA_TARGET: dict[str, Any] = {
+    "provider": "jira",
+    "ref": "THOR-123",
+    "jiraIssue": {
+        "key": "THOR-123",
+        "summary": "Wire the widget",
+        "description": "Body",
+        "url": "https://example.atlassian.net/browse/THOR-123",
+        "status": "In Progress",
+        "assignee": "Nate",
+    },
+    "repository": "MoonLadderStudios/MoonMind",
+}
+
+_GITHUB_TARGET: dict[str, Any] = {
+    "provider": "github",
+    "ref": "MoonLadderStudios/MoonMind#42",
+    "githubIssue": {
+        "repository": "MoonLadderStudios/MoonMind",
+        "number": 42,
+        "title": "Fix the bug",
+        "body": "Body",
+        "url": "https://github.com/MoonLadderStudios/MoonMind/issues/42",
+        "state": "open",
+        "labels": ["bug"],
+    },
+    "repository": "MoonLadderStudios/MoonMind",
+}
+
+
+def _jira_config(module, **overrides):
+    defaults = dict(
+        preset_slug="jira-implement",
+        preset_version="1.1.0",
+        preset_scope="global",
+        publish_mode="pr",
+        constraints="Be careful",
+    )
+    defaults.update(overrides)
+    return module["TargetConfig"](**defaults)
+
+
+def _github_config(module, **overrides):
+    defaults = dict(
+        preset_slug="github-issue-implement",
+        preset_version="1.0.0",
+        preset_scope="global",
+        publish_mode="branch",
+        constraints="",
+    )
+    defaults.update(overrides)
+    return module["TargetConfig"](**defaults)
+
+
+def test_bind_child_inputs_jira_auto_binds_issue_object_and_key():
+    module = _load_module()
+    inputs = module["bind_child_inputs"](_JIRA_TARGET, "jira-implement", "Be careful")
+    assert inputs["jira_issue"]["key"] == "THOR-123"
+    assert inputs["jira_issue_key"] == "THOR-123"
+    assert inputs["constraints"] == "Be careful"
+
+
+def test_bind_child_inputs_github_auto_binds_issue_object_and_ref():
+    module = _load_module()
+    inputs = module["bind_child_inputs"](_GITHUB_TARGET, "github-issue-implement", "")
+    assert inputs["github_issue"]["number"] == 42
+    assert inputs["github_issue_ref"] == "MoonLadderStudios/MoonMind#42"
+    assert inputs["constraints"] == ""
+
+
+def test_bind_child_inputs_returns_none_for_provider_mismatch():
+    module = _load_module()
+    assert module["bind_child_inputs"](_GITHUB_TARGET, "jira-implement", "") is None
+    assert (
+        module["bind_child_inputs"](_JIRA_TARGET, "github-issue-implement", "") is None
+    )
+
+
+def test_child_goal_routes_to_selected_preset_via_scheduler():
+    module = _load_module()
+    jira_goal = module["child_goal_for_target"](_JIRA_TARGET, "jira-implement")
+    github_goal = module["child_goal_for_target"](
+        _GITHUB_TARGET, "github-issue-implement"
+    )
+    assert jira_goal is not None
+    assert github_goal is not None
+    # The queued child goal must expand the intended preset server-side.
+    assert schedule_preset_from_goal(jira_goal).slug == "jira-implement"
+    assert schedule_preset_from_goal(github_goal).slug == "github-issue-implement"
+
+
+def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
+    module = _load_module()
+    runtime = module["RuntimeSelection"](
+        mode="codex_cli",
+        model="gpt-5.5",
+        effort="xhigh",
+        provider_profile="profile-1",
+    )
+    request = module["build_child_request"](
+        _JIRA_TARGET,
+        config=_jira_config(module),
+        runtime=runtime,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert request is not None
+    payload = request["payload"]
+    # Runtime inheritance contract plus the fallback runtime copy.
+    assert payload["runtimeInheritance"] == "caller"
+    assert payload["targetRuntime"] == "codex_cli"
+    assert payload["task"]["runtime"] == {
+        "mode": "codex_cli",
+        "model": "gpt-5.5",
+        "effort": "xhigh",
+        "executionProfileRef": "profile-1",
+    }
+    # Shared publish policy + repository + bound issue inputs.
+    assert payload["task"]["publish"] == {"mode": "pr"}
+    assert payload["repository"] == "MoonLadderStudios/MoonMind"
+    assert payload["task"]["inputs"]["jira_issue_key"] == "THOR-123"
+    assert payload["task"]["batchTargetPreset"]["slug"] == "jira-implement"
+    # Stable, length-bounded idempotency key.
+    key = payload["idempotencyKey"]
+    assert key.startswith("batch-workflows:jira:THOR-123:sha256:")
+    assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
+
+
+def test_build_child_request_without_caller_omits_inheritance_directive():
+    module = _load_module()
+    runtime = module["RuntimeSelection"](mode="claude_code")
+    request = module["build_child_request"](
+        _GITHUB_TARGET,
+        config=_github_config(module),
+        runtime=runtime,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=False,
+    )
+    payload = request["payload"]
+    assert "runtimeInheritance" not in payload
+    # Fallback runtime is still stamped so the child reuses the caller runtime.
+    assert payload["targetRuntime"] == "claude_code"
+    assert payload["task"]["publish"] == {"mode": "branch"}
+
+
+def test_build_child_requests_caps_at_max_workflows():
+    module = _load_module()
+    targets = [
+        {**_JIRA_TARGET, "ref": f"THOR-{n}", "jiraIssue": {"key": f"THOR-{n}"}}
+        for n in range(5)
+    ]
+    submissions, skipped = module["build_child_requests"](
+        targets,
+        config=_jira_config(module),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        max_workflows=2,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert len(submissions) == 2
+    overflow = [item for item in skipped if item.reason == "max_workflows_exceeded"]
+    assert len(overflow) == 3
+
+
+def test_build_child_requests_skips_unsupported_preset():
+    module = _load_module()
+    submissions, skipped = module["build_child_requests"](
+        [_JIRA_TARGET],
+        config=_jira_config(module, preset_slug="some-custom-preset"),
+        runtime=module["RuntimeSelection"](mode="codex_cli"),
+        max_workflows=25,
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+    assert submissions == []
+    assert skipped[0].reason == "unsupported_preset"
+
+
+def test_normalize_publish_mode_falls_back_to_pr():
+    module = _load_module()
+    assert module["_normalize_publish_mode"]("none") == "none"
+    assert module["_normalize_publish_mode"]("branch") == "branch"
+    assert module["_normalize_publish_mode"]("pr") == "pr"
+    assert module["_normalize_publish_mode"]("bogus") == "pr"
+
+
+def test_batch_workflows_parent_is_self_managed_publish():
+    # The parent orchestration queues children and performs no repo publish, so
+    # its own publish mode is forced to "none" (parity with batch-pr-resolver).
+    assert is_self_managed_publish_skill("batch-workflows") is True
+    assert resolve_publish_mode_for_skill("batch-workflows", None) == "none"
+    assert resolve_publish_mode_for_skill("batch-workflows", "none") == "none"
+    with pytest.raises(WorkflowContractError):
+        resolve_publish_mode_for_skill("batch-workflows", "pr")


### PR DESCRIPTION
## Issue

[MM-885: Batch Workflow preset](https://moonladder.atlassian.net/browse/MM-885)

## Summary

Ships a first-class **Batch Workflows** orchestration preset (slug `batch-workflows`) that resolves a set of Jira board-column or GitHub repository issue targets and queues one child MoonMind workflow per target, using a selected child preset, inherited runtime settings, and a single shared publish policy. The parent records a summary artifact that links every queued child workflow.

- **`api_service/data/presets/batch-workflows.yaml`** — declarative orchestration preset with:
  - a top-level `source.kind` discriminator (`jira_board_column` / `github_repo_issues`) that reshapes the form;
  - the Jira board-column source (cascading board → column, plus tag/label, issue-type, assignee filters, repository picker, max-workflows cap, and sort) resolving to the documented `{provider:"jira", ref, jiraIssue{...}, repository}` target shape;
  - the GitHub repo-issues source (repository picker plus state, label, assignee, milestone, search-query filters, max-workflows cap, and sort) resolving to the documented `{provider:"github", ref, githubIssue{...}, repository}` target shape;
  - a `targetPreset` selector (`slug`/`version`/`scope`/`scopeRef`) with default issue bindings for `jira-implement` and `github-issue-implement`, shared inputs (e.g. `constraints`), and advanced field mapping for arbitrary presets;
  - a single shared publish policy (`none`/`branch`/`pr`) and `runtimeInheritance=caller`;
  - an orchestration step that resolves targets, previews them, and queues children.
- **`.agents/skills/batch-workflows/`** — skill bundle. `SKILL.md` drives target resolution + preview; `bin/batch_workflows.py` fans out one child execution per resolved target with `runtimeInheritance="caller"` plus a fallback copy of effective runtime fields, auto-bound issue inputs, shared constraints, the chosen publish mode, a stable idempotency key, and a summary artifact linking every queued child.
- Registered `batch-workflows` as a self-managed-publish, built-in skill (parity with `batch-pr-resolver`): the parent orchestration performs no repo publish, so its own publish mode is forced to `none` while children publish per the chosen policy. (`moonmind/services/skill_resolution.py`, `moonmind/workflows/executions/execution_contract.py`)

## Tests run

- `./tools/test_unit.sh tests/unit/test_batch_workflows.py tests/unit/api/test_batch_workflows_preset.py` — **12 passed** (fan-out request construction: bindings, runtime inheritance, publish-mode fallback, idempotency, max-workflows cap, unsupported-preset skip, provider-mismatch; plus catalog validation/expansion of the seeded preset and the parent publish-mode contract).
- Frontend unit suite ran as part of the runner: **467 passed, 236 skipped**.
- New integration coverage added in `tests/integration/test_startup_preset_seeding.py` for startup seeding of the new preset (compose-backed `integration_ci` tier; run in CI).

## Remaining risks

- The orchestration fan-out exercises the live `batch_workflows.py` HTTP submission path against the worker API at runtime; unit coverage validates request construction and contract shape, but end-to-end multi-child queueing is best confirmed in a full compose/integration run.
- `tests/unit/api/routers/test_executions.py::test_describe_execution_*` exhibit a **pre-existing, environment-related** `IllegalStateChangeError` that reproduces on `main` and is unrelated to this change (it exercises untouched `describe_execution` paths). Not a regression from this PR.
- This change adds the preset, skill, and parent fan-out plumbing; the Mission Control form rendering described in the brief (cascading dropdowns, target-list preview UI) relies on the existing preset input/UI-schema annotation mechanism and is driven declaratively by the seeded preset rather than bespoke new frontend components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
