### PR TITLE
MM-882: Add canonical structured provider failure events from runtime adapters

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -62,7 +62,10 @@ from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.codex_session_timeouts import (
     MAX_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
-from moonmind.workflows.provider_failures import classify_provider_failure
+from moonmind.workflows.provider_failures import (
+    build_provider_failure_event,
+    classify_provider_failure,
+)
 from moonmind.workflows.executions.runtime_defaults import resolve_runtime_defaults
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
@@ -1824,12 +1827,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             metadata["turnMetadata"] = dict(turn_metadata)
         if session_artifacts is not None:
             metadata["sessionArtifacts"] = dict(session_artifacts)
-        if classification is not None:
-            metadata["providerFailure"] = {
-                "providerErrorCode": classification.provider_error_code,
-                "retryRecommendation": classification.retry_recommendation,
-                "reason": summary_text,
-            }
+        provider_failure_event = build_provider_failure_event(
+            classification=classification,
+        )
+        if provider_failure_event is not None:
+            metadata["providerFailure"] = provider_failure_event.to_metadata()
         failure_result = AgentRunResult(
             outputRefs=list(output_refs),
             summary=summary_text,

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -1,15 +1,40 @@
-"""Shared classification helpers for managed-provider failures."""
+"""Shared classification helpers for managed-provider failures.
+
+MM-882: this module owns the canonical structured provider failure event
+contract emitted by runtime adapters. Provider-manager cooldown and retry
+decisions prefer the structured fields (``provider_error_class``,
+``retry_after_seconds``, ``reset_at``, ``quota_scope``) and fall back to brittle
+text-marker classification only when those structured fields are absent.
+
+The event deliberately carries no raw provider text: the operator-facing
+``sanitized_summary`` is derived from the canonical class, and raw provider
+detail is referenced by ``raw_error_ref`` (an artifact ref) so it is never
+leaked into ordinary logs or workflow payloads.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from datetime import datetime, timezone
+from typing import Any, Mapping
 
 PROVIDER_RATE_LIMIT_ERROR_CODE = "429"
 PROVIDER_CAPACITY_ERROR_CODE = "provider_capacity"
 PROVIDER_AUTH_ERROR_CODE = "401"
+PROVIDER_CREDENTIAL_SCOPE_ERROR_CODE = "403"
 RETRY_AFTER_COOLDOWN_RECOMMENDATION = "retry_after_cooldown"
 REAUTHENTICATE_RECOMMENDATION = "reauthenticate"
+EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION = "expand_credential_scope"
+
+# Canonical ``provider_error_class`` values (MM-882). Runtime adapters set these
+# from structured provider responses where available; the text-marker classifier
+# derives them as a fallback.
+PROVIDER_ERROR_CLASS_AUTH = "auth"
+PROVIDER_ERROR_CLASS_RATE_LIMIT = "rate_limit"
+PROVIDER_ERROR_CLASS_CAPACITY = "capacity"
+PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE = "credential_scope"
+
+_MAX_PROVIDER_ERROR_CLASS_LEN = 64
 
 _RATE_LIMIT_MARKERS = (
     "429",
@@ -58,17 +83,117 @@ _AUTH_FAILURE_MARKERS = (
     "please run /login",
 )
 
+_CREDENTIAL_SCOPE_MARKERS = (
+    "http 403",
+    "status 403",
+    "403 forbidden",
+    "forbidden",
+    "insufficient scope",
+    "insufficient_scope",
+    "insufficient permission",
+    "insufficient permissions",
+    "missing scope",
+    "missing required scope",
+    "requires the following scopes",
+    "permission denied",
+)
+
+# Distinct sanitized operator summaries per canonical class. These intentionally
+# contain no raw provider text, so they are safe for ordinary logs and workflow
+# payloads (raw detail is referenced via ``raw_error_ref``).
+_SANITIZED_SUMMARY_BY_CLASS: dict[str, str] = {
+    PROVIDER_ERROR_CLASS_AUTH: (
+        "Provider authentication failed; reauthenticate the selected provider profile."
+    ),
+    PROVIDER_ERROR_CLASS_RATE_LIMIT: (
+        "Provider rate limit reached; the run will retry after a profile cooldown."
+    ),
+    PROVIDER_ERROR_CLASS_CAPACITY: (
+        "Provider capacity is temporarily exhausted; the run will retry after a "
+        "profile cooldown."
+    ),
+    PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE: (
+        "Provider credentials lack the required scope; grant the missing "
+        "credential scope before retrying."
+    ),
+}
+
+_CODE_TO_CLASS: dict[str, str] = {
+    PROVIDER_AUTH_ERROR_CODE: PROVIDER_ERROR_CLASS_AUTH,
+    PROVIDER_RATE_LIMIT_ERROR_CODE: PROVIDER_ERROR_CLASS_RATE_LIMIT,
+    PROVIDER_CAPACITY_ERROR_CODE: PROVIDER_ERROR_CLASS_CAPACITY,
+    PROVIDER_CREDENTIAL_SCOPE_ERROR_CODE: PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE,
+}
+
+_CLASS_TO_CODE: dict[str, str] = {
+    PROVIDER_ERROR_CLASS_AUTH: PROVIDER_AUTH_ERROR_CODE,
+    PROVIDER_ERROR_CLASS_RATE_LIMIT: PROVIDER_RATE_LIMIT_ERROR_CODE,
+    PROVIDER_ERROR_CLASS_CAPACITY: PROVIDER_CAPACITY_ERROR_CODE,
+    PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE: PROVIDER_CREDENTIAL_SCOPE_ERROR_CODE,
+}
+
+_CLASS_TO_RECOMMENDATION: dict[str, str] = {
+    PROVIDER_ERROR_CLASS_AUTH: REAUTHENTICATE_RECOMMENDATION,
+    PROVIDER_ERROR_CLASS_RATE_LIMIT: RETRY_AFTER_COOLDOWN_RECOMMENDATION,
+    PROVIDER_ERROR_CLASS_CAPACITY: RETRY_AFTER_COOLDOWN_RECOMMENDATION,
+    PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE: EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION,
+}
+
+# Canonical classes whose default disposition is a profile cooldown retry.
+_COOLDOWN_CLASSES = frozenset(
+    {PROVIDER_ERROR_CLASS_RATE_LIMIT, PROVIDER_ERROR_CLASS_CAPACITY}
+)
+
 @dataclass(frozen=True)
 class ProviderFailureClassification:
+    """Text-marker classification result (the fallback path).
+
+    ``provider_error_class`` carries the canonical class derived from the marker
+    match so callers can build a :class:`ProviderFailureEvent` without
+    re-deriving it from ``provider_error_code``.
+    """
+
     failure_class: str
     provider_error_code: str
     retry_recommendation: str
     reason: str
+    provider_error_class: str
+
+@dataclass(frozen=True)
+class ProviderFailureEvent:
+    """Canonical structured provider failure event emitted by runtime adapters.
+
+    Adapters populate the structured fields they can observe directly from the
+    provider response (status, headers, structured error body). Downstream
+    provider-manager cooldown/retry decisions prefer these canonical fields over
+    brittle text-marker classification.
+    """
+
+    provider_error_class: str | None = None
+    provider_error_code: str | None = None
+    retry_recommendation: str | None = None
+    retry_after_seconds: int | None = None
+    reset_at: str | None = None
+    quota_scope: str | None = None
+    credential_scope: str | None = None
+    provider_request_id: str | None = None
+    raw_error_ref: str | None = None
+    sanitized_summary: str | None = None
+
+    def requires_cooldown(self) -> bool:
+        return provider_failure_event_requires_cooldown(self)
+
+    def to_metadata(self) -> dict[str, Any]:
+        return provider_failure_event_to_metadata(self)
 
 def classify_provider_failure(
     reason: Any,
 ) -> ProviderFailureClassification | None:
-    """Return structured metadata for provider failures that need policy handling."""
+    """Return structured metadata for provider failures that need policy handling.
+
+    This is the text-marker fallback path. Canonical structured event data is
+    preferred by callers; see :func:`build_provider_failure_event`.
+    """
 
     rendered = str(reason or "").strip()
     if not rendered:
@@ -80,6 +205,15 @@ def classify_provider_failure(
             provider_error_code=PROVIDER_AUTH_ERROR_CODE,
             retry_recommendation=REAUTHENTICATE_RECOMMENDATION,
             reason=rendered,
+            provider_error_class=PROVIDER_ERROR_CLASS_AUTH,
+        )
+    if any(marker in normalized for marker in _CREDENTIAL_SCOPE_MARKERS):
+        return ProviderFailureClassification(
+            failure_class="user_error",
+            provider_error_code=PROVIDER_CREDENTIAL_SCOPE_ERROR_CODE,
+            retry_recommendation=EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION,
+            reason=rendered,
+            provider_error_class=PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE,
         )
     if any(marker in normalized for marker in _RATE_LIMIT_MARKERS):
         return ProviderFailureClassification(
@@ -87,6 +221,7 @@ def classify_provider_failure(
             provider_error_code=PROVIDER_RATE_LIMIT_ERROR_CODE,
             retry_recommendation=RETRY_AFTER_COOLDOWN_RECOMMENDATION,
             reason=rendered,
+            provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
         )
     if any(marker in normalized for marker in _CAPACITY_MARKERS):
         return ProviderFailureClassification(
@@ -94,15 +229,142 @@ def classify_provider_failure(
             provider_error_code=PROVIDER_CAPACITY_ERROR_CODE,
             retry_recommendation=RETRY_AFTER_COOLDOWN_RECOMMENDATION,
             reason=rendered,
+            provider_error_class=PROVIDER_ERROR_CLASS_CAPACITY,
         )
     return None
+
+def _coerce_optional_str(value: Any) -> str | None:
+    normalized = str(value).strip() if value is not None else ""
+    return normalized or None
+
+def _coerce_optional_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+def provider_error_class_for_code(provider_error_code: Any) -> str | None:
+    """Map a known ``provider_error_code`` onto its canonical class."""
+
+    normalized = _coerce_optional_str(provider_error_code)
+    if normalized is None:
+        return None
+    return _CODE_TO_CLASS.get(normalized.lower())
+
+def sanitized_summary_for_class(provider_error_class: Any) -> str | None:
+    """Return a distinct, raw-text-free operator summary for a class."""
+
+    normalized = _coerce_optional_str(provider_error_class)
+    if normalized is None:
+        return None
+    summary = _SANITIZED_SUMMARY_BY_CLASS.get(normalized.lower())
+    if summary is not None:
+        return summary
+    # Unknown/unclassified class: still produce a distinct, raw-text-free summary
+    # that names the reported class label (bounded so a noisy token cannot bloat
+    # the payload).
+    safe_label = normalized[:_MAX_PROVIDER_ERROR_CLASS_LEN]
+    return (
+        "Provider reported an unclassified failure "
+        f"(provider_error_class={safe_label})."
+    )
+
+def build_provider_failure_event(
+    *,
+    classification: ProviderFailureClassification | None = None,
+    reason: Any = None,
+    provider_error_class: Any = None,
+    provider_error_code: Any = None,
+    retry_recommendation: Any = None,
+    retry_after_seconds: Any = None,
+    reset_at: Any = None,
+    quota_scope: Any = None,
+    credential_scope: Any = None,
+    provider_request_id: Any = None,
+    raw_error_ref: Any = None,
+) -> ProviderFailureEvent | None:
+    """Build the canonical structured failure event.
+
+    Explicit structured fields win. When no structured class/code is supplied,
+    classification falls back to text-marker matching of *reason*. Returns
+    ``None`` when no failure signal (class, code, retry metadata, quota, or
+    credential scope) is present.
+    """
+
+    resolved_class = _coerce_optional_str(provider_error_class)
+    resolved_code = _coerce_optional_str(provider_error_code)
+    resolved_recommendation = _coerce_optional_str(retry_recommendation)
+
+    if (
+        classification is None
+        and resolved_class is None
+        and resolved_code is None
+        and reason is not None
+    ):
+        classification = classify_provider_failure(reason)
+
+    if classification is not None:
+        resolved_class = resolved_class or classification.provider_error_class
+        resolved_code = resolved_code or classification.provider_error_code
+        resolved_recommendation = (
+            resolved_recommendation or classification.retry_recommendation
+        )
+
+    if resolved_class is None and resolved_code is not None:
+        resolved_class = provider_error_class_for_code(resolved_code)
+    if resolved_code is None and resolved_class is not None:
+        resolved_code = _CLASS_TO_CODE.get(resolved_class.lower())
+    if resolved_recommendation is None and resolved_class is not None:
+        resolved_recommendation = _CLASS_TO_RECOMMENDATION.get(resolved_class.lower())
+
+    retry_after = _coerce_optional_int(retry_after_seconds)
+    if retry_after is not None and retry_after <= 0:
+        retry_after = None
+    reset = _coerce_optional_str(reset_at)
+    quota = _coerce_optional_str(quota_scope)
+    credential = _coerce_optional_str(credential_scope)
+    request_id = _coerce_optional_str(provider_request_id)
+    raw_ref = _coerce_optional_str(raw_error_ref)
+
+    has_signal = any(
+        (
+            resolved_class is not None,
+            resolved_code is not None,
+            retry_after is not None,
+            reset is not None,
+            quota is not None,
+            credential is not None,
+            request_id is not None,
+        )
+    )
+    if not has_signal:
+        return None
+
+    return ProviderFailureEvent(
+        provider_error_class=resolved_class,
+        provider_error_code=resolved_code,
+        retry_recommendation=resolved_recommendation,
+        retry_after_seconds=retry_after,
+        reset_at=reset,
+        quota_scope=quota,
+        credential_scope=credential,
+        provider_request_id=request_id,
+        raw_error_ref=raw_ref,
+        sanitized_summary=sanitized_summary_for_class(resolved_class),
+    )
 
 def provider_error_requires_cooldown(
     *,
     provider_error_code: str | None,
     retry_recommendation: str | None = None,
 ) -> bool:
-    """Return whether an agent result should be routed through profile cooldown."""
+    """Return whether an agent result should be routed through profile cooldown.
+
+    This is the text-marker / code fallback. Structured callers should prefer
+    :func:`provider_failure_event_requires_cooldown`.
+    """
 
     normalized_code = str(provider_error_code or "").strip().lower()
     normalized_retry = str(retry_recommendation or "").strip().lower()
@@ -111,6 +373,116 @@ def provider_error_requires_cooldown(
         PROVIDER_CAPACITY_ERROR_CODE,
     } or normalized_retry == RETRY_AFTER_COOLDOWN_RECOMMENDATION
 
+def provider_failure_event_requires_cooldown(
+    event: ProviderFailureEvent | None,
+) -> bool:
+    """Decide cooldown routing, preferring structured fields over markers."""
+
+    if event is None:
+        return False
+    # Structured retry/quota signals take precedence over marker-derived codes.
+    if event.retry_after_seconds is not None and event.retry_after_seconds > 0:
+        return True
+    if event.reset_at:
+        return True
+    if event.quota_scope:
+        return True
+    normalized_class = (event.provider_error_class or "").strip().lower()
+    if normalized_class in _COOLDOWN_CLASSES:
+        return True
+    return provider_error_requires_cooldown(
+        provider_error_code=event.provider_error_code,
+        retry_recommendation=event.retry_recommendation,
+    )
+
+def _seconds_until_reset(reset_at: str | None, *, now: datetime) -> int | None:
+    normalized = _coerce_optional_str(reset_at)
+    if normalized is None:
+        return None
+    candidate = normalized
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        reset_dt = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if reset_dt.tzinfo is None:
+        reset_dt = reset_dt.replace(tzinfo=timezone.utc)
+    reference = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    delta = (reset_dt - reference).total_seconds()
+    if delta <= 0:
+        return None
+    return int(delta)
+
+def resolve_provider_cooldown_seconds(
+    event: ProviderFailureEvent | None,
+    *,
+    now: datetime,
+    default_seconds: int,
+) -> int:
+    """Resolve cooldown seconds, preferring retry_after_seconds then reset_at.
+
+    Falls back to *default_seconds* (e.g. the profile's configured cooldown)
+    when no structured retry metadata is present.
+    """
+
+    default = max(int(default_seconds), 0)
+    if event is None:
+        return default
+    if event.retry_after_seconds is not None and event.retry_after_seconds > 0:
+        return event.retry_after_seconds
+    derived = _seconds_until_reset(event.reset_at, now=now)
+    if derived is not None and derived > 0:
+        return derived
+    return default
+
+def provider_failure_event_to_metadata(
+    event: ProviderFailureEvent,
+) -> dict[str, Any]:
+    """Serialize a failure event into the canonical ``providerFailure`` envelope."""
+
+    metadata: dict[str, Any] = {}
+    if event.provider_error_class is not None:
+        metadata["providerErrorClass"] = event.provider_error_class
+    if event.provider_error_code is not None:
+        metadata["providerErrorCode"] = event.provider_error_code
+    if event.retry_recommendation is not None:
+        metadata["retryRecommendation"] = event.retry_recommendation
+    if event.retry_after_seconds is not None:
+        metadata["retryAfterSeconds"] = event.retry_after_seconds
+    if event.reset_at is not None:
+        metadata["resetAt"] = event.reset_at
+    if event.quota_scope is not None:
+        metadata["quotaScope"] = event.quota_scope
+    if event.credential_scope is not None:
+        metadata["credentialScope"] = event.credential_scope
+    if event.provider_request_id is not None:
+        metadata["providerRequestId"] = event.provider_request_id
+    if event.raw_error_ref is not None:
+        metadata["rawErrorRef"] = event.raw_error_ref
+    if event.sanitized_summary is not None:
+        metadata["sanitizedSummary"] = event.sanitized_summary
+    return metadata
+
+def provider_failure_event_from_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> ProviderFailureEvent | None:
+    """Reconstruct a failure event from a ``providerFailure`` envelope."""
+
+    if not isinstance(metadata, Mapping):
+        return None
+    return build_provider_failure_event(
+        provider_error_class=metadata.get("providerErrorClass"),
+        provider_error_code=metadata.get("providerErrorCode"),
+        retry_recommendation=metadata.get("retryRecommendation"),
+        retry_after_seconds=metadata.get("retryAfterSeconds"),
+        reset_at=metadata.get("resetAt"),
+        quota_scope=metadata.get("quotaScope"),
+        credential_scope=metadata.get("credentialScope"),
+        provider_request_id=metadata.get("providerRequestId"),
+        raw_error_ref=metadata.get("rawErrorRef"),
+    )
+
 def provider_failure_search_markers() -> tuple[str, ...]:
     """Return the provider-failure markers suitable for coarse log searches."""
 
@@ -118,6 +490,7 @@ def provider_failure_search_markers() -> tuple[str, ...]:
         dict.fromkeys(
             (
                 *_AUTH_FAILURE_MARKERS,
+                *_CREDENTIAL_SCOPE_MARKERS,
                 *_RATE_LIMIT_MARKERS,
                 *_CAPACITY_MARKERS,
             )
@@ -127,11 +500,25 @@ def provider_failure_search_markers() -> tuple[str, ...]:
 __all__ = [
     "PROVIDER_AUTH_ERROR_CODE",
     "PROVIDER_CAPACITY_ERROR_CODE",
+    "PROVIDER_CREDENTIAL_SCOPE_ERROR_CODE",
     "PROVIDER_RATE_LIMIT_ERROR_CODE",
+    "PROVIDER_ERROR_CLASS_AUTH",
+    "PROVIDER_ERROR_CLASS_CAPACITY",
+    "PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE",
+    "PROVIDER_ERROR_CLASS_RATE_LIMIT",
+    "EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION",
     "REAUTHENTICATE_RECOMMENDATION",
     "RETRY_AFTER_COOLDOWN_RECOMMENDATION",
     "ProviderFailureClassification",
+    "ProviderFailureEvent",
+    "build_provider_failure_event",
     "classify_provider_failure",
-    "provider_failure_search_markers",
+    "provider_error_class_for_code",
     "provider_error_requires_cooldown",
+    "provider_failure_event_from_metadata",
+    "provider_failure_event_requires_cooldown",
+    "provider_failure_event_to_metadata",
+    "provider_failure_search_markers",
+    "resolve_provider_cooldown_seconds",
+    "sanitized_summary_for_class",
 ]

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -83,6 +83,12 @@ _AUTH_FAILURE_MARKERS = (
     "please run /login",
 )
 
+# Credential-scope markers are deliberately scoped to HTTP 403 wording or
+# explicit credential/scope phrasing. A bare ``permission denied`` is omitted on
+# purpose: it also appears in ordinary shell/git/filesystem errors (for example
+# ``bash: ./script: Permission denied`` or ``remote: Permission denied``) that
+# ``provider_failure_search_markers()`` would otherwise surface from recovery log
+# scans and misclassify as a provider ``403``/``credential_scope`` failure.
 _CREDENTIAL_SCOPE_MARKERS = (
     "http 403",
     "status 403",
@@ -95,7 +101,6 @@ _CREDENTIAL_SCOPE_MARKERS = (
     "missing scope",
     "missing required scope",
     "requires the following scopes",
-    "permission denied",
 )
 
 # Distinct sanitized operator summaries per canonical class. These intentionally

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -3622,11 +3622,13 @@ class MoonMindAgentRun:
                             provider_failure_event
                         )
                     )
-                else:
+                elif self.final_result is not None:
                     requires_provider_cooldown = provider_error_requires_cooldown(
                         provider_error_code=self.final_result.provider_error_code,
                         retry_recommendation=self.final_result.retry_recommendation,
                     )
+                else:
+                    requires_provider_cooldown = False
 
                 if (
                     request.agent_kind == "managed"

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -58,8 +58,12 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.provider_failures import (
+        build_provider_failure_event,
         classify_provider_failure,
         provider_error_requires_cooldown,
+        provider_failure_event_from_metadata,
+        provider_failure_event_requires_cooldown,
+        resolve_provider_cooldown_seconds,
     )
 
 # Map canonical AgentRunState literals to workflow-usable status constants.
@@ -153,6 +157,13 @@ RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
     "agent-run-runtime-selection-profile-clear-v1"
 )
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
+# Prefer the canonical structured provider failure event (retry_after_seconds /
+# reset_at / quota_scope / provider_error_class) when deciding profile cooldowns,
+# falling back to text-marker classification only when the structured fields are
+# absent. Gated so in-flight runs keep their recorded marker-based decision.
+AGENT_RUN_STRUCTURED_PROVIDER_FAILURE_PATCH_ID = (
+    "agent-run-structured-provider-failure-cooldown-v1"
+)
 AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
     "agent-run-managed-no-progress-reconciliation-v1"
 )
@@ -1199,12 +1210,11 @@ class MoonMindAgentRun:
                 by_alias=True,
             )
         classification = classify_provider_failure(summary)
-        if classification is not None:
-            metadata["providerFailure"] = {
-                "providerErrorCode": classification.provider_error_code,
-                "retryRecommendation": classification.retry_recommendation,
-                "reason": classification.reason,
-            }
+        provider_failure_event = build_provider_failure_event(
+            classification=classification,
+        )
+        if provider_failure_event is not None:
+            metadata["providerFailure"] = provider_failure_event.to_metadata()
         return AgentRunResult(
             summary=summary,
             failureClass=(
@@ -3594,18 +3604,50 @@ class MoonMindAgentRun:
                                     }
                                 )
 
-                if (
-                    request.agent_kind == "managed"
-                    and manager_handle
-                    and provider_error_requires_cooldown(
+                # Prefer the canonical structured provider failure event for the
+                # cooldown decision when present; fall back to text-marker codes.
+                prefer_structured_failure = workflow.patched(
+                    AGENT_RUN_STRUCTURED_PROVIDER_FAILURE_PATCH_ID
+                )
+                provider_failure_event = (
+                    provider_failure_event_from_metadata(
+                        self.final_result.metadata.get("providerFailure")
+                    )
+                    if self.final_result is not None
+                    else None
+                )
+                if prefer_structured_failure and provider_failure_event is not None:
+                    requires_provider_cooldown = (
+                        provider_failure_event_requires_cooldown(
+                            provider_failure_event
+                        )
+                    )
+                else:
+                    requires_provider_cooldown = provider_error_requires_cooldown(
                         provider_error_code=self.final_result.provider_error_code,
                         retry_recommendation=self.final_result.retry_recommendation,
                     )
+
+                if (
+                    request.agent_kind == "managed"
+                    and manager_handle
+                    and requires_provider_cooldown
                 ):
                     if workflow.patched("gemini-429-cooldown-retry-signal"):
                         runtime_id = self._managed_runtime_id(request.agent_id)
                         profile_id = str(request.execution_profile_ref or self._assigned_profile_id or "").strip() or None
                         cooldown_seconds = self._cooldown_seconds_for_profile(profile_id)
+                        if (
+                            prefer_structured_failure
+                            and provider_failure_event is not None
+                        ):
+                            # Prefer retry_after_seconds / reset_at from the
+                            # structured event over the profile default.
+                            cooldown_seconds = resolve_provider_cooldown_seconds(
+                                provider_failure_event,
+                                now=workflow.now(),
+                                default_seconds=cooldown_seconds,
+                            )
                         waiting_reason = self._build_managed_rate_limit_waiting_reason(
                             runtime_id=runtime_id,
                             profile_id=profile_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -7399,6 +7399,9 @@ class MoonMindRunWorkflow:
             provider_failure.get("retry_recommendation"),
         )
         reason = _first_text(
+            # MM-882: canonical sanitized summary; ``reason`` is read only as an
+            # in-flight fallback for run histories that predate the envelope.
+            provider_failure.get("sanitizedSummary"),
             provider_failure.get("reason"),
             outputs.get("summary"),
             self._get_from_result(result, "summary"),

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -2022,7 +2022,14 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
         "artifact:session-summary",
         "artifact:session-checkpoint",
     ]
-    assert result.metadata["providerFailure"]["providerErrorCode"] == "provider_capacity"
+    provider_failure = result.metadata["providerFailure"]
+    assert provider_failure["providerErrorCode"] == "provider_capacity"
+    # MM-882: the adapter emits the canonical structured failure envelope with a
+    # distinct sanitized summary and no raw provider text ("high demand").
+    assert provider_failure["providerErrorClass"] == "capacity"
+    assert provider_failure["retryRecommendation"] == "retry_after_cooldown"
+    assert "high demand" not in provider_failure["sanitizedSummary"].lower()
+    assert "reason" not in provider_failure
     assert result.metadata["profileId"] == "codex-default"
 
     persisted_record = run_store.load(binding.agent_run_id)
@@ -2180,7 +2187,12 @@ async def test_start_classifies_codex_auth_failure_as_user_error(
     assert result.failure_class == "user_error"
     assert result.provider_error_code == "401"
     assert result.retry_recommendation == "reauthenticate"
-    assert result.metadata["providerFailure"]["providerErrorCode"] == "401"
+    provider_failure = result.metadata["providerFailure"]
+    assert provider_failure["providerErrorCode"] == "401"
+    # MM-882: canonical auth failure class with a distinct sanitized summary.
+    assert provider_failure["providerErrorClass"] == "auth"
+    assert "reason" not in provider_failure
+    assert "authentication" in provider_failure["sanitizedSummary"].lower()
     assert result.metadata["profileId"] == "codex-default"
 
     persisted_record = run_store.load(binding.agent_run_id)

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -3148,7 +3148,7 @@ def test_activity_result_provider_failure_summary_reads_profile_from_failure() -
                 "providerFailure": {
                     "providerErrorCode": "401",
                     "profileId": "codex_default",
-                    "reason": "http 401",
+                    "sanitizedSummary": "http 401",
                     "retryRecommendation": "reauthenticate",
                 },
             },
@@ -3354,7 +3354,7 @@ async def test_run_execution_stage_fail_fast_raises_provider_failure_summary(
                 "providerFailure": {
                     "providerErrorCode": "401",
                     "retryRecommendation": "reauthenticate",
-                    "reason": "http 401",
+                    "sanitizedSummary": "http 401",
                 },
             },
         )

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -163,6 +163,32 @@ def test_classifies_credential_scope_forbidden_as_distinct_class() -> None:
     assert result.failure_class == "user_error"
     assert result.retry_recommendation == EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION
 
+def test_bare_permission_denied_is_not_credential_scope_failure() -> None:
+    """Ordinary shell/git permission errors must not classify as provider 403.
+
+    A bare ``permission denied`` appears in shell/git/filesystem failures (for
+    example ``bash: ./script: Permission denied`` or
+    ``remote: Permission denied``). These are execution errors, not provider
+    credential-scope failures, so the marker classifier must return ``None`` and
+    the phrase must not be a credential-scope search marker.
+    """
+
+    for shell_error in (
+        "bash: ./script: Permission denied",
+        "remote: Permission denied (publickey).",
+        "OSError: [Errno 13] Permission denied: '/work/output'",
+    ):
+        assert classify_provider_failure(shell_error) is None
+
+    markers = provider_failure_search_markers()
+    assert "permission denied" not in markers
+    # Explicit credential-scope wording must still be classifiable.
+    scoped = classify_provider_failure(
+        "HTTP 403 Forbidden: insufficient scope for this operation"
+    )
+    assert scoped is not None
+    assert scoped.provider_error_class == PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE
+
 def test_build_event_from_structured_fields_prefers_explicit_values() -> None:
     event = build_provider_failure_event(
         provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from moonmind.workflows.provider_failures import (
+    EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION,
+    PROVIDER_ERROR_CLASS_AUTH,
+    PROVIDER_ERROR_CLASS_CAPACITY,
+    PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE,
+    PROVIDER_ERROR_CLASS_RATE_LIMIT,
+    ProviderFailureEvent,
+    build_provider_failure_event,
     classify_provider_failure,
+    provider_error_class_for_code,
     provider_error_requires_cooldown,
+    provider_failure_event_from_metadata,
+    provider_failure_event_requires_cooldown,
+    provider_failure_event_to_metadata,
     provider_failure_search_markers,
+    resolve_provider_cooldown_seconds,
+    sanitized_summary_for_class,
 )
 
 def test_classifies_high_demand_as_provider_capacity() -> None:
@@ -58,6 +73,8 @@ def test_provider_failure_search_markers_cover_classification_markers() -> None:
         "try again later",
         "usage_limit_reached",
         "http 401",
+        "http 403",
+        "insufficient scope",
     ):
         assert expected in markers
 
@@ -117,3 +134,248 @@ def test_provider_cooldown_rejects_auth_reauthenticate_failure() -> None:
         provider_error_code="401",
         retry_recommendation="reauthenticate",
     )
+
+# ---------------------------------------------------------------------------
+# MM-882: canonical structured provider failure event contract
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 6, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+def test_classification_exposes_canonical_provider_error_class() -> None:
+    assert classify_provider_failure("http 401").provider_error_class == (
+        PROVIDER_ERROR_CLASS_AUTH
+    )
+    assert classify_provider_failure("rate limit").provider_error_class == (
+        PROVIDER_ERROR_CLASS_RATE_LIMIT
+    )
+    assert classify_provider_failure("http 503").provider_error_class == (
+        PROVIDER_ERROR_CLASS_CAPACITY
+    )
+
+def test_classifies_credential_scope_forbidden_as_distinct_class() -> None:
+    result = classify_provider_failure(
+        "HTTP 403 Forbidden: your token is missing the required scope"
+    )
+
+    assert result is not None
+    assert result.provider_error_class == PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE
+    assert result.provider_error_code == "403"
+    assert result.failure_class == "user_error"
+    assert result.retry_recommendation == EXPAND_CREDENTIAL_SCOPE_RECOMMENDATION
+
+def test_build_event_from_structured_fields_prefers_explicit_values() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
+        retry_after_seconds=42,
+        reset_at="2026-06-24T12:05:00Z",
+        quota_scope="account",
+        provider_request_id="req_abc123",
+        raw_error_ref="art_raw_error_1",
+    )
+
+    assert event is not None
+    assert event.provider_error_class == PROVIDER_ERROR_CLASS_RATE_LIMIT
+    assert event.provider_error_code == "429"
+    assert event.retry_after_seconds == 42
+    assert event.reset_at == "2026-06-24T12:05:00Z"
+    assert event.quota_scope == "account"
+    assert event.provider_request_id == "req_abc123"
+    assert event.raw_error_ref == "art_raw_error_1"
+    assert event.sanitized_summary is not None
+
+def test_build_event_text_marker_fallback_when_no_structured_fields() -> None:
+    event = build_provider_failure_event(reason="You've hit your usage limit")
+
+    assert event is not None
+    assert event.provider_error_class == PROVIDER_ERROR_CLASS_RATE_LIMIT
+    assert event.provider_error_code == "429"
+    assert event.retry_recommendation == "retry_after_cooldown"
+    # No structured retry metadata available from text markers.
+    assert event.retry_after_seconds is None
+    assert event.reset_at is None
+
+def test_build_event_derives_class_from_provider_error_code_only() -> None:
+    event = build_provider_failure_event(provider_error_code="429")
+
+    assert event is not None
+    assert event.provider_error_class == PROVIDER_ERROR_CLASS_RATE_LIMIT
+
+def test_build_event_returns_none_without_any_failure_signal() -> None:
+    assert build_provider_failure_event() is None
+    assert build_provider_failure_event(reason="all good, finished cleanly") is None
+
+def test_build_event_unknown_provider_error_class_is_preserved() -> None:
+    event = build_provider_failure_event(provider_error_class="moon_specific_glitch")
+
+    assert event is not None
+    assert event.provider_error_class == "moon_specific_glitch"
+    # Unknown class still produces a distinct, raw-text-free operator summary.
+    assert event.sanitized_summary == (
+        "Provider reported an unclassified failure "
+        "(provider_error_class=moon_specific_glitch)."
+    )
+    # Unknown classes do not map to a cooldown by themselves.
+    assert provider_failure_event_requires_cooldown(event) is False
+
+def test_distinct_sanitized_summaries_per_class() -> None:
+    summaries = {
+        PROVIDER_ERROR_CLASS_AUTH: sanitized_summary_for_class(
+            PROVIDER_ERROR_CLASS_AUTH
+        ),
+        PROVIDER_ERROR_CLASS_RATE_LIMIT: sanitized_summary_for_class(
+            PROVIDER_ERROR_CLASS_RATE_LIMIT
+        ),
+        PROVIDER_ERROR_CLASS_CAPACITY: sanitized_summary_for_class(
+            PROVIDER_ERROR_CLASS_CAPACITY
+        ),
+        PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE: sanitized_summary_for_class(
+            PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE
+        ),
+    }
+
+    assert all(value for value in summaries.values())
+    # Every class yields a distinct operator-facing summary.
+    assert len(set(summaries.values())) == 4
+
+def test_provider_error_class_for_code_mapping() -> None:
+    assert provider_error_class_for_code("401") == PROVIDER_ERROR_CLASS_AUTH
+    assert provider_error_class_for_code("403") == (
+        PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE
+    )
+    assert provider_error_class_for_code("provider_capacity") == (
+        PROVIDER_ERROR_CLASS_CAPACITY
+    )
+    assert provider_error_class_for_code("totally_unknown") is None
+
+def test_event_cooldown_decision_prefers_structured_retry_after() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
+        retry_after_seconds=120,
+    )
+
+    assert provider_failure_event_requires_cooldown(event) is True
+    assert (
+        resolve_provider_cooldown_seconds(event, now=_NOW, default_seconds=900)
+        == 120
+    )
+
+def test_event_cooldown_decision_derives_seconds_from_reset_at() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_CAPACITY,
+        reset_at="2026-06-24T12:03:00Z",
+    )
+
+    assert provider_failure_event_requires_cooldown(event) is True
+    # reset_at is 3 minutes after _NOW.
+    assert (
+        resolve_provider_cooldown_seconds(event, now=_NOW, default_seconds=900)
+        == 180
+    )
+
+def test_event_cooldown_quota_scope_present_triggers_cooldown() -> None:
+    # Even an otherwise-unknown class is routed to cooldown when a quota scope
+    # marker is present (structured fields preferred over markers).
+    event = build_provider_failure_event(
+        provider_error_class="weird_quota_state",
+        quota_scope="model",
+    )
+
+    assert event is not None
+    assert provider_failure_event_requires_cooldown(event) is True
+
+def test_event_cooldown_missing_retry_metadata_falls_back_to_default() -> None:
+    # Rate-limit class with no retry_after_seconds/reset_at must still cooldown,
+    # using the caller-provided default (e.g. the profile's configured value).
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
+    )
+
+    assert provider_failure_event_requires_cooldown(event) is True
+    assert event.retry_after_seconds is None
+    assert event.reset_at is None
+    assert (
+        resolve_provider_cooldown_seconds(event, now=_NOW, default_seconds=900)
+        == 900
+    )
+
+def test_event_cooldown_ignores_past_reset_at() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
+        reset_at="2020-01-01T00:00:00Z",
+    )
+
+    # A stale reset_at must not produce a zero/negative cooldown.
+    assert (
+        resolve_provider_cooldown_seconds(event, now=_NOW, default_seconds=900)
+        == 900
+    )
+
+def test_credential_scope_event_does_not_cooldown() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_CREDENTIAL_SCOPE,
+    )
+
+    assert event is not None
+    assert provider_failure_event_requires_cooldown(event) is False
+
+def test_resolve_cooldown_seconds_none_event_returns_default() -> None:
+    assert resolve_provider_cooldown_seconds(None, now=_NOW, default_seconds=900) == 900
+
+def test_event_metadata_round_trips() -> None:
+    event = build_provider_failure_event(
+        provider_error_class=PROVIDER_ERROR_CLASS_RATE_LIMIT,
+        retry_after_seconds=30,
+        reset_at="2026-06-24T12:05:00Z",
+        quota_scope="account",
+        provider_request_id="req_round_trip",
+        raw_error_ref="art_raw_2",
+    )
+    assert event is not None
+
+    metadata = provider_failure_event_to_metadata(event)
+    assert metadata["providerErrorClass"] == PROVIDER_ERROR_CLASS_RATE_LIMIT
+    assert metadata["retryAfterSeconds"] == 30
+    assert metadata["resetAt"] == "2026-06-24T12:05:00Z"
+    assert metadata["quotaScope"] == "account"
+    assert metadata["providerRequestId"] == "req_round_trip"
+    assert metadata["rawErrorRef"] == "art_raw_2"
+    assert metadata["sanitizedSummary"] == event.sanitized_summary
+    # Raw provider text is never serialized into the envelope.
+    assert "reason" not in metadata
+
+    rebuilt = provider_failure_event_from_metadata(metadata)
+    assert rebuilt == event
+
+def test_event_from_metadata_legacy_marker_payload_still_cools_down() -> None:
+    # In-flight runs may carry the previous marker-only envelope shape.
+    legacy_metadata = {
+        "providerErrorCode": "429",
+        "retryRecommendation": "retry_after_cooldown",
+    }
+
+    event = provider_failure_event_from_metadata(legacy_metadata)
+    assert event is not None
+    assert event.provider_error_class == PROVIDER_ERROR_CLASS_RATE_LIMIT
+    assert provider_failure_event_requires_cooldown(event) is True
+    assert (
+        resolve_provider_cooldown_seconds(event, now=_NOW, default_seconds=900)
+        == 900
+    )
+
+def test_event_from_metadata_handles_missing_or_blank_envelope() -> None:
+    assert provider_failure_event_from_metadata(None) is None
+    assert provider_failure_event_from_metadata({}) is None
+
+def test_event_to_metadata_omits_unset_optional_fields() -> None:
+    event = ProviderFailureEvent(
+        provider_error_class=PROVIDER_ERROR_CLASS_AUTH,
+        provider_error_code="401",
+        retry_recommendation="reauthenticate",
+        sanitized_summary=sanitized_summary_for_class(PROVIDER_ERROR_CLASS_AUTH),
+    )
+
+    metadata = provider_failure_event_to_metadata(event)
+    assert "retryAfterSeconds" not in metadata
+    assert "resetAt" not in metadata
+    assert "quotaScope" not in metadata
+    assert "rawErrorRef" not in metadata


### PR DESCRIPTION
## Issue

Jira: [MM-882](https://moonladder.atlassian.net/browse/MM-882) — Add canonical structured provider failure events from runtime adapters.

## Summary

Moves provider failure handling away from brittle CLI/provider text-marker matching toward a canonical structured event contract, while retaining text matching as a fallback only.

- **Structured event contract** — Adds `ProviderFailureEvent` to `moonmind/workflows/provider_failures.py` with the canonical fields `provider_error_class`, `retry_after_seconds`, `reset_at`, `quota_scope`, `credential_scope`, `provider_request_id`, `raw_error_ref`, and `sanitized_summary`, plus build/decision/envelope helper functions. Text-marker classification now also derives the canonical class, including a distinct `credential_scope` class.
- **Adapter boundaries emit the canonical envelope** — `agent_run._managed_start_failure_result` and `codex_session_adapter._persist_failed_run_state` now emit the canonical `providerFailure` envelope. The envelope carries a distinct sanitized operator summary per class and no raw provider text; raw detail is referenced via `raw_error_ref`. The raw `reason` field is dropped in favor of `sanitizedSummary`.
- **Provider-manager prefers structured fields** — The AgentRun cooldown decision prefers `retry_after_seconds`/`reset_at` over marker-derived seconds when present, falling back to the profile default. `quota_scope`/`reset_at`/rate-limit and capacity classes route to cooldown; auth and `credential_scope` do not. The new behavior is gated behind a workflow patch so in-flight runs keep their marker-based decision; a follow-up commit restores the null-result guard so non-managed/null-handle runs default to no cooldown.
- **Consumer update** — The run-workflow provider failure summary reads `sanitizedSummary`, with a tolerant legacy `reason` fallback for in-flight run histories.
- **Secret-safety preserved** — Raw provider details are referenced (`raw_error_ref`) or sanitized rather than logged into ordinary logs or workflow payloads.

## Tests run

`MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` on the changed test files:

- `tests/unit/workflows/test_provider_failures.py`
- `tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `tests/unit/workflows/temporal/test_run_artifacts.py`

Result: **155 Python tests passed**. The frontend Vitest suite also ran as part of the script: **469 passed, 236 skipped**.

New tests cover structured events, fallback text markers, unknown `provider_error_class`, missing retry metadata, credential-scope summaries, legacy/in-flight envelopes, and the adapter envelope shape.

## Remaining risks

- **Workflow-boundary / in-flight compatibility** — The structured-field cooldown preference is gated behind a new workflow patch and the consumer retains a legacy `reason` fallback, so in-flight runs and previously persisted histories should remain compatible; this depends on the patch gate being evaluated correctly under replay.
- **Partial scope** — Per the assessment this issue was `PARTIALLY_IMPLEMENTED` at the start; this change implements the core structured-event contract, provider-manager preference, credential-scope class, sanitized summaries, and `raw_error_ref`. Downstream consumers that still read marker-only fields elsewhere were not exhaustively migrated and may warrant follow-up.
- **Classification coverage** — The canonical class is still derived in part from text markers as a fallback; provider wording changes could leave some failures classified via the fallback path rather than from structured fields.


[MM-882]: https://moonladder.atlassian.net/browse/MM-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