### PR TITLE
MM-893 Load recurring schedule details by definitionId

### DIFF
--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -298,6 +298,34 @@ describe("SchedulesPage", () => {
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha/runs?limit=200")).toBe(true);
   });
 
+  it("ignores malformed schedule route ids instead of throwing during render", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    } as Response);
+
+    renderWithClient(
+      <SchedulesPage
+        payload={{
+          ...detailPayload,
+          initialData: {
+            dashboardConfig: {
+              initialPath: "/schedules/%",
+              sources: {
+                schedules: {
+                  list: "/console/schedules?scope=personal",
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("No recurring schedules yet. Create one from the workflow page.")).not.toBeNull();
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("/console/schedules?scope=personal");
+  });
+
   it("keeps update requests keyed by the route definition id", async () => {
     mockScheduleDetailFetch(fetchSpy);
 
@@ -318,6 +346,56 @@ describe("SchedulesPage", () => {
       ).toBe(true);
     });
     expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sends an empty description when the edit form clears an existing description", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    await waitFor(() => {
+      const updateCall = fetchSpy.mock.calls.find(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      ));
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(String(updateCall?.[1]?.body || "{}")).description).toBe("");
+    });
+  });
+
+  it("reports update and run failures separately", async () => {
+    fetchSpy.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = String(init?.method || "GET").toUpperCase();
+      if (url === "/console/schedules/schedule-alpha" && method === "PATCH") {
+        return { ok: false, statusText: "Update rejected", json: async () => ({}) } as Response;
+      }
+      if (url === "/console/schedules/schedule-alpha/run" && method === "POST") {
+        return { ok: false, statusText: "Run rejected", json: async () => ({}) } as Response;
+      }
+      if (url === "/console/schedules/schedule-alpha/runs?limit=200") {
+        return { ok: true, json: async () => detailRuns } as Response;
+      }
+      if (url === "/console/schedules/schedule-alpha") {
+        return { ok: true, json: async () => detailSchedule } as Response;
+      }
+      throw new Error(`Unexpected fetch ${method} ${url}`);
+    });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run now" }));
+
+    expect(await screen.findByText("Failed to update schedule: Update rejected")).not.toBeNull();
+    expect(await screen.findByText("Failed to run schedule: Run rejected")).not.toBeNull();
   });
 
   it("runs schedules from the same routed definition id and leaves run links on workflow detail routes", async () => {

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 import type { BootPayload } from "../boot/parseBootPayload";
 import { renderWithClient } from "../utils/test-utils";
@@ -10,6 +10,108 @@ const mockPayload: BootPayload = {
   apiBase: "/api",
   initialData: {},
 };
+
+const detailSchedule = {
+  id: "schedule-alpha",
+  name: "Nightly detail sweep",
+  description: "Keeps the repository current.",
+  enabled: true,
+  scheduleType: "cron",
+  cron: "0 2 * * *",
+  timezone: "UTC",
+  lastDispatchStatus: "enqueued",
+  lastDispatchError: null,
+  nextRunAt: "2026-06-25T02:00:00Z",
+  lastScheduledFor: "2026-06-24T02:00:00Z",
+  scopeType: "personal",
+  scopeRef: "user-1",
+  target: {
+    kind: "queue_task",
+    job: {
+      payload: {
+        repository: "MoonLadderStudios/MoonMind",
+      },
+    },
+  },
+  policy: {
+    overlap: { mode: "skip" },
+    catchup: { mode: "latest" },
+  },
+  version: 1,
+  createdAt: "2026-06-20T00:00:00Z",
+  updatedAt: "2026-06-24T00:00:00Z",
+};
+
+const detailRuns = {
+  items: [
+    {
+      id: "run-1",
+      definitionId: "schedule-alpha",
+      scheduledFor: "2026-06-24T02:00:00Z",
+      trigger: "schedule",
+      outcome: "enqueued",
+      dispatchAttempts: 1,
+      dispatchAfter: null,
+      temporalWorkflowId: "workflow-from-schedule",
+      temporalRunId: "temporal-run-1",
+      message: "Started",
+      createdAt: "2026-06-24T02:00:01Z",
+      updatedAt: "2026-06-24T02:00:02Z",
+    },
+  ],
+};
+
+const detailPayload: BootPayload = {
+  page: "schedules",
+  apiBase: "/api",
+  initialData: {
+    dashboardConfig: {
+      initialPath: "/schedules/schedule-alpha",
+      sources: {
+        schedules: {
+          list: "/console/schedules?scope=personal",
+          detail: "/console/schedules/{definitionId}",
+          update: "/console/schedules/{definitionId}",
+          runNow: "/console/schedules/{definitionId}/run",
+          runs: "/console/schedules/{definitionId}/runs?limit=200",
+        },
+      },
+    },
+  },
+};
+
+function mockScheduleDetailFetch(fetchSpy: MockInstance, overrides: Partial<typeof detailSchedule> = {}) {
+  const schedule = { ...detailSchedule, ...overrides };
+  fetchSpy.mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = String(init?.method || "GET").toUpperCase();
+    if (url === "/console/schedules/schedule-alpha" && method === "PATCH") {
+      return {
+        ok: true,
+        json: async () => ({ ...schedule, ...(JSON.parse(String(init?.body || "{}")) as object) }),
+      } as Response;
+    }
+    if (url === "/console/schedules/schedule-alpha/run" && method === "POST") {
+      return {
+        ok: true,
+        json: async () => ({ ...detailRuns.items[0], id: "run-manual", trigger: "manual" }),
+      } as Response;
+    }
+    if (url === "/console/schedules/schedule-alpha/runs?limit=200") {
+      return {
+        ok: true,
+        json: async () => detailRuns,
+      } as Response;
+    }
+    if (url === "/console/schedules/schedule-alpha") {
+      return {
+        ok: true,
+        json: async () => schedule,
+      } as Response;
+    }
+    throw new Error(`Unexpected fetch ${method} ${url}`);
+  });
+}
 
 describe("SchedulesPage", () => {
   let fetchSpy: MockInstance;
@@ -177,5 +279,66 @@ describe("SchedulesPage", () => {
 
     expect(await screen.findByText("No recurring schedules yet. Create one from the workflow page.")).not.toBeNull();
     expect(fetchSpy.mock.calls[0]?.[0]).toBe("/tenant/api/recurring-tasks?scope=personal");
+  });
+
+  it("loads the recurring schedule detail route by the routed definition id", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("MoonLadderStudios/MoonMind")).not.toBeNull();
+    expect(screen.getByText("Started")).not.toBeNull();
+    expect(screen.getByRole("link", { name: "workflow-from-schedule" }).getAttribute("href")).toBe(
+      "/workflows/workflow-from-schedule?source=temporal",
+    );
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules?scope=personal")).toBe(false);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha")).toBe(true);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha/runs?limit=200")).toBe(true);
+  });
+
+  it("keeps update requests keyed by the route definition id", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Nightly detail sweep updated" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url, init]) => (
+          String(url) === "/console/schedules/schedule-alpha"
+          && String(init?.method || "GET").toUpperCase() === "PATCH"
+          && String(init?.body || "").includes("Nightly detail sweep updated")
+        )),
+      ).toBe(true);
+    });
+    expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("runs schedules from the same routed definition id and leaves run links on workflow detail routes", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Run now" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url, init]) => (
+          String(url) === "/console/schedules/schedule-alpha/run"
+          && String(init?.method || "GET").toUpperCase() === "POST"
+        )),
+      ).toBe(true);
+    });
+    expect(screen.getByRole("link", { name: "workflow-from-schedule" }).getAttribute("href")).toBe(
+      "/workflows/workflow-from-schedule?source=temporal",
+    );
+    expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { DataTable } from '../components/tables/DataTable';
 
 import { z } from 'zod';
