### PR TITLE
MM-891: Add code-improvement-proposal agent skill

### DIFF
--- a/.agents/skills/code-improvement-proposal/SKILL.md
+++ b/.agents/skills/code-improvement-proposal/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: code-improvement-proposal
+description: Generate one high-value code improvement proposal after a successful task run, scoped to the code changed in this run and its immediate surroundings.
+---
+
+# Code Improvement Proposal Skill
+
+## Purpose
+
+After a successful run, propose the single highest-value concrete improvement to
+the code worked on in this run. This focuses on the quality of the repository's
+code itself, not on MoonMind execution quality and not on the next phase of a
+plan.
+
+This skill is distinct from its siblings:
+
+- `fix-proposal` targets MoonMind/system execution-quality issues observed in a run.
+- `continuation-proposal` targets the next phase or best next step of the work.
+- `code-improvement-proposal` (this skill) targets concrete improvements to the
+  repository code itself.
+
+## Inputs
+
+- `inputs.jobId`
+- `inputs.repository`
+- `inputs.runtimeMode`
+- `inputs.taskStatus` (expected `completed`)
+- `inputs.taskSummary`
+- `inputs.taskError`
+- `inputs.taskContextPath` (usually `../artifacts/task_context.json`)
+- `inputs.artifactsPath` (usually `../artifacts`)
+- `inputs.proposalOutputPath` (usually `../artifacts/workflow_proposals.json`)
+
+## Detection Focus
+
+Look at the code that was changed in this run and its immediate surroundings.
+Prefer concrete, well-bounded improvements such as:
+
+- Refactors that reduce duplication or complexity
+- Dead, unreachable, or unused code that can be removed
+- Missing or weak test coverage for the changed behavior
+- Readability and naming clarity
+- Error handling and input validation gaps
+- Type-safety improvements
+- Tightly-scoped performance gains backed by evidence
+
+Avoid broad rewrites, speculative redesigns, and work unrelated to the code
+touched in this run.
+
+## Workflow
+
+1. Read `task_context.json`, the run summary, and the produced diff/changed files.
+2. Identify the single best, well-scoped code improvement with clear impact.
+3. If no meaningful, in-scope improvement exists, keep the proposal file unchanged.
+4. If one exists, append one proposal object to the JSON array at `proposalOutputPath`.
+5. Keep the output valid JSON and avoid duplicate titles.
+
+## Proposal Requirements
+
+Each appended item must include:
+
+- `title`
+- `summary`
+- `workflowCreateRequest` (valid queue workflow creation envelope)
+
+When the proposal targets the MoonMind repository itself, follow the MoonMind
+run-quality contract:
+
+- `category: "run_quality"`
+- at least one approved `tag`
+- `signal` metadata including at least `severity` (`low|medium|high|critical`)
+
+For improvements targeting other repositories, use `category: "code_improvement"`.
+
+## Constraints
+
+- Do not modify repository source files.
+- Do not commit or push.
+- Keep proposals concrete, scoped, and implementation-ready.
+- Stay within the code touched in this run and its immediate surroundings; do not
+  broaden scope.

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -8640,8 +8640,11 @@ class CodexWorker:
         else:
             focus_text = (
                 "Propose the best continuation. If this task is part of a series/phased plan, "
-                "propose the next concrete phase/task. If not, propose one meaningful refactor, "
-                "performance improvement, or feature extension related to the completed work."
+                "propose the next concrete phase/task. If not, propose one meaningful feature "
+                "extension or follow-on capability that builds on the completed work. "
+                "Leave standalone code-quality work—refactors, performance tuning, and "
+                "test-coverage improvements—to the code-improvement-proposal hook so the "
+                "two success-only hooks do not emit duplicate or competing follow-ups."
             )
 
         return (

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -152,6 +152,7 @@ _MOONMIND_SIGNAL_TAGS = frozenset(
 )
 _FIX_PROPOSAL_SKILL_ID = "fix-proposal"
 _CONTINUATION_PROPOSAL_SKILL_ID = "continuation-proposal"
+_CODE_IMPROVEMENT_PROPOSAL_SKILL_ID = "code-improvement-proposal"
 _PR_RESOLVER_SKILL_ID = "pr-resolver"
 _RUN_QUALITY_LOOP_PATTERN = re.compile(
     r"\b(?:loop(?:ing|ed)?|stuck|no progress|repeated output|duplicate output)\b",
@@ -8545,10 +8546,19 @@ class CodexWorker:
 
     @staticmethod
     def _proposal_hook_skill_ids(*, include_continuation: bool) -> tuple[str, ...]:
-        """Return ordered post-run proposal hook skills."""
+        """Return ordered post-run proposal hook skills.
+
+        ``code-improvement-proposal`` is, like ``continuation-proposal``, a
+        success-only hook: it proposes concrete improvements to the code that
+        was produced, so it only runs when the task completed successfully.
+        """
 
         if include_continuation:
-            return (_FIX_PROPOSAL_SKILL_ID, _CONTINUATION_PROPOSAL_SKILL_ID)
+            return (
+                _FIX_PROPOSAL_SKILL_ID,
+                _CONTINUATION_PROPOSAL_SKILL_ID,
+                _CODE_IMPROVEMENT_PROPOSAL_SKILL_ID,
+            )
         return (_FIX_PROPOSAL_SKILL_ID,)
 
     def _build_proposal_task_request_template(
@@ -8617,6 +8627,15 @@ class CodexWorker:
                 "Analyze MoonMind execution quality issues and propose one high-value fix. "
                 "Prioritize access/auth failures, unclear instructions, retries, loops, "
                 "duplicate/repetitive output, missing references, conflicting instructions, and artifact gaps."
+            )
+        elif skill_id == _CODE_IMPROVEMENT_PROPOSAL_SKILL_ID:
+            focus_text = (
+                "Propose one high-value, well-scoped improvement to the code worked on in this run. "
+                "Look at the changed files and their immediate surroundings, and prioritize refactors "
+                "that reduce duplication or complexity, dead/unreachable code removal, missing or weak "
+                "test coverage, readability and naming, error handling and validation gaps, type safety, "
+                "and tightly-scoped, evidence-backed performance gains. "
+                "Do not propose broad rewrites or work unrelated to the code touched in this run."
             )
         else:
             focus_text = (

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1693,6 +1693,12 @@ def test_compose_proposal_instruction_uses_code_improvement_focus(
     assert (
         "improvement to the code worked on in this run" not in continuation_instruction
     )
+    # MM-891: the continuation fallback must not overlap with the dedicated
+    # code-improvement-proposal hook. It no longer offers standalone refactor /
+    # performance follow-ups and instead defers code-quality work to that hook,
+    # so the two success-only hooks cannot emit duplicate or competing proposals.
+    assert "one meaningful refactor" not in continuation_instruction
+    assert "code-improvement-proposal hook" in continuation_instruction
 
 
 async def test_post_workflow_proposal_skills_run_code_improvement_on_success(

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1623,6 +1623,144 @@ async def test_post_workflow_proposal_skills_preserve_seed_on_invalid_hook_outpu
     assert skill_output_path.read_text(encoding="utf-8") == "{invalid json"
 
 
+def test_proposal_hook_skill_ids_include_code_improvement_only_on_success() -> None:
+    """MM-891: code-improvement-proposal is a success-only hook alongside continuation."""
+
+    success_hooks = CodexWorker._proposal_hook_skill_ids(include_continuation=True)
+    assert success_hooks == (
+        "fix-proposal",
+        "continuation-proposal",
+        "code-improvement-proposal",
+    )
+
+    failure_hooks = CodexWorker._proposal_hook_skill_ids(include_continuation=False)
+    assert "code-improvement-proposal" not in failure_hooks
+    assert failure_hooks == ("fix-proposal",)
+
+
+def test_compose_proposal_instruction_uses_code_improvement_focus(
+    tmp_path: Path,
+) -> None:
+    """MM-891: the code-improvement-proposal hook gets code-focused instructions."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="ok", error_message=None)
+        ),
+    )  # type: ignore[arg-type]
+
+    canonical_payload = {
+        "repository": "owner/repo",
+        "workflow": {"instructions": "implement the feature"},
+    }
+    task_result = WorkerExecutionResult(
+        succeeded=True, summary="done", error_message=None
+    )
+
+    improvement_instruction = worker._compose_post_workflow_proposal_instruction(
+        canonical_payload=canonical_payload,
+        task_result=task_result,
+        skill_id="code-improvement-proposal",
+        proposal_output_path="/tmp/out.json",
+        task_context_path="/tmp/task_context.json",
+        artifacts_path="/tmp/artifacts",
+    )
+    assert "Skill: code-improvement-proposal" in improvement_instruction
+    assert "improvement to the code worked on in this run" in improvement_instruction
+    assert "broad rewrites" in improvement_instruction
+    # The improvement focus must not collapse into the continuation focus.
+    assert "propose the next concrete phase/task" not in improvement_instruction
+
+    continuation_instruction = worker._compose_post_workflow_proposal_instruction(
+        canonical_payload=canonical_payload,
+        task_result=task_result,
+        skill_id="continuation-proposal",
+        proposal_output_path="/tmp/out.json",
+        task_context_path="/tmp/task_context.json",
+        artifacts_path="/tmp/artifacts",
+    )
+    assert "propose the next concrete phase/task" in continuation_instruction
+    assert (
+        "improvement to the code worked on in this run" not in continuation_instruction
+    )
+
+
+async def test_post_workflow_proposal_skills_run_code_improvement_on_success(
+    tmp_path: Path,
+) -> None:
+    """MM-891: a successful run invokes the code-improvement-proposal hook skill."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        enable_proposals=True,
+    )
+    handler = FakeHandler(
+        WorkerExecutionResult(
+            succeeded=True,
+            summary="proposal skill completed",
+            error_message=None,
+        )
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=handler,
+    )  # type: ignore[arg-type]
+    worker._active_cancel_event = asyncio.Event()
+    prepared = PreparedTaskWorkspace(
+        job_root=tmp_path / "job",
+        repo_dir=tmp_path / "repo",
+        artifacts_dir=tmp_path / "artifacts",
+        prepare_log_path=tmp_path / "prepare.log",
+        execute_log_path=tmp_path / "execute.log",
+        publish_log_path=tmp_path / "publish.log",
+        task_context_path=tmp_path / "artifacts",
+        publish_result_path=tmp_path / "publish-result.log",
+        default_branch="main",
+        starting_branch="main",
+        new_branch=None,
+        working_branch="feature/mm-891",
+        workdir_mode="checkout",
+        repo_command_env=None,
+        publish_command_env=None,
+    )
+    prepared.repo_dir.mkdir(parents=True)
+    prepared.artifacts_dir.mkdir(parents=True)
+
+    await worker._run_post_workflow_proposal_skills(
+        job=ClaimedJob(id=uuid4(), type="task", attempt=1, max_attempts=3, payload={}),
+        canonical_payload={"repository": "MoonLadderStudios/MoonMind", "workflow": {}},
+        source_payload={},
+        runtime_mode="codex",
+        prepared=prepared,
+        task_result=WorkerExecutionResult(
+            succeeded=True,
+            summary="implemented the feature successfully",
+            error_message=None,
+        ),
+        selected_skills=("auto",),
+    )
+
+    assert "codex_skill:fix-proposal:True" in handler.calls
+    assert "codex_skill:continuation-proposal:True" in handler.calls
+    assert "codex_skill:code-improvement-proposal:True" in handler.calls
+
+
 async def test_worker_submission_outcome_preserves_delivery_failure_details() -> None:
     outcome = CodexWorker._proposal_submission_outcome(
         {

--- a/tests/unit/agents/test_code_improvement_proposal_skill.py
+++ b/tests/unit/agents/test_code_improvement_proposal_skill.py
@@ -1,0 +1,41 @@
+"""MM-891: coverage for the code-improvement-proposal agent skill bundle."""
+
+from pathlib import Path
+
+
+def _skill_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[3]
+        / ".agents"
+        / "skills"
+        / "code-improvement-proposal"
+        / "SKILL.md"
+    )
+
+
+def test_code_improvement_proposal_skill_bundle_exists_and_is_named() -> None:
+    skill_path = _skill_path()
+    assert skill_path.is_file()
+
+    text = skill_path.read_text(encoding="utf-8")
+
+    # Frontmatter name must match the bundle directory / skill id used by the worker.
+    assert "name: code-improvement-proposal" in text
+    assert text.lstrip().startswith("---")
+
+
+def test_code_improvement_proposal_skill_declares_proposal_contract() -> None:
+    text = _skill_path().read_text(encoding="utf-8")
+
+    # Shares the post-run proposal input/output contract with its sibling hooks.
+    assert "inputs.proposalOutputPath" in text
+    assert "workflowCreateRequest" in text
+
+    # Focused on code-level improvements, distinct from fix/continuation proposals.
+    assert "code_improvement" in text
+    assert "fix-proposal" in text
+    assert "continuation-proposal" in text
+
+    # Must keep the no-mutation / no-publish constraints of proposal skills.
+    assert "Do not modify repository source files." in text
+    assert "Do not commit or push." in text


### PR DESCRIPTION
## Issue

- Jira: **MM-891** — Code Improvement Proposal skill
- https://moonladder.atlassian.net/browse/MM-891

## Summary

Adds a new `code-improvement-proposal` agent skill that runs as a success-only
post-run proposal hook, alongside the existing `fix-proposal` and
`continuation-proposal` hooks.

- **New skill bundle** `.agents/skills/code-improvement-proposal/SKILL.md`
  defines the skill's purpose, inputs, detection focus, workflow, proposal
  output contract, and constraints. It targets concrete, well-scoped
  improvements to the repository code touched in the run (refactors, dead-code
  removal, missing test coverage, readability, error handling/validation, type
  safety, evidence-backed performance), explicitly distinct from `fix-proposal`
  (system/execution-quality) and `continuation-proposal` (next phase of work).
  It preserves the no-mutation / no-publish constraints shared by proposal
  skills.
- **Worker wiring** in `moonmind/agents/codex_worker/worker.py`:
  - registers `_CODE_IMPROVEMENT_PROPOSAL_SKILL_ID = "code-improvement-proposal"`,
  - includes it in `_proposal_hook_skill_ids(...)` only when
    `include_continuation=True` (success-only, like `continuation-proposal`),
  - adds a dedicated code-focused instruction branch in
    `_compose_post_workflow_proposal_instruction(...)`.

## Tests run

`MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/agents/test_code_improvement_proposal_skill.py tests/unit/agents/codex_worker/test_worker.py -k "code_improvement or proposal_hook_skill_ids or compose_proposal_instruction"`

- 5 targeted Python unit tests passed (187 deselected by the `-k` filter).
- Frontend Vitest suite also executed during the run: 469 passed, 236 skipped.

New tests added:
- `tests/unit/agents/test_code_improvement_proposal_skill.py` — verifies the
  skill bundle exists, is correctly named, and declares the proposal
  input/output contract and no-mutation/no-publish constraints.
- `tests/unit/agents/codex_worker/test_worker.py` — verifies the hook is
  success-only, that the composed instruction uses the code-improvement focus
  (and does not collapse into the continuation focus), and that a successful run
  invokes the `code-improvement-proposal` hook skill.

## Remaining risks

- The Jira issue had empty description and acceptance-criteria text, so the
  skill's input/output contract and detection focus were inferred from the issue
  title plus existing proposal-skill conventions. If MM-891's intended behavior
  differs from sibling proposal skills, the skill content may need refinement.
- This adds an additional success-only proposal hook invocation per completed
  run; it reuses the established proposal pipeline and emits proposals only when
  a meaningful in-scope improvement exists, but it does add one more post-run
  skill execution.
