### PR TITLE
MM-883: Add shared cross-runtime managed-session conformance suite

### DIFF
--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -574,7 +574,41 @@ Codex-specific behavior belongs in Codex-managed-session docs. Claude Code, Gemi
 
 ---
 
-## 12. Required invariants
+## 12. Cross-runtime managed-session conformance
+
+Runtime resilience capabilities must be truthful, uniform, and regression-tested before Mission Control surfaces a runtime as session-capable. A shared, runtime-neutral conformance suite defines and enforces this.
+
+### 12.1 Conformance expectations
+
+The suite defines one canonical set of required managed-session behaviors that every session-capable runtime must satisfy:
+
+- `launch`
+- `turn_control`
+- `interrupt`
+- `reset_epoch`
+- `resume`
+- `terminate`
+- `rate_limit`
+- `no_progress`
+- `checkpoint`
+- `outbound_scan`
+- `correlation`
+
+`checkpoint`, `outbound_scan`, and `correlation` (observability) are evaluated uniformly across runtimes, not as runtime-specific concerns.
+
+### 12.2 Capability metadata at the adapter boundary
+
+Each session-capable runtime adapter exposes bounded, runtime-neutral capability metadata describing, per behavior, whether it is supported, the invocation contract used at the adapter boundary, and the trace/artifact correlation surfaces that evidence it. The conformance suite consumes this metadata so it evaluates the same contract the runtime advertises. Boundary-level tests assert that the declared invocation shapes and correlation surfaces match the runtime's real behavior.
+
+### 12.3 Truthful, binary determination
+
+Conformance determination is binary: a runtime is session-capable only when every required behavior conforms. There is intentionally no "partially session-capable" state. Any missing or unsupported behavior produces an actionable capability gap and forces the determination to not-session-capable.
+
+A runtime with no canonical managed-session runtime id must never be determined session-capable, even if it declares every behavior. A runtime that claims session capability it cannot back with conforming behaviors fails the suite, preventing unsupported runtimes from being surfaced as session-capable.
+
+Codex CLI is the only runtime that currently conforms. Claude Code, Gemini CLI, and future runtimes are reported as not-session-capable with explicit capability gaps until they implement their own session planes and pass the suite.
+
+## 13. Required invariants
 
 The following invariants must hold across managed session planes:
 
@@ -591,7 +625,7 @@ The following invariants must hold across managed session planes:
 
 ---
 
-## 13. Document relationship
+## 14. Document relationship
 
 Use the managed-agent docs as follows:
 

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -70,6 +70,10 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     EMPTY_ASSISTANT_FAILURE_CAUSE,
 )
+from moonmind.workflows.temporal.managed_session_conformance import (
+    ManagedSessionRuntimeCapabilities,
+    codex_managed_session_capabilities,
+)
 from moonmind.workflows.temporal.managed_session_errors import (
     is_managed_session_locator_mismatch_error,
 )
@@ -341,6 +345,16 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             defer_turn_instructions_until_session_launch
         )
         self._run_states: dict[str, CodexSessionExecutionState] = {}
+
+    @classmethod
+    def managed_session_capabilities(cls) -> ManagedSessionRuntimeCapabilities:
+        """Expose the Codex managed-session capability descriptor.
+
+        The shared cross-runtime conformance suite consumes this metadata at the
+        adapter boundary to determine, truthfully, that Codex is session-capable.
+        """
+
+        return codex_managed_session_capabilities()
 
     async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
         binding = self._require_binding(request)

