### PR TITLE
[codex] fix PentestGPT provider profile routing

### DIFF
--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -161,8 +161,8 @@ This document locks the following decisions.
 5. Default execution is **non-interactive** and **artifact-first**.
 6. A PentestGPT run must always carry an explicit **authorized scope artifact** or an equivalent approved execution envelope.
 7. Arbitrary container images, arbitrary host mounts, and raw Docker daemon access are not part of the contract.
-8. PentestGPT provider selection and credential shaping use **Provider Profiles** with `runtime_id = pentestgpt`.
-9. PentestGPT profile capacity and cooldown may participate in `MoonMind.ProviderProfileManager` orchestration in the same way other launchable runtimes do.
+8. PentestGPT provider selection and credential shaping use **Provider Profiles**. Dedicated PentestGPT profiles with `runtime_id = pentestgpt` remain valid, and the workflow may also pass the selected managed-runtime provider profile snapshot to the curated runner when that profile is SecretRef-backed and maps to a supported PentestGPT provider shape.
+9. PentestGPT profile capacity and cooldown participate in the `MoonMind.ProviderProfileManager` for the selected profile's `runtime_id`, not a hardcoded PentestGPT manager. OAuth-backed Codex CLI or Claude Code home profiles are not directly consumable by the current PentestGPT runner; they fail fast with an explicit `oauth_profile_unsupported` diagnostic instead of being misreported as provider capacity failures.
 10. MoonMind-managed PentestGPT runs must disable upstream telemetry by default.
 11. Elevated network/device privilege such as VPN/TUN access is available only through explicit runner profiles.
 12. Raw PentestGPT logs and exports are evidence, but MoonMind must also publish a normalized findings artifact and a human-readable summary.

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -8,7 +8,7 @@ from ipaddress import ip_address, ip_network
 from pathlib import PurePosixPath
 import posixpath
 import re
