### PR TITLE
[codex] Fix Jira implement task expansion

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -46,11 +46,13 @@ _DOWNSTREAM_PRESET_IMPLEMENT = "implement"
 _DOWNSTREAM_PRESETS: dict[str, dict[str, str]] = {
     _DOWNSTREAM_PRESET_ORCHESTRATE: {
         "slug": "jira-orchestrate",
+        "version": "1.0.0",
         "label": "Jira Orchestrate",
         "idempotencyPrefix": "jira-orchestrate",
     },
     _DOWNSTREAM_PRESET_IMPLEMENT: {
         "slug": "jira-implement",
+        "version": "1.1.0",
         "label": "Jira Implement",
         "idempotencyPrefix": "jira-implement",
     },
@@ -1155,6 +1157,7 @@ def _downstream_task_payload(
     preset = _DOWNSTREAM_PRESETS[target_preset]
     preset_label = preset["label"]
     preset_slug = preset["slug"]
+    preset_version = preset["version"]
     issue_key = _string(mapping.get("issueKey") or mapping.get("issue_key"))
     story_id = _string(mapping.get("storyId") or mapping.get("story_id"))
     summary = _string(mapping.get("summary")) or issue_key
@@ -1213,7 +1216,7 @@ def _downstream_task_payload(
         },
         "taskTemplate": {
             "slug": preset_slug,
-            "version": "1.0.0",
+            "version": preset_version,
         },
     }
     if runtime:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6256,7 +6256,7 @@ class MoonMindRunWorkflow:
 
                     if (
                         tool_type != "agent_runtime"
-                        and step_execution_manifest_enabled
+                        and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)
                     ):
                         await self._record_step_execution_manifest(
                             node_id,
@@ -9404,6 +9404,62 @@ class MoonMindRunWorkflow:
             "jira_noop",
         }
 
+    @staticmethod
+    def _trusted_jira_output_summary(outputs: Mapping[str, Any]) -> str | None:
+        story_output = outputs.get("storyOutput") or outputs.get("story_output")
+        if isinstance(story_output, Mapping):
+            status = str(story_output.get("status") or "").strip()
+            created_count = story_output.get("createdCount")
+            story_count = story_output.get("storyCount")
+            eligible_count = story_output.get("eligibleStoryCount")
+            dependency_mode = str(story_output.get("dependencyMode") or "").strip()
+            if status in {"jira_created", "jira_partial", "jira_noop"}:
+                verb = "Created" if status != "jira_noop" else "Created no"
+                parts = [f"{verb} Jira issues"]
+                if isinstance(created_count, int):
+                    parts.append(f"created={created_count}")
+                if isinstance(eligible_count, int):
+                    parts.append(f"eligible={eligible_count}")
+                if isinstance(story_count, int):
+                    parts.append(f"stories={story_count}")
+                if dependency_mode:
+                    parts.append(f"dependencyMode={dependency_mode}")
+                return "; ".join(parts) + "."
+            reason = str(story_output.get("reason") or "").strip()
+            if status:
+                return f"Jira story output finished with status {status}: {reason}".strip()
+
+        orchestration = outputs.get("jiraOrchestration") or outputs.get(
+            "jira_orchestration"
+        )
+        if isinstance(orchestration, Mapping):
+            status = str(orchestration.get("status") or "").strip()
+            created_count = orchestration.get("createdTaskCount")
+            story_count = orchestration.get("storyCount")
+            dependency_count = orchestration.get("dependencyCount")
+            parts = []
+            if isinstance(created_count, int):
+                parts.append(f"createdTasks={created_count}")
+            if isinstance(story_count, int):
+                parts.append(f"stories={story_count}")
+            if isinstance(dependency_count, int):
+                parts.append(f"dependencies={dependency_count}")
+            failures = orchestration.get("failures")
+            if isinstance(failures, list) and failures:
+                first_failure = failures[0] if isinstance(failures[0], Mapping) else {}
+                message = str(first_failure.get("message") or "").strip()
+                error_code = str(first_failure.get("errorCode") or "").strip()
+                if error_code or message:
+                    message = message.rstrip(".")
+                    parts.append(
+                        "firstFailure="
+                        + ": ".join(part for part in (error_code, message) if part)
+                    )
+            if status:
+                suffix = f" ({'; '.join(parts)})" if parts else ""
+                return f"Jira downstream task creation {status}{suffix}."
+        return None
+
     def _record_execution_context(self, *, node_id: str, execution_result: Any) -> None:
         outputs = self._get_from_result(execution_result, "outputs")
         if not isinstance(outputs, Mapping):
@@ -9421,12 +9477,21 @@ class MoonMindRunWorkflow:
             if operator_summary and not is_generic_completion_summary(operator_summary)
             else None
         )
+        trusted_jira_summary = self._trusted_jira_output_summary(outputs)
         if meaningful_operator_summary:
             self._operator_summary = operator_summary
+        elif trusted_jira_summary:
+            self._operator_summary = self._sanitize_operator_summary(
+                self._coerce_text(trusted_jira_summary, max_chars=1600)
+            )
 
