### PR TITLE
[codex] fix Steps fallback and replay-safe memo upsert

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -28,6 +28,7 @@ from temporalio.client import Client
 from temporalio.service import RPCError
 
 from api_service.auth_providers import get_current_user
+from api_service.core import sync as execution_sync
 from api_service.db.base import get_async_session
 from api_service.db.models import (
     ManagedAgentProviderProfile,
@@ -9098,13 +9099,31 @@ async def describe_execution_steps(
     response: Response,
     service: TemporalExecutionService = Depends(_get_service),
     user: User = Depends(get_current_user()),
+    session: AsyncSession = Depends(get_async_session),
     temporal_client: Client = Depends(get_temporal_client),
 ) -> StepLedgerSnapshotModel:
     canonical_workflow_id, alias_used = _canonicalize_execution_identifier(workflow_id)
+    if settings.temporal.temporal_authoritative_read_enabled:
+        try:
+            await execution_sync.fetch_and_sync_execution(
+                session,
+                canonical_workflow_id,
+                temporal_client,
+            )
+            await session.commit()
+        except Exception as exc:
+            await session.rollback()
+            logger.warning(
+                "Failed to sync execution %s from Temporal for step ledger: %s",
+                canonical_workflow_id,
+                exc,
+                exc_info=True,
+            )
     record = await _get_owned_execution(
         service=service,
         workflow_id=workflow_id,
         user=user,
+        include_orphaned_projection=True,
     )
     workflow_type_value = _enum_value(getattr(record, "workflow_type", None)) or ""
     if workflow_type_value != "MoonMind.UserWorkflow":
@@ -9139,8 +9158,6 @@ async def describe_execution(
 ) -> ExecutionModel:
     canonical_workflow_id, alias_used = _canonicalize_execution_identifier(workflow_id)
 
-    from api_service.core.sync import fetch_and_sync_execution
-
     source_is_temporal = source == "temporal"
     use_projection_read = source_is_temporal
     temporal_sync_unavailable = False
@@ -9148,7 +9165,11 @@ async def describe_execution(
     if settings.temporal.temporal_authoritative_read_enabled or source_is_temporal:
         try:
             client = temporal_client
-            await fetch_and_sync_execution(session, canonical_workflow_id, client)
+            await execution_sync.fetch_and_sync_execution(
+                session,
+                canonical_workflow_id,
+                client,
+            )
             await session.commit()
             # Return the synced projection to avoid clobbering it with stale source data.
             use_projection_read = True

--- a/docs/tmp/RunStatusMemoUpsertCutover.md
+++ b/docs/tmp/RunStatusMemoUpsertCutover.md
@@ -1,0 +1,50 @@
+Status: rollout note (2026-06-24)
+
+# Run Status Memo Upsert Cutover
+
+## Context
+
+`MoonMind.UserWorkflow._update_search_attributes()` used an ungated
+`workflow.upsert_memo(...)` call for status-only metadata
+(`waiting_reason`, `attention_required`). That command emits
+`WorkflowPropertiesModified` in Temporal history.
+
+Some in-flight histories predate that command and have an activity scheduled at
+the same point. Replaying those histories with the ungated memo upsert causes a
+nondeterminism failure because the worker expects `WorkflowPropertiesModified`
+where the history contains `ActivityTaskScheduled`.
+
+## Cutover Decision
+
+New histories use the patch marker `run-status-memo-upsert-v1` before emitting
+the status-only memo update. Histories that do not contain the marker skip that
+status-only memo update and continue with the existing search-attribute upsert.
+Mission Control still receives owner, state, and title visibility through search
+attributes and can fall back to stored projections for step reads.
+
+## In-Flight Compatibility Boundary
+
+A new patch marker cannot distinguish both legacy shapes:
+
+- histories that predate the status-only memo command and therefore need the
+  command skipped, and
+- histories that already recorded the prior ungated status-only memo command and
+  therefore need the command preserved.
+
+The current patch is deliberately targeted at recovering the first shape, which
+wedges affected runs with `ModifyWorkflowPropertiesMachine does not handle
+HistoryEvent(... ActivityTaskScheduled)`.
+
+If an operator has active histories that already recorded the ungated status-only
+memo command but have not completed, those runs must use one of these cutover
+paths:
+
+1. Keep them assigned to a worker build that still contains the ungated command
+   until they complete, or
+2. reset those workflow executions to a safe event before the status-only memo
+   command and replay them on a build with `run-status-memo-upsert-v1`, or
+3. terminate/restart the affected automation when reset is not acceptable.
+
+Do not route both legacy history shapes to the same unversioned worker build and
+expect a single `workflow.patched(...)` branch to infer which command sequence was
+recorded.

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -486,6 +486,9 @@ RUN_STEP_RESILIENCE_POLICY_PATCH = "run-step-resilience-policy-v1"
 # correlated under one trace id. Gated so in-flight histories that predate the
 # trace-ref stamp / incident-manifest writes keep replaying deterministically.
 RUN_INCIDENT_RECONSTRUCTION_PATCH = "run-incident-reconstruction-v1"
+# Replay-stable patch id for the status-only memo update emitted from
+# _update_search_attributes. Older histories scheduled activities at this point.
+RUN_STATUS_MEMO_UPSERT_PATCH = "run-status-memo-upsert-v1"
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
@@ -13253,13 +13256,14 @@ class MoonMindRunWorkflow:
             "waiting_reason": self._waiting_reason,
             "attention_required": self._attention_required,
         }
-        try:
-            workflow.upsert_memo(memo)
-        except Exception as exc:
-            self._get_logger().warning(
-                "Failed to upsert memo",
-                extra={"error": str(exc)},
-            )
+        if workflow.patched(RUN_STATUS_MEMO_UPSERT_PATCH):
+            try:
+                workflow.upsert_memo(memo)
+            except Exception as exc:
+                self._get_logger().warning(
+                    "Failed to upsert memo",
+                    extra={"error": str(exc)},
+                )
 
         pairs = [
             SearchAttributePair(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -487,7 +487,9 @@ RUN_STEP_RESILIENCE_POLICY_PATCH = "run-step-resilience-policy-v1"
 # trace-ref stamp / incident-manifest writes keep replaying deterministically.
 RUN_INCIDENT_RECONSTRUCTION_PATCH = "run-incident-reconstruction-v1"
 # Replay-stable patch id for the status-only memo update emitted from
-# _update_search_attributes. Older histories scheduled activities at this point.
+# _update_search_attributes. Histories that already recorded the prior ungated
+# memo command require a reset/versioning cutover; see
+# docs/tmp/RunStatusMemoUpsertCutover.md.
 RUN_STATUS_MEMO_UPSERT_PATCH = "run-status-memo-upsert-v1"
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -8656,6 +8656,63 @@ def test_get_execution_steps_returns_503_for_slow_temporal_query(
     assert observed_timeouts == [0.01]
     assert response.json()["detail"]["code"] == "temporal_unavailable"
 
+def test_get_execution_steps_uses_projection_fallback_when_temporal_query_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    user = _override_user_dependencies(app, is_superuser=False)
+    record = _build_execution_record(owner_id=str(user.id))
+    record.memo = {
+        **record.memo,
+        "summary": "Executing plan step 1/1: implement",
+    }
+    record.parameters = {
+        "workflow": {
+            "steps": [
+                {
+                    "id": "implement",
+                    "title": "Implement fix",
+                    "type": "skill",
+                    "skill": {"id": "pr-resolver"},
+                },
+            ],
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    _override_query_client(
+        app,
+        error=RPCError(
+            "Unable to query workflow due to Workflow Task in failed state.",
+            RPCStatusCode.FAILED_PRECONDITION,
+            None,
+        ),
+    )
+    monkeypatch.setattr(settings.temporal, "temporal_authoritative_read_enabled", True)
+
+    async def _raise_sync_failure(*_args, **_kwargs):
+        raise RPCError("Temporal query failed", RPCStatusCode.FAILED_PRECONDITION, None)
+
+    monkeypatch.setattr(
+        "api_service.core.sync.fetch_and_sync_execution",
+        _raise_sync_failure,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["workflowId"] == "mm:wf-1"
+    assert payload["steps"][0]["logicalStepId"] == "implement"
+    assert payload["steps"][0]["status"] == "running"
+    session.rollback.assert_awaited_once()
+    assert mock_service.describe_execution.await_args.kwargs["include_orphaned"] is True
+
 def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query_times_out(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1655,6 +1655,11 @@ def _captured_search_attribute_pairs(
     )
     monkeypatch.setattr(
         run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
         "upsert_search_attributes",
         lambda pairs: captured.__setitem__("pairs", pairs),
     )

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1115,6 +1115,30 @@ def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "progress" not in latest_memo
     assert "checks" not in latest_memo
 
+def test_update_search_attributes_status_memo_is_patch_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    memo_updates = _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._waiting_reason = "dependency_wait"
+    workflow._attention_required = True
+
+    workflow._update_search_attributes()
+
+    assert memo_updates == []
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_STATUS_MEMO_UPSERT_PATCH,
+    )
+    workflow._update_search_attributes()
+
+    assert memo_updates[-1] == {
+        "waiting_reason": "dependency_wait",
+        "attention_required": True,
+    }
+
 def test_run_memo_includes_current_step_order_when_step_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a Mission Control Steps failure where `/api/executions/{workflowId}/steps` could report `execution_not_found` even though the workflow existed and the detail endpoint advertised a `stepsHref`.

Also makes the status-only memo upsert in `MoonMind.UserWorkflow` replay-safe by guarding it behind a Temporal patch marker. Older histories that scheduled activities at that command position can now continue replaying instead of failing with a nondeterminism error.

## Root cause

The Steps route did not use the same projection-backed lookup behavior as execution detail, so a live-query failure or orphaned projection could surface as a misleading 404. Separately, an unversioned `workflow.upsert_memo(...)` inside `_update_search_attributes()` added a `WorkflowPropertiesModified` command to histories that previously scheduled an activity there.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py -q`
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
