### PR TITLE
MM-908: Add advisory documentation-architecture validation helper

### DIFF
--- a/docs/DocumentationArchitectureValidation.md
+++ b/docs/DocumentationArchitectureValidation.md
@@ -1,0 +1,69 @@
+# Documentation Architecture Validation (Advisory)
+
+**Document Class:** Cross-Cutting Concept View
+**Status:** Current standard and target direction
+**Updated:** 2026-06-25
+**Audience:** Anyone authoring or reviewing durable documentation, or wiring documentation checks into tooling
+**Purpose:** Describe the **advisory, non-blocking** validation that flags obvious drift from the [MoonSpec Documentation Architecture Standard](DocumentationArchitecture.md) and the [MoonSpec Document Model](Workflows/MoonSpecDocumentModel.md), so reviewers catch documentation-architecture problems early.
+
+> **Traceability:** This is the deliverable of **MM-908** (source design **MM-900**, "Implement MoonSpec Documentation Architecture Standard"); it covers **DESIGN-REQ-018**. It builds on the taxonomy authored in **MM-902**.
+
+---
+
+## 1. Advisory only in v1
+
+This validation is **advisory only**. It **does not block CI** and is **not** added to any required pipeline in this story. Its job is to surface likely documentation-architecture issues so a human reviewer can decide. Findings are emitted as **structured warnings** (stable rule ids + a `severity` field) precisely so the convention can later be **promoted to a blocking CI gate** — once it proves stable — without reworking callers.
+
+The helper exits `0` regardless of findings. A future promotion can run it with `--strict` (which exits non-zero when findings exist); v1 CI must not.
+
+## 2. The helper
+
+`tools/check_documentation_architecture.py` implements the enumerated checks.
+
+```bash
+# Advisory scan of docs changed vs origin/main (default):
+python tools/check_documentation_architecture.py
+
+# Scan the whole docs/ tree:
+python tools/check_documentation_architecture.py --scope all
+
+# Machine-readable output (structured warnings):
+python tools/check_documentation_architecture.py --scope all --format json
+
+# Check specific files:
+python tools/check_documentation_architecture.py docs/MyNewView.md
+```
+
+By default it scopes to **new/changed** docs (`git diff` vs `--base`, default `origin/main`) so it focuses on what a change introduces; `--scope all` audits the full tree. If git is unavailable it falls back to a full scan.
+
+## 3. What it checks
+
+Each check maps to one acceptance criterion of MM-908 and emits a finding with a stable `rule` id:
+
+| Rule id | Flags | Reference |
+|---------|-------|-----------|
+| `missing-document-class` | A canonical doc under `docs/` that declares no Document Class (no `Document Class:` marker and no recognized base-class/viewpoint name). | [Standard §3](DocumentationArchitecture.md), [Document Model — Document Classes](Workflows/MoonSpecDocumentModel.md) |
+| `imperative-plan-in-canonical-area` | A `*Plan.md` (or `*Tracker.md` / `*Checklist.md` / `*Backlog.md`) placed in a canonical folder instead of `docs/tmp/` (or another approved imperative working area). | [Standard §4](DocumentationArchitecture.md) |
+| `duplicate-canonical-authority` | Two canonical docs sharing an H1 title (overlapping authority), or more than one root-level System Architecture View. | [Standard §3.1](DocumentationArchitecture.md), [Document Model — Precedence](Workflows/MoonSpecDocumentModel.md) |
+| `contract-missing-authority-statement` | A contract doc (`*Contract.md` / `*Contracts.md`) with no authority statement naming its single authoritative owner / source of truth. | [Standard §6.1](DocumentationArchitecture.md) |
+| `discouraged-decision-record` | A separate `decisions/` directory or ADR-style doc, introduced instead of embedding rationale in the owning canonical view. | [Standard §8](DocumentationArchitecture.md) |
+
+## 4. Reviewer checklist
+
+When reviewing a change that adds or moves durable docs, confirm:
+
+- [ ] Each new canonical doc names its **Document Class** (one of the Document Model classes or one of the five Standard viewpoints).
+- [ ] Plans, rollout/migration plans, and status/checklist trackers live under `docs/tmp/` (or a gitignored handoff path), **not** in a canonical architecture folder, and are not named `*Plan.md` under `docs/`.
+- [ ] No two canonical docs claim the **same authority** (same title / same scope); there is one root-level System Architecture View.
+- [ ] Each **contract** doc states who **owns** it and that it is the **single source of truth** for that interface.
+- [ ] Rationale is **embedded** in the owning canonical view rather than added as a separate `decisions/` or ADR-style doc.
+
+## 5. Document Class marker convention
+
+To satisfy `missing-document-class`, a canonical doc should carry a near-the-top marker, for example:
+
+```markdown
+**Document Class:** Module Contract Specification
+```
+
+The recognized values are the Document Model base classes (canonical declarative document, temporary execution artifact, imperative working document) and the five Standard viewpoints (System Architecture View, Module Architecture View, System / Feature Design View, Module Contract Specification, Cross-Cutting Concept View). A doc that names its viewpoint inline already satisfies the check.

