### PR TITLE
MM-906: Provide concise reusable viewpoint templates/examples

### DIFF
--- a/docs/DocumentationArchitecture.md
+++ b/docs/DocumentationArchitecture.md
@@ -1,0 +1,66 @@
+# MoonSpec Documentation Architecture Standard
+
+**Status:** Active
+**Document Class:** Canonical declarative
+**Owner:** MoonMind Engineering
+**Last Updated:** 2026-06-24
+**Audience:** Anyone authoring or reviewing documentation under `docs/`
+**Related:** `.specify/memory/constitution.md` (Principles XII, XV), `docs/Workflows/MoonSpecDocumentModel.md`
+**Source:** MM-900 (Implement MoonSpec Documentation Architecture Standard); template deliverable tracked by MM-906
+
+This standard defines the **viewpoints** MoonMind documentation is written against and the **metadata headers** every document must carry. It complements `docs/Workflows/MoonSpecDocumentModel.md`, which defines the underlying document classes (canonical declarative, temporary execution artifact, imperative working document) and their precedence rules — this standard does not restate those rules.
+
+## Viewpoints
+
+A *viewpoint* answers one question about the system at one altitude. Pick the single viewpoint that matches what you are documenting; do not blend them in one file.
+
+| Viewpoint | Answers | Document class | Header |
+|-----------|---------|----------------|--------|
+| **System Architecture View** | How do the major components fit together across the whole system? | Canonical declarative | Canonical metadata header |
+| **Module Architecture View** | How is one module/subsystem structured internally? | Canonical declarative | Canonical metadata header |
+| **System / Feature Design View** | What is the intended behavior and shape of a system or feature? | Canonical declarative | Canonical metadata header |
+| **Module Contract Specification** | What interface/contract does a module expose and guarantee? | Canonical declarative | Canonical metadata header |
+| **Migration / Implementation Plan** | What steps move us from current to desired state? | Imperative working document | Imperative-plan header |
+
+The first four are **canonical viewpoints**: they describe desired state and live durably under `docs/`. The Migration / Implementation Plan is **imperative**: it describes steps, phases, or status and lives under `docs/tmp/` or a gitignored handoff path, to be deleted or archived when the work completes (Constitution XII / XV).
+
+## Metadata headers
+
+Every document opens with a metadata header immediately after its `#` title.
+
+### Canonical metadata header
+
+Used by the four canonical viewpoints.
+
+```
+**Status:** <Draft | Active | Implemented>
+**Document Class:** Canonical declarative
+**Viewpoint:** <System Architecture View | Module Architecture View | System / Feature Design View | Module Contract Specification>
+**Owner:** <team or person>
+**Last Updated:** <YYYY-MM-DD>
+**Audience:** <primary readers>
+**Related:** <links to related canonical docs and/or source issues>
+```
+
+### Imperative-plan header
+
+Used by the Migration / Implementation Plan only.
+
+```
+**Status:** <proposal | in progress | done> (<YYYY-MM-DD>)
+**Document Class:** Imperative working document
+**Location policy:** docs/tmp/ or gitignored handoff path (delete or archive on completion)
+**Owner:** <person driving the work>
+**Last Updated:** <YYYY-MM-DD>
+**Tracks:** <canonical doc(s) and/or issue this plan executes against>
+```
+
+## Viewpoint templates
+
+Copy the matching template to start a new document. Each template embeds the correct header and a concise section skeleton drawn from this standard. Templates are starting points, not a heavyweight process: delete sections that do not apply.
+
+- [System Architecture View](./_viewpoints/SystemArchitectureView.template.md)
+- [Module Architecture View](./_viewpoints/ModuleArchitectureView.template.md)
+- [System / Feature Design View](./_viewpoints/SystemFeatureDesignView.template.md)
+- [Module Contract Specification](./_viewpoints/ModuleContractSpecification.template.md)
+- [Migration / Implementation Plan](./_viewpoints/MigrationImplementationPlan.template.md)

--- a/docs/_viewpoints/MigrationImplementationPlan.template.md
+++ b/docs/_viewpoints/MigrationImplementationPlan.template.md
@@ -1,0 +1,33 @@
+# <Work Name> — Migration / Implementation Plan
+
+**Status:** proposal (<YYYY-MM-DD>)
+**Document Class:** Imperative working document
+**Location policy:** docs/tmp/ or gitignored handoff path (delete or archive on completion)
+**Owner:** <person driving the work>
+**Last Updated:** <YYYY-MM-DD>
+**Tracks:** <canonical doc(s) and/or issue this plan executes against>
+
+> Template per the [MoonSpec Documentation Architecture Standard](../DocumentationArchitecture.md). This is an imperative plan: keep it out of canonical `docs/` and delete or archive it when the work lands. Delete any sections that do not apply.
+
+## 1. Goal
+
+The desired end state this plan moves toward, and a link to the canonical doc that defines it.
+
+## 2. Current state
+
+What exists today and why the change is needed.
+
+## 3. Steps
+
+Ordered steps to reach the goal. Mark status inline (`[ ]` / `[x]`).
+
+- [ ] Step 1
+- [ ] Step 2
+
+## 4. Cutover & in-flight safety
+
+How the change is rolled out safely, including any in-flight/replay compatibility concerns.
+
+## 5. Done & cleanup
+
+How completion is verified and what gets deleted or archived (including this plan).

