### PR TITLE
MM-909: Enforce self-conformance and run docs validation for the docs architecture standard

### DIFF
--- a/docs/tmp/MoonSpecDocsArchitectureConformanceReview.md
+++ b/docs/tmp/MoonSpecDocsArchitectureConformanceReview.md
@@ -1,0 +1,61 @@
+# MoonSpec Documentation Architecture — Self-Conformance Review
+
+Status: evidence / self-conformance review (2026-06-25). Time-bound guardrail record — lives in `docs/tmp/` per Constitution XV and the standard's own Imperative Working Document placement rule (§4). This is **not** a canonical declarative view and introduces no new documentation authority.
+
+> **Traceability:** This review is the deliverable of **MM-909** (source design **MM-900**, "Implement MoonSpec Documentation Architecture Standard"). It covers **DESIGN-REQ-019** and **DESIGN-REQ-020** (advisory validation and self-conformance). It reviews, but does not redefine, the standard authored by **MM-902** at [`docs/DocumentationArchitecture.md`](../DocumentationArchitecture.md), which extends [`docs/Workflows/MoonSpecDocumentModel.md`](../Workflows/MoonSpecDocumentModel.md).
+
+## Purpose
+
+MM-909 is the guardrail story for the MoonSpec Documentation Architecture Standard. It owns the issue's **non-goals** and **self-conformance** acceptance criteria. This document records the result of:
+
+1. A self-conformance review of every new doc/template/plan introduced by this issue against the declarative/imperative split and the non-goals.
+2. The available docs validation / lint / link checks that were run.
+3. Any unresolved documentation-authority conflicts (recorded here and cross-referenced from the migration plan).
+
+It is a one-time evidence record; the durable, repeatable form of these guardrails lives in `tests/unit/docs/test_documentation_architecture_conformance.py`.
+
+## Documents in scope
+
+The docs introduced or owned by the MoonSpec Documentation Architecture Standard effort (source MM-900):
+
+| Document | Class | Role |
+|----------|-------|------|
+| [`docs/DocumentationArchitecture.md`](../DocumentationArchitecture.md) | Canonical declarative view (Cross-Cutting Concept / standard) | The standard itself (MM-902). |
+| [`docs/tmp/MoonSpecDocsFirstAlignmentPlan.md`](MoonSpecDocsFirstAlignmentPlan.md) | Imperative working document (Migration/Implementation Plan) | The execution plan for the docs-first alignment effort. |
+| `docs/tmp/MoonSpecDocsArchitectureConformanceReview.md` (this file) | Imperative working document (evidence) | This self-conformance record (MM-909). |
+
+The standard layers on the pre-existing [`docs/Workflows/MoonSpecDocumentModel.md`](../Workflows/MoonSpecDocumentModel.md), which predates MM-900 and is not a doc "introduced by this issue"; it is reviewed only as the authority the standard must not contradict.
+
+## Self-conformance review against the non-goals
+
+Each row is an acceptance-criteria condition this guardrail must confirm, the verdict, and the evidence.
+
+| # | Non-goal / condition | Verdict | Evidence |
+|---|----------------------|---------|----------|
+| 1 | No new **canonical** doc is primarily framed as a migration, checklist, rollout, or status tracker. | PASS | `docs/DocumentationArchitecture.md` carries `Status: Current standard and target direction` and is structured as desired-state taxonomy (umbrella vocabulary, five declarative viewpoints, module boundary policy, contract ownership). It has no checklist/phase/status primary framing. The two migration/evidence docs are confined to `docs/tmp/` and are explicitly labelled non-canonical. |
+| 2 | No new **imperative plan** is presented as authoritative desired-state architecture. | PASS | `MoonSpecDocsFirstAlignmentPlan.md` and this review live under `docs/tmp/` and self-label as time-bound execution/evidence material; neither is cited as canonical architecture. The standard (§4) explicitly states imperative working documents are **not** part of the canonical Architecture Description. |
+| 3 | The standard introduces no separate ADRs, decision logs, or `decisions/` directories. | PASS | No `docs/adr/`, `docs/ADR/`, `docs/decisions/`, or `docs/Decisions/` directory exists. `docs/DocumentationArchitecture.md` defines exactly five canonical viewpoints and four imperative types — none of which is an ADR/decision-log type — and does not mandate decision records. |
+| 4 | The standard does not force every module to be a DDD bounded context, adds no hard-blocking validation, and adds no heavyweight ceremony. | PASS | §5 makes "architectural boundary / ownership surface" the **default**, with Bounded Context as a subtype permitted **only** when all three boundary tests pass ("If any test fails, the directory is an architectural boundary or ownership surface — not a Bounded Context"). The validation added by this issue is **advisory** (terminology check + this review + read-only unit guardrails); nothing newly blocks merge or commit. No new required process ceremony is introduced. |
+| 5 | The work does not rewrite all docs, rename every existing doc, mass-backfill metadata, or move all plans in one pass. | PASS | The MM-909 change set adds this review, a guardrail test, and a recorded authority-conflict outcome in the migration plan. No existing canonical doc is renamed, rewritten, or mass-backfilled; no bulk plan migration is performed. |
+| 6 | The standard does not treat `specs/` as durable documentation and does not rely on roadmap text alone as implementation evidence. | PASS | `docs/DocumentationArchitecture.md` never names `specs/` as durable/canonical. Constitution XIV/XV and the standard treat `specs/` as gitignored, run-local, disposable. Implementation evidence for this story is the conformance review plus the validation runs and the guardrail test — not roadmap prose. The terminology gate (`tools/check_terminology.sh`) actively bans `specs/<feature>/` durable-doc framing in canonical docs and passes. |
+| 7 | Owner/module matrices are preserved as canonical state/evidence surfaces where applicable. | PASS | No owner/module matrix is removed or downgraded by this issue. §5–§6 of the standard preserve module-owned doc sets and the contract-authority/ownership rules as the canonical state surface for module ownership. |
+| 8 | New docs do not contradict MoonSpec, Tactics/constitution rules, or docs-first traceability. | PASS | `docs/DocumentationArchitecture.md` §1 explicitly defers to `MoonSpecDocumentModel.md` for the underlying class/precedence/reconciliation rules and states its terms are additive refinements, never substitutes. It is consistent with Constitution XIV (Docs-First) and XV (desired state vs. migration backlog). No contradiction found. |
+
+## Docs validation / lint / link checks
+
+Available repository docs validation was run; results recorded here as DESIGN-REQ-019 evidence.
+
+| Check | Command | Outcome |
+|-------|---------|---------|
+| Docs terminology gate | `bash tools/check_terminology.sh` | **PASS** — "Docs terminology check passed (141 files scanned)." Includes the `specs/<feature>/` durable-doc-guidance ban in canonical docs. |
+| Workflow terminology guardrails | `python tools/verify_workflow_terminology.py --mode all` | **PASS** — "MM-731 workflow terminology check passed (all)." |
+| Markdown lint (markdownlint/remark) | n/a | **Not configured** in this repository; no markdownlint/remark/link-check tooling is present. Recorded as unavailable rather than skipped silently (no new heavyweight validation is introduced by this issue — non-goal honored). |
+| Link check | n/a | **Not configured**; intra-repo links in this review and the standard were verified by hand to resolve to existing paths. |
+
+## Unresolved documentation-authority conflicts
+
+**None.** The self-conformance review found no unresolved documentation-authority conflict. `docs/DocumentationArchitecture.md` defers to `MoonSpecDocumentModel.md` for the base classes and to the constitution for the desired-state/migration-backlog separation, so it creates no second authority. This outcome is cross-referenced from the migration plan (`docs/tmp/MoonSpecDocsFirstAlignmentPlan.md`, "MM-909 self-conformance and authority-conflict record"). Should a future conflict surface, it must be recorded in that migration plan or in the MM-909 issue comments per the acceptance criteria.
+
+## Cleanup
+
+This review and the migration plan are time-bound working documents. When the MoonSpec Documentation Architecture Standard effort (MM-900 and its child stories) is fully completed and merged, delete or archive both rather than leaving them as stale canonical-looking material (Constitution XV; standard §4).