--- a/tests/unit/tools/test_check_documentation_architecture.py
+++ b/tests/unit/tools/test_check_documentation_architecture.py
@@ -194,6 +194,37 @@ def test_clean_canonical_doc_produces_no_findings() -> None:
     assert mod.run_checks(docs) == []
 
 
+def test_focus_paths_reports_only_changed_doc_but_uses_full_context() -> None:
+    # Regression: with the default ``changed`` scope, a new/changed doc that
+    # duplicates the title of an *unchanged* canonical doc must still be flagged.
+    # Global checks see the full canonical set (``docs``) while reporting is
+    # scoped to the changed path via ``focus_paths``.
+    changed = "docs/B/Overview.md"
+    cls = "\n\nThis is a Cross-Cutting Concept View describing X.\n"
+    docs = [
+        _doc("docs/A/Overview.md", f"# Execution Model{cls}"),
+        _doc(changed, f"# Execution Model{cls}"),
+    ]
+    findings = mod.run_checks(docs, focus_paths=[changed])
+    assert _rules(findings) == {"duplicate-canonical-authority"}
+    # Only the changed doc is reported; the unchanged counterpart is not flagged.
+    assert {finding.path for finding in findings} == {changed}
+    # The unchanged counterpart is still surfaced in the detail for the reviewer.
+    assert any("docs/A/Overview.md" in finding.detail for finding in findings)
+
+
+def test_focus_paths_none_reports_every_finding() -> None:
+    docs = [
+        _doc("docs/A/Overview.md", "# Execution Model\n\nx\n"),
+        _doc("docs/B/Overview.md", "# Execution Model\n\ny\n"),
+    ]
+    findings = mod.run_checks(docs, focus_paths=None)
+    assert {finding.path for finding in findings} == {
+        "docs/A/Overview.md",
+        "docs/B/Overview.md",
+    }
+
+
 def test_findings_are_sorted_deterministically() -> None:
     docs = [
         _doc("docs/Z/Zed.md", "# Zed\n"),

--- a/tests/unit/tools/test_check_documentation_architecture.py
+++ b/tests/unit/tools/test_check_documentation_architecture.py
@@ -1,0 +1,247 @@
+"""MM-908 advisory documentation-architecture validation helper tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "tools" / "check_documentation_architecture.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "check_documentation_architecture", MODULE_PATH
+)
+assert SPEC is not None
+check_documentation_architecture = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = check_documentation_architecture
+SPEC.loader.exec_module(check_documentation_architecture)
+
+mod = check_documentation_architecture
+DocFile = mod.DocFile
+
+
+def _doc(path: str, text: str) -> "mod.DocFile":
+    return DocFile(path=path, text=text)
+
+
+def _rules(findings) -> set[str]:
+    return {finding.rule for finding in findings}
+
+
+def test_missing_document_class_flags_canonical_doc_without_marker() -> None:
+    docs = [_doc("docs/NewThing.md", "# New Thing\n\nSome architecture prose.\n")]
+    findings = mod.check_missing_document_class(docs)
+    assert _rules(findings) == {"missing-document-class"}
+    assert findings[0].severity == mod.SEVERITY_ADVISORY
+
+
+def test_document_class_marker_satisfies_check() -> None:
+    docs = [
+        _doc(
+            "docs/NewThing.md",
+            "# New Thing\n\n**Document Class:** System Architecture View\n",
+        )
+    ]
+    assert mod.check_missing_document_class(docs) == []
+
+
+def test_inline_viewpoint_name_satisfies_document_class_check() -> None:
+    docs = [
+        _doc(
+            "docs/NewThing.md",
+            "# New Thing\n\nThis is a Cross-Cutting Concept View describing X.\n",
+        )
+    ]
+    assert mod.check_missing_document_class(docs) == []
+
+
+def test_non_canonical_dirs_are_exempt_from_document_class() -> None:
+    docs = [
+        _doc("docs/tmp/SomethingPlan.md", "# Plan\n\nstep 1\n"),
+        _doc("docs/assets/note.md", "# Asset\n"),
+        _doc("docs/ReleaseNotes/v1.md", "# Release\n"),
+    ]
+    assert mod.check_missing_document_class(docs) == []
+
+
+def test_plan_in_canonical_area_is_flagged_but_tmp_is_allowed() -> None:
+    docs = [
+        _doc("docs/Workflows/BigMigrationPlan.md", "# Plan\n"),
+        _doc("docs/Steps/RolloutPlan.md", "# Rollout\n"),
+        _doc("docs/tmp/FeatureImplementationPlan.md", "# Plan\n"),
+    ]
+    findings = mod.check_imperative_plan_in_canonical_area(docs)
+    flagged = {finding.path for finding in findings}
+    assert flagged == {
+        "docs/Workflows/BigMigrationPlan.md",
+        "docs/Steps/RolloutPlan.md",
+    }
+    assert _rules(findings) == {"imperative-plan-in-canonical-area"}
+
+
+def test_tracker_naming_is_flagged_in_canonical_area() -> None:
+    docs = [_doc("docs/Temporal/StatusTracker.md", "# Status\n")]
+    findings = mod.check_imperative_plan_in_canonical_area(docs)
+    assert _rules(findings) == {"imperative-plan-in-canonical-area"}
+
+
+def test_duplicate_titles_flag_overlapping_authority() -> None:
+    docs = [
+        _doc("docs/A/Overview.md", "# Execution Model\n\nx\n"),
+        _doc("docs/B/Overview.md", "# Execution Model\n\ny\n"),
+    ]
+    findings = mod.check_duplicate_canonical_authority(docs)
+    assert _rules(findings) == {"duplicate-canonical-authority"}
+    assert {finding.path for finding in findings} == {
+        "docs/A/Overview.md",
+        "docs/B/Overview.md",
+    }
+    # The overlapping counterpart is recorded for the reviewer.
+    assert any("docs/B/Overview.md" in finding.detail for finding in findings)
+
+
+def test_multiple_system_architecture_views_flagged() -> None:
+    docs = [
+        _doc(
+            "docs/MoonMindArchitecture.md",
+            "# MoonMind Architecture\n\n**Document Class:** System Architecture View\n",
+        ),
+        _doc(
+            "docs/OtherArchitecture.md",
+            "# Other Architecture\n\n**Document Class:** System Architecture View\n",
+        ),
+    ]
+    findings = mod.check_duplicate_canonical_authority(docs)
+    assert _rules(findings) == {"duplicate-canonical-authority"}
+    assert {finding.path for finding in findings} == {
+        "docs/MoonMindArchitecture.md",
+        "docs/OtherArchitecture.md",
+    }
+
+
+def test_single_system_architecture_view_is_fine() -> None:
+    docs = [
+        _doc(
+            "docs/MoonMindArchitecture.md",
+            "# MoonMind Architecture\n\n**Document Class:** System Architecture View\n",
+        )
+    ]
+    assert mod.check_duplicate_canonical_authority(docs) == []
+
+
+def test_documentation_architecture_standard_not_miscounted_as_system_view() -> None:
+    # The standard names itself with an *Architecture.md path but is not a
+    # System Architecture View; it must not collide with the real system view.
+    docs = [
+        _doc(
+            "docs/MoonMindArchitecture.md",
+            "# MoonMind Architecture\n\n**Document Class:** System Architecture View\n",
+        ),
+        _doc(
+            "docs/DocumentationArchitecture.md",
+            "# MoonSpec Documentation Architecture Standard\n\nTaxonomy of viewpoints.\n",
+        ),
+    ]
+    assert mod.check_duplicate_canonical_authority(docs) == []
+
+
+def test_contract_without_authority_statement_flagged() -> None:
+    docs = [
+        _doc("docs/Api/WidgetContract.md", "# Widget Contract\n\nFields: a, b.\n")
+    ]
+    findings = mod.check_contract_missing_authority_statement(docs)
+    assert _rules(findings) == {"contract-missing-authority-statement"}
+
+
+def test_contract_with_authority_statement_is_fine() -> None:
+    docs = [
+        _doc(
+            "docs/Api/WidgetContract.md",
+            "# Widget Contract\n\nThis is the authoritative source of truth, "
+            "owned by the widget module.\n",
+        )
+    ]
+    assert mod.check_contract_missing_authority_statement(docs) == []
+
+
+def test_decision_record_directory_and_adr_file_are_discouraged() -> None:
+    docs = [
+        _doc("docs/decisions/0001-use-x.md", "# Decision\n"),
+        _doc("docs/Workflows/adr-0002-pick-y.md", "# ADR\n"),
+        _doc("docs/Workflows/Normal.md", "# Normal\n"),
+    ]
+    findings = mod.check_discouraged_decision_record(docs)
+    assert _rules(findings) == {"discouraged-decision-record"}
+    assert {finding.path for finding in findings} == {
+        "docs/decisions/0001-use-x.md",
+        "docs/Workflows/adr-0002-pick-y.md",
+    }
+
+
+def test_clean_canonical_doc_produces_no_findings() -> None:
+    docs = [
+        _doc(
+            "docs/Workflows/CleanContract.md",
+            "# Clean Contract\n\n**Document Class:** Module Contract Specification\n\n"
+            "This document is the authoritative source of truth, owned by the "
+            "workflows module.\n",
+        )
+    ]
+    assert mod.run_checks(docs) == []
+
+
+def test_findings_are_sorted_deterministically() -> None:
+    docs = [
+        _doc("docs/Z/Zed.md", "# Zed\n"),
+        _doc("docs/A/Ay.md", "# Ay\n"),
+    ]
+    findings = mod.run_checks(docs)
+    paths = [finding.path for finding in findings]
+    assert paths == sorted(paths)
+
+
+def test_repo_doc_helpers_resolve_real_tree() -> None:
+    # The shipped advisory docs/tool must exist and be classifiable.
+    paths = mod.all_doc_paths()
+    assert "docs/DocumentationArchitectureValidation.md" in paths
+    assert mod.is_canonical_doc("docs/MoonMindArchitecture.md")
+    assert not mod.is_canonical_doc("docs/tmp/SomePlan.md")
+
+
+def test_shipped_validation_doc_declares_document_class() -> None:
+    doc = mod.load_docs(["docs/DocumentationArchitectureValidation.md"])
+    assert doc, "validation doc should load"
+    assert mod.check_missing_document_class(doc) == []
+
+
+def test_cli_json_output_is_advisory_and_exit_zero(capsys) -> None:
+    rc = mod.main(["--format", "json", "docs/DocumentationArchitectureValidation.md"])
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert rc == 0
+    assert payload["advisory_only"] is True
+    assert payload["issue"] == "MM-908"
+    # The shipped validation doc is clean, so it produces no findings.
+    assert payload["finding_count"] == 0
+
+
+def test_default_full_scan_is_non_blocking(capsys) -> None:
+    # Advisory v1: a full-tree scan never blocks, even though existing docs have
+    # not yet adopted the Document Class marker.
+    rc = mod.main(["--scope", "all"])
+    capsys.readouterr()
+    assert rc == 0
+
+
+def test_strict_mode_returns_nonzero_when_findings_exist(capsys) -> None:
+    # The strict flag is the future-promotion path: it is opt-in and v1 CI must
+    # not use it. With many docs not yet carrying the marker, a strict full scan
+    # surfaces findings and exits non-zero.
+    rc = mod.main(["--strict", "--scope", "all"])
+    out = capsys.readouterr().out
+    assert "advisory" in out.lower()
+    assert rc == 1

--- a/tools/check_documentation_architecture.py
+++ b/tools/check_documentation_architecture.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""MM-908 advisory documentation-architecture validation helper.
+
+Advisory-only (v1): this helper NEVER blocks CI. It emits *structured* warnings
+that flag likely drift from the MoonSpec Documentation Architecture Standard
+(``docs/DocumentationArchitecture.md``) and the MoonSpec Document Model
+(``docs/Workflows/MoonSpecDocumentModel.md``) so reviewers can catch obvious
+documentation-architecture problems early without gating the pipeline.
+
+Findings carry stable rule ids and a severity so the convention can later be
+promoted to a blocking CI gate (``--strict``) once it proves stable, without
+reworking callers. By default the tool exits ``0`` regardless of findings.
+
+Traceability: MM-908 (source design MM-900, "Implement MoonSpec Documentation
+Architecture Standard"); covers DESIGN-REQ-018.
+
+Enumerated advisory checks:
+  1. ``missing-document-class``      new canonical docs missing a Document Class.
+  2. ``imperative-plan-in-canonical-area``
+                                     new ``*Plan.md`` / tracker docs placed
+                                     outside ``docs/tmp/`` (canonical folders).
+  3. ``duplicate-canonical-authority``
+                                     duplicate canonical docs with overlapping
+                                     authority.
+  4. ``contract-missing-authority-statement``
+                                     contract docs missing an authority
+                                     statement.
+  5. ``discouraged-decision-record`` separate ``decisions/`` or ADR-style docs
+                                     introduced instead of embedded rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Canonical declarative documentation lives under ``docs/`` (and the
+# constitution) per the Document Model. These ``docs/`` subtrees are NOT part of
+# the canonical Architecture Description and are excluded from canonical checks.
+CANONICAL_DOCS_ROOT = "docs"
+NON_CANONICAL_DOC_DIRS = ("docs/tmp", "docs/assets", "docs/ReleaseNotes")
+
+# Approved imperative working areas for plans/trackers (Document Model §
+# "Imperative working documents"). Plans outside these are flagged.
+APPROVED_IMPERATIVE_DIRS = ("docs/tmp",)
+
+# A canonical declarative doc should declare its Document Class. v1 accepts an
+# explicit ``Document Class:`` marker OR any recognized base class / viewpoint
+# name (so existing docs that name their viewpoint inline are not flagged).
+DOCUMENT_CLASS_MARKER_RE = re.compile(r"document\s+class\s*[:|]", re.IGNORECASE)
+DOCUMENT_CLASS_TERMS = (
+    # Document Model base classes.
+    "canonical declarative document",
+    "temporary execution artifact",
+    "imperative working document",
+    # Documentation Architecture Standard viewpoints.
+    "system architecture view",
+    "module architecture view",
+    "system / feature design view",
+    "feature design view",
+    "module contract specification",
+    "cross-cutting concept view",
+)
+DOCUMENT_CLASS_TERMS_RE = re.compile(
+    "|".join(re.escape(term) for term in DOCUMENT_CLASS_TERMS), re.IGNORECASE
+)
+
+# ``*Plan.md`` plus Status / Checklist Tracker naming (imperative working docs).
+IMPERATIVE_DOC_NAME_RE = re.compile(
+    r"(?:Plan|Tracker|Checklist|Backlog)\.md$", re.IGNORECASE
+)
+
+# Contract docs (Module Contract Specification) by preferred naming.
+CONTRACT_DOC_NAME_RE = re.compile(r"Contract(?:s)?\.md$", re.IGNORECASE)
+
+# An authority statement names the single authoritative owner / source of truth
+# (Documentation Architecture §6.1 contract authority rule).
+AUTHORITY_STATEMENT_RE = re.compile(
+    r"authoritative|source of truth|authority|owned by|single .*home|owns\b",
+    re.IGNORECASE,
+)
+
+# Separate decision records / ADRs are discouraged; rationale should be embedded
+# in the owning canonical view instead.
+DECISION_DIR_RE = re.compile(r"(?:^|/)(?:decisions|adr|adrs)/", re.IGNORECASE)
+ADR_FILE_RE = re.compile(r"(?:^|/)(?:adr[-_].+|\d{3,4}[-_].+-decision|.*\bADR\b.*)\.md$")
+
+# A System Architecture View is one-per-project. It is identified only by an
+# explicit ``Document Class: System Architecture View`` declaration -- not by a
+# prose mention of the viewpoint -- so docs that merely *discuss* viewpoints
+# (the standard, this validation doc) are not miscounted as views.
+SYSTEM_ARCH_DECLARATION_RE = re.compile(
+    r"document\s+class\s*[:|]\s*\**\s*system architecture view", re.IGNORECASE
+)
+
+SEVERITY_ADVISORY = "advisory"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single structured advisory finding.
+
+    ``rule`` is a stable identifier and ``severity`` is ``advisory`` in v1; both
+    are carried explicitly so a future CI gate can select/promote rules without
+    changing the emitting code.
+    """
+
+    rule: str
+    severity: str
+    path: str
+    message: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class DocFile:
+    """A markdown doc under ``docs/`` paired with its current text."""
+
+    path: str  # repo-relative POSIX path
+    text: str
+
+    @property
+    def name(self) -> str:
+        return self.path.rsplit("/", 1)[-1]
+
+
+def _is_under(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def is_canonical_doc(path: str) -> bool:
+    """True for canonical declarative docs (``docs/**.md`` minus excluded trees)."""
+
+    if not path.endswith(".md"):
+        return False
+    if not _is_under(path, CANONICAL_DOCS_ROOT):
+        return False
+    return not any(_is_under(path, excluded) for excluded in NON_CANONICAL_DOC_DIRS)
+
+
+def _h1_title(text: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip().lower()
+        if stripped:
+            # Front matter / metadata before the title is fine; keep scanning.
+            continue
+    return None
+
+
+def check_missing_document_class(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in docs:
+        if not is_canonical_doc(doc.path):
+            continue
+        if DOCUMENT_CLASS_MARKER_RE.search(doc.text):
+            continue
+        if DOCUMENT_CLASS_TERMS_RE.search(doc.text):
+            continue
+        findings.append(
+            Finding(
+                rule="missing-document-class",
+                severity=SEVERITY_ADVISORY,
+                path=doc.path,
+                message=(
+                    "Canonical doc does not declare a Document Class. Add a "
+                    "`Document Class:` marker naming its viewpoint "
+                    "(see docs/DocumentationArchitecture.md)."
+                ),
+            )
+        )
+    return findings
+
+
+def check_imperative_plan_in_canonical_area(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in docs:
+        if not doc.path.endswith(".md"):
+            continue
+        if not _is_under(doc.path, CANONICAL_DOCS_ROOT):
+            continue
+        if any(_is_under(doc.path, allowed) for allowed in APPROVED_IMPERATIVE_DIRS):
+            continue
+        if not IMPERATIVE_DOC_NAME_RE.search(doc.name):
+            continue
+        findings.append(
+            Finding(
+                rule="imperative-plan-in-canonical-area",
+                severity=SEVERITY_ADVISORY,
+                path=doc.path,
+                message=(
+                    "Imperative plan/tracker doc placed in a canonical folder. "
+                    "Move it under docs/tmp/ or a gitignored handoff path "
+                    "(see docs/DocumentationArchitecture.md §4)."
+                ),
+            )
+        )
+    return findings
+
+
+def check_duplicate_canonical_authority(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    canonical = [doc for doc in docs if is_canonical_doc(doc.path)]
+
+    # Duplicate H1 titles imply two docs claiming the same canonical authority.
+    by_title: dict[str, list[str]] = {}
+    for doc in canonical:
+        title = _h1_title(doc.text)
+        if title:
+            by_title.setdefault(title, []).append(doc.path)
+    for title, paths in sorted(by_title.items()):
+        if len(paths) < 2:
+            continue
+        ordered = sorted(paths)
+        for path in ordered:
+            others = [other for other in ordered if other != path]
+            findings.append(
+                Finding(
+                    rule="duplicate-canonical-authority",
+                    severity=SEVERITY_ADVISORY,
+                    path=path,
+                    message=(
+                        "Multiple canonical docs share the title "
+                        f"'{title}', implying overlapping authority. Consolidate "
+                        "to one source of truth (Document Model precedence rule)."
+                    ),
+                    detail="overlaps: " + ", ".join(others),
+                )
+            )
+
+    # More than one doc declaring the System Architecture View viewpoint
+    # (one-per-project, §3.1). Identified by declaration, not naming, so the
+    # documentation-architecture standard itself is not miscounted as a view.
+    system_views = sorted(
+        doc.path for doc in canonical if SYSTEM_ARCH_DECLARATION_RE.search(doc.text)
+    )
+    if len(system_views) > 1:
+        for path in system_views:
+            others = [other for other in system_views if other != path]
+            findings.append(
+                Finding(
+                    rule="duplicate-canonical-authority",
+                    severity=SEVERITY_ADVISORY,
+                    path=path,
+                    message=(
+                        "More than one doc declares the System Architecture View "
+                        "viewpoint; there is one Architecture Description per "
+                        "project (see docs/DocumentationArchitecture.md §3.1)."
+                    ),
+                    detail="overlaps: " + ", ".join(others),
+                )
+            )
+    return findings
+
+
+def check_contract_missing_authority_statement(
+    docs: Sequence[DocFile],
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in docs:
+        if not is_canonical_doc(doc.path):
+            continue
+        if not CONTRACT_DOC_NAME_RE.search(doc.name):
+            continue
+        if AUTHORITY_STATEMENT_RE.search(doc.text):
+            continue
+        findings.append(
+            Finding(
+                rule="contract-missing-authority-statement",
+                severity=SEVERITY_ADVISORY,
+                path=doc.path,
+                message=(
+                    "Contract doc has no authority statement naming its single "
+                    "authoritative owner / source of truth "
+                    "(see docs/DocumentationArchitecture.md §6.1)."
+                ),
+            )
+        )
+    return findings
+
+
+def check_discouraged_decision_record(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in docs:
+        if not doc.path.endswith(".md"):
+            continue
+        if not _is_under(doc.path, CANONICAL_DOCS_ROOT):
+            continue
+        if DECISION_DIR_RE.search(doc.path) or ADR_FILE_RE.search(doc.path):
+            findings.append(
+                Finding(
+                    rule="discouraged-decision-record",
+                    severity=SEVERITY_ADVISORY,
+                    path=doc.path,
+                    message=(
+                        "Separate decisions/ or ADR-style doc is discouraged. "
+                        "Embed the rationale in the owning canonical view "
+                        "instead (see docs/DocumentationArchitecture.md)."
+                    ),
+                )
+            )
+    return findings
+
+
+ALL_CHECKS = (
+    check_missing_document_class,
+    check_imperative_plan_in_canonical_area,
+    check_duplicate_canonical_authority,
+    check_contract_missing_authority_statement,
+    check_discouraged_decision_record,
+)
+
+
+def run_checks(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for check in ALL_CHECKS:
+        findings.extend(check(docs))
+    return sorted(findings, key=lambda f: (f.path, f.rule, f.message))
+
+
+def _load_doc(root: Path, rel_path: str) -> DocFile | None:
+    abs_path = root / rel_path
+    try:
+        text = abs_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    return DocFile(path=rel_path, text=text)
+
+
+def load_docs(paths: Iterable[str], *, root: Path = REPO_ROOT) -> list[DocFile]:
+    docs: list[DocFile] = []
+    for rel_path in sorted(set(paths)):
+        if not rel_path.endswith(".md"):
+            continue
+        doc = _load_doc(root, rel_path)
+        if doc is not None:
+            docs.append(doc)
+    return docs
+
+
+def all_doc_paths(*, root: Path = REPO_ROOT) -> list[str]:
+    docs_dir = root / CANONICAL_DOCS_ROOT
+    if not docs_dir.is_dir():
+        return []
+    return [
+        child.relative_to(root).as_posix()
+        for child in sorted(docs_dir.rglob("*.md"))
+        if child.is_file()
+    ]
+
+
+def _git_lines(args: Sequence[str], *, root: Path) -> list[str] | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def changed_doc_paths(base_ref: str, *, root: Path = REPO_ROOT) -> list[str] | None:
+    """Markdown docs added/modified vs ``base_ref`` plus untracked working-tree docs.
+
+    Returns ``None`` when git is unavailable or the base ref cannot be resolved,
+    so the caller can fall back to a full scan.
+    """
+
+    tracked = _git_lines(
+        ["diff", "--name-only", "--diff-filter=AMR", base_ref, "--"], root=root
+    )
+    if tracked is None:
+        return None
+    untracked = (
+        _git_lines(["ls-files", "--others", "--exclude-standard"], root=root) or []
+    )
+    paths = {
+        path
+        for path in (*tracked, *untracked)
+        if path.endswith(".md") and _is_under(path, CANONICAL_DOCS_ROOT)
+    }
+    return sorted(paths)
+
+
+def _format_text(findings: Sequence[Finding], *, scope: str) -> str:
+    header = (
+        "MM-908 advisory documentation-architecture check "
+        f"(scope={scope}, advisory-only — does not block CI)."
+    )
+    if not findings:
+        return f"{header}\nNo advisory findings."
+    lines = [header, f"{len(findings)} advisory finding(s):"]
+    for finding in findings:
+        line = (
+            f"  [{finding.severity}] {finding.path}: {finding.rule}: "
+            f"{finding.message}"
+        )
+        if finding.detail:
+            line += f" ({finding.detail})"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _format_json(findings: Sequence[Finding], *, scope: str) -> str:
+    payload = {
+        "tool": "check_documentation_architecture",
+        "issue": "MM-908",
+        "scope": scope,
+        "advisory_only": True,
+        "finding_count": len(findings),
+        "findings": [asdict(finding) for finding in findings],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scope",
+        choices=("changed", "all"),
+        default="changed",
+        help=(
+            "'changed' (default): only docs added/modified vs --base. "
+            "'all': scan the whole docs/ tree."
+        ),
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git base ref for --scope changed (default: origin/main).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Exit non-zero when advisory findings exist. v1 CI MUST NOT use this; "
+            "reserved for a future promotion to a blocking gate."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Explicit doc paths to check (overrides --scope).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.paths:
+        scope = "explicit"
+        doc_paths: list[str] = list(args.paths)
+    elif args.scope == "all":
+        scope = "all"
+        doc_paths = all_doc_paths()
+    else:
+        changed = changed_doc_paths(args.base)
+        if changed is None:
+            scope = "all (git unavailable, fell back to full scan)"
+            doc_paths = all_doc_paths()
+        else:
+            scope = f"changed vs {args.base}"
+            doc_paths = changed
+
+    docs = load_docs(doc_paths)
+    findings = run_checks(docs)
+
+    if args.format == "json":
+        print(_format_json(findings, scope=scope))
+    else:
+        print(_format_text(findings, scope=scope))
+
+    if args.strict and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_documentation_architecture.py
+++ b/tools/check_documentation_architecture.py
@@ -321,10 +321,26 @@ ALL_CHECKS = (
 )
 
 
-def run_checks(docs: Sequence[DocFile]) -> list[Finding]:
+def run_checks(
+    docs: Sequence[DocFile], *, focus_paths: Iterable[str] | None = None
+) -> list[Finding]:
+    """Run every advisory check over ``docs``.
+
+    ``focus_paths`` scopes *reported* findings to a subset of paths while still
+    evaluating every check against the full ``docs`` context. Global checks such
+    as ``check_duplicate_canonical_authority`` must see unchanged canonical docs
+    to detect a changed doc duplicating an existing one; passing the full
+    canonical set as ``docs`` and the changed subset as ``focus_paths`` keeps
+    that detection working without reporting on docs the caller did not target.
+    When ``focus_paths`` is ``None`` every finding is reported.
+    """
+
     findings: list[Finding] = []
     for check in ALL_CHECKS:
         findings.extend(check(docs))
+    if focus_paths is not None:
+        focus = set(focus_paths)
+        findings = [finding for finding in findings if finding.path in focus]
     return sorted(findings, key=lambda f: (f.path, f.rule, f.message))
 
 
@@ -465,23 +481,32 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    # ``focus_paths`` scopes which paths are *reported*; ``context_paths`` is the
+    # full set loaded so global checks (duplicate authority) can compare a
+    # changed doc against unchanged canonical docs. ``focus_paths=None`` reports
+    # every finding (the ``all`` / full-scan scopes).
+    focus_paths: list[str] | None
     if args.paths:
         scope = "explicit"
-        doc_paths: list[str] = list(args.paths)
+        focus_paths = list(args.paths)
+        context_paths = sorted(set(focus_paths) | set(all_doc_paths()))
     elif args.scope == "all":
         scope = "all"
-        doc_paths = all_doc_paths()
+        focus_paths = None
+        context_paths = all_doc_paths()
     else:
         changed = changed_doc_paths(args.base)
         if changed is None:
             scope = "all (git unavailable, fell back to full scan)"
-            doc_paths = all_doc_paths()
+            focus_paths = None
+            context_paths = all_doc_paths()
         else:
             scope = f"changed vs {args.base}"
-            doc_paths = changed
+            focus_paths = changed
+            context_paths = sorted(set(changed) | set(all_doc_paths()))
 
-    docs = load_docs(doc_paths)
-    findings = run_checks(docs)
+    docs = load_docs(context_paths)
+    findings = run_checks(docs, focus_paths=focus_paths)
 
     if args.format == "json":
         print(_format_json(findings, scope=scope))


### PR DESCRIPTION
## Issue
[MM-908](https://moonladder.atlassian.net/browse/MM-908) — Add an advisory (non-blocking) documentation-architecture validation helper

## Summary
Implements an advisory-only documentation-architecture validation helper that catches MoonSpec Documentation Architecture Standard drift early without blocking CI. This is the validation story deferred by MM-902 (which authored the standard and document model but explicitly left validation out of scope).

- New helper `tools/check_documentation_architecture.py` implements the enumerated advisory checks:
  - flags new canonical docs missing a **Document Class**
  - flags new plans placed outside `docs/tmp/` (or another approved imperative working area) and `*Plan.md` files under canonical architecture folders
  - flags duplicate canonical documents with overlapping authority
  - flags contract docs missing an authority statement
  - flags separate `decisions/` or ADR-style additions as discouraged
- Warnings are **structured** (machine-readable) so they can later be promoted to a CI gate if the convention proves stable.
- Validation is **advisory-only in v1**: it is non-blocking and clearly marked as advisory.
- `docs/DocumentationArchitectureValidation.md` documents the helper, its checks, and the advisory-to-gate promotion path.

## Tests run
- `python -m pytest tests/unit/tools/test_check_documentation_architecture.py -q` → **20 passed**

## Remaining risks
- **Advisory-only by design**: warnings can be ignored (the MM-908 "advisory-validation-ignored" risk). Mitigation is the structured output enabling a future opt-in CI gate; promotion is intentionally out of scope here.
- Heuristic checks (e.g. overlapping-authority / authority-statement detection) may produce false positives/negatives; kept non-blocking precisely so review judgment remains authoritative until the convention stabilizes.


[MM-908]: https://moonladder.atlassian.net/browse/MM-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