### PR TITLE
Handle artifact.create list return shape in resilience policy compile path

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1099,8 +1099,8 @@ class MoonMindRunWorkflow:
             create_payload,
             **self._execute_kwargs_for_route(artifact_create_route),
         )
-        if isinstance(artifact_create_result, tuple) and artifact_create_result:
-            artifact_ref = artifact_create_result[0]
+        if isinstance(artifact_create_result, (list, tuple)):
+            artifact_ref = artifact_create_result[0] if artifact_create_result else None
         else:
             artifact_ref = artifact_create_result
         artifact_id = (

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1863,6 +1863,43 @@ async def test_write_step_execution_manifest_requires_real_artifact_id(
         )
 
 
+@pytest.mark.asyncio
+async def test_write_json_artifact_supports_serialized_list_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: Any,
+        **_kwargs: Any,
+    ) -> list[dict[str, str]]:
+        assert activity_type == "artifact.create"
+        return [{"artifact_id": "art_list_payload"}, {"upload_url": "unused"}]
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> None:
+        assert activity_type == "artifact.write_complete"
+        assert run_module._get_from_result(payload, "artifact_id") == "art_list_payload"
+        return None
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_module, "execute_typed_activity", fake_execute_typed_activity)
+
+    assert (
+        await workflow._write_json_artifact(
+            name="step-execution-manifest.json",
+            payload={"schemaVersion": "v1"},
+            content_type=STEP_EXECUTION_MANIFEST_CONTENT_TYPE,
+        )
+        == "art_list_payload"
+    )
+
+
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Handle both tuple and list return shapes from `artifact.create` in `_write_json_artifact` so resilience-policy compilation can reliably extract `artifact_id`.
- Add regression coverage for list-shaped `artifact.create` results in `test_write_json_artifact_supports_serialized_list_result`.

## Why
Fixes a workflow failure for `mm:a4c8902b-b500-49f9-a5cb-57bc19316589` where `artifact.create` returned a list and the workflow logic only handled tuples, producing `artifact.create returned no artifact_id for reports/resilience_policy.json`.

## Testing
- Not run (not requested for this PR).