--- a/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
+++ b/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
@@ -151,3 +151,13 @@ Implementation note (deviation from the original draft): preset `version` labels
 ## Suggested execution order
 
 Phase 1 (doctrine + guidance reconciliation) → Phase 2 (skill text) → Phase 3 (new skill) → Phase 4 (presets + handler) → Phase 5 (tests). Phases 1–3 are mergeable independently; Phase 4 should land with Phase 5 in one change.
+
+---
+
+## MM-909 self-conformance and authority-conflict record
+
+MM-909 (source design MM-900; DESIGN-REQ-019, DESIGN-REQ-020) ran the self-conformance guardrail over the docs introduced by the MoonSpec Documentation Architecture Standard effort. The full review is recorded in [`MoonSpecDocsArchitectureConformanceReview.md`](MoonSpecDocsArchitectureConformanceReview.md).
+
+- **Self-conformance review:** All non-goal conditions PASS — no new canonical doc is framed as migration/checklist/rollout/status; no imperative plan is presented as canonical architecture; no ADRs/decision logs/`decisions/` directories are introduced; module directories are not forced to be DDD bounded contexts; no hard-blocking validation or heavyweight ceremony is added; `specs/` is not treated as durable documentation; owner/module ownership surfaces are preserved.
+- **Docs validation:** `tools/check_terminology.sh` (141 files) and `python tools/verify_workflow_terminology.py --mode all` both PASS. No markdownlint/remark/link-check tooling is configured in this repository; recorded as unavailable rather than silently skipped.
+- **Unresolved documentation-authority conflicts:** **None.** `docs/DocumentationArchitecture.md` defers to `docs/Workflows/MoonSpecDocumentModel.md` for base classes and to the constitution for the desired-state/migration-backlog separation, so it creates no second authority. Any future conflict must be recorded here or in the MM-909 issue comments.