@@ -29,17 +29,51 @@ const SchedulesResponseSchema = z.object({
   items: z.array(ScheduleSchema),
 });
 
+const ScheduleRunSchema = z.object({
+  id: z.string(),
+  definitionId: z.string(),
+  scheduledFor: z.string(),
+  trigger: z.string(),
+  outcome: z.string(),
+  dispatchAttempts: z.number(),
+  dispatchAfter: z.string().nullable().optional(),
+  temporalWorkflowId: z.string().nullable().optional(),
+  temporalRunId: z.string().nullable().optional(),
+  message: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}).passthrough();
+
+const ScheduleRunsResponseSchema = z.object({
+  items: z.array(ScheduleRunSchema),
+});
+
 type Schedule = z.infer<typeof ScheduleSchema>;
+type ScheduleRun = z.infer<typeof ScheduleRunSchema>;
+
+type ScheduleSources = {
+  list?: string | undefined;
+  detail?: string | undefined;
+  update?: string | undefined;
+  runNow?: string | undefined;
+  runs?: string | undefined;
+};
 
 const SchedulesBootDataSchema = z
   .object({
+    initialPath: z.string().optional(),
     dashboardConfig: z
       .object({
+        initialPath: z.string().optional(),
         sources: z
           .object({
             schedules: z
               .object({
                 list: z.string().optional(),
+                detail: z.string().optional(),
+                update: z.string().optional(),
+                runNow: z.string().optional(),
+                runs: z.string().optional(),
               })
               .partial()
               .optional(),
@@ -54,6 +88,10 @@ const SchedulesBootDataSchema = z
         schedules: z
           .object({
             list: z.string().optional(),
+            detail: z.string().optional(),
+            update: z.string().optional(),
+            runNow: z.string().optional(),
+            runs: z.string().optional(),
           })
           .partial()
           .optional(),
@@ -63,12 +101,46 @@ const SchedulesBootDataSchema = z
   })
   .passthrough();
 
-function scheduleListEndpoint(payload: BootPayload): string {
+function scheduleBootData(payload: BootPayload) {
   const parsed = SchedulesBootDataSchema.safeParse(payload.initialData || {});
-  const schedules = parsed.success
-    ? parsed.data.dashboardConfig?.sources?.schedules || parsed.data.sources?.schedules
-    : undefined;
+  return parsed.success ? parsed.data : undefined;
+}
+
+function scheduleSources(payload: BootPayload): ScheduleSources | undefined {
+  const bootData = scheduleBootData(payload);
+  return bootData?.dashboardConfig?.sources?.schedules || bootData?.sources?.schedules;
+}
+
+function scheduleListEndpoint(payload: BootPayload): string {
+  const schedules = scheduleSources(payload);
   return schedules?.list || `${payload.apiBase || '/api'}/recurring-tasks?scope=personal`;
+}
+
+function scheduleRouteDefinitionId(payload: BootPayload): string | null {
+  const bootData = scheduleBootData(payload);
+  const rawPath = bootData?.dashboardConfig?.initialPath || bootData?.initialPath || '';
+  const path = rawPath.split('?')[0]?.split('#')[0] || '';
+  const match = path.match(/^\/schedules\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+  const definitionId = decodeURIComponent(match[1] || '').trim();
+  return definitionId && definitionId.toLowerCase() !== 'new' ? definitionId : null;
+}
+
+function scheduleEndpoint(
+  payload: BootPayload,
+  key: 'detail' | 'update' | 'runNow' | 'runs',
+  definitionId: string,
+): string {
+  const fallbackPath = key === 'runNow'
+    ? '/recurring-workflows/{definitionId}/run'
+    : key === 'runs'
+      ? '/recurring-workflows/{definitionId}/runs?limit=200'
+      : '/recurring-workflows/{definitionId}';
+  const template = scheduleSources(payload)?.[key] || `${payload.apiBase || '/api'}${fallbackPath}`;
+  const encoded = encodeURIComponent(definitionId);
+  return template.replaceAll('{definitionId}', encoded).replaceAll('{id}', encoded);
 }
 
 function formatWhen(value: string | null | undefined): string {
@@ -142,6 +214,39 @@ function policySummary(schedule: Schedule): string {
   return [overlapMode, catchupMode].filter(Boolean).map((value) => titleCaseLabel(formatStatusLabel(value))).join(' / ') || '-';
 }
 
+function formatJsonValue(value: unknown): string {
+  if (!value || (typeof value === 'object' && Object.keys(value as Record<string, unknown>).length === 0)) {
+    return '-';
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function runWorkflowHref(run: ScheduleRun): string | null {
+  return run.temporalWorkflowId ? `/workflows/${encodeURIComponent(run.temporalWorkflowId)}?source=temporal` : null;
+}
+
+type ScheduleEditForm = {
+  name: string;
+  description: string;
+  enabled: boolean;
+  cron: string;
+  timezone: string;
+};
+
+function editFormFromSchedule(schedule: Schedule): ScheduleEditForm {
+  return {
+    name: schedule.name,
+    description: schedule.description || '',
+    enabled: schedule.enabled,
+    cron: schedule.cron,
+    timezone: schedule.timezone,
+  };
+}
+
 function isDueSoon(schedule: Schedule, now: number): boolean {
   if (!schedule.enabled || !schedule.nextRunAt) {
     return false;
@@ -150,7 +255,372 @@ function isDueSoon(schedule: Schedule, now: number): boolean {
   return Number.isFinite(nextRun) && nextRun >= now && nextRun <= now + 24 * 60 * 60 * 1000;
 }
 
+function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; definitionId: string }) {
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
+  const detailEndpoint = useMemo(() => scheduleEndpoint(payload, 'detail', definitionId), [payload, definitionId]);
+  const updateEndpoint = useMemo(() => scheduleEndpoint(payload, 'update', definitionId), [payload, definitionId]);
+  const runNowEndpoint = useMemo(() => scheduleEndpoint(payload, 'runNow', definitionId), [payload, definitionId]);
+  const runsEndpoint = useMemo(() => scheduleEndpoint(payload, 'runs', definitionId), [payload, definitionId]);
+
+  const detailQuery = useQuery({
+    queryKey: ['schedule-detail', definitionId, detailEndpoint],
+    queryFn: async () => {
+      const response = await fetch(detailEndpoint, { credentials: 'include' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch schedule: ${response.statusText}`);
+      }
+      return ScheduleSchema.parse(await response.json());
+    },
+  });
+
+  const runsQuery = useQuery({
+    queryKey: ['schedule-runs', definitionId, runsEndpoint],
+    queryFn: async () => {
+      const response = await fetch(runsEndpoint, { credentials: 'include' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch schedule runs: ${response.statusText}`);
+      }
+      return ScheduleRunsResponseSchema.parse(await response.json());
+    },
+  });
+
+  useEffect(() => {
+    if (detailQuery.data && !isEditing) {
+      setEditForm(editFormFromSchedule(detailQuery.data));
+    }
+  }, [detailQuery.data, isEditing]);
+
+  const refreshDetail = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['schedule-detail', definitionId] }),
+      queryClient.invalidateQueries({ queryKey: ['schedule-runs', definitionId] }),
+    ]);
+  };
+
+  const updateMutation = useMutation({
+    mutationFn: async (form: ScheduleEditForm) => {
+      const response = await fetch(updateEndpoint, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || null,
+          enabled: form.enabled,
+          cron: form.cron,
+          timezone: form.timezone,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to update schedule: ${response.statusText}`);
+      }
+      return ScheduleSchema.parse(await response.json());
+    },
+    onSuccess: async (updated) => {
+      queryClient.setQueryData(['schedule-detail', definitionId, detailEndpoint], updated);
+      setEditForm(editFormFromSchedule(updated));
+      setIsEditing(false);
+      await refreshDetail();
+    },
+  });
+
+  const runNowMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch(runNowEndpoint, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to run schedule: ${response.statusText}`);
+      }
+      return ScheduleRunSchema.parse(await response.json());
+    },
+    onSuccess: async () => {
+      await refreshDetail();
+    },
+  });
+
+  const schedule = detailQuery.data;
+  const runs = runsQuery.data?.items || [];
+  const currentForm = editForm || (schedule ? editFormFromSchedule(schedule) : null);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (currentForm) {
+      updateMutation.mutate(currentForm);
+    }
+  };
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="schedules-page stack">
+        <p className="loading">Loading recurring schedule...</p>
+      </div>
+    );
+  }
+
+  if (detailQuery.isError || !schedule) {
+    return (
+      <div className="schedules-page stack">
+        <a href="/schedules" className="secondary">Back to schedules</a>
+        <div className="schedules-error" role="alert">{(detailQuery.error as Error)?.message || 'Schedule not found'}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="schedules-page schedules-detail-page stack">
+      <header className="toolbar schedules-toolbar">
+        <div className="schedules-detail-title">
+          <nav className="page-meta" aria-label="Breadcrumb">
+            <a href="/schedules">Schedules</a>
+            <span>/</span>
+            <span>{schedule.name}</span>
+          </nav>
+          <h2 className="page-title">{schedule.name}</h2>
+          <p className="page-meta">{displayValue(schedule.description)}</p>
+          <p className="page-meta" title={definitionId}>Definition ID: {definitionId}</p>
+        </div>
+        <div className="toolbar-controls">
+          <span className={`schedules-state schedules-state--${scheduleState(schedule)}`}>
+            {stateLabel(schedule)}
+          </span>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => void refreshDetail()}
+            disabled={detailQuery.isFetching || runsQuery.isFetching}
+          >
+            {detailQuery.isFetching || runsQuery.isFetching ? 'Refreshing' : 'Refresh'}
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => {
+              setEditForm(editFormFromSchedule(schedule));
+              setIsEditing((value) => !value);
+            }}
+          >
+            {isEditing ? 'Cancel edit' : 'Edit schedule'}
+          </button>
+          <button
+            type="button"
+            className="button"
+            onClick={() => runNowMutation.mutate()}
+            disabled={runNowMutation.isPending}
+          >
+            {runNowMutation.isPending ? 'Running' : 'Run now'}
+          </button>
+        </div>
+      </header>
+
+      {(updateMutation.isError || runNowMutation.isError) && (
+        <div className="schedules-error" role="alert">
+          {((updateMutation.error || runNowMutation.error) as Error).message}
+        </div>
+      )}
+
+      <section className="schedules-summary-grid" aria-label="Schedule detail summary">
+        <div className="schedules-summary-item">
+          <span>Next Run</span>
+          <strong>{formatWhen(schedule.nextRunAt)}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Cadence</span>
+          <strong>{schedule.cron}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Last Run</span>
+          <strong>{formatWhen(schedule.lastScheduledFor)}</strong>
+        </div>
+        <div className="schedules-summary-item">
+          <span>Dispatch</span>
+          <strong>{schedule.lastDispatchStatus ? titleCaseLabel(formatStatusLabel(schedule.lastDispatchStatus)) : '-'}</strong>
+        </div>
+      </section>
+
+      <div className="schedules-detail-grid">
+        <section className="panel--data schedules-detail-panel" aria-label="Schedule configuration">
+          <div className="section-heading-row">
+            <h3>Configuration</h3>
+          </div>
+          {isEditing && currentForm ? (
+            <form className="schedules-edit-form" onSubmit={onSubmit}>
+              <label>
+                <span>Name</span>
+                <input
+                  value={currentForm.name}
+                  onChange={(event) => setEditForm({ ...currentForm, name: event.currentTarget.value })}
+                  required
+                />
+              </label>
+              <label>
+                <span>Description</span>
+                <textarea
+                  value={currentForm.description}
+                  onChange={(event) => setEditForm({ ...currentForm, description: event.currentTarget.value })}
+                  rows={3}
+                />
+              </label>
+              <label>
+                <span>Cron</span>
+                <input
+                  value={currentForm.cron}
+                  onChange={(event) => setEditForm({ ...currentForm, cron: event.currentTarget.value })}
+                  required
+                />
+              </label>
+              <label>
+                <span>Timezone</span>
+                <input
+                  value={currentForm.timezone}
+                  onChange={(event) => setEditForm({ ...currentForm, timezone: event.currentTarget.value })}
+                  required
+                />
+              </label>
+              <label className="schedules-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={currentForm.enabled}
+                  onChange={(event) => setEditForm({ ...currentForm, enabled: event.currentTarget.checked })}
+                />
+                <span>Enabled</span>
+              </label>
+              <div className="toolbar-controls">
+                <button type="submit" className="button" disabled={updateMutation.isPending}>
+                  {updateMutation.isPending ? 'Saving' : 'Save schedule'}
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => {
+                    setEditForm(editFormFromSchedule(schedule));
+                    setIsEditing(false);
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : (
+            <dl className="schedules-detail-list">
+              <div>
+                <dt>Cron</dt>
+                <dd><code>{schedule.cron}</code></dd>
+              </div>
+              <div>
+                <dt>Timezone</dt>
+                <dd>{displayValue(schedule.timezone)}</dd>
+              </div>
+              <div>
+                <dt>Target</dt>
+                <dd>{targetKind(schedule)}</dd>
+              </div>
+              <div>
+                <dt>Repository</dt>
+                <dd>{targetRepository(schedule)}</dd>
+              </div>
+              <div>
+                <dt>Policy</dt>
+                <dd>{policySummary(schedule)}</dd>
+              </div>
+              <div>
+                <dt>Last Dispatch Error</dt>
+                <dd>{displayValue(schedule.lastDispatchError)}</dd>
+              </div>
+            </dl>
+          )}
+        </section>
+
+        <aside className="panel--data schedules-detail-panel" aria-label="Schedule facts">
+          <div className="section-heading-row">
+            <h3>Facts</h3>
+          </div>
+          <dl className="schedules-detail-list">
+            <div>
+              <dt>Definition ID</dt>
+              <dd title={definitionId}>{definitionId}</dd>
+            </div>
+            <div>
+              <dt>Scope</dt>
+              <dd>{displayValue(schedule.scopeType)} / {displayValue(schedule.scopeRef)}</dd>
+            </div>
+            <div>
+              <dt>Type</dt>
+              <dd>{displayValue(schedule.scheduleType)}</dd>
+            </div>
+            <div>
+              <dt>Updated</dt>
+              <dd>{formatWhen(schedule.updatedAt)}</dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+
+      <section className="panel--data schedules-detail-panel" aria-label="Schedule run history">
+        <div className="section-heading-row">
+          <h3>Runs</h3>
+        </div>
+        {runsQuery.isError ? (
+          <div className="schedules-error" role="alert">{(runsQuery.error as Error).message}</div>
+        ) : (
+          <DataTable
+            data={runs}
+            columns={[
+              {
+                key: 'scheduledFor',
+                header: 'Scheduled For',
+                render: (item) => formatWhen(item.scheduledFor),
+              },
+              {
+                key: 'outcome',
+                header: 'Outcome',
+                render: (item) => titleCaseLabel(formatStatusLabel(item.outcome)),
+              },
+              {
+                key: 'trigger',
+                header: 'Trigger',
+                render: (item) => titleCaseLabel(formatStatusLabel(item.trigger)),
+              },
+              {
+                key: 'temporalWorkflowId',
+                header: 'Workflow',
+                render: (item) => {
+                  const href = runWorkflowHref(item);
+                  return href ? <a href={href}>{item.temporalWorkflowId}</a> : '-';
+                },
+              },
+              {
+                key: 'message',
+                header: 'Message',
+                render: (item) => displayValue(item.message),
+              },
+            ]}
+            emptyMessage={runsQuery.isLoading ? 'Loading schedule runs...' : 'No runs recorded for this schedule.'}
+            getRowKey={(item) => item.id}
+            ariaLabel="Schedule runs"
+          />
+        )}
+      </section>
+
+      <section className="panel--data schedules-detail-panel" aria-label="Schedule target payload">
+        <div className="section-heading-row">
+          <h3>Target Payload</h3>
+        </div>
+        <pre className="schedules-json-block">{formatJsonValue(schedule.target)}</pre>
+      </section>
+    </div>
+  );
+}
+
 export function SchedulesPage({ payload }: { payload: BootPayload }) {
+  const routeDefinitionId = useMemo(() => scheduleRouteDefinitionId(payload), [payload]);
+  if (routeDefinitionId) {
+    return <ScheduleDetailPage payload={payload} definitionId={routeDefinitionId} />;
+  }
+
   const listEndpoint = useMemo(() => scheduleListEndpoint(payload), [payload]);
   const { data, isLoading, isError, error, isFetching, refetch } = useQuery({
     queryKey: ['schedules', listEndpoint],

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -124,8 +124,12 @@ function scheduleRouteDefinitionId(payload: BootPayload): string | null {
   if (!match) {
     return null;
   }
-  const definitionId = decodeURIComponent(match[1] || '').trim();
-  return definitionId && definitionId.toLowerCase() !== 'new' ? definitionId : null;
+  try {
+    const definitionId = decodeURIComponent(match[1] || '').trim();
+    return definitionId && definitionId.toLowerCase() !== 'new' ? definitionId : null;
+  } catch {
+    return null;
+  }
 }
 
 function scheduleEndpoint(
@@ -162,6 +166,10 @@ function compactId(id: string): string {
 function displayValue(value: string | null | undefined): string {
   const normalized = String(value || '').trim();
   return normalized || '-';
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }
 
 function titleCaseLabel(value: string): string {
@@ -307,7 +315,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           name: form.name,
-          description: form.description || null,
+          description: form.description,
           enabled: form.enabled,
           cron: form.cron,
           timezone: form.timezone,
@@ -365,7 +373,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
     return (
       <div className="schedules-page stack">
         <a href="/schedules" className="secondary">Back to schedules</a>
-        <div className="schedules-error" role="alert">{(detailQuery.error as Error)?.message || 'Schedule not found'}</div>
+        <div className="schedules-error" role="alert">{errorMessage(detailQuery.error, 'Schedule not found')}</div>
       </div>
     );
   }
@@ -416,9 +424,14 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         </div>
       </header>
 
-      {(updateMutation.isError || runNowMutation.isError) && (
+      {updateMutation.isError && (
         <div className="schedules-error" role="alert">
-          {((updateMutation.error || runNowMutation.error) as Error).message}
+          {errorMessage(updateMutation.error, 'Failed to update schedule')}
+        </div>
+      )}
+      {runNowMutation.isError && (
+        <div className="schedules-error" role="alert">
+          {errorMessage(runNowMutation.error, 'Failed to run schedule')}
         </div>
       )}
 
@@ -452,7 +465,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 <span>Name</span>
                 <input
                   value={currentForm.name}
-                  onChange={(event) => setEditForm({ ...currentForm, name: event.currentTarget.value })}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, name: value } : null);
+                  }}
                   required
                 />
               </label>
@@ -460,7 +476,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 <span>Description</span>
                 <textarea
                   value={currentForm.description}
-                  onChange={(event) => setEditForm({ ...currentForm, description: event.currentTarget.value })}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, description: value } : null);
+                  }}
                   rows={3}
                 />
               </label>
