### PR TITLE
[codex] Skip unreadable Codex plugin cache seed files

### DIFF
--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -136,6 +136,12 @@ At session startup, the Codex session runtime copies eligible auth entries from
 `MANAGED_AUTH_VOLUME_PATH` into the per-run `codexHomePath`, then starts Codex
 App Server with `CODEX_HOME` pointing at that per-run home.
 
+Eligible auth entries exclude generated config, session transcripts, temporary
+runtime directories, logs/state databases, and transient Codex remote-plugin
+installer metadata. Actual credential seed files remain fail-fast if unreadable;
+optional plugin cache files may be skipped when their source permissions do not
+allow the managed-session user to copy them.
+
 ## 4. Volume Targeting Rules
 
 1. **Auth volumes are provider-profile credential stores.**

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -56,6 +56,7 @@ _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = (
 )
 _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({".tmp", "config.toml", "sessions", "tmp"})
+_AUTH_SEED_EXCLUDED_FILE_NAMES = frozenset({".codex-remote-plugin-install.json"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
@@ -486,10 +487,26 @@ class CodexManagedSessionRuntime:
         return not any(name.startswith(prefix) for prefix in _AUTH_SEED_EXCLUDED_PREFIXES)
 
     @staticmethod
+    def _should_seed_auth_file(path: Path) -> bool:
+        return path.name not in _AUTH_SEED_EXCLUDED_FILE_NAMES
+
+    @staticmethod
+    def _is_optional_auth_seed_cache_path(path: Path) -> bool:
+        parts = path.parts
+        needle = ("plugins", "cache")
+        return any(
+            tuple(parts[index : index + len(needle)]) == needle
+            for index in range(0, max(len(parts) - len(needle) + 1, 0))
+        )
+
+    @staticmethod
     def _copy_auth_seed_file(
         source: str | os.PathLike[str],
         destination: str | os.PathLike[str],
     ) -> None:
+        source_path = Path(source)
+        if not CodexManagedSessionRuntime._should_seed_auth_file(source_path):
+            return
         destination_path = Path(destination)
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         if destination_path.is_symlink() or destination_path.exists():
@@ -499,7 +516,14 @@ class CodexManagedSessionRuntime:
                     f"{destination_path}"
                 )
             destination_path.unlink()
-        shutil.copy2(source, destination_path)
+        try:
+            shutil.copy2(source_path, destination_path)
+        except PermissionError:
+            if CodexManagedSessionRuntime._is_optional_auth_seed_cache_path(
+                source_path
+            ):
+                return
+            raise
 
     def _seed_codex_home_from_auth_volume(self) -> None:
         if self._auth_volume_path is None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import time
 from datetime import UTC, datetime, timedelta
@@ -3314,6 +3315,136 @@ def test_runtime_launch_session_seeds_auth_directories_and_excludes_sessions(
     assert not Path(request.codex_home_path, ".tmp").exists()
     assert not Path(request.codex_home_path, "tmp").exists()
     assert not Path(request.codex_home_path, "linked-auth.json").exists()
+
+
+def test_runtime_launch_session_skips_unreadable_plugin_install_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    (auth_volume_path / "auth.json").write_text('{"token":"oauth"}', encoding="utf-8")
+    remote_plugin_dir = (
+        auth_volume_path
+        / "plugins"
+        / "cache"
+        / "openai-curated-remote"
+        / "github"
+    )
+    remote_plugin_dir.mkdir(parents=True)
+    marker_path = remote_plugin_dir / ".codex-remote-plugin-install.json"
+    marker_path.write_text('{"installed":true}', encoding="utf-8")
+    cache_index_path = remote_plugin_dir / "plugin-cache-index.json"
+    cache_index_path.write_text('{"cache":true}', encoding="utf-8")
+    skill_path = remote_plugin_dir / "0.1.5" / "skills" / "github" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# GitHub\n", encoding="utf-8")
+
+    real_copy2 = shutil.copy2
+
+    def _copy2_without_marker(
+        source: str | os.PathLike[str],
+        destination: str | os.PathLike[str],
+        *args: object,
+        **kwargs: object,
+    ) -> str:
+        if Path(source).name == ".codex-remote-plugin-install.json":
+            raise AssertionError("plugin install metadata should not be copied")
+        if Path(source) == cache_index_path:
+            raise PermissionError("optional plugin cache metadata is unreadable")
+        return str(real_copy2(source, destination, *args, **kwargs))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.shutil.copy2",
+        _copy2_without_marker,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    runtime.launch_session(request)
+
+    codex_home_path = Path(request.codex_home_path)
+    assert (codex_home_path / "auth.json").is_file()
+    assert (
+        codex_home_path
+        / "plugins"
+        / "cache"
+        / "openai-curated-remote"
+        / "github"
+        / "0.1.5"
+        / "skills"
+        / "github"
+        / "SKILL.md"
+    ).is_file()
+    assert not (
+        codex_home_path
+        / "plugins"
+        / "cache"
+        / "openai-curated-remote"
+        / "github"
+        / ".codex-remote-plugin-install.json"
+    ).exists()
+    assert not (
+        codex_home_path
+        / "plugins"
+        / "cache"
+        / "openai-curated-remote"
+        / "github"
+        / "plugin-cache-index.json"
+    ).exists()
+
+
+def test_runtime_launch_session_fails_on_unreadable_auth_seed_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    auth_path = auth_volume_path / "auth.json"
+    auth_path.write_text('{"token":"oauth"}', encoding="utf-8")
+
+    def _raise_permission(
+        source: str | os.PathLike[str],
+        _destination: str | os.PathLike[str],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        if Path(source) == auth_path:
+            raise PermissionError("auth seed unreadable")
+        raise AssertionError(f"unexpected copy source: {source}")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.shutil.copy2",
+        _raise_permission,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    with pytest.raises(PermissionError, match="auth seed unreadable"):
+        runtime.launch_session(request)
+
 
 def test_runtime_launch_session_auth_seed_overwrites_read_only_files_on_retry(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Seed Codex managed-session homes without copying transient remote-plugin installer metadata.
- Skip unreadable optional plugin cache files while preserving fail-fast behavior for unreadable auth seed files.
- Document eligible auth seed boundaries for OAuth-backed Codex sessions.

## Root Cause
Workflow `mm:57e0e947-c4d8-4df6-8d84-bb7d73c74e68` failed in `agent_runtime.launch_session` because root-owned `.codex-remote-plugin-install.json` files in the Codex auth volume were copied into the run-scoped `CODEX_HOME`. The managed-session user could stat the plugin cache but could not read those non-auth marker files, so `shutil.copytree` aborted before Codex App Server launched.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`