--- a/docs/_viewpoints/ModuleArchitectureView.template.md
+++ b/docs/_viewpoints/ModuleArchitectureView.template.md
@@ -1,0 +1,31 @@
+# <Module Name> — Module Architecture View
+
+**Status:** Draft
+**Document Class:** Canonical declarative
+**Viewpoint:** Module Architecture View
+**Owner:** <team or person>
+**Last Updated:** <YYYY-MM-DD>
+**Audience:** <primary readers>
+**Related:** <links to related canonical docs and/or source issues>
+
+> Template per the [MoonSpec Documentation Architecture Standard](../DocumentationArchitecture.md). Delete this line and any sections that do not apply.
+
+## 1. Purpose
+
+What this module does and where it sits in the wider system.
+
+## 2. Internal structure
+
+The main internal pieces (packages, classes, services) and their responsibilities.
+
+## 3. Collaborators
+
+What this module depends on and what depends on it.
+
+## 4. Key flows
+
+The important paths through the module (request handling, background work, error paths).
+
+## 5. Constraints & decisions
+
+Invariants the module must uphold and the design decisions behind its structure.

--- a/docs/_viewpoints/ModuleContractSpecification.template.md
+++ b/docs/_viewpoints/ModuleContractSpecification.template.md
@@ -28,4 +28,4 @@ How the contract behaves on invalid input, downstream failure, and degraded cond
 
 ## 5. Versioning & compatibility
 
-How changes to this contract are versioned and what compatibility callers can expect.
+How changes to this contract are versioned and what compatibility callers can expect. For Temporal-facing contracts (workflows, activities, signals, updates), explicitly address replay safety, in-flight compatibility, and workflow boundary test coverage.

--- a/docs/_viewpoints/ModuleContractSpecification.template.md
+++ b/docs/_viewpoints/ModuleContractSpecification.template.md
@@ -1,0 +1,31 @@
+# <Module Name> — Module Contract Specification
+
+**Status:** Draft
+**Document Class:** Canonical declarative
+**Viewpoint:** Module Contract Specification
+**Owner:** <team or person>
+**Last Updated:** <YYYY-MM-DD>
+**Audience:** <primary readers>
+**Related:** <links to related canonical docs and/or source issues>
+
+> Template per the [MoonSpec Documentation Architecture Standard](../DocumentationArchitecture.md). Delete this line and any sections that do not apply.
+
+## 1. Purpose
+
+What contract this module exposes and who consumes it.
+
+## 2. Interface
+
+The operations, inputs, and outputs the module guarantees (signatures, payload shapes, status values).
+
+## 3. Guarantees & invariants
+
+What callers can rely on: ordering, idempotency, error semantics, compatibility commitments.
+
+## 4. Failure modes
+
+How the contract behaves on invalid input, downstream failure, and degraded conditions.
+
+## 5. Versioning & compatibility
+
+How changes to this contract are versioned and what compatibility callers can expect.

--- a/docs/_viewpoints/SystemArchitectureView.template.md
+++ b/docs/_viewpoints/SystemArchitectureView.template.md
@@ -1,0 +1,31 @@
+# <System Name> — System Architecture View
+
+**Status:** Draft
+**Document Class:** Canonical declarative
+**Viewpoint:** System Architecture View
+**Owner:** <team or person>
+**Last Updated:** <YYYY-MM-DD>
+**Audience:** <primary readers>
+**Related:** <links to related canonical docs and/or source issues>
+
+> Template per the [MoonSpec Documentation Architecture Standard](../DocumentationArchitecture.md). Delete this line and any sections that do not apply.
+
+## 1. Purpose
+
+What system this describes and why it exists, in two or three sentences.
+
+## 2. Components
+
+The major components and what each is responsible for.
+
+## 3. Interactions
+
+How components communicate (calls, queues, events) and the key data that flows between them.
+
+## 4. Boundaries & dependencies
+
+External systems, trust boundaries, and runtime/deployment boundaries.
+
+## 5. Constraints & decisions
+
+Non-negotiable constraints and the architecture decisions that shape this system.

