### PR TITLE
[codex] fix Jira blocker recheck retry handling

### DIFF
--- a/api_service/db/base.py
+++ b/api_service/db/base.py
@@ -1,18 +1,20 @@
 from __future__ import annotations  # Ensure this is at the very top
 
 from collections.abc import AsyncGenerator  # Use collections.abc for Python 3.9+
+from contextlib import asynccontextmanager
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from moonmind.config.settings import settings
 
 DATABASE_URL = settings.database.POSTGRES_URL
 
-engine = create_async_engine(DATABASE_URL)
-async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+def create_application_engine(database_url: str) -> AsyncEngine:
+    return create_async_engine(database_url, pool_pre_ping=True)
 
-from contextlib import asynccontextmanager
+engine = create_application_engine(DATABASE_URL)
+async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session_maker() as session:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -176,6 +176,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
 )
 DEPENDENCY_RECONCILE_INTERVAL = timedelta(seconds=30)
 _TERMINAL_LAST_ERROR_UNSET = object()
+JIRA_BLOCKER_RECHECK_MIN_ACTIVITY_ATTEMPTS = 3
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 
@@ -383,6 +384,9 @@ RUN_BLOCKED_OUTCOME_SHORT_CIRCUIT_PATCH = "run-blocked-outcome-short-circuit-v1"
 RUN_JIRA_BLOCKER_RECHECK_PATCH = "run-jira-blocker-recheck-v1"
 RUN_FAILED_RESULT_BLOCKER_PATCH = "run-failed-result-blocker-v1"
 RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH = "run-jira-blocker-wait-coalescing-v1"
+RUN_JIRA_BLOCKER_RECHECK_RETRY_FLOOR_PATCH = (
+    "run-jira-blocker-recheck-retry-floor-v1"
+)
 # Replay-stable patch id for the v2 workflow-scoped Codex termination path. The
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
@@ -1089,6 +1093,40 @@ class MoonMindRunWorkflow:
                 seconds=route.timeouts.heartbeat_timeout_seconds
             )
         return kwargs
