### PR TITLE
MM-897 surface schedule detail actions

### DIFF
--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -424,6 +424,63 @@ describe("SchedulesPage", () => {
     expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("disables pause and resume while editing schedule configuration", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    const pauseButton = screen.getByRole("button", { name: "Pause schedule" }) as HTMLButtonElement;
+    expect(pauseButton.disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+
+    expect((screen.getByRole("button", { name: "Pause schedule" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("preserves unsaved edits when a pending pause update resolves after editing starts", async () => {
+    let resolvePause: ((response: Response) => void) | undefined;
+    fetchSpy.mockImplementation(async (input, init) => {
+      const url = String(input);
+      const method = String(init?.method || "GET").toUpperCase();
+      if (url === "/console/schedules/schedule-alpha" && method === "PATCH") {
+        return new Promise<Response>((resolve) => {
+          resolvePause = resolve;
+        });
+      }
+      if (url === "/console/schedules/schedule-alpha/run" && method === "POST") {
+        return { ok: true, json: async () => ({ ...detailRuns.items[0], id: "run-manual", trigger: "manual" }) } as Response;
+      }
+      if (url === "/console/schedules/schedule-alpha/runs?limit=200") {
+        return { ok: true, json: async () => detailRuns } as Response;
+      }
+      if (url === "/console/schedules/schedule-alpha") {
+        return { ok: true, json: async () => detailSchedule } as Response;
+      }
+      throw new Error(`Unexpected fetch ${method} ${url}`);
+    });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Pause schedule" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit schedule" }));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Unsaved schedule name" } });
+
+    await waitFor(() => {
+      expect(resolvePause).toBeDefined();
+    });
+    resolvePause?.({
+      ok: true,
+      json: async () => ({ ...detailSchedule, enabled: false }),
+    } as Response);
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe("Unsaved schedule name");
+      expect((screen.getByLabelText("Enabled") as HTMLInputElement).checked).toBe(false);
+    });
+  });
+
   it("pauses schedules through the detail update contract", async () => {
     mockScheduleDetailFetch(fetchSpy);
 

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -296,6 +296,10 @@ describe("SchedulesPage", () => {
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules?scope=personal")).toBe(false);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha")).toBe(true);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha/runs?limit=200")).toBe(true);
+    expect(screen.getByRole("button", { name: "Edit schedule" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Run now" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Pause schedule" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /delete schedule/i })).toBeNull();
   });
 
   it("ignores malformed schedule route ids instead of throwing during render", async () => {
@@ -418,5 +422,41 @@ describe("SchedulesPage", () => {
       "/workflows/workflow-from-schedule?source=temporal",
     );
     expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("pauses schedules through the detail update contract", async () => {
+    mockScheduleDetailFetch(fetchSpy);
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Pause schedule" }));
+
+    await waitFor(() => {
+      const pauseCall = fetchSpy.mock.calls.find(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+        && JSON.parse(String(init?.body || "{}")).enabled === false
+      ));
+      expect(pauseCall).toBeDefined();
+    });
+  });
+
+  it("resumes paused schedules through the detail update contract", async () => {
+    mockScheduleDetailFetch(fetchSpy, { enabled: false });
+
+    renderWithClient(<SchedulesPage payload={detailPayload} />);
+
+    expect(await screen.findByRole("heading", { name: "Nightly detail sweep" })).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Resume schedule" }));
+
+    await waitFor(() => {
+      const resumeCall = fetchSpy.mock.calls.find(([url, init]) => (
+        String(url) === "/console/schedules/schedule-alpha"
+        && String(init?.method || "GET").toUpperCase() === "PATCH"
+        && JSON.parse(String(init?.body || "{}")).enabled === true
+      ));
+      expect(resumeCall).toBeDefined();
+    });
   });
 });

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -350,6 +350,26 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
     },
   });
 
