### PR TITLE
MM-896 Add recurring schedule detail editing

### DIFF
--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -80,7 +80,7 @@ const detailPayload: BootPayload = {
   },
 };
 
-function mockScheduleDetailFetch(fetchSpy: MockInstance, overrides: Partial<typeof detailSchedule> = {}) {
+function mockScheduleDetailFetch(fetchSpy: MockInstance, overrides: Record<string, unknown> = {}) {
   const schedule = { ...detailSchedule, ...overrides };
   fetchSpy.mockImplementation(async (input, init) => {
     const url = String(input);
@@ -337,13 +337,14 @@ describe("SchedulesPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
 
     await waitFor(() => {
-      expect(
-        fetchSpy.mock.calls.some(([url, init]) => (
-          String(url) === "/console/schedules/schedule-alpha"
-          && String(init?.method || "GET").toUpperCase() === "PATCH"
-          && String(init?.body || "").includes("Nightly detail sweep updated")
-        )),
-      ).toBe(true);
+      const updateCall = fetchSpy.mock.calls.find(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      ));
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(String(updateCall?.[1]?.body || "{}"))).toEqual({
+        name: "Nightly detail sweep updated",
+      });
     });
     expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
   });
@@ -364,7 +365,92 @@ describe("SchedulesPage", () => {
         && String(init?.method || "GET").toUpperCase() === "PATCH"
       ));
       expect(updateCall).toBeDefined();
-      expect(JSON.parse(String(updateCall?.[1]?.body || "{}")).description).toBe("");
+      expect(JSON.parse(String(updateCall?.[1]?.body || "{}"))).toEqual({
+        description: "",
+      });
+    });
+  });
+
+  it("edits policy and target workflow parameters through the backend update contract", async () => {
+    mockScheduleDetailFetch(fetchSpy, {
+      target: {
+        workflowType: "MoonMind.WorkflowExecution",
+        initialParameters: {
+          repository: "MoonLadderStudios/MoonMind",
+          branch: "main",
+        },
+      },
+      policy: {
+        overlap: { mode: "skip", maxConcurrentRuns: 1 },
+        catchup: { mode: "last", maxBackfill: 3 },
+        jitterSeconds: 0,
+      },
+    });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Overlap Policy"), { target: { value: "buffer_one" } });
+    fireEvent.change(screen.getByLabelText("Catchup Policy"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Jitter Seconds"), { target: { value: "45" } });
+    fireEvent.change(screen.getByLabelText("Target Workflow Parameters"), {
+      target: {
+        value: JSON.stringify({
+          workflowType: "MoonMind.WorkflowExecution",
+          initialParameters: {
+            repository: "MoonLadderStudios/MoonMind",
+            branch: "release",
+          },
+        }, null, 2),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    await waitFor(() => {
+      const updateCall = fetchSpy.mock.calls.find(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      ));
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(String(updateCall?.[1]?.body || "{}"))).toEqual({
+        policy: {
+          overlap: { mode: "buffer_one", maxConcurrentRuns: 1 },
+          catchup: { mode: "all", maxBackfill: 3 },
+          jitterSeconds: 45,
+        },
+        target: {
+          workflowType: "MoonMind.WorkflowExecution",
+          initialParameters: {
+            repository: "MoonLadderStudios/MoonMind",
+            branch: "release",
+          },
+        },
+      });
+    });
+  });
+
+  it("shows immediate cron and timezone feedback and blocks invalid saves", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Cron"), { target: { value: "bad cron" } });
+    fireEvent.change(screen.getByLabelText("Timezone"), { target: { value: "Mars/Base" } });
+
+    expect(await screen.findByText("Cron must contain exactly 5 fields.")).not.toBeNull();
+    expect(screen.getByText("Timezone 'Mars/Base' is invalid.")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url, init]) => (
+          String(url) === "/console/schedules/schedule-alpha"
+          && String(init?.method || "GET").toUpperCase() === "PATCH"
+        )),
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -35,7 +35,7 @@ const detailSchedule = {
   },
   policy: {
     overlap: { mode: "skip" },
-    catchup: { mode: "latest" },
+    catchup: { mode: "last" },
   },
   version: 1,
   createdAt: "2026-06-20T00:00:00Z",
@@ -430,7 +430,7 @@ describe("SchedulesPage", () => {
     });
   });
 