+
+    def _jira_blocker_recheck_retry_attempts_override(
+        self,
+        *,
+        route: TemporalActivityRoute,
+        execute_payload: Mapping[str, Any],
+        step_retry_overrides_enabled: bool,
+    ) -> int | None:
+        if step_retry_overrides_enabled:
+            invocation_payload = execute_payload.get("invocation_payload")
+            if isinstance(invocation_payload, Mapping):
+                invocation_inputs = invocation_payload.get("inputs")
+                invocation_options = invocation_payload.get("options")
+                explicit_override = self._step_retry_attempts_override(
+                    node_inputs=(
+                        invocation_inputs
+                        if isinstance(invocation_inputs, Mapping)
+                        else None
+                    ),
+                    node_options=(
+                        invocation_options
+                        if isinstance(invocation_options, Mapping)
+                        else None
+                    ),
+                )
+                if explicit_override is not None:
+                    return explicit_override
+
+        if (
+            workflow.patched(RUN_JIRA_BLOCKER_RECHECK_RETRY_FLOOR_PATCH)
+            and route.retries.max_attempts < JIRA_BLOCKER_RECHECK_MIN_ACTIVITY_ATTEMPTS
+        ):
+            return JIRA_BLOCKER_RECHECK_MIN_ACTIVITY_ATTEMPTS
+        return None
 
     def _decode_json_payload(
         self,
@@ -8225,24 +8263,13 @@ class MoonMindRunWorkflow:
                     raise ValueError(
                         "skill Jira blocker recheck requires activity context"
                     )
-                max_attempts_override = None
-                if step_retry_overrides_enabled:
-                    invocation_payload = execute_payload.get("invocation_payload")
-                    if isinstance(invocation_payload, Mapping):
-                        invocation_inputs = invocation_payload.get("inputs")
-                        invocation_options = invocation_payload.get("options")
-                        max_attempts_override = self._step_retry_attempts_override(
-                            node_inputs=(
-                                invocation_inputs
-                                if isinstance(invocation_inputs, Mapping)
-                                else None
-                            ),
-                            node_options=(
-                                invocation_options
-                                if isinstance(invocation_options, Mapping)
-                                else None
-                            ),
-                        )
+                max_attempts_override = (
+                    self._jira_blocker_recheck_retry_attempts_override(
+                        route=route,
+                        execute_payload=execute_payload,
+                        step_retry_overrides_enabled=step_retry_overrides_enabled,
+                    )
+                )
                 if coalesce_wait:
                     recheck_payload = self._compact_jira_blocker_recheck_payload(
                         execute_payload

--- a/tests/unit/api_service/test_db_base.py
+++ b/tests/unit/api_service/test_db_base.py
@@ -1,0 +1,12 @@
+import pytest
+
+from api_service.db.base import create_application_engine
+
+
+@pytest.mark.asyncio
+async def test_create_application_engine_enables_pool_pre_ping() -> None:
+    engine = create_application_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        assert engine.sync_engine.pool._pre_ping is True
+    finally:
+        await engine.dispose()

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1860,6 +1860,131 @@ async def test_jira_blocker_wait_rechecks_with_compact_payload_and_no_manifest(
 
 
 @pytest.mark.asyncio
+async def test_jira_blocker_recheck_applies_retry_floor_for_one_attempt_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    captured_max_attempts: list[int] = []
+    blocked_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "blocked",
+            "blockingIssues": [{"issueKey": "MM-685", "done": False}],
+            "summary": "MM-686 is blocked by MM-685.",
+        },
+    }
+    continue_result = {
+        "status": "COMPLETED",
+        "outputs": {
+            "targetIssueKey": "MM-686",
+            "decision": "continue",
+            "blockingIssues": [],
+            "summary": "All Jira blockers are Done.",
+        },
+    }
+    execute_payload = {
+        "registry_snapshot_ref": "art_registry",
+        "principal": "owner-1",
+        "invocation_payload": {
+            "id": "check-blockers",
+            "tool": {
+                "type": "skill",
+                "name": "jira.check_blockers",
+                "version": "1.0",
+            },
+            "inputs": {
+                "targetIssueKey": "MM-686",
+                "blockerPreflight": {
+                    "targetIssueKey": "MM-686",
+                    "linkType": "Blocks",
+                },
+            },
+            "options": {},
+        },
+        "idempotency_key": "base-key",
+    }
+    route = TemporalActivityRoute(
+        activity_type="mm.tool.execute",
+        task_queue="mm.activity.integrations",
+        fleet="integrations",
+        capability_class="tools",
+        timeouts=TemporalActivityTimeouts(
+            start_to_close_seconds=30,
+            schedule_to_close_seconds=120,
+        ),
+        retries=TemporalActivityRetries(max_attempts=1, max_interval_seconds=30),
+    )
+
+    async def fake_execute_activity(
+        _activity_type: str,
+        _payload: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        captured_max_attempts.append(kwargs["retry_policy"].maximum_attempts)
+        return continue_result
+
+    async def fake_noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "wait_condition",
+        _timeout_wait_condition,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_workflow_module.RUN_JIRA_BLOCKER_WAIT_COALESCING_PATCH,
+            run_workflow_module.RUN_JIRA_BLOCKER_RECHECK_RETRY_FLOOR_PATCH,
+        },
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_wait_if_paused_at_safe_boundary",
+        fake_noop_async,
+    )
+
+    result, skipped = await workflow._wait_for_jira_blocker_resolution(
+        execution_result=blocked_result,
+        node_id="check-blockers",
+        tool_name="jira.check_blockers",
+        tool_type="skill",
+        failure_mode="FAIL_FAST",
+        route=route,
+        execute_payload=execute_payload,
+    )
+
+    assert skipped is False
+    assert result == continue_result
+    assert captured_max_attempts == [
+        run_workflow_module.JIRA_BLOCKER_RECHECK_MIN_ACTIVITY_ATTEMPTS
+    ]
+
+
+@pytest.mark.asyncio
 async def test_jira_blocker_recheck_activity_failure_respects_failure_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Enable SQLAlchemy pool pre-ping for the shared async engine so closed pooled DB connections are discarded before use.
- Add a replay-patched retry floor for idempotent Jira blocker re-check activities.
- Add regression coverage for the retry floor and DB engine configuration.

## Root Cause
Workflow `mm:b7550f31-6c23-4cf1-86a4-e2d720cce2c0` failed during a periodic Jira blocker re-check. The registry artifact existed and was complete, but the re-check activity inherited a one-attempt retry policy, so a stale asyncpg connection while reading the artifact ended the workflow.

## Validation
- `pytest tests/unit/api_service/test_db_base.py tests/unit/workflows/temporal/test_run_artifacts.py::test_jira_blocker_wait_rechecks_with_compact_payload_and_no_manifest tests/unit/workflows/temporal/test_run_artifacts.py::test_jira_blocker_recheck_applies_retry_floor_for_one_attempt_route tests/unit/workflows/temporal/test_run_artifacts.py::test_jira_blocker_recheck_activity_failure_respects_failure_mode -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
