### PR TITLE
[codex] fix direct skill plan inputs

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1671,10 +1671,9 @@ def _build_runtime_planner():
                     for key, value in step_tool_inputs.items():
                         step_node_inputs.setdefault(key, value)
                 else:
-                    step_node_inputs = {
-                        **step_extra_inputs,
-                        **dict(step_tool_inputs),
-                    }
+                    step_node_inputs = dict(step_tool_inputs)
+                    if step_tool_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
+                        step_node_inputs.setdefault("instructions", step_instructions)
                 step_runtime_payload = _coerce_mapping(step_node_inputs.get("runtime"))
                 step_runtime_raw = (
                     step_runtime_payload.get("mode")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1625,45 +1625,56 @@ def _build_runtime_planner():
                 step_id = str(step_entry.get("id") or "").strip() or f"step-{idx + 1}"
                 base_runtime_payload = _coerce_mapping(node_inputs.get("runtime"))
                 step_runtime_payload = _coerce_mapping(step_entry.get("runtime"))
-                step_node_inputs: dict[str, Any] = {
-                    **node_inputs,
-                    **{
-                        k: v
-                        for k, v in step_entry.items()
-                        if k
-                        not in {
-                            "id",
-                            "tool",
-                            "skill",
-                            "instructions",
-                            "runtime",
-                            "dependsOn",
-                            "depends_on",
-                            "dependencies",
-                        }
-                    },
-                    "instructions": step_instructions,
-                }
-                if base_runtime_payload or step_runtime_payload:
-                    step_node_inputs["runtime"] = {
-                        **base_runtime_payload,
-                        **step_runtime_payload,
-                    }
-                base_story_output = _coerce_mapping(node_inputs.get("storyOutput"))
-                step_story_output = _coerce_mapping(
-                    step_entry.get("storyOutput") or step_entry.get("story_output")
-                )
-                if base_story_output or step_story_output:
-                    step_node_inputs["storyOutput"] = {
-                        **base_story_output,
-                        **step_story_output,
-                    }
                 step_tool_inputs = _selected_step_tool_inputs(step_entry)
-                for key, value in step_tool_inputs.items():
-                    step_node_inputs.setdefault(key, value)
 
                 # Per-step tool/skill override
                 step_tool_name = _selected_step_tool_name(step_entry)
+                tool_type = _selected_step_tool_type(step_entry)
+                tool_version = _selected_step_tool_version(step_entry)
+                is_agent_runtime_step = tool_type == "agent_runtime"
+                step_extra_inputs = {
+                    k: v
+                    for k, v in step_entry.items()
+                    if k
+                    not in {
+                        "id",
+                        "type",
+                        "tool",
+                        "skill",
+                        "instructions",
+                        "runtime",
+                        "dependsOn",
+                        "depends_on",
+                        "dependencies",
+                    }
+                }
+                if is_agent_runtime_step:
+                    step_node_inputs: dict[str, Any] = {
+                        **node_inputs,
+                        **step_extra_inputs,
+                        "instructions": step_instructions,
+                    }
+                    if base_runtime_payload or step_runtime_payload:
+                        step_node_inputs["runtime"] = {
+                            **base_runtime_payload,
+                            **step_runtime_payload,
+                        }
+                    base_story_output = _coerce_mapping(node_inputs.get("storyOutput"))
+                    step_story_output = _coerce_mapping(
+                        step_entry.get("storyOutput") or step_entry.get("story_output")
+                    )
+                    if base_story_output or step_story_output:
+                        step_node_inputs["storyOutput"] = {
+                            **base_story_output,
+                            **step_story_output,
+                        }
+                    for key, value in step_tool_inputs.items():
+                        step_node_inputs.setdefault(key, value)
+                else:
+                    step_node_inputs = {
+                        **step_extra_inputs,
+                        **dict(step_tool_inputs),
+                    }
                 step_runtime_payload = _coerce_mapping(step_node_inputs.get("runtime"))
                 step_runtime_raw = (
                     step_runtime_payload.get("mode")
@@ -1675,9 +1686,6 @@ def _build_runtime_planner():
                     if step_runtime_raw is not None
                     else None
                 )
-                tool_type = _selected_step_tool_type(step_entry)
-                tool_version = _selected_step_tool_version(step_entry)
-                is_agent_runtime_step = tool_type == "agent_runtime"
                 is_story_output_tool = (
                     step_tool_name.lower() in _STORY_OUTPUT_TASK_TOOLS
                 )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -3426,6 +3426,83 @@ async def test_plan_generate_fallback_registry_includes_input_artifact_tool_step
                 for item in registry_payload["skills"]
             ] == [("jira.get_issue", "1.0.0")]
 
