### PR TITLE
[codex] Handle empty Jira story artifacts

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -511,6 +511,22 @@ def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:
         return [dict(value)] if value.get("summary") or value.get("title") else []
     return [dict(story) for story in _list(value) if isinstance(story, Mapping)]
 
+def _has_explicit_empty_story_list(value: Any) -> bool:
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return False
+    if isinstance(value, Mapping):
+        for key in ("stories", "userStories", "user_stories", "items", "issues"):
+            if key not in value:
+                continue
+            return not _list(value.get(key))
+        return False
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return len(value) == 0
+    return False
+
 def _story_summary(story: Mapping[str, Any], *, index: int) -> str:
     for key in ("summary", "title", "name", "userStory", "user_story"):
         value = _string(story.get(key))
@@ -1591,6 +1607,58 @@ def _fallback_result(
         },
     )
 
+def _jira_noop_result(
+    *,
+    original_story_count: int,
+    dependency_mode: str,
+    skipped_stories: Sequence[Mapping[str, Any]] = (),
+    blocked_stories: Sequence[Mapping[str, Any]] = (),
+    partial_stories_adjusted: Sequence[Mapping[str, Any]] = (),
+    story_breakdown_artifact_ref: str = "",
+    story_breakdown_path: str = "",
+) -> ToolResult:
+    story_output: dict[str, Any] = {
+        "mode": "jira",
+        "status": "jira_noop",
+        "storyCount": original_story_count,
+        "eligibleStoryCount": 0,
+        "createdCount": 0,
+        "dependencyMode": dependency_mode,
+        "skippedStories": [dict(story) for story in skipped_stories],
+        "blockedStories": [dict(story) for story in blocked_stories],
+        "partialStoriesAdjusted": [
+            dict(story) for story in partial_stories_adjusted
+        ],
+    }
+    if story_breakdown_artifact_ref:
+        story_output["storyBreakdownArtifactRef"] = story_breakdown_artifact_ref
+    if story_breakdown_path:
+        story_output["storyBreakdownPath"] = story_breakdown_path
+    return ToolResult(
+        status="COMPLETED",
+        outputs={
+            "storyOutput": story_output,
+            "jira": {
+                "createdCount": 0,
+                "createdIssues": [],
+                "dependencyMode": dependency_mode,
+                "issueMappings": [],
+                "linkResults": [],
+                "linkCount": 0,
+                "dependencyChainComplete": (
+                    None
+                    if dependency_mode == JIRA_DEPENDENCY_MODE_NONE
+                    else True
+                ),
+                "skippedStories": [dict(story) for story in skipped_stories],
+                "blockedStories": [dict(story) for story in blocked_stories],
+                "partialStoriesAdjusted": [
+                    dict(story) for story in partial_stories_adjusted
+                ],
+            },
+        },
+    )
+
 def _unpublished_handoff_reason(
     *,
     previous_outputs: Mapping[str, Any],
@@ -1895,6 +1963,9 @@ async def create_jira_issues_from_stories(
     )
     breakdown_source_path = _breakdown_source_path(raw_story_payload)
     stories = _coerce_story_payload(raw_story_payload)
+    artifact_ref_was_read = False
+    artifact_payload_had_explicit_empty_stories = False
+    artifact_ref = ""
     if not stories:
         artifact_ref = _string(
             inputs.get("storyBreakdownArtifactRef")
@@ -1928,6 +1999,10 @@ async def create_jira_issues_from_stories(
                         parsed_payload = artifact_payload
                 breakdown_source_path = _breakdown_source_path(parsed_payload)
                 stories = _coerce_story_payload(parsed_payload)
+                artifact_ref_was_read = True
+                artifact_payload_had_explicit_empty_stories = (
+                    _has_explicit_empty_story_list(parsed_payload)
+                )
             except Exception as exc:
                 if fallback_for_missing_stories:
                     return _fallback_result(
@@ -1939,6 +2014,22 @@ async def create_jira_issues_from_stories(
                         dependency_mode=dependency_mode,
                     )
                 raise
+    if (
+        not stories
+        and artifact_ref_was_read
+        and artifact_payload_had_explicit_empty_stories
+    ):
+        return _jira_noop_result(
+            original_story_count=0,
+            dependency_mode=dependency_mode,
+            story_breakdown_artifact_ref=artifact_ref,
+            story_breakdown_path=_string(
+                inputs.get("storyBreakdownPath")
+                or story_output.get("storyBreakdownPath")
+                or previous_outputs.get("storyBreakdownPath")
+                or previous_story_output.get("storyBreakdownPath")
+            ),
+        )
     if not stories:
         repo = _string(inputs.get("repository") or inputs.get("repo"))
         ref = _string(
@@ -2019,37 +2110,12 @@ async def create_jira_issues_from_stories(
         partial_stories_adjusted,
     ) = _reconcile_stories_for_jira_creation(stories)
     if not stories:
-        return ToolResult(
-            status="COMPLETED",
-            outputs={
-                "storyOutput": {
-                    "mode": "jira",
-                    "status": "jira_noop",
-                    "storyCount": original_story_count,
-                    "eligibleStoryCount": 0,
-                    "createdCount": 0,
-                    "dependencyMode": dependency_mode,
-                    "skippedStories": skipped_stories,
-                    "blockedStories": blocked_stories,
-                    "partialStoriesAdjusted": partial_stories_adjusted,
-                },
-                "jira": {
-                    "createdCount": 0,
-                    "createdIssues": [],
-                    "dependencyMode": dependency_mode,
-                    "issueMappings": [],
-                    "linkResults": [],
-                    "linkCount": 0,
-                    "dependencyChainComplete": (
-                        None
-                        if dependency_mode == JIRA_DEPENDENCY_MODE_NONE
-                        else True
-                    ),
-                    "skippedStories": skipped_stories,
-                    "blockedStories": blocked_stories,
-                    "partialStoriesAdjusted": partial_stories_adjusted,
-                },
-            },
+        return _jira_noop_result(
+            original_story_count=original_story_count,
+            dependency_mode=dependency_mode,
+            skipped_stories=skipped_stories,
+            blocked_stories=blocked_stories,
+            partial_stories_adjusted=partial_stories_adjusted,
         )
 
     if not project_key:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -521,7 +521,12 @@ def _has_explicit_empty_story_list(value: Any) -> bool:
         for key in ("stories", "userStories", "user_stories", "items", "issues"):
             if key not in value:
                 continue
-            return not _list(value.get(key))
+            stories_value = value.get(key)
+            return (
+                isinstance(stories_value, Sequence)
+                and not isinstance(stories_value, (str, bytes, bytearray))
+                and len(stories_value) == 0
+            )
         return False
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return len(value) == 0

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -607,6 +607,66 @@ async def test_create_jira_issues_reads_story_artifact_ref_from_previous_outputs
     assert service.requests[0].summary == "Create previous-output artifact Jira story"
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_noops_for_empty_previous_story_artifact():
+    service = _FakeJiraService()
+    breakdown = {
+        "source": {"referencePath": "docs/Designs/RuntimeTypes.md"},
+        "stories": [],
+        "reconciliation": {"status": "no_stories_to_reconcile"},
+    }
+    fetch_calls: list[tuple[str, str, str]] = []
+    artifact_reads: list[str] = []
+
+    async def artifact_reader(ref: str) -> bytes:
+        artifact_reads.append(ref)
+        return json.dumps(breakdown).encode("utf-8")
+
+    async def fetcher(repo: str, ref: str, path: str) -> str:
+        fetch_calls.append((repo, ref, path))
+        raise AssertionError("repo fetch should not run when artifact ref is present")
+
+    result = await create_jira_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "breakdown-branch",
+            "storyBreakdownPath": "artifacts/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "handoff": "artifact",
+                "requiresStoryBreakdownArtifactRef": True,
+                "fallback": "fail",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            },
+        },
+        {
+            "previousOutputs": {
+                "storyOutput": {
+                    "storyBreakdownArtifactRef": "art_empty_story_breakdown",
+                }
+            }
+        },
+        jira_service_factory=lambda: service,
+        story_fetcher=fetcher,
+        artifact_reader=artifact_reader,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_noop"
+    assert result.outputs["storyOutput"]["storyCount"] == 0
+    assert result.outputs["storyOutput"]["createdCount"] == 0
+    assert (
+        result.outputs["storyOutput"]["storyBreakdownArtifactRef"]
+        == "art_empty_story_breakdown"
+    )
+    assert result.outputs["jira"]["issueMappings"] == []
+    assert artifact_reads == ["art_empty_story_breakdown"]
+    assert fetch_calls == []
+    assert service.requests == []
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_reads_previous_outputs_from_tool_inputs():
     service = _FakeJiraService()
     breakdown = {

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -666,6 +666,73 @@ async def test_create_jira_issues_noops_for_empty_previous_story_artifact():
     assert fetch_calls == []
     assert service.requests == []
 
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"stories": []}, True),
+        ({"userStories": []}, True),
+        ([], True),
+        ({"stories": None}, False),
+        ({"stories": "some description string"}, False),
+        ({"stories": {"summary": "Not a list"}}, False),
+        ({"stories": 1}, False),
+        ('{"stories": []}', True),
+        ('{"stories": "some description string"}', False),
+        ("not json", False),
+    ],
+)
+def test_has_explicit_empty_story_list_requires_empty_sequence(
+    payload: Any,
+    expected: bool,
+):
+    assert story_tools._has_explicit_empty_story_list(payload) is expected
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "breakdown",
+    [
+        {"stories": None},
+        {"stories": "some description string"},
+        {"stories": {"summary": "Not a list"}},
+        {"stories": 1},
+    ],
+)
+async def test_create_jira_issues_rejects_malformed_empty_story_artifact_payload(
+    breakdown: dict[str, Any],
+):
+    service = _FakeJiraService()
+    artifact_reads: list[str] = []
+
+    async def artifact_reader(ref: str) -> bytes:
+        artifact_reads.append(ref)
+        return json.dumps(breakdown).encode("utf-8")
+
+    with pytest.raises(ValueError, match="No stories were available"):
+        await create_jira_issues_from_stories(
+            {
+                "storyOutput": {
+                    "mode": "jira",
+                    "fallback": "fail",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeName": "Story",
+                    },
+                },
+            },
+            {
+                "previousOutputs": {
+                    "storyOutput": {
+                        "storyBreakdownArtifactRef": "art_malformed_story_breakdown",
+                    }
+                }
+            },
+            jira_service_factory=lambda: service,
+            artifact_reader=artifact_reader,
+        )
+
+    assert artifact_reads == ["art_malformed_story_breakdown"]
+    assert service.requests == []
+
 @pytest.mark.asyncio
 async def test_create_jira_issues_reads_previous_outputs_from_tool_inputs():
     service = _FakeJiraService()


### PR DESCRIPTION
## Summary

- Treat successfully read artifact-backed empty story breakdowns as a Jira no-op instead of falling through to repository fallback.
- Centralize the Jira no-op result shape for empty eligible story sets.
- Add a regression test for previous-output artifact refs whose payload contains an explicit empty `stories` list.

## Root Cause

A failed workflow had a durable `storyBreakdownArtifactRef`, but the artifact payload contained `stories: []`. `story.create_jira_issues` read the artifact, found no stories, and then continued into the missing-artifact/repo-fallback branch. That produced a misleading failure saying no artifact reference had been provided.

## Validation

- `pytest tests/unit/workflows/temporal/test_story_output_tools.py -q` -> `76 passed`
- `python3 -m py_compile moonmind/workflows/temporal/story_output_tools.py`
- `./tools/test_unit.sh` -> Python: `7050 passed, 6 skipped, 1 xpassed`; UI: `29 passed`, `471 passed`
- Restarted `temporal-worker-integrations`; health check returned `healthy`
- In-container smoke check returned `jira_noop 0 art_empty`