-from typing import Any, Literal
+from typing import Any, Literal, Mapping
 from urllib.parse import urlparse
 
 from pydantic import (
@@ -194,7 +194,13 @@ class PentestProviderProfile(PentestBaseModel):
     provider_id: str = Field(..., min_length=1)
     provider_label: str | None = None
     credential_source: Literal["secret_ref", "none", "oauth_volume"]
-    runtime_materialization_mode: Literal["api_key_env", "composite", "oauth_home"]
+    runtime_materialization_mode: Literal[
+        "api_key_env",
+        "composite",
+        "config_bundle",
+        "env_bundle",
+        "oauth_home",
+    ]
     enabled: bool = True
     tags: tuple[str, ...] = ()
     priority: int = Field(100, ge=0)
@@ -219,9 +225,10 @@ class PentestProviderProfile(PentestBaseModel):
     @field_validator("runtime_id")
     @classmethod
     def _validate_runtime_id(cls, value: str) -> str:
-        if value != PENTEST_RUNTIME_ID:
-            raise ValueError("Pentest provider profiles must use runtime_id=pentestgpt")
-        return value
+        normalized = str(value or "").strip()
+        if not normalized:
+            raise ValueError("runtime_id is required")
+        return normalized
 
 class PentestProviderMaterialization(PentestBaseModel):
     """Secret-safe provider materialization result for PentestGPT."""
@@ -403,6 +410,7 @@ class PentestWorkloadRequest(PentestBaseModel):
     scope_artifact_ref: str | None = None
     runner_profile_id: str = Field(..., min_length=1)
     execution_profile_ref: str | None = None
+    provider_profile_snapshot: dict[str, Any] | None = None
     provider_selector: PentestProviderSelector | None = None
     provider_runtime_state: dict[str, PentestProviderRuntimeState] = Field(
         default_factory=dict
@@ -1375,6 +1383,133 @@ def get_pentest_provider_profile(profile_id: str) -> PentestProviderProfile:
         )
     return profile
 
+def _managed_secret_refs_from_snapshot(
+    snapshot: Mapping[str, Any],
+) -> dict[str, dict[str, str]]:
+    raw_secret_refs = snapshot.get("secret_refs")
+    if not isinstance(raw_secret_refs, Mapping):
+        return {}
+    secret_refs: dict[str, dict[str, str]] = {}
+    for raw_key, raw_value in raw_secret_refs.items():
+        key = str(raw_key or "").strip()
+        if not key:
+            continue
+        if isinstance(raw_value, str):
+            secret_refs[key] = {"secret_ref": raw_value}
+        elif isinstance(raw_value, Mapping):
+            secret_refs[key] = {
+                str(item_key): str(item_value)
+                for item_key, item_value in raw_value.items()
+                if item_value is not None
+            }
+    return secret_refs
+
+def _managed_env_template_from_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    raw_env_template = snapshot.get("env_template")
+    if not isinstance(raw_env_template, Mapping):
+        return {}
+    return {str(key): value for key, value in raw_env_template.items()}
+
+def _secret_role_for_env(
+    *,
+    env_template: Mapping[str, Any],
+    secret_refs: Mapping[str, Any],
+    env_key: str,
+    preferred_roles: tuple[str, ...],
+) -> str | None:
+    current = env_template.get(env_key)
+    if isinstance(current, Mapping):
+        role = str(current.get("from_secret_ref") or "").strip()
+        if role:
+            return role
+    for role in preferred_roles:
+        if role in secret_refs:
+            return role
+    return None
+
+def pentest_provider_profile_from_snapshot(
+    snapshot: Mapping[str, Any],
+) -> PentestProviderProfile:
+    """Adapt a managed-runtime provider profile snapshot for Pentest execution."""
+
+    profile_id = str(snapshot.get("profile_id") or "").strip()
+    runtime_id = str(snapshot.get("runtime_id") or "").strip()
+    provider_id = str(snapshot.get("provider_id") or "").strip()
+    if not profile_id or not runtime_id or not provider_id:
+        raise PentestProviderMaterializationError(
+            "provider profile snapshot is missing required identity fields",
+            reason="invalid_provider_profile_snapshot",
+            diagnostics={"profile_id": profile_id, "runtime_id": runtime_id},
+        )
+
+    secret_refs = _managed_secret_refs_from_snapshot(snapshot)
+    env_template = _managed_env_template_from_snapshot(snapshot)
+    credential_source = str(snapshot.get("credential_source") or "none").strip()
+    materialization_mode = str(
+        snapshot.get("runtime_materialization_mode") or "api_key_env"
+    ).strip()
+    provider_label = snapshot.get("provider_label")
+    clear_env_keys_raw = snapshot.get("clear_env_keys")
+    clear_env_keys = (
+        tuple(str(item).strip() for item in clear_env_keys_raw if str(item).strip())
+        if isinstance(clear_env_keys_raw, (list, tuple))
+        else ()
+    )
+
+    if provider_id == "openrouter" and credential_source == "secret_ref":
+        role = _secret_role_for_env(
+            env_template=env_template,
+            secret_refs=secret_refs,
+            env_key="OPENROUTER_API_KEY",
+            preferred_roles=("openrouter_api_key", "provider_api_key", "api_key"),
+        )
+        if role:
+            env_template["OPENROUTER_API_KEY"] = {"from_secret_ref": role}
+        env_template.setdefault("PENTESTGPT_AUTH_MODE", "openrouter")
+        clear_env_keys = tuple(dict.fromkeys((*clear_env_keys, "ANTHROPIC_API_KEY")))
+    elif provider_id == "anthropic" and credential_source == "secret_ref":
+        role = _secret_role_for_env(
+            env_template=env_template,
+            secret_refs=secret_refs,
+            env_key="ANTHROPIC_API_KEY",
+            preferred_roles=("anthropic_api_key", "provider_api_key", "api_key"),
+        )
+        if role:
+            env_template["ANTHROPIC_API_KEY"] = {"from_secret_ref": role}
+        env_template.setdefault("PENTESTGPT_AUTH_MODE", "anthropic")
+        clear_env_keys = tuple(dict.fromkeys((*clear_env_keys, "OPENROUTER_API_KEY")))
+
+    return PentestProviderProfile(
+        profile_id=profile_id,
+        runtime_id=runtime_id,
+        provider_id=provider_id,
+        provider_label=str(provider_label) if provider_label is not None else None,
+        credential_source=credential_source,  # type: ignore[arg-type]
+        runtime_materialization_mode=materialization_mode,  # type: ignore[arg-type]
+        enabled=bool(snapshot.get("enabled", True)),
+        tags=tuple(snapshot.get("tags") or ()),
+        priority=int(snapshot.get("priority") or 100),
+        max_parallel_runs=int(snapshot.get("max_parallel_runs") or 1),
+        cooldown_after_429_seconds=int(
+            snapshot.get("cooldown_after_429_seconds") or 300
+        ),
+        rate_limit_policy=str(  # type: ignore[arg-type]
+            snapshot.get("rate_limit_policy") or "backoff"
+        ),
+        max_lease_duration_seconds=int(
+            snapshot.get("max_lease_duration_seconds") or 7200
+        ),
+        secret_refs=secret_refs,
+        clear_env_keys=clear_env_keys,
+        env_template=env_template,
+        command_behavior={
+            str(key): value
+            for key, value in (snapshot.get("command_behavior") or {}).items()
+        }
+        if isinstance(snapshot.get("command_behavior"), Mapping)
+        else {},
+    )
+
 def resolve_pentest_provider_profile(
     *,
     execution_profile_ref: str | None = None,
@@ -1448,9 +1583,25 @@ def materialize_pentest_provider_profile(
         or profile.runtime_materialization_mode == "oauth_home"
     ):
         raise PentestProviderMaterializationError(
-            "OAuth-backed PentestGPT profiles are a future out-of-band path",
-            reason="oauth_future_path",
+            (
+                "OAuth-backed provider profiles cannot be used by "
+                "security.pentest.run; the current PentestGPT runner requires a "
+                "SecretRef-backed Anthropic or OpenRouter profile."
+            ),
+            reason="oauth_profile_unsupported",
             diagnostics={"profile_id": profile.profile_id},
+        )
+    if profile.provider_id not in {"anthropic", "openrouter", "local"}:
+        raise PentestProviderMaterializationError(
+            (
+                "Unsupported PentestGPT provider profile. The current runner "
+                "supports Anthropic, OpenRouter, or local profiles."
+            ),
+            reason="unsupported_provider",
+            diagnostics={
+                "profile_id": profile.profile_id,
+                "provider_id": profile.provider_id,
+            },
         )
 
     env: dict[str, str] = {}

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -53,6 +53,7 @@ from moonmind.integrations.pentest.models import (
     classify_pentest_failure,
     materialize_pentest_provider_profile,
     pentest_provider_lease_metadata,
+    pentest_provider_profile_from_snapshot,
     redact_pentest_human_text,
     resolve_pentest_provider_profile,
     strictly_normalize_pentest_finding_set,
@@ -899,6 +900,31 @@ class TemporalPentestActivities:
                     request_payload[key] = raw_payload[key]
             context_payload = raw_payload.get("context")
             context = context_payload if isinstance(context_payload, Mapping) else {}
+            runtime_context_raw = context.get("runtime")
+            runtime_context = (
+                runtime_context_raw if isinstance(runtime_context_raw, Mapping) else {}
+            )
+            inherited_execution_profile_ref = (
+                runtime_context.get("executionProfileRef")
+                or runtime_context.get("execution_profile_ref")
+                or runtime_context.get("profileId")
+                or runtime_context.get("profile_id")
+            )
+            if (
+                inherited_execution_profile_ref
+                and not request_payload.get("execution_profile_ref")
+            ):
+                request_payload["execution_profile_ref"] = str(
+                    inherited_execution_profile_ref
+                ).strip()
+            provider_profile_snapshot = runtime_context.get("providerProfile")
+            if (
+                isinstance(provider_profile_snapshot, Mapping)
+                and not request_payload.get("provider_profile_snapshot")
+            ):
+                request_payload["provider_profile_snapshot"] = dict(
+                    provider_profile_snapshot
+                )
             workflow_id = str(
                 context.get("workflow_id")
                 or context.get("run_id")
@@ -1130,10 +1156,21 @@ class TemporalPentestActivities:
             self._validate_pentest_request_policy(request, request.approved_scope)
             self._validate_pentest_runner_profiles_registered()
             launch_plan = build_pentest_launch_plan(request)
+            request_profiles = None
+            if request.provider_profile_snapshot:
+                request_profiles = (
+                    pentest_provider_profile_from_snapshot(
+                        request.provider_profile_snapshot
+                    ),
+                )
             provider_profile = resolve_pentest_provider_profile(
                 execution_profile_ref=request.execution_profile_ref,
                 provider_selector=request.provider_selector,
+                profiles=request_profiles,
                 runtime_state=request.provider_runtime_state,
+            )
+            provider_materialization = materialize_pentest_provider_profile(
+                provider_profile
             )
             lease_runtime_id = provider_profile.runtime_id
             lease_profile_id = provider_profile.profile_id
@@ -1174,9 +1211,6 @@ class TemporalPentestActivities:
                     reason=str(exc),
                     diagnostics={"provider_capacity": "lease_manager_failure"},
                 )
-            provider_materialization = materialize_pentest_provider_profile(
-                provider_profile
-            )
             execution_materialization = build_pentest_execution_materialization(
                 request
             )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -239,7 +239,6 @@ async def _run_command(cmd, **kwargs):
 
 logger = getLogger(__name__)
 
-_PENTEST_PROVIDER_MANAGER_WORKFLOW_ID = "provider-profile-manager:pentestgpt"
 _PENTEST_RUNNING_HEARTBEAT_INTERVAL_SECONDS = 60.0
 _MANAGED_AGENT_UID = 1000
 _MANAGED_AGENT_GID = 1000
@@ -293,6 +292,33 @@ class TemporalPentestProviderLeaseManager:
     def __init__(self, client_adapter: Any) -> None:
         self._client_adapter = client_adapter
 
+    @staticmethod
+    def _workflow_id(runtime_id: str) -> str:
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            workflow_id_for_runtime,
+        )
+
+        return workflow_id_for_runtime(runtime_id)
+
+    async def _ensure_manager(self, runtime_id: str) -> None:
+        start_workflow = getattr(self._client_adapter, "start_workflow", None)
+        if start_workflow is None:
+            return
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            WORKFLOW_NAME as PROVIDER_PROFILE_MANAGER_WF,
+        )
+
+        await start_workflow(
+            workflow_type=PROVIDER_PROFILE_MANAGER_WF,
+            workflow_id=self._workflow_id(runtime_id),
+            input_args={"runtime_id": runtime_id},
+        )
+
+    @staticmethod
+    def _looks_like_missing_manager(exc: BaseException) -> bool:
+        text = str(exc).lower()
+        return "workflow not found" in text or "not found" in text
+
     async def acquire(
         self,
         *,
@@ -304,16 +330,24 @@ class TemporalPentestProviderLeaseManager:
         update_workflow = getattr(self._client_adapter, "update_workflow", None)
         if update_workflow is None:
             raise RuntimeError("Temporal client adapter does not support workflow updates")
-        await update_workflow(
-            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
-            "AcquireSlot",
-            {
-                "requester_workflow_id": owner,
-                "runtime_id": runtime_id,
-                "execution_profile_ref": profile_id,
-                "metadata": dict(metadata),
-            },
-        )
+        workflow_id = self._workflow_id(runtime_id)
+        payload = {
+            "requester_workflow_id": owner,
+            "runtime_id": runtime_id,
+            "execution_profile_ref": profile_id,
+            "metadata": dict(metadata),
+        }
+        try:
+            result = await update_workflow(workflow_id, "AcquireSlot", payload)
+        except Exception as exc:
+            if not self._looks_like_missing_manager(exc):
+                raise
+            await self._ensure_manager(runtime_id)
+            result = await update_workflow(workflow_id, "AcquireSlot", payload)
+        if isinstance(result, Mapping):
+            lease_id = str(result.get("lease_id") or "").strip()
+            if lease_id:
+                return lease_id
         return owner
 
     async def release(
@@ -325,7 +359,7 @@ class TemporalPentestProviderLeaseManager:
         lease_id: str,
     ) -> None:
         await self._client_adapter.signal_workflow(
-            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
+            self._workflow_id(runtime_id),
             "release_slot",
             {
                 "requester_workflow_id": owner,
@@ -345,7 +379,7 @@ class TemporalPentestProviderLeaseManager:
         reason: str,
     ) -> None:
         await self._client_adapter.signal_workflow(
-            _PENTEST_PROVIDER_MANAGER_WORKFLOW_ID,
+            self._workflow_id(runtime_id),
             "report_cooldown",
             {
                 "runtime_id": runtime_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -423,6 +423,7 @@ RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH = (
 MERGE_AUTOMATION_CONTINUATION_DISPOSITIONS = frozenset({"reenter_gate"})
 RUN_PUBLISH_REPAIR_FEEDBACK_PATCH = "run-publish-repair-feedback-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
+RUN_LEGACY_SKILL_RUNTIME_CONTEXT_PATCH = "run-legacy-skill-runtime-context-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
 RUN_DEFER_WORKFLOW_SCOPED_SESSION_UNTIL_SLOT_PATCH = (
     "run-defer-task-scoped-session-until-slot-v1"
@@ -6401,6 +6402,18 @@ class MoonMindRunWorkflow:
                             if isinstance(node.get("options"), Mapping)
                             else {}
                         )
+                        activity_context = {
+                            "namespace": workflow.info().namespace,
+                            "workflow_id": workflow.info().workflow_id,
+                            "run_id": workflow.info().run_id,
+                            "node_id": node_id,
+                        }
+                        if workflow.patched(RUN_LEGACY_SKILL_RUNTIME_CONTEXT_PATCH):
+                            runtime_context = self._legacy_skill_runtime_context(
+                                parameters
+                            )
+                            if runtime_context:
+                                activity_context["runtime"] = runtime_context
                         execute_payload = {
                             "registry_snapshot_ref": snapshot.artifact_ref,
                             "principal": self._principal(),
@@ -6418,12 +6431,7 @@ class MoonMindRunWorkflow:
                                 "inputs": node_inputs,
                                 "options": node_options,
                             },
-                            "context": {
-                                "namespace": workflow.info().namespace,
-                                "workflow_id": workflow.info().workflow_id,
-                                "run_id": workflow.info().run_id,
-                                "node_id": node_id,
-                            },
+                            "context": activity_context,
                             "idempotency_key": step_execution_operation_idempotency_key(
                                 workflow_id=workflow.info().workflow_id,
                                 run_id=workflow.info().run_id,
@@ -11416,6 +11424,39 @@ class MoonMindRunWorkflow:
                     source_label="Inherited",
                 )
         return None
+
+    def _legacy_skill_runtime_context(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Return selected runtime/profile context for activity-backed tools."""
+
+        task_payload = self._mapping_value(parameters, "task") or {}
+        task_runtime_payload = (
+            self._mapping_value(task_payload, "runtime")
+            if isinstance(task_payload, Mapping)
+            else {}
+        ) or {}
+        runtime_context: dict[str, Any] = {}
+        for source in (parameters, task_runtime_payload):
+            runtime_context.update(self._runtime_selection_from_source(source))
+
+        target_runtime = self._coerce_text(
+            runtime_context.get("targetRuntime"),
+            max_chars=160,
+        )
+        execution_profile_ref = self._inherited_execution_profile_ref(
+            parameters,
+            agent_id=target_runtime,
+        )
+        if execution_profile_ref:
+            runtime_context["executionProfileRef"] = execution_profile_ref
+            snapshots = getattr(self, "_profile_snapshots", None)
+            if isinstance(snapshots, Mapping):
+                snapshot = snapshots.get(execution_profile_ref)
+                if isinstance(snapshot, Mapping):
+                    runtime_context["providerProfile"] = dict(snapshot)
+        return runtime_context
 
     def _validated_execution_profile_ref(
         self,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1436,6 +1436,50 @@ async def test_temporal_pentest_provider_lease_manager_acquires_slot_with_update
         )
     ]
 
+async def test_temporal_pentest_provider_lease_manager_uses_runtime_manager_and_autostarts():
+    class _ClientAdapter:
+        def __init__(self) -> None:
+            self.starts: list[dict[str, object]] = []
+            self.updates: list[tuple[str, str, dict[str, object]]] = []
+
+        async def start_workflow(self, **kwargs: object) -> object:
+            self.starts.append(dict(kwargs))
+            return SimpleNamespace(workflow_id=kwargs.get("workflow_id"))
+
+        async def update_workflow(
+            self, workflow_id: str, update_name: str, arg: dict[str, object]
+        ) -> dict[str, object]:
+            self.updates.append((workflow_id, update_name, arg))
+            if len(self.updates) == 1:
+                raise RuntimeError(f"workflow not found for ID: {workflow_id}")
+            return {
+                "profile_id": "codex_openrouter_qwen36_plus",
+                "lease_id": "lease-owner-1",
+            }
+
+    client = _ClientAdapter()
+    manager = TemporalPentestProviderLeaseManager(client)
+
+    lease_id = await manager.acquire(
+        runtime_id="codex_cli",
+        profile_id="codex_openrouter_qwen36_plus",
+        owner="owner-1",
+        metadata={"target_hash": "hash-1"},
+    )
+
+    assert lease_id == "lease-owner-1"
+    assert client.starts == [
+        {
+            "workflow_type": "MoonMind.ProviderProfileManager",
+            "workflow_id": "provider-profile-manager:codex_cli",
+            "input_args": {"runtime_id": "codex_cli"},
+        }
+    ]
+    assert [update[0] for update in client.updates] == [
+        "provider-profile-manager:codex_cli",
+        "provider-profile-manager:codex_cli",
+    ]
+
 async def test_temporal_pentest_provider_lease_manager_fails_closed_without_updates():
     class _ClientAdapter:
         async def signal_workflow(
@@ -2091,6 +2135,98 @@ async def test_security_pentest_execute_acquires_lease_after_scope_validation_be
     }
     assert "https://lab.example.test" not in str(payload["metadata"])
     assert "sk-resolved-provider-value" not in str(result)
+
+async def test_security_pentest_execute_uses_inherited_openrouter_profile_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    lease_manager = _FakePentestLeaseManager()
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakePentestArtifactService(
+            {"art_scope_valid": _scope_artifact_bytes()}
+        ),
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+
+    async def _fake_resolver(ref: object, *, field_name: str) -> str:
+        assert ref == {"secret_ref": "env://OPENROUTER_API_KEY"}
+        assert field_name == "OPENROUTER_API_KEY"
+        return "sk-resolved-provider-value"
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.activity_runtime.resolve_managed_api_key_reference",
+        _fake_resolver,
+    )
+
+    payload = _pentest_artifact_activity_payload()
+    payload.setdefault("context", {})["runtime"] = {
+        "targetRuntime": "codex_cli",
+        "executionProfileRef": "codex_openrouter_qwen36_plus",
+        "providerProfile": {
+            "profile_id": "codex_openrouter_qwen36_plus",
+            "runtime_id": "codex_cli",
+            "provider_id": "openrouter",
+            "provider_label": "OpenRouter",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "enabled": True,
+            "auth_state": "connected",
+            "secret_refs": {"provider_api_key": "env://OPENROUTER_API_KEY"},
+            "env_template": {
+                "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
+            },
+            "clear_env_keys": ["OPENAI_API_KEY"],
+            "max_parallel_runs": 1,
+            "cooldown_after_429_seconds": 900,
+            "rate_limit_policy": "backoff",
+            "max_lease_duration_seconds": 7200,
+        },
+    }
+
+    result = await activities.security_pentest_execute(payload)
+
+    assert result["status"] == "completed"
+    assert result["provider_profile"]["profile_id"] == "codex_openrouter_qwen36_plus"
+    assert result["provider_profile"]["runtime_id"] == "codex_cli"
+    assert result["provider_profile"]["env"]["PENTESTGPT_AUTH_MODE"] == "openrouter"
+    assert result["provider_lease"]["runtime_id"] == "codex_cli"
+    assert lease_manager.events[0][1]["profile_id"] == "codex_openrouter_qwen36_plus"
+    assert result["wrapper_invocation"]["envOverrides"]["OPENROUTER_API_KEY"] == (
+        "sk-resolved-provider-value"
+    )
+
+async def test_security_pentest_execute_rejects_inherited_oauth_profile_snapshot():
+    lease_manager = _FakePentestLeaseManager()
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=_FakePentestArtifactService(
+            {"art_scope_valid": _scope_artifact_bytes()}
+        ),
+        workload_launcher=_FakePentestLauncher(),
+        workload_registry=_RecordingPentestRegistry(),
+        pentest_provider_lease_manager=lease_manager,
+    )
+    payload = _pentest_artifact_activity_payload()
+    payload.setdefault("context", {})["runtime"] = {
+        "targetRuntime": "codex_cli",
+        "executionProfileRef": "codex_default",
+        "providerProfile": {
+            "profile_id": "codex_default",
+            "runtime_id": "codex_cli",
+            "provider_id": "openai",
+            "credential_source": "oauth_volume",
+            "runtime_materialization_mode": "oauth_home",
+            "enabled": True,
+            "auth_state": "connected",
+        },
+    }
+
+    result = await activities.security_pentest_execute(payload)
+
+    assert result["status"] == "validation_failed"
+    assert result["diagnostics"]["policy_reason"] == "oauth_profile_unsupported"
+    assert result["terminal_cleanup"]["provider_lease_released"] is False
+    assert lease_manager.events == []
 
 async def test_security_pentest_execute_does_not_acquire_lease_for_invalid_scope():
     lease_manager = _FakePentestLeaseManager()

--- a/tests/unit/workflows/temporal/workflows/test_run_legacy_skill_runtime_context.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_legacy_skill_runtime_context.py
@@ -1,0 +1,43 @@
+"""Runtime/profile context propagation for activity-backed plan tools."""
+
+from __future__ import annotations
+
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def test_legacy_skill_runtime_context_includes_selected_provider_snapshot() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._profile_snapshots = {
+        "codex_openrouter_qwen36_plus": {
+            "profile_id": "codex_openrouter_qwen36_plus",
+            "runtime_id": "codex_cli",
+            "provider_id": "openrouter",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "enabled": True,
+            "launch_ready": True,
+            "auth_state": "connected",
+            "secret_refs": {"provider_api_key": "env://OPENROUTER_API_KEY"},
+            "env_template": {
+                "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
+            },
+        }
+    }
+
+    context = workflow._legacy_skill_runtime_context(
+        {
+            "targetRuntime": "codex_cli",
+            "profileId": "codex_openrouter_qwen36_plus",
+            "task": {
+                "runtime": {
+                    "mode": "codex_cli",
+                    "profileId": "codex_openrouter_qwen36_plus",
+                }
+            },
+        }
+    )
+
+    assert context["targetRuntime"] == "codex_cli"
+    assert context["executionProfileRef"] == "codex_openrouter_qwen36_plus"
+    assert context["providerProfile"]["runtime_id"] == "codex_cli"
+    assert context["providerProfile"]["provider_id"] == "openrouter"


### PR DESCRIPTION
## Summary

Fixes `security.pentest.run` provider-profile routing so the PentestGPT activity no longer hardcodes `provider-profile-manager:pentestgpt` for every provider selection.

## Root cause

Legacy activity-backed tools did not receive the workflow's selected runtime/provider-profile context. The PentestGPT activity therefore fell back to dedicated `pentestgpt` provider profiles, but local deployments only had managed-runtime profiles such as `codex_default`, `codex_openrouter_qwen36_plus`, and `claude_anthropic`. The Pentest lease manager then attempted `provider-profile-manager:pentestgpt`, which was not running/populated, producing `PROVIDER_CAPACITY_FAILED` before launch.

## Changes

- Pass selected runtime/profile context and provider-profile snapshots into legacy `tool.type=skill` activity payloads behind a Temporal patch marker.
- Adapt supported SecretRef-backed managed provider profiles, such as OpenRouter, for the PentestGPT runner.
- Route Pentest lease acquire/release/cooldown calls to `provider-profile-manager:<runtime_id>` dynamically and auto-start the manager on missing-manager update failures.
- Fail fast with `oauth_profile_unsupported` for OAuth-home Codex CLI / Claude Code profiles because the current PentestGPT runner requires SecretRef-backed Anthropic or OpenRouter env materialization.
- Update PentestTool docs and add boundary regression tests.

## Validation

Not run in this session; no test execution was explicitly requested.