--- a/tests/unit/docs/test_documentation_architecture_conformance.py
+++ b/tests/unit/docs/test_documentation_architecture_conformance.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -105,6 +107,12 @@ def test_standard_defers_to_document_model_no_second_authority() -> None:
 
 
 def test_conformance_review_is_non_canonical_working_doc_with_traceability() -> None:
+    if not CONFORMANCE_REVIEW.exists():
+        pytest.skip(
+            "docs/tmp self-conformance evidence is disposable; the durable "
+            "guardrails on the canonical standard cover the regression surface "
+            "once this working doc is archived/removed after MM-900 completes."
+        )
     text = _read(CONFORMANCE_REVIEW)
     # Self-labels as time-bound docs/tmp evidence, not a canonical view.
     assert "docs/tmp/" in text
@@ -122,6 +130,12 @@ def test_conformance_review_is_non_canonical_working_doc_with_traceability() -> 
 
 
 def test_migration_plan_records_authority_conflict_outcome() -> None:
+    if not MIGRATION_PLAN.exists():
+        pytest.skip(
+            "docs/tmp migration/alignment plan is disposable working evidence; "
+            "it is not a permanent test fixture and may be archived/removed once "
+            "MM-900 completes without failing the required unit suite."
+        )
     text = _read(MIGRATION_PLAN)
     assert "MM-909 self-conformance and authority-conflict record" in text
     assert "MoonSpecDocsArchitectureConformanceReview.md" in text