--- a/docs/_viewpoints/SystemFeatureDesignView.template.md
+++ b/docs/_viewpoints/SystemFeatureDesignView.template.md
@@ -1,0 +1,31 @@
+# <System / Feature Name> — System / Feature Design View
+
+**Status:** Draft
+**Document Class:** Canonical declarative
+**Viewpoint:** System / Feature Design View
+**Owner:** <team or person>
+**Last Updated:** <YYYY-MM-DD>
+**Audience:** <primary readers>
+**Related:** <links to related canonical docs and/or source issues>
+
+> Template per the [MoonSpec Documentation Architecture Standard](../DocumentationArchitecture.md). Delete this line and any sections that do not apply.
+
+## 1. Purpose
+
+The problem this system or feature solves and the intended user-visible outcome.
+
+## 2. Desired behavior
+
+How it should behave, including the primary scenarios and edge cases that matter.
+
+## 3. Shape
+
+The key entities, states, and interfaces involved in the design.
+
+## 4. Non-goals
+
+What this design deliberately does not do.
+
+## 5. Constraints & decisions
+
+Constraints that bound the design and the decisions made within them.

--- a/tests/unit/docs/test_viewpoint_templates.py
+++ b/tests/unit/docs/test_viewpoint_templates.py
@@ -1,0 +1,62 @@
+"""Coverage for the MM-906 viewpoint templates and their reference from the standard.
+
+Traceability: MM-906 (templates) / source issue MM-900 (DocumentationArchitecture standard).
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STANDARD = REPO_ROOT / "docs" / "DocumentationArchitecture.md"
+VIEWPOINTS_DIR = REPO_ROOT / "docs" / "_viewpoints"
+
+CANONICAL_TEMPLATES = {
+    "SystemArchitectureView.template.md": "System Architecture View",
+    "ModuleArchitectureView.template.md": "Module Architecture View",
+    "SystemFeatureDesignView.template.md": "System / Feature Design View",
+    "ModuleContractSpecification.template.md": "Module Contract Specification",
+}
+PLAN_TEMPLATE = "MigrationImplementationPlan.template.md"
+ALL_TEMPLATES = tuple(CANONICAL_TEMPLATES) + (PLAN_TEMPLATE,)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("filename", ALL_TEMPLATES)
+def test_template_exists(filename: str) -> None:
+    assert (VIEWPOINTS_DIR / filename).is_file()
+
+
+@pytest.mark.parametrize(("filename", "viewpoint"), list(CANONICAL_TEMPLATES.items()))
+def test_canonical_template_embeds_canonical_header(filename: str, viewpoint: str) -> None:
+    text = _read(VIEWPOINTS_DIR / filename)
+    assert "**Document Class:** Canonical declarative" in text
+    assert f"**Viewpoint:** {viewpoint}" in text
+    # Canonical viewpoints must not carry the imperative-plan markers.
+    assert "Imperative working document" not in text
+
+
+def test_plan_template_embeds_imperative_plan_header() -> None:
+    text = _read(VIEWPOINTS_DIR / PLAN_TEMPLATE)
+    assert "**Document Class:** Imperative working document" in text
+    assert "**Location policy:**" in text
+    assert "**Tracks:**" in text
+    assert "Canonical declarative" not in text
+
+
+@pytest.mark.parametrize("filename", ALL_TEMPLATES)
+def test_standard_references_each_template(filename: str) -> None:
+    standard_text = _read(STANDARD)
+    assert f"./_viewpoints/{filename}" in standard_text
+
+
+def test_standard_defines_both_headers_and_traceability() -> None:
+    text = _read(STANDARD)
+    assert "Canonical metadata header" in text
+    assert "Imperative-plan header" in text
+    # Source-issue traceability is preserved in the standard.
+    assert "MM-900" in text
+    assert "MM-906" in text


### PR DESCRIPTION
## Issue
[MM-906](https://moonladder.atlassian.net/browse/MM-906) — Provide concise reusable viewpoint templates/examples

## Summary
Adds five concise, copyable viewpoint templates under `docs/_viewpoints/`, each embedding the correct metadata header and a short section skeleton drawn from the MoonSpec Documentation Architecture Standard:

- `SystemArchitectureView.template.md` (canonical metadata header)
- `ModuleArchitectureView.template.md` (canonical metadata header)
- `SystemFeatureDesignView.template.md` (canonical metadata header)
- `ModuleContractSpecification.template.md` (canonical metadata header)
- `MigrationImplementationPlan.template.md` (imperative-plan header)

Also adds `docs/DocumentationArchitecture.md`, which defines the viewpoints and the canonical vs. imperative-plan metadata headers, and references all five templates. Templates are deliberately lightweight starting points, not heavyweight process documents.

## Tests run
- `./tools/test_unit.sh tests/unit/docs/test_viewpoint_templates.py` — 16 passed (verifies each template exists, carries the right header, and is linked from the standard).
- Full unit run includes the frontend Vitest suite (471 passed, 236 skipped).

## Remaining risks
- Low. Changes are documentation/templates plus a doc-conformance test; no runtime/workflow code is touched. The main risk is template wording drifting from the standard over time, which the conformance test partially guards.


[MM-906]: https://moonladder.atlassian.net/browse/MM-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