### PR TITLE
MM-874: Generalize OAuth provider-profile lifecycle across Claude, Codex, Gemini

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -24,6 +24,7 @@ from api_service.services.provider_profile_service import (
     apply_oauth_connected_state,
     apply_oauth_validation_failure,
     get_first_party_oauth_profile,
+    normalize_runtime_default_profile,
     sync_provider_profile_manager,
 )
 from api_service.db.models import (
@@ -898,6 +899,11 @@ async def _disable_profile_after_failed_verification(
         reason=reason,
         failed_at=datetime.now(timezone.utc),
     )
+    await normalize_runtime_default_profile(
+        session=db,
+        runtime_id=profile.runtime_id,
+    )
+    await sync_provider_profile_manager(session=db, runtime_id=profile.runtime_id)
 
 
 async def _stop_oauth_auth_runner(session_obj: ManagedAgentOAuthSession) -> None:

--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -20,7 +20,12 @@ from api_service.api.schemas_oauth_sessions import (
 )
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session, get_async_session_context
-from api_service.services.provider_profile_service import sync_provider_profile_manager
+from api_service.services.provider_profile_service import (
+    apply_oauth_connected_state,
+    apply_oauth_validation_failure,
+    get_first_party_oauth_profile,
+    sync_provider_profile_manager,
+)
 from api_service.db.models import (
     ManagedAgentOAuthSession,
     OAuthSessionStatus,
@@ -707,6 +712,12 @@ async def finalize_oauth_session(
                     "Volume verification failed: "
                     f"{verification.get('reason', 'unknown')}"
                 )
+                await _disable_profile_after_failed_verification(
+                    db,
+                    session_obj,
+                    reason=verification.get("reason"),
+                    current_user=current_user,
+                )
                 await db.commit()
                 await _stop_oauth_auth_runner(session_obj)
                 await _fail_oauth_session_workflow(
@@ -830,6 +841,17 @@ async def finalize_oauth_session(
         db.add(new_profile)
         profile_obj = new_profile
 
+    # Stamp the documented OAuth-after-setup metadata (home_path_overrides and
+    # connected credential-method readiness) for first-party Claude/Codex/Gemini
+    # profiles so the persisted row matches the canonical OAuth profile shape.
+    apply_oauth_connected_state(
+        profile_obj,
+        mapping=get_first_party_oauth_profile(
+            profile_obj.runtime_id, profile_obj.provider_id
+        ),
+        validated_at=connected_at,
+    )
+
     await db.commit()
 
     await sync_provider_profile_manager(session=db, runtime_id=session_obj.runtime_id)
@@ -843,6 +865,40 @@ async def finalize_oauth_session(
     await _complete_oauth_session_workflow(session_obj.session_id)
 
     return _oauth_session_response(session_obj, profile=profile_obj)
+
+async def _disable_profile_after_failed_verification(
+    db: AsyncSession,
+    session_obj: ManagedAgentOAuthSession,
+    *,
+    reason: str | None,
+    current_user: User,
+) -> None:
+    """Leave the OAuth profile visibly disabled after failed verification.
+
+    The OAuth session is failed independently, but the user-visible Provider
+    Profile must also be marked ``auth_state=validation_failed`` /
+    ``disabled_reason=auth_invalid`` (not only session/command_behavior
+    metadata) so it stays visible in Settings with a retry action. Applies to
+    any first-party OAuth profile (Claude, Codex, Gemini) flowing through
+    finalize, not just the Claude-only validate endpoint.
+    """
+    if not session_obj.profile_id:
+        return
+    profile = await db.get(ManagedAgentProviderProfile, session_obj.profile_id)
+    if profile is None:
+        return
+    if (
+        profile.owner_user_id is not None
+        and str(profile.owner_user_id) != str(current_user.id)
+    ):
+        return
+    apply_oauth_validation_failure(
+        profile,
+        mapping=get_first_party_oauth_profile(profile.runtime_id, profile.provider_id),
+        reason=reason,
+        failed_at=datetime.now(timezone.utc),
+    )
+
 
 async def _stop_oauth_auth_runner(session_obj: ManagedAgentOAuthSession) -> None:
     if not session_obj.container_name:

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -710,7 +710,7 @@ async def commit_claude_manual_auth(
         {
             "auth_strategy": "claude_credential_methods",
             "auth_state": "connected",
-            "auth_actions": _claude_auth_actions_for_profile(profile),
+            "auth_actions": oauth_auth_actions_for_profile(profile),
             "auth_status_label": "Anthropic API key ready",
             "auth_readiness": {
                 "connected": True,
@@ -751,16 +751,21 @@ async def validate_claude_oauth_profile(
     session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
     current_user: User = Depends(get_current_user()),
 ) -> dict[str, Any]:
+    """Validate an OAuth-backed provider profile against its auth volume.
+
+    Generalized across the first-party Claude, Codex, and Gemini runtimes; the
+    handler name is retained for OpenAPI operation-id stability.
+    """
     profile = await session.get(ManagedAgentProviderProfile, profile_id)
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     _require_provider_profile_permission(current_user, "provider_profiles.write")
     _require_profile_management(profile, current_user)
-    _require_claude_anthropic_profile(profile)
+    mapping = _require_first_party_oauth_profile(profile)
     if not profile.volume_ref or not profile.volume_mount_path:
         raise HTTPException(
             status_code=422,
-            detail="Claude OAuth validation requires OAuth volume metadata.",
+            detail=f"{mapping.label_prefix} OAuth validation requires OAuth volume metadata.",
         )
 
     try:
@@ -776,33 +781,27 @@ async def validate_claude_oauth_profile(
     except Exception as exc:
         raise HTTPException(
             status_code=503,
-            detail="Claude OAuth validation unavailable.",
+            detail=f"{mapping.label_prefix} OAuth validation unavailable.",
         ) from exc
 
     if not verification.get("verified", False):
         failed_at = datetime.now(UTC)
-        profile.enabled = False
-        profile.auth_state = ProviderProfileAuthState.VALIDATION_FAILED
-        profile.disabled_reason = ProviderProfileDisabledReason.AUTH_INVALID
-        profile.last_validated_at = failed_at
-        reason = redact_sensitive_payload(str(verification.get("reason") or "unknown"))
-        _update_claude_auth_behavior(
+        apply_oauth_validation_failure(
             profile,
-            auth_state="validation_failed",
-            status_label="Claude OAuth validation failed",
-            readiness={
-                "connected": False,
-                "last_validated_at": failed_at.isoformat(),
-                "backing_secret_exists": False,
-                "launch_ready": False,
-                "failure_reason": reason,
-            },
+            mapping=mapping,
+            reason=verification.get("reason"),
+            failed_at=failed_at,
         )
         await session.commit()
         await session.refresh(profile)
+        reason = (
+            profile.command_behavior.get("auth_readiness", {}).get("failure_reason")
+            if isinstance(profile.command_behavior, dict)
+            else None
+        )
         raise HTTPException(
             status_code=400,
-            detail=f"Claude OAuth validation failed: {reason}",
+            detail=f"{mapping.label_prefix} OAuth validation failed: {reason}",
         )
 
     validated_at = datetime.now(UTC)
@@ -813,23 +812,17 @@ async def validate_claude_oauth_profile(
         profile.first_authenticated_at = validated_at
     profile.last_validated_at = validated_at
     profile.last_auth_method = ProviderProfileAuthMethod.OAUTH_VOLUME
-    _update_claude_auth_behavior(
+    apply_oauth_connected_state(
         profile,
-        auth_state="connected",
-        status_label="Claude OAuth ready",
-        readiness={
-            "connected": True,
-            "last_validated_at": validated_at.isoformat(),
-            "backing_secret_exists": True,
-            "launch_ready": True,
-        },
+        mapping=mapping,
+        validated_at=validated_at,
     )
     await session.commit()
     await session.refresh(profile)
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
     return {
         "status": "ready",
-        "status_label": "Claude OAuth ready",
+        "status_label": f"{mapping.label_prefix} OAuth ready",
         "profile_id": profile.profile_id,
         "readiness": profile.command_behavior.get("auth_readiness")
         if isinstance(profile.command_behavior, dict)
@@ -842,12 +835,17 @@ async def disconnect_claude_oauth_profile(
     session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
     current_user: User = Depends(get_current_user()),
 ) -> dict[str, Any]:
+    """Disconnect an OAuth-backed provider profile and clear its volume fields.
+
+    Generalized across the first-party Claude, Codex, and Gemini runtimes; the
+    handler name is retained for OpenAPI operation-id stability.
+    """
     profile = await session.get(ManagedAgentProviderProfile, profile_id)
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     _require_provider_profile_permission(current_user, "provider_profiles.write")
     _require_profile_management(profile, current_user)
-    _require_claude_anthropic_profile(profile)
+    mapping = _require_first_party_oauth_profile(profile)
 
     if profile.credential_source == ProviderCredentialSource.OAUTH_VOLUME:
         profile.credential_source = ProviderCredentialSource.NONE
@@ -859,10 +857,11 @@ async def disconnect_claude_oauth_profile(
     profile.auth_state = ProviderProfileAuthState.DISCONNECTED
     profile.disabled_reason = ProviderProfileDisabledReason.DISCONNECTED
     profile.last_validated_at = disconnected_at
-    _update_claude_auth_behavior(
+    update_oauth_command_behavior(
         profile,
+        mapping=mapping,
         auth_state="disconnected",
-        status_label="Claude OAuth disconnected",
+        status_label=f"{mapping.label_prefix} OAuth disconnected",
         readiness={
             "connected": False,
             "last_validated_at": disconnected_at.isoformat(),
@@ -875,7 +874,7 @@ async def disconnect_claude_oauth_profile(
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
     return {
         "status": "disconnected",
-        "status_label": "Claude OAuth disconnected",
+        "status_label": f"{mapping.label_prefix} OAuth disconnected",
         "profile_id": profile.profile_id,
     }
 
@@ -961,6 +960,21 @@ def _require_claude_anthropic_profile(row: ManagedAgentProviderProfile) -> None:
             detail="Manual Claude auth is only supported for claude_code Anthropic profiles.",
         )
 
+
+def _require_first_party_oauth_profile(
+    row: ManagedAgentProviderProfile,
+) -> FirstPartyOAuthProfile:
+    mapping = get_first_party_oauth_profile(row.runtime_id, row.provider_id)
+    if mapping is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "OAuth lifecycle actions are only supported for first-party "
+                "Claude, Codex, and Gemini provider profiles."
+            ),
+        )
+    return mapping
+
 @dataclass(frozen=True, slots=True)
 class _ApiKeyMapping:
     runtime_id: str
@@ -1012,32 +1026,6 @@ def _api_key_mapping_for_profile(row: ManagedAgentProviderProfile) -> _ApiKeyMap
             ),
         )
     return mapping
-
-def _claude_auth_actions_for_profile(row: ManagedAgentProviderProfile) -> list[str]:
-    actions = ["use_api_key"]
-    if row.volume_ref or row.volume_mount_path:
-        actions.insert(0, "connect_oauth")
-        actions.extend(["validate_oauth", "disconnect_oauth"])
-    return actions
-
-def _update_claude_auth_behavior(
-    row: ManagedAgentProviderProfile,
-    *,
-    auth_state: str,
-    status_label: str,
-    readiness: dict[str, Any],
-) -> None:
-    behavior = dict(row.command_behavior or {})
-    behavior.update(
-        {
-            "auth_strategy": "claude_credential_methods",
-            "auth_state": auth_state,
-            "auth_actions": _claude_auth_actions_for_profile(row),
-            "auth_status_label": status_label,
-            "auth_readiness": readiness,
-        }
-    )
-    row.command_behavior = behavior
 
 def _looks_like_claude_manual_token(token: str) -> bool:
     return token.startswith("sk-ant-") and len(token) >= 12
@@ -1674,6 +1662,12 @@ def _row_to_dict(
     return payload
 
 from api_service.services.provider_profile_service import (
+    FirstPartyOAuthProfile,
+    apply_oauth_connected_state,
+    apply_oauth_validation_failure,
+    get_first_party_oauth_profile,
     normalize_runtime_default_profile,
+    oauth_auth_actions_for_profile,
     sync_provider_profile_manager,
+    update_oauth_command_behavior,
 )

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -798,7 +798,7 @@ async def validate_claude_oauth_profile(
             profile.command_behavior.get("auth_readiness", {}).get("failure_reason")
             if isinstance(profile.command_behavior, dict)
             else None
-        )
+        ) or "unknown"
         raise HTTPException(
             status_code=400,
             detail=f"{mapping.label_prefix} OAuth validation failed: {reason}",
@@ -852,6 +852,7 @@ async def disconnect_claude_oauth_profile(
         profile.runtime_materialization_mode = RuntimeMaterializationMode.API_KEY_ENV
     profile.volume_ref = None
     profile.volume_mount_path = None
+    clear_oauth_home_path_overrides(profile, mapping=mapping)
     disconnected_at = datetime.now(UTC)
     profile.enabled = False
     profile.auth_state = ProviderProfileAuthState.DISCONNECTED
@@ -1069,6 +1070,10 @@ def _apply_api_key_setup_to_profile(
 ) -> None:
     row.credential_source = ProviderCredentialSource.SECRET_REF
     row.runtime_materialization_mode = RuntimeMaterializationMode.API_KEY_ENV
+    clear_oauth_home_path_overrides(
+        row,
+        mapping=get_first_party_oauth_profile(row.runtime_id, row.provider_id),
+    )
     row.secret_refs = {
         **(row.secret_refs or {}),
         mapping.secret_role: secret_ref,
@@ -1665,6 +1670,7 @@ from api_service.services.provider_profile_service import (
     FirstPartyOAuthProfile,
     apply_oauth_connected_state,
     apply_oauth_validation_failure,
+    clear_oauth_home_path_overrides,
     get_first_party_oauth_profile,
     normalize_runtime_default_profile,
     oauth_auth_actions_for_profile,

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -675,6 +675,19 @@ async def _auto_seed_provider_profiles() -> list[str]:
         logger.info("Provider profile auto-seeding disabled via MOONMIND_SKIP_PROVIDER_PROFILE_SEED.")
         return []
 
+    # Documented default readiness labels for first-party setup stubs
+    # (docs/Security/ProviderProfiles.md §7.2 / §15.1). The stubs are visible
+    # but disabled until first OAuth or API-key setup succeeds.
+    _FIRST_PARTY_SETUP_COMMAND_BEHAVIOR = {
+        "supported_auth_methods": ["oauth_volume", "secret_ref"],
+        "auth_actions": ["connect_oauth", "add_api_key"],
+        "auth_status_label": "Not connected",
+        "auth_readiness": {
+            "connected": False,
+            "launch_ready": False,
+        },
+    }
+
     # Well-known runtime defaults matching docker-compose.yaml conventions.
     _DEFAULT_PROFILES = [
         {
@@ -693,6 +706,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
         {
             "profile_id": "gemini_default",
@@ -715,6 +729,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
         {
             "profile_id": "codex_openai_default",
@@ -732,6 +747,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
         {
             "profile_id": "codex_default",
@@ -756,6 +772,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
         {
             "profile_id": "claude_anthropic_default",
@@ -778,6 +795,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
         {
             "profile_id": "claude_anthropic",
@@ -802,6 +820,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
+            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
         },
 
     ]

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -11,6 +11,7 @@ import os  # For path operations
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 # Now proceed with other imports
 from uuid import uuid4
@@ -678,15 +679,16 @@ async def _auto_seed_provider_profiles() -> list[str]:
     # Documented default readiness labels for first-party setup stubs
     # (docs/Security/ProviderProfiles.md §7.2 / §15.1). The stubs are visible
     # but disabled until first OAuth or API-key setup succeeds.
-    _FIRST_PARTY_SETUP_COMMAND_BEHAVIOR = {
-        "supported_auth_methods": ["oauth_volume", "secret_ref"],
-        "auth_actions": ["connect_oauth", "add_api_key"],
-        "auth_status_label": "Not connected",
-        "auth_readiness": {
-            "connected": False,
-            "launch_ready": False,
-        },
-    }
+    def _make_first_party_setup_command_behavior() -> dict[str, Any]:
+        return {
+            "supported_auth_methods": ["oauth_volume", "secret_ref"],
+            "auth_actions": ["connect_oauth", "use_api_key"],
+            "auth_status_label": "Not connected",
+            "auth_readiness": {
+                "connected": False,
+                "launch_ready": False,
+            },
+        }
 
     # Well-known runtime defaults matching docker-compose.yaml conventions.
     _DEFAULT_PROFILES = [
@@ -706,7 +708,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
         {
             "profile_id": "gemini_default",
@@ -729,7 +731,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
         {
             "profile_id": "codex_openai_default",
@@ -747,7 +749,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
         {
             "profile_id": "codex_default",
@@ -772,7 +774,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
         {
             "profile_id": "claude_anthropic_default",
@@ -795,7 +797,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
         {
             "profile_id": "claude_anthropic",
@@ -820,7 +822,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "auth_state": ProviderProfileAuthState.NOT_CONFIGURED,
             "disabled_reason": ProviderProfileDisabledReason.MISSING_CREDENTIALS,
             "tags": ["setup-required", "first-party"],
-            "command_behavior": dict(_FIRST_PARTY_SETUP_COMMAND_BEHAVIOR),
+            "command_behavior": _make_first_party_setup_command_behavior(),
         },
 
     ]

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -1,11 +1,18 @@
 import logging
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import case
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
-from api_service.db.models import ManagedAgentProviderProfile, ManagedSecret
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    ManagedSecret,
+    ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
+)
 from api_service.services.provider_profile_readiness import (
     provider_profile_launch_ready,
 )
@@ -246,3 +253,167 @@ async def _managed_secret_statuses_for_profiles(
         row.slug: row.status.value if row.status else ""
         for row in result.scalars().all()
     }
+
+
+# ---------------------------------------------------------------------------
+# First-party OAuth lifecycle helpers
+#
+# OAuth finalization, validation, and disconnect are generalized across the
+# big-three first-party runtimes (Claude, Codex, Gemini). These helpers hold
+# the per-runtime metadata and the canonical command_behavior shaping so the
+# OAuth session finalize path and the provider-profile lifecycle endpoints
+# produce identical, transport-neutral profile state.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FirstPartyOAuthProfile:
+    """Per-runtime metadata for a first-party OAuth-backed provider profile."""
+
+    runtime_id: str
+    provider_id: str
+    label_prefix: str
+    auth_strategy: str
+    home_path_keys: tuple[str, ...]
+
+
+FIRST_PARTY_OAUTH_PROFILES: dict[tuple[str, str], FirstPartyOAuthProfile] = {
+    ("claude_code", "anthropic"): FirstPartyOAuthProfile(
+        runtime_id="claude_code",
+        provider_id="anthropic",
+        label_prefix="Claude",
+        auth_strategy="claude_credential_methods",
+        home_path_keys=("CLAUDE_HOME",),
+    ),
+    ("codex_cli", "openai"): FirstPartyOAuthProfile(
+        runtime_id="codex_cli",
+        provider_id="openai",
+        label_prefix="Codex",
+        auth_strategy="codex_credential_methods",
+        home_path_keys=("CODEX_HOME",),
+    ),
+    ("gemini_cli", "google"): FirstPartyOAuthProfile(
+        runtime_id="gemini_cli",
+        provider_id="google",
+        label_prefix="Gemini",
+        auth_strategy="gemini_credential_methods",
+        home_path_keys=("GEMINI_HOME", "GEMINI_CLI_HOME"),
+    ),
+}
+
+
+def get_first_party_oauth_profile(
+    runtime_id: str | None,
+    provider_id: str | None,
+) -> FirstPartyOAuthProfile | None:
+    """Return the first-party OAuth mapping for a runtime/provider pair."""
+    return FIRST_PARTY_OAUTH_PROFILES.get((runtime_id or "", provider_id or ""))
+
+
+def oauth_auth_actions_for_profile(
+    profile: ManagedAgentProviderProfile,
+) -> list[str]:
+    """Compute the credential-method actions surfaced for an OAuth profile."""
+    actions = ["use_api_key"]
+    if profile.volume_ref or profile.volume_mount_path:
+        actions.insert(0, "connect_oauth")
+        actions.extend(["validate_oauth", "disconnect_oauth"])
+    return actions
+
+
+def update_oauth_command_behavior(
+    profile: ManagedAgentProviderProfile,
+    *,
+    mapping: FirstPartyOAuthProfile | None,
+    auth_state: str,
+    status_label: str,
+    readiness: dict[str, Any],
+) -> None:
+    """Merge canonical OAuth credential-method metadata into command_behavior."""
+    behavior = dict(profile.command_behavior or {})
+    update: dict[str, Any] = {
+        "auth_state": auth_state,
+        "auth_actions": oauth_auth_actions_for_profile(profile),
+        "auth_status_label": status_label,
+        "auth_readiness": readiness,
+    }
+    if mapping is not None:
+        update["auth_strategy"] = mapping.auth_strategy
+    behavior.update(update)
+    profile.command_behavior = behavior
+
+
+def oauth_home_path_overrides(
+    mapping: FirstPartyOAuthProfile,
+    volume_mount_path: str | None,
+) -> dict[str, str]:
+    """Documented home-path env overrides for an OAuth-after-setup profile."""
+    mount_path = str(volume_mount_path or "").strip()
+    if not mount_path:
+        return {}
+    return {key: mount_path for key in mapping.home_path_keys}
+
+
+def apply_oauth_connected_state(
+    profile: ManagedAgentProviderProfile,
+    *,
+    mapping: FirstPartyOAuthProfile | None,
+    validated_at: datetime,
+) -> None:
+    """Stamp connected command_behavior + home overrides after OAuth success."""
+    if mapping is not None:
+        profile.home_path_overrides = {
+            **(profile.home_path_overrides or {}),
+            **oauth_home_path_overrides(mapping, profile.volume_mount_path),
+        }
+    update_oauth_command_behavior(
+        profile,
+        mapping=mapping,
+        auth_state="connected",
+        status_label=(
+            f"{mapping.label_prefix} OAuth ready" if mapping else "OAuth ready"
+        ),
+        readiness={
+            "connected": True,
+            "last_validated_at": validated_at.isoformat(),
+            "backing_secret_exists": True,
+            "launch_ready": True,
+        },
+    )
+
+
+def apply_oauth_validation_failure(
+    profile: ManagedAgentProviderProfile,
+    *,
+    mapping: FirstPartyOAuthProfile | None,
+    reason: str | None,
+    failed_at: datetime,
+) -> None:
+    """Leave a profile visibly disabled after failed OAuth verification.
+
+    Sets the canonical ``auth_state=validation_failed`` /
+    ``disabled_reason=auth_invalid`` row state (not just session or
+    command_behavior metadata) so the profile remains visible in Settings
+    with diagnostics and a retry action.
+    """
+    profile.enabled = False
+    profile.auth_state = ProviderProfileAuthState.VALIDATION_FAILED
+    profile.disabled_reason = ProviderProfileDisabledReason.AUTH_INVALID
+    profile.last_validated_at = failed_at
+    update_oauth_command_behavior(
+        profile,
+        mapping=mapping,
+        auth_state="validation_failed",
+        status_label=(
+            f"{mapping.label_prefix} OAuth validation failed"
+            if mapping
+            else "OAuth validation failed"
+        ),
+        readiness={
+            "connected": False,
+            "last_validated_at": failed_at.isoformat(),
+            "backing_secret_exists": False,
+            "launch_ready": False,
+            "failure_reason": redact_sensitive_payload(str(reason or "unknown")),
+        },
+    )

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -354,6 +354,21 @@ def oauth_home_path_overrides(
     return {key: mount_path for key in mapping.home_path_keys}
 
 
+def clear_oauth_home_path_overrides(
+    profile: ManagedAgentProviderProfile,
+    *,
+    mapping: FirstPartyOAuthProfile | None,
+) -> None:
+    """Remove persisted OAuth home env overrides when leaving OAuth auth mode."""
+    if mapping is None or not profile.home_path_overrides:
+        return
+    profile.home_path_overrides = {
+        key: value
+        for key, value in profile.home_path_overrides.items()
+        if key not in mapping.home_path_keys
+    }
+
+
 def apply_oauth_connected_state(
     profile: ManagedAgentProviderProfile,
     *,

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -526,7 +526,7 @@ Examples:
 
 - `suppress_cli_model_flag_when_env_model_present: true`
 - `default_codex_profile_name: "m27"`
-- `auth_actions: ["connect_oauth", "add_api_key"]`
+- `auth_actions: ["connect_oauth", "use_api_key"]`
 - `auth_readiness: {"connected": false, "launch_ready": false}`
 
 #### `max_lease_duration_seconds`
@@ -608,7 +608,7 @@ command_behavior:
   supported_auth_methods: ["oauth_volume", "secret_ref"]
   auth_actions:
     - connect_oauth
-    - add_api_key
+    - use_api_key
   auth_status_label: "Not connected"
   auth_readiness:
     connected: false
@@ -760,7 +760,7 @@ Recommended behavior:
 def may_enable_profile(profile, *, action, readiness, policy) -> bool:
     if policy.blocks_launch(profile):
         return False
-    if action in {"connect_oauth", "reconnect_oauth", "add_api_key", "rotate_api_key"}:
+    if action in {"connect_oauth", "reconnect_oauth", "use_api_key", "rotate_api_key"}:
         return readiness.credentials_verified
     if profile.disabled_reason == "user_disabled":
         return False
@@ -1407,7 +1407,7 @@ home_path_overrides: {}
 
 command_behavior:
   supported_auth_methods: ["oauth_volume", "secret_ref"]
-  auth_actions: ["connect_oauth", "add_api_key"]
+  auth_actions: ["connect_oauth", "use_api_key"]
   auth_status_label: "Not connected"
   auth_readiness:
     connected: false

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -787,7 +787,13 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Validate Claude Oauth Profile */
+        /**
+         * Validate Claude Oauth Profile
+         * @description Validate an OAuth-backed provider profile against its auth volume.
+         *
+         *     Generalized across the first-party Claude, Codex, and Gemini runtimes; the
+         *     handler name is retained for OpenAPI operation-id stability.
+         */
         post: operations["validate_claude_oauth_profile_api_v1_provider_profiles__profile_id__oauth_validate_post"];
         delete?: never;
         options?: never;
@@ -804,7 +810,13 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Disconnect Claude Oauth Profile */
+        /**
+         * Disconnect Claude Oauth Profile
+         * @description Disconnect an OAuth-backed provider profile and clear its volume fields.
+         *
+         *     Generalized across the first-party Claude, Codex, and Gemini runtimes; the
+         *     handler name is retained for OpenAPI operation-id stability.
+         */
         post: operations["disconnect_claude_oauth_profile_api_v1_provider_profiles__profile_id__oauth_disconnect_post"];
         delete?: never;
         options?: never;

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -21,6 +21,7 @@ from api_service.db.models import (
     ProviderCredentialSource,
     ProviderProfileAuthMethod,
     ProviderProfileAuthState,
+    ProviderProfileDisabledReason,
     RuntimeMaterializationMode,
 )
 from api_service.main import app
@@ -870,18 +871,59 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     session_id = "oas_verifyfailed1"
+    profile_id = "codex-cli-failed-verify"
+    fallback_profile_id = "codex-cli-failed-verify-fallback"
+    synced_runtimes: list[str] = []
 
     async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.runtime_id == "codex_cli"
+            )
+        )
+        for row in result.scalars():
+            row.is_default = False
+        await session.flush()
         session.add(
             ManagedAgentOAuthSession(
                 session_id=session_id,
                 runtime_id="codex_cli",
-                profile_id="codex-cli-failed-verify",
+                profile_id=profile_id,
                 volume_ref="codex_auth_volume",
                 volume_mount_path="/home/app/.codex",
                 status=OAuthSessionStatus.AWAITING_USER,
                 requested_by_user_id="None",
                 account_label="codex account",
+            )
+        )
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                provider_label="OpenAI",
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                enabled=True,
+                is_default=True,
+                priority=10_100,
+                auth_state=ProviderProfileAuthState.CONNECTED,
+            )
+        )
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=fallback_profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                provider_label="OpenAI",
+                credential_source=ProviderCredentialSource.NONE,
+                runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+                enabled=True,
+                is_default=False,
+                priority=10_000,
+                auth_state=ProviderProfileAuthState.CONNECTED,
             )
         )
         await session.commit()
@@ -900,6 +942,9 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
         failed_signal["session_id"] = session_id
         failed_signal["reason"] = reason
 
+    async def _fake_sync(*, session: AsyncSession, runtime_id: str) -> None:
+        synced_runtimes.append(runtime_id)
+
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
         _failed_verify,
@@ -911,6 +956,10 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
     monkeypatch.setattr(
         "api_service.api.routers.oauth_sessions._fail_oauth_session_workflow",
         _capture_fail_signal,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions.sync_provider_profile_manager",
+        _fake_sync,
     )
 
     async with db_base.async_session_maker() as session:
@@ -930,6 +979,15 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
         assert row is not None
         assert row.status == OAuthSessionStatus.FAILED
         assert row.failure_reason == "Volume verification failed: no_credentials_found"
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        assert profile.enabled is False
+        assert profile.is_default is False
+        assert profile.auth_state == ProviderProfileAuthState.VALIDATION_FAILED
+        assert profile.disabled_reason == ProviderProfileDisabledReason.AUTH_INVALID
+        fallback = await session.get(ManagedAgentProviderProfile, fallback_profile_id)
+        assert fallback is not None
+        assert fallback.is_default is True
     assert stopped == {
         "session_id": session_id,
         "container_name": "moonmind_auth_oas_verifyfailed1",
@@ -938,6 +996,7 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
         "session_id": session_id,
         "reason": "Volume verification failed: no_credentials_found",
     }
+    assert synced_runtimes == ["codex_cli"]
 
 @pytest.mark.asyncio
 async def test_finalize_oauth_session_registers_oauth_home_codex_profile(

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -1689,3 +1689,166 @@ async def test_claude_oauth_terminal_websocket_rejects_replayed_attach_token(
 
     assert websocket.closed == [4403]
     assert websocket.accepted is False
+
+
+@pytest.mark.asyncio
+async def test_finalize_failed_verification_disables_existing_profile(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed OAuth verification must leave the visible profile disabled.
+
+    The generic finalize path (used by Codex/Gemini OAuth, not just the
+    Claude-only validate endpoint) must mark the profile
+    auth_state=validation_failed / disabled_reason=auth_invalid, not only fail
+    the OAuth session.
+    """
+    session_id = "oas_failverify_disable1"
+    profile_id = "codex-cli-failverify-disable"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                enabled=True,
+                auth_state=ProviderProfileAuthState.CONNECTED,
+            )
+        )
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="None",
+                account_label="codex account",
+            )
+        )
+        await session.commit()
+
+    async def _failed_verify(**_kwargs):
+        return {"verified": False, "reason": "no_credentials_found"}
+
+    async def _noop_stop(_session_obj):
+        return None
+
+    async def _noop_fail(_session_id, _reason):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _failed_verify,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _noop_stop,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._fail_oauth_session_workflow",
+        _noop_fail,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
+
+    assert response.status_code == 400
+
+    async with db_base.async_session_maker() as session:
+        oauth_session = await session.get(ManagedAgentOAuthSession, session_id)
+        assert oauth_session is not None
+        assert oauth_session.status == OAuthSessionStatus.FAILED
+
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        assert profile.enabled is False
+        assert profile.auth_state == ProviderProfileAuthState.VALIDATION_FAILED
+        assert (
+            profile.disabled_reason.value
+            if profile.disabled_reason
+            else None
+        ) == "auth_invalid"
+        readiness = (profile.command_behavior or {}).get("auth_readiness", {})
+        assert readiness.get("connected") is False
+        assert readiness.get("failure_reason") == "no_credentials_found"
+
+
+@pytest.mark.asyncio
+async def test_finalize_success_stamps_oauth_home_overrides_and_readiness(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OAuth-after-setup profiles persist documented home_path_overrides."""
+    session_id = "oas_gemini_homeoverrides1"
+    profile_id = "gemini-cli-home-overrides"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="gemini_cli",
+                profile_id=profile_id,
+                volume_ref="gemini_auth_volume",
+                volume_mount_path="/var/lib/gemini-auth",
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="None",
+                account_label="gemini account",
+                metadata_json={
+                    "provider_id": "google",
+                    "provider_label": "Google",
+                },
+            )
+        )
+        await session.commit()
+
+    async def _successful_verify(**_kwargs):
+        return {"verified": True}
+
+    async def _noop_sync(**_kwargs):
+        return None
+
+    async def _noop_stop(_session_obj):
+        return None
+
+    async def _noop_complete(_session_id):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _successful_verify,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions.sync_provider_profile_manager",
+        _noop_sync,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _noop_stop,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._complete_oauth_session_workflow",
+        _noop_complete,
+    )
+
+    async with client_app as client:
+        response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
+
+    assert response.status_code == 200
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        assert profile.auth_state == ProviderProfileAuthState.CONNECTED
+        assert profile.home_path_overrides == {
+            "GEMINI_HOME": "/var/lib/gemini-auth",
+            "GEMINI_CLI_HOME": "/var/lib/gemini-auth",
+        }
+        behavior = profile.command_behavior or {}
+        assert behavior.get("auth_strategy") == "gemini_credential_methods"
+        assert behavior.get("auth_status_label") == "Gemini OAuth ready"
+        assert behavior.get("auth_readiness", {}).get("connected") is True

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -1520,7 +1520,17 @@ async def test_provider_api_key_setup_stores_secret_ref_mappings_only(
                     is_default=False,
                 )
             )
-            await session.commit()
+            await session.flush()
+            existing = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert existing is not None
+        existing.home_path_overrides = {
+            "CLAUDE_HOME": "/oauth/claude",
+            "CODEX_HOME": "/oauth/codex",
+            "GEMINI_HOME": "/oauth/gemini",
+            "GEMINI_CLI_HOME": "/oauth/gemini",
+            "CUSTOM_HOME": "/custom/home",
+        }
+        await session.commit()
 
     async with client_app as client:
         response = await client.post(
@@ -1561,6 +1571,21 @@ async def test_provider_api_key_setup_stores_secret_ref_mappings_only(
         "CUSTOM_ENV": {"from_secret_ref": "custom_tool"},
         env_key: {"from_secret_ref": secret_role},
     }
+    expected_home_path_overrides = {
+        "CLAUDE_HOME": "/oauth/claude",
+        "CODEX_HOME": "/oauth/codex",
+        "GEMINI_HOME": "/oauth/gemini",
+        "GEMINI_CLI_HOME": "/oauth/gemini",
+        "CUSTOM_HOME": "/custom/home",
+    }
+    if runtime_id == "claude_code":
+        expected_home_path_overrides.pop("CLAUDE_HOME")
+    elif runtime_id == "codex_cli":
+        expected_home_path_overrides.pop("CODEX_HOME")
+    elif runtime_id == "gemini_cli":
+        expected_home_path_overrides.pop("GEMINI_HOME")
+        expected_home_path_overrides.pop("GEMINI_CLI_HOME")
+    assert profile_payload["home_path_overrides"] == expected_home_path_overrides
     assert clear_env_key in profile_payload["clear_env_keys"]
     assert profile_payload["account_label"] == "MM-875 route test"
     assert profile_payload["enabled"] is True
@@ -2180,6 +2205,53 @@ async def test_claude_oauth_validate_failure_redacts_secret_like_reason(
 
 
 @pytest.mark.asyncio
+async def test_claude_oauth_validate_failure_uses_unknown_reason_fallback(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _override_current_user()
+    profile_id = "claude-oauth-missing-failure-reason"
+
+    async def _fake_verify(
+        *,
+        runtime_id: str,
+        volume_ref: str,
+        volume_mount_path: str | None,
+    ) -> dict[str, object]:
+        return {"verified": False}
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _fake_verify,
+    )
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="claude_code",
+                provider_id="anthropic",
+                provider_label="Anthropic",
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="claude_auth_volume",
+                volume_mount_path="/home/app/.claude",
+                enabled=True,
+            )
+        )
+        await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/validate"
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Claude OAuth validation failed: unknown"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     (
         "profile_id",
@@ -2268,7 +2340,16 @@ async def test_first_party_oauth_lifecycle_generalized_across_runtimes(
                     enabled=True,
                 )
             )
-            await session.commit()
+            await session.flush()
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert profile is not None
+        profile.credential_source = ProviderCredentialSource.OAUTH_VOLUME
+        profile.runtime_materialization_mode = RuntimeMaterializationMode.OAUTH_HOME
+        profile.volume_ref = volume_ref
+        profile.volume_mount_path = mount_path
+        profile.home_path_overrides = {"CUSTOM_HOME": "/custom/home"}
+        profile.enabled = True
+        await session.commit()
 
     async with client_app as client:
         validate_response = await client.post(
@@ -2292,7 +2373,10 @@ async def test_first_party_oauth_lifecycle_generalized_across_runtimes(
     assert connected_payload["auth_state"] == "connected"
     assert connected_payload["disabled_reason"] is None
     assert connected_payload["last_auth_method"] == "oauth_volume"
-    assert connected_payload["home_path_overrides"] == expected_home_overrides
+    assert connected_payload["home_path_overrides"] == {
+        "CUSTOM_HOME": "/custom/home",
+        **expected_home_overrides,
+    }
     behavior = connected_payload["command_behavior"]
     assert behavior["auth_strategy"] == auth_strategy
     assert behavior["auth_status_label"] == f"{label_prefix} OAuth ready"
@@ -2307,6 +2391,9 @@ async def test_first_party_oauth_lifecycle_generalized_across_runtimes(
     assert disconnected_payload["credential_source"] == "none"
     assert disconnected_payload["volume_ref"] is None
     assert disconnected_payload["volume_mount_path"] is None
+    assert disconnected_payload["home_path_overrides"] == {
+        "CUSTOM_HOME": "/custom/home"
+    }
     assert disconnected_payload["auth_state"] == "disconnected"
     assert disconnected_payload["disabled_reason"] == "disconnected"
     assert disconnected_payload["enabled"] is False

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -65,6 +65,19 @@ def _module_db(tmp_path_factory):
 def client_app(_module_db) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
 
+
+@pytest.fixture(autouse=True)
+def _reset_dependency_overrides():
+    """Prevent ``_override_current_user`` overrides from leaking across modules.
+
+    These tests mutate the shared ``app.dependency_overrides`` to inject a
+    current user. Without cleanup, the last override leaks into sibling test
+    modules (e.g. the settings API tests) and changes their authenticated
+    principal, causing spurious 403s.
+    """
+    yield
+    app.dependency_overrides.clear()
+
 def _override_current_user(
     *,
     user_id=None,
@@ -2164,3 +2177,190 @@ async def test_claude_oauth_validate_failure_redacts_secret_like_reason(
         assert raw_secret not in str(readiness)
         assert raw_path not in str(readiness)
         assert readiness["failure_reason"] == "token=[REDACTED] in [REDACTED_AUTH_PATH]"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "profile_id",
+        "runtime_id",
+        "provider_id",
+        "volume_ref",
+        "mount_path",
+        "label_prefix",
+        "auth_strategy",
+        "expected_home_overrides",
+    ),
+    [
+        (
+            "codex-openai-oauth-lifecycle",
+            "codex_cli",
+            "openai",
+            "codex_auth_volume",
+            "/home/app/.codex",
+            "Codex",
+            "codex_credential_methods",
+            {"CODEX_HOME": "/home/app/.codex"},
+        ),
+        (
+            "gemini-google-oauth-lifecycle",
+            "gemini_cli",
+            "google",
+            "gemini_auth_volume",
+            "/var/lib/gemini-auth",
+            "Gemini",
+            "gemini_credential_methods",
+            {
+                "GEMINI_HOME": "/var/lib/gemini-auth",
+                "GEMINI_CLI_HOME": "/var/lib/gemini-auth",
+            },
+        ),
+    ],
+)
+async def test_first_party_oauth_lifecycle_generalized_across_runtimes(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+    profile_id: str,
+    runtime_id: str,
+    provider_id: str,
+    volume_ref: str,
+    mount_path: str,
+    label_prefix: str,
+    auth_strategy: str,
+    expected_home_overrides: dict[str, str],
+) -> None:
+    """validate + disconnect work for Codex and Gemini, not only Claude."""
+    _override_current_user()
+    synced_runtimes: list[str] = []
+
+    async def _fake_verify(
+        *,
+        runtime_id: str,
+        volume_ref: str,
+        volume_mount_path: str | None,
+    ) -> dict[str, object]:
+        return {"verified": True}
+
+    async def _fake_sync(*, session: AsyncSession, runtime_id: str) -> None:
+        synced_runtimes.append(runtime_id)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _fake_verify,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.provider_profiles.sync_provider_profile_manager",
+        _fake_sync,
+    )
+
+    async with db_base.async_session_maker() as session:
+        if await session.get(ManagedAgentProviderProfile, profile_id) is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id=runtime_id,
+                    provider_id=provider_id,
+                    credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                    runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                    volume_ref=volume_ref,
+                    volume_mount_path=mount_path,
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        validate_response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/validate"
+        )
+        connected_payload = (
+            await client.get(f"/api/v1/provider-profiles/{profile_id}")
+        ).json()
+        disconnect_response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/disconnect"
+        )
+        disconnected_payload = (
+            await client.get(f"/api/v1/provider-profiles/{profile_id}")
+        ).json()
+
+    assert validate_response.status_code == 200
+    assert validate_response.json()["status"] == "ready"
+    assert validate_response.json()["status_label"] == f"{label_prefix} OAuth ready"
+
+    assert connected_payload["enabled"] is True
+    assert connected_payload["auth_state"] == "connected"
+    assert connected_payload["disabled_reason"] is None
+    assert connected_payload["last_auth_method"] == "oauth_volume"
+    assert connected_payload["home_path_overrides"] == expected_home_overrides
+    behavior = connected_payload["command_behavior"]
+    assert behavior["auth_strategy"] == auth_strategy
+    assert behavior["auth_status_label"] == f"{label_prefix} OAuth ready"
+    assert behavior["auth_readiness"]["connected"] is True
+
+    assert disconnect_response.status_code == 200
+    assert disconnect_response.json()["status"] == "disconnected"
+    assert (
+        disconnect_response.json()["status_label"]
+        == f"{label_prefix} OAuth disconnected"
+    )
+    assert disconnected_payload["credential_source"] == "none"
+    assert disconnected_payload["volume_ref"] is None
+    assert disconnected_payload["volume_mount_path"] is None
+    assert disconnected_payload["auth_state"] == "disconnected"
+    assert disconnected_payload["disabled_reason"] == "disconnected"
+    assert disconnected_payload["enabled"] is False
+    assert disconnected_payload["command_behavior"]["auth_actions"] == ["use_api_key"]
+    assert synced_runtimes == [runtime_id, runtime_id]
+
+
+@pytest.mark.asyncio
+async def test_oauth_lifecycle_rejects_non_first_party_profile(
+    client_app: AsyncClient,
+    _module_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OAuth validate/disconnect are only available to first-party profiles."""
+    _override_current_user()
+    profile_id = "thirdparty-oauth-not-supported"
+
+    async def _unexpected_verify(**_kwargs):
+        raise AssertionError("non-first-party profiles must fail before verification")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
+        _unexpected_verify,
+    )
+
+    async with db_base.async_session_maker() as session:
+        if await session.get(ManagedAgentProviderProfile, profile_id) is None:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id=profile_id,
+                    runtime_id="custom_runtime",
+                    provider_id="acme",
+                    credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                    runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                    volume_ref="acme_auth_volume",
+                    volume_mount_path="/home/app/.acme",
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+    async with client_app as client:
+        validate_response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/validate"
+        )
+        disconnect_response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/oauth/disconnect"
+        )
+
+    expected_detail = (
+        "OAuth lifecycle actions are only supported for first-party "
+        "Claude, Codex, and Gemini provider profiles."
+    )
+    assert validate_response.status_code == 422
+    assert validate_response.json()["detail"] == expected_detail
+    assert disconnect_response.status_code == 422
+    assert disconnect_response.json()["detail"] == expected_detail

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -652,7 +652,7 @@ async def test_auto_seed_first_party_stubs_have_default_readiness_labels(
 
     expected_command_behavior = {
         "supported_auth_methods": ["oauth_volume", "secret_ref"],
-        "auth_actions": ["connect_oauth", "add_api_key"],
+        "auth_actions": ["connect_oauth", "use_api_key"],
         "auth_status_label": "Not connected",
         "auth_readiness": {
             "connected": False,
@@ -669,3 +669,9 @@ async def test_auto_seed_first_party_stubs_have_default_readiness_labels(
         assert profile.command_behavior == expected_command_behavior, profile_id
         # Stubs stay pre-OAuth: no home_path_overrides until setup succeeds.
         assert not profile.home_path_overrides
+
+    readiness_ids = {
+        id(profiles[profile_id].command_behavior["auth_readiness"])
+        for profile_id in FIRST_PARTY_SETUP_PROFILE_IDS
+    }
+    assert len(readiness_ids) == len(FIRST_PARTY_SETUP_PROFILE_IDS)

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -636,3 +636,36 @@ async def test_auto_seed_does_not_overwrite_custom_openrouter_codex_config_templ
         )
 
     assert profile.file_templates == custom_template
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_first_party_stubs_have_default_readiness_labels(
+    _module_db, monkeypatch
+):
+    """First-party setup stubs carry the documented command_behavior labels."""
+    from api_service.main import _auto_seed_provider_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    await _auto_seed_provider_profiles()
+
+    expected_command_behavior = {
+        "supported_auth_methods": ["oauth_volume", "secret_ref"],
+        "auth_actions": ["connect_oauth", "add_api_key"],
+        "auth_status_label": "Not connected",
+        "auth_readiness": {
+            "connected": False,
+            "launch_ready": False,
+        },
+    }
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(select(ManagedAgentProviderProfile))
+        profiles = {p.profile_id: p for p in result.scalars().all()}
+
+    for profile_id in FIRST_PARTY_SETUP_PROFILE_IDS:
+        profile = profiles[profile_id]
+        assert profile.command_behavior == expected_command_behavior, profile_id
+        # Stubs stay pre-OAuth: no home_path_overrides until setup succeeds.
+        assert not profile.home_path_overrides


### PR DESCRIPTION
## Issue

Jira: [MM-874](https://moonladder.atlassian.net/browse/MM-874) — Complete remaining behavior for Register OAuth-backed provider profiles after verification.

Covers DESIGN-REQ-009, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-020 (source: `docs/Security/ProviderProfiles.md`).

## Summary

The assess step found MM-874 `PARTIALLY_IMPLEMENTED`: OAuth finalization success persistence, secret/terminal-detail exclusion, `first_authenticated_at` preservation, and the Claude OAuth lifecycle were already present, but the validation-failure / disconnect / switch-to-API-key lifecycle was gated Claude-only and the runtime-generic finalize failure path never disabled the visible profile. This change completes the bounded remaining backlog:

- **Generalize OAuth `validate` and `disconnect` provider-profile endpoints** from Claude-only to all first-party runtimes (Claude/Anthropic, Codex/OpenAI, Gemini/Google) via a shared `FIRST_PARTY_OAUTH_PROFILES` mapping and `_require_first_party_oauth_profile` gate. Non-first-party profiles are rejected with 422. Handler names are retained for OpenAPI operation-id stability.
- **Disable the visible profile on the runtime-generic OAuth finalize verification-failure path**: set `auth_state=validation_failed`, `disabled_reason=auth_invalid`, `enabled=false` (previously only the Claude-only validate endpoint did this), matching `docs/Security/ProviderProfiles.md` §8.4. This closes the Codex/Gemini gap where a failed verification left the profile enabled.
- **Stamp documented OAuth-after-setup `home_path_overrides`** on finalize success (`CLAUDE_HOME` / `CODEX_HOME` / `GEMINI_HOME`+`GEMINI_CLI_HOME`) and connected credential-method `command_behavior` readiness (§15.2/15.4/15.5).
- **Seed first-party setup stubs with the documented default readiness-labels** `command_behavior` block (§7.2/§15.1).
- **Add shared OAuth lifecycle helpers** in `provider_profile_service` so the finalize path and the lifecycle endpoints produce identical profile state. Provider Profile rows continue to carry only profile-owned metadata — no PTY bridge IDs, WebSocket URLs, terminal session IDs, access/refresh tokens.

## Tests run

`MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` targeting the changed suites:

- `tests/unit/api_service/api/routers/test_oauth_sessions.py`
- `tests/unit/api_service/api/routers/test_provider_profiles.py`
- `tests/unit/api_service/test_provider_profile_auto_seed.py`

Result: **102 Python tests passed**; frontend Vitest suite **469 passed / 236 skipped**. New coverage: Codex/Gemini validate+disconnect generalization, non-first-party 422 rejection, finalize verification-failure profile disable, finalize-success home overrides + readiness, and seed-stub default readiness labels.

## Remaining risks

- Scope was deliberately bounded to the unmet/partially-met acceptance criteria from the assessment; the previously-`met` finalization-success persistence and secret-exclusion behavior was not modified.
- Endpoint handler functions were kept Claude-named for OpenAPI operation-id stability while their gate was generalized — a future rename would change generated client operation ids and should be done as an explicit contract change.
- `home_path_overrides` / readiness labels follow the documented per-runtime values in `docs/Security/ProviderProfiles.md`; if a runtime's documented home path changes, the mapping must be updated alongside the doc.
- No Temporal workflow/activity payload shapes changed; this is API-router + service-layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-874]: https://moonladder.atlassian.net/browse/MM-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