--- a/tests/unit/docs/test_documentation_architecture_conformance.py
+++ b/tests/unit/docs/test_documentation_architecture_conformance.py
@@ -1,0 +1,129 @@
+"""MM-909 self-conformance guardrails for the MoonSpec Documentation Architecture Standard.
+
+These tests are the durable, repeatable form of the self-conformance review
+recorded in ``docs/tmp/MoonSpecDocsArchitectureConformanceReview.md``. They
+assert that the docs introduced by the standard (source design MM-900, authored
+by MM-902) keep honoring the issue's non-goals: the standard stays declarative
+desired state, introduces no ADR/decision-log authority, does not force every
+module to be a DDD bounded context, does not treat ``specs/`` as durable
+documentation, and the self-conformance evidence stays a non-canonical
+``docs/tmp/`` working document with preserved MM-900/MM-909 traceability.
+
+The checks are read-only and advisory in spirit (no hard-blocking validation is
+introduced by this issue); they only protect the conditions the guardrail story
+owns from silent regression.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+STANDARD_DOC = REPO_ROOT / "docs" / "DocumentationArchitecture.md"
+DOCUMENT_MODEL_DOC = REPO_ROOT / "docs" / "Workflows" / "MoonSpecDocumentModel.md"
+CONFORMANCE_REVIEW = (
+    REPO_ROOT / "docs" / "tmp" / "MoonSpecDocsArchitectureConformanceReview.md"
+)
+MIGRATION_PLAN = REPO_ROOT / "docs" / "tmp" / "MoonSpecDocsFirstAlignmentPlan.md"
+
+FORBIDDEN_DECISION_DIRS = (
+    REPO_ROOT / "docs" / "adr",
+    REPO_ROOT / "docs" / "ADR",
+    REPO_ROOT / "docs" / "decisions",
+    REPO_ROOT / "docs" / "Decisions",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_standard_is_declarative_desired_state_not_a_tracker() -> None:
+    text = _read(STANDARD_DOC)
+
+    # Declarative status, not a migration/checklist/status framing.
+    assert "**Status:** Current standard and target direction" in text
+    # The standard explicitly declares itself a desired-state strategy, not a plan.
+    assert "not a migration plan or a checklist" in text
+    # No checklist/status checkbox framing leaks into the canonical standard.
+    assert "- [ ]" not in text
+    assert "- [x]" not in text
+    # The five declarative viewpoints remain the backbone.
+    for viewpoint in (
+        "System Architecture View",
+        "Module Architecture View",
+        "System / Feature Design View",
+        "Module Contract Specification",
+        "Cross-Cutting Concept View",
+    ):
+        assert viewpoint in text, viewpoint
+
+
+def test_standard_introduces_no_adr_or_decision_log_authority() -> None:
+    for directory in FORBIDDEN_DECISION_DIRS:
+        assert not directory.exists(), directory
+
+    text = _read(STANDARD_DOC)
+    lowered = text.lower()
+    # The standard must not establish ADRs / decision logs / decisions dirs.
+    assert "decision log" not in lowered
+    assert "decisions/" not in lowered
+    # "ADR" must not be introduced as a document type (guards the non-goal).
+    assert "adr" not in lowered.replace("standard", "")
+
+
+def test_standard_does_not_force_bounded_contexts() -> None:
+    text = _read(STANDARD_DOC)
+    # Architectural boundary / ownership surface is the default, not Bounded Context.
+    assert "architectural boundary" in text
+    assert "ownership surface" in text
+    # Bounded Context is gated as a subtype behind boundary tests.
+    assert "subtype" in text.lower()
+    assert (
+        "the directory is an architectural boundary or ownership surface — not a Bounded Context"
+        in text
+    )
+
+
+def test_standard_does_not_treat_specs_as_durable_docs() -> None:
+    text = _read(STANDARD_DOC)
+    lowered = text.lower()
+    # specs/ must never be promoted to durable/canonical documentation here.
+    assert "specs/ as durable" not in lowered
+    assert "specs/ is the source of truth" not in lowered
+
+
+def test_standard_defers_to_document_model_no_second_authority() -> None:
+    assert DOCUMENT_MODEL_DOC.exists()
+    text = _read(STANDARD_DOC)
+    # The standard extends, not replaces, the Document Model — no second authority.
+    assert "extends, and does not replace" in text
+    assert "MoonSpecDocumentModel.md" in text
+    assert "additive refinements" in text
+
+
+def test_conformance_review_is_non_canonical_working_doc_with_traceability() -> None:
+    text = _read(CONFORMANCE_REVIEW)
+    # Self-labels as time-bound docs/tmp evidence, not a canonical view.
+    assert "docs/tmp/" in text
+    assert "not** a canonical" in text or "not a canonical" in text
+    # MM-900 source traceability and MM-909 ownership are preserved.
+    assert "MM-909" in text
+    assert "MM-900" in text
+    assert "MM-902" in text
+    assert "DESIGN-REQ-019" in text
+    assert "DESIGN-REQ-020" in text
+    # Records the validation outcome and the authority-conflict result.
+    assert "check_terminology.sh" in text
+    assert "verify_workflow_terminology.py" in text
+    assert "Unresolved documentation-authority conflicts" in text
+
+
+def test_migration_plan_records_authority_conflict_outcome() -> None:
+    text = _read(MIGRATION_PLAN)
+    assert "MM-909 self-conformance and authority-conflict record" in text
+    assert "MoonSpecDocsArchitectureConformanceReview.md" in text
+    # The recorded outcome: no unresolved authority conflict.
+    assert "Unresolved documentation-authority conflicts:" in text


### PR DESCRIPTION
## Issue
[MM-909](https://moonladder.atlassian.net/browse/MM-909) — Enforce self-conformance and run docs validation so new docs honor the declarative/imperative split and non-goals (source design MM-900; standard authored by MM-902). Covers DESIGN-REQ-019 (advisory validation) and DESIGN-REQ-020 (self-conformance).

## Summary
MM-909 is the guardrail story for the MoonSpec Documentation Architecture Standard. It owns the issue's non-goals and self-conformance acceptance criteria. This change delivers the missing guardrail artifacts:

- **`docs/tmp/MoonSpecDocsArchitectureConformanceReview.md`** — a self-conformance review of every new doc/template/plan introduced by this effort against the declarative/imperative split and the issue's non-goals (8 conditions, all PASS with evidence), plus the recorded docs-validation outcome and an explicit "no unresolved authority conflict" finding. Placed under `docs/tmp/` as a non-canonical, time-bound evidence record so the guardrail itself does not introduce a second documentation authority.
- **`docs/tmp/MoonSpecDocsFirstAlignmentPlan.md`** — records the self-conformance and authority-conflict outcome (no unresolved conflict) per the acceptance criteria, cross-referencing the review.
- **`tests/unit/docs/test_documentation_architecture_conformance.py`** — durable, read-only guardrails asserting the standard stays declarative desired state, introduces no ADR/decision-log authority or `decisions/` directory, does not force DDD bounded contexts, does not treat `specs/` as durable docs, defers to `MoonSpecDocumentModel.md`, and that the evidence/traceability records persist.

No canonical doc is renamed, rewritten, or mass-backfilled; no hard-blocking validation or heavyweight ceremony is added (non-goals honored).

## Tests run
- `python -m pytest tests/unit/docs/test_documentation_architecture_conformance.py -q` → **7 passed**
- Docs validation recorded as DESIGN-REQ-019 evidence: `bash tools/check_terminology.sh` → **PASS** (141 files scanned); `python tools/verify_workflow_terminology.py --mode all` → **PASS**.
- Markdownlint/remark/link-check tooling is **not configured** in this repository; recorded as unavailable rather than skipped silently. Intra-repo links verified by hand.

## Remaining risks
- The conformance review and migration plan are time-bound working documents under `docs/tmp/`; they should be deleted/archived once the MM-900 effort is fully completed and merged, to avoid stale canonical-looking material.
- No markdownlint/remark/link-check tooling exists in the repo, so markdown/link validation was manual rather than automated; if such tooling is later added, the recorded evidence should be refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-909]: https://moonladder.atlassian.net/browse/MM-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