### PR TITLE
[codex] Preserve Jira issue key for merge automation

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -10419,16 +10419,50 @@ class MoonMindRunWorkflow:
             nested = task_payload.get(key)
             if isinstance(nested, Mapping):
                 mappings.append(nested)
+        templates = task_payload.get("appliedStepTemplates")
+        if isinstance(templates, Sequence) and not isinstance(
+            templates, (str, bytes)
+        ):
+            for template in templates:
+                if not isinstance(template, Mapping):
+                    continue
+                mappings.append(template)
+                for key in ("inputs", "input", "inputMapping"):
+                    nested = template.get(key)
+                    if isinstance(nested, Mapping):
+                        mappings.append(nested)
         for mapping in mappings:
-            candidate = self._coerce_text(
-                mapping.get("jiraIssueKey")
-                or mapping.get("jira_issue_key")
-                or mapping.get("issueKey")
-                or mapping.get("issue_key"),
+            candidate = self._jira_issue_key_from_mapping(mapping)
+            if candidate:
+                return candidate
+        return None
+
+    def _jira_issue_key_from_mapping(self, mapping: Mapping[str, Any]) -> str | None:
+        candidate = self._coerce_text(
+            mapping.get("jiraIssueKey")
+            or mapping.get("jira_issue_key")
+            or mapping.get("issueKey")
+            or mapping.get("issue_key"),
+            max_chars=40,
+        )
+        normalized = str(candidate or "").strip().upper()
+        if normalized and _JIRA_ISSUE_KEY_PATTERN.fullmatch(normalized):
+            return normalized
+        for key in ("jiraIssue", "jira_issue", "jira"):
+            nested = mapping.get(key)
+            if not isinstance(nested, Mapping):
+                continue
+            nested_candidate = self._coerce_text(
+                nested.get("key")
+                or nested.get("issueKey")
+                or nested.get("issue_key"),
                 max_chars=40,
             )
-            if candidate and _JIRA_ISSUE_KEY_PATTERN.fullmatch(candidate.upper()):
-                return candidate.upper()
+            normalized_nested = str(nested_candidate or "").strip().upper()
+            if normalized_nested and _JIRA_ISSUE_KEY_PATTERN.fullmatch(
+                normalized_nested
+            ):
+                return normalized_nested
         return None
 
     def _is_jira_backed_task(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -10419,15 +10419,19 @@ class MoonMindRunWorkflow:
             nested = task_payload.get(key)
             if isinstance(nested, Mapping):
                 mappings.append(nested)
-        templates = task_payload.get("appliedStepTemplates")
-        if isinstance(templates, Sequence) and not isinstance(
-            templates, (str, bytes)
+        for templates in (
+            task_payload.get("appliedStepTemplates"),
+            task_payload.get("applied_step_templates"),
         ):
+            if not isinstance(templates, Sequence) or isinstance(
+                templates, (str, bytes)
+            ):
+                continue
             for template in templates:
                 if not isinstance(template, Mapping):
                     continue
                 mappings.append(template)
-                for key in ("inputs", "input", "inputMapping"):
+                for key in ("inputs", "input", "inputMapping", "input_mapping"):
                     nested = template.get(key)
                     if isinstance(nested, Mapping):
                         mappings.append(nested)

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -303,6 +303,40 @@ def test_build_merge_gate_start_payload_carries_structured_jira_issue_key() -> N
     assert payload["mergeAutomationConfig"]["postMergeJira"]["enabled"] is True
 
 
+def test_merge_automation_uses_snake_case_applied_template_jira_key() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(
+        {
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "workflow": {
+                "title": "Run Jira Implement for MM-904.",
+                "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+                "instructions": (
+                    "Run Jira Implement for MM-904. Preserve source issue "
+                    "MM-900 traceability."
+                ),
+                "applied_step_templates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.1.0",
+                        "input_mapping": {
+                            "jira_issue_key": "MM-904",
+                            "constraints": "Preserve source issue MM-900 traceability.",
+                        },
+                    }
+                ],
+            },
+        }
+    )
+
+    assert request is not None
+    assert request["jiraIssueKey"] == "MM-904"
+    assert request["postMergeJira"]["enabled"] is True
+    assert request["postMergeJira"]["required"] is True
+
+
 def test_merge_automation_request_does_not_guess_ambiguous_jira_issue_key() -> None:
     workflow = MoonMindRunWorkflow()
 

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -189,6 +189,120 @@ def test_build_merge_gate_start_payload_carries_workflow_keyed_jira_key() -> Non
     assert payload["mergeAutomationConfig"]["postMergeJira"]["enabled"] is True
 
 
