### PR TITLE
MM-898 Render schedule-owned run history links

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2146,7 +2146,7 @@ def _serialize_execution(
         actions=actions,
         resume=resume_summary,
         related_runs=related_runs,
-        recurrence=_execution_recurrence_provenance(params),
+        recurrence=_execution_recurrence_provenance(params, memo),
         target_diagnostics=target_diagnostics,
         run_metrics=run_metrics,
         improvement_signals=improvement_signals,
@@ -2781,15 +2781,22 @@ def _execution_related_run_metadata(record: TemporalExecutionRecord) -> dict[str
 
 
 def _execution_recurrence_provenance(
-    params: Mapping[str, Any],
+    params: Mapping[str, Any] | None,
+    memo: Mapping[str, Any] | None = None,
 ) -> dict[str, str] | None:
+    if not isinstance(params, Mapping):
+        params = {}
     system_payload = params.get("system")
-    if not isinstance(system_payload, Mapping):
-        return None
-    recurrence_payload = system_payload.get("recurrence")
-    if not isinstance(recurrence_payload, Mapping):
-        return None
-    definition_id = str(recurrence_payload.get("definitionId") or "").strip()
+    recurrence_payload = (
+        system_payload.get("recurrence") if isinstance(system_payload, Mapping) else None
+    )
+    definition_id = (
+        str(recurrence_payload.get("definitionId") or "").strip()
+        if isinstance(recurrence_payload, Mapping)
+        else ""
+    )
+    if not definition_id and isinstance(memo, Mapping):
+        definition_id = str(memo.get("definitionId") or "").strip()
     if not definition_id:
         return None
     return {

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2146,6 +2146,7 @@ def _serialize_execution(
         actions=actions,
         resume=resume_summary,
         related_runs=related_runs,
+        recurrence=_execution_recurrence_provenance(params),
         target_diagnostics=target_diagnostics,
         run_metrics=run_metrics,
         improvement_signals=improvement_signals,
@@ -2776,6 +2777,24 @@ def _execution_related_run_metadata(record: TemporalExecutionRecord) -> dict[str
             or None
         ),
         "created_at": getattr(record, "created_at", None),
+    }
+
+
+def _execution_recurrence_provenance(
+    params: Mapping[str, Any],
+) -> dict[str, str] | None:
+    system_payload = params.get("system")
+    if not isinstance(system_payload, Mapping):
+        return None
+    recurrence_payload = system_payload.get("recurrence")
+    if not isinstance(recurrence_payload, Mapping):
+        return None
+    definition_id = str(recurrence_payload.get("definitionId") or "").strip()
+    if not definition_id:
+        return None
+    return {
+        "definitionId": definition_id,
+        "href": f"/schedules/{quote(definition_id, safe='')}",
     }
 
 

--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -77,6 +77,7 @@ class RecurringWorkflowRunModel(BaseModel):
     outcome: str = Field(..., alias="outcome")
     dispatch_attempts: int = Field(..., alias="dispatchAttempts")
     dispatch_after: Optional[datetime] = Field(None, alias="dispatchAfter")
+    started_at: Optional[datetime] = Field(None, alias="startedAt")
     temporal_workflow_id: Optional[str] = Field(None, alias="temporalWorkflowId")
     temporal_run_id: Optional[str] = Field(None, alias="temporalRunId")
     message: Optional[str] = Field(None, alias="message")
@@ -170,7 +171,11 @@ def _serialize_definition(
         updated_at=definition.updated_at,
     )
 
-def _serialize_run(run: RecurringWorkflowRun) -> RecurringWorkflowRunModel:
+def _serialize_run(
+    run: RecurringWorkflowRun,
+    *,
+    started_at: datetime | None = None,
+) -> RecurringWorkflowRunModel:
     return RecurringWorkflowRunModel(
         id=run.id,
         definition_id=run.definition_id,
@@ -179,6 +184,7 @@ def _serialize_run(run: RecurringWorkflowRun) -> RecurringWorkflowRunModel:
         outcome=run.outcome.value,
         dispatch_attempts=run.dispatch_attempts,
         dispatch_after=run.dispatch_after,
+        started_at=started_at,
         temporal_workflow_id=run.temporal_workflow_id,
         temporal_run_id=run.temporal_run_id,
         message=run.message,
@@ -486,6 +492,9 @@ async def list_recurring_workflow_runs(
             can_manage_global=bool(getattr(user, "is_superuser", False)),
         )
         runs = await service.list_runs(definition_id=definition.id, limit=limit)
+        started_at_by_workflow_id = await service.started_at_by_workflow_id(
+            item.temporal_workflow_id for item in runs if item.temporal_workflow_id
+        )
     except Exception as exc:  # pragma: no cover - thin mapping layer
         _log_route_exception(
             action="list_recurring_workflow_runs",
@@ -495,4 +504,14 @@ async def list_recurring_workflow_runs(
         )
         raise _map_error(exc) from exc
 
-    return RecurringWorkflowRunListResponse(items=[_serialize_run(item) for item in runs])
+    return RecurringWorkflowRunListResponse(
+        items=[
+            _serialize_run(
+                item,
+                started_at=started_at_by_workflow_id.get(
+                    str(item.temporal_workflow_id or "")
+                ),
+            )
+            for item in runs
+        ]
+    )

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -19,6 +19,7 @@ from api_service.db.models import (
     RecurringWorkflowRunOutcome,
     RecurringWorkflowRunTrigger,
     RecurringWorkflowScopeType,
+    TemporalExecutionRecord,
 )
 from moonmind.workflows.recurring.cron import (
     compute_next_occurrence,
@@ -915,6 +916,29 @@ class RecurringWorkflowsService:
         
         # Temporal reconciliation could be added here in the future using adapter.describe_schedule
         return runs
+
+    async def started_at_by_workflow_id(
+        self,
+        workflow_ids: Iterable[str],
+    ) -> dict[str, datetime]:
+        normalized_ids = sorted(
+            {str(item).strip() for item in workflow_ids if str(item).strip()}
+        )
+        if not normalized_ids:
+            return {}
+        stmt = select(
+            TemporalExecutionRecord.workflow_id,
+            TemporalExecutionRecord.started_at,
+        ).where(
+            TemporalExecutionRecord.workflow_id.in_(normalized_ids),
+            TemporalExecutionRecord.started_at.is_not(None),
+        )
+        rows = (await self._session.execute(stmt)).all()
+        return {
+            str(workflow_id): started_at
+            for workflow_id, started_at in rows
+            if started_at
+        }
 
     async def runtime_summary_for_definition(
         self,

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -932,6 +932,8 @@ class RecurringWorkflowsService:
         ).where(
             TemporalExecutionRecord.workflow_id.in_(normalized_ids),
             TemporalExecutionRecord.started_at.is_not(None),
+        ).order_by(
+            TemporalExecutionRecord.started_at.asc(),
         )
         rows = (await self._session.execute(stmt)).all()
         return {

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -53,6 +53,7 @@ const detailRuns = {
       outcome: "enqueued",
       dispatchAttempts: 1,
       dispatchAfter: null,
+      startedAt: "2026-06-24T02:00:02Z",
       temporalWorkflowId: "workflow-from-schedule",
       temporalRunId: "temporal-run-1",
       message: "Started",
@@ -292,10 +293,17 @@ describe("SchedulesPage", () => {
     expect(screen.getByText("Temporal Schedule ID")).not.toBeNull();
     expect(screen.getByText("temporal-schedule-alpha")).not.toBeNull();
     expect(screen.getByText("MoonLadderStudios/MoonMind")).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "Actual Start" })).not.toBeNull();
+    expect(screen.getByRole("columnheader", { name: "Status" })).not.toBeNull();
     expect(screen.getByText("Started")).not.toBeNull();
     expect(screen.getByRole("link", { name: "workflow-from-schedule" }).getAttribute("href")).toBe(
       "/workflows/workflow-from-schedule?source=temporal",
     );
+    expect(screen.queryByRole("heading", { name: "Steps" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Artifacts" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Logs" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Proposals" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Diagnostics" })).toBeNull();
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules?scope=personal")).toBe(false);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha")).toBe(true);
     expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/console/schedules/schedule-alpha/runs?limit=200")).toBe(true);

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -38,6 +38,7 @@ const ScheduleRunSchema = z.object({
   outcome: z.string(),
   dispatchAttempts: z.number(),
   dispatchAfter: z.string().nullable().optional(),
+  startedAt: z.string().nullable().optional(),
   temporalWorkflowId: z.string().nullable().optional(),
   temporalRunId: z.string().nullable().optional(),
   message: z.string().nullable().optional(),
@@ -608,8 +609,13 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 render: (item) => formatWhen(item.scheduledFor),
               },
               {
+                key: 'startedAt',
+                header: 'Actual Start',
+                render: (item) => formatWhen(item.startedAt),
+              },
+              {
                 key: 'outcome',
-                header: 'Outcome',
+                header: 'Status',
                 render: (item) => titleCaseLabel(formatStatusLabel(item.outcome)),
               },
               {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -3488,6 +3488,10 @@ describe('Workflow Detail Entrypoint', () => {
       startedAt: '2026-03-28T00:00:01Z',
       updatedAt: '2026-03-28T00:00:02Z',
       closedAt: '2026-03-28T00:00:03Z',
+      recurrence: {
+        definitionId: 'schedule-alpha',
+        href: '/schedules/schedule-alpha',
+      },
       actions: { canSetTitle: true, canCancel: false, canRerun: false },
     };
 
@@ -3540,6 +3544,8 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getByText('profile:gemini-default')).toBeTruthy();
       expect(screen.getByText('Priority').closest('div')?.textContent).toContain('4');
       expect(screen.getByRole('link', { name: 'https://github.com/MoonLadderStudios/MoonMind/pull/123' })).toBeTruthy();
+      expect(screen.getByText(/Created by schedule/)).toBeTruthy();
+      expect(screen.getByRole('link', { name: 'schedule-alpha' }).getAttribute('href')).toBe('/schedules/schedule-alpha');
     });
 
     expect(screen.queryByText('Inspect the repository.')).toBeNull();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5630,8 +5630,13 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       {execution?.recurrence?.definitionId ? (
         <div className="page-meta">
           Created by schedule{' '}
-          <a href={execution.recurrence.href || `/schedules/${encodeURIComponent(execution.recurrence.definitionId)}`}>
-            {execution.recurrence.definitionId}
+          <a
+            href={
+              execution.recurrence?.href ||
+              `/schedules/${encodeURIComponent(execution.recurrence?.definitionId || '')}`
+            }
+          >
+            {execution.recurrence?.definitionId}
           </a>
         </div>
       ) : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -723,6 +723,14 @@ const ExecutionDetailSchema = z
       )
       .default([])
       .optional(),
+    recurrence: z
+      .object({
+        definitionId: z.string(),
+        href: z.string(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
     targetDiagnostics: TargetDiagnosticsSchema.nullable().optional(),
     recoveryEligibility: RecoveryEligibilitySchema.nullable().optional(),
     interventionAudit: z
@@ -5617,6 +5625,15 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           current={detailSubroute}
           search={search}
         />
+      ) : null}
+
+      {execution?.recurrence?.definitionId ? (
+        <div className="page-meta">
+          Created by schedule{' '}
+          <a href={execution.recurrence.href || `/schedules/${encodeURIComponent(execution.recurrence.definitionId)}`}>
+            {execution.recurrence.definitionId}
+          </a>
+        </div>
       ) : null}
 
       {actionsOn && actions ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4766,6 +4766,7 @@ export interface components {
             resume?: components["schemas"]["ExecutionResumeSummaryModel"] | null;
             /** Relatedruns */
             relatedRuns?: components["schemas"]["ExecutionRelatedRunModel"][];
+            recurrence?: components["schemas"]["ExecutionRecurrenceProvenanceModel"] | null;
             targetDiagnostics?: components["schemas"]["ExecutionTargetDiagnosticsModel"] | null;
             /** Runmetrics */
             runMetrics?: {
@@ -4969,6 +4970,16 @@ export interface components {
             remediation?: string | null;
             /** Cause */
             cause?: string | null;
+        };
+        /**
+         * ExecutionRecurrenceProvenanceModel
+         * @description Schedule provenance for executions spawned by recurring definitions.
+         */
+        ExecutionRecurrenceProvenanceModel: {
+            /** Definitionid */
+            definitionId: string;
+            /** Href */
+            href: string;
         };
         /**
          * ExecutionRefreshEnvelope
@@ -7175,6 +7186,8 @@ export interface components {
             dispatchAttempts: number;
             /** Dispatchafter */
             dispatchAfter?: string | null;
+            /** Startedat */
+            startedAt?: string | null;
             /** Temporalworkflowid */
             temporalWorkflowId?: string | null;
             /** Temporalrunid */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2987,6 +2987,14 @@ class ExecutionRelatedRunModel(BaseModel):
     created_at: Optional[datetime] = Field(None, alias="createdAt")
     href: str = Field(..., alias="href", min_length=1)
 
+class ExecutionRecurrenceProvenanceModel(BaseModel):
+    """Schedule provenance for executions spawned by recurring definitions."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    definition_id: str = Field(..., alias="definitionId", min_length=1)
+    href: str = Field(..., alias="href", min_length=1)
+
 class ExecutionTargetDiagnosticAttachmentModel(BaseModel):
     """Attachment bound to the objective or a single executable step."""
 
@@ -3190,6 +3198,9 @@ class ExecutionModel(BaseModel):
     resume: ExecutionResumeSummaryModel | None = Field(None, alias="resume")
     related_runs: list[ExecutionRelatedRunModel] = Field(
         default_factory=list, alias="relatedRuns"
+    )
+    recurrence: ExecutionRecurrenceProvenanceModel | None = Field(
+        None, alias="recurrence"
     )
     target_diagnostics: ExecutionTargetDiagnosticsModel | None = Field(
         None, alias="targetDiagnostics"

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6871,6 +6871,36 @@ def test_serialize_execution_leaves_immediate_run_unscheduled() -> None:
     assert payload.scheduled_for is None
     assert payload.created_at == created_at
 
+def test_serialize_execution_surfaces_recurring_schedule_provenance() -> None:
+    created_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
+    record = SimpleNamespace(
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={},
+        owner_id="user-1",
+        entry="run",
+        workflow_type=SimpleNamespace(value="MoonMind.UserWorkflow"),
+        state=MoonMindWorkflowState.EXECUTING,
+        workflow_id="wf-1",
+        namespace="moonmind",
+        run_id="run-1",
+        artifact_refs=[],
+        scheduled_for=None,
+        created_at=created_at,
+        started_at=created_at,
+        updated_at=created_at,
+        closed_at=None,
+        integration_state=None,
+        parameters={"system": {"recurrence": {"definitionId": "schedule-alpha"}}},
+    )
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["recurrence"] == {
+        "definitionId": "schedule-alpha",
+        "href": "/schedules/schedule-alpha",
+    }
+
 def test_serialize_execution_falls_back_to_updated_at_without_scheduled_time() -> None:
     updated_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
     record = SimpleNamespace(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -26,6 +26,7 @@ from api_service.api.routers.executions import (
     _build_original_workflow_input_snapshot_payload,
     _build_recurring_target,
     _checkpoint_failed_step_execution,
+    _execution_recurrence_provenance,
     _expand_goal_preset_for_workflow_submission,
     _extract_cost_estimate_usd,
     _effective_user_roles,
@@ -6900,6 +6901,46 @@ def test_serialize_execution_surfaces_recurring_schedule_provenance() -> None:
         "definitionId": "schedule-alpha",
         "href": "/schedules/schedule-alpha",
     }
+
+
+def test_serialize_execution_surfaces_recurring_schedule_provenance_from_memo() -> None:
+    created_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
+    record = SimpleNamespace(
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={"definitionId": "schedule-from-memo"},
+        owner_id="user-1",
+        entry="run",
+        workflow_type=SimpleNamespace(value="MoonMind.UserWorkflow"),
+        state=MoonMindWorkflowState.EXECUTING,
+        workflow_id="wf-1",
+        namespace="moonmind",
+        run_id="run-1",
+        artifact_refs=[],
+        scheduled_for=None,
+        created_at=created_at,
+        started_at=created_at,
+        updated_at=created_at,
+        closed_at=None,
+        integration_state=None,
+        parameters={},
+    )
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["recurrence"] == {
+        "definitionId": "schedule-from-memo",
+        "href": "/schedules/schedule-from-memo",
+    }
+
+
+def test_execution_recurrence_provenance_ignores_non_mapping_params() -> None:
+    assert _execution_recurrence_provenance(None) is None
+    assert _execution_recurrence_provenance(None, {"definitionId": "memo-schedule"}) == {
+        "definitionId": "memo-schedule",
+        "href": "/schedules/memo-schedule",
+    }
+
 
 def test_serialize_execution_falls_back_to_updated_at_without_scheduled_time() -> None:
     updated_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -170,7 +170,10 @@ async def test_create_recurring_workflow_returns_serialized_definition() -> None
 async def test_run_recurring_workflow_now_returns_run_row() -> None:
     service = AsyncMock()
     definition = _definition()
-    run_row = _run(definition_id=definition.id)
+    run_row = _run(
+        definition_id=definition.id,
+        temporal_workflow_id="workflow-from-schedule",
+    )
     service.require_authorized_definition.return_value = definition
     service.create_manual_run.return_value = run_row
     user = SimpleNamespace(id=uuid4(), is_superuser=False)
@@ -183,4 +186,32 @@ async def test_run_recurring_workflow_now_returns_run_row() -> None:
 
     assert response.definition_id == definition.id
     assert response.outcome == "pending_dispatch"
+    assert response.started_at is None
     service.create_manual_run.assert_awaited_once_with(definition)
+
+@pytest.mark.asyncio
+async def test_list_recurring_workflow_runs_hydrates_actual_start_time() -> None:
+    service = AsyncMock()
+    definition = _definition()
+    started_at = datetime(2026, 6, 24, 2, 0, 2, tzinfo=UTC)
+    run_row = _run(
+        definition_id=definition.id,
+        temporal_workflow_id="workflow-from-schedule",
+    )
+    service.require_authorized_definition.return_value = definition
+    service.list_runs.return_value = [run_row]
+    service.started_at_by_workflow_id.return_value = {
+        "workflow-from-schedule": started_at
+    }
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    response = await recurring_router.list_recurring_workflow_runs(
+        definition_id=definition.id,
+        limit=200,
+        service=service,
+        user=user,
+    )
+
+    assert response.items[0].temporal_workflow_id == "workflow-from-schedule"
+    assert response.items[0].started_at == started_at
+    service.started_at_by_workflow_id.assert_awaited_once()

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -118,6 +118,18 @@ async def test_create_definition_creates_temporal_schedule(
                 "mm_owner_id": str(definition.owner_user_id),
             }
 
+
+async def test_started_at_by_workflow_id_orders_duplicate_rows_deterministically() -> None:
+    session = AsyncMock(spec=AsyncSession)
+    session.execute.return_value = SimpleNamespace(all=lambda: [])
+    service = RecurringWorkflowsService(session)
+
+    assert await service.started_at_by_workflow_id(["wf-1"]) == {}
+
+    statement = session.execute.await_args.args[0]
+    assert "ORDER BY temporal_executions.started_at ASC" in str(statement)
+
+
 async def test_create_definition_normalizes_snake_case_target_aliases(
     tmp_path: Path, mock_temporal_adapter
 ) -> None:


### PR DESCRIPTION
Issue reference: MM-898

Summary:
- Adds actual start time and status labeling to schedule-owned run rows returned by the recurring workflow runs API and rendered on the schedule detail Runs tab.
- Keeps run rows linked to the normal workflow detail route through temporal workflow IDs.
- Adds optional workflow-detail recurrence provenance so executions created by a schedule can link back to `/schedules/{definitionId}`.
- Covers the schedule detail and workflow detail behavior in API and frontend unit tests.

Tests run:
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/api/routers/test_recurring_workflows.py --ui-args frontend/src/entrypoints/schedules.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx`

Remaining risks:
- Full repository unit suite was not rerun in this handoff step; targeted API and UI coverage for the changed surfaces passed.