-        step_summary = meaningful_operator_summary or self._coerce_text(
-            outputs.get("summary") or outputs.get("message"),
-            max_chars=1600,
+        step_summary = (
+            meaningful_operator_summary
+            or trusted_jira_summary
+            or self._coerce_text(
+                outputs.get("summary") or outputs.get("message"),
+                max_chars=1600,
+            )
         )
         self._last_step_summary = self._sanitize_operator_summary(
             step_summary

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6256,7 +6256,7 @@ class MoonMindRunWorkflow:
 
                     if (
                         tool_type != "agent_runtime"
-                        and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)
+                        and step_execution_manifest_enabled
                     ):
                         await self._record_step_execution_manifest(
                             node_id,
@@ -9427,7 +9427,8 @@ class MoonMindRunWorkflow:
                 return "; ".join(parts) + "."
             reason = str(story_output.get("reason") or "").strip()
             if status:
-                return f"Jira story output finished with status {status}: {reason}".strip()
+                suffix = f": {reason}" if reason else ""
+                return f"Jira story output finished with status {status}{suffix}."
 
         orchestration = outputs.get("jiraOrchestration") or outputs.get(
             "jira_orchestration"

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1978,7 +1978,7 @@ async def test_create_jira_implement_tasks_targets_jira_implement_preset():
     first_task = first_request["initial_parameters"]["workflow"]
     assert first_task["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.0.0",
+        "version": "1.1.0",
     }
     assert first_task["title"].startswith("Run Jira Implement for MM-501")
     assert "Run Jira Implement for MM-501" in first_task["instructions"]

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2274,6 +2274,15 @@ def test_record_execution_context_summarizes_trusted_jira_downstream_outputs(
     )
     assert mock_run_workflow._operator_summary == mock_run_workflow._last_step_summary
 
+
+def test_trusted_jira_output_summary_omits_empty_reason_suffix() -> None:
+    summary = MoonMindRunWorkflow._trusted_jira_output_summary(
+        {"storyOutput": {"status": "jira_blocked", "reason": ""}}
+    )
+
+    assert summary == "Jira story output finished with status jira_blocked."
+
+
 def test_record_execution_context_scrubs_operator_summary_and_ignores_negative_commit_count(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2242,6 +2242,38 @@ def test_record_execution_context_resets_last_step_fields_when_current_node_has_
     assert mock_run_workflow._last_step_summary is None
     assert mock_run_workflow._last_diagnostics_ref is None
 
+def test_record_execution_context_summarizes_trusted_jira_downstream_outputs(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="create-implement-tasks",
+        execution_result={
+            "outputs": {
+                "jiraOrchestration": {
+                    "status": "no_downstream_tasks",
+                    "storyCount": 7,
+                    "createdTaskCount": 0,
+                    "dependencyCount": 0,
+                    "failures": [
+                        {
+                            "errorCode": "task_creation_failed",
+                            "message": "Missing required template input 'jira_issue_key'.",
+                        }
+                    ],
+                }
+            }
+        },
+    )
+
+    assert mock_run_workflow._last_step_id == "create-implement-tasks"
+    assert mock_run_workflow._last_step_summary == (
+        "Jira downstream task creation no_downstream_tasks "
+        "(createdTasks=0; stories=7; dependencies=0; "
+        "firstFailure=task_creation_failed: Missing required template input "
+        "'jira_issue_key')."
+    )
+    assert mock_run_workflow._operator_summary == mock_run_workflow._last_step_summary
+
 def test_record_execution_context_scrubs_operator_summary_and_ignores_negative_commit_count(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -193,13 +193,19 @@ def test_run_exposes_one_canonical_step_execution_manifest_record_surface() -> N
 def test_step_execution_manifest_start_write_keeps_replay_patch_guard() -> None:
     source = Path(run_module.__file__).read_text()
 
-    guard = "and workflow.patched(RUN_STEP_EXECUTION_MANIFEST_PATCH)"
+    guard_assignment = (
+        "step_execution_manifest_enabled = workflow.patched(\n"
+        "                        RUN_STEP_EXECUTION_MANIFEST_PATCH\n"
+        "                    )"
+    )
+    guard = "and step_execution_manifest_enabled"
     start_manifest_call = (
         "await self._record_step_execution_manifest(\n"
         "                            node_id,\n"
         '                            phase="start",'
     )
 
+    assert source.index(guard_assignment) < source.index(guard)
     assert source.index(guard) < source.index(start_manifest_call)
 
 


### PR DESCRIPTION
## Summary

Fix the Jira Breakdown and Implement preset flow so downstream Jira Implement tasks target the current `jira-implement` template version.

## Root Cause

The Breakdown flow created Jira issues correctly, but downstream implement task creation still targeted `jira-implement` version `1.0.0`. The current template is `1.1.0`, where `jira_issue_key` is derived from the structured `jira_issue` input. The mismatch caused downstream task expansion to fail with a missing `jira_issue_key` input while the workflow summary continued showing an earlier reconciliation message.

## Changes

- Add explicit downstream preset versions and route Jira Implement tasks to `jira-implement` `1.1.0`.
- Summarize trusted Jira story-output and downstream orchestration results in workflow operator summaries.
- Add regression tests for the Jira Implement template version and trusted Jira downstream failure summaries.

## Validation

- `./tools/test_unit.sh`
- `npm run ui:test`