-  it("shows immediate cron and timezone feedback and blocks invalid saves", async () => {
+  it("shows submitted cron and timezone feedback and blocks invalid saves", async () => {
     mockScheduleDetailFetch(fetchSpy);
 
     renderWithClient(<SchedulesPage payload={detailPayload} />);
@@ -440,10 +440,12 @@ describe("SchedulesPage", () => {
     fireEvent.change(screen.getByLabelText("Cron"), { target: { value: "bad cron" } });
     fireEvent.change(screen.getByLabelText("Timezone"), { target: { value: "Mars/Base" } });
 
-    expect(await screen.findByText("Cron must contain exactly 5 fields.")).not.toBeNull();
-    expect(screen.getByText("Timezone 'Mars/Base' is invalid.")).not.toBeNull();
+    expect(screen.queryByText("Cron must contain exactly 5 fields.")).toBeNull();
+    expect(screen.queryByText("Timezone 'Mars/Base' is invalid.")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+    expect(await screen.findByText("Cron must contain exactly 5 fields.")).not.toBeNull();
+    expect(screen.getByText("Timezone 'Mars/Base' is invalid.")).not.toBeNull();
     await waitFor(() => {
       expect(
         fetchSpy.mock.calls.some(([url, init]) => (
@@ -452,6 +454,89 @@ describe("SchedulesPage", () => {
         )),
       ).toBe(false);
     });
+  });
+
+  it("does not patch when saving an unchanged schedule", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Save schedule" })).toBeNull();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      )),
+    ).toBe(false);
+  });
+
+  it("does not patch target values when only JSON object key order changes", async () => {
+    mockScheduleDetailFetch(fetchSpy, {
+      target: {
+        workflowType: "MoonMind.WorkflowExecution",
+        initialParameters: {
+          repository: "MoonLadderStudios/MoonMind",
+          branch: "main",
+        },
+      },
+    });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Target Workflow Parameters"), {
+      target: {
+        value: JSON.stringify({
+          initialParameters: {
+            branch: "main",
+            repository: "MoonLadderStudios/MoonMind",
+          },
+          workflowType: "MoonMind.WorkflowExecution",
+        }, null, 2),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Save schedule" })).toBeNull();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      )),
+    ).toBe(false);
+  });
+
+  it("blocks editing unsupported catchup modes instead of rewriting them", async () => {
+    mockScheduleDetailFetch(fetchSpy, {
+      policy: {
+        overlap: { mode: "skip" },
+        catchup: { mode: "latest" },
+      },
+    });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Jitter Seconds"), { target: { value: "30" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
+
+    expect(await screen.findByText("Catchup policy 'latest' is not supported for editing.")).not.toBeNull();
+    expect(
+      fetchSpy.mock.calls.some(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+      )),
+    ).toBe(false);
   });
 
   it("reports update and run failures separately", async () => {
@@ -477,6 +562,7 @@ describe("SchedulesPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Nightly detail sweep updated" } });
     fireEvent.click(screen.getByRole("button", { name: "Save schedule" }));
     fireEvent.click(screen.getByRole("button", { name: "Run now" }));
 

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -249,6 +249,8 @@ type ScheduleEditForm = {
   targetJson: string;
 };
 
+const SUPPORTED_CATCHUP_MODES = new Set(['none', 'last', 'all']);
+
 function editFormFromSchedule(schedule: Schedule): ScheduleEditForm {
   const overlap = schedule.policy?.overlap;
   const catchup = schedule.policy?.catchup;
@@ -265,7 +267,7 @@ function editFormFromSchedule(schedule: Schedule): ScheduleEditForm {
     overlapMode: overlap && typeof overlap === 'object' && 'mode' in overlap
       ? String((overlap as { mode?: unknown }).mode || 'skip')
       : 'skip',
-    catchupMode: catchupMode === 'latest' ? 'last' : catchupMode,
+    catchupMode,
     jitterSeconds: typeof jitterSeconds === 'number' || typeof jitterSeconds === 'string'
       ? String(jitterSeconds)
       : '0',
@@ -374,6 +376,9 @@ function validateScheduleEditForm(form: ScheduleEditForm): ScheduleEditErrors {
   if (!Number.isInteger(jitter) || jitter < 0) {
     errors.jitterSeconds = 'Jitter seconds must be a non-negative integer.';
   }
+  if (!SUPPORTED_CATCHUP_MODES.has(form.catchupMode)) {
+    errors.catchupMode = `Catchup policy '${form.catchupMode}' is not supported for editing.`;
+  }
   const targetResult = parseTargetJson(form.targetJson);
   if (targetResult.error) {
     errors.targetJson = targetResult.error;
@@ -386,7 +391,17 @@ function hasFormErrors(errors: ScheduleEditErrors): boolean {
 }
 
 function stableJson(value: unknown): string {
-  return JSON.stringify(value);
+  return JSON.stringify(value, (_, candidate) => {
+    if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      return Object.keys(candidate as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((result, key) => {
+          result[key] = (candidate as Record<string, unknown>)[key];
+          return result;
+        }, {});
+    }
+    return candidate;
+  });
 }
 
 function buildPolicyPayload(schedule: Schedule, form: ScheduleEditForm): Record<string, unknown> {
@@ -510,8 +525,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   };
 
   const updateMutation = useMutation({
-    mutationFn: async ({ form, schedule }: { form: ScheduleEditForm; schedule: Schedule }) => {
-      const patchPayload = buildSchedulePatchPayload(schedule, form);
+    mutationFn: async ({ patchPayload }: { patchPayload: Record<string, unknown> }) => {
       const response = await fetch(updateEndpoint, {
         method: 'PATCH',
         credentials: 'include',
@@ -551,8 +565,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   const schedule = detailQuery.data;
   const runs = runsQuery.data?.items || [];
   const currentForm = editForm || (schedule ? editFormFromSchedule(schedule) : null);
-  const formErrors = currentForm ? validateScheduleEditForm(currentForm) : {};
-  const visibleFormErrors = { ...submitErrors, ...formErrors };
+  const visibleFormErrors = submitErrors;
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -562,7 +575,12 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
       if (hasFormErrors(errors)) {
         return;
       }
-      updateMutation.mutate({ form: currentForm, schedule });
+      const patchPayload = buildSchedulePatchPayload(schedule, currentForm);
+      if (Object.keys(patchPayload).length === 0) {
+        setIsEditing(false);
+        return;
+      }
+      updateMutation.mutate({ patchPayload });
     }
   };
 
@@ -740,12 +758,15 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   onChange={(event) => {
                     const value = event.currentTarget.value;
                     setEditForm((previous) => previous ? { ...previous, catchupMode: value } : null);
+                    setSubmitErrors((previous) => ({ ...previous, catchupMode: undefined }));
                   }}
+                  aria-invalid={Boolean(visibleFormErrors.catchupMode)}
                 >
                   <option value="none">Do not catch up</option>
                   <option value="last">Run latest missed occurrence</option>
                   <option value="all">Run all missed occurrences</option>
                 </select>
+                {visibleFormErrors.catchupMode && <span className="schedules-field-error">{visibleFormErrors.catchupMode}</span>}
               </label>
               <label>
                 <span>Jitter Seconds</span>

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -243,16 +243,217 @@ type ScheduleEditForm = {
   enabled: boolean;
   cron: string;
   timezone: string;
+  overlapMode: string;
+  catchupMode: string;
+  jitterSeconds: string;
+  targetJson: string;
 };
 
 function editFormFromSchedule(schedule: Schedule): ScheduleEditForm {
+  const overlap = schedule.policy?.overlap;
+  const catchup = schedule.policy?.catchup;
+  const jitterSeconds = schedule.policy?.jitterSeconds;
+  const catchupMode = catchup && typeof catchup === 'object' && 'mode' in catchup
+    ? String((catchup as { mode?: unknown }).mode || 'last')
+    : 'last';
   return {
     name: schedule.name,
     description: schedule.description || '',
     enabled: schedule.enabled,
     cron: schedule.cron,
     timezone: schedule.timezone,
+    overlapMode: overlap && typeof overlap === 'object' && 'mode' in overlap
+      ? String((overlap as { mode?: unknown }).mode || 'skip')
+      : 'skip',
+    catchupMode: catchupMode === 'latest' ? 'last' : catchupMode,
+    jitterSeconds: typeof jitterSeconds === 'number' || typeof jitterSeconds === 'string'
+      ? String(jitterSeconds)
+      : '0',
+    targetJson: JSON.stringify(schedule.target || {}, null, 2),
   };
+}
+
+type ScheduleEditErrors = Partial<Record<keyof ScheduleEditForm, string | undefined>>;
+
+function parseCronField(
+  raw: string,
+  min: number,
+  max: number,
+  fieldName: string,
+  allowSundaySeven = false,
+): string | null {
+  for (const part of raw.split(',')) {
+    const segment = part.trim();
+    if (!segment) {
+      return `${fieldName} contains an empty segment`;
+    }
+    const [rangePart, stepPart] = segment.split('/');
+    if (!rangePart || segment.split('/').length > 2) {
+      return `${fieldName} contains an invalid step`;
+    }
+    if (stepPart !== undefined) {
+      const step = Number(stepPart);
+      if (!Number.isInteger(step) || step <= 0) {
+        return `${fieldName} step must be a positive integer`;
+      }
+    }
+    const bounds = rangePart === '*' ? [String(min), String(max)] : rangePart.split('-');
+    if (bounds.length > 2 || !bounds[0] || !bounds[bounds.length - 1]) {
+      return `${fieldName} contains an invalid range`;
+    }
+    const start = Number(bounds[0]);
+    const end = Number(bounds[bounds.length - 1]);
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start > end) {
+      return `${fieldName} contains an invalid value`;
+    }
+    const normalizedStart = allowSundaySeven && start === 7 ? 0 : start;
+    const normalizedEnd = allowSundaySeven && end === 7 ? 0 : end;
+    if (
+      normalizedStart < min
+      || normalizedStart > max
+      || normalizedEnd < min
+      || normalizedEnd > max
+    ) {
+      return `${fieldName} value is out of range`;
+    }
+  }
+  return null;
+}
+
+function validateCronExpression(value: string): string | null {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  if (parts.length !== 5) {
+    return 'Cron must contain exactly 5 fields.';
+  }
+  return parseCronField(parts[0] || '', 0, 59, 'Minute')
+    || parseCronField(parts[1] || '', 0, 23, 'Hour')
+    || parseCronField(parts[2] || '', 1, 31, 'Day')
+    || parseCronField(parts[3] || '', 1, 12, 'Month')
+    || parseCronField(parts[4] || '', 0, 6, 'Weekday', true);
+}
+
+function validateTimezone(value: string): string | null {
+  const timezone = value.trim();
+  if (!timezone) {
+    return 'Timezone is required.';
+  }
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date());
+    return null;
+  } catch {
+    return `Timezone '${timezone}' is invalid.`;
+  }
+}
+
+function parseTargetJson(value: string): { value?: Record<string, unknown>; error?: string } {
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { error: 'Target must be a JSON object.' };
+    }
+    return { value: parsed as Record<string, unknown> };
+  } catch {
+    return { error: 'Target must be valid JSON.' };
+  }
+}
+
+function validateScheduleEditForm(form: ScheduleEditForm): ScheduleEditErrors {
+  const errors: ScheduleEditErrors = {};
+  if (!form.name.trim()) {
+    errors.name = 'Name is required.';
+  }
+  const cronError = validateCronExpression(form.cron);
+  if (cronError) {
+    errors.cron = cronError;
+  }
+  const timezoneError = validateTimezone(form.timezone);
+  if (timezoneError) {
+    errors.timezone = timezoneError;
+  }
+  const jitter = Number(form.jitterSeconds);
+  if (!Number.isInteger(jitter) || jitter < 0) {
+    errors.jitterSeconds = 'Jitter seconds must be a non-negative integer.';
+  }
+  const targetResult = parseTargetJson(form.targetJson);
+  if (targetResult.error) {
+    errors.targetJson = targetResult.error;
+  }
+  return errors;
+}
+
+function hasFormErrors(errors: ScheduleEditErrors): boolean {
+  return Object.values(errors).some(Boolean);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function buildPolicyPayload(schedule: Schedule, form: ScheduleEditForm): Record<string, unknown> {
+  const policy = { ...(schedule.policy || {}) };
+  const overlap = policy.overlap && typeof policy.overlap === 'object'
+    ? { ...(policy.overlap as Record<string, unknown>) }
+    : {};
+  overlap.mode = form.overlapMode;
+  policy.overlap = overlap;
+  const catchup = policy.catchup && typeof policy.catchup === 'object'
+    ? { ...(policy.catchup as Record<string, unknown>) }
+    : {};
+  catchup.mode = form.catchupMode;
+  policy.catchup = catchup;
+  policy.jitterSeconds = Number(form.jitterSeconds);
+  return policy;
+}
+
+function buildSchedulePatchPayload(schedule: Schedule, form: ScheduleEditForm): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (form.name !== schedule.name) {
+    payload.name = form.name;
+  }
+  if (form.description !== (schedule.description || '')) {
+    payload.description = form.description;
+  }
+  if (form.enabled !== schedule.enabled) {
+    payload.enabled = form.enabled;
+  }
+  if (form.cron !== schedule.cron) {
+    payload.cron = form.cron;
+  }
+  if (form.timezone !== schedule.timezone) {
+    payload.timezone = form.timezone;
+  }
+  const initialForm = editFormFromSchedule(schedule);
+  if (
+    form.overlapMode !== initialForm.overlapMode
+    || form.catchupMode !== initialForm.catchupMode
+    || form.jitterSeconds !== initialForm.jitterSeconds
+  ) {
+    payload.policy = buildPolicyPayload(schedule, form);
+  }
+  const target = parseTargetJson(form.targetJson).value || {};
+  if (stableJson(target) !== stableJson(schedule.target || {})) {
+    payload.target = target;
+  }
+  return payload;
+}
+
+async function responseErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = await response.json();
+    const detail = body?.detail;
+    if (typeof detail === 'string' && detail.trim()) {
+      return detail;
+    }
+    if (detail && typeof detail === 'object') {
+      const message = detail.message || detail.error;
+      if (typeof message === 'string' && message.trim()) {
+        return message;
+      }
+    }
+  } catch {
+    // Ignore malformed error bodies and use the status text below.
+  }
+  return `${fallback}: ${response.statusText}`;
 }
 
 function isDueSoon(schedule: Schedule, now: number): boolean {
@@ -267,6 +468,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
+  const [submitErrors, setSubmitErrors] = useState<ScheduleEditErrors>({});
   const detailEndpoint = useMemo(() => scheduleEndpoint(payload, 'detail', definitionId), [payload, definitionId]);
   const updateEndpoint = useMemo(() => scheduleEndpoint(payload, 'update', definitionId), [payload, definitionId]);
   const runNowEndpoint = useMemo(() => scheduleEndpoint(payload, 'runNow', definitionId), [payload, definitionId]);
@@ -308,27 +510,23 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   };
 
   const updateMutation = useMutation({
-    mutationFn: async (form: ScheduleEditForm) => {
+    mutationFn: async ({ form, schedule }: { form: ScheduleEditForm; schedule: Schedule }) => {
+      const patchPayload = buildSchedulePatchPayload(schedule, form);
       const response = await fetch(updateEndpoint, {
         method: 'PATCH',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          name: form.name,
-          description: form.description,
-          enabled: form.enabled,
-          cron: form.cron,
-          timezone: form.timezone,
-        }),
+        body: JSON.stringify(patchPayload),
       });
       if (!response.ok) {
-        throw new Error(`Failed to update schedule: ${response.statusText}`);
+        throw new Error(await responseErrorMessage(response, 'Failed to update schedule'));
       }
       return ScheduleSchema.parse(await response.json());
     },
     onSuccess: async (updated) => {
       queryClient.setQueryData(['schedule-detail', definitionId, detailEndpoint], updated);
       setEditForm(editFormFromSchedule(updated));
+      setSubmitErrors({});
       setIsEditing(false);
       await refreshDetail();
     },
@@ -341,7 +539,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         credentials: 'include',
       });
       if (!response.ok) {
-        throw new Error(`Failed to run schedule: ${response.statusText}`);
+        throw new Error(await responseErrorMessage(response, 'Failed to run schedule'));
       }
       return ScheduleRunSchema.parse(await response.json());
     },
@@ -353,11 +551,18 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   const schedule = detailQuery.data;
   const runs = runsQuery.data?.items || [];
   const currentForm = editForm || (schedule ? editFormFromSchedule(schedule) : null);
+  const formErrors = currentForm ? validateScheduleEditForm(currentForm) : {};
+  const visibleFormErrors = { ...submitErrors, ...formErrors };
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (currentForm) {
-      updateMutation.mutate(currentForm);
+    if (currentForm && schedule) {
+      const errors = validateScheduleEditForm(currentForm);
+      setSubmitErrors(errors);
+      if (hasFormErrors(errors)) {
+        return;
+      }
+      updateMutation.mutate({ form: currentForm, schedule });
     }
   };
 
@@ -408,6 +613,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
             className="secondary"
             onClick={() => {
               setEditForm(editFormFromSchedule(schedule));
+              setSubmitErrors({});
               setIsEditing((value) => !value);
             }}
           >
@@ -471,6 +677,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   }}
                   required
                 />
+                {visibleFormErrors.name && <span className="schedules-field-error">{visibleFormErrors.name}</span>}
               </label>
               <label>
                 <span>Description</span>
@@ -490,9 +697,12 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   onChange={(event) => {
                     const value = event.currentTarget.value;
                     setEditForm((previous) => previous ? { ...previous, cron: value } : null);
+                    setSubmitErrors((previous) => ({ ...previous, cron: undefined }));
                   }}
                   required
+                  aria-invalid={Boolean(visibleFormErrors.cron)}
                 />
+                {visibleFormErrors.cron && <span className="schedules-field-error">{visibleFormErrors.cron}</span>}
               </label>
               <label>
                 <span>Timezone</span>
@@ -501,9 +711,72 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   onChange={(event) => {
                     const value = event.currentTarget.value;
                     setEditForm((previous) => previous ? { ...previous, timezone: value } : null);
+                    setSubmitErrors((previous) => ({ ...previous, timezone: undefined }));
                   }}
                   required
+                  aria-invalid={Boolean(visibleFormErrors.timezone)}
                 />
+                {visibleFormErrors.timezone && <span className="schedules-field-error">{visibleFormErrors.timezone}</span>}
+              </label>
+              <label>
+                <span>Overlap Policy</span>
+                <select
+                  value={currentForm.overlapMode}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, overlapMode: value } : null);
+                  }}
+                >
+                  <option value="skip">Skip overlapping run</option>
+                  <option value="allow">Allow overlapping runs</option>
+                  <option value="buffer_one">Buffer one run</option>
+                  <option value="cancel_previous">Cancel previous run</option>
+                </select>
+              </label>
+              <label>
+                <span>Catchup Policy</span>
+                <select
+                  value={currentForm.catchupMode}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, catchupMode: value } : null);
+                  }}
+                >
+                  <option value="none">Do not catch up</option>
+                  <option value="last">Run latest missed occurrence</option>
+                  <option value="all">Run all missed occurrences</option>
+                </select>
+              </label>
+              <label>
+                <span>Jitter Seconds</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={currentForm.jitterSeconds}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, jitterSeconds: value } : null);
+                    setSubmitErrors((previous) => ({ ...previous, jitterSeconds: undefined }));
+                  }}
+                  aria-invalid={Boolean(visibleFormErrors.jitterSeconds)}
+                />
+                {visibleFormErrors.jitterSeconds && <span className="schedules-field-error">{visibleFormErrors.jitterSeconds}</span>}
+              </label>
+              <label>
+                <span>Target Workflow Parameters</span>
+                <textarea
+                  value={currentForm.targetJson}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    setEditForm((previous) => previous ? { ...previous, targetJson: value } : null);
+                    setSubmitErrors((previous) => ({ ...previous, targetJson: undefined }));
+                  }}
+                  rows={9}
+                  spellCheck={false}
+                  aria-invalid={Boolean(visibleFormErrors.targetJson)}
+                />
+                {visibleFormErrors.targetJson && <span className="schedules-field-error">{visibleFormErrors.targetJson}</span>}
               </label>
               <label className="schedules-checkbox-label">
                 <input
