### PR TITLE
[codex] fix run workflow replay for stuck slot waits

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -486,6 +486,7 @@ RUN_STEP_RESILIENCE_POLICY_PATCH = "run-step-resilience-policy-v1"
 # correlated under one trace id. Gated so in-flight histories that predate the
 # trace-ref stamp / incident-manifest writes keep replaying deterministically.
 RUN_INCIDENT_RECONSTRUCTION_PATCH = "run-incident-reconstruction-v1"
+RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH = "run-json-artifact-write-complete-v1"
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
@@ -1144,6 +1145,8 @@ class MoonMindRunWorkflow:
         )
         if not artifact_id:
             raise ValueError(f"artifact.create returned no artifact_id for {name}")
+        if not workflow.patched(RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH):
+            return str(artifact_id)
         await execute_typed_activity(
             "artifact.write_complete",
             ArtifactWriteCompleteInput(
@@ -6201,10 +6204,16 @@ class MoonMindRunWorkflow:
                         boundary="before_execution",
                         updated_at=workflow.now(),
                     )
+                    step_execution_naming_enabled = workflow.patched(
+                        RUN_STEP_EXECUTION_NAMING_PATCH
+                    )
+                    step_execution_manifest_enabled = workflow.patched(
+                        RUN_STEP_EXECUTION_MANIFEST_PATCH
+                    )
 
                     if (
                         tool_type != "agent_runtime"
-                        and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)
+                        and step_execution_manifest_enabled
                     ):
                         await self._record_step_execution_manifest(
                             node_id,
@@ -6294,7 +6303,7 @@ class MoonMindRunWorkflow:
                                 execution_profile_ref=request.execution_profile_ref,
                                 parameters=parameters,
                             )
-                            if workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH):
+                            if step_execution_manifest_enabled:
                                 await self._record_step_execution_manifest(
                                     node_id,
                                     phase="start",
@@ -6335,6 +6344,9 @@ class MoonMindRunWorkflow:
                                     logical_step_id=node_id,
                                     attempt=current_step_execution,
                                 )
+                            slot_continuity_enabled = workflow.patched(
+                                RUN_SLOT_CONTINUITY_PATCH
+                            )
                             if self._is_step_execution_launch_blocked(
                                 node_id,
                                 attempt=current_step_execution,
@@ -6350,7 +6362,7 @@ class MoonMindRunWorkflow:
                                 }
                                 result_status = "FAILED"
                                 break
-                            if workflow.patched(RUN_SLOT_CONTINUITY_PATCH):
+                            if slot_continuity_enabled:
                                 self._mark_slot_continuity_for_next_step(
                                     request=request,
                                     ordered_nodes=ordered_nodes,
@@ -6377,7 +6389,7 @@ class MoonMindRunWorkflow:
                             )
                             if current_step_execution > 1:
                                 step_execution_label = "attempt"