--- a/moonmind/workflows/temporal/managed_session_conformance.py
+++ b/moonmind/workflows/temporal/managed_session_conformance.py
@@ -1,0 +1,500 @@
+"""Shared cross-runtime managed-session conformance suite (MM-883).
+
+This module defines a runtime-neutral conformance contract for MoonMind managed
+sessions. It does two things:
+
+1. Defines the bounded, runtime-neutral *capability metadata* that a managed
+   session-capable runtime adapter exposes about itself
+   (:class:`ManagedSessionRuntimeCapabilities`).
+2. Evaluates that metadata against the canonical set of required managed-session
+   behaviors (launch, turn control, interrupt, reset/epoch, resume, terminate,
+   rate-limit, no-progress, checkpoint, outbound scan, and correlation) and
+   produces a deterministic conformance report.
+
+The determination is *truthful* and *binary*: a runtime is either session-capable
+(every required behavior conforms) or it is not. There is intentionally no
+"partially session-capable" verdict. Non-conforming runtimes are reported with
+precise, actionable capability gaps so they cannot be surfaced as session-capable
+by mistake.
+
+Concrete adapters expose their descriptor at the adapter boundary (for example
+``CodexSessionAdapter.managed_session_capabilities()``) so the suite runs against
+the same metadata the runtime advertises. Boundary-level adapter tests assert that
+the declared invocation shapes and trace/artifact correlation surfaces match the
+runtime's real behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from moonmind.schemas._validation import NonBlankStr
+from moonmind.schemas.managed_session_models import (
+    MANAGED_SESSION_CONTROL_ACTIONS,
+    ManagedSessionControlAction,
+    canonical_managed_session_runtime_id,
+)
+
+MANAGED_SESSION_CONFORMANCE_SUITE_ID = "managed-session-conformance"
+
+ManagedSessionConformanceBehavior = Literal[
+    "launch",
+    "turn_control",
+    "interrupt",
+    "reset_epoch",
+    "resume",
+    "terminate",
+    "rate_limit",
+    "no_progress",
+    "checkpoint",
+    "outbound_scan",
+    "correlation",
+]
+
+# The canonical, ordered set of behaviors a managed-session runtime must satisfy
+# before it can be surfaced as session-capable. These map one-to-one to the
+# MM-883 acceptance criteria.
+REQUIRED_MANAGED_SESSION_BEHAVIORS: tuple[ManagedSessionConformanceBehavior, ...] = (
+    "launch",
+    "turn_control",
+    "interrupt",
+    "reset_epoch",
+    "resume",
+    "terminate",
+    "rate_limit",
+    "no_progress",
+    "checkpoint",
+    "outbound_scan",
+    "correlation",
+)
+
+# Coverage IDs carried through from the MM-883 design reference so downstream
+# verification and the pull request can trace the requirements this suite covers.
+MM883_COVERAGE_IDS: tuple[str, ...] = (
+    "DESIGN-REQ-001",
+    "DESIGN-REQ-002",
+    "DESIGN-REQ-005",
+    "DESIGN-REQ-006",
+    "DESIGN-REQ-007",
+    "DESIGN-REQ-011",
+    "DESIGN-REQ-013",
+    "DESIGN-REQ-014",
+)
+
+# Runtimes the suite evaluates by default. Only ``codex_cli`` currently has a
+# concrete managed-session plane; the others must be reported as non-conforming
+# with explicit capability gaps rather than session-capable.
+KNOWN_MANAGED_SESSION_RUNTIMES: tuple[str, ...] = (
+    "codex_cli",
+    "claude",
+    "claude_code",
+    "gemini_cli",
+)
+
+ManagedSessionBehaviorDecision = Literal["conforms", "capability_gap"]
+
+
+class ManagedSessionBehaviorSupport(BaseModel):
+    """Runtime-declared support for one required managed-session behavior."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    behavior: ManagedSessionConformanceBehavior = Field(..., alias="behavior")
+    supported: bool = Field(..., alias="supported")
+    invocation: str | None = Field(None, alias="invocation")
+    evidence: tuple[str, ...] = Field(default=(), alias="evidence")
+    gap_reason: str | None = Field(None, alias="gapReason")
+
+    @model_validator(mode="after")
+    def _validate(self) -> "ManagedSessionBehaviorSupport":
+        if self.supported:
+            if not (self.invocation or "").strip():
+                raise ValueError(
+                    f"behavior '{self.behavior}' is supported but declares no "
+                    "invocation contract"
+                )
+            if not self.evidence:
+                raise ValueError(
+                    f"behavior '{self.behavior}' is supported but declares no "
+                    "evidence surfaces"
+                )
+            if self.gap_reason is not None:
+                raise ValueError(
+                    f"behavior '{self.behavior}' is supported and must not carry "
+                    "a gapReason"
+                )
+        else:
+            if not (self.gap_reason or "").strip():
+                raise ValueError(
+                    f"behavior '{self.behavior}' is unsupported and must declare "
+                    "an actionable gapReason"
+                )
+        return self
+
+
+class ManagedSessionRuntimeCapabilities(BaseModel):
+    """Bounded, runtime-neutral metadata a managed-session adapter exposes."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+
+    runtime_id: NonBlankStr = Field(..., alias="runtimeId")
+    runtime_family: str | None = Field(None, alias="runtimeFamily")
+    session_capable_claim: bool = Field(..., alias="sessionCapableClaim")
+    control_actions: tuple[ManagedSessionControlAction, ...] = Field(
+        default=(), alias="controlActions"
+    )
+    behaviors: tuple[ManagedSessionBehaviorSupport, ...] = Field(
+        ..., alias="behaviors"
+    )
+
+    @model_validator(mode="after")
+    def _validate(self) -> "ManagedSessionRuntimeCapabilities":
+        keys = [support.behavior for support in self.behaviors]
+        if len(keys) != len(set(keys)):
+            raise ValueError("behaviors must be unique per behavior key")
+        return self
+
+    def behavior(
+        self, behavior: ManagedSessionConformanceBehavior
+    ) -> ManagedSessionBehaviorSupport | None:
+        for support in self.behaviors:
+            if support.behavior == behavior:
+                return support
+        return None
+
+
+def _gap(behavior: str, reason: str) -> dict[str, Any]:
+    return {"behavior": behavior, "reason": reason}
+
+
+def evaluate_managed_session_conformance(
+    capabilities: ManagedSessionRuntimeCapabilities,
+) -> dict[str, Any]:
+    """Evaluate one runtime's capability metadata against the required behaviors.
+
+    Returns a deterministic report. ``sessionCapable`` is a truthful binary
+    determination: it is ``True`` only when every required behavior conforms.
+    Any missing or unsupported behavior produces an actionable capability gap and
+    forces ``sessionCapable`` to ``False`` -- there is no partial verdict.
+    """
+
+    behavior_decisions: list[dict[str, Any]] = []
+    capability_gaps: list[dict[str, Any]] = []
+
+    for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS:
+        support = capabilities.behavior(behavior)
+        if support is None:
+            reason = (
+                f"runtime '{capabilities.runtime_id}' does not declare the "
+                f"'{behavior}' managed-session behavior"
+            )
+            capability_gaps.append(_gap(behavior, reason))
+            behavior_decisions.append(
+                {
+                    "behavior": behavior,
+                    "decision": "capability_gap",
+                    "supported": False,
+                    "invocation": None,
+                    "evidence": [],
+                    "gapReason": reason,
+                }
+            )
+            continue
+        if not support.supported:
+            reason = support.gap_reason or (
+                f"runtime '{capabilities.runtime_id}' does not support the "
+                f"'{behavior}' managed-session behavior"
+            )
+            capability_gaps.append(_gap(behavior, reason))
+            behavior_decisions.append(
+                {
+                    "behavior": behavior,
+                    "decision": "capability_gap",
+                    "supported": False,
+                    "invocation": support.invocation,
+                    "evidence": list(support.evidence),
+                    "gapReason": reason,
+                }
+            )
+            continue
+        behavior_decisions.append(
+            {
+                "behavior": behavior,
+                "decision": "conforms",
+                "supported": True,
+                "invocation": support.invocation,
+                "evidence": list(support.evidence),
+                "gapReason": None,
+            }
+        )
+
+    canonical_runtime_id = canonical_managed_session_runtime_id(
+        capabilities.runtime_id
+    )
+    # Defense in depth: a runtime with no canonical managed-session id must never
+    # be determined session-capable, even if it declares every behavior.
+    if canonical_runtime_id is None and not capability_gaps:
+        reason = (
+            f"runtime '{capabilities.runtime_id}' has no canonical managed-session "
+            "runtime id and must not be surfaced as session-capable"
+        )
+        capability_gaps.append(_gap("runtime_identity", reason))
+
+    session_capable = not capability_gaps
+    claim_truthful = session_capable == capabilities.session_capable_claim
+
+    return {
+        "runtimeId": capabilities.runtime_id,
+        "runtimeFamily": capabilities.runtime_family,
+        "canonicalRuntimeId": canonical_runtime_id,
+        "sessionCapableClaim": capabilities.session_capable_claim,
+        "sessionCapable": session_capable,
+        "claimTruthful": claim_truthful,
+        "result": "passed" if claim_truthful else "failed",
+        "controlActions": list(capabilities.control_actions),
+        "behaviorDecisions": behavior_decisions,
+        "capabilityGaps": capability_gaps,
+    }
+
+
+def _codex_behavior(
+    behavior: ManagedSessionConformanceBehavior,
+    invocation: str,
+    evidence: tuple[str, ...],
+) -> ManagedSessionBehaviorSupport:
+    return ManagedSessionBehaviorSupport(
+        behavior=behavior,
+        supported=True,
+        invocation=invocation,
+        evidence=evidence,
+    )
+
+
+def codex_managed_session_capabilities() -> ManagedSessionRuntimeCapabilities:
+    """Canonical capability descriptor for the Codex CLI managed-session plane.
+
+    Each behavior records the bounded invocation contract used at the adapter
+    boundary plus the trace/artifact correlation surfaces that prove the behavior.
+    Boundary-level adapter tests assert these claims against the real adapter.
+    """
+
+    return ManagedSessionRuntimeCapabilities(
+        runtimeId="codex_cli",
+        runtimeFamily="codex",
+        sessionCapableClaim=True,
+        controlActions=MANAGED_SESSION_CONTROL_ACTIONS,
+        behaviors=(
+            _codex_behavior(
+                "launch",
+                "LaunchCodexManagedSessionRequest",
+                (
+                    "CodexSessionAdapter._ensure_remote_session",
+                    "start_session control action",
+                ),
+            ),
+            _codex_behavior(
+                "turn_control",
+                "SendCodexManagedSessionTurnRequest",
+                (
+                    "send_turn control action",
+                    "SteerCodexManagedSessionTurnRequest",
+                ),
+            ),
+            _codex_behavior(
+                "interrupt",
+                "InterruptCodexManagedSessionTurnRequest",
+                (
+                    "CodexSessionAdapter.interrupt_turn",
+                    "CodexSessionAdapter.cancel",
+                    "interrupt_turn control action",
+                ),
+            ),
+            _codex_behavior(
+                "reset_epoch",
+                "CodexManagedSessionClearRequest",
+                (
+                    "CodexSessionAdapter.clear_session",
+                    "CodexManagedSessionState.clear_session",
+                    "clear_session control action",
+                    "sessionEpoch increment",
+                ),
+            ),
+            _codex_behavior(
+                "resume",
+                "CodexManagedSessionLocator",
+                (
+                    "CodexSessionAdapter._ensure_remote_session resume path",
+                    "resume_session control action",
+                ),
+            ),
+            _codex_behavior(
+                "terminate",
+                "TerminateCodexManagedSessionRequest",
+                (
+                    "CodexSessionAdapter.terminate_session",
+                    "terminate_session control action",
+                ),
+            ),
+            _codex_behavior(
+                "rate_limit",
+                "classify_provider_failure",
+                (
+                    "provider_error_code=429",
+                    "retry_after_cooldown recommendation",
+                    "ManagedAgentAdapter cooldown_reporter",
+                ),
+            ),
+            _codex_behavior(
+                "no_progress",
+                "TemporalTimeoutError -> turn_status=timed_out",
+                (
+                    "turnCompletionTimeoutSeconds budget",
+                    "operator-actionable timeout summary",
+                ),
+            ),
+            _codex_behavior(
+                "checkpoint",
+                "PublishCodexManagedSessionArtifactsRequest",
+                (
+                    "CodexManagedSessionSummary.latestCheckpointRef",
+                    "latestResetBoundaryRef",
+                ),
+            ),
+            _codex_behavior(
+                "outbound_scan",
+                "scan_outbound_text",
+                (
+                    "OutboundScanDecision.BLOCK",
+                    "high_security_mode",
+                    "redact_sensitive_text",
+                ),
+            ),
+            _codex_behavior(
+                "correlation",
+                "AgentExecutionRequest.correlationId",
+                (
+                    "observabilityEventsRef",
+                    "CodexManagedSessionLocator sessionId/containerId/threadId",
+                    "AgentRunHandle.metadata.sessionId",
+                ),
+            ),
+        ),
+    )
+
+
+def unsupported_runtime_managed_session_capabilities(
+    runtime_id: str,
+) -> ManagedSessionRuntimeCapabilities:
+    """Descriptor for a runtime with no managed-session plane.
+
+    Every required behavior is reported as an explicit, actionable capability gap
+    so the runtime cannot be surfaced as session-capable.
+    """
+
+    base_reason = (
+        f"runtime '{runtime_id}' has no managed-session plane; "
+        "canonical_managed_session_runtime_id returns None until it implements "
+        "its own runtime-specific session plane"
+    )
+    return ManagedSessionRuntimeCapabilities(
+        runtimeId=runtime_id,
+        runtimeFamily=None,
+        sessionCapableClaim=False,
+        controlActions=(),
+        behaviors=tuple(
+            ManagedSessionBehaviorSupport(
+                behavior=behavior,
+                supported=False,
+                gapReason=f"{behavior}: {base_reason}",
+            )
+            for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS
+        ),
+    )
+
+
+def managed_session_capabilities_for_runtime(
+    runtime_id: str,
+) -> ManagedSessionRuntimeCapabilities:
+    """Return the capability descriptor the suite uses for ``runtime_id``."""
+
+    if canonical_managed_session_runtime_id(runtime_id) == "codex_cli":
+        return codex_managed_session_capabilities()
+    return unsupported_runtime_managed_session_capabilities(runtime_id)
+
+
+def build_managed_session_conformance_summary(
+    *,
+    capabilities: Iterable[ManagedSessionRuntimeCapabilities] | None = None,
+) -> dict[str, Any]:
+    """Evaluate every known managed-session runtime and aggregate the result."""
+
+    descriptors = (
+        list(capabilities)
+        if capabilities is not None
+        else [
+            managed_session_capabilities_for_runtime(runtime_id)
+            for runtime_id in KNOWN_MANAGED_SESSION_RUNTIMES
+        ]
+    )
+    reports = [
+        evaluate_managed_session_conformance(descriptor) for descriptor in descriptors
+    ]
+    overall_result = (
+        "passed" if all(report["result"] == "passed" for report in reports) else "failed"
+    )
+    return {
+        "suite": MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+        "overallResult": overall_result,
+        "requiredBehaviors": list(REQUIRED_MANAGED_SESSION_BEHAVIORS),
+        "coverageIds": list(MM883_COVERAGE_IDS),
+        "reports": reports,
+        "sessionCapableRuntimes": [
+            report["runtimeId"] for report in reports if report["sessionCapable"]
+        ],
+        "failedRuntimes": [
+            report["runtimeId"] for report in reports if report["result"] != "passed"
+        ],
+    }
+
+
+def run_managed_session_conformance() -> dict[str, Any]:
+    """Run the suite and return a compact pass/fail result."""
+
+    summary = build_managed_session_conformance_summary()
+    return {
+        "suite": summary["suite"],
+        "overallResult": summary["overallResult"],
+        "sessionCapableRuntimes": summary["sessionCapableRuntimes"],
+        "failedRuntimes": summary["failedRuntimes"],
+        "capabilityGaps": {
+            report["runtimeId"]: report["capabilityGaps"]
+            for report in summary["reports"]
+            if report["capabilityGaps"]
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="emit the full conformance summary instead of the compact result",
+    )
+    args = parser.parse_args(argv)
+
+    if args.full:
+        result = build_managed_session_conformance_summary()
+    else:
+        result = run_managed_session_conformance()
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["overallResult"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py
+++ b/tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py
@@ -1,0 +1,466 @@
+"""Adapter-boundary conformance tests for the managed-session suite (MM-883).
+
+These tests drive the real :class:`CodexSessionAdapter` through the managed-session
+lifecycle and assert that the invocation request shapes and trace/artifact
+correlation surfaces match the capability descriptor the adapter advertises to the
+shared conformance suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionBinding,
+    CodexManagedSessionClearRequest,
+    CodexManagedSessionHandle,
+    CodexManagedSessionSnapshot,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+    InterruptCodexManagedSessionTurnRequest,
+    LaunchCodexManagedSessionRequest,
+    SendCodexManagedSessionTurnRequest,
+    TerminateCodexManagedSessionRequest,
+)
+from moonmind.workflows.adapters.codex_session_adapter import CodexSessionAdapter
+from moonmind.workflows.temporal.managed_session_conformance import (
+    evaluate_managed_session_conformance,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _fake_profiles(profiles: list[dict[str, Any]]):
+    async def _fetcher(*, runtime_id: str):
+        return {"profiles": profiles}
+
+    return _fetcher
+
+
+async def _async_noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+async def _prepare_turn_instructions(payload: dict[str, Any]) -> str:
+    request = payload.get("request") if isinstance(payload, dict) else {}
+    instruction_ref = ""
+    if isinstance(request, dict):
+        instruction_ref = str(
+            request.get("instructionRef") or request.get("instruction_ref") or ""
+        ).strip()
+    return f"{instruction_ref}\n\nManaged Codex CLI note:"
+
+
+def _binding() -> CodexManagedSessionBinding:
+    return CodexManagedSessionBinding(
+        workflowId="wf-task-1:session:codex_cli",
+        agentRunId="wf-task-1",
+        sessionId="sess:wf-task-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+
+def _snapshot(
+    *,
+    binding: CodexManagedSessionBinding,
+    container_id: str | None = None,
+    thread_id: str | None = None,
+) -> CodexManagedSessionSnapshot:
+    return CodexManagedSessionSnapshot(
+        binding=binding,
+        status="active",
+        containerId=container_id,
+        threadId=thread_id,
+        activeTurnId=None,
+        terminationRequested=False,
+    )
+
+
+def _request(
+    binding: CodexManagedSessionBinding,
+    *,
+    workspace_path: str,
+) -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        instructionRef="artifact:instructions",
+        managedSession=binding,
+        workspaceSpec={"workspacePath": workspace_path},
+        parameters={"publishMode": "none"},
+        timeoutPolicy={},
+    )
+
+
+def _session_handle(
+    *,
+    session_id: str,
+    session_epoch: int,
+    container_id: str,
+    thread_id: str,
+    status: str = "ready",
+) -> CodexManagedSessionHandle:
+    return CodexManagedSessionHandle(
+        sessionState={
+            "sessionId": session_id,
+            "sessionEpoch": session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        status=status,
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl=f"docker-exec://{container_id}",
+    )
+
+
+def _turn_response(
+    *,
+    binding: CodexManagedSessionBinding,
+    container_id: str,
+    thread_id: str,
+    status: str = "completed",
+) -> CodexManagedSessionTurnResponse:
+    return CodexManagedSessionTurnResponse(
+        sessionState={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        turnId="turn-1",
+        status=status,
+        outputRefs=("artifact:turn-output",),
+        metadata={"assistantText": "Implemented through the session container."},
+    )
+
+
+def _summary(
+    *, binding: CodexManagedSessionBinding, container_id: str, thread_id: str
+) -> CodexManagedSessionSummary:
+    return CodexManagedSessionSummary(
+        sessionState={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        latestSummaryRef="artifact:session-summary",
+        latestCheckpointRef="artifact:session-checkpoint",
+        metadata={"lastAssistantText": "Implemented through the session container."},
+    )
+
+
+def _publication(
+    *, binding: CodexManagedSessionBinding, container_id: str, thread_id: str
+) -> CodexManagedSessionArtifactsPublication:
+    return CodexManagedSessionArtifactsPublication(
+        sessionState={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        publishedArtifactRefs=(
+            "artifact:stdout",
+            "artifact:stderr",
+            "artifact:diagnostics",
+            "artifact:observability.events.jsonl",
+            "artifact:session-summary",
+            "artifact:session-checkpoint",
+        ),
+        latestSummaryRef="artifact:session-summary",
+        latestCheckpointRef="artifact:session-checkpoint",
+    )
+
+
+def _descriptor_invocation(behavior: str) -> str | None:
+    support = CodexSessionAdapter.managed_session_capabilities().behavior(behavior)
+    assert support is not None, behavior
+    return support.invocation
+
+
+async def test_launch_and_turn_boundary_shapes_and_correlation(tmp_path: Path) -> None:
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
+    launch_calls: list[Any] = []
+    send_turn_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(request: Any) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(binding=binding, container_id="container-1", thread_id="thread-1")
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            binding=binding, container_id="container-1", thread_id="thread-1"
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    request = _request(binding, workspace_path=str(workspace_path))
+    handle = await adapter.start(request)
+    result = await adapter.fetch_result(handle.run_id)
+    persisted_record = run_store.load(binding.agent_run_id)
+
+    # --- launch boundary invocation shape ---
+    assert len(launch_calls) == 1
+    launch_request = LaunchCodexManagedSessionRequest.model_validate(
+        launch_calls[0]["request"]
+    )
+    assert launch_request.session_id == binding.session_id
+    assert _descriptor_invocation("launch") == "LaunchCodexManagedSessionRequest"
+
+    # --- turn-control boundary invocation shape ---
+    assert len(send_turn_calls) == 1
+    assert isinstance(send_turn_calls[0], SendCodexManagedSessionTurnRequest)
+    assert _descriptor_invocation("turn_control") == "SendCodexManagedSessionTurnRequest"
+
+    # --- trace/artifact correlation ---
+    assert request.correlation_id == "corr-1"
+    assert handle.metadata["sessionId"] == binding.session_id
+    assert handle.metadata["containerId"] == "container-1"
+    assert handle.metadata["sessionEpoch"] == binding.session_epoch
+    assert persisted_record is not None
+    assert (
+        persisted_record.observability_events_ref
+        == "artifact:observability.events.jsonl"
+    )
+    # checkpoint <-> artifact correlation flows back into the run result.
+    assert (
+        result.metadata["sessionArtifacts"]["latestCheckpointRef"]
+        == "artifact:session-checkpoint"
+    )
+    # control events correlate to the same session container/thread.
+    start_event = next(c for c in control_calls if c["action"] == "start_session")
+    send_event = next(c for c in control_calls if c["action"] == "send_turn")
+    assert start_event["containerId"] == "container-1"
+    assert send_event["containerId"] == "container-1"
+    assert send_event["threadId"] == "thread-1"
+
+
+def _control_adapter(
+    *,
+    binding: CodexManagedSessionBinding,
+    load_snapshot,
+    interrupt_turn=_async_noop,
+    clear_remote_session=_async_noop,
+    terminate_remote_session=_async_noop,
+    apply_control_action=_async_noop,
+    attach_runtime_handles=_async_noop,
+) -> CodexSessionAdapter:
+    return CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=None,
+        load_session_snapshot=load_snapshot,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=interrupt_turn,
+        clear_remote_session=clear_remote_session,
+        terminate_remote_session=terminate_remote_session,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=attach_runtime_handles,
+        apply_session_control_action=apply_control_action,
+        workspace_root="/work/agent_jobs",
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+
+async def test_interrupt_boundary_invocation_shape() -> None:
+    binding = _binding()
+    interrupt_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+
+    async def _interrupt_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        interrupt_calls.append(request)
+        return _turn_response(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+            status="interrupted",
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = _control_adapter(
+        binding=binding,
+        load_snapshot=_load_snapshot,
+        interrupt_turn=_interrupt_turn,
+        apply_control_action=_apply_control_action,
+    )
+
+    response = await adapter.interrupt_turn(
+        binding=binding, turn_id="turn-1", reason="operator interrupt"
+    )
+
+    assert len(interrupt_calls) == 1
+    assert isinstance(interrupt_calls[0], InterruptCodexManagedSessionTurnRequest)
+    assert interrupt_calls[0].turn_id == "turn-1"
+    assert response.status == "interrupted"
+    assert _descriptor_invocation("interrupt") == "InterruptCodexManagedSessionTurnRequest"
+    assert any(c["action"] == "interrupt_turn" for c in control_calls)
+
+
+async def test_reset_epoch_boundary_invocation_shape() -> None:
+    binding = _binding()
+    clear_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        clear_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch + 1,
+            container_id="container-1",
+            thread_id="thread-2",
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = _control_adapter(
+        binding=binding,
+        load_snapshot=_load_snapshot,
+        clear_remote_session=_clear_remote_session,
+        apply_control_action=_apply_control_action,
+    )
+
+    handle = await adapter.clear_session(
+        binding=binding, new_thread_id="thread-2", reason="reset"
+    )
+
+    assert len(clear_calls) == 1
+    assert isinstance(clear_calls[0], CodexManagedSessionClearRequest)
+    assert clear_calls[0].new_thread_id == "thread-2"
+    # reset advances to a new continuity interval (epoch increment, same container).
+    assert handle.session_state.session_epoch == binding.session_epoch + 1
+    assert handle.session_state.container_id == "container-1"
+    assert handle.session_state.thread_id == "thread-2"
+    assert _descriptor_invocation("reset_epoch") == "CodexManagedSessionClearRequest"
+    assert any(c["action"] == "clear_session" for c in control_calls)
+
+
+async def test_terminate_boundary_invocation_shape() -> None:
+    binding = _binding()
+    terminate_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding, container_id="container-1", thread_id="thread-1")
+
+    async def _terminate_remote_session(request: Any) -> CodexManagedSessionHandle:
+        terminate_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            status="terminated",
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = _control_adapter(
+        binding=binding,
+        load_snapshot=_load_snapshot,
+        terminate_remote_session=_terminate_remote_session,
+        apply_control_action=_apply_control_action,
+    )
+
+    handle = await adapter.terminate_session(binding=binding, reason="run complete")
+
+    assert len(terminate_calls) == 1
+    assert isinstance(terminate_calls[0], TerminateCodexManagedSessionRequest)
+    assert handle.status == "terminated"
+    assert _descriptor_invocation("terminate") == "TerminateCodexManagedSessionRequest"
+    assert any(c["action"] == "terminate_session" for c in control_calls)
+
+
+async def test_adapter_capability_descriptor_runs_conformance_at_boundary() -> None:
+    capabilities = CodexSessionAdapter.managed_session_capabilities()
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert capabilities.runtime_id == "codex_cli"
+    assert report["sessionCapable"] is True
+    assert report["capabilityGaps"] == []

--- a/tests/unit/workflows/temporal/test_managed_session_conformance.py
+++ b/tests/unit/workflows/temporal/test_managed_session_conformance.py
@@ -1,0 +1,237 @@
+"""Suite-level tests for the cross-runtime managed-session conformance suite (MM-883)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.managed_session_models import (
+    MANAGED_SESSION_CONTROL_ACTIONS,
+)
+from moonmind.workflows.temporal.managed_session_conformance import (
+    KNOWN_MANAGED_SESSION_RUNTIMES,
+    MANAGED_SESSION_CONFORMANCE_SUITE_ID,
+    MM883_COVERAGE_IDS,
+    REQUIRED_MANAGED_SESSION_BEHAVIORS,
+    ManagedSessionBehaviorSupport,
+    ManagedSessionRuntimeCapabilities,
+    build_managed_session_conformance_summary,
+    codex_managed_session_capabilities,
+    evaluate_managed_session_conformance,
+    managed_session_capabilities_for_runtime,
+    run_managed_session_conformance,
+    unsupported_runtime_managed_session_capabilities,
+)
+
+
+def _supported(behavior: str) -> ManagedSessionBehaviorSupport:
+    return ManagedSessionBehaviorSupport(
+        behavior=behavior,
+        supported=True,
+        invocation=f"{behavior}-invocation",
+        evidence=(f"{behavior}-evidence",),
+    )
+
+
+def _fully_supported_behaviors() -> tuple[ManagedSessionBehaviorSupport, ...]:
+    return tuple(_supported(behavior) for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS)
+
+
+def test_required_behaviors_match_acceptance_criteria() -> None:
+    assert REQUIRED_MANAGED_SESSION_BEHAVIORS == (
+        "launch",
+        "turn_control",
+        "interrupt",
+        "reset_epoch",
+        "resume",
+        "terminate",
+        "rate_limit",
+        "no_progress",
+        "checkpoint",
+        "outbound_scan",
+        "correlation",
+    )
+
+
+def test_codex_descriptor_conforms_and_is_truthfully_session_capable() -> None:
+    capabilities = codex_managed_session_capabilities()
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert capabilities.runtime_id == "codex_cli"
+    assert capabilities.control_actions == MANAGED_SESSION_CONTROL_ACTIONS
+    assert report["sessionCapable"] is True
+    assert report["claimTruthful"] is True
+    assert report["result"] == "passed"
+    assert report["capabilityGaps"] == []
+    covered = {decision["behavior"] for decision in report["behaviorDecisions"]}
+    assert covered == set(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    assert all(
+        decision["decision"] == "conforms"
+        for decision in report["behaviorDecisions"]
+    )
+
+
+def test_codex_descriptor_declares_every_required_behavior_with_evidence() -> None:
+    capabilities = codex_managed_session_capabilities()
+
+    for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS:
+        support = capabilities.behavior(behavior)
+        assert support is not None, behavior
+        assert support.supported is True
+        assert support.invocation
+        assert support.evidence
+
+
+@pytest.mark.parametrize("runtime_id", ["claude", "claude_code", "gemini_cli"])
+def test_unsupported_runtimes_report_capability_gaps_not_partial(runtime_id: str) -> None:
+    capabilities = managed_session_capabilities_for_runtime(runtime_id)
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    # Truthful binary determination: not session-capable, and never "partial".
+    assert report["sessionCapable"] is False
+    assert report["sessionCapableClaim"] is False
+    assert report["claimTruthful"] is True
+    assert report["result"] == "passed"
+    assert len(report["capabilityGaps"]) == len(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    gap_behaviors = {gap["behavior"] for gap in report["capabilityGaps"]}
+    assert gap_behaviors == set(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    assert all(gap["reason"] for gap in report["capabilityGaps"])
+    assert "partial" not in str(report).lower()
+
+
+def test_partially_implemented_runtime_is_not_surfaced_as_session_capable() -> None:
+    # A runtime that implements only a subset of behaviors must surface as
+    # non-conforming with the exact gaps -- not as "partially" session-capable.
+    behaviors: list[ManagedSessionBehaviorSupport] = []
+    implemented = {"launch", "turn_control", "resume"}
+    for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS:
+        if behavior in implemented:
+            behaviors.append(_supported(behavior))
+        else:
+            behaviors.append(
+                ManagedSessionBehaviorSupport(
+                    behavior=behavior,
+                    supported=False,
+                    gapReason=f"{behavior} not implemented yet",
+                )
+            )
+    capabilities = ManagedSessionRuntimeCapabilities(
+        runtimeId="codex_cli",
+        runtimeFamily="codex",
+        sessionCapableClaim=False,
+        behaviors=tuple(behaviors),
+    )
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert report["sessionCapable"] is False
+    missing = set(REQUIRED_MANAGED_SESSION_BEHAVIORS) - implemented
+    gap_behaviors = {gap["behavior"] for gap in report["capabilityGaps"]}
+    assert gap_behaviors == missing
+
+
+def test_runtime_falsely_claiming_session_capability_fails_truthfully() -> None:
+    # claims session-capable but is missing the interrupt behavior entirely.
+    behaviors = [
+        _supported(behavior)
+        for behavior in REQUIRED_MANAGED_SESSION_BEHAVIORS
+        if behavior != "interrupt"
+    ]
+    capabilities = ManagedSessionRuntimeCapabilities(
+        runtimeId="codex_cli",
+        runtimeFamily="codex",
+        sessionCapableClaim=True,
+        behaviors=tuple(behaviors),
+    )
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert report["sessionCapable"] is False
+    assert report["claimTruthful"] is False
+    assert report["result"] == "failed"
+    assert {gap["behavior"] for gap in report["capabilityGaps"]} == {"interrupt"}
+
+
+def test_non_canonical_runtime_cannot_be_session_capable_even_if_fully_declared() -> None:
+    # Defense in depth: a runtime with no canonical managed-session id must never
+    # be determined session-capable even if it declares every behavior.
+    capabilities = ManagedSessionRuntimeCapabilities(
+        runtimeId="gemini_cli",
+        runtimeFamily="gemini",
+        sessionCapableClaim=True,
+        behaviors=_fully_supported_behaviors(),
+    )
+
+    report = evaluate_managed_session_conformance(capabilities)
+
+    assert report["canonicalRuntimeId"] is None
+    assert report["sessionCapable"] is False
+    assert report["result"] == "failed"
+    assert any(
+        gap["behavior"] == "runtime_identity" for gap in report["capabilityGaps"]
+    )
+
+
+def test_summary_only_surfaces_codex_as_session_capable() -> None:
+    summary = build_managed_session_conformance_summary()
+
+    assert summary["suite"] == MANAGED_SESSION_CONFORMANCE_SUITE_ID
+    assert summary["overallResult"] == "passed"
+    assert summary["requiredBehaviors"] == list(REQUIRED_MANAGED_SESSION_BEHAVIORS)
+    assert summary["coverageIds"] == list(MM883_COVERAGE_IDS)
+    assert summary["sessionCapableRuntimes"] == ["codex_cli"]
+    assert summary["failedRuntimes"] == []
+    reported_runtimes = {report["runtimeId"] for report in summary["reports"]}
+    assert reported_runtimes == set(KNOWN_MANAGED_SESSION_RUNTIMES)
+
+
+def test_summary_fails_when_a_runtime_misrepresents_session_capability() -> None:
+    truthful_codex = codex_managed_session_capabilities()
+    misrepresented = unsupported_runtime_managed_session_capabilities("gemini_cli").model_copy(
+        update={"session_capable_claim": True}
+    )
+
+    summary = build_managed_session_conformance_summary(
+        capabilities=[truthful_codex, misrepresented]
+    )
+
+    assert summary["overallResult"] == "failed"
+    assert "gemini_cli" in summary["failedRuntimes"]
+    assert summary["sessionCapableRuntimes"] == ["codex_cli"]
+
+
+def test_run_managed_session_conformance_compact_result() -> None:
+    result = run_managed_session_conformance()
+
+    assert result["suite"] == MANAGED_SESSION_CONFORMANCE_SUITE_ID
+    assert result["overallResult"] == "passed"
+    assert result["sessionCapableRuntimes"] == ["codex_cli"]
+    assert result["failedRuntimes"] == []
+    # Non-session-capable runtimes report their gaps for operator action.
+    assert set(result["capabilityGaps"]) == {"claude", "claude_code", "gemini_cli"}
+
+
+def test_behavior_support_requires_invocation_and_evidence_when_supported() -> None:
+    with pytest.raises(ValidationError, match="declares no invocation contract"):
+        ManagedSessionBehaviorSupport(behavior="launch", supported=True, evidence=("e",))
+
+    with pytest.raises(ValidationError, match="declares no evidence surfaces"):
+        ManagedSessionBehaviorSupport(
+            behavior="launch", supported=True, invocation="x"
+        )
+
+
+def test_behavior_support_requires_gap_reason_when_unsupported() -> None:
+    with pytest.raises(ValidationError, match="must declare an actionable gapReason"):
+        ManagedSessionBehaviorSupport(behavior="launch", supported=False)
+
+
+def test_capabilities_reject_duplicate_behaviors() -> None:
+    with pytest.raises(ValidationError, match="behaviors must be unique"):
+        ManagedSessionRuntimeCapabilities(
+            runtimeId="codex_cli",
+            sessionCapableClaim=True,
+            behaviors=(_supported("launch"), _supported("launch")),
+        )


### PR DESCRIPTION
## Issue

MM-883 — Create the shared cross-runtime managed-session conformance suite.
https://moonladder.atlassian.net/browse/MM-883

## Summary

Adds the runtime-neutral, shared cross-runtime managed-session conformance suite that MM-883 calls for, so Codex, Claude, Gemini, and future managed-session runtimes are evaluated against one contract before Mission Control can surface them as session-capable.

- **New suite — `moonmind/workflows/temporal/managed_session_conformance.py`**: defines runtime-neutral capability metadata (`ManagedSessionRuntimeCapabilities` / `ManagedSessionBehaviorSupport`) and `evaluate_managed_session_conformance()`, which checks a runtime's declared metadata against the canonical ordered set of required behaviors — launch, turn control, interrupt, reset/epoch, resume, terminate, rate-limit, no-progress, checkpoint, outbound scan, and correlation. The verdict is **truthful and binary**: a runtime is session-capable only if every required behavior conforms; there is no "partially session-capable" state. Non-conforming runtimes are reported with precise, actionable `capabilityGaps`. Also provides `codex_managed_session_capabilities()`, `unsupported_runtime_managed_session_capabilities()`, `managed_session_capabilities_for_runtime()`, `build_managed_session_conformance_summary()`, and a CLI entrypoint.
- **Adapter boundary — `CodexSessionAdapter.managed_session_capabilities()`**: exposes the Codex capability descriptor at the adapter boundary so the suite runs against the exact metadata the runtime advertises.
- **Capability truthfulness**: unsupported runtimes (claude / claude_code / gemini_cli) resolve to non-conforming descriptors with capability gaps and cannot be reported as session-capable, consistent with `canonical_managed_session_runtime_id` returning `None` for them.
- **Docs**: `docs/ManagedAgents/SharedManagedAgentAbstractions.md` updated to describe the shared conformance suite and its adapter-boundary contract.

## Tests run

`MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_managed_session_conformance.py tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/schemas/test_managed_session_models.py`

- **117 passed** (Python) — new suite evaluation tests, adapter boundary invocation-shape + trace/artifact correlation tests, existing Codex session adapter tests, and managed-session model capability tests.
- Frontend Vitest suite executed as part of the run: **469 passed, 236 skipped**.

New coverage:
- `tests/unit/workflows/temporal/test_managed_session_conformance.py` — suite/evaluation behavior and capability-gap reporting.
- `tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py` — adapter invocation shapes for launch/turn/interrupt and trace/artifact correlation.

## Remaining risks

- Codex CLI remains the only concrete session-capable runtime; Claude and Gemini descriptors are intentionally non-conforming and report capability gaps until they implement their own session planes. The suite asserts truthfulness today, but actual behavioral parity for those runtimes is future work.
- Capability metadata is self-declared by each adapter. Boundary tests verify the declared invocation shapes match real behavior for Codex; new managed-session runtimes must add equivalent boundary tests when they onboard.
- Verification in this step was scoped to the targeted unit/boundary tests above plus the frontend suite; the full unit and hermetic integration suites were not re-run in this step.
