### PR TITLE
If any skills or presets currently refer to a Code Review status or column in Jira, change it to simply Review

### DIFF
--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -155,7 +155,7 @@ steps:
     inputs.issue_provider }} issue {{ inputs.issue_ref }} to Done automatically. If
     the runtime instructions, task parameters, authentication, remote configuration,
     branch protection, or repository permissions prevent committing, pushing, or creating
-    the pull request in this step, stop before changing Jira to Code Review and report
+    the pull request in this step, stop before changing Jira to Review and report
     the exact blocker.
 
 

--- a/api_service/data/presets/jira-implement.yaml
+++ b/api_service/data/presets/jira-implement.yaml
@@ -3,7 +3,7 @@ title: Jira Implement
 description: Move a Jira issue through implementation by first assessing the current
   state of the branch against the issue. If the issue is already fully implemented,
   advance it directly to Done. Otherwise, finish any partial work, create a PR, and
-  advance the issue to Code Review. When PR merge automation is enabled the issue
+  advance the issue to Review. When PR merge automation is enabled the issue
   advances to Done automatically after merge.
 scope: global
 version: 1.1.0
@@ -222,11 +222,11 @@ steps:
 
 
     - Otherwise (the initial verdict was PARTIALLY_IMPLEMENTED or NOT_IMPLEMENTED),
-    transition Jira issue {{ inputs.jira_issue_key }} to status Code Review only after
+    transition Jira issue {{ inputs.jira_issue_key }} to status Review only after
     the pull request exists. Read the previous pull request creation result or artifacts/jira-implement-pr.json
     and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key
     }}. If no confirmed pull request URL is available, stop without changing Jira
-    and report that Code Review is blocked until PR creation succeeds. Add or preserve
+    and report that Review is blocked until PR creation succeeds. Add or preserve
     a Jira-visible reference to the pull request when supported by the trusted tools.
 
 
@@ -237,10 +237,10 @@ steps:
 
 
     Note: when this task was submitted with PR merge automation enabled and the work
-    followed the Code Review path, the parent workflow will transition Jira issue
+    followed the Review path, the parent workflow will transition Jira issue
     {{ inputs.jira_issue_key }} to Done automatically after the pull request merges.
     This in-task step only owns the explicit Done transition for the already-implemented
-    case and the Code Review transition for the freshly-implemented case.'
+    case and the Review transition for the freshly-implemented case.'
   skill:
     id: jira-issue-updater
     requiredCapabilities:

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -1,6 +1,6 @@
 slug: jira-orchestrate
 title: Jira Orchestrate
-description: Move a Jira issue through implementation by using its preset brief as the MoonSpec orchestration input, creating a PR, and advancing the issue to Code Review.
+description: Move a Jira issue through implementation by using its preset brief as the MoonSpec orchestration input, creating a PR, and advancing the issue to Review.
 scope: global
 version: 1.0.0
 tags:
@@ -474,7 +474,7 @@ steps:
 
       Before committing, inspect the latest post-remediation moonspec-verify result and confirm the verdict is FULLY_IMPLEMENTED. If the latest verdict is ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, FAILED_UNRECOVERABLE, or ENVIRONMENT_CONTAMINATED_BY_SKILL_PROJECTION, stop without committing, pushing, creating a pull request, or changing Jira. Classify runtime or infrastructure causes as environment failure.
 
-      This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Code Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
+      This Jira Orchestrate handoff step is the explicit PR-publication step for this preset. It intentionally owns pull request creation before the Jira Review transition so the confirmed pull request URL is available to both Jira and MoonMind publish handling. If generic managed-runtime guidance says not to push or create a pull request, treat this step-specific handoff instruction as the controlling instruction for this step only. If the task is submitted with PR merge automation enabled, the parent workflow must use the pull request URL produced by this step as the published PR and then run merge automation against that PR. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Review and report the exact blocker.
 
       First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a non-draft pull request with the available authenticated GitHub tooling.
 
@@ -496,15 +496,15 @@ steps:
       args: {}
       requiredCapabilities:
         - git
-  - title: Move Jira issue to Code Review
+  - title: Move Jira issue to Review
     annotations:
       jiraOrchestrateRole: code-review-handoff
     instructions: |-
-      Change Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists.
+      Change Jira issue {{ inputs.jira_issue_key }} to status Review only after the pull request exists.
 
-      Before using any Jira transition tool, read the previous pull request creation result or artifacts/jira-orchestrate-pr.json and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key }}. If no confirmed pull request URL is available, stop without changing Jira and report that Code Review is blocked until PR creation succeeds.
+      Before using any Jira transition tool, read the previous pull request creation result or artifacts/jira-orchestrate-pr.json and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key }}. If no confirmed pull request URL is available, stop without changing Jira and report that Review is blocked until PR creation succeeds.
 
-      Use the trusted Jira issue updater workflow and Jira transition tools. Match Code Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
+      Use the trusted Jira issue updater workflow and Jira transition tools. Match Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
     skill:
       id: jira-issue-updater
       requiredCapabilities:

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -196,13 +196,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         code_review_step = next(
             step
             for step in jira_orchestrate_template.latest_version.steps
-            if step["title"] == "Move Jira issue to Code Review"
+            if step["title"] == "Move Jira issue to Review"
         )
         assert code_review_step == jira_orchestrate_template.latest_version.steps[-1]
         assert code_review_step["annotations"] == {
             "jiraOrchestrateRole": "code-review-handoff"
         }
-        assert "Code Review" in code_review_step["instructions"]
+        assert "status Review" in code_review_step["instructions"]
         assert "pull_request_url" in code_review_step["instructions"]
 
         result = await session.execute(
@@ -331,7 +331,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert implement_finalize_step["title"] == "Finalize Jira status"
         assert implement_finalize_step["skill"]["id"] == "jira-issue-updater"
         assert "Done" in implement_finalize_step["instructions"]
-        assert "Code Review" in implement_finalize_step["instructions"]
+        assert "status Review" in implement_finalize_step["instructions"]
         assert "pull_request_url" in implement_finalize_step["instructions"]
         assert (
             "FULLY_IMPLEMENTED" in implement_finalize_step["instructions"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2540,7 +2540,7 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "stop without changing Jira" in expanded["steps"][25][
                 "instructions"
             ]
-            assert "Code Review" in expanded["steps"][25]["instructions"]
+            assert "status Review" in expanded["steps"][25]["instructions"]
             assert all(
                 step["title"] != "Return Jira orchestration report"
                 for step in expanded["steps"]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1936,7 +1936,7 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert task["steps"][23]["title"] == "Reconcile declarative docs"
     assert task["steps"][23]["skill"]["id"] == "moonspec-doc-reconcile"
     assert task["steps"][24]["title"] == "Create pull request"
-    assert task["steps"][25]["title"] == "Move Jira issue to Code Review"
+    assert task["steps"][25]["title"] == "Move Jira issue to Review"
     assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
     assert len(task["appliedStepTemplates"][0]["stepIds"]) == 26
     assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"


### PR DESCRIPTION
If any skills or presets currently refer to a Code Review status or column in Jira, change it to simply Review