-                                if workflow.patched(RUN_STEP_EXECUTION_NAMING_PATCH):
+                                if step_execution_naming_enabled:
                                     step_execution_label = "execution"
                                 child_workflow_id = (
                                     f"{child_workflow_id}:{step_execution_label}{current_step_execution}"
@@ -11558,6 +11570,8 @@ class MoonMindRunWorkflow:
                     if self._managed_runtime_id(agent_id) != self._managed_runtime_id(
                         source_agent_id
                     ):
+                        if self._workflow_is_replaying():
+                            return profile_id
                         raise ValueError(
                             "Inherited execution_profile_ref '%s' targets runtime "
                             "'%s' but child runtime is '%s'."
@@ -11607,6 +11621,8 @@ class MoonMindRunWorkflow:
             return profile_id
         child_runtime_id = self._managed_runtime_id(agent_id)
         if runtime_id != child_runtime_id:
+            if self._workflow_is_replaying():
+                return profile_id
             raise ValueError(
                 "%s execution_profile_ref '%s' belongs to runtime '%s' but child "
                 "runtime is '%s'."
@@ -11625,6 +11641,15 @@ class MoonMindRunWorkflow:
         }
         normalized_agent_id = _normalize_agent_runtime_id(agent_id)
         return runtime_mapping.get(normalized_agent_id, normalized_agent_id)
+
+    @staticmethod
+    def _workflow_is_replaying() -> bool:
+        try:
+            return bool(workflow.unsafe.is_replaying())
+        except Exception as exc:
+            if exc.__class__.__name__ == "_NotInWorkflowEventLoopError":
+                return False
+            raise
 
     @staticmethod
     def _plan_node_tool_mapping(node: Mapping[str, Any]) -> Mapping[str, Any] | None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -4,6 +4,7 @@ Pure unit tests — no Temporal test server needed.
 """
 
 import unittest
+import inspect
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -21,6 +22,11 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
 )
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
+)
+from moonmind.workflows.temporal.workflows.run import RUN_STEP_EXECUTION_NAMING_PATCH
+from moonmind.workflows.temporal.workflows.run import RUN_SLOT_CONTINUITY_PATCH
 
 
 def _resolved_skill(skill_name: str) -> ResolvedSkillEntry:
@@ -58,6 +64,66 @@ class TestAgentKindForId(unittest.TestCase):
             )
 
 class TestSlotContinuityMetadata(unittest.TestCase):
+    def test_profile_runtime_mismatch_guard_is_replay_only(self) -> None:
+        inherited_source = inspect.getsource(
+            MoonMindRunWorkflow._inherited_execution_profile_ref
+        )
+        validated_source = inspect.getsource(
+            MoonMindRunWorkflow._validated_execution_profile_ref
+        )
+
+        self.assertIn("self._workflow_is_replaying()", inherited_source)
+        self.assertIn("self._workflow_is_replaying()", validated_source)
+        self.assertIn("raise ValueError", inherited_source)
+        self.assertIn("raise ValueError", validated_source)
+
+    def test_step_execution_naming_marker_precedes_manifest_marker(self) -> None:
+        source = inspect.getsource(MoonMindRunWorkflow._run_execution_stage)
+        self.assertEqual(
+            RUN_STEP_EXECUTION_NAMING_PATCH,
+            "run-step-execution-naming-v1",
+        )
+
+        naming_index = source.index(
+            "step_execution_naming_enabled = workflow.patched("
+        )
+        manifest_index = source.index(
+            "step_execution_manifest_enabled = workflow.patched(",
+            naming_index,
+        )
+
+        self.assertLess(naming_index, manifest_index)
+
+    def test_json_artifact_write_complete_is_replay_patch_guarded(self) -> None:
+        source = inspect.getsource(MoonMindRunWorkflow._write_json_artifact)
+        self.assertEqual(
+            RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH,
+            "run-json-artifact-write-complete-v1",
+        )
+
+        guard_index = source.index(
+            "workflow.patched(RUN_JSON_ARTIFACT_WRITE_COMPLETE_PATCH)"
+        )
+        write_complete_index = source.index(
+            '"artifact.write_complete"',
+            guard_index,
+        )
+
+        self.assertLess(guard_index, write_complete_index)
+
+    def test_slot_continuity_patch_marker_precedes_launch_block_short_circuit(self) -> None:
+        source = inspect.getsource(MoonMindRunWorkflow._run_execution_stage)
+        self.assertEqual(RUN_SLOT_CONTINUITY_PATCH, "run-slot-continuity-v1")
+        marker_index = source.index(
+            "slot_continuity_enabled = workflow.patched("
+        )
+        launch_block_index = source.index(
+            "if self._is_step_execution_launch_blocked(",
+            marker_index,
+        )
+
+        self.assertLess(marker_index, launch_block_index)
+
     def test_marks_request_when_next_step_uses_same_managed_runtime(self) -> None:
         wf = MoonMindRunWorkflow()
         request = AgentExecutionRequest(


### PR DESCRIPTION
## Summary

Fixes a run-workflow replay trap that left executions visually stuck in `awaiting_slot` even after their managed child workflow had completed.

## Root Cause

Older workflow histories can contain patch markers such as `run-step-execution-naming-v1`, `run-step-attempt-manifest-v1`, and `run-slot-continuity-v1` before the child workflow launch. Newer control flow could skip the matching `workflow.patched(...)` calls on replay, which caused Temporal nondeterminism before the parent could consume the completed child result.

A separate replay-only guard is also needed for histories whose authored task payload preserved a stale cross-runtime profile reference. Live execution still fails fast for that mismatch; replay can pass through so already-recorded history remains processable.

## Changes

- Preserve replay command ordering for step execution naming, manifest, and slot-continuity patch markers.
- Guard the newer JSON artifact `write_complete` activity behind a replay patch marker.
- Add replay-only bypasses for historical profile/runtime mismatch validation.
- Add focused regression tests covering patch ordering and replay-only guard placement.

## Validation

- Replayed the affected workflow history locally with `REPLAY_FAILURE None`.
- Ran `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py -q` successfully.