+def test_merge_automation_uses_structured_jira_issue_over_source_traceability() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(
+        {
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "workflow": {
+                "title": (
+                    "Run Jira Implement for MM-904: Define authoring conventions"
+                ),
+                "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+                "inputs": {
+                    "jira_issue": {
+                        "key": "MM-904",
+                        "summary": "Define authoring conventions",
+                        "url": "https://moonladder.atlassian.net/browse/MM-904",
+                    },
+                    "constraints": "Preserve source issue MM-900 traceability.",
+                },
+                "taskTemplate": {
+                    "slug": "jira-implement",
+                    "version": "1.1.0",
+                    "scope": "global",
+                },
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.1.0",
+                        "inputs": {
+                            "jira_issue_key": "MM-904",
+                            "jira_issue": {
+                                "key": "MM-904",
+                                "summary": "Define authoring conventions",
+                                "url": "https://moonladder.atlassian.net/browse/MM-904",
+                            },
+                            "constraints": "Preserve source issue MM-900 traceability.",
+                        },
+                    }
+                ],
+                "steps": [
+                    {
+                        "title": "Finalize Jira status",
+                        "instructions": (
+                            "Transition Jira issue MM-904 to Code Review. "
+                            "Preserve source issue MM-900 traceability."
+                        ),
+                    }
+                ],
+            },
+        }
+    )
+
+    assert request is not None
+    assert request["jiraIssueKey"] == "MM-904"
+    assert request["postMergeJira"]["enabled"] is True
+    assert request["postMergeJira"]["required"] is True
+
+
+def test_build_merge_gate_start_payload_carries_structured_jira_issue_key() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._publish_context["branch"] = (
+        "run-jira-implement-for-mm-904-define-authoring"
+    )
+    workflow._publish_context["baseRef"] = "main"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters={
+            "publishMode": "pr",
+            "mergeAutomation": {"enabled": True},
+            "workflow": {
+                "title": "Run Jira Implement for MM-904.",
+                "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
+                "inputs": {
+                    "jira_issue": {
+                        "key": "MM-904",
+                        "summary": "Define authoring conventions",
+                    },
+                    "constraints": "Preserve source issue MM-900 traceability.",
+                },
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.1.0",
+                        "inputs": {
+                            "jira_issue_key": "MM-904",
+                            "constraints": "Preserve source issue MM-900 traceability.",
+                        },
+                    }
+                ],
+                "steps": [
+                    {
+                        "title": "Finalize Jira status",
+                        "instructions": (
+                            "Transition Jira issue MM-904 to Code Review. "
+                            "Preserve source issue MM-900 traceability."
+                        ),
+                    }
+                ],
+            },
+        },
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/2653",
+        head_sha="5d8f11673fac6c346ae0b0a378748ce631435201",
+        parent_workflow_id="mm:f4edab93",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["jiraIssueKey"] == "MM-904"
+    assert payload["mergeAutomationConfig"]["gate"]["jira"]["issueKey"] == "MM-904"
+    assert payload["mergeAutomationConfig"]["postMergeJira"]["enabled"] is True
+
+
 def test_merge_automation_request_does_not_guess_ambiguous_jira_issue_key() -> None:
     workflow = MoonMindRunWorkflow()
 


### PR DESCRIPTION
## Summary

- Read canonical Jira issue keys from structured Jira picker inputs such as `inputs.jira_issue.key`.
- Also inspect normalized applied preset inputs when building merge automation requests.
- Add regression coverage for Jira Implement payloads that include a separate source issue reference, so the target issue still enables required post-merge Jira completion.

## Root Cause

Jira Implement submissions can carry the target issue as a structured `jira_issue` object while also mentioning a source issue in constraints. Merge automation only recognized scalar issue-key fields or unambiguous text, so it started without `jiraIssueKey` and skipped post-merge Jira completion.

## Validation

- `pytest tests/unit/workflows/temporal/test_run_merge_gate_start.py -q`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_run_merge_gate_start.py`
- `./tools/test_unit.sh`
- Replayed the MM-904 workflow input locally and confirmed it now resolves `MM-904` with `postMergeJira.enabled=true` and `required=true`.