+async def test_plan_generate_direct_skill_step_uses_only_authored_tool_inputs(
+    tmp_path: Path,
+):
+    from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            planner = TemporalPlanActivities(
+                artifact_service=service,
+                planner=_build_runtime_planner(),
+            )
+
+            result = await planner.plan_generate(
+                principal="user-1",
+                parameters={
+                    "repository": "g3-qrtr/crash_server_main",
+                    "targetRuntime": "claude_code",
+                    "model": "claude-opus-4-8",
+                    "profileId": "claude_anthropic",
+                    "effort": "xhigh",
+                    "publishMode": "none",
+                    "maxAttempts": 3,
+                    "stepCount": 1,
+                    "workflow": {
+                        "tool": {"type": "skill", "name": "auto", "version": "1.0"},
+                        "runtime": {
+                            "mode": "claude_code",
+                            "model": "claude-opus-4-8",
+                            "profileId": "claude_anthropic",
+                            "effort": "xhigh",
+                        },
+                        "steps": [
+                            {
+                                "id": "step-1",
+                                "type": "tool",
+                                "tool": {
+                                    "id": "security.pentest.run",
+                                    "inputs": {
+                                        "target": "https://lab.example.test",
+                                        "scope_artifact_ref": "art_scope_valid",
+                                        "operation_mode": "recon_only",
+                                        "runner_profile_id": "pentestgpt-safe",
+                                        "time_budget_minutes": 60,
+                                        "evidence_level": "standard",
+                                    },
+                                },
+                            }
+                        ],
+                    },
+                },
+            )
+
+            _artifact, payload = await service.read(
+                artifact_id=result.plan_ref.artifact_id,
+                principal="user-1",
+            )
+            plan_payload = json.loads(payload.decode("utf-8"))
+            node = plan_payload["nodes"][0]
+
+            assert node["tool"] == {
+                "type": "skill",
+                "name": "security.pentest.run",
+                "version": "1.0",
+            }
+            assert node["inputs"] == {
+                "target": "https://lab.example.test",
+                "scope_artifact_ref": "art_scope_valid",
+                "operation_mode": "recon_only",
+                "runner_profile_id": "pentestgpt-safe",
+                "time_budget_minutes": 60,
+                "evidence_level": "standard",
+            }
+
 async def test_default_registry_payload_uses_extended_timeouts_for_pr_resolver():
     payload = _default_registry_skill_payload(name="pr-resolver", version="1.0")
     policies = payload.get("policies", {})

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -3464,7 +3464,9 @@ async def test_plan_generate_direct_skill_step_uses_only_authored_tool_inputs(
                         "steps": [
                             {
                                 "id": "step-1",
+                                "title": "Run approved PentestGPT assessment",
                                 "type": "tool",
+                                "instructions": "Run the curated PentestGPT tool.",
                                 "tool": {
                                     "id": "security.pentest.run",
                                     "inputs": {


### PR DESCRIPTION
## Summary
- Fix `plan.generate` so direct `tool.type = "skill"` steps receive only their authored tool inputs.
- Preserve inherited runtime, instruction, git, and story-output context for `agent_runtime` steps.
- Add a regression test for the failed `security.pentest.run` submission shape.

## Root Cause
Direct curated skill steps were built from task-level agent runtime inputs before merging the authored tool inputs. That leaked generic fields such as `branch`, `repo`, `runtime`, `instructions`, `publishMode`, and `stepCount` into `security.pentest.execute`, where the strict `PentestWorkloadRequest` correctly rejected them as extra fields.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py::test_plan_generate_direct_skill_step_uses_only_authored_tool_inputs`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py::test_plan_generate_fallback_registry_includes_input_artifact_tool_steps tests/unit/workflows/temporal/test_activity_runtime.py::test_plan_generate_direct_skill_step_uses_only_authored_tool_inputs tests/unit/workflows/temporal/test_activity_runtime.py::test_security_pentest_execute_accepts_workflow_invocation_envelope`
- `git diff --check`
