### PR TITLE
MM-892: Implement PentestGPT Claude Code OAuth auth path

### DIFF
--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -31,6 +31,48 @@ profiles:
       killGraceSeconds: 30
     devicePolicy:
       mode: none
+  - id: pentestgpt-claude-oauth
+    kind: one_shot
+    image: ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6
+    workdirTemplate: /work/agent_jobs/${task_run_id}/repo
+    requiredMounts:
+      - type: volume
+        source: agent_workspaces
+        target: /work/agent_jobs
+    credentialMounts:
+      - type: volume
+        source: claude_auth_volume
+        target: /home/pentester/.claude-oauth-src
+        readOnly: true
+        justification: Read-only seed of the Claude Code OAuth subscription volume; the runner copies it into a writable per-run Claude home so the durable auth volume is never mutated.
+        approvalRef: MM-892
+    envAllowlist:
+      - PENTESTGPT_AUTH_MODE
+      - LANGFUSE_ENABLED
+      - MM_PENTEST_TARGET
+      - MM_PENTEST_MODE
+      - MM_PENTEST_INSTRUCTION_FILE
+      - HOME
+      - CLAUDE_CONFIG_DIR
+      - CLAUDE_HOME
+      - MM_PENTEST_CLAUDE_OAUTH_SOURCE
+      - MM_PENTEST_SEED_CLAUDE_HOME
+    networkPolicy: bridge
+    resources:
+      cpu: "4"
+      memory: 8g
+      shmSize: 1g
+      maxCpu: "4"
+      maxMemory: 8g
+      maxShmSize: 1g
+    timeoutSeconds: 28800
+    maxTimeoutSeconds: 28800
+    maxConcurrency: 1
+    cleanup:
+      removeContainerOnExit: true
+      killGraceSeconds: 30
+    devicePolicy:
+      mode: none
   - id: moonmind-integration-ci
     kind: one_shot
     image: ghcr.io/moonladderstudios/moonmind-integration-ci:1.0

--- a/docs/Security/PentestOperations.md
+++ b/docs/Security/PentestOperations.md
@@ -82,6 +82,8 @@ Use provider profiles with `runtime_id=pentestgpt`. The built-in profiles are:
 
 - `pentestgpt_anthropic_api_team`
 - `pentestgpt_openrouter_default`
+- `pentestgpt_local_default`
+- `pentestgpt_claude_oauth` (Claude Code OAuth subscription; disabled by default)
 
 Restrict usable profiles with:
 
@@ -93,6 +95,19 @@ PENTESTGPT_OPENROUTER_SECRET_ID=secret://providers/openrouter/pentestgpt
 ```
 
 Raw `ANTHROPIC_API_KEY` and `OPENROUTER_API_KEY` may be present only in controlled worker environments. They are not user-editable task inputs and must not appear in artifacts, logs, workflow history, or UI previews.
+
+### Claude Code OAuth subscription profile
+
+The `pentestgpt_claude_oauth` profile authenticates the bundled Claude Code CLI against a Claude subscription using the durable `claude_auth_volume` OAuth volume (populated out of band via `MoonMind.OAuthSession`). It is gated and disabled by default:
+
+```dotenv
+MOONMIND_PENTEST_ALLOW_CLAUDE_OAUTH_PROFILE=true
+MOONMIND_PENTEST_ENABLED_PROVIDER_PROFILES=pentestgpt_claude_oauth
+# Optional: share the credential lease with the canonical Claude profile.
+MOONMIND_PENTEST_CLAUDE_OAUTH_CREDENTIAL_PROFILE_REF=claude_anthropic
+```
+
+When enabled, requests must use `runner_profile_id=pentestgpt-claude-oauth` and `execution_profile_ref=pentestgpt_claude_oauth`, and the scope artifact must list the OAuth runner profile in `allowed_runner_profiles`. The runner mounts `claude_auth_volume` read-only and seeds a writable per-run Claude home so the durable volume is never mutated; the launcher clears `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`/`CLAUDE_API_KEY`/`CLAUDE_CODE_OAUTH_TOKEN`/`OPENAI_API_KEY` so Claude Code falls through to subscription OAuth. The profile is only launch-ready when its provider runtime state reports `auth_state=connected` with the OAuth volume present. See [PentestTool.md §11.3](../Steps/PentestTool.md#113-claude-code-oauth-backed-profile).
 
 ## Runner Image
 

--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -758,7 +758,7 @@ This allows MoonMind to express:
 - Anthropic API-key mode,
 - OpenRouter mode,
 - local OpenAI-compatible mode,
-- optional future OAuth-backed mode,
+- Claude Code OAuth subscription mode (see [§11.3](#113-claude-code-oauth-backed-profile)),
 - profile-level concurrency and cooldown policy.
 
 ### 11.2 Canonical profiles
@@ -894,13 +894,71 @@ command_behavior:
   force_non_interactive: true
 ```
 
-### 11.3 Optional future OAuth-backed profile
+### 11.3 Claude Code OAuth-backed profile
 
-MoonMind may later support an OAuth-backed profile using the same OAuth terminal architecture used by other runtimes.
+PentestGPT supports an OAuth-backed profile (`pentestgpt_claude_oauth`) that authenticates the bundled Claude Code CLI against a Claude subscription using the same `claude_auth_volume` OAuth volume the canonical Claude runtime uses. The interactive OAuth login that populates that volume is still performed out of band through `MoonMind.OAuthSession`; ordinary pentest runs stay non-interactive and consume the resulting auth volume through this Provider Profile.
 
-That profile would be registered out of band through `MoonMind.OAuthSession`, not during ordinary PentestGPT workflow execution.
+This profile is **disabled by default** and is gated by `MOONMIND_PENTEST_ALLOW_CLAUDE_OAUTH_PROFILE=true` plus the dedicated `pentestgpt-claude-oauth` runner profile. Selecting it requires the request to use `runner_profile_id = pentestgpt-claude-oauth` and `execution_profile_ref = pentestgpt_claude_oauth`, and the scope artifact must list the OAuth runner profile in `allowed_runner_profiles`.
 
-Normal pentest runs would stay non-interactive and would use the resulting auth volume through a Provider Profile.
+```yaml
+profile_id: pentestgpt_claude_oauth
+runtime_id: pentestgpt
+provider_id: anthropic
+provider_label: "Anthropic"
+
+credential_source: oauth_volume
+runtime_materialization_mode: oauth_home
+
+enabled: true
+tags: ["oauth", "subscription", "claude-code"]
+priority: 110
+
+max_parallel_runs: 1
+cooldown_after_429_seconds: 300
+rate_limit_policy: queue
+max_lease_duration_seconds: 32400
+
+# Backing Claude OAuth subscription volume, mounted as the Claude auth home.
+volume_ref: claude_auth_volume
+volume_mount_path: /home/pentester/.claude
+# Optional: share the lease with the canonical Claude profile by backing identity.
+credential_profile_ref: null
+secret_refs: {}
+
+# Prefer seeding a writable per-run Claude home over mutating the durable volume.
+seed_per_run_home: true
+
+# Claude Code auth precedence puts these ahead of subscription OAuth, so the
+# launcher clears them and the runner falls through to the mounted OAuth home.
+clear_env_keys:
+  - ANTHROPIC_API_KEY
+  - ANTHROPIC_AUTH_TOKEN
+  - CLAUDE_API_KEY
+  - CLAUDE_CODE_OAUTH_TOKEN
+  - OPENAI_API_KEY
+
+home_path_overrides:
+  HOME: /home/pentester
+  CLAUDE_CONFIG_DIR: /home/pentester/.claude
+  CLAUDE_HOME: /home/pentester/.claude
+
+env_template:
+  PENTESTGPT_AUTH_MODE: "manual"
+  LANGFUSE_ENABLED: "false"
+
+command_behavior:
+  force_non_interactive: true
+```
+
+**Launch behavior.** When the OAuth profile is resolved the launcher:
+
+1. Resolves a launch-ready Claude OAuth profile. Readiness fails closed: it requires `enabled`, `auth_state == connected`, and the backing OAuth volume to be present (`oauth_volume_present`), supplied as provider runtime state.
+2. Acquires a shared credential lease keyed by the backing-credential identity (`credential_profile_ref` or the Claude `volume_ref`) rather than the per-run provider `profile_id`, so concurrent runs serialize on the same Claude subscription.
+3. Launches the `pentestgpt-claude-oauth` runner, which mounts `claude_auth_volume` **read-only** at `/home/pentester/.claude-oauth-src`.
+4. Sets `HOME=/home/pentester`, `CLAUDE_CONFIG_DIR=/home/pentester/.claude`, and `CLAUDE_HOME=/home/pentester/.claude`, with `PENTESTGPT_AUTH_MODE=manual`.
+5. Clears the API-key/token env vars above so Claude Code uses the mounted subscription OAuth.
+
+**Per-run home over durable mutation.** With `seed_per_run_home: true` (the default and recommended production setting), the durable OAuth volume is mounted read-only as a seed source and the runner copies it into a writable per-run Claude home (`MM_PENTEST_SEED_CLAUDE_HOME=1`, `MM_PENTEST_CLAUDE_OAUTH_SOURCE=/home/pentester/.claude-oauth-src`). This prevents PentestGPT from mutating the shared durable auth volume while still letting Claude Code refresh session/credential state in its per-run home. Setting `seed_per_run_home: false` is a fast-prototype mode that uses the durable volume directly.
 
 ### 11.4 Provider profile selection
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1512,6 +1512,57 @@ class PentestSettings(BaseSettings):
             "MOONMIND_PENTEST_NETWORK_ATTACHMENT_REQUIRED_FOR_VPN"
         ),
     )
+    allow_claude_oauth_profile: bool = Field(
+        False,
+        validation_alias=AliasChoices("MOONMIND_PENTEST_ALLOW_CLAUDE_OAUTH_PROFILE"),
+        description=(
+            "Enable the Claude Code OAuth subscription runner/provider profiles for "
+            "PentestGPT. Disabled by default; the backing OAuth volume must be "
+            "provisioned out of band via MoonMind.OAuthSession."
+        ),
+    )
+    claude_oauth_runner_profile_id: str = Field(
+        "pentestgpt-claude-oauth",
+        validation_alias=AliasChoices(
+            "MOONMIND_PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID"
+        ),
+    )
+    claude_oauth_provider_profile_id: str = Field(
+        "pentestgpt_claude_oauth",
+        validation_alias=AliasChoices(
+            "MOONMIND_PENTEST_CLAUDE_OAUTH_PROVIDER_PROFILE_ID"
+        ),
+    )
+    claude_oauth_volume: str = Field(
+        "claude_auth_volume",
+        validation_alias=AliasChoices("MOONMIND_PENTEST_CLAUDE_OAUTH_VOLUME"),
+        description="Durable Claude Code OAuth subscription volume mounted for PentestGPT.",
+    )
+    claude_oauth_mount_path: str = Field(
+        "/home/pentester/.claude",
+        validation_alias=AliasChoices("MOONMIND_PENTEST_CLAUDE_OAUTH_MOUNT_PATH"),
+        description="In-container Claude config home the PentestGPT runner authenticates against.",
+    )
+    claude_oauth_credential_profile_ref: str | None = Field(
+        None,
+        validation_alias=AliasChoices(
+            "MOONMIND_PENTEST_CLAUDE_OAUTH_CREDENTIAL_PROFILE_REF"
+        ),
+        description=(
+            "Optional canonical Claude provider profile id the PentestGPT OAuth "
+            "profile shares its backing credential lease with."
+        ),
+    )
+    claude_oauth_seed_per_run_home: bool = Field(
+        True,
+        validation_alias=AliasChoices(
+            "MOONMIND_PENTEST_CLAUDE_OAUTH_SEED_PER_RUN_HOME"
+        ),
+        description=(
+            "Seed a writable per-run Claude home from the read-only durable OAuth "
+            "volume instead of mutating the durable volume in place."
+        ),
+    )
     default_provider_profile: str | None = Field(
         None,
         validation_alias=AliasChoices("MOONMIND_PENTEST_DEFAULT_PROVIDER_PROFILE"),
@@ -1632,6 +1683,7 @@ class PentestSettings(BaseSettings):
         "provider_profiles_file",
         "anthropic_secret_id",
         "openrouter_secret_id",
+        "claude_oauth_credential_profile_ref",
         "provider_lease_seconds",
         mode="before",
     )

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -311,11 +311,20 @@ class PentestProviderProfile(PentestBaseModel):
                 "credential_source=oauth_volume and "
                 "runtime_materialization_mode=oauth_home"
             )
-        if is_oauth_source and (not self.volume_ref or not self.volume_mount_path):
-            raise ValueError(
-                "OAuth Pentest provider profiles require volume_ref and "
-                "volume_mount_path"
-            )
+        if is_oauth_source:
+            if not self.volume_ref or not self.volume_mount_path:
+                raise ValueError(
+                    "OAuth Pentest provider profiles require volume_ref and "
+                    "volume_mount_path"
+                )
+            # ``volume_mount_path`` is the in-container Claude auth home; a
+            # relative path would resolve unpredictably and break the runner's
+            # HOME/CLAUDE_CONFIG_DIR wiring, so require an absolute POSIX path.
+            if not PurePosixPath(self.volume_mount_path).is_absolute():
+                raise ValueError(
+                    "OAuth Pentest provider profiles require an absolute "
+                    "volume_mount_path"
+                )
         return self
 
 class PentestProviderMaterialization(PentestBaseModel):
@@ -1952,6 +1961,10 @@ def _pentest_provider_profiles() -> dict[str, PentestProviderProfile]:
     claude_oauth_mount_path = (
         pentest_settings.claude_oauth_mount_path or PENTEST_CLAUDE_CONFIG_DIR
     )
+    claude_oauth_provider_profile_id = (
+        pentest_settings.claude_oauth_provider_profile_id
+        or PENTEST_CLAUDE_OAUTH_PROFILE_ID
+    )
     enabled_provider_profiles = set(pentest_settings.enabled_provider_profiles)
 
     def _enabled(profile_id: str) -> bool:
@@ -2033,14 +2046,23 @@ def _pentest_provider_profiles() -> dict[str, PentestProviderProfile]:
             },
             command_behavior={"force_non_interactive": True},
         ),