+  const pauseResumeMutation = useMutation({
+    mutationFn: async (enabled: boolean) => {
+      const response = await fetch(updateEndpoint, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to ${enabled ? 'resume' : 'pause'} schedule: ${response.statusText}`);
+      }
+      return ScheduleSchema.parse(await response.json());
+    },
+    onSuccess: async (updated) => {
+      queryClient.setQueryData(['schedule-detail', definitionId, detailEndpoint], updated);
+      setEditForm(editFormFromSchedule(updated));
+      await refreshDetail();
+    },
+  });
+
   const schedule = detailQuery.data;
   const runs = runsQuery.data?.items || [];
   const currentForm = editForm || (schedule ? editFormFromSchedule(schedule) : null);
@@ -421,6 +441,16 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
           >
             {runNowMutation.isPending ? 'Running' : 'Run now'}
           </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => pauseResumeMutation.mutate(!schedule.enabled)}
+            disabled={pauseResumeMutation.isPending}
+          >
+            {pauseResumeMutation.isPending
+              ? (schedule.enabled ? 'Pausing' : 'Resuming')
+              : (schedule.enabled ? 'Pause schedule' : 'Resume schedule')}
+          </button>
         </div>
       </header>
 
@@ -432,6 +462,11 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
       {runNowMutation.isError && (
         <div className="schedules-error" role="alert">
           {errorMessage(runNowMutation.error, 'Failed to run schedule')}
+        </div>
+      )}
+      {pauseResumeMutation.isError && (
+        <div className="schedules-error" role="alert">
+          {errorMessage(pauseResumeMutation.error, schedule.enabled ? 'Failed to pause schedule' : 'Failed to resume schedule')}
         </div>
       )}
 

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { DataTable } from '../components/tables/DataTable';
 
 import { z } from 'zod';
@@ -267,6 +267,11 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
+  const isEditingRef = useRef(false);
+
+  useEffect(() => {
+    isEditingRef.current = isEditing;
+  }, [isEditing]);
   const detailEndpoint = useMemo(() => scheduleEndpoint(payload, 'detail', definitionId), [payload, definitionId]);
   const updateEndpoint = useMemo(() => scheduleEndpoint(payload, 'update', definitionId), [payload, definitionId]);
   const runNowEndpoint = useMemo(() => scheduleEndpoint(payload, 'runNow', definitionId), [payload, definitionId]);
@@ -329,6 +334,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
     onSuccess: async (updated) => {
       queryClient.setQueryData(['schedule-detail', definitionId, detailEndpoint], updated);
       setEditForm(editFormFromSchedule(updated));
+      isEditingRef.current = false;
       setIsEditing(false);
       await refreshDetail();
     },
@@ -365,7 +371,12 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
     },
     onSuccess: async (updated) => {
       queryClient.setQueryData(['schedule-detail', definitionId, detailEndpoint], updated);
-      setEditForm(editFormFromSchedule(updated));
+      setEditForm((previous) => {
+        if (isEditingRef.current && previous) {
+          return { ...previous, enabled: updated.enabled };
+        }
+        return editFormFromSchedule(updated);
+      });
       await refreshDetail();
     },
   });
@@ -428,7 +439,11 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
             className="secondary"
             onClick={() => {
               setEditForm(editFormFromSchedule(schedule));
-              setIsEditing((value) => !value);
+              setIsEditing((value) => {
+                const next = !value;
+                isEditingRef.current = next;
+                return next;
+              });
             }}
           >
             {isEditing ? 'Cancel edit' : 'Edit schedule'}
@@ -445,7 +460,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
             type="button"
             className="secondary"
             onClick={() => pauseResumeMutation.mutate(!schedule.enabled)}
-            disabled={pauseResumeMutation.isPending}
+            disabled={pauseResumeMutation.isPending || isEditing || updateMutation.isPending}
           >
             {pauseResumeMutation.isPending
               ? (schedule.enabled ? 'Pausing' : 'Resuming')
@@ -560,6 +575,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                   className="secondary"
                   onClick={() => {
                     setEditForm(editFormFromSchedule(schedule));
+                    isEditingRef.current = false;
                     setIsEditing(false);
                   }}
                 >


### PR DESCRIPTION
Issue reference: MM-897

Summary:
- Added a first-class pause/resume action to the recurring schedule detail header using the existing PATCH update contract.
- Kept delete hidden because the backend DELETE contract and sources.schedules.delete template are still absent.
- Added schedule detail tests for visible actions, delete gating, and pause/resume PATCH requests.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/schedules.test.tsx

Remaining risks:
- Full unit suite was not run in this PR publication step.
- Delete confirmation and delete success/failure behavior remain gated until backend delete support exists.