### PR TITLE
When images and prerequisites are added on the start workflow page, the X button appears slightly too close to them, too big, and not vertically cente

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3738,30 +3738,26 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-top: 0;
 }
 
-.queue-step-attachments-list li,
-#queue-dependency-list li {
+:is(.queue-step-attachments-list, #queue-dependency-list) li {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.queue-step-attachments-list li > span:first-child,
-#queue-dependency-list li > span:first-child {
+:is(.queue-step-attachments-list, #queue-dependency-list) li > span:first-child {
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
-.queue-step-attachments-list .queue-step-icon-button,
-#queue-dependency-list .queue-step-icon-button {
+:is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-icon-button {
   width: 1.85rem;
   height: 1.85rem;
   border-radius: 0.5rem;
   flex: 0 0 auto;
 }
 
-.queue-step-attachments-list .queue-step-icon-button svg,
-#queue-dependency-list .queue-step-icon-button svg {
+:is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-icon-button svg {
   width: 1rem;
   height: 1rem;
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3738,6 +3738,34 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-top: 0;
 }
 
+.queue-step-attachments-list li,
+#queue-dependency-list li {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.queue-step-attachments-list li > span:first-child,
+#queue-dependency-list li > span:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.queue-step-attachments-list .queue-step-icon-button,
+#queue-dependency-list .queue-step-icon-button {
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.queue-step-attachments-list .queue-step-icon-button svg,
+#queue-dependency-list .queue-step-icon-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 .queue-attachment-preview {
   display: block;
   max-width: min(100%, 16rem);


### PR DESCRIPTION
When images and prerequisites are added on the start workflow page, the X button appears slightly too close to them, too big, and not vertically centered. I want a slight space between the end of the image / prerequisite text and the X button. The X button should be a bit smaller (not as big as the step X button). And the x button should appear vertically centered on the line and not notably extend above the line.