-        PENTEST_CLAUDE_OAUTH_PROFILE_ID: PentestProviderProfile(
-            profile_id=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+        claude_oauth_provider_profile_id: PentestProviderProfile(
+            profile_id=claude_oauth_provider_profile_id,
             runtime_id=PENTEST_RUNTIME_ID,
             provider_id="anthropic",
             provider_label="Anthropic",
             credential_source="oauth_volume",
             runtime_materialization_mode="oauth_home",
-            enabled=_enabled(PENTEST_CLAUDE_OAUTH_PROFILE_ID),
+            # Gate the OAuth provider profile behind the deployment allow flag so
+            # it cannot win automatic (selectorless) resolution, or be honored by
+            # exact ref, unless the operator has explicitly enabled the Claude
+            # OAuth path. Without this the higher-priority OAuth profile would be
+            # auto-selected for default requests whenever OAuth readiness is
+            # present, even on the safe runner that cannot mount the OAuth volume.
+            enabled=(
+                _enabled(claude_oauth_provider_profile_id)
+                and pentest_settings.allow_claude_oauth_profile
+            ),
             tags=("oauth", "subscription", "claude-code"),
             priority=110,
             max_parallel_runs=1,

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -93,9 +93,44 @@ PENTEST_TOOL_VERSION = "1.0.0"
 PENTEST_RUNTIME_ID = "pentestgpt"
 PENTEST_SAFE_PROFILE_ID = "pentestgpt-safe"
 PENTEST_VPN_LAB_PROFILE_ID = "pentestgpt-vpn-lab"
+PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID = "pentestgpt-claude-oauth"
 PENTEST_ANTHROPIC_PROFILE_ID = "pentestgpt_anthropic_api_team"
 PENTEST_OPENROUTER_PROFILE_ID = "pentestgpt_openrouter_default"
 PENTEST_LOCAL_PROFILE_ID = "pentestgpt_local_default"
+PENTEST_CLAUDE_OAUTH_PROFILE_ID = "pentestgpt_claude_oauth"
+# Backing Claude Code OAuth subscription volume and the in-container Claude home
+# the runner authenticates against. ``claude_auth_volume`` is the same durable
+# OAuth volume the canonical ``claude_anthropic`` profile is backed by, so the
+# PentestGPT runtime reuses the operator's Claude subscription auth.
+PENTEST_CLAUDE_AUTH_VOLUME = "claude_auth_volume"
+PENTEST_CLAUDE_HOME_DIR = "/home/pentester"
+PENTEST_CLAUDE_CONFIG_DIR = "/home/pentester/.claude"
+# The durable OAuth volume is mounted read-only here as a per-run *seed source*.
+# The runner copies it into the writable per-run Claude home so Claude Code can
+# refresh session/credential state without mutating the shared durable volume.
+PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR = "/home/pentester/.claude-oauth-src"
+# Claude Code auth precedence puts these cloud/provider env vars ahead of
+# subscription OAuth, so they must be cleared for the runner to fall through to
+# the mounted Claude Code OAuth subscription. See PentestTool.md sec 11.3.
+_PENTEST_OAUTH_CLEAR_ENV_KEYS: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "OPENAI_API_KEY",
+)
+_PENTEST_OAUTH_ENV_ALLOWLIST: tuple[str, ...] = (
+    "PENTESTGPT_AUTH_MODE",
+    "LANGFUSE_ENABLED",
+    "MM_PENTEST_TARGET",
+    "MM_PENTEST_MODE",
+    "MM_PENTEST_INSTRUCTION_FILE",
+    "HOME",
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_HOME",
+    "MM_PENTEST_CLAUDE_OAUTH_SOURCE",
+    "MM_PENTEST_SEED_CLAUDE_HOME",
+)
 _PENTEST_IMAGE = (
     "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
     "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
@@ -134,6 +169,15 @@ _PENTEST_AGENT_WORKSPACES_MOUNT = {
     "source": "agent_workspaces",
     "target": "/work/agent_jobs",
     "read_only": False,
+}
+# Read-only seed mount of the durable Claude OAuth volume for the Claude OAuth
+# runner profile. Read-only enforces the "do not mutate the durable auth volume"
+# boundary; the runner seeds a writable per-run Claude home from this source.
+_PENTEST_CLAUDE_OAUTH_SEED_MOUNT = {
+    "type": "volume",
+    "source": PENTEST_CLAUDE_AUTH_VOLUME,
+    "target": PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR,
+    "read_only": True,
 }
 _CONTAINER_NAME_SAFE_PATTERN = re.compile(r"[^a-zA-Z0-9_.-]+")
 _SECRET_VALUE_PATTERN = re.compile(
@@ -206,6 +250,16 @@ class PentestProviderProfile(PentestBaseModel):
     clear_env_keys: tuple[str, ...] = ()
     env_template: dict[str, Any] = Field(default_factory=dict)
     command_behavior: dict[str, Any] = Field(default_factory=dict)
+    # OAuth-backed (``oauth_volume`` / ``oauth_home``) materialization fields.
+    # ``volume_ref`` is the durable Claude OAuth subscription volume mounted as
+    # the runner's Claude auth home; ``credential_profile_ref`` optionally points
+    # at the canonical Claude profile so the lease is shared by backing identity.
+    volume_ref: str | None = None
+    volume_mount_path: str | None = None
+    credential_profile_ref: str | None = None
+    home_path_overrides: dict[str, str] = Field(default_factory=dict)
+    # Prefer seeding a per-run Claude home over mutating the durable auth volume.
+    seed_per_run_home: bool = True
 
     @field_validator("tags", "clear_env_keys", mode="before")
     @classmethod
@@ -216,12 +270,53 @@ class PentestProviderProfile(PentestBaseModel):
             raise ValueError("value must be an array")
         return tuple(str(item).strip() for item in value if str(item).strip())
 
+    @field_validator(
+        "volume_ref",
+        "volume_mount_path",
+        "credential_profile_ref",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_oauth_string(cls, value: object) -> str | None:
+        if value in (None, ""):
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    @field_validator("home_path_overrides", mode="before")
+    @classmethod
+    def _normalize_home_path_overrides(cls, value: object) -> dict[str, str]:
+        if value in (None, ""):
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("home_path_overrides must be an object")
+        return {str(key): str(item) for key, item in value.items() if item is not None}
+
     @field_validator("runtime_id")
     @classmethod
     def _validate_runtime_id(cls, value: str) -> str:
         if value != PENTEST_RUNTIME_ID:
             raise ValueError("Pentest provider profiles must use runtime_id=pentestgpt")
         return value
+
+    @model_validator(mode="after")
+    def _validate_oauth_bindings(self) -> "PentestProviderProfile":
+        is_oauth_source = self.credential_source == "oauth_volume"
+        is_oauth_mode = self.runtime_materialization_mode == "oauth_home"
+        # ``oauth_volume`` and ``oauth_home`` are two halves of the same OAuth
+        # path; one without the other is a misconfiguration that must fail fast.
+        if is_oauth_source != is_oauth_mode:
+            raise ValueError(
+                "OAuth Pentest provider profiles must set both "
+                "credential_source=oauth_volume and "
+                "runtime_materialization_mode=oauth_home"
+            )
+        if is_oauth_source and (not self.volume_ref or not self.volume_mount_path):
+            raise ValueError(
+                "OAuth Pentest provider profiles require volume_ref and "
+                "volume_mount_path"
+            )
+        return self
 
 class PentestProviderMaterialization(PentestBaseModel):
     """Secret-safe provider materialization result for PentestGPT."""
@@ -234,6 +329,15 @@ class PentestProviderMaterialization(PentestBaseModel):
     env: dict[str, str] = Field(default_factory=dict)
     secret_env: dict[str, str] = Field(default_factory=dict)
     secret_refs: dict[str, dict[str, str]] = Field(default_factory=dict)
+    # OAuth (``oauth_home``) materialization metadata. ``auth_volume_name`` is the
+    # durable Claude OAuth volume; ``seed_source_mount_path`` is where the launcher
+    # mounts it read-only when seeding a per-run Claude home; ``credential_lease_key``
+    # is the shared backing-credential identity used for cross-runtime leasing.
+    auth_volume_name: str | None = None
+    auth_volume_mount_path: str | None = None
+    seed_source_mount_path: str | None = None
+    seed_per_run_home: bool = False
+    credential_lease_key: str | None = None
     diagnostics: dict[str, str] = Field(default_factory=dict)
 
 class PentestProviderRuntimeState(PentestBaseModel):
@@ -243,6 +347,11 @@ class PentestProviderRuntimeState(PentestBaseModel):
     current_leases: tuple[str, ...] = ()
     available_slots: int | None = Field(default=None, ge=0)
     cooldown_until: str | None = None
+    # OAuth readiness fields supplied for ``oauth_volume`` profiles. A launch-ready
+    # Claude OAuth profile requires ``auth_state == "connected"`` and the backing
+    # OAuth volume to be present. They stay ``None`` for API-key profiles.
+    auth_state: str | None = None
+    oauth_volume_present: bool | None = None
 
     @field_validator("current_leases", mode="before")
     @classmethod
@@ -253,7 +362,7 @@ class PentestProviderRuntimeState(PentestBaseModel):
             raise ValueError("current_leases must be an array")
         return tuple(str(item).strip() for item in value if str(item).strip())
 
-    @field_validator("cooldown_until", mode="before")
+    @field_validator("cooldown_until", "auth_state", mode="before")
     @classmethod
     def _normalize_optional_string(cls, value: object) -> str | None:
         if value in (None, ""):
@@ -1438,6 +1547,25 @@ def resolve_pentest_provider_profile(
     candidates.sort(key=lambda profile: profile.priority, reverse=True)
     return candidates[0]
 
+def pentest_provider_lease_key(profile: PentestProviderProfile) -> str:
+    """Return the lease key for a Pentest provider profile.
+
+    For OAuth profiles the lease is keyed by the shared backing-credential
+    identity (``credential_profile_ref`` or the Claude OAuth ``volume_ref``) so
+    concurrent runs against the same Claude subscription serialize on one lease,
+    instead of by the per-run provider ``profile_id``. API-key profiles keep
+    keying by ``profile_id``.
+    """
+
+    if profile.credential_source == "oauth_volume":
+        return (
+            profile.credential_profile_ref
+            or profile.volume_ref
+            or profile.profile_id
+        )
+    return profile.profile_id
+
+
 def materialize_pentest_provider_profile(
     profile: PentestProviderProfile,
 ) -> PentestProviderMaterialization:
@@ -1447,11 +1575,7 @@ def materialize_pentest_provider_profile(
         profile.credential_source == "oauth_volume"
         or profile.runtime_materialization_mode == "oauth_home"
     ):
-        raise PentestProviderMaterializationError(
-            "OAuth-backed PentestGPT profiles are a future out-of-band path",
-            reason="oauth_future_path",
-            diagnostics={"profile_id": profile.profile_id},
-        )
+        return _materialize_pentest_oauth_profile(profile)
 
     env: dict[str, str] = {}
     secret_env: dict[str, str] = {}
@@ -1482,6 +1606,94 @@ def materialize_pentest_provider_profile(
         diagnostics={
             "materialization_mode": profile.runtime_materialization_mode,
             "credential_source": profile.credential_source,
+        },
+    )
+
+def _materialize_pentest_oauth_profile(
+    profile: PentestProviderProfile,
+) -> PentestProviderMaterialization:
+    """Materialize an OAuth (``oauth_home``) PentestGPT provider profile.
+
+    The runner authenticates against a mounted Claude Code OAuth subscription
+    volume. This sets the Claude auth-home env (``HOME``/``CLAUDE_CONFIG_DIR``/
+    ``CLAUDE_HOME``), forces ``PENTESTGPT_AUTH_MODE=manual``, and clears every
+    API-key/token env var so Claude Code falls through to subscription OAuth. No
+    secrets are materialized — the credential is the mounted volume.
+    """
+
+    if (
+        profile.credential_source != "oauth_volume"
+        or profile.runtime_materialization_mode != "oauth_home"
+    ):
+        raise PentestProviderMaterializationError(
+            "OAuth Pentest provider profiles require credential_source=oauth_volume "
+            "and runtime_materialization_mode=oauth_home",
+            reason="invalid_oauth_profile",
+            diagnostics={"profile_id": profile.profile_id},
+        )
+    volume_ref = str(profile.volume_ref or "").strip()
+    mount_path = str(profile.volume_mount_path or "").strip()
+    if not volume_ref or not mount_path:
+        raise PentestProviderMaterializationError(
+            "OAuth Pentest provider profiles require volume_ref and volume_mount_path",
+            reason="missing_oauth_volume",
+            diagnostics={"profile_id": profile.profile_id},
+        )
+
+    env: dict[str, str] = {}
+    for key, value in profile.env_template.items():
+        if not isinstance(value, str):
+            # OAuth profiles never reference secrets — the mounted volume is the
+            # credential. Reject ``from_secret_ref`` and other non-string values.
+            raise PentestProviderMaterializationError(
+                "OAuth Pentest provider env_template values must be strings",
+                reason="unsupported_env_template",
+                diagnostics={"profile_id": profile.profile_id, "env_key": str(key)},
+            )
+        env[key] = value
+    for key, value in profile.home_path_overrides.items():
+        env[str(key)] = str(value)
+    # Authoritative Claude auth-home env. ``volume_mount_path`` is the live
+    # writable Claude config home (a per-run home when seeding); the durable
+    # volume is mounted read-only at the seed source.
+    env.setdefault("HOME", str(PurePosixPath(mount_path).parent))
+    env["CLAUDE_CONFIG_DIR"] = mount_path
+    env["CLAUDE_HOME"] = mount_path
+    env.setdefault("PENTESTGPT_AUTH_MODE", "manual")
+    env.setdefault("LANGFUSE_ENABLED", "false")
+
+    seed_source_mount_path: str | None = None
+    if profile.seed_per_run_home:
+        seed_source_mount_path = PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR
+        env["MM_PENTEST_CLAUDE_OAUTH_SOURCE"] = seed_source_mount_path
+        env["MM_PENTEST_SEED_CLAUDE_HOME"] = "1"
+
+    clear_env_keys = tuple(
+        dict.fromkeys((*_PENTEST_OAUTH_CLEAR_ENV_KEYS, *profile.clear_env_keys))
+    )
+    lease_key = pentest_provider_lease_key(profile)
+    return PentestProviderMaterialization(
+        profile_id=profile.profile_id,
+        runtime_id=profile.runtime_id,
+        provider_id=profile.provider_id,
+        force_non_interactive=bool(
+            profile.command_behavior.get("force_non_interactive", True)
+        ),
+        clear_env_keys=clear_env_keys,
+        env=env,
+        secret_env={},
+        secret_refs={},
+        auth_volume_name=volume_ref,
+        auth_volume_mount_path=mount_path,
+        seed_source_mount_path=seed_source_mount_path,
+        seed_per_run_home=profile.seed_per_run_home,
+        credential_lease_key=lease_key,
+        diagnostics={
+            "materialization_mode": profile.runtime_materialization_mode,
+            "credential_source": profile.credential_source,
+            "auth_volume": volume_ref,
+            "credential_lease_key": lease_key,
+            "seed_per_run_home": "true" if profile.seed_per_run_home else "false",
         },
     )
 
@@ -1540,11 +1752,18 @@ def pentest_provider_lease_metadata(
     *,
     release_required: bool = False,
 ) -> dict[str, Any]:
-    """Return compact Provider Profile lease handoff metadata."""
+    """Return compact Provider Profile lease handoff metadata.
+
+    ``lease_key`` is the key the lease manager serializes on. For OAuth profiles
+    it is the shared backing-credential identity (so the Claude subscription is
+    not used concurrently across runtimes); for API-key profiles it is the
+    provider ``profile_id``.
+    """
 
     return {
         "runtime_id": profile.runtime_id,
         "profile_id": profile.profile_id,
+        "lease_key": pentest_provider_lease_key(profile),
         "lease_required": True,
         "release_required": release_required,
         "cooldown_after_429_seconds": profile.cooldown_after_429_seconds,
@@ -1697,6 +1916,24 @@ def _pentest_runner_profiles() -> dict[str, PentestRunnerProfile]:
             timeout_seconds=28800,
             cleanup=_PENTEST_CLEANUP,
         ),
+        PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID: PentestRunnerProfile(
+            id=PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
+            image=pentest_settings.runner_image or _PENTEST_IMAGE,
+            workdir_template=_PENTEST_WORKDIR_TEMPLATE,
+            entrypoint=_PENTEST_ENTRYPOINT,
+            required_mounts=(
+                _PENTEST_AGENT_WORKSPACES_MOUNT,
+                _PENTEST_CLAUDE_OAUTH_SEED_MOUNT,
+            ),
+            optional_mounts=(),
+            env_allowlist=_PENTEST_OAUTH_ENV_ALLOWLIST,
+            resource_profile=_PENTEST_RESOURCE_PROFILE,
+            network_policy="bridge_approved_lab",
+            linux_capabilities=(),
+            devices=(),
+            timeout_seconds=28800,
+            cleanup=_PENTEST_CLEANUP,
+        ),
     }
 
 def _pentest_provider_profiles() -> dict[str, PentestProviderProfile]:
@@ -1708,6 +1945,12 @@ def _pentest_provider_profiles() -> dict[str, PentestProviderProfile]:
     )
     openrouter_secret_id = (
         pentest_settings.openrouter_secret_id or "sec_pentestgpt_openrouter_default"
+    )
+    claude_oauth_volume = (
+        pentest_settings.claude_oauth_volume or PENTEST_CLAUDE_AUTH_VOLUME
+    )
+    claude_oauth_mount_path = (
+        pentest_settings.claude_oauth_mount_path or PENTEST_CLAUDE_CONFIG_DIR
     )
     enabled_provider_profiles = set(pentest_settings.enabled_provider_profiles)
 
@@ -1790,6 +2033,36 @@ def _pentest_provider_profiles() -> dict[str, PentestProviderProfile]:
             },
             command_behavior={"force_non_interactive": True},
         ),
+        PENTEST_CLAUDE_OAUTH_PROFILE_ID: PentestProviderProfile(
+            profile_id=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+            runtime_id=PENTEST_RUNTIME_ID,
+            provider_id="anthropic",
+            provider_label="Anthropic",
+            credential_source="oauth_volume",
+            runtime_materialization_mode="oauth_home",
+            enabled=_enabled(PENTEST_CLAUDE_OAUTH_PROFILE_ID),
+            tags=("oauth", "subscription", "claude-code"),
+            priority=110,
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="queue",
+            secret_refs={},
+            volume_ref=claude_oauth_volume,
+            volume_mount_path=claude_oauth_mount_path,
+            credential_profile_ref=pentest_settings.claude_oauth_credential_profile_ref,
+            seed_per_run_home=pentest_settings.claude_oauth_seed_per_run_home,
+            clear_env_keys=_PENTEST_OAUTH_CLEAR_ENV_KEYS,
+            home_path_overrides={
+                "HOME": PENTEST_CLAUDE_HOME_DIR,
+                "CLAUDE_CONFIG_DIR": claude_oauth_mount_path,
+                "CLAUDE_HOME": claude_oauth_mount_path,
+            },
+            env_template={
+                "PENTESTGPT_AUTH_MODE": "manual",
+                "LANGFUSE_ENABLED": "false",
+            },
+            command_behavior={"force_non_interactive": True},
+        ),
     }
 
 def _provider_profile_matches_selector(
@@ -1824,6 +2097,13 @@ def _provider_profile_is_runtime_available(
     state: PentestProviderRuntimeState | None,
     now: datetime,
 ) -> bool:
+    if profile.credential_source == "oauth_volume":
+        # OAuth profiles fail closed: a launch-ready Claude OAuth profile requires
+        # explicit readiness (auth_state == connected and the backing OAuth volume
+        # present). Without that runtime state the profile is never selected.
+        if not _provider_oauth_is_ready(state):
+            return False
+
     if state is None:
         return profile.enabled and profile.max_parallel_runs > 0
 
@@ -1835,6 +2115,15 @@ def _provider_profile_is_runtime_available(
         else max(0, profile.max_parallel_runs - len(state.current_leases))
     )
     return available_slots > 0
+
+def _provider_oauth_is_ready(state: PentestProviderRuntimeState | None) -> bool:
+    """Return whether an OAuth profile's runtime state is launch-ready."""
+
+    if state is None:
+        return False
+    if str(state.auth_state or "").strip().lower() != "connected":
+        return False
+    return bool(state.oauth_volume_present)
 
 def _provider_state_is_in_cooldown(
     state: PentestProviderRuntimeState,

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -52,6 +52,7 @@ from moonmind.integrations.pentest.models import (
     build_pentest_terminal_cleanup_result,
     classify_pentest_failure,
     materialize_pentest_provider_profile,
+    pentest_provider_lease_key,
     pentest_provider_lease_metadata,
     redact_pentest_human_text,
     resolve_pentest_provider_profile,
@@ -213,6 +214,11 @@ class TemporalPentestActivities:
             and pentest_settings.vpn_lab_profile_id
         ):
             allowed_profiles.add(pentest_settings.vpn_lab_profile_id)
+        if (
+            pentest_settings.allow_claude_oauth_profile
+            and pentest_settings.claude_oauth_runner_profile_id
+        ):
+            allowed_profiles.add(pentest_settings.claude_oauth_runner_profile_id)
         if request.runner_profile_id not in allowed_profiles:
             raise PentestLaunchPolicyError(
                 "Pentest runner profile is not enabled by deployment policy",
@@ -298,6 +304,8 @@ class TemporalPentestActivities:
         configured_profiles.add(pentest_settings.safe_profile_id)
         if pentest_settings.allow_vpn_lab_profile:
             configured_profiles.add(pentest_settings.vpn_lab_profile_id)
+        if pentest_settings.allow_claude_oauth_profile:
+            configured_profiles.add(pentest_settings.claude_oauth_runner_profile_id)
         registered = {
             profile_id: self._workload_registry.get(profile_id)
             for profile_id in configured_profiles
@@ -1136,7 +1144,9 @@ class TemporalPentestActivities:
                 runtime_state=request.provider_runtime_state,
             )
             lease_runtime_id = provider_profile.runtime_id
-            lease_profile_id = provider_profile.profile_id
+            # OAuth profiles serialize on the shared backing-credential lease key
+            # (the Claude subscription) rather than the per-run provider profile id.
+            lease_profile_id = pentest_provider_lease_key(provider_profile)
             lease_owner = _pentest_provider_lease_owner(
                 agent_run_id=request.agent_run_id,
                 step_id=request.step_id,
@@ -1328,8 +1338,8 @@ class TemporalPentestActivities:
             ).model_dump(mode="json")
             try:
                 await self._pentest_provider_lease_manager.record_cooldown(
-                    runtime_id=provider_profile.runtime_id,
-                    profile_id=provider_profile.profile_id,
+                    runtime_id=lease_runtime_id or provider_profile.runtime_id,
+                    profile_id=lease_profile_id or provider_profile.profile_id,
                     owner=lease_owner or "",
                     cooldown_seconds=provider_profile.cooldown_after_429_seconds,
                     reason=failure_category,

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -7,6 +7,9 @@ from pydantic import ValidationError
 
 from moonmind.config.settings import PentestSettings
 from moonmind.integrations.pentest.models import (
+    PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+    PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
+    PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR,
     PENTEST_TOOL_NAME,
     PENTEST_HEARTBEAT_PHASES,
     PentestApprovedScope,
@@ -15,6 +18,7 @@ from moonmind.integrations.pentest.models import (
     PentestFindingSummary,
     PentestLaunchPolicyError,
     PentestProviderMaterializationError,
+    PentestProviderProfile,
     PentestProviderSelector,
     PentestScopeValidationError,
     PentestTerminalCleanupResult,
@@ -33,6 +37,8 @@ from moonmind.integrations.pentest.models import (
     normalize_pentest_confidence,
     pentest_orphan_cleanup_candidate_matches,
     pentest_cleanup_selector,
+    pentest_provider_lease_key,
+    pentest_provider_lease_metadata,
     redact_pentest_human_text,
     resolve_pentest_provider_profile,
     validate_pentest_heartbeat_phase,
@@ -650,6 +656,19 @@ def test_pentest_launch_plan_uses_deterministic_metadata_and_cleanup_selector() 
             set(),
             {"ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"},
         ),
+        (
+            "pentestgpt_claude_oauth",
+            "anthropic",
+            "manual",
+            set(),
+            {
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+                "CLAUDE_API_KEY",
+                "CLAUDE_CODE_OAUTH_TOKEN",
+                "OPENAI_API_KEY",
+            },
+        ),
     ],
 )
 def test_pentest_provider_profiles_have_canonical_shapes(
@@ -745,20 +764,182 @@ def test_pentest_provider_materialization_is_secret_safe_and_clears_conflicts() 
     assert "sec_pentestgpt_anthropic_team" not in str(dumped["env"])
     assert "sk-" not in str(dumped)
 
-def test_pentest_provider_materialization_rejects_oauth_future_path() -> None:
-    profile = get_pentest_provider_profile("pentestgpt_anthropic_api_team").model_copy(
-        update={
-            "profile_id": "pentestgpt_oauth_future",
-            "credential_source": "oauth_volume",
-            "runtime_materialization_mode": "oauth_home",
-        }
+def test_pentest_claude_oauth_materialization_mounts_auth_home_and_clears_keys() -> None:
+    profile = get_pentest_provider_profile(PENTEST_CLAUDE_OAUTH_PROFILE_ID)
+
+    assert profile.credential_source == "oauth_volume"
+    assert profile.runtime_materialization_mode == "oauth_home"
+    assert profile.volume_ref == "claude_auth_volume"
+    assert profile.volume_mount_path == "/home/pentester/.claude"
+
+    materialized = materialize_pentest_provider_profile(profile)
+    dumped = materialized.model_dump(mode="json")
+
+    # The runner authenticates against the mounted Claude OAuth subscription home.
+    assert dumped["env"]["HOME"] == "/home/pentester"
+    assert dumped["env"]["CLAUDE_CONFIG_DIR"] == "/home/pentester/.claude"
+    assert dumped["env"]["CLAUDE_HOME"] == "/home/pentester/.claude"
+    assert dumped["env"]["PENTESTGPT_AUTH_MODE"] == "manual"
+    assert dumped["env"]["LANGFUSE_ENABLED"] == "false"
+    # Per-run home seeding wiring.
+    assert dumped["env"]["MM_PENTEST_SEED_CLAUDE_HOME"] == "1"
+    assert dumped["env"]["MM_PENTEST_CLAUDE_OAUTH_SOURCE"] == (
+        PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR
+    )
+    # Every API-key/token env var is cleared so Claude Code falls through to OAuth.
+    assert set(dumped["clear_env_keys"]) == {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+    }
+    # No secrets are materialized — the mounted volume is the credential.
+    assert dumped["secret_env"] == {}
+    assert dumped["secret_refs"] == {}
+    assert dumped["auth_volume_name"] == "claude_auth_volume"
+    assert dumped["auth_volume_mount_path"] == "/home/pentester/.claude"
+    assert dumped["seed_source_mount_path"] == PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR
+    assert dumped["seed_per_run_home"] is True
+    assert dumped["credential_lease_key"] == "claude_auth_volume"
+    assert dumped["force_non_interactive"] is True
+
+def test_pentest_oauth_profile_requires_volume_binding() -> None:
+    with pytest.raises(ValidationError):
+        PentestProviderProfile(
+            profile_id="pentestgpt_oauth_invalid",
+            runtime_id="pentestgpt",
+            provider_id="anthropic",
+            credential_source="oauth_volume",
+            runtime_materialization_mode="oauth_home",
+        )
+
+    with pytest.raises(ValidationError):
+        # ``oauth_volume`` and ``oauth_home`` must be set together.
+        PentestProviderProfile(
+            profile_id="pentestgpt_oauth_half",
+            runtime_id="pentestgpt",
+            provider_id="anthropic",
+            credential_source="oauth_volume",
+            runtime_materialization_mode="api_key_env",
+            volume_ref="claude_auth_volume",
+            volume_mount_path="/home/pentester/.claude",
+        )
+
+def test_pentest_oauth_materialization_rejects_secret_env_template() -> None:
+    profile = PentestProviderProfile(
+        profile_id="pentestgpt_oauth_secret",
+        runtime_id="pentestgpt",
+        provider_id="anthropic",
+        credential_source="oauth_volume",
+        runtime_materialization_mode="oauth_home",
+        volume_ref="claude_auth_volume",
+        volume_mount_path="/home/pentester/.claude",
+        env_template={"ANTHROPIC_API_KEY": {"from_secret_ref": "anthropic_api_key"}},
     )
 
     with pytest.raises(PentestProviderMaterializationError) as exc_info:
         materialize_pentest_provider_profile(profile)
 
-    assert exc_info.value.reason == "oauth_future_path"
-    assert "prompt" not in str(exc_info.value.diagnostics).lower()
+    assert exc_info.value.reason == "unsupported_env_template"
+
+def test_pentest_oauth_seed_disabled_mounts_durable_home_directly() -> None:
+    profile = PentestProviderProfile(
+        profile_id="pentestgpt_oauth_direct",
+        runtime_id="pentestgpt",
+        provider_id="anthropic",
+        credential_source="oauth_volume",
+        runtime_materialization_mode="oauth_home",
+        volume_ref="claude_auth_volume",
+        volume_mount_path="/home/pentester/.claude",
+        seed_per_run_home=False,
+        home_path_overrides={
+            "HOME": "/home/pentester",
+            "CLAUDE_CONFIG_DIR": "/home/pentester/.claude",
+            "CLAUDE_HOME": "/home/pentester/.claude",
+        },
+        env_template={"PENTESTGPT_AUTH_MODE": "manual"},
+    )
+
+    materialized = materialize_pentest_provider_profile(profile)
+
+    assert materialized.seed_per_run_home is False
+    assert materialized.seed_source_mount_path is None
+    assert "MM_PENTEST_SEED_CLAUDE_HOME" not in materialized.env
+    assert "MM_PENTEST_CLAUDE_OAUTH_SOURCE" not in materialized.env
+
+def test_pentest_oauth_resolution_requires_connected_auth_state() -> None:
+    checked_at = datetime(2026, 4, 22, tzinfo=UTC)
+
+    # Without runtime readiness state, the OAuth profile fails closed.
+    with pytest.raises(PentestProviderMaterializationError) as exc_info:
+        resolve_pentest_provider_profile(
+            execution_profile_ref=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+            now=checked_at,
+        )
+    assert exc_info.value.reason == "profile_unavailable"
+
+    # auth_state present but not connected is still unavailable.
+    with pytest.raises(PentestProviderMaterializationError):
+        resolve_pentest_provider_profile(
+            execution_profile_ref=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+            runtime_state={
+                PENTEST_CLAUDE_OAUTH_PROFILE_ID: {
+                    "profile_id": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                    "auth_state": "pending",
+                    "oauth_volume_present": True,
+                }
+            },
+            now=checked_at,
+        )
+
+    # Connected + OAuth volume present resolves the launch-ready profile.
+    selected = resolve_pentest_provider_profile(
+        execution_profile_ref=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+        runtime_state={
+            PENTEST_CLAUDE_OAUTH_PROFILE_ID: {
+                "profile_id": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                "auth_state": "connected",
+                "oauth_volume_present": True,
+            }
+        },
+        now=checked_at,
+    )
+    assert selected.profile_id == PENTEST_CLAUDE_OAUTH_PROFILE_ID
+
+def test_pentest_oauth_lease_key_uses_shared_backing_credential() -> None:
+    profile = get_pentest_provider_profile(PENTEST_CLAUDE_OAUTH_PROFILE_ID)
+    # Default OAuth profile keys its lease on the backing Claude volume.
+    assert pentest_provider_lease_key(profile) == "claude_auth_volume"
+    assert pentest_provider_lease_metadata(profile)["lease_key"] == "claude_auth_volume"
+
+    # An explicit credential_profile_ref takes precedence so the lease is shared
+    # with the canonical Claude profile.
+    shared = profile.model_copy(update={"credential_profile_ref": "claude_anthropic"})
+    assert pentest_provider_lease_key(shared) == "claude_anthropic"
+
+    # API-key profiles keep keying by their own profile id.
+    api_profile = get_pentest_provider_profile("pentestgpt_anthropic_api_team")
+    assert pentest_provider_lease_key(api_profile) == "pentestgpt_anthropic_api_team"
+
+def test_pentest_claude_oauth_runner_profile_seeds_read_only_volume() -> None:
+    runner = get_pentest_runner_profile(PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID)
+
+    seed_mounts = [
+        mount
+        for mount in runner.required_mounts
+        if mount.get("source") == "claude_auth_volume"
+    ]
+    assert len(seed_mounts) == 1
+    seed_mount = seed_mounts[0]
+    # The durable OAuth volume is mounted read-only as a per-run seed source.
+    assert seed_mount["read_only"] is True
+    assert seed_mount["target"] == PENTEST_CLAUDE_OAUTH_SEED_SOURCE_DIR
+    # The Claude auth-home env keys must be allowlisted for the materialized env.
+    for key in ("HOME", "CLAUDE_CONFIG_DIR", "CLAUDE_HOME"):
+        assert key in runner.env_allowlist
+    # API-key env vars are not allowlisted on the OAuth runner.
+    assert "ANTHROPIC_API_KEY" not in runner.env_allowlist
 
 def test_pentest_execution_policy_and_failure_classification_are_conservative() -> None:
     policy = PentestExecutionPolicy()

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
-from moonmind.config.settings import PentestSettings
+from moonmind.config.settings import PentestSettings, settings
 from moonmind.integrations.pentest.models import (
     PENTEST_CLAUDE_OAUTH_PROFILE_ID,
     PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
@@ -868,8 +868,12 @@ def test_pentest_oauth_seed_disabled_mounts_durable_home_directly() -> None:
     assert "MM_PENTEST_SEED_CLAUDE_HOME" not in materialized.env
     assert "MM_PENTEST_CLAUDE_OAUTH_SOURCE" not in materialized.env
 
-def test_pentest_oauth_resolution_requires_connected_auth_state() -> None:
+def test_pentest_oauth_resolution_requires_connected_auth_state(monkeypatch) -> None:
     checked_at = datetime(2026, 4, 22, tzinfo=UTC)
+
+    # The OAuth provider profile is gated behind the deployment allow flag; enable
+    # it so this test can exercise the runtime-readiness gating in isolation.
+    monkeypatch.setattr(settings.pentest, "allow_claude_oauth_profile", True)
 
     # Without runtime readiness state, the OAuth profile fails closed.
     with pytest.raises(PentestProviderMaterializationError) as exc_info:
@@ -906,6 +910,76 @@ def test_pentest_oauth_resolution_requires_connected_auth_state() -> None:
         now=checked_at,
     )
     assert selected.profile_id == PENTEST_CLAUDE_OAUTH_PROFILE_ID
+
+def test_pentest_oauth_profile_gated_off_unless_allow_flag(monkeypatch) -> None:
+    checked_at = datetime(2026, 4, 22, tzinfo=UTC)
+
+    # Default deployment policy disables the Claude OAuth provider profile.
+    monkeypatch.setattr(settings.pentest, "allow_claude_oauth_profile", False)
+
+    # Even when OAuth readiness is reported, the higher-priority OAuth profile
+    # must not win selectorless (automatic) resolution; a default request falls
+    # back to the highest-priority enabled API-key profile instead.
+    selected = resolve_pentest_provider_profile(
+        runtime_state={
+            PENTEST_CLAUDE_OAUTH_PROFILE_ID: {
+                "profile_id": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                "auth_state": "connected",
+                "oauth_volume_present": True,
+            }
+        },
+        now=checked_at,
+    )
+    assert selected.profile_id == "pentestgpt_anthropic_api_team"
+
+    # An exact ref to the disabled OAuth profile fails fast rather than silently
+    # honoring a profile the operator has not enabled.
+    with pytest.raises(PentestProviderMaterializationError) as exc_info:
+        resolve_pentest_provider_profile(
+            execution_profile_ref=PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+            runtime_state={
+                PENTEST_CLAUDE_OAUTH_PROFILE_ID: {
+                    "profile_id": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                    "auth_state": "connected",
+                    "oauth_volume_present": True,
+                }
+            },
+            now=checked_at,
+        )
+    assert exc_info.value.reason == "profile_disabled"
+
+def test_pentest_oauth_profile_honors_configured_provider_profile_id(
+    monkeypatch,
+) -> None:
+    # Operators can rename the OAuth provider profile id; the configured id must
+    # become the active profile's id and resolvable map key.
+    monkeypatch.setattr(settings.pentest, "allow_claude_oauth_profile", True)
+    monkeypatch.setattr(
+        settings.pentest,
+        "claude_oauth_provider_profile_id",
+        "pentestgpt_claude_oauth_custom",
+    )
+
+    profile = get_pentest_provider_profile("pentestgpt_claude_oauth_custom")
+    assert profile.profile_id == "pentestgpt_claude_oauth_custom"
+    assert profile.credential_source == "oauth_volume"
+
+    # The hard-coded default id is no longer registered when overridden.
+    with pytest.raises(PentestProviderMaterializationError) as exc_info:
+        get_pentest_provider_profile(PENTEST_CLAUDE_OAUTH_PROFILE_ID)
+    assert exc_info.value.reason == "unknown_profile"
+
+def test_pentest_oauth_profile_requires_absolute_mount_path() -> None:
+    with pytest.raises(ValidationError):
+        PentestProviderProfile(
+            profile_id="pentestgpt_oauth_relative",
+            runtime_id="pentestgpt",
+            provider_id="anthropic",
+            credential_source="oauth_volume",
+            runtime_materialization_mode="oauth_home",
+            volume_ref="claude_auth_volume",
+            volume_mount_path="home/pentester/.claude",
+        )
 
 def test_pentest_oauth_lease_key_uses_shared_backing_credential() -> None:
     profile = get_pentest_provider_profile(PENTEST_CLAUDE_OAUTH_PROFILE_ID)

--- a/tests/unit/workflows/temporal/test_pentest_activity_extraction.py
+++ b/tests/unit/workflows/temporal/test_pentest_activity_extraction.py
@@ -274,6 +274,46 @@ def test_failure_finding_set_pins_runner_failed_status() -> None:
     assert fallback["summary"]["findings_count"] == 0
 
 
+def _claude_oauth_request() -> PentestWorkloadRequest:
+    scope = _approved_pentest_scope()
+    scope["allowed_runner_profiles"] = ["pentestgpt-claude-oauth"]
+    return _request(
+        runner_profile_id="pentestgpt-claude-oauth",
+        execution_profile_ref="pentestgpt_claude_oauth",
+        approved_scope=scope,
+    )
+
+
+def test_claude_oauth_runner_profile_disabled_by_default(monkeypatch) -> None:
+    """The OAuth runner profile must be gated off unless explicitly enabled."""
+
+    from moonmind.integrations.pentest.models import PentestLaunchPolicyError
+
+    monkeypatch.setattr(settings.pentest, "allow_claude_oauth_profile", False)
+    request = _claude_oauth_request()
+
+    with pytest.raises(PentestLaunchPolicyError) as exc_info:
+        TemporalPentestActivities._validate_pentest_request_policy(
+            request, request.approved_scope
+        )
+    assert exc_info.value.reason == "runner_profile_disabled"
+
+
+def test_claude_oauth_runner_profile_allowed_when_enabled(monkeypatch) -> None:
+    """Enabling the gate admits the OAuth runner profile through policy."""
+
+    monkeypatch.setattr(settings.pentest, "allow_claude_oauth_profile", True)
+    monkeypatch.setattr(
+        settings.pentest, "claude_oauth_runner_profile_id", "pentestgpt-claude-oauth"
+    )
+    request = _claude_oauth_request()
+
+    # Should not raise — the gated profile is now an allowed runner profile.
+    TemporalPentestActivities._validate_pentest_request_policy(
+        request, request.approved_scope
+    )
+
+
 def test_loader_uses_request_fallbacks_when_file_omits_fields(tmp_path) -> None:
     # A findings file that omits target/operation_mode/runner fields still
     # produces a valid finding set by falling back to the request defaults.


### PR DESCRIPTION
## Issue

[MM-892: PentestGPT Auth](https://moonladder.atlassian.net/browse/MM-892)

## Summary

Implements the core Claude Code OAuth subscription auth path for PentestGPT, finishing the requirements the MM-892 assessment flagged as `not_met` (verdict: `PARTIALLY_IMPLEMENTED`). The surrounding architecture the brief mandates already existed — PentestGPT runs in a separate pinned runner image with only a thin adapter/launcher in MoonMind, the provider-profile framework (resolution, secret-safe materialization, per-profile lease/cooldown) was in place, and TARGET/INSTRUCTION/logs/results already flow through the artifact/reference system. What was missing — and previously hard-deferred as `oauth_future_path` — was the actual OAuth-volume auth mechanism. This change builds it:

- **OAuth provider-profile fields** added to `PentestProviderProfile` (`volume_ref`, `volume_mount_path`, `credential_profile_ref`, `home_path_overrides`, `seed_per_run_home`) with an `oauth_volume` ⇄ `oauth_home` consistency validator that fails fast on half-configured profiles.
- **Real `oauth_home` materialization** replaces the `oauth_future_path` rejection: sets `HOME`/`CLAUDE_CONFIG_DIR`/`CLAUDE_HOME`, forces `PENTESTGPT_AUTH_MODE=manual`, and clears API-key/token env vars (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`) so Claude Code falls through to subscription OAuth. No secrets are materialized — the mounted volume is the credential.
- **`pentestgpt_claude_oauth` provider profile** and **`pentestgpt-claude-oauth` runner profile** registered in `models.py` and `config/workloads/default-runner-profiles.yaml`, with a read-only `claude_auth_volume` seed mount and an OAuth-scoped env allowlist.
- **Launch-ready readiness gate**: OAuth profiles fail closed unless runtime state reports `auth_state == connected` with the backing OAuth volume present.
- **Shared backing-credential lease**: the lease is keyed by `credential_profile_ref`/`volume_ref` (the Claude subscription identity) rather than the per-run `profile_id`, so PentestGPT and `claude_code` serialize on one Claude subscription. Wired through acquire/release/cooldown in the activity.
- **Per-run home seeding** preferred over mutating the durable OAuth volume (read-only seed mount + `MM_PENTEST_SEED_CLAUDE_HOME` wiring).
- **Gated behind `MOONMIND_PENTEST_ALLOW_CLAUDE_OAUTH_PROFILE`** (off by default) plus supporting settings; the backing OAuth volume is provisioned out of band via `MoonMind.OAuthSession`.
- Docs (`docs/Steps/PentestTool.md` §11.3, `docs/Security/PentestOperations.md`) updated from future-work to implemented.

## Tests run

- `./tools/test_unit.sh tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_pentest_activity_extraction.py` — **97 passed** (Python). New coverage includes OAuth materialization (env/home/clear-keys), the `oauth_volume`/`oauth_home` validator, lease-key derivation, and the readiness fail-closed path.
- Frontend Vitest suite bundled by the runner: **471 passed, 236 skipped** (unaffected by this backend change).

## Remaining risks

- The path is **off by default** and depends on a Claude OAuth volume provisioned out of band via `MoonMind.OAuthSession`; an end-to-end live run against a real subscription has not been exercised in CI (hermetic tests cover contracts/materialization only).
- The runner image is expected to honor `MM_PENTEST_SEED_CLAUDE_HOME`/`MM_PENTEST_CLAUDE_OAUTH_SOURCE` to copy the read-only seed into a writable per-run Claude home; if the pinned runner image does not implement that seeding step, the read-only mount would prevent Claude Code from refreshing session state.
- Cross-runtime lease sharing assumes `claude_code` and `pentestgpt_cli` are leased through the same backing-credential key; profiles configured with a mismatched `credential_profile_ref`/`volume_ref` could still run concurrently against one subscription.
- Claude Code auth precedence is sensitive to env leakage — any token env var not in the clear list could shadow subscription OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
