### PR TITLE
When a filter is added which results in highly restricting the results on the workflows page, launching the filter view afterward ends up cut off beca

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -76,15 +76,19 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
 });
 
 describe('Workflow list table dropdown overflow', () => {
-  it('reserves vertical room for table filter and action popovers without disabling horizontal scroll', () => {
+  it('lets table filter and action popovers overflow the table edges instead of clipping them', () => {
+    // `overflow-x: auto` on the wrapper is coerced to `overflow-y: auto` by the
+    // browser, so the wrapper clips popovers. A highly restrictive filter leaves
+    // a short table that cut the filter popover off. While a popover is open the
+    // wrapper must switch to `overflow: visible` so the popover can escape.
     const wrapperBlock = cssRuleBlock(
       `.workflow-list-data-slab .queue-table-wrapper:has(
         .workflow-list-header-filter-popover,
         .td-workflow-actions-popover
       )`,
     );
-    expect(wrapperBlock).toContain('padding-bottom: min(18rem, 45vh);');
-    expect(wrapperBlock).not.toContain('overflow: visible;');
+    expect(wrapperBlock).toContain('overflow: visible;');
+    expect(wrapperBlock).not.toContain('padding-bottom:');
 
     const tableBlock = cssRuleBlock('.queue-table-wrapper table');
     expect(tableBlock).not.toContain('overflow: visible;');

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -3760,7 +3760,7 @@ describe.skip("Task Create Entrypoint", () => {
         (screen.getByLabelText(/Skill \(optional\)/) as HTMLInputElement).value,
       ).toBe("speckit-implement");
     });
-    expect(screen.queryByText("Schedule (optional)")).toBeNull();
+    expect(screen.queryByText("Schedule")).toBeNull();
     expect(screen.getByRole("button", { name: "Save Changes" })).toBeTruthy();
   });
 
@@ -3904,7 +3904,7 @@ describe.skip("Task Create Entrypoint", () => {
         headers: { Accept: "application/json" },
       }),
     );
-    expect(screen.queryByText("Schedule (optional)")).toBeNull();
+    expect(screen.queryByText("Schedule")).toBeNull();
     expect(screen.getByRole("button", { name: "Start New Run" })).toBeTruthy();
   });
 
@@ -4950,7 +4950,11 @@ describe.skip("Task Create Entrypoint", () => {
 
     const objectiveItem = (await screen.findByText("objective.png (1.2 KB)"))
       .closest("li") as HTMLElement;
-    fireEvent.click(within(objectiveItem).getByRole("button", { name: "Remove" }));
+    fireEvent.click(
+      within(objectiveItem).getByRole("button", {
+        name: "Remove objective attachment objective.png",
+      }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => {
@@ -6429,7 +6433,7 @@ describe.skip("Task Create Entrypoint", () => {
     fireEvent.change(await screen.findByLabelText("Instructions"), {
       target: { value: "Run the dependent stage." },
     });
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "mm:dep-1" },
     });
 
@@ -7851,7 +7855,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
     expect(await screen.findByDisplayValue("3")).not.toBeNull();
     expect(screen.getByText("Task Presets (optional)")).not.toBeNull();
-    expect(screen.getByText("Schedule (optional)")).not.toBeNull();
+    expect(screen.getByText("Schedule")).not.toBeNull();
   });
 
   it("right-aligns Task Presets actions with Apply last", async () => {
@@ -10630,7 +10634,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
 
     // Add mm:dep-1 first time (selecting the option adds it directly).
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "mm:dep-1" },
     });
 
@@ -10641,7 +10645,7 @@ describe.skip("Task Create Entrypoint", () => {
     // After adding, mm:dep-1 should be removed from the dropdown options
     // (filtered out by availableDependencyOptions).
     const select = screen.getByRole("combobox", {
-      name: "Dependencies",
+      name: "Prerequisite",
     }) as HTMLSelectElement;
     const options = Array.from(select.options).map((o) => o.value);
     expect(options).not.toContain("mm:dep-1");
@@ -10652,7 +10656,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(within(list as HTMLElement).getAllByRole("listitem")).toHaveLength(1);
 
     // Add a second dependency to verify the list grows.
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "mm:dep-2" },
     });
 
@@ -10670,7 +10674,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     // Add 10 dependencies (each selection adds the chosen prerequisite).
     for (let i = 1; i <= 10; i += 1) {
-      fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+      fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
         target: { value: `mm:dep-${i}` },
       });
     }
@@ -10683,7 +10687,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
 
     // Try to add an 11th.
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "mm:dep-11" },
     });
 
@@ -10759,7 +10763,7 @@ describe.skip("Task Create Entrypoint", () => {
     });
 
     // Re-selecting the placeholder option is a no-op: nothing is added.
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "" },
     });
 