@@ -525,6 +798,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   className="secondary"
                   onClick={() => {
                     setEditForm(editFormFromSchedule(schedule));
+                    setSubmitErrors({});
                     setIsEditing(false);
                   }}
                 >

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1300,6 +1300,7 @@ h1 {
 }
 
 .schedules-edit-form input,
+.schedules-edit-form select,
 .schedules-edit-form textarea {
   width: 100%;
   border: 1px solid rgb(var(--mm-border));
@@ -1307,6 +1308,17 @@ h1 {
   background: rgb(var(--mm-panel));
   color: rgb(var(--mm-ink));
   font: inherit;
+}
+
+.schedules-edit-form input[aria-invalid="true"],
+.schedules-edit-form textarea[aria-invalid="true"] {
+  border-color: rgb(var(--mm-danger) / 0.78);
+}
+
+.schedules-field-error {
+  color: color-mix(in srgb, rgb(var(--mm-danger)) 76%, rgb(var(--mm-ink)) 24%);
+  font-size: 0.78rem;
+  font-weight: 640;
 }
 
 .schedules-checkbox-label {


### PR DESCRIPTION
Issue reference: MM-896

Summary:
- Added recurring schedule detail editing controls for policy, jitter, and backend-supported target workflow parameters.
- Added client-side cron/timezone validation and changed-field PATCH payload construction.
- Refetches schedule detail and run history after successful save while keeping users on the detail page.
- Added regression coverage for the schedule edit flow and validation behavior.

Tests run:
- `node node_modules/typescript/bin/tsc --noEmit -p frontend/tsconfig.json`
- Attempted `npm run ui:test -- frontend/src/entrypoints/schedules.test.tsx` after `npm ci --no-fund --no-audit`; blocked because the npm script could not resolve `vitest` from the generated bin shim in this container.
- Attempted direct `node node_modules/vitest/vitest.mjs run --config frontend/vite.config.ts src/entrypoints/schedules.test.tsx`; Vitest launched but failed resolving the test module as `/frontend/src/entrypoints/schedules.test.tsx` in this workspace.

Remaining risks:
- Focused Vitest execution could not complete in this managed workspace due local test harness/module-resolution issues, so CI should provide the authoritative UI test result.