@@ -468,7 +487,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 <span>Cron</span>
                 <input
                   value={currentForm.cron}
-                  onChange={(event) => setEditForm({ ...currentForm, cron: event.currentTarget.value })}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, cron: value } : null);
+                  }}
                   required
                 />
               </label>
@@ -476,7 +498,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 <span>Timezone</span>
                 <input
                   value={currentForm.timezone}
-                  onChange={(event) => setEditForm({ ...currentForm, timezone: event.currentTarget.value })}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, timezone: value } : null);
+                  }}
                   required
                 />
               </label>
@@ -484,7 +509,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 <input
                   type="checkbox"
                   checked={currentForm.enabled}
-                  onChange={(event) => setEditForm({ ...currentForm, enabled: event.currentTarget.checked })}
+                  onChange={(event) => {
+                    const value = event.currentTarget.checked;
+                    setEditForm((previous) => previous ? { ...previous, enabled: value } : null);
+                  }}
                 />
                 <span>Enabled</span>
               </label>
@@ -564,7 +592,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
           <h3>Runs</h3>
         </div>
         {runsQuery.isError ? (
-          <div className="schedules-error" role="alert">{(runsQuery.error as Error).message}</div>
+          <div className="schedules-error" role="alert">{errorMessage(runsQuery.error, 'Failed to fetch schedule runs')}</div>
         ) : (
           <DataTable
             data={runs}
@@ -682,7 +710,7 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
         {isLoading ? (
           <p className="loading">Loading recurring schedules...</p>
         ) : isError ? (
-          <div className="schedules-error" role="alert">{(error as Error).message}</div>
+          <div className="schedules-error" role="alert">{errorMessage(error, 'Failed to fetch schedules')}</div>
         ) : (
           <DataTable
             data={schedules}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1226,6 +1226,109 @@ h1 {
   color: color-mix(in srgb, rgb(var(--mm-danger)) 76%, rgb(var(--mm-ink)) 24%);
 }
 
+.schedules-detail-title {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.schedules-detail-title nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.schedules-detail-title a {
+  color: rgb(var(--mm-accent));
+  text-decoration: none;
+}
+
+.schedules-detail-title a:hover {
+  text-decoration: underline;
+}
+
+.schedules-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(16rem, 0.85fr);
+  gap: 0.85rem;
+}
+
+.schedules-detail-panel {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.schedules-detail-list {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.schedules-detail-list div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.schedules-detail-list dt {
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+  font-weight: 720;
+  text-transform: uppercase;
+}
+
+.schedules-detail-list dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: rgb(var(--mm-ink));
+  font-size: 0.92rem;
+}
+
+.schedules-edit-form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.schedules-edit-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.84rem;
+  font-weight: 680;
+}
+
+.schedules-edit-form input,
+.schedules-edit-form textarea {
+  width: 100%;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-panel));
+  color: rgb(var(--mm-ink));
+  font: inherit;
+}
+
+.schedules-checkbox-label {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  width: fit-content;
+}
+
+.schedules-json-block {
+  max-height: 22rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0.85rem;
+  border: 1px solid rgb(var(--mm-border) / 0.68);
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-ink) / 0.04);
+  color: rgb(var(--mm-ink));
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .manifests-advanced-grid,
 .manifests-filter-grid {
   display: grid;
@@ -1684,6 +1787,10 @@ tbody tr:hover {
 @media (max-width: 720px) {
   .schedules-summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .schedules-detail-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .provider-profiles-table-wrap {


### PR DESCRIPTION
Issue reference: MM-893

Summary:
- Adds routed schedule detail handling for /schedules/{definitionId} so the frontend loads the exact recurring schedule by definitionId.
- Keeps list navigation and creation redirect semantics keyed to the stable definitionId.
- Adds UI coverage for deep-link detail loading and preserving the route key after schedule edits/spawned runs.

Tests run:
- ./tools/test_unit.sh --ui-args frontend/src/entrypoints/schedules.test.tsx

Remaining risks:
- No known remaining risks; existing warnings from the broader unit wrapper are unrelated deprecations/test marker warnings.