### PR TITLE
Implement recurring workflow schedule handling and tests

### DIFF
--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -20,6 +20,7 @@ from api_service.db.models import (
     User,
 )
 from api_service.services.recurring_workflows_service import (
+    RecurringScheduleRuntimeSummary,
     RecurringWorkflowAuthorizationError,
     RecurringWorkflowNotFoundError,
     RecurringWorkflowsService,
@@ -127,6 +128,7 @@ async def _get_service(
 
 def _serialize_definition(
     definition: RecurringWorkflowDefinition,
+    runtime_summary: RecurringScheduleRuntimeSummary | None = None,
 ) -> RecurringWorkflowDefinitionModel:
     return RecurringWorkflowDefinitionModel(
         id=definition.id,
@@ -136,10 +138,26 @@ def _serialize_definition(
         schedule_type=definition.schedule_type.value,
         cron=definition.cron,
         timezone=definition.timezone,
-        next_run_at=definition.next_run_at,
-        last_scheduled_for=definition.last_scheduled_for,
-        last_dispatch_status=definition.last_dispatch_status,
-        last_dispatch_error=definition.last_dispatch_error,
+        next_run_at=(
+            runtime_summary.next_run_at
+            if runtime_summary is not None
+            else definition.next_run_at
+        ),
+        last_scheduled_for=(
+            runtime_summary.last_scheduled_for
+            if runtime_summary is not None
+            else definition.last_scheduled_for
+        ),
+        last_dispatch_status=(
+            runtime_summary.last_dispatch_status
+            if runtime_summary is not None
+            else definition.last_dispatch_status
+        ),
+        last_dispatch_error=(
+            runtime_summary.last_dispatch_error
+            if runtime_summary is not None
+            else definition.last_dispatch_error
+        ),
         owner_user_id=definition.owner_user_id,
         scope_type=definition.scope_type.value,
         scope_ref=definition.scope_ref,
@@ -264,8 +282,15 @@ async def list_recurring_workflows(
         user_id=user_id if isinstance(user_id, UUID) else None,
         limit=limit,
     )
+    runtime_summaries = await service.runtime_summaries_for_definitions(definitions)
     return RecurringWorkflowDefinitionListResponse(
-        items=[_serialize_definition(item) for item in definitions]
+        items=[
+            _serialize_definition(
+                item,
+                runtime_summary=runtime_summaries.get(item.id),
+            )
+            for item in definitions
+        ]
     )
 
 @router.post(
@@ -343,6 +368,7 @@ async def get_recurring_workflow(
             user_id=user_id if isinstance(user_id, UUID) else None,
             can_manage_global=bool(getattr(user, "is_superuser", False)),
         )
+        runtime_summary = await service.runtime_summary_for_definition(definition)
     except Exception as exc:  # pragma: no cover - thin mapping layer
         _log_route_exception(
             action="get_recurring_workflow",
@@ -351,7 +377,7 @@ async def get_recurring_workflow(
             exc=exc,
         )
         raise _map_error(exc) from exc
-    return _serialize_definition(definition)
+    return _serialize_definition(definition, runtime_summary=runtime_summary)
 
 @router.patch("/{definition_id}", response_model=RecurringWorkflowDefinitionModel)
 async def update_recurring_workflow(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1219,6 +1219,29 @@ async def ensure_managed_session_reconcile_schedule_started() -> None:
         schedule_id,
     )
 
+async def ensure_recurring_workflow_schedules_reconciled() -> None:
+    """Best-effort repair for persisted recurring workflow Temporal schedules."""
+    from api_service.db.base import get_async_session_context
+    from api_service.services.recurring_workflows_service import (
+        RecurringWorkflowsService,
+    )
+
+    try:
+        async with get_async_session_context() as session:
+            reconciled = await RecurringWorkflowsService(
+                session,
+            ).reconcile_schedules(limit=500)
+    except Exception:
+        logger.warning(
+            "Failed to reconcile recurring workflow schedules during API startup",
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "Reconciled recurring workflow schedules during API startup: count=%s",
+        reconciled,
+    )
+
 def _register_settings_change_subscribers() -> None:
     """Wire the default SettingsChangePublisher subscribers once per process.
 
@@ -1387,6 +1410,7 @@ async def startup_event():
     # Wait for the Temporal client to be available and initialize provider profile managers
     await ensure_provider_profile_managers_started()
     await ensure_managed_session_reconcile_schedule_started()
+    await ensure_recurring_workflow_schedules_reconciled()
     logger.info("Application startup events completed.")
 
 def teardown_providers():

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -334,7 +335,13 @@ def _last_temporal_action(info: object) -> object | None:
     def _sort_key(action: object) -> datetime:
         return (
             _coerce_optional_utc_datetime(
+                _object_value(action, "started_at", "startedAt")
+            )
+            or _coerce_optional_utc_datetime(
                 _object_value(action, "actual_time", "actualTime")
+            )
+            or _coerce_optional_utc_datetime(
+                _object_value(action, "scheduled_at", "scheduledAt")
             )
             or _coerce_optional_utc_datetime(
                 _object_value(action, "schedule_time", "scheduleTime")
@@ -347,6 +354,8 @@ def _last_temporal_action(info: object) -> object | None:
 def _dispatch_status_from_temporal_action(action: object | None) -> str | None:
     if action is None:
         return None
+    if _object_value(action, "action") is not None:
+        return RecurringWorkflowRunOutcome.ENQUEUED.value
     result = _object_value(action, "start_workflow_result", "startWorkflowResult")
     if result is not None:
         return RecurringWorkflowRunOutcome.ENQUEUED.value
@@ -843,24 +852,39 @@ class RecurringWorkflowsService:
                 workflow_type, workflow_input = self._workflow_bundle_for_definition(
                     dfn
                 )
-                note = (dfn.name or "") if mismatch else None
-                await self._adapter.update_schedule(
-                    definition_id=dfn.id,
-                    cron_expression=dfn.cron if mismatch else None,
-                    timezone=dfn.timezone if mismatch else None,
-                    overlap_mode=policy_obj.overlap_mode if mismatch else None,
-                    catchup_mode=policy_obj.catchup_mode if mismatch else None,
-                    jitter_seconds=policy_obj.jitter_seconds if mismatch else None,
-                    enabled=bool(dfn.enabled) if mismatch else None,
-                    note=note,
-                    workflow_type=workflow_type,
-                    workflow_input=workflow_input,
-                    memo={"definitionId": str(dfn.id)},
-                    search_attributes=self._owner_search_attributes(
-                        dfn.owner_user_id
-                    ),
+                action = getattr(sched, "action", None)
+                temporal_workflow_type = _object_value(action, "workflow")
+                temporal_args = _object_value(action, "args") or []
+                temporal_input = temporal_args[0] if temporal_args else None
+                action_mismatch = (
+                    temporal_workflow_type != workflow_type
+                    or temporal_input != workflow_input
                 )
-                reconciled += 1
+
+                if mismatch or action_mismatch:
+                    logger.info("Reconcile updating schedule for %s", dfn.id)
+                    note = (dfn.name or "") if mismatch else None
+                    await self._adapter.update_schedule(
+                        definition_id=dfn.id,
+                        cron_expression=dfn.cron if mismatch else None,
+                        timezone=dfn.timezone if mismatch else None,
+                        overlap_mode=policy_obj.overlap_mode if mismatch else None,
+                        catchup_mode=policy_obj.catchup_mode if mismatch else None,
+                        jitter_seconds=policy_obj.jitter_seconds if mismatch else None,
+                        enabled=bool(dfn.enabled) if mismatch else None,
+                        note=note,
+                        workflow_type=workflow_type if action_mismatch else None,
+                        workflow_input=workflow_input if action_mismatch else None,
+                        memo={"definitionId": str(dfn.id)}
+                        if action_mismatch
+                        else None,
+                        search_attributes=self._owner_search_attributes(
+                            dfn.owner_user_id
+                        )
+                        if action_mismatch
+                        else None,
+                    )
+                    reconciled += 1
 
             except ScheduleAdapterError as exc:
                 logger.warning("Reconciliation adapter error for %s: %s", dfn.id, exc)
@@ -935,12 +959,20 @@ class RecurringWorkflowsService:
         info = _object_value(description, "info")
         next_run_at = None if paused else _first_temporal_datetime(
             info,
+            "next_action_times",
+            "nextActionTimes",
             "future_action_times",
             "futureActionTimes",
         )
         last_action = _last_temporal_action(info)
         last_scheduled_for = _coerce_optional_utc_datetime(
-            _object_value(last_action, "schedule_time", "scheduleTime")
+            _object_value(
+                last_action,
+                "scheduled_at",
+                "scheduledAt",
+                "schedule_time",
+                "scheduleTime",
+            )
         )
         dispatch_status = _dispatch_status_from_temporal_action(last_action)
         dispatch_error = _dispatch_error_from_temporal_action(last_action)
@@ -958,12 +990,14 @@ class RecurringWorkflowsService:
         self,
         definitions: Iterable[RecurringWorkflowDefinition],
     ) -> dict[UUID, RecurringScheduleRuntimeSummary]:
-        summaries: dict[UUID, RecurringScheduleRuntimeSummary] = {}
-        for definition in definitions:
-            summaries[definition.id] = await self.runtime_summary_for_definition(
-                definition
+        definition_list = list(definitions)
+        results = await asyncio.gather(
+            *(
+                self.runtime_summary_for_definition(definition)
+                for definition in definition_list
             )
-        return summaries
+        )
+        return dict(zip((definition.id for definition in definition_list), results))
 
 __all__ = [
     "RecurringScheduleRuntimeSummary",

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 from uuid import UUID, uuid4
 
 from sqlalchemy import Select, select
@@ -57,6 +57,15 @@ class RecurringPolicy:
     max_backfill: int = 3
     misfire_grace_seconds: int = 900
     jitter_seconds: int = 0
+
+@dataclass(frozen=True, slots=True)
+class RecurringScheduleRuntimeSummary:
+    """Read-only Temporal projection for a recurring schedule definition."""
+
+    next_run_at: datetime | None = None
+    last_scheduled_for: datetime | None = None
+    last_dispatch_status: str | None = None
+    last_dispatch_error: str | None = None
 
 def _json_object(value: object, *, field_name: str) -> dict[str, Any]:
     if value is None:
@@ -268,6 +277,100 @@ def _coerce_utc(value: datetime) -> datetime:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
 
+def _object_value(source: object, *keys: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        for key in keys:
+            if key in source:
+                return source[key]
+        return None
+    for key in keys:
+        value = getattr(source, key, None)
+        if value is not None:
+            return value
+    return None
+
+def _coerce_optional_utc_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _coerce_utc(value)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return _coerce_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+def _first_temporal_datetime(source: object, *keys: str) -> datetime | None:
+    values = _object_value(source, *keys)
+    if not values:
+        return None
+    if isinstance(values, (datetime, str)):
+        return _coerce_optional_utc_datetime(values)
+    try:
+        iterator = iter(values)
+    except TypeError:
+        return _coerce_optional_utc_datetime(values)
+    for item in iterator:
+        coerced = _coerce_optional_utc_datetime(item)
+        if coerced is not None:
+            return coerced
+    return None
+
+def _last_temporal_action(info: object) -> object | None:
+    actions = _object_value(info, "recent_actions", "recentActions") or []
+    try:
+        action_list = list(actions)
+    except TypeError:
+        return None
+    if not action_list:
+        return None
+
+    def _sort_key(action: object) -> datetime:
+        return (
+            _coerce_optional_utc_datetime(
+                _object_value(action, "actual_time", "actualTime")
+            )
+            or _coerce_optional_utc_datetime(
+                _object_value(action, "schedule_time", "scheduleTime")
+            )
+            or datetime.min.replace(tzinfo=UTC)
+        )
+
+    return max(action_list, key=_sort_key)
+
+def _dispatch_status_from_temporal_action(action: object | None) -> str | None:
+    if action is None:
+        return None
+    result = _object_value(action, "start_workflow_result", "startWorkflowResult")
+    if result is not None:
+        return RecurringWorkflowRunOutcome.ENQUEUED.value
+    raw_status = _object_value(action, "start_workflow_status", "startWorkflowStatus")
+    status_name = str(getattr(raw_status, "name", raw_status) or "").lower()
+    if (
+        "failed" in status_name
+        or "terminated" in status_name
+        or "canceled" in status_name
+    ):
+        return RecurringWorkflowRunOutcome.DISPATCH_ERROR.value
+    if status_name:
+        return RecurringWorkflowRunOutcome.ENQUEUED.value
+    return None
+
+def _dispatch_error_from_temporal_action(action: object | None) -> str | None:
+    if action is None:
+        return None
+    for key in ("failure", "error", "message"):
+        value = _object_value(action, key)
+        if value:
+            return str(value)
+    return None
+
 class RecurringWorkflowsService:
     """CRUD and dispatch helpers for recurring definitions."""
 
@@ -367,13 +470,13 @@ class RecurringWorkflowsService:
         system["recurrence"] = recurrence
         initial_parameters["system"] = system
         return workflow_type, {
-            "workflowType": workflow_type,
+            "workflow_type": workflow_type,
             "title": str(target_payload.get("title") or name),
-            "ownerUserId": str(owner_user_id) if owner_user_id else None,
-            "initialParameters": initial_parameters,
-            "inputArtifactRef": target_payload.get("inputArtifactRef"),
-            "planArtifactRef": target_payload.get("planArtifactRef"),
-            "failurePolicy": target_payload.get("failurePolicy"),
+            "owner_user_id": str(owner_user_id) if owner_user_id else None,
+            "initial_parameters": initial_parameters,
+            "input_artifact_ref": target_payload.get("inputArtifactRef"),
+            "plan_artifact_ref": target_payload.get("planArtifactRef"),
+            "failure_policy": target_payload.get("failurePolicy"),
         }
 
     def _owner_search_attributes(self, owner_user_id: UUID | None) -> dict[str, str]:
@@ -541,14 +644,14 @@ class RecurringWorkflowsService:
             )
 
         try:
-            # We don't update workflow inputs for target changes yet, since update_schedule
-            # doesn't natively support updating action/input args without recreating.
-            # Only cron, policy, state are updated in Phase 2
             if enabled is False:
                 await self._adapter.pause_schedule(definition_id=definition.id)
             elif enabled is True:
                 await self._adapter.unpause_schedule(definition_id=definition.id)
-                
+
+            workflow_type, workflow_input = self._workflow_bundle_for_definition(
+                definition
+            )
             await self._adapter.update_schedule(
                 definition_id=definition.id,
                 cron_expression=cron_normalized,
@@ -558,6 +661,12 @@ class RecurringWorkflowsService:
                 jitter_seconds=policy_obj.jitter_seconds if policy_obj else None,
                 enabled=enabled,
                 note=name if name is not None else None,
+                workflow_type=workflow_type,
+                workflow_input=workflow_input,
+                memo={"definitionId": str(definition.id)},
+                search_attributes=self._owner_search_attributes(
+                    definition.owner_user_id
+                ),
             )
         except Exception as exc:
             logger.error(f"Failed to update temporal schedule for {definition.id}: {exc}")
@@ -643,6 +752,10 @@ class RecurringWorkflowsService:
                 jitter_seconds=policy_obj.jitter_seconds,
                 enabled=bool(dfn.enabled),
                 note=dfn.name or "",
+                workflow_type=workflow_type,
+                workflow_input=workflow_input,
+                memo={"definitionId": str(dfn.id)},
+                search_attributes=self._owner_search_attributes(dfn.owner_user_id),
             )
 
     async def reconcile_schedules(self, limit: int = 100) -> int:
@@ -726,16 +839,27 @@ class RecurringWorkflowsService:
                 )
 
                 if mismatch:
-                    await self._adapter.update_schedule(
-                        definition_id=dfn.id,
-                        cron_expression=dfn.cron,
-                        timezone=dfn.timezone,
-                        overlap_mode=policy_obj.overlap_mode,
-                        catchup_mode=policy_obj.catchup_mode,
-                        jitter_seconds=policy_obj.jitter_seconds,
-                        enabled=bool(dfn.enabled),
-                        note=dfn.name or "",
-                    )
+                    logger.info("Reconcile updating schedule metadata for %s", dfn.id)
+                workflow_type, workflow_input = self._workflow_bundle_for_definition(
+                    dfn
+                )
+                note = (dfn.name or "") if mismatch else None
+                await self._adapter.update_schedule(
+                    definition_id=dfn.id,
+                    cron_expression=dfn.cron if mismatch else None,
+                    timezone=dfn.timezone if mismatch else None,
+                    overlap_mode=policy_obj.overlap_mode if mismatch else None,
+                    catchup_mode=policy_obj.catchup_mode if mismatch else None,
+                    jitter_seconds=policy_obj.jitter_seconds if mismatch else None,
+                    enabled=bool(dfn.enabled) if mismatch else None,
+                    note=note,
+                    workflow_type=workflow_type,
+                    workflow_input=workflow_input,
+                    memo={"definitionId": str(dfn.id)},
+                    search_attributes=self._owner_search_attributes(
+                        dfn.owner_user_id
+                    ),
+                )
                 reconciled += 1
 
             except ScheduleAdapterError as exc:
@@ -768,7 +892,81 @@ class RecurringWorkflowsService:
         # Temporal reconciliation could be added here in the future using adapter.describe_schedule
         return runs
 
+    async def runtime_summary_for_definition(
+        self,
+        definition: RecurringWorkflowDefinition,
+    ) -> RecurringScheduleRuntimeSummary:
+        """Return the current Temporal schedule timing/status projection."""
+
+        fallback = RecurringScheduleRuntimeSummary(
+            next_run_at=definition.next_run_at,
+            last_scheduled_for=definition.last_scheduled_for,
+            last_dispatch_status=definition.last_dispatch_status,
+            last_dispatch_error=definition.last_dispatch_error,
+        )
+        if not definition.temporal_schedule_id:
+            return fallback
+
+        try:
+            description = await self._adapter.describe_schedule(
+                definition_id=definition.id
+            )
+        except ScheduleNotFoundError as exc:
+            return RecurringScheduleRuntimeSummary(
+                next_run_at=None,
+                last_scheduled_for=definition.last_scheduled_for,
+                last_dispatch_status=(
+                    definition.last_dispatch_status
+                    or RecurringWorkflowRunOutcome.DISPATCH_ERROR.value
+                ),
+                last_dispatch_error=str(exc),
+            )
+        except ScheduleAdapterError as exc:
+            logger.warning(
+                "Failed to describe recurring schedule %s for runtime summary: %s",
+                definition.id,
+                exc,
+            )
+            return fallback
+
+        schedule = _object_value(description, "schedule")
+        state = _object_value(schedule, "state")
+        paused = bool(_object_value(state, "paused")) if state is not None else False
+        info = _object_value(description, "info")
+        next_run_at = None if paused else _first_temporal_datetime(
+            info,
+            "future_action_times",
+            "futureActionTimes",
+        )
+        last_action = _last_temporal_action(info)
+        last_scheduled_for = _coerce_optional_utc_datetime(
+            _object_value(last_action, "schedule_time", "scheduleTime")
+        )
+        dispatch_status = _dispatch_status_from_temporal_action(last_action)
+        dispatch_error = _dispatch_error_from_temporal_action(last_action)
+
+        return RecurringScheduleRuntimeSummary(
+            next_run_at=next_run_at,
+            last_scheduled_for=last_scheduled_for
+            if last_scheduled_for is not None
+            else definition.last_scheduled_for,
+            last_dispatch_status=dispatch_status or definition.last_dispatch_status,
+            last_dispatch_error=dispatch_error or definition.last_dispatch_error,
+        )
+
+    async def runtime_summaries_for_definitions(
+        self,
+        definitions: Iterable[RecurringWorkflowDefinition],
+    ) -> dict[UUID, RecurringScheduleRuntimeSummary]:
+        summaries: dict[UUID, RecurringScheduleRuntimeSummary] = {}
+        for definition in definitions:
+            summaries[definition.id] = await self.runtime_summary_for_definition(
+                definition
+            )
+        return summaries
+
 __all__ = [
+    "RecurringScheduleRuntimeSummary",
     "RecurringWorkflowAuthorizationError",
     "RecurringWorkflowNotFoundError",
     "RecurringWorkflowValidationError",

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -663,6 +663,10 @@ class TemporalClientAdapter:
         jitter_seconds: int | None = None,
         enabled: bool | None = None,
         note: str | None = None,
+        workflow_type: str | None = None,
+        workflow_input: Mapping[str, Any] | None = None,
+        memo: Mapping[str, Any] | None = None,
+        search_attributes: Mapping[str, Any] | None = None,
     ) -> None:
         """Update the spec, policy, or state of an existing schedule.
 
@@ -673,14 +677,27 @@ class TemporalClientAdapter:
             ScheduleNotFoundError: if the schedule does not exist.
             ScheduleOperationError: on unexpected SDK failure.
         """
+        from uuid import UUID as _UUID
+
+        from temporalio.client import ScheduleActionStartWorkflow
+
         from moonmind.workflows.temporal.schedule_errors import ScheduleOperationError
         from moonmind.workflows.temporal.schedule_mapping import (
             build_schedule_policy,
             build_schedule_spec,
             build_schedule_state,
+            make_workflow_id_template,
         )
 
+        definition_uuid = _UUID(str(definition_id))
         handle, _desc = await self._get_schedule_handle(definition_id)
+        task_queue = self._get_task_queue()
+
+        formatted_sa = {
+            k: v if isinstance(v, list) else [v]
+            for k, v in (search_attributes or {}).items()
+        }
+        typed_search_attributes = _build_typed_search_attributes(formatted_sa)
 
         async def _do_update(input: Any) -> Any:  # noqa: A002
             schedule = input.schedule
@@ -731,6 +748,21 @@ class TemporalClientAdapter:
                 schedule.state = build_schedule_state(
                     enabled=not current_paused if enabled is None else enabled,
                     note=note if note is not None else current_note,
+                )
+
+            if workflow_type is not None:
+                args = [workflow_input] if workflow_input is not None else []
+                schedule.action = ScheduleActionStartWorkflow(
+                    workflow_type,
+                    args=args,
+                    id=make_workflow_id_template(definition_uuid),
+                    task_queue=task_queue,
+                    memo=memo,
+                    **(
+                        {"typed_search_attributes": typed_search_attributes}
+                        if typed_search_attributes
+                        else {}
+                    ),
                 )
 
             return schedule

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -691,7 +691,7 @@ class TemporalClientAdapter:
 
         definition_uuid = _UUID(str(definition_id))
         handle, _desc = await self._get_schedule_handle(definition_id)
-        task_queue = self._get_task_queue()
+        task_queue = self._get_task_queue(workflow_type)
 
         formatted_sa = {
             k: v if isinstance(v, list) else [v]

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -17,7 +17,10 @@ from api_service.db.models import (
     RecurringWorkflowScheduleType,
     RecurringWorkflowScopeType,
 )
-from api_service.services.recurring_workflows_service import RecurringWorkflowValidationError
+from api_service.services.recurring_workflows_service import (
+    RecurringScheduleRuntimeSummary,
+    RecurringWorkflowValidationError,
+)
 
 def _definition(**overrides):
     now = datetime.now(UTC)
@@ -97,6 +100,36 @@ async def test_list_recurring_workflows_global_requires_operator() -> None:
         )
 
     assert exc.value.status_code == 403
+
+@pytest.mark.asyncio
+async def test_list_recurring_workflows_uses_runtime_schedule_summary() -> None:
+    service = AsyncMock()
+    stale_next_run = datetime(2026, 6, 23, 13, tzinfo=UTC)
+    live_next_run = datetime(2026, 6, 24, 13, tzinfo=UTC)
+    last_scheduled_for = datetime(2026, 6, 23, 13, tzinfo=UTC)
+    definition = _definition(next_run_at=stale_next_run)
+    service.list_definitions.return_value = [definition]
+    service.runtime_summaries_for_definitions.return_value = {
+        definition.id: RecurringScheduleRuntimeSummary(
+            next_run_at=live_next_run,
+            last_scheduled_for=last_scheduled_for,
+            last_dispatch_status="enqueued",
+            last_dispatch_error=None,
+        )
+    }
+    user = SimpleNamespace(id=definition.owner_user_id, is_superuser=False)
+
+    response = await recurring_router.list_recurring_workflows(
+        scope="personal",
+        limit=50,
+        service=service,
+        user=user,
+    )
+
+    assert response.items[0].next_run_at == live_next_run
+    assert response.items[0].last_scheduled_for == last_scheduled_for
+    assert response.items[0].last_dispatch_status == "enqueued"
+    service.runtime_summaries_for_definitions.assert_awaited_once_with([definition])
 
 @pytest.mark.asyncio
 async def test_create_recurring_workflow_returns_serialized_definition() -> None:

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 from uuid import uuid4
 
 import pytest
@@ -391,14 +391,14 @@ async def test_runtime_summary_uses_temporal_future_and_recent_actions(
             mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
                 schedule=SimpleNamespace(state=SimpleNamespace(paused=False)),
                 info=SimpleNamespace(
-                    future_action_times=[next_run],
+                    next_action_times=[next_run],
                     recent_actions=[
                         SimpleNamespace(
-                            schedule_time=scheduled_for,
-                            actual_time=scheduled_for,
-                            start_workflow_result=SimpleNamespace(
-                                workflow_id="mm:schedule:run",
-                                run_id="run-id",
+                            scheduled_at=scheduled_for,
+                            started_at=scheduled_for,
+                            action=SimpleNamespace(
+                                workflow="MoonMind.UserWorkflow",
+                                args=[],
                             ),
                         )
                     ],
@@ -471,3 +471,88 @@ async def test_reconcile_repairs_existing_schedule_action_payload(
                 "MoonMind.UserWorkflow"
             )
             assert "workflowType" not in call_kwargs["workflow_input"]
+
+async def test_reconcile_skips_update_when_metadata_and_action_match(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            _workflow_type, workflow_input = service._workflow_bundle_for_definition(
+                definition
+            )
+            mock_temporal_adapter.create_schedule.reset_mock()
+            mock_temporal_adapter.update_schedule.reset_mock()
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    spec=SimpleNamespace(
+                        cron_expressions=["0 6 * * *"],
+                        time_zone_name="UTC",
+                        jitter=timedelta(seconds=0),
+                    ),
+                    policy=SimpleNamespace(
+                        overlap=SimpleNamespace(name="SKIP"),
+                        catchup_window=timedelta(minutes=15),
+                    ),
+                    state=SimpleNamespace(paused=False, note="Daily Demo"),
+                    action=SimpleNamespace(
+                        workflow="MoonMind.UserWorkflow",
+                        args=[workflow_input],
+                    ),
+                )
+            )
+
+            reconciled = await service.reconcile_schedules()
+
+            assert reconciled == 0
+            mock_temporal_adapter.update_schedule.assert_not_called()
+
+async def test_runtime_summaries_for_definitions_describes_concurrently(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            first = SimpleNamespace(id=uuid4())
+            second = SimpleNamespace(id=uuid4())
+            first_summary = RecurringScheduleRuntimeSummary(last_dispatch_status="one")
+            second_summary = RecurringScheduleRuntimeSummary(last_dispatch_status="two")
+            service.runtime_summary_for_definition = AsyncMock(
+                side_effect=[first_summary, second_summary]
+            )
+
+            summaries = await service.runtime_summaries_for_definitions(
+                [first, second]
+            )
+
+            assert summaries == {
+                first.id: first_summary,
+                second.id: second_summary,
+            }
+            service.runtime_summary_for_definition.assert_has_awaits(
+                [call(first), call(second)]
+            )

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -20,6 +21,7 @@ from api_service.db.models import (
     RecurringWorkflowRunOutcome,
 )
 from api_service.services.recurring_workflows_service import (
+    RecurringScheduleRuntimeSummary,
     RecurringWorkflowsService,
     RecurringWorkflowValidationError,
 )
@@ -53,6 +55,7 @@ def mock_temporal_adapter():
     adapter.unpause_schedule = AsyncMock()
     adapter.trigger_schedule = AsyncMock()
     adapter.delete_schedule = AsyncMock()
+    adapter.describe_schedule = AsyncMock()
     return adapter
 
 async def test_create_definition_creates_temporal_schedule(
@@ -100,11 +103,14 @@ async def test_create_definition_creates_temporal_schedule(
             assert call_kwargs["cron_expression"] == "0 6 * * *"
             assert call_kwargs["timezone"] == "UTC"
             assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
-            assert call_kwargs["workflow_input"]["workflowType"] == "MoonMind.UserWorkflow"
-            assert call_kwargs["workflow_input"]["initialParameters"]["task"][
+            assert call_kwargs["workflow_input"]["workflow_type"] == (
+                "MoonMind.UserWorkflow"
+            )
+            assert "workflowType" not in call_kwargs["workflow_input"]
+            assert call_kwargs["workflow_input"]["initial_parameters"]["task"][
                 "instructions"
             ] == "Queue job"
-            assert call_kwargs["workflow_input"]["initialParameters"]["system"][
+            assert call_kwargs["workflow_input"]["initial_parameters"]["system"][
                 "recurrence"
             ]["definitionId"] == str(definition.id)
             assert call_kwargs["search_attributes"] == {
@@ -155,13 +161,13 @@ async def test_create_definition_normalizes_snake_case_target_aliases(
             assert "initial_parameters" not in definition.target
             assert "input_artifact_ref" not in definition.target
             call_kwargs = mock_temporal_adapter.create_schedule.call_args.kwargs
-            assert call_kwargs["workflow_input"]["inputArtifactRef"] == (
+            assert call_kwargs["workflow_input"]["input_artifact_ref"] == (
                 "artifact://input/1"
             )
-            assert call_kwargs["workflow_input"]["planArtifactRef"] == (
+            assert call_kwargs["workflow_input"]["plan_artifact_ref"] == (
                 "artifact://plan/1"
             )
-            assert call_kwargs["workflow_input"]["failurePolicy"] == "fail_fast"
+            assert call_kwargs["workflow_input"]["failure_policy"] == "fail_fast"
 
 async def test_create_definition_manifest_reads_action_options_from_initial_parameters(
     tmp_path: Path, mock_temporal_adapter
@@ -309,6 +315,13 @@ async def test_update_definition_updates_temporal_schedule(
             assert call_kwargs["definition_id"] == definition.id
             assert call_kwargs["cron_expression"] == "0 12 * * *"
             assert call_kwargs["enabled"] is False
+            assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"]["workflow_type"] == (
+                "MoonMind.UserWorkflow"
+            )
+            assert call_kwargs["workflow_input"]["initial_parameters"]["task"][
+                "instructions"
+            ] == "Queue job"
 
 async def test_create_manual_run_triggers_temporal_schedule(
     tmp_path: Path, mock_temporal_adapter
@@ -344,3 +357,117 @@ async def test_create_manual_run_triggers_temporal_schedule(
             mock_temporal_adapter.trigger_schedule.assert_called_once_with(definition_id=definition.id)
             assert run.outcome == RecurringWorkflowRunOutcome.ENQUEUED
             assert run.message == "Triggered via Temporal Schedule"
+
+async def test_runtime_summary_uses_temporal_future_and_recent_actions(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            next_run = datetime(2026, 6, 24, 13, tzinfo=UTC)
+            scheduled_for = datetime(2026, 6, 23, 13, tzinfo=UTC)
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(state=SimpleNamespace(paused=False)),
+                info=SimpleNamespace(
+                    future_action_times=[next_run],
+                    recent_actions=[
+                        SimpleNamespace(
+                            schedule_time=scheduled_for,
+                            actual_time=scheduled_for,
+                            start_workflow_result=SimpleNamespace(
+                                workflow_id="mm:schedule:run",
+                                run_id="run-id",
+                            ),
+                        )
+                    ],
+                ),
+            )
+
+            summary = await service.runtime_summary_for_definition(definition)
+
+            assert summary == RecurringScheduleRuntimeSummary(
+                next_run_at=next_run,
+                last_scheduled_for=scheduled_for,
+                last_dispatch_status=RecurringWorkflowRunOutcome.ENQUEUED.value,
+                last_dispatch_error=None,
+            )
+
+async def test_reconcile_repairs_existing_schedule_action_payload(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            mock_temporal_adapter.create_schedule.reset_mock()
+            mock_temporal_adapter.update_schedule.reset_mock()
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    spec=SimpleNamespace(
+                        cron_expressions=["0 6 * * *"],
+                        time_zone_name="UTC",
+                        jitter=timedelta(seconds=0),
+                    ),
+                    policy=SimpleNamespace(
+                        overlap=SimpleNamespace(name="SKIP"),
+                        catchup_window=timedelta(minutes=15),
+                    ),
+                    state=SimpleNamespace(paused=False, note="Daily Demo"),
+                )
+            )
+
+            reconciled = await service.reconcile_schedules()
+
+            assert reconciled == 1
+            mock_temporal_adapter.update_schedule.assert_called_once()
+            call_kwargs = mock_temporal_adapter.update_schedule.call_args.kwargs
+            assert call_kwargs["definition_id"] == definition.id
+            assert call_kwargs["cron_expression"] is None
+            assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"]["workflow_type"] == (
+                "MoonMind.UserWorkflow"
+            )
+            assert "workflowType" not in call_kwargs["workflow_input"]

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -430,6 +430,23 @@ class TestUpdateSchedule:
             "owner-123"
         )
 
+    @pytest.mark.asyncio
+    async def test_update_resolves_task_queue_for_workflow_type(self) -> None:
+        handle = _mock_schedule_handle()
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle = MagicMock(return_value=handle)
+
+        adapter = _make_adapter(mock_client)
+        adapter._get_task_queue = MagicMock(return_value="mm.workflow.user.v2")
+
+        await adapter.update_schedule(
+            definition_id=_TEST_UUID,
+            workflow_type="MoonMind.UserWorkflow.v2",
+            workflow_input={"workflow_type": "MoonMind.UserWorkflow.v2"},
+        )
+
+        adapter._get_task_queue.assert_called_once_with("MoonMind.UserWorkflow.v2")
+
 class TestDescribeSchedule:
     """DOC-REQ-002: describe schedule."""
 

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -384,6 +384,52 @@ class TestUpdateSchedule:
         assert updated_schedule.state.paused is True
         assert updated_schedule.state.note == "Original note"
 
+    @pytest.mark.asyncio
+    async def test_update_rewrites_schedule_action_when_workflow_input_provided(
+        self,
+    ) -> None:
+        handle = _mock_schedule_handle()
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle = MagicMock(return_value=handle)
+
+        mock_update_input = MagicMock()
+        mock_update_input.schedule.spec.cron_expressions = ["0 0 * * *"]
+        mock_update_input.schedule.spec.time_zone_name = "UTC"
+        mock_update_input.schedule.spec.jitter = timedelta(seconds=0)
+        mock_update_input.schedule.policy.overlap.name = "SKIP"
+        mock_update_input.schedule.policy.catchup_window = timedelta(minutes=15)
+        mock_update_input.schedule.state.paused = False
+        mock_update_input.schedule.state.note = "Original note"
+
+        adapter = _make_adapter(mock_client)
+        workflow_input = {
+            "workflow_type": "MoonMind.UserWorkflow",
+            "initial_parameters": {"task": {"instructions": "Queue job"}},
+        }
+        await adapter.update_schedule(
+            definition_id=_TEST_UUID,
+            workflow_type="MoonMind.UserWorkflow",
+            workflow_input=workflow_input,
+            memo={"definitionId": str(_TEST_UUID)},
+            search_attributes={
+                "mm_owner_type": "user",
+                "mm_owner_id": "owner-123",
+            },
+        )
+
+        update_callback = handle.update.call_args[0][0]
+        updated_schedule = await update_callback(mock_update_input)
+
+        assert updated_schedule.action.workflow == "MoonMind.UserWorkflow"
+        assert updated_schedule.action.args == [workflow_input]
+        assert updated_schedule.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
+        assert updated_schedule.action.task_queue == "mm.workflow"
+        assert updated_schedule.action.memo == {"definitionId": str(_TEST_UUID)}
+        typed_search_attributes = updated_schedule.action.typed_search_attributes
+        assert typed_search_attributes.get(SearchAttributeKey.for_keyword("mm_owner_id")) == (
+            "owner-123"
+        )
+
 class TestDescribeSchedule:
     """DOC-REQ-002: describe schedule."""
 


### PR DESCRIPTION
## Summary
- Implement recurring workflow schedule support logic in API/router, service, and temporal client layers.
- Add unit coverage for router input validation, service behavior, and temporal client schedule interactions.

## Testing
- Added/updated tests in:
  - `tests/unit/api/routers/test_recurring_workflows.py`
  - `tests/unit/services/test_recurring_workflows_service.py`
  - `tests/unit/workflows/temporal/test_client_schedules.py`