@@ -13565,7 +13569,7 @@ describe("Task Create MM-641 authoring validation", () => {
     fireEvent.change(publishModeSelect, { target: { value: "branch" } });
     // Selecting a prerequisite from the dropdown adds it directly; there is no
     // separate "Add dependency" button.
-    fireEvent.change(screen.getByRole("combobox", { name: "Dependencies" }), {
+    fireEvent.change(screen.getByRole("combobox", { name: "Prerequisite" }), {
       target: { value: "mm:dep-641" },
     });
     await waitFor(() => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -10549,7 +10549,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                 </a>
                                 <button
                                   type="button"
-                                  className="button secondary"
+                                  className="queue-step-icon-button destructive"
+                                  aria-label={`Remove objective attachment ${attachment.filename}`}
                                   title={`Remove objective attachment ${attachment.filename}`}
                                   onClick={() =>
                                     removePersistedObjectiveAttachment(
@@ -10557,7 +10558,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                     )
                                   }
                                 >
-                                  Remove
+                                  <CloseIcon />
+                                  <span className="sr-only">{`Remove objective attachment ${attachment.filename}`}</span>
                                 </button>
                               </li>
                             ))}
@@ -10583,7 +10585,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                 </a>
                                 <button
                                   type="button"
-                                  className="button secondary"
+                                  className="queue-step-icon-button destructive"
+                                  aria-label={`Remove Step ${index + 1} attachment ${attachment.filename}`}
                                   title={`Remove Step ${index + 1} attachment ${attachment.filename}`}
                                   onClick={() =>
                                     removePersistedStepAttachment(
@@ -10592,7 +10595,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                     )
                                   }
                                 >
-                                  Remove
+                                  <CloseIcon />
+                                  <span className="sr-only">{`Remove Step ${index + 1} attachment ${attachment.filename}`}</span>
                                 </button>
                               </li>
                             ))}
@@ -10627,14 +10631,15 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                                 ) : null}
                                 <button
                                   type="button"
-                                  className="secondary"
+                                  className="queue-step-icon-button destructive"
                                   aria-label={`Remove Step ${index + 1} attachment ${file.name}`}
                                   title={`Remove Step ${index + 1} attachment ${file.name}`}
                                   onClick={() =>
                                     removeStepAttachment(step.localId, file)
                                   }
                                 >
-                                  Remove
+                                  <CloseIcon />
+                                  <span className="sr-only">{`Remove Step ${index + 1} attachment ${file.name}`}</span>
                                 </button>
                               </li>
                             ))}
@@ -11030,16 +11035,14 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         </section>
 
         {pageMode.mode === "create" ? (
-        <details
-          className="card"
+        <section
+          className="stack"
           id="schedule-panel"
           data-canonical-create-section="Schedule"
           aria-label="Schedule"
         >
-          <summary>
-            <strong>Schedule (optional)</strong>
-          </summary>
-          <div className="stack" style={{ marginTop: "0.75rem" }}>
+          <strong>Schedule</strong>
+          <div className="stack">
             <label>
               Schedule Mode
               <select
@@ -11133,7 +11136,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
               </label>
             </div>
           </div>
-        </details>
+        </section>
         ) : null}
 
         <section
@@ -11183,7 +11186,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             </div>
           ) : null}
           <label htmlFor="queue-dependency-picker">
-            Dependencies
+            Prerequisite
             <select
               id="queue-dependency-picker"
               value={selectedDependencyWorkflowId}
@@ -11219,11 +11222,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                     </span>
                     <button
                       type="button"
-                      className="secondary small"
-                      title={`Remove dependency ${workflowId}`}
+                      className="queue-step-icon-button destructive"
+                      aria-label={`Remove prerequisite ${workflowId}`}
+                      title={`Remove prerequisite ${workflowId}`}
                       onClick={() => removeDependency(workflowId)}
                     >
-                      Remove
+                      <CloseIcon />
+                      <span className="sr-only">{`Remove prerequisite ${workflowId}`}</span>
                     </button>
                   </li>
                 );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1534,11 +1534,21 @@ tbody tr:hover {
   background: transparent;
 }
 
+/*
+ * While a column filter or row actions popover is open, let the table wrapper
+ * overflow visibly so the popover can extend past the table edges. The wrapper
+ * is normally `overflow-x: auto`, which browsers coerce to `overflow-y: auto`
+ * as well — that turns the wrapper into a clipping box. When a highly
+ * restrictive filter leaves only a few rows, the short table clipped the
+ * popover and made it unreadable. Dropping to `overflow: visible` only while a
+ * popover is present lets it escape into the page (which scrolls) instead of
+ * being cut off, and the fixed-layout table never needs horizontal scrolling.
+ */
 .workflow-list-data-slab .queue-table-wrapper:has(
   .workflow-list-header-filter-popover,
   .td-workflow-actions-popover
 ) {
-  padding-bottom: min(18rem, 45vh);
+  overflow: visible;
 }
 
 .queue-table-wrapper table {


### PR DESCRIPTION
When a filter is added which results in highly restricting the results on the workflows page, launching the filter view afterward ends up cut off because the filter does not seem to overflow the edges of the table. The filter view needs to not be cutoff in this way since it becomes unreadable and unusable.

I also want to improve the start workflow page. I want to have the Schedule section and the Dependencies section appear more consistent. I do not want the Schedule section to say (optional) any longer and I do not want it to have a dropdown arrow with the section wrapped in a border. I do not like that the Dependencies section now lists Dependencies twice. The label above the dropdown can read Workflow to Await, Run to Await, or Prerequisite, whichever you think is easier to understand for an end user.

When prerequisites are added, instead of a "Remove" button at the end, I'd like to reuse the X button used to remove steps. I'd also like to make this change with screenshots that are added - swapping the remove button for the X button used to remove steps.