### PR TITLE
Default pentest external targets to enabled

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -55,9 +55,10 @@ MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 # Curated PentestGPT tool (`security.pentest.run`)
 # Discovery is enabled by default; the tool is visible in Mission Control and
 # `/workflows/new`. This does not relax execution guardrails (approved scope is
-# still required, external targets stay disabled, only the safe runner profile is
-# allowlisted). Set MOONMIND_PENTEST_ENABLED="false" as the operator disable
-# override in deployments that are not approved for pentest operation.
+# still required, external targets still require manual approval by default, and
+# only the safe runner profile is allowlisted). Set MOONMIND_PENTEST_ENABLED="false"
+# as the operator disable override in deployments that are not approved for
+# pentest operation.
 MOONMIND_PENTEST_ENABLED="true"
 MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
 MOONMIND_PENTEST_SAFE_PROFILE_ID="pentestgpt-safe"
@@ -83,7 +84,7 @@ MOONMIND_PENTEST_MAX_TIME_BUDGET_MINUTES="480"
 MOONMIND_PENTEST_REQUIRE_APPROVED_SCOPE="true"
 MOONMIND_PENTEST_REQUIRE_MANUAL_APPROVAL_FOR_EXTERNAL="true"
 MOONMIND_PENTEST_REQUIRE_MANUAL_APPROVAL_FOR_FULL_AUTHORIZED="true"
-MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS="false"
+MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS="true"
 MOONMIND_PENTEST_TELEMETRY_ENABLED="false"
 
 LANGCHAIN_PROJECT="MoonMind"

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -240,7 +240,7 @@ All items shipped: per-step runtime/model/effort selection, cost tracking and bi
 - GitHub token permission scoping.
 - PR publishing gated on MoonSpec verification.
 - Deliberately gated exceptional workloads.
-- PentestGPT safety posture — approved-scope artifact requirement, conservative default operation modes, safe runner profile allowlist, external targets disabled by default, telemetry disabled by default, no arbitrary image/host-mount/raw Docker arguments, and report-first artifacts.
+- PentestGPT safety posture — approved-scope artifact requirement, conservative default operation modes, safe runner profile allowlist, manual approval required for external targets by default, telemetry disabled by default, no arbitrary image/host-mount/raw Docker arguments, and report-first artifacts.
 - PentestGPT runner supply-chain gates — provenance labels, tag-drift checks, runner self-test, upstream CLI contract check, and vulnerability threshold gate.
 
 ### Remaining work

--- a/docs/Security/PentestOperations.md
+++ b/docs/Security/PentestOperations.md
@@ -135,9 +135,13 @@ level, reach any network the Docker host can reach. The first production-safe
 posture therefore relies on **approved-scope validation**, not on network
 enforcement:
 
-- `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=false` keeps targets confined to
+- `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=true` allows
+  `external_authorized` scopes by default, but
+  `MOONMIND_PENTEST_REQUIRE_MANUAL_APPROVAL_FOR_EXTERNAL=true` still requires
+  recorded manual approval for external targets.
+- Set `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=false` to confine targets to
   lab/internal-authorized classes recorded in the approved scope artifact.
-- The `pentestgpt-safe` profile is intended for **approved lab targets only**.
+- The `pentestgpt-safe` profile is intended for **approved targets only**.
 - Operator docs, launch-plan metadata, runner profile names, and UI copy must
   describe this profile as Docker `bridge` for approved lab targets — never as
   an enforced egress firewall.
@@ -252,7 +256,7 @@ For local development only:
 MOONMIND_PENTEST_ENABLED=true
 MOONMIND_PENTEST_ALLOWED_OPERATION_MODES=recon_only,validate_hypothesis
 MOONMIND_PENTEST_ALLOWED_RUNNER_PROFILES=pentestgpt-safe
-MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=false
+MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS=true
 MOONMIND_PENTEST_TELEMETRY_ENABLED=false
 ```
 
@@ -310,8 +314,8 @@ passing and on security review for the escalations:
 3. Run staging tests with the real provider profile manager.
 4. Enable `recon_only` for internal lab scopes.
 5. Enable `validate_hypothesis` for internal authorized scopes.
-6. Keep `full_authorized`, VPN profiles, and external targets disabled until a
-   separate security review signs off.
+6. Keep `full_authorized` and VPN profiles disabled; external targets must still
+   carry an approved scope and recorded manual approval by default.
 
 ## Acceptance Criteria (MM-845)
 
@@ -321,5 +325,5 @@ Default-on discovery and the schema-driven Start Workflow inputs are accepted wh
 2. `MOONMIND_PENTEST_ENABLED=false` still hides the tool from discovery and rejects submissions (operator disable override preserved).
 3. `/workflows/new` renders the required PentestGPT fields after the tool is selected: `target`, `scope_artifact_ref`, `operation_mode`, `runner_profile_id`.
 4. `/workflows/new` renders the optional/advanced fields: `objective`, `execution_profile_ref`, `provider_selector`, `time_budget_minutes`, `repo_dir`, `evidence_level`, `network_attachment_ref`, with raw JSON demoted to an edit-JSON fallback.
-5. Backend safety constraints are unchanged by the default flip: approved scope required, external targets disabled by default, only the safe runner profile allowlisted by default, and inline scope rejected for untrusted submissions.
+5. Backend safety constraints are unchanged by the default flip: approved scope required, external targets require recorded manual approval by default, only the safe runner profile allowlisted by default, and inline scope rejected for untrusted submissions.
 6. Backend, frontend, integration, and regression coverage exists, including enable-by-default and disable-override regression tests.

--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -59,7 +59,7 @@ The implementation includes:
 9. a curated runner image definition under `docker/pentestgpt-runner/`,
 10. CI publishing for `ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0`.
 
-`security.pentest.run` discovery is enabled by default: `MOONMIND_PENTEST_ENABLED` defaults to `true`, and `MOONMIND_PENTEST_ENABLED=false` remains the operator disable override that hides the tool and rejects submissions. Discovery being on does not relax execution policy — the rest of the deployment posture stays conservative: approved scope is required, telemetry is disabled, external targets are disabled, only the safe runner profile is allowlisted, VPN/lab profiles are hidden, and `full_authorized` is not allowlisted unless an operator explicitly enables it.
+`security.pentest.run` discovery is enabled by default: `MOONMIND_PENTEST_ENABLED` defaults to `true`, and `MOONMIND_PENTEST_ENABLED=false` remains the operator disable override that hides the tool and rejects submissions. Discovery being on does not relax execution policy — the rest of the deployment posture stays conservative: approved scope is required, telemetry is disabled, external targets require recorded manual approval by default, only the safe runner profile is allowlisted, VPN/lab profiles are hidden, and `full_authorized` is not allowlisted unless an operator explicitly enables it.
 
 #### Production hardening status
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1588,7 +1588,7 @@ class PentestSettings(BaseSettings):
         ),
     )
     allow_external_targets: bool = Field(
-        False,
+        True,
         validation_alias=AliasChoices("MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS"),
     )
     telemetry_enabled: bool = Field(

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -193,7 +193,11 @@ def test_pentest_settings_accepts_approved_runner_images(runner_image: str) -> N
     assert parsed.runner_image == runner_image
 
 def test_pentest_settings_default_enables_tool_with_disable_override() -> None:
-    assert PentestSettings().enabled is True
+    defaults = PentestSettings(_env_file=None)
+
+    assert defaults.enabled is True
+    assert defaults.allow_external_targets is True
+    assert defaults.require_manual_approval_for_external is True
     assert PentestSettings(MOONMIND_PENTEST_ENABLED="false").enabled is False
     assert PentestSettings(MOONMIND_PENTEST_ENABLED="true").enabled is True
 

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -192,7 +192,15 @@ def test_pentest_settings_accepts_approved_runner_images(runner_image: str) -> N
 
     assert parsed.runner_image == runner_image
 
-def test_pentest_settings_default_enables_tool_with_disable_override() -> None:
+def test_pentest_settings_default_enables_tool_with_disable_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MOONMIND_PENTEST_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS", raising=False)
+    monkeypatch.delenv(
+        "MOONMIND_PENTEST_REQUIRE_MANUAL_APPROVAL_FOR_EXTERNAL",
+        raising=False,
+    )
     defaults = PentestSettings(_env_file=None)
 
     assert defaults.enabled is True


### PR DESCRIPTION
## Summary
- default `MOONMIND_PENTEST_ALLOW_EXTERNAL_TARGETS` to true
- keep manual approval required for external targets by default
- update pentest docs/template and settings coverage

## Tests
- `./tools/test_unit.sh --python-only tests/unit/integrations/pentest/test_pentest_models.py`
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_activity_runtime.py -k 'pentest_settings or security_pentest_execute_fails_before_launch_when_policy_disallows_mode'`\n\nNote: broader `./tools/test_unit.sh` attempts reached unrelated existing Vitest failures in Mission Control/workflow-list tests.