### PR TITLE
MM-912 Convert presets to slug/scope current definitions

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -31,7 +31,7 @@ in the In Progress column of the THOR board" with a single batch run.
 - GitHub repo issues source: `github_repository`, `github_issue_state`
   (default `open`), optional `github_label_filter`, `github_assignee_filter`,
   `github_milestone_filter`, `github_search_query`.
-- `target_preset_slug` / `target_preset_version` / `target_preset_scope`
+- `target_preset_slug` / `target_preset_scope`
   (default `global`) / `target_preset_scope_ref`: the child preset to run per
   target. Known issue presets (`jira-implement`, `github-issue-implement`) are
   auto-bound; other presets must be mapped explicitly.
@@ -84,8 +84,8 @@ in the In Progress column of the THOR board" with a single batch run.
    python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
      --targets artifacts/batch-workflows-targets.json \
      --target-preset-slug <slug> \
-     --target-preset-version <version> \
      --target-preset-scope <global|personal> \
+     --target-preset-scope-ref <scope-ref-or-empty> \
      --publish-mode <none|branch|pr> \
      --constraints-file <optional path to shared constraints> \
      --max-workflows <cap>

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -26,6 +26,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 import httpx
 from moonmind.workflows.executions.execution_contract import SUPPORTED_PUBLISH_MODES
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
@@ -65,7 +69,6 @@ class RuntimeSelection:
 @dataclass
 class TargetConfig:
     preset_slug: str
-    preset_version: str
     preset_scope: str = "global"
     preset_scope_ref: str | None = None
     publish_mode: str = "pr"
@@ -229,14 +232,13 @@ def build_child_request(
         "inputs": inputs,
         "publish": {"mode": publish_mode},
         # Author the child with the selected preset via ``taskTemplate`` so the
-        # execution API expands the exact slug/version/scope/scopeRef (see
+        # execution API expands the exact slug/scope/scopeRef (see
         # expand_preset_for_child_run). Without this the child is goal-only and
-        # the server goal scheduler silently substitutes a hard-coded global
-        # preset version, dropping any non-default version, personal scope, or
-        # scopeRef. ``batchTargetPreset`` has no readers, so it is not emitted.
+        # the server goal scheduler silently substitutes a global preset,
+        # dropping any personal scope or scopeRef. ``batchTargetPreset`` has no
+        # readers, so it is not emitted.
         "taskTemplate": {
             "slug": config.preset_slug,
-            "version": config.preset_version,
             "scope": config.preset_scope,
             **(
                 {"scopeRef": config.preset_scope_ref}
@@ -621,7 +623,6 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--targets", required=True, help="Path to resolved targets JSON."
     )
     parser.add_argument("--target-preset-slug", required=True)
-    parser.add_argument("--target-preset-version", required=True)
     parser.add_argument("--target-preset-scope", default="global")
     parser.add_argument("--target-preset-scope-ref", default=None)
     parser.add_argument("--publish-mode", default="pr")
@@ -646,7 +647,6 @@ async def main(argv: list[str] | None = None) -> int:
 
     config = TargetConfig(
         preset_slug=str(args.target_preset_slug).strip(),
-        preset_version=str(args.target_preset_version).strip(),
         preset_scope=str(args.target_preset_scope or "global").strip() or "global",
         preset_scope_ref=_text(args.target_preset_scope_ref),
         publish_mode=_normalize_publish_mode(args.publish_mode),
@@ -668,7 +668,6 @@ async def main(argv: list[str] | None = None) -> int:
         "actor": os.getenv("GITHUB_ACTOR") or os.getenv("USER") or "unknown",
         "targetPreset": {
             "slug": config.preset_slug,
-            "version": config.preset_version,
             "scope": config.preset_scope,
             "scopeRef": config.preset_scope_ref,
         },
@@ -708,7 +707,7 @@ async def main(argv: list[str] | None = None) -> int:
     print(json.dumps(payload, indent=2))
     print(
         f"queued={payload['created']} skipped={len(skipped)} errors={len(errors)} "
-        f"preset={config.preset_slug}@{config.preset_version}"
+        f"preset={config.preset_slug}"
     )
     return 1 if errors else 0
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5566,16 +5566,17 @@ def _apply_goal_schedule_metadata(
     task_payload["appliedStepTemplates"] = [applied_template_payload]
     task_payload["taskTemplate"] = {
         "slug": str(applied_template.get("slug") or schedule.slug),
-        "version": str(applied_template.get("version") or schedule.version),
         "scope": "global",
     }
     task_payload["presetSchedule"] = {
         "source": "goal",
         "reason": schedule.reason,
         "presetSlug": schedule.slug,
-        "presetVersion": schedule.version,
         "jiraIssueKey": schedule.issue_key,
     }
+    preset_digest = str(applied_template.get("presetDigest") or "").strip()
+    if preset_digest:
+        task_payload["taskTemplate"]["presetDigest"] = preset_digest
 
 
 async def _expand_goal_preset_for_workflow_submission(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -5540,7 +5540,13 @@ def _apply_goal_schedule_metadata(
     )
     applied_template_payload = {
         "slug": str(applied_template.get("slug") or schedule.slug),
-        "version": str(applied_template.get("version") or schedule.version),
+        **(
+            {
+                "presetDigest": str(applied_template.get("presetDigest")).strip(),
+            }
+            if str(applied_template.get("presetDigest") or "").strip()
+            else {}
+        ),
         "inputs": (
             dict(applied_template.get("inputs"))
             if isinstance(applied_template.get("inputs"), Mapping)
@@ -5626,7 +5632,6 @@ async def _expand_goal_preset_for_workflow_submission(
         "slug": schedule.slug,
         "scope": "global",
         "scope_ref": None,
-        "version": schedule.version,
         "inputs": template_inputs,
         "context": context,
         "options": ExpandOptions(should_enforce_step_limit=True),

--- a/api_service/api/routers/presets.py
+++ b/api_service/api/routers/presets.py
@@ -214,7 +214,6 @@ async def expand_template(
             slug=slug,
             scope=resolved_scope,
             scope_ref=resolved_scope_ref,
-            version=payload.version,
             inputs=payload.inputs,
             context=payload.context,
             options=ExpandOptions(
@@ -247,46 +246,15 @@ async def get_template(
             slug=slug,
             scope=resolved_scope,
             scope_ref=resolved_scope_ref,
-            version=None,
             user_id=getattr(user, "id", None),
         )
     except Exception as exc:  # pragma: no cover - thin API mapping
         raise _map_service_error(exc) from exc
     return PresetResponseSchema.model_validate(item)
 
-@router.get("/{slug}/versions/{version}", response_model=PresetResponseSchema)
-async def get_template_version(
+@router.put("/{slug}/review", response_model=PresetResponseSchema)
+async def review_template(
     slug: str,
-    version: str,
-    scope: str = Query(...),
-    scope_ref: str | None = Query(None, alias="scopeRef"),
-    service: PresetCatalogService = Depends(_get_catalog_service),
-    user: User = Depends(get_current_user()),
-) -> PresetResponseSchema:
-    ensure_preset_catalog_enabled()
-
-    resolved_scope, resolved_scope_ref = resolve_template_scope_for_user(
-        user=user,
-        scope=scope,
-        scope_ref=scope_ref,
-        write=False,
-    )
-    try:
-        item = await service.get_template(
-            slug=slug,
-            scope=resolved_scope,
-            scope_ref=resolved_scope_ref,
-            version=version,
-            user_id=getattr(user, "id", None),
-        )
-    except Exception as exc:  # pragma: no cover - thin API mapping
-        raise _map_service_error(exc) from exc
-    return PresetResponseSchema.model_validate(item)
-
-@router.put("/{slug}/versions/{version}", response_model=PresetResponseSchema)
-async def review_template_version(
-    slug: str,
-    version: str,
     payload: PresetReviewRequestSchema,
     scope: str = Query(...),
     scope_ref: str | None = Query(None, alias="scopeRef"),
@@ -306,7 +274,6 @@ async def review_template_version(
             slug=slug,
             scope=resolved_scope,
             scope_ref=resolved_scope_ref,
-            version=version,
             release_status=PresetReleaseStatus(payload.release_status),
             reviewer_id=getattr(user, "id", None),
         )

--- a/api_service/api/routers/workflow_proposals.py
+++ b/api_service/api/routers/workflow_proposals.py
@@ -126,7 +126,7 @@ def _build_workflow_preview(
             for key in (
                 "presetId",
                 "presetSlug",
-                "presetVersion",
+                "presetDigest",
                 "includePath",
                 "originalStepId",
             ):

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 if TYPE_CHECKING:
     pass
@@ -368,7 +368,7 @@ class WorkerPauseSnapshotResponse(BaseModel):
     signal_status: Optional[str] = Field(None, alias="signalStatus")
 
 class PresetInputSchema(BaseModel):
-    """Input definition used by preset versions."""
+    """Input definition used by presets."""
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -442,6 +442,14 @@ class PresetStepBlueprintSchema(BaseModel):
     skill: Optional[PresetStepSkillSchema] = None
     annotations: dict[str, Any] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def reject_preset_version_identity(self) -> "PresetStepBlueprintSchema":
+        if self.version is not None:
+            raise ValueError(
+                "Preset includes use slug/scope only; remove version."
+            )
+        return self
+
 class PresetSummarySchema(BaseModel):
     """List response model for presets."""
 
@@ -452,8 +460,7 @@ class PresetSummarySchema(BaseModel):
     scope_ref: Optional[str] = Field(None, alias="scopeRef")
     title: str
     description: str
-    latest_version: str = Field(..., alias="latestVersion")
-    version: str
+    preset_digest: Optional[str] = Field(None, alias="presetDigest")
     tags: list[str] = Field(default_factory=list)
     is_favorite: bool = Field(False, alias="isFavorite")
     recent_applied_at: Optional[str] = Field(None, alias="recentAppliedAt")
@@ -470,7 +477,7 @@ class PresetListResponseSchema(BaseModel):
     items: list[PresetSummarySchema] = Field(default_factory=list)
 
 class PresetResponseSchema(PresetSummarySchema):
-    """Detail response model for one template version."""
+    """Detail response model for one preset."""
 
     inputs: list[PresetInputSchema] = Field(default_factory=list)
     input_schema: dict[str, Any] = Field(default_factory=dict, alias="inputSchema")
@@ -499,6 +506,17 @@ class PresetCreateRequestSchema(BaseModel):
         default_factory=list, alias="requiredCapabilities"
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict) and (
+            value.get("version") is not None or value.get("presetVersion") is not None
+        ):
+            raise ValueError(
+                "Preset definitions use slug/scope only; remove version or presetVersion."
+            )
+        return value
+
 class PresetExpandOptionsSchema(BaseModel):
     """Optional expansion flags."""
 
@@ -511,12 +529,22 @@ class PresetExpandRequestSchema(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    version: str
     inputs: dict[str, Any] = Field(default_factory=dict)
     context: dict[str, Any] = Field(default_factory=dict)
     options: PresetExpandOptionsSchema = Field(
         default_factory=PresetExpandOptionsSchema
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict) and (
+            value.get("version") is not None or value.get("presetVersion") is not None
+        ):
+            raise ValueError(
+                "Preset expansion uses slug/scope only; remove version or presetVersion."
+            )
+        return value
 
 class PresetAppliedMetadataSchema(BaseModel):
     """Audit metadata describing one template application."""
@@ -524,7 +552,7 @@ class PresetAppliedMetadataSchema(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     slug: str
-    version: str
+    preset_digest: Optional[str] = Field(None, alias="presetDigest")
     inputs: dict[str, Any] = Field(default_factory=dict)
     step_ids: list[str] = Field(default_factory=list, alias="stepIds")
     applied_at: Optional[str] = Field(None, alias="appliedAt")

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -5,7 +5,6 @@ description: Resolve a set of Jira board-column or GitHub repository issue targe
   inherited runtime/provider/model settings, and a shared publish policy. The parent
   records a summary artifact that links every queued child workflow.
 scope: global
-version: 1.0.0
 tags:
 - batch
 - orchestration
@@ -37,7 +36,6 @@ annotations:
     required:
     - source_kind
     - target_preset_slug
-    - target_preset_version
     - publish_mode
     properties:
       source_kind:
@@ -92,9 +90,6 @@ annotations:
       target_preset_slug:
         type: string
         title: Run this preset for each item
-      target_preset_version:
-        type: string
-        title: Target preset version
       target_preset_scope:
         type: string
         title: Target preset scope
@@ -163,7 +158,6 @@ annotations:
     source_kind: jira_board_column
     github_issue_state: open
     target_preset_slug: jira-implement
-    target_preset_version: 1.1.0
     target_preset_scope: global
     publish_mode: pr
     max_workflows: '25'
@@ -246,11 +240,6 @@ inputs:
   type: text
   required: true
   default: jira-implement
-- name: target_preset_version
-  label: Target Preset Version
-  type: text
-  required: true
-  default: 1.1.0
 - name: target_preset_scope
   label: Target Preset Scope
   type: enum
@@ -320,7 +309,7 @@ steps:
     credentials, web scraping, or guessed issue content to build targets.
 
     Step 2 — Queue one child workflow per resolved target running preset
-    "{{ inputs.target_preset_slug }}" version "{{ inputs.target_preset_version }}".
+    "{{ inputs.target_preset_slug }}".
     Auto-bind the resolved issue target into the child preset's issue input
     (jira_issue/jira_issue_key for jira-implement, github_issue/github_issue_ref for
     github-issue-implement) and copy the shared constraints into every child. Apply
@@ -331,7 +320,6 @@ steps:
     python3 .agents/skills/batch-workflows/bin/batch_workflows.py \
     --targets artifacts/batch-workflows-targets.json \
     --target-preset-slug "{{ inputs.target_preset_slug }}" \
-    --target-preset-version "{{ inputs.target_preset_version }}" \
     --target-preset-scope "{{ inputs.target_preset_scope }}" \
     --target-preset-scope-ref "{{ inputs.target_preset_scope_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
@@ -364,7 +352,6 @@ steps:
         searchQuery: '{{ inputs.github_search_query }}'
     targetPreset:
       slug: '{{ inputs.target_preset_slug }}'
-      version: '{{ inputs.target_preset_version }}'
       scope: '{{ inputs.target_preset_scope }}'
       scopeRef: '{{ inputs.target_preset_scope_ref }}'
     sharedInputs:

--- a/api_service/data/presets/document-health-update.yaml
+++ b/api_service/data/presets/document-health-update.yaml
@@ -5,7 +5,6 @@ description: Review the health of a documentation scope, then remediate the issu
   the current implementation and records a structured health report, then a document
   health remediate step that fixes only the reported issues.
 scope: global
-version: 1.0.0
 tags:
 - documentation
 - document-health

--- a/api_service/data/presets/document-update-orchestrate.yaml
+++ b/api_service/data/presets/document-update-orchestrate.yaml
@@ -2,7 +2,6 @@ slug: document-update-orchestrate
 title: Document Update Orchestrate
 description: Scan a document directory for .md, .txt, and .tex files, then create a document-update task for each discovered document.
 scope: global
-version: 1.0.0
 tags:
   - documentation
   - document-update

--- a/api_service/data/presets/github-issue-implement.yaml
+++ b/api_service/data/presets/github-issue-implement.yaml
@@ -3,7 +3,6 @@ title: GitHub Issue Implement
 description: Implement a GitHub issue by assessing repository state, completing missing
   work, creating a pull request, and updating the issue.
 scope: global
-version: 1.0.0
 tags:
 - github
 - implementation
@@ -111,7 +110,6 @@ steps:
       issueNumber: '{{ inputs.github_issue.number }}'
 - kind: include
   slug: issue-implement-assessment
-  version: 1.0.0
   alias: assess
   scope: global
   inputMapping:
@@ -166,7 +164,6 @@ steps:
       mode: start
 - kind: include
   slug: issue-implement-work-pr
-  version: 1.0.0
   alias: work-pr
   scope: global
   inputMapping:

--- a/api_service/data/presets/issue-implement-assessment.yaml
+++ b/api_service/data/presets/issue-implement-assessment.yaml
@@ -3,7 +3,6 @@ title: Issue Implement Assessment
 description: Assess whether an issue brief is already implemented before provider-specific
   lifecycle updates run.
 scope: global
-version: 1.0.0
 tags:
 - implementation
 - assessment

--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -3,7 +3,6 @@ title: Issue Implement Work and Pull Request
 description: Complete remaining issue implementation work, verify it, and publish
   a pull request using provider-neutral issue inputs.
 scope: global
-version: 1.0.0
 tags:
 - implementation
 - verification

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -2,7 +2,6 @@ slug: jira-breakdown-implement
 title: Jira Breakdown and Implement
 description: Break a broad Jira or design input into stories, create Jira issues, then create dependent Jira Implement tasks for each generated issue.
 scope: global
-version: 1.0.0
 tags:
   - jira
   - moonspec

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -2,7 +2,6 @@ slug: jira-breakdown-orchestrate
 title: Jira Breakdown and Orchestrate
 description: Break a broad Jira or design input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
 scope: global
-version: 1.0.0
 tags:
   - jira
   - moonspec

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -2,7 +2,6 @@ slug: jira-breakdown
 title: Jira Breakdown
 description: Break a declarative design into MoonSpec story candidates, then create Jira Story issues from the generated breakdown.
 scope: global
-version: 1.0.0
 tags:
   - jira
   - moonspec

--- a/api_service/data/presets/jira-implement.yaml
+++ b/api_service/data/presets/jira-implement.yaml
@@ -6,7 +6,6 @@ description: Move a Jira issue through implementation by first assessing the cur
   advance the issue to Review. When PR merge automation is enabled the issue
   advances to Done automatically after merge.
 scope: global
-version: 1.1.0
 tags:
 - jira
 - implementation
@@ -100,7 +99,6 @@ steps:
       issueKey: '{{ inputs.jira_issue_key }}'
 - kind: include
   slug: issue-implement-assessment
-  version: 1.0.0
   alias: assess
   scope: global
   inputMapping:
@@ -190,7 +188,6 @@ steps:
     args: {}
 - kind: include
   slug: issue-implement-work-pr
-  version: 1.0.0
   alias: work-pr
   scope: global
   inputMapping:

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -2,7 +2,6 @@ slug: jira-orchestrate
 title: Jira Orchestrate
 description: Move a Jira issue through implementation by using its preset brief as the MoonSpec orchestration input, creating a PR, and advancing the issue to Review.
 scope: global
-version: 1.0.0
 tags:
   - jira
   - moonspec

--- a/api_service/data/presets/moonspec-orchestrate.yaml
+++ b/api_service/data/presets/moonspec-orchestrate.yaml
@@ -2,7 +2,6 @@ slug: moonspec-orchestrate
 title: MoonSpec Orchestrate
 description: Run the full Moon Spec lifecycle from a preselected single-story request or active feature context through specification, planning, alignment, implementation, and verification.
 scope: global
-version: 1.0.0
 tags:
   - moonspec
   - orchestration

--- a/api_service/data/presets/pentest-recon.yaml
+++ b/api_service/data/presets/pentest-recon.yaml
@@ -2,7 +2,6 @@ slug: pentest-recon
 title: Pentest Recon
 description: Run a policy-gated PentestGPT recon pass against an approved lab or authorized target scope and publish a report-first result bundle.
 scope: global
-version: 1.0.0
 tags:
   - security
   - pentest
@@ -115,7 +114,6 @@ steps:
     tool:
       type: skill
       name: security.pentest.run
-      version: 1.0.0
       inputs:
         target: "{{ inputs.target }}"
         scope_artifact_ref: "{{ inputs.scope_artifact_ref }}"

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -378,7 +378,6 @@ __all__ = [
     "PresetScopeType",
     "PresetReleaseStatus",
     "Preset",
-    "PresetVersion",
     "PresetFavorite",
     "PresetRecent",
     "SecretStatus",
@@ -559,7 +558,7 @@ class PresetScopeType(str, enum.Enum):
     PERSONAL = "personal"
 
 class PresetReleaseStatus(str, enum.Enum):
-    """Release lifecycle for preset versions."""
+    """Lifecycle state for current preset definitions."""
 
     DRAFT = "draft"
     ACTIVE = "active"
@@ -598,74 +597,14 @@ class Preset(Base):
     required_capabilities: Mapped[list[str]] = mapped_column(
         mutable_json_list(), default=list
     )
-    latest_version_id: Mapped[Optional[UUID]] = mapped_column(
-        Uuid,
-        ForeignKey(
-            "preset_versions.id",
-            name="fk_preset_latest_version",
-            use_alter=True,
-            ondelete="SET NULL",
-        ),
-        nullable=True,
-    )
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    created_by: Mapped[Optional[UUID]] = mapped_column(
-        Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        onupdate=func.now(),
-    )
-
-    latest_version: Mapped[Optional["PresetVersion"]] = relationship(
-        "PresetVersion", foreign_keys=[latest_version_id], post_update=True
-    )
-    versions: Mapped[list["PresetVersion"]] = relationship(
-        "PresetVersion",
-        back_populates="template",
-        foreign_keys="PresetVersion.template_id",
-        cascade="all, delete-orphan",
-        order_by="PresetVersion.created_at",
-    )
-    favorites: Mapped[list["PresetFavorite"]] = relationship(
-        "PresetFavorite",
-        back_populates="template",
-        cascade="all, delete-orphan",
-    )
-
-class PresetVersion(Base):
-    """Immutable release of a template blueprint."""
-
-    # legacy_run contract: table/index/constraint names rename in WP7
-    __tablename__ = "preset_versions"
-    __table_args__ = (
-        UniqueConstraint(
-            "template_id", "version", name="uq_preset_version_label"
-        ),
-        Index("ix_preset_versions_template", "template_id"),
-    )
-
-    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
-    template_id: Mapped[UUID] = mapped_column(
-        Uuid, ForeignKey("presets.id", ondelete="CASCADE"), nullable=False
-    )
-    version: Mapped[str] = mapped_column(String(32), nullable=False)
     inputs_schema: Mapped[list[dict[str, Any]]] = mapped_column(
-        mutable_json_list(), nullable=False
+        mutable_json_list(), nullable=False, default=list
     )
     steps: Mapped[list[dict[str, Any]]] = mapped_column(
-        mutable_json_list(), nullable=False
+        mutable_json_list(), nullable=False, default=list
     )
     annotations: Mapped[Optional[dict[str, Any]]] = mapped_column(
         mutable_json_dict(), nullable=True
-    )
-    required_capabilities: Mapped[list[str]] = mapped_column(
-        mutable_json_list(), default=list
     )
     max_step_count: Mapped[int] = mapped_column(Integer, nullable=False, default=25)
     release_status: Mapped[PresetReleaseStatus] = mapped_column(
@@ -685,6 +624,10 @@ class PresetVersion(Base):
     reviewed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     seed_source: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_by: Mapped[Optional[UUID]] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -695,14 +638,9 @@ class PresetVersion(Base):
         onupdate=func.now(),
     )
 
-    template: Mapped[Preset] = relationship(
-        "Preset",
-        back_populates="versions",
-        foreign_keys=[template_id],
-    )
-    recents: Mapped[list["PresetRecent"]] = relationship(
-        "PresetRecent",
-        back_populates="template_version",
+    favorites: Mapped[list["PresetFavorite"]] = relationship(
+        "PresetFavorite",
+        back_populates="template",
         cascade="all, delete-orphan",
     )
 
@@ -740,8 +678,8 @@ class PresetRecent(Base):
         Index("ix_preset_recents_user", "user_id"),
         UniqueConstraint(
             "user_id",
-            "template_version_id",
-            name="uq_preset_recent_user_version",
+            "template_id",
+            name="uq_preset_recent_user_template",
         ),
     )
 
@@ -749,18 +687,16 @@ class PresetRecent(Base):
     user_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
     )
-    template_version_id: Mapped[UUID] = mapped_column(
+    template_id: Mapped[UUID] = mapped_column(
         Uuid,
-        ForeignKey("preset_versions.id", ondelete="CASCADE"),
+        ForeignKey("presets.id", ondelete="CASCADE"),
         nullable=False,
     )
     applied_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    template_version: Mapped[PresetVersion] = relationship(
-        "PresetVersion", back_populates="recents"
-    )
+    template: Mapped[Preset] = relationship("Preset")
 
 class WorkflowRunStatus(str, enum.Enum):
     """Lifecycle states tracked for Spec workflow runs."""

--- a/api_service/migrations/versions/327_mm912_slug_scope_presets.py
+++ b/api_service/migrations/versions/327_mm912_slug_scope_presets.py
@@ -1,0 +1,99 @@
+"""Convert presets to slug/scope current definitions for MM-912.
+
+Source traceability: MM-901.
+
+Revision ID: 327_mm912_slug_scope_presets
+Revises: 326_profile_effort
+Create Date: 2026-06-25
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "327_mm912_slug_scope_presets"
+down_revision: Union[str, None] = "326_profile_effort"
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+
+def upgrade() -> None:
+    op.add_column("presets", sa.Column("inputs_schema", sa.JSON(), nullable=True))
+    op.add_column("presets", sa.Column("steps", sa.JSON(), nullable=True))
+    op.add_column("presets", sa.Column("annotations", sa.JSON(), nullable=True))
+    op.add_column(
+        "presets",
+        sa.Column("max_step_count", sa.Integer(), nullable=False, server_default="25"),
+    )
+    op.add_column(
+        "presets",
+        sa.Column("release_status", sa.Enum("draft", "active", "inactive", name="presetreleasestatus"), nullable=False, server_default="draft"),
+    )
+    op.add_column("presets", sa.Column("reviewed_by", sa.Uuid(), nullable=True))
+    op.add_column("presets", sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("presets", sa.Column("notes", sa.Text(), nullable=True))
+    op.add_column("presets", sa.Column("seed_source", sa.String(length=255), nullable=True))
+
+    op.execute(
+        """
+        update presets p
+           set inputs_schema = coalesce(v.inputs_schema, '[]'::jsonb),
+               steps = coalesce(v.steps, '[]'::jsonb),
+               annotations = v.annotations,
+               max_step_count = coalesce(v.max_step_count, 25),
+               release_status = coalesce(v.release_status, 'draft'),
+               reviewed_by = v.reviewed_by,
+               reviewed_at = v.reviewed_at,
+               notes = v.notes,
+               seed_source = v.seed_source
+          from preset_versions v
+         where v.id = p.latest_version_id
+        """
+    )
+    op.execute("update presets set inputs_schema = '[]'::jsonb where inputs_schema is null")
+    op.execute("update presets set steps = '[]'::jsonb where steps is null")
+    op.alter_column("presets", "inputs_schema", nullable=False)
+    op.alter_column("presets", "steps", nullable=False)
+
+    op.add_column("preset_recents", sa.Column("template_id", sa.Uuid(), nullable=True))
+    op.execute(
+        """
+        update preset_recents r
+           set template_id = v.template_id
+          from preset_versions v
+         where v.id = r.template_version_id
+        """
+    )
+    op.alter_column("preset_recents", "template_id", nullable=False)
+    op.drop_constraint("uq_preset_recent_user_version", "preset_recents", type_="unique")
+    op.create_unique_constraint(
+        "uq_preset_recent_user_template",
+        "preset_recents",
+        ["user_id", "template_id"],
+    )
+    op.drop_constraint(
+        "preset_recents_template_version_id_fkey",
+        "preset_recents",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "preset_recents_template_id_fkey",
+        "preset_recents",
+        "presets",
+        ["template_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_column("preset_recents", "template_version_id")
+
+    op.drop_constraint("fk_preset_latest_version", "presets", type_="foreignkey")
+    op.drop_column("presets", "latest_version_id")
+    op.drop_index("ix_preset_versions_template", table_name="preset_versions")
+    op.drop_table("preset_versions")
+
+
+def downgrade() -> None:
+    raise RuntimeError("MM-912 removes preset semantic versions; downgrade is unsupported.")

--- a/api_service/migrations/versions/327_mm912_slug_scope_presets.py
+++ b/api_service/migrations/versions/327_mm912_slug_scope_presets.py
@@ -68,6 +68,24 @@ def upgrade() -> None:
         """
     )
     op.alter_column("preset_recents", "template_id", nullable=False)
+    op.execute(
+        """
+        delete from preset_recents r
+         using (
+            select id
+              from (
+                select id,
+                       row_number() over (
+                         partition by user_id, template_id
+                         order by applied_at desc, id desc
+                       ) as row_number
+                  from preset_recents
+              ) ranked
+             where ranked.row_number > 1
+         ) duplicates
+         where r.id = duplicates.id
+        """
+    )
     op.drop_constraint("uq_preset_recent_user_version", "preset_recents", type_="unique")
     op.create_unique_constraint(
         "uq_preset_recent_user_template",

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -29,7 +30,6 @@ from api_service.db.models import (
     Preset,
     PresetFavorite,
     PresetRecent,
-    PresetVersion,
     PresetReleaseStatus,
     PresetScopeType,
 )
@@ -119,7 +119,6 @@ _INCLUDE_STEP_KEYS = frozenset(
     {
         "kind",
         "slug",
-        "version",
         "alias",
         "scope",
         "inputMapping",
@@ -480,15 +479,13 @@ def _normalize_preset_payload(raw_preset: Any, *, index: int) -> dict[str, Any]:
             message="Preset steps require preset.slug or preset.id.",
             code="required",
         )
-    version = str(
-        raw_preset.get("version") or raw_preset.get("presetVersion") or ""
-    ).strip()
-    if not version:
+    if raw_preset.get("version") is not None or raw_preset.get("presetVersion") is not None:
         raise _step_validation_error(
             index=index,
             path="preset.version",
-            message="Preset steps require preset.version.",
-            code="required",
+            message="Preset steps use slug/scope only; remove preset.version or presetVersion.",
+            code="preset_version_not_supported",
+            recoverable=False,
         )
     inputs = raw_preset.get("inputs", raw_preset.get("inputMapping", {}))
     if inputs is None:
@@ -501,7 +498,6 @@ def _normalize_preset_payload(raw_preset: Any, *, index: int) -> dict[str, Any]:
         )
     preset_payload: dict[str, Any] = {
         "slug": _normalize_slug(preset_slug),
-        "version": version,
         "inputs": dict(inputs),
     }
     scope = raw_preset.get("scope")
@@ -523,7 +519,6 @@ def _preset_step_to_include(
     include_payload: dict[str, Any] = {
         "kind": _INCLUDE_KIND,
         "slug": preset["slug"],
-        "version": preset["version"],
         "alias": _normalize_slug(str(alias_source)),
         "inputMapping": dict(preset["inputs"]),
     }
@@ -541,15 +536,29 @@ def _hash_from_inputs(values: dict[str, Any]) -> str:
     normalized = repr(sorted(values.items())).encode("utf-8")
     return hashlib.sha1(normalized).hexdigest()[:8]
 
-def _build_step_id(
-    *, slug: str, version: str, index: int, inputs: dict[str, Any]
-) -> str:
-    return f"tpl:{slug}:{version}:{index:02d}:{_hash_from_inputs(inputs)}"
+def _preset_digest(template: Preset) -> str:
+    payload = json.dumps(
+        {
+            "slug": template.slug,
+            "scope": template.scope_type.value,
+            "scopeRef": template.scope_ref,
+            "inputs": template.inputs_schema or [],
+            "steps": template.steps or [],
+            "annotations": template.annotations or {},
+            "requiredCapabilities": template.required_capabilities or [],
+            "maxStepCount": template.max_step_count,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
 
-def _template_path_label(
-    *, slug: str, version: str, alias: str | None = None
-) -> str:
-    label = f"{slug}@{version}"
+
+def _build_step_id(*, slug: str, index: int, inputs: dict[str, Any]) -> str:
+    return f"tpl:{slug}:{index:02d}:{_hash_from_inputs(inputs)}"
+
+def _template_path_label(*, slug: str, alias: str | None = None) -> str:
+    label = slug
     if alias:
         return f"{alias}:{label}"
     return label
@@ -579,7 +588,7 @@ def _authored_presets_from_composition(node: dict[str, Any]) -> list[dict[str, A
     def visit(candidate: dict[str, Any]) -> None:
         entry: dict[str, Any] = {
             "presetSlug": str(candidate.get("slug") or "").strip(),
-            "presetVersion": str(candidate.get("version") or "").strip(),
+            "presetDigest": str(candidate.get("digest") or "").strip(),
             "scope": str(candidate.get("scope") or "").strip(),
             "includePath": [
                 str(item).strip()
@@ -1064,13 +1073,12 @@ def _normalize_seed_annotations(item: Mapping[str, Any]) -> dict[str, Any]:
 def _serialize_template(
     *,
     template: Preset,
-    version: PresetVersion,
     is_favorite: bool,
     recent_applied_at: datetime | None,
 ) -> dict[str, Any]:
     input_schema, ui_schema, defaults = _capability_contract_from_inputs(
-        inputs_schema=version.inputs_schema or [],
-        annotations=version.annotations or {},
+        inputs_schema=template.inputs_schema or [],
+        annotations=template.annotations or {},
     )
     return {
         "slug": template.slug,
@@ -1079,28 +1087,22 @@ def _serialize_template(
         "title": template.title,
         "description": template.description,
         "tags": list(template.tags or []),
-        "version": version.version,
-        "latestVersion": (
-            template.latest_version.version
-            if template.latest_version
-            else version.version
-        ),
         "inputs": _effective_inputs_schema(
             slug=template.slug,
-            inputs_schema=version.inputs_schema or [],
+            inputs_schema=template.inputs_schema or [],
         ),
         "inputSchema": input_schema,
         "uiSchema": ui_schema,
         "defaults": defaults,
-        "steps": list(version.steps or []),
-        "annotations": dict(version.annotations or {}),
+        "steps": list(template.steps or []),
+        "annotations": dict(template.annotations or {}),
         "requiredCapabilities": _normalize_capabilities(
             list(template.required_capabilities or [])
-            + list(version.required_capabilities or [])
         ),
-        "releaseStatus": version.release_status.value,
-        "reviewedBy": str(version.reviewed_by) if version.reviewed_by else None,
-        "reviewedAt": version.reviewed_at.isoformat() if version.reviewed_at else None,
+        "releaseStatus": template.release_status.value,
+        "reviewedBy": str(template.reviewed_by) if template.reviewed_by else None,
+        "reviewedAt": template.reviewed_at.isoformat() if template.reviewed_at else None,
+        "presetDigest": _preset_digest(template),
         "isFavorite": is_favorite,
         "recentAppliedAt": (
             recent_applied_at.astimezone(UTC).isoformat() if recent_applied_at else None
@@ -1153,10 +1155,6 @@ class PresetCatalogService:
                 Preset.scope_type == scope,
                 Preset.scope_ref == scope_ref,
             )
-            .options(
-                selectinload(Preset.latest_version),
-                selectinload(Preset.versions),
-            )
             .limit(1)
         )
         if not include_inactive:
@@ -1178,9 +1176,7 @@ class PresetCatalogService:
         user_id: UUID | None = None,
         include_inactive: bool = False,
     ) -> list[dict[str, Any]]:
-        stmt = select(Preset).options(
-            selectinload(Preset.latest_version)
-        )
+        stmt = select(Preset)
         if not include_inactive:
             stmt = stmt.where(Preset.is_active.is_(True))
         if scope is not None:
@@ -1215,13 +1211,8 @@ class PresetCatalogService:
             recent_rows = (
                 await self._session.execute(
                     select(
-                        PresetVersion.template_id,
+                        PresetRecent.template_id,
                         PresetRecent.applied_at,
-                    )
-                    .join(
-                        PresetVersion,
-                        PresetVersion.id
-                        == PresetRecent.template_version_id,
                     )
                     .where(PresetRecent.user_id == user_id)
                     .order_by(PresetRecent.applied_at.desc())
@@ -1233,11 +1224,6 @@ class PresetCatalogService:
 
         serialized: list[dict[str, Any]] = []
         for template in template_rows:
-            version = template.latest_version
-            if version is None and template.versions:
-                version = template.versions[-1]
-            if version is None:
-                continue
             if lowered_tag and lowered_tag not in {
                 str(item).lower() for item in template.tags or []
             }:
@@ -1259,7 +1245,6 @@ class PresetCatalogService:
             serialized.append(
                 _serialize_template(
                     template=template,
-                    version=version,
                     is_favorite=is_favorite,
                     recent_applied_at=recents_map.get(template.id),
                 )
@@ -1289,9 +1274,12 @@ class PresetCatalogService:
         slug: str,
         scope: str,
         scope_ref: str | None,
-        version: str | None = None,
         user_id: UUID | None = None,
     ) -> dict[str, Any]:
+        if version is not None:
+            raise PresetValidationError(
+                "Preset lookup uses slug/scope only; remove version."
+            )
         scope_type = _normalize_scope(scope)
         normalized_scope_ref = _normalize_scope_ref(scope_type, scope_ref)
         template = await self._get_template_for_scope(
@@ -1299,15 +1287,6 @@ class PresetCatalogService:
             scope=scope_type,
             scope_ref=normalized_scope_ref,
         )
-        version_model = template.latest_version
-        if version is not None:
-            for candidate in template.versions:
-                if candidate.version == version:
-                    version_model = candidate
-                    break
-        if version_model is None:
-            raise PresetNotFoundError("Template version not found.")
-
         is_favorite = False
         recent_applied_at = None
         if user_id is not None:
@@ -1322,7 +1301,7 @@ class PresetCatalogService:
                 select(PresetRecent.applied_at)
                 .where(
                     PresetRecent.user_id == user_id,
-                    PresetRecent.template_version_id == version_model.id,
+                    PresetRecent.template_id == template.id,
                 )
                 .order_by(PresetRecent.applied_at.desc())
                 .limit(1)
@@ -1331,7 +1310,6 @@ class PresetCatalogService:
 
         return _serialize_template(
             template=template,
-            version=version_model,
             is_favorite=is_favorite,
             recent_applied_at=recent_applied_at,
         )
@@ -1350,7 +1328,6 @@ class PresetCatalogService:
         annotations: dict[str, Any] | None = None,
         required_capabilities: list[Any] | None = None,
         created_by: UUID | None = None,
-        version: str = "1.0.0",
         release_status: PresetReleaseStatus = PresetReleaseStatus.DRAFT,
         seed_source: str | None = None,
         auto_commit: bool = True,
@@ -1387,7 +1364,6 @@ class PresetCatalogService:
                 for cap in _extract_step_capabilities(step)
             ]
         )
-        version_label = str(version or "").strip() or "1.0.0"
         template = Preset(
             id=uuid4(),
             slug=normalized_slug,
@@ -1397,24 +1373,16 @@ class PresetCatalogService:
             description=normalized_description,
             tags=_normalize_tag_list(tags),
             required_capabilities=derived_capabilities,
-            is_active=True,
-            created_by=created_by,
-        )
-        version_model = PresetVersion(
-            id=uuid4(),
-            template=template,
-            version=version_label,
             inputs_schema=validated_inputs,
             steps=validated_steps,
             annotations=dict(annotations or {}),
-            required_capabilities=derived_capabilities,
             max_step_count=max(25, len(validated_steps)),
             release_status=release_status,
             seed_source=seed_source,
+            is_active=True,
+            created_by=created_by,
         )
-        template.latest_version = version_model
         self._session.add(template)
-        self._session.add(version_model)
         await self._session.flush()
         if auto_commit:
             await self._session.commit()
@@ -1423,13 +1391,11 @@ class PresetCatalogService:
                 extra={
                     "slug": normalized_slug,
                     "scope": normalized_scope.value,
-                    "version": version_label,
                 },
             )
             _METRICS.increment("create")
         return _serialize_template(
             template=template,
-            version=version_model,
             is_favorite=False,
             recent_applied_at=None,
         )
@@ -1541,6 +1507,10 @@ class PresetCatalogService:
                     f"Step {index} kind must be one of: {_STEP_KIND}, {_INCLUDE_KIND}."
                 )
             if kind == _INCLUDE_KIND:
+                if raw_step.get("version") is not None:
+                    raise PresetValidationError(
+                        f"Step {index} include uses slug/scope only; remove version."
+                    )
                 unsupported = sorted(
                     key
                     for key in raw_step
@@ -1552,16 +1522,7 @@ class PresetCatalogService:
                         f"{', '.join(unsupported)}."
                     )
                 include_slug = _normalize_slug(str(raw_step.get("slug") or ""))
-                include_version = str(raw_step.get("version") or "").strip()
                 include_alias = _normalize_slug(str(raw_step.get("alias") or ""))
-                if not include_version:
-                    raise PresetValidationError(
-                        f"Step {index} include requires a pinned version."
-                    )
-                if _UNRESOLVED_PLACEHOLDER_PATTERN.search(include_version):
-                    raise PresetValidationError(
-                        f"Step {index} include version must be a literal pinned version."
-                    )
                 if include_alias in include_aliases:
                     raise PresetValidationError(
                         f"Step {index} include alias '{include_alias}' is duplicated."
@@ -1571,7 +1532,6 @@ class PresetCatalogService:
                 include_payload: dict[str, Any] = {
                     "kind": _INCLUDE_KIND,
                     "slug": include_slug,
-                    "version": include_version,
                     "alias": include_alias,
                 }
                 if include_scope is not None:
@@ -1666,43 +1626,32 @@ class PresetCatalogService:
             validated.append(step_payload)
         return validated
 
-    def _select_template_version(
-        self, template: Preset, version: str
-    ) -> PresetVersion:
-        for candidate in template.versions:
-            if candidate.version == version:
-                return candidate
-        raise PresetNotFoundError("Template version not found.")
-
-    async def _expand_version_steps(
+    async def _expand_preset_steps(
         self,
         *,
         template: Preset,
-        version_model: PresetVersion,
         scope: PresetScopeType,
         scope_ref: str | None,
         variables: dict[str, Any],
         root_slug: str,
-        root_version: str,
         root_inputs: dict[str, Any],
         root_max_step_count: int,
         enforce_limit: bool,
         path: list[str],
-        visited: set[tuple[str, str, str]],
+        visited: set[tuple[str, str, str | None]],
         resolved_steps: list[dict[str, Any]],
         alias: str | None = None,
         input_mapping: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         node: dict[str, Any] = {
             "slug": template.slug,
-            "version": version_model.version,
+            "digest": _preset_digest(template),
             "scope": scope.value,
             "path": list(path),
             "stepIds": [],
             "includes": [],
             "requiredCapabilities": _normalize_capabilities(
                 list(template.required_capabilities or [])
-                + list(version_model.required_capabilities or [])
             ),
         }
         if alias:
@@ -1710,7 +1659,7 @@ class PresetCatalogService:
         if input_mapping:
             node["inputMapping"] = dict(input_mapping)
 
-        for source_index, source_step in enumerate(version_model.steps or [], start=1):
+        for source_index, source_step in enumerate(template.steps or [], start=1):
             rendered = _render_value(
                 self._template_env, source_step, variables=variables
             )
@@ -1728,7 +1677,23 @@ class PresetCatalogService:
                 kind = _INCLUDE_KIND
             if kind == _INCLUDE_KIND:
                 include_slug = _normalize_slug(str(rendered.get("slug") or ""))
-                include_version = str(rendered.get("version") or "").strip()
+                if rendered.get("version") is not None:
+                    include_path = [
+                        *path,
+                        _template_path_label(
+                            slug=include_slug,
+                            alias=_normalize_slug(str(rendered.get("alias") or "")),
+                        ),
+                    ]
+                    raise _include_tree_error(
+                        message=(
+                            "Preset includes use slug/scope only; remove version at "
+                            f"{_format_include_path(include_path)}."
+                        ),
+                        code="preset_include_version_not_supported",
+                        include_path=include_path,
+                        recoverable=False,
+                    )
                 include_alias = _normalize_slug(str(rendered.get("alias") or ""))
                 include_scope = _normalize_scope(str(rendered.get("scope") or scope.value))
                 include_scope_ref = (
@@ -1740,7 +1705,6 @@ class PresetCatalogService:
                     *path,
                     _template_path_label(
                         slug=include_slug,
-                        version=include_version,
                         alias=include_alias,
                     ),
                 ]
@@ -1754,7 +1718,7 @@ class PresetCatalogService:
                         code="preset_include_scope_violation",
                         include_path=include_path,
                     )
-                target_key = (include_scope.value, include_slug, include_version)
+                target_key = (include_scope.value, include_slug, include_scope_ref)
                 if target_key in visited:
                     message = (
                         "Preset include cycle detected at "
@@ -1781,22 +1745,7 @@ class PresetCatalogService:
                         code="preset_include_missing",
                         include_path=include_path,
                     ) from exc
-                try:
-                    child_version = self._select_template_version(
-                        child_template, include_version
-                    )
-                except PresetNotFoundError as exc:
-                    message = (
-                        f"Preset include version mismatch at "
-                        f"{_format_include_path(include_path)}: requested version "
-                        f"{include_version!r} is not available."
-                    )
-                    raise _include_tree_error(
-                        message=message,
-                        code="preset_include_version_mismatch",
-                        include_path=include_path,
-                    ) from exc
-                if child_version.release_status is PresetReleaseStatus.INACTIVE:
+                if child_template.release_status is PresetReleaseStatus.INACTIVE:
                     message = (
                         f"Preset include target is inactive at "
                         f"{_format_include_path(include_path)}."
@@ -1820,7 +1769,7 @@ class PresetCatalogService:
                 try:
                     child_schema = _effective_inputs_schema(
                         slug=child_template.slug,
-                        inputs_schema=child_version.inputs_schema or [],
+                        inputs_schema=child_template.inputs_schema or [],
                         context=variables.get("context"),
                     )
                     submitted_child_inputs = _apply_contextual_input_overrides(
@@ -1828,7 +1777,7 @@ class PresetCatalogService:
                         inputs_schema=child_schema,
                         submitted=dict(input_mapping),
                         context=variables.get("context"),
-                        annotations=child_version.annotations or {},
+                        annotations=child_template.annotations or {},
                     )
                     child_inputs = self._resolve_inputs(
                         schema=child_schema,
@@ -1853,14 +1802,12 @@ class PresetCatalogService:
                     **variables,
                     "inputs": child_inputs,
                 }
-                child_node = await self._expand_version_steps(
+                child_node = await self._expand_preset_steps(
                     template=child_template,
-                    version_model=child_version,
                     scope=include_scope,
                     scope_ref=include_scope_ref,
                     variables=child_variables,
                     root_slug=root_slug,
-                    root_version=root_version,
                     root_inputs=root_inputs,
                     root_max_step_count=root_max_step_count,
                     enforce_limit=enforce_limit,
@@ -1907,17 +1854,16 @@ class PresetCatalogService:
             step_payload: dict[str, Any] = {
                 "id": _build_step_id(
                     slug=root_slug,
-                    version=root_version,
                     index=next_index,
                     inputs=root_inputs,
                 ),
                 "type": step_type,
                 "instructions": instructions,
                 "presetProvenance": {
-                    "root": {"slug": root_slug, "version": root_version},
+                    "root": {"slug": root_slug},
                     "source": {
                         "slug": template.slug,
-                        "version": version_model.version,
+                        "presetDigest": _preset_digest(template),
                         "scope": scope.value,
                         "stepIndex": source_index,
                     },
@@ -1926,7 +1872,7 @@ class PresetCatalogService:
                 "source": {
                     "kind": "preset-derived",
                     "presetSlug": template.slug,
-                    "presetVersion": version_model.version,
+                    "presetDigest": _preset_digest(template),
                     "includePath": list(path),
                 },
             }
@@ -1985,7 +1931,6 @@ class PresetCatalogService:
         slug: str,
         scope: str,
         scope_ref: str | None,
-        version: str,
         inputs: dict[str, Any],
         context: dict[str, Any] | None = None,
         options: ExpandOptions | None = None,
@@ -1998,7 +1943,6 @@ class PresetCatalogService:
             scope=normalized_scope,
             scope_ref=normalized_scope_ref,
         )
-        selected_version = self._select_template_version(template, version)
 
         effective_context = dict(context or {})
         if not _repository_from_context(effective_context):
@@ -2010,13 +1954,13 @@ class PresetCatalogService:
                 effective_context["repo"] = input_repository.strip()
         effective_schema = _effective_inputs_schema(
             slug=template.slug,
-            inputs_schema=selected_version.inputs_schema or [],
+            inputs_schema=template.inputs_schema or [],
             context=effective_context,
         )
-        annotated_schema = (selected_version.annotations or {}).get("inputSchema")
+        annotated_schema = (template.annotations or {}).get("inputSchema")
         if isinstance(annotated_schema, Mapping):
-            annotated_ui_schema = (selected_version.annotations or {}).get("uiSchema")
-            annotated_defaults = (selected_version.annotations or {}).get("defaults")
+            annotated_ui_schema = (template.annotations or {}).get("uiSchema")
+            annotated_defaults = (template.annotations or {}).get("defaults")
             contract_definitions = _schema_contract_input_definitions(
                 input_schema=annotated_schema,
                 ui_schema=annotated_ui_schema
@@ -2043,7 +1987,7 @@ class PresetCatalogService:
             inputs_schema=effective_schema,
             submitted=dict(inputs or {}),
             context=effective_context,
-            annotations=selected_version.annotations or {},
+            annotations=template.annotations or {},
         )
         validated_inputs = self._resolve_inputs(
             schema=effective_schema,
@@ -2064,30 +2008,27 @@ class PresetCatalogService:
         resolved_steps: list[dict[str, Any]] = []
         warnings: list[str] = []
         enforce_limit = options.should_enforce_step_limit if options else True
-        max_step_count = max(int(selected_version.max_step_count or 25), 1)
+        max_step_count = max(int(template.max_step_count or 25), 1)
         root_path = [
-            _template_path_label(slug=template.slug, version=selected_version.version)
+            _template_path_label(slug=template.slug)
         ]
-        composition = await self._expand_version_steps(
+        composition = await self._expand_preset_steps(
             template=template,
-            version_model=selected_version,
             scope=normalized_scope,
             scope_ref=normalized_scope_ref,
             variables=variables,
             root_slug=template.slug,
-            root_version=selected_version.version,
             root_inputs=validated_inputs,
             root_max_step_count=max_step_count,
             enforce_limit=enforce_limit,
             path=root_path,
-            visited={(normalized_scope.value, template.slug, selected_version.version)},
+            visited={(normalized_scope.value, template.slug, normalized_scope_ref)},
             resolved_steps=resolved_steps,
         )
         authored_presets = _authored_presets_from_composition(composition)
 
         template_caps = _normalize_capabilities(
             list(template.required_capabilities or [])
-            + list(selected_version.required_capabilities or [])
             + _composition_capabilities(composition)
             + [
                 cap
@@ -2095,13 +2036,13 @@ class PresetCatalogService:
                 for cap in _extract_step_capabilities(step)
             ]
         )
-        if selected_version.release_status is PresetReleaseStatus.INACTIVE:
-            warnings.append("Template version is marked inactive.")
+        if template.release_status is PresetReleaseStatus.INACTIVE:
+            warnings.append("Template is marked inactive.")
 
         if user_id is not None:
             await self.record_recent(
                 user_id=user_id,
-                template_version_id=selected_version.id,
+                template_id=template.id,
             )
 
         applied_at = datetime.now(UTC).isoformat()
@@ -2110,7 +2051,6 @@ class PresetCatalogService:
             extra={
                 "slug": template.slug,
                 "scope": normalized_scope.value,
-                "version": selected_version.version,
                 "steps": len(resolved_steps),
             },
         )
@@ -2121,7 +2061,7 @@ class PresetCatalogService:
             "authoredPresets": authored_presets,
             "appliedTemplate": {
                 "slug": template.slug,
-                "version": selected_version.version,
+                "presetDigest": _preset_digest(template),
                 "inputs": validated_inputs,
                 "stepIds": [step["id"] for step in resolved_steps],
                 "appliedAt": applied_at,
@@ -2326,7 +2266,7 @@ class PresetCatalogService:
         self,
         *,
         user_id: UUID,
-        template_version_id: UUID,
+        template_id: UUID,
         auto_commit: bool = True,
     ) -> None:
         dialect_name = self._session.bind.dialect.name if self._session.bind else ""
@@ -2335,10 +2275,10 @@ class PresetCatalogService:
                 pg_insert(PresetRecent)
                 .values(
                     user_id=user_id,
-                    template_version_id=template_version_id,
+                    template_id=template_id,
                 )
                 .on_conflict_do_update(
-                    index_elements=["user_id", "template_version_id"],
+                    index_elements=["user_id", "template_id"],
                     set_={"applied_at": datetime.now(UTC)},
                 )
             )
@@ -2346,7 +2286,7 @@ class PresetCatalogService:
             self._session.add(
                 PresetRecent(
                     user_id=user_id,
-                    template_version_id=template_version_id,
+                    template_id=template_id,
                 )
             )
         await self._session.flush()
@@ -2371,7 +2311,7 @@ class PresetCatalogService:
             await self._session.flush()
         logger.info(
             "preset_catalog.recent",
-            extra={"template_version_id": str(template_version_id)},
+            extra={"template_id": str(template_id)},
         )
         _METRICS.increment("recent")
 
@@ -2446,7 +2386,6 @@ class PresetCatalogService:
         slug: str,
         scope: str,
         scope_ref: str | None,
-        version: str,
         release_status: PresetReleaseStatus,
         reviewer_id: UUID | None = None,
     ) -> dict[str, Any]:
@@ -2458,33 +2397,22 @@ class PresetCatalogService:
             scope_ref=normalized_scope_ref,
             include_inactive=True,
         )
-        target = None
-        for candidate in template.versions:
-            if candidate.version == version:
-                target = candidate
-                break
-        if target is None:
-            raise PresetNotFoundError("Template version not found.")
-        target.release_status = release_status
+        template.release_status = release_status
         if reviewer_id is not None:
-            target.reviewed_by = reviewer_id
-            target.reviewed_at = datetime.now(UTC)
-        if release_status is PresetReleaseStatus.ACTIVE:
-            template.latest_version = target
+            template.reviewed_by = reviewer_id
+            template.reviewed_at = datetime.now(UTC)
         await self._session.commit()
         logger.info(
             "preset_catalog.review",
             extra={
                 "slug": template.slug,
                 "scope": scope_type.value,
-                "version": target.version,
                 "release_status": release_status.value,
             },
         )
         _METRICS.increment("review")
         return _serialize_template(
             template=template,
-            version=target,
             is_favorite=False,
             recent_applied_at=None,
         )
@@ -2499,7 +2427,10 @@ class PresetCatalogService:
         created = 0
         for item in loaded:
             scope = str(item.get("scope", "global")).strip() or "global"
-            version = str(item.get("version", "1.0.0")).strip() or "1.0.0"
+            if item.get("version") is not None:
+                raise PresetValidationError(
+                    "Seed presets use slug/scope only; remove version."
+                )
             try:
                 await self.create_template(
                     slug=str(
@@ -2516,7 +2447,6 @@ class PresetCatalogService:
                     annotations=_normalize_seed_annotations(item),
                     required_capabilities=item.get("requiredCapabilities") or [],
                     created_by=None,
-                    version=version,
                     release_status=PresetReleaseStatus.ACTIVE,
                     seed_source=item.get("seedSource"),
                     auto_commit=False,
@@ -2546,7 +2476,10 @@ class PresetCatalogService:
             normalized_slug = _normalize_slug(slug)
             title = str(item.get("title") or "").strip()
             description = str(item.get("description") or "").strip() or "Seed template."
-            version_label = str(item.get("version", "1.0.0")).strip() or "1.0.0"
+            if item.get("version") is not None:
+                raise PresetValidationError(
+                    "Seed presets use slug/scope only; remove version."
+                )
             validated_inputs = self._validate_inputs_schema(item.get("inputs") or [])
             validated_steps = self._validate_template_steps(item.get("steps") or [])
             annotations = _normalize_seed_annotations(item)
@@ -2567,8 +2500,6 @@ class PresetCatalogService:
                     Preset.scope_ref == scope_ref,
                 )
                 .options(
-                    selectinload(Preset.latest_version),
-                    selectinload(Preset.versions),
                 )
                 .limit(1)
             )
@@ -2587,7 +2518,6 @@ class PresetCatalogService:
                     annotations=annotations,
                     required_capabilities=derived_capabilities,
                     created_by=None,
-                    version=version_label,
                     release_status=PresetReleaseStatus.ACTIVE,
                     seed_source=item.get("seedSource"),
                     auto_commit=False,
@@ -2613,57 +2543,24 @@ class PresetCatalogService:
                 template.is_active = True
                 updated = True
 
-            version_model = next(
-                (
-                    candidate
-                    for candidate in template.versions
-                    if candidate.version == version_label
-                ),
-                None,
-            )
-            if version_model is None:
-                version_model = PresetVersion(
-                    id=uuid4(),
-                    template=template,
-                    version=version_label,
-                    inputs_schema=validated_inputs,
-                    steps=validated_steps,
-                    annotations=annotations,
-                    required_capabilities=derived_capabilities,
-                    max_step_count=max(25, len(validated_steps)),
-                    release_status=PresetReleaseStatus.ACTIVE,
-                    seed_source=item.get("seedSource"),
-                )
-                self._session.add(version_model)
+            if list(template.inputs_schema or []) != validated_inputs:
+                template.inputs_schema = validated_inputs
                 updated = True
-            else:
-                if list(version_model.inputs_schema or []) != validated_inputs:
-                    version_model.inputs_schema = validated_inputs
-                    updated = True
-                if list(version_model.steps or []) != validated_steps:
-                    version_model.steps = validated_steps
-                    updated = True
-                if dict(version_model.annotations or {}) != annotations:
-                    version_model.annotations = annotations
-                    updated = True
-                if list(version_model.required_capabilities or []) != list(
-                    derived_capabilities
-                ):
-                    version_model.required_capabilities = list(derived_capabilities)
-                    updated = True
-                max_step_count = max(25, len(validated_steps))
-                if int(version_model.max_step_count or 0) != max_step_count:
-                    version_model.max_step_count = max_step_count
-                    updated = True
-                if version_model.release_status is not PresetReleaseStatus.ACTIVE:
-                    version_model.release_status = PresetReleaseStatus.ACTIVE
-                    updated = True
-                if version_model.seed_source != item.get("seedSource"):
-                    version_model.seed_source = item.get("seedSource")
-                    updated = True
-
-            if template.latest_version_id != version_model.id:
-                template.latest_version = version_model
+            if list(template.steps or []) != validated_steps:
+                template.steps = validated_steps
+                updated = True
+            if dict(template.annotations or {}) != annotations:
+                template.annotations = annotations
+                updated = True
+            max_step_count = max(25, len(validated_steps))
+            if int(template.max_step_count or 0) != max_step_count:
+                template.max_step_count = max_step_count
+                updated = True
+            if template.release_status is not PresetReleaseStatus.ACTIVE:
+                template.release_status = PresetReleaseStatus.ACTIVE
+                updated = True
+            if template.seed_source != item.get("seedSource"):
+                template.seed_source = item.get("seedSource")
                 updated = True
             if updated:
                 result.updated += 1

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -1276,10 +1276,6 @@ class PresetCatalogService:
         scope_ref: str | None,
         user_id: UUID | None = None,
     ) -> dict[str, Any]:
-        if version is not None:
-            raise PresetValidationError(
-                "Preset lookup uses slug/scope only; remove version."
-            )
         scope_type = _normalize_scope(scope)
         normalized_scope_ref = _normalize_scope_ref(scope_type, scope_ref)
         template = await self._get_template_for_scope(

--- a/api_service/services/presets/save.py
+++ b/api_service/services/presets/save.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import (
     Preset,
-    PresetVersion,
     PresetScopeType,
 )
 from api_service.services.presets.catalog import (
@@ -181,7 +180,6 @@ class PresetSaveService:
                 annotations={},
                 required_capabilities=[],
                 created_by=created_by,
-                version="1.0.0",
                 auto_commit=False,
             )
             if created_by is not None:
@@ -192,27 +190,22 @@ class PresetSaveService:
                     scope_ref=normalized_scope_ref,
                     auto_commit=False,
                 )
-                version_id = (
+                preset_id = (
                     await self._session.execute(
-                        select(PresetVersion.id)
-                        .join(
-                            Preset,
-                            Preset.id == PresetVersion.template_id,
-                        )
+                        select(Preset.id)
                         .where(
                             Preset.slug == unique_slug,
                             Preset.scope_type
                             == PresetScopeType(normalized_scope),
                             Preset.scope_ref == normalized_scope_ref,
                         )
-                        .order_by(PresetVersion.created_at.desc())
                         .limit(1)
                     )
                 ).scalar_one_or_none()
-                if version_id is not None:
+                if preset_id is not None:
                     await self._catalog.record_recent(
                         user_id=created_by,
-                        template_version_id=version_id,
+                        template_id=preset_id,
                         auto_commit=False,
                     )
             await self._session.commit()

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -648,8 +648,8 @@ describe.skip("Task Create Entrypoint", () => {
                   scope: "personal",
                   title: "Personal Demo",
                   description: "A user-owned preset.",
-                  latestVersion: "1.0.0",
-                  version: "1.0.0",
+                  latestVersion: "1",
+                  version: "1",
                 },
               ],
             }),
@@ -674,16 +674,16 @@ describe.skip("Task Create Entrypoint", () => {
                   title: "Objective Request Demo",
                   description:
                     "Use template inputs to derive the task objective.",
-                  latestVersion: "2.0.0",
-                  version: "2.0.0",
+                  latestVersion: "2",
+                  version: "2",
                 },
                 {
                   slug: "pr-resolver",
                   scope: "global",
                   title: "PR Resolver",
                   description: "Resolve pull request checks and feedback.",
-                  latestVersion: "1.0.0",
-                  version: "1.0.0",
+                  latestVersion: "1",
+                  version: "1",
                 },
               ],
             }),
@@ -742,8 +742,8 @@ describe.skip("Task Create Entrypoint", () => {
               scope: "global",
               title: "Objective Request Demo",
               description: "Use template inputs to derive the task objective.",
-              latestVersion: "2.0.0",
-              version: "2.0.0",
+              latestVersion: "2",
+              version: "2",
               inputs: [
                 {
                   name: "request",
@@ -763,8 +763,8 @@ describe.skip("Task Create Entrypoint", () => {
               scope: "global",
               title: "PR Resolver",
               description: "Resolve pull request checks and feedback.",
-              latestVersion: "1.0.0",
-              version: "1.0.0",
+              latestVersion: "1",
+              version: "1",
               inputs: [],
             }),
           } as Response);
@@ -811,7 +811,7 @@ describe.skip("Task Create Entrypoint", () => {
             json: async () => ({
               steps: [
                 {
-                  id: "tpl:objective-demo:2.0.0:01",
+                  id: "tpl:objective-demo:2:01",
                   title: "Clarify request",
                   instructions: "",
                   skill: {
@@ -820,14 +820,14 @@ describe.skip("Task Create Entrypoint", () => {
                   },
                 },
                 {
-                  id: "tpl:objective-demo:2.0.0:02",
+                  id: "tpl:objective-demo:2:02",
                   title: "Review objective",
                   instructions: "Review the resulting task objective.",
                 },
               ],
               appliedTemplate: {
                 slug: "objective-demo",
-                version: "2.0.0",
+                version: "2",
               },
               warnings: [],
             }),
@@ -843,14 +843,14 @@ describe.skip("Task Create Entrypoint", () => {
             json: async () => ({
               steps: [
                 {
-                  id: "tpl:pr-resolver:1.0.0:01",
+                  id: "tpl:pr-resolver:1:01",
                   title: "Resolve PR",
                   instructions: "Resolve the current branch PR.",
                 },
               ],
               appliedTemplate: {
                 slug: "pr-resolver",
-                version: "1.0.0",
+                version: "1",
               },
               warnings: [],
             }),
@@ -1371,7 +1371,7 @@ describe.skip("Task Create Entrypoint", () => {
                   },
                   steps: [
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                      id: "tpl:jira-breakdown-orchestrate:1:01",
                       title: "Break down declarative design",
                       instructions: "Break down the Grid UI overlay plan.",
                       skill: {
@@ -1380,7 +1380,7 @@ describe.skip("Task Create Entrypoint", () => {
                       },
                     },
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                      id: "tpl:jira-breakdown-orchestrate:1:02",
                       title: "Create Jira stories",
                       skill: { id: "story.create_jira_issues" },
                       storyOutput: {
@@ -1394,7 +1394,7 @@ describe.skip("Task Create Entrypoint", () => {
                       },
                     },
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                      id: "tpl:jira-breakdown-orchestrate:1:03",
                       title: "Create dependent Jira Orchestrate tasks",
                       skill: { id: "story.create_jira_orchestrate_tasks" },
                       jiraOrchestration: {
@@ -1971,7 +1971,7 @@ describe.skip("Task Create Entrypoint", () => {
               slug: "saved-preset",
               scope: "personal",
               title: "Saved preset",
-              latestVersion: "1.0.0",
+              latestVersion: "1",
             }),
           } as Response);
         }
@@ -2216,7 +2216,7 @@ describe.skip("Task Create Entrypoint", () => {
                     appliedStepTemplates: [
                       {
                         slug: "jira-breakdown-orchestrate",
-                        version: "1.0.0",
+                        version: "1",
                         inputs: {
                           feature_request: "Break down the Grid UI overlay plan.",
                           jira_project_key: "MM",
@@ -2228,9 +2228,9 @@ describe.skip("Task Create Entrypoint", () => {
                           source_issue_key: "",
                         },
                         stepIds: [
-                          "tpl:jira-breakdown-orchestrate:1.0.0:01",
-                          "tpl:jira-breakdown-orchestrate:1.0.0:02",
-                          "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                          "tpl:jira-breakdown-orchestrate:1:01",
+                          "tpl:jira-breakdown-orchestrate:1:02",
+                          "tpl:jira-breakdown-orchestrate:1:03",
                         ],
                         appliedAt: "2026-04-26T19:29:23.784091+00:00",
                         capabilities: ["git"],
@@ -2238,7 +2238,7 @@ describe.skip("Task Create Entrypoint", () => {
                     ],
                     steps: [
                       {
-                        id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                        id: "tpl:jira-breakdown-orchestrate:1:01",
                         title: "Break down declarative design",
                         instructions: "Break down the Grid UI overlay plan.",
                         tool: {
@@ -2254,7 +2254,7 @@ describe.skip("Task Create Entrypoint", () => {
                         },
                       },
                       {
-                        id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                        id: "tpl:jira-breakdown-orchestrate:1:02",
                         title: "Create Jira stories",
                         tool: {
                           type: "skill",
@@ -2277,7 +2277,7 @@ describe.skip("Task Create Entrypoint", () => {
                         },
                       },
                       {
-                        id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                        id: "tpl:jira-breakdown-orchestrate:1:03",
                         title: "Create dependent Jira Orchestrate tasks",
                         tool: {
                           type: "skill",
@@ -2316,15 +2316,15 @@ describe.skip("Task Create Entrypoint", () => {
                 task: {
                   steps: [
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                      id: "tpl:jira-breakdown-orchestrate:1:01",
                       instructions: "Break down the Grid UI overlay plan.",
                     },
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                      id: "tpl:jira-breakdown-orchestrate:1:02",
                       instructions: "Create Jira stories from recovered input.",
                     },
                     {
-                      id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                      id: "tpl:jira-breakdown-orchestrate:1:03",
                       instructions:
                         "Create dependent orchestrate tasks from recovered input.",
                     },
@@ -2573,8 +2573,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "Jira Orchestrate",
         description: "Jira preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
       {
         key: "global::::speckit-orchestrate",
@@ -2582,8 +2582,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
       {
         key: "global::::moonspec-orchestrate",
@@ -2591,8 +2591,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "MoonSpec Orchestrate",
         description: "MoonSpec preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
     ]);
 
@@ -2608,8 +2608,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
       {
         key: "global::::moonspec-orchestrate",
@@ -2617,8 +2617,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "MoonSpec Orchestrate",
         description: "MoonSpec preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
     ]);
 
@@ -2634,8 +2634,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "Other Template",
         description: "Other preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
       {
         key: "global::::speckit-orchestrate",
@@ -2643,8 +2643,8 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1.0.0",
-        version: "1.0.0",
+        latestVersion: "1",
+        version: "1",
       },
     ]);
 
@@ -4266,15 +4266,15 @@ describe.skip("Task Create Entrypoint", () => {
                 publish_mode: "pr",
               }),
               stepIds: [
-                "tpl:jira-breakdown-orchestrate:1.0.0:01",
-                "tpl:jira-breakdown-orchestrate:1.0.0:02",
-                "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                "tpl:jira-breakdown-orchestrate:1:01",
+                "tpl:jira-breakdown-orchestrate:1:02",
+                "tpl:jira-breakdown-orchestrate:1:03",
               ],
             }),
           ],
           steps: [
             expect.objectContaining({
-              id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+              id: "tpl:jira-breakdown-orchestrate:1:01",
               tool: expect.objectContaining({
                 name: "moonspec-breakdown",
                 requiredCapabilities: ["git"],
@@ -4285,7 +4285,7 @@ describe.skip("Task Create Entrypoint", () => {
               }),
             }),
             expect.objectContaining({
-              id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+              id: "tpl:jira-breakdown-orchestrate:1:02",
               instructions: "Create Jira stories from recovered input.",
               storyOutput: {
                 mode: "jira",
@@ -4298,7 +4298,7 @@ describe.skip("Task Create Entrypoint", () => {
               },
             }),
             expect.objectContaining({
-              id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+              id: "tpl:jira-breakdown-orchestrate:1:03",
               instructions:
                 "Create dependent orchestrate tasks from recovered input.",
               jiraOrchestration: {
@@ -6650,16 +6650,16 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Breakdown",
                 description: "Create Jira stories from a breakdown.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
               {
                 slug: "moonspec-orchestrate",
                 scope: "global",
                 title: "MoonSpec Orchestrate",
                 description: "Keep the default preset off Jira Breakdown.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -6714,16 +6714,16 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Breakdown and Orchestrate",
                 description: "Create dependent Jira Orchestrate tasks.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
               {
                 slug: "moonspec-orchestrate",
                 scope: "global",
                 title: "MoonSpec Orchestrate",
                 description: "Default preset.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -6774,8 +6774,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Orchestrate",
                 description: "Run MoonSpec from a Jira issue.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -6791,8 +6791,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Jira Orchestrate",
             description: "Run MoonSpec from a Jira issue.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "jira_issue_key",
@@ -6866,8 +6866,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "MoonSpec Orchestrate",
                 description: "Run MoonSpec.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -6883,8 +6883,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "MoonSpec Orchestrate",
             description: "Run MoonSpec.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -6956,8 +6956,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Orchestrate",
                 description: "Run MoonSpec from a Jira issue.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -6971,8 +6971,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Jira Orchestrate",
             description: "Run MoonSpec from a Jira issue.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "jira_issue_key",
@@ -7002,7 +7002,7 @@ describe.skip("Task Create Entrypoint", () => {
             ],
             appliedTemplate: {
               slug: "jira-orchestrate",
-              version: "1.0.0",
+              version: "1",
               inputs: { jira_issue_key: "THOR-352" },
               stepIds: ["tpl:jira-orchestrate:1"],
             },
@@ -7081,8 +7081,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Breakdown and Orchestrate",
                 description: "Create dependent Jira Orchestrate tasks.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -7100,8 +7100,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Jira Breakdown and Orchestrate",
             description: "Create dependent Jira Orchestrate tasks.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -7165,8 +7165,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Breakdown",
                 description: "Create Jira stories from a breakdown.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -7180,8 +7180,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Jira Breakdown",
             description: "Create Jira stories from a breakdown.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -7224,14 +7224,14 @@ describe.skip("Task Create Entrypoint", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:jira-breakdown:1.0.0:01",
+                id: "tpl:jira-breakdown:1:01",
                 title: "Create Jira stories",
                 instructions: `Selected Jira board ID: ${body.inputs.jira_board_id}`,
               },
             ],
             appliedTemplate: {
               slug: "jira-breakdown",
-              version: "1.0.0",
+              version: "1",
               inputs: body.inputs,
             },
             warnings: [],
@@ -7284,8 +7284,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Option Demo",
                 description: "Preset options.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -7299,8 +7299,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Option Demo",
             description: "Preset options.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -7332,14 +7332,14 @@ describe.skip("Task Create Entrypoint", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:option-demo:1.0.0:01",
+                id: "tpl:option-demo:1:01",
                 title: "Options",
                 instructions: JSON.stringify(body.inputs),
               },
             ],
             appliedTemplate: {
               slug: "option-demo",
-              version: "1.0.0",
+              version: "1",
               inputs: body.inputs,
             },
             warnings: [],
@@ -7388,16 +7388,16 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Preset A",
                 description: "First preset.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
               {
                 slug: "preset-b",
                 scope: "global",
                 title: "Preset B",
                 description: "Second preset.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -7411,8 +7411,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Preset A",
             description: "First preset.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -7440,8 +7440,8 @@ describe.skip("Task Create Entrypoint", () => {
             scope: "global",
             title: "Preset B",
             description: "Second preset.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -7468,14 +7468,14 @@ describe.skip("Task Create Entrypoint", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:preset-b:1.0.0:01",
+                id: "tpl:preset-b:1:01",
                 title: "Preset B",
                 instructions: body.inputs.jira_dependency_mode,
               },
             ],
             appliedTemplate: {
               slug: "preset-b",
-              version: "1.0.0",
+              version: "1",
               inputs: body.inputs,
             },
             warnings: [],
@@ -7536,8 +7536,8 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Jira Breakdown",
                 description: "Create Jira stories from a breakdown.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -8282,8 +8282,8 @@ describe.skip("Task Create Entrypoint", () => {
           scope: "global",
           title: label,
           description: `${label} detail.`,
-          latestVersion: "1.0.0",
-          version: "1.0.0",
+          latestVersion: "1",
+          version: "1",
           inputs: [
             {
               name: `${slug}_input`,
@@ -8306,16 +8306,16 @@ describe.skip("Task Create Entrypoint", () => {
                 scope: "global",
                 title: "Preset A",
                 description: "First preset.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
               {
                 slug: "preset-b",
                 scope: "global",
                 title: "Preset B",
                 description: "Second preset.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -10452,7 +10452,7 @@ describe.skip("Task Create Entrypoint", () => {
       resolveObjectiveInstructions("", "", [
         {
           slug: "objective-demo",
-          version: "2.0.0",
+          version: "2",
           appliedAt: "2026-04-03T00:00:00Z",
           inputs: {
             request: "Restore the legacy Start Workflow objective handling.",
@@ -14020,8 +14020,8 @@ describe("Task Create MM-578 Preset expansion", () => {
               scope: "global",
               title: "MM-578 Preset",
               description: "Expand Preset steps.",
-              latestVersion: "1.0.0",
-              version: "1.0.0",
+              latestVersion: "1",
+              version: "1",
             },
           ],
         }),
@@ -14035,8 +14035,8 @@ describe("Task Create MM-578 Preset expansion", () => {
           scope: "global",
           title: "MM-578 Preset",
           description: "Expand Preset steps.",
-          latestVersion: "1.0.0",
-          version: "1.0.0",
+          latestVersion: "1",
+          version: "1",
           inputs: [
             {
               name: "issue_key",
@@ -14058,7 +14058,7 @@ describe("Task Create MM-578 Preset expansion", () => {
         json: async () => ({
           steps: [
             {
-              id: "tpl:mm-578-preset:1.0.0:01",
+              id: "tpl:mm-578-preset:1:01",
               title: "Fetch Jira issue",
               instructions: "Fetch MM-578.",
               tool: {
@@ -14069,13 +14069,13 @@ describe("Task Create MM-578 Preset expansion", () => {
               source: {
                 kind: "preset-derived",
                 presetId: "mm-578-preset",
-                presetVersion: "1.0.0",
+                presetDigest: "digest-1",
                 includePath: ["root", "fetch"],
                 originalStepId: "fetch-jira-issue",
               },
             },
             {
-              id: "tpl:mm-578-preset:1.0.0:02",
+              id: "tpl:mm-578-preset:1:02",
               title: "Implement preset story",
               instructions: "Implement MM-578.",
               skill: {
@@ -14085,7 +14085,7 @@ describe("Task Create MM-578 Preset expansion", () => {
               source: {
                 kind: "preset-derived",
                 presetId: "mm-578-preset",
-                presetVersion: "1.0.0",
+                presetDigest: "digest-1",
                 includePath: ["root", "implement"],
                 originalStepId: "implement-preset-story",
               },
@@ -14093,26 +14093,26 @@ describe("Task Create MM-578 Preset expansion", () => {
           ],
           appliedTemplate: {
             slug: "mm-578-preset",
-            version: "1.0.0",
+            version: "1",
             stepIds: [
-              "tpl:mm-578-preset:1.0.0:01",
-              "tpl:mm-578-preset:1.0.0:02",
+              "tpl:mm-578-preset:1:01",
+              "tpl:mm-578-preset:1:02",
             ],
             composition: {
               slug: "mm-578-preset",
-              version: "1.0.0",
-              path: ["mm-578-preset@1.0.0"],
+              version: "1",
+              path: ["mm-578-preset"],
               stepIds: [
-                "tpl:mm-578-preset:1.0.0:01",
-                "tpl:mm-578-preset:1.0.0:02",
+                "tpl:mm-578-preset:1:01",
+                "tpl:mm-578-preset:1:02",
               ],
               includes: [],
             },
             authoredPresets: [
               {
                 presetSlug: "mm-578-preset",
-                presetVersion: "1.0.0",
-                includePath: ["mm-578-preset@1.0.0"],
+                presetDigest: "digest-1",
+                includePath: ["mm-578-preset"],
               },
             ],
           },
@@ -14165,7 +14165,7 @@ describe("Task Create MM-578 Preset expansion", () => {
                   preset: {
                     id: "global::::mm-578-preset",
                     slug: "mm-578-preset",
-                    version: "1.0.0",
+                    version: "1",
                     inputs: { issue_key: "MM-578" },
                   },
                 },
@@ -14201,21 +14201,21 @@ describe("Task Create MM-578 Preset expansion", () => {
               publish: { mode: "pr" },
               taskTemplate: {
                 slug: "jira-implement",
-                version: "1.0.0",
+                version: "1",
               },
               appliedStepTemplates: [
                 {
                   slug: "jira-implement",
-                  version: "1.0.0",
+                  version: "1",
                   stepIds: [
-                    "tpl:jira-implement:1.0.0:01",
-                    "tpl:jira-implement:1.0.0:02",
+                    "tpl:jira-implement:1:01",
+                    "tpl:jira-implement:1:02",
                   ],
                 },
               ],
               steps: [
                 {
-                  id: "tpl:jira-implement:1.0.0:01",
+                  id: "tpl:jira-implement:1:01",
                   title: "Fetch Jira issue",
                   instructions: "Fetch MM-901.",
                   tool: {
@@ -14225,7 +14225,7 @@ describe("Task Create MM-578 Preset expansion", () => {
                   },
                 },
                 {
-                  id: "tpl:jira-implement:1.0.0:02",
+                  id: "tpl:jira-implement:1:02",
                   title: "Implement preset story",
                   instructions: "Implement MM-901.",
                   skill: {
@@ -14295,8 +14295,8 @@ describe("Task Create MM-578 Preset expansion", () => {
                 scope: "global",
                 title: "Jira Orchestrate",
                 description: "Run MoonSpec from a Jira issue.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -14310,8 +14310,8 @@ describe("Task Create MM-578 Preset expansion", () => {
             scope: "global",
             title: "Jira Orchestrate",
             description: "Run MoonSpec from a Jira issue.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "jira_issue_key",
@@ -14333,7 +14333,7 @@ describe("Task Create MM-578 Preset expansion", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:jira-orchestrate:1.0.0:01",
+                id: "tpl:jira-orchestrate:1:01",
                 title: "Move Jira issue",
                 instructions: "Transition THOR-352 to In Progress.",
                 skill: { id: "jira-issue-updater", args: {} },
@@ -14341,9 +14341,9 @@ describe("Task Create MM-578 Preset expansion", () => {
             ],
             appliedTemplate: {
               slug: "jira-orchestrate",
-              version: "1.0.0",
+              version: "1",
               inputs: { jira_issue_key: "THOR-352" },
-              stepIds: ["tpl:jira-orchestrate:1.0.0:01"],
+              stepIds: ["tpl:jira-orchestrate:1:01"],
             },
             warnings: [],
           }),
@@ -14410,8 +14410,8 @@ describe("Task Create MM-578 Preset expansion", () => {
                 scope: "global",
                 title: "Jira Breakdown and Orchestrate",
                 description: "Create dependent Jira Orchestrate tasks.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -14429,8 +14429,8 @@ describe("Task Create MM-578 Preset expansion", () => {
             scope: "global",
             title: "Jira Breakdown and Orchestrate",
             description: "Create dependent Jira Orchestrate tasks.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -14460,19 +14460,19 @@ describe("Task Create MM-578 Preset expansion", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                id: "tpl:jira-breakdown-orchestrate:1:01",
                 title: "Break down declarative design",
                 instructions: "Break down the feature request.",
                 skill: { id: "moonspec-breakdown", args: {} },
               },
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                id: "tpl:jira-breakdown-orchestrate:1:02",
                 title: "Create Jira stories",
                 instructions: "Create Jira stories.",
                 skill: { id: "story.create_jira_issues", args: {} },
               },
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                id: "tpl:jira-breakdown-orchestrate:1:03",
                 title: "Create dependent Jira Orchestrate tasks",
                 instructions: "Create one Jira Orchestrate task per story.",
                 skill: { id: "story.create_jira_orchestrate_tasks", args: {} },
@@ -14490,7 +14490,7 @@ describe("Task Create MM-578 Preset expansion", () => {
             ],
             appliedTemplate: {
               slug: "jira-breakdown-orchestrate",
-              version: "1.0.0",
+              version: "1",
             },
             capabilities: ["git"],
             warnings: [],
@@ -14573,8 +14573,8 @@ describe("Task Create MM-578 Preset expansion", () => {
                 scope: "global",
                 title: "Jira Breakdown and Orchestrate",
                 description: "Create dependent Jira Orchestrate tasks.",
-                latestVersion: "1.0.0",
-                version: "1.0.0",
+                latestVersion: "1",
+                version: "1",
               },
             ],
           }),
@@ -14592,8 +14592,8 @@ describe("Task Create MM-578 Preset expansion", () => {
             scope: "global",
             title: "Jira Breakdown and Orchestrate",
             description: "Create dependent Jira Orchestrate tasks.",
-            latestVersion: "1.0.0",
-            version: "1.0.0",
+            latestVersion: "1",
+            version: "1",
             inputs: [
               {
                 name: "feature_request",
@@ -14615,19 +14615,19 @@ describe("Task Create MM-578 Preset expansion", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:01",
+                id: "tpl:jira-breakdown-orchestrate:1:01",
                 title: "Break down declarative design",
                 instructions: "Break down the feature request.",
                 skill: { id: "moonspec-breakdown", args: {} },
               },
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:02",
+                id: "tpl:jira-breakdown-orchestrate:1:02",
                 title: "Create Jira stories",
                 instructions: "Create Jira stories.",
                 skill: { id: "story.create_jira_issues", args: {} },
               },
               {
-                id: "tpl:jira-breakdown-orchestrate:1.0.0:03",
+                id: "tpl:jira-breakdown-orchestrate:1:03",
                 title: "Create dependent Jira Orchestrate tasks",
                 instructions: "Create one Jira Orchestrate task per story.",
                 skill: { id: "story.create_jira_orchestrate_tasks", args: {} },
@@ -14635,7 +14635,7 @@ describe("Task Create MM-578 Preset expansion", () => {
             ],
             appliedTemplate: {
               slug: "jira-breakdown-orchestrate",
-              version: "1.0.0",
+              version: "1",
             },
             capabilities: ["git"],
             warnings: [],
@@ -14787,7 +14787,6 @@ describe("Task Create MM-578 Preset expansion", () => {
     expect(submittedStep.source).toMatchObject({
       kind: "detached",
       presetId: "mm-578-preset",
-      presetVersion: "1.0.0",
       includePath: ["root", "fetch"],
       originalStepId: "fetch-jira-issue",
     });
@@ -14829,7 +14828,7 @@ describe("Task Create MM-578 Preset expansion", () => {
       };
     };
     expect(request.payload.task.steps[0]).toEqual({
-      id: "tpl:mm-578-preset:1.0.0:01",
+      id: "tpl:mm-578-preset:1:01",
       title: "Fetch Jira issue",
       type: "tool",
       instructions: "Fetch MM-578.",
@@ -14841,14 +14840,14 @@ describe("Task Create MM-578 Preset expansion", () => {
       source: {
         kind: "preset-derived",
         presetId: "mm-578-preset",
-        presetVersion: "1.0.0",
+        presetDigest: "digest-1",
         includePath: ["root", "fetch"],
         originalStepId: "fetch-jira-issue",
       },
     });
     expect(request.payload.task.steps[0]?.["skill"]).toBeUndefined();
     expect(request.payload.task.steps[1]).toEqual({
-      id: "tpl:mm-578-preset:1.0.0:02",
+      id: "tpl:mm-578-preset:1:02",
       title: "Implement preset story",
       type: "skill",
       instructions: "Implement MM-578.",
@@ -14859,7 +14858,7 @@ describe("Task Create MM-578 Preset expansion", () => {
       source: {
         kind: "preset-derived",
         presetId: "mm-578-preset",
-        presetVersion: "1.0.0",
+        presetDigest: "digest-1",
         includePath: ["root", "implement"],
         originalStepId: "implement-preset-story",
       },
@@ -14868,8 +14867,8 @@ describe("Task Create MM-578 Preset expansion", () => {
     expect(request.payload.task.authoredPresets).toEqual([
       {
         presetSlug: "mm-578-preset",
-        presetVersion: "1.0.0",
-        includePath: ["mm-578-preset@1.0.0"],
+        presetDigest: "digest-1",
+        includePath: ["mm-578-preset"],
       },
     ]);
     expect(request.payload.task.appliedStepTemplates?.[0]).toMatchObject({
@@ -14877,14 +14876,14 @@ describe("Task Create MM-578 Preset expansion", () => {
       composition: {
         slug: "mm-578-preset",
         stepIds: [
-          "tpl:mm-578-preset:1.0.0:01",
-          "tpl:mm-578-preset:1.0.0:02",
+          "tpl:mm-578-preset:1:01",
+          "tpl:mm-578-preset:1:02",
         ],
       },
       authoredPresets: [
         {
           presetSlug: "mm-578-preset",
-          presetVersion: "1.0.0",
+          presetDigest: "digest-1",
         },
       ],
     });
@@ -14916,7 +14915,7 @@ describe("Task Create MM-578 Preset expansion", () => {
     expect(steps[0]?.source).toEqual({
       kind: "preset-derived",
       presetId: "mm-578-preset",
-      presetVersion: "1.0.0",
+      presetDigest: "digest-1",
       includePath: ["root", "fetch"],
       originalStepId: "fetch-jira-issue",
     });
@@ -14934,8 +14933,8 @@ describe("Task Create MM-578 Preset expansion", () => {
     ).toEqual([
       {
         presetSlug: "mm-578-preset",
-        presetVersion: "1.0.0",
-        includePath: ["mm-578-preset@1.0.0"],
+        presetDigest: "digest-1",
+        includePath: ["mm-578-preset"],
       },
     ]);
     expect(
@@ -14999,12 +14998,12 @@ describe("Task Create MM-578 Preset expansion", () => {
           ?.originalStepId,
       ]),
     ).toEqual([
-      ["tpl:mm-578-preset:1.0.0:01", "tool", "fetch-jira-issue"],
-      ["tpl:mm-578-preset:1.0.0:02", "skill", "implement-preset-story"],
-      ["tpl:mm-578-preset:1.0.0:01", "tool", "fetch-jira-issue"],
-      ["tpl:mm-578-preset:1.0.0:02", "skill", "implement-preset-story"],
-      ["tpl:mm-578-preset:1.0.0:01", "tool", "fetch-jira-issue"],
-      ["tpl:mm-578-preset:1.0.0:02", "skill", "implement-preset-story"],
+      ["tpl:mm-578-preset:1:01", "tool", "fetch-jira-issue"],
+      ["tpl:mm-578-preset:1:02", "skill", "implement-preset-story"],
+      ["tpl:mm-578-preset:1:01", "tool", "fetch-jira-issue"],
+      ["tpl:mm-578-preset:1:02", "skill", "implement-preset-story"],
+      ["tpl:mm-578-preset:1:01", "tool", "fetch-jira-issue"],
+      ["tpl:mm-578-preset:1:02", "skill", "implement-preset-story"],
     ]);
   });
 
@@ -15025,7 +15024,7 @@ describe("Task Create MM-578 Preset expansion", () => {
               steps: [],
               appliedTemplate: {
                 slug: "mm-578-preset",
-                version: "1.0.0",
+                version: "1",
               },
               warnings: [],
             }),
@@ -15244,7 +15243,7 @@ describe("Task Create MM-578 Preset expansion", () => {
           json: async () => ({
             steps: [
               {
-                id: "tpl:mm-578-preset:1.0.0:01",
+                id: "tpl:mm-578-preset:1:01",
                 title: "Fetch Jira issue",
                 instructions: "Fetch MM-578.",
                 tool: {
@@ -15349,7 +15348,7 @@ describe("Task Create MM-578 Preset expansion", () => {
       json: async () => ({
         steps: [
           {
-            id: "tpl:mm-578-preset:1.0.0:01",
+            id: "tpl:mm-578-preset:1:01",
             title: "Fetch Jira issue",
             instructions: "Fetch MM-578.",
             tool: {
@@ -15361,7 +15360,7 @@ describe("Task Create MM-578 Preset expansion", () => {
         ],
         appliedTemplate: {
           slug: "mm-578-preset",
-          version: "1.0.0",
+          version: "1",
         },
       }),
     } as Response);
@@ -15494,24 +15493,24 @@ describe("Task Create schema-driven capability inputs", () => {
               scope: "global",
               title: "Jira Schema Preset",
               description: "Schema-driven Jira preset.",
-              latestVersion: "1.0.0",
-              version: "1.0.0",
+              latestVersion: "1",
+              version: "1",
             },
             {
               slug: "github-schema-preset",
               scope: "global",
               title: "GitHub Schema Preset",
               description: "Schema-driven GitHub preset.",
-              latestVersion: "1.0.0",
-              version: "1.0.0",
+              latestVersion: "1",
+              version: "1",
             },
             {
               slug: "generic-schema-preset",
               scope: "global",
               title: "Generic Schema Preset",
               description: "Schema-driven generic preset.",
-              latestVersion: "1.0.0",
-              version: "1.0.0",
+              latestVersion: "1",
+              version: "1",
             },
           ],
         }),
@@ -15525,8 +15524,8 @@ describe("Task Create schema-driven capability inputs", () => {
           scope: "global",
           title: "Jira Schema Preset",
           description: "Schema-driven Jira preset.",
-          latestVersion: "1.0.0",
-          version: "1.0.0",
+          latestVersion: "1",
+          version: "1",
           inputSchema: {
             type: "object",
             required: ["jira_issue"],
@@ -15561,8 +15560,8 @@ describe("Task Create schema-driven capability inputs", () => {
           scope: "global",
           title: "GitHub Schema Preset",
           description: "Schema-driven GitHub preset.",
-          latestVersion: "1.0.0",
-          version: "1.0.0",
+          latestVersion: "1",
+          version: "1",
           inputSchema: {
             type: "object",
             required: ["github_issue"],
@@ -15602,8 +15601,8 @@ describe("Task Create schema-driven capability inputs", () => {
           scope: "global",
           title: "Generic Schema Preset",
           description: "Schema-driven generic preset.",
-          latestVersion: "1.0.0",
-          version: "1.0.0",
+          latestVersion: "1",
+          version: "1",
           inputSchema: {
             type: "object",
             required: ["summary", "urgent"],
@@ -15669,13 +15668,13 @@ describe("Task Create schema-driven capability inputs", () => {
         json: async () => ({
           steps: [
             {
-              id: "tpl:github-schema-preset:1.0.0:01",
+              id: "tpl:github-schema-preset:1:01",
               title: "Use GitHub issue",
               instructions: "Use GitHub issue.",
               tool: { type: "tool", id: "github.load_issue_preset_brief", inputs: payload.inputs },
             },
           ],
-          appliedTemplate: { slug: "github-schema-preset", version: "1.0.0", inputs: payload.inputs },
+          appliedTemplate: { slug: "github-schema-preset", version: "1", inputs: payload.inputs },
           capabilities: ["gh"],
           warnings: [],
         }),
@@ -15690,7 +15689,7 @@ describe("Task Create schema-driven capability inputs", () => {
         json: async () => ({
           steps: [
             {
-              id: "tpl:jira-schema-preset:1.0.0:01",
+              id: "tpl:jira-schema-preset:1:01",
               title: "Use Jira issue",
               instructions: `Use ${(payload.inputs?.jira_issue as { key?: string })?.key || ""}.`,
               tool: {
@@ -15702,7 +15701,7 @@ describe("Task Create schema-driven capability inputs", () => {
           ],
           appliedTemplate: {
             slug: "jira-schema-preset",
-            version: "1.0.0",
+            version: "1",
             inputs: payload.inputs,
           },
           capabilities: ["jira"],

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -2573,8 +2573,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "Jira Orchestrate",
         description: "Jira preset.",
-        latestVersion: "1",
-        version: "1",
       },
       {
         key: "global::::speckit-orchestrate",
@@ -2582,8 +2580,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1",
-        version: "1",
       },
       {
         key: "global::::moonspec-orchestrate",
@@ -2591,8 +2587,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "MoonSpec Orchestrate",
         description: "MoonSpec preset.",
-        latestVersion: "1",
-        version: "1",
       },
     ]);
 
@@ -2608,8 +2602,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1",
-        version: "1",
       },
       {
         key: "global::::moonspec-orchestrate",
@@ -2617,8 +2609,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "MoonSpec Orchestrate",
         description: "MoonSpec preset.",
-        latestVersion: "1",
-        version: "1",
       },
     ]);
 
@@ -2634,8 +2624,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "Other Template",
         description: "Other preset.",
-        latestVersion: "1",
-        version: "1",
       },
       {
         key: "global::::speckit-orchestrate",
@@ -2643,8 +2631,6 @@ describe.skip("Task Create Entrypoint", () => {
         scope: "global",
         title: "SpecKit Orchestrate",
         description: "Legacy preset.",
-        latestVersion: "1",
-        version: "1",
       },
     ]);
 
@@ -10452,7 +10438,7 @@ describe.skip("Task Create Entrypoint", () => {
       resolveObjectiveInstructions("", "", [
         {
           slug: "objective-demo",
-          version: "2",
+          presetDigest: "sha256:objective-demo",
           appliedAt: "2026-04-03T00:00:00Z",
           inputs: {
             request: "Restore the legacy Start Workflow objective handling.",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -586,8 +586,7 @@ interface PresetSummary {
   scopeRef?: string | null;
   title: string;
   description: string;
-  latestVersion: string;
-  version: string;
+  presetDigest?: string | null;
 }
 
 interface PresetDetail extends PresetSummary {
@@ -645,7 +644,7 @@ interface PresetExpandResponse {
   steps?: ExpandedStepPayload[];
   appliedTemplate?: {
     slug?: string;
-    version?: string;
+    presetDigest?: string;
     inputs?: Record<string, unknown>;
     stepIds?: string[];
     appliedAt?: string;
@@ -798,7 +797,6 @@ interface PresetSubmitExpansionState {
 interface PresetExpansionState {
   presetKey: string;
   presetTitle: string;
-  version: string;
   expandedSteps: ExpandedStepPayload[];
   inputs: Record<string, unknown>;
   assumptions: string[];
@@ -809,7 +807,7 @@ interface PresetExpansionState {
 
 interface AppliedTemplateState {
   slug: string;
-  version: string;
+  presetDigest?: string;
   inputs: Record<string, unknown>;
   stepIds: string[];
   appliedAt: string;
@@ -931,11 +929,11 @@ function compactSourceFromPresetProvenance(
     ? provenance.path.map((entry) => String(entry).trim()).filter(Boolean)
     : [];
   const presetSlug = String(source.slug || "").trim();
-  const presetVersion = String(source.version || "").trim();
+  const presetDigest = String(source.presetDigest || source.digest || "").trim();
   const originalStepId = String(source.originalStepId || "").trim();
   const compact: Record<string, unknown> = { kind: "preset-derived" };
   if (presetSlug) compact.presetSlug = presetSlug;
-  if (presetVersion) compact.presetVersion = presetVersion;
+  if (presetDigest) compact.presetDigest = presetDigest;
   if (path.length > 0) compact.includePath = path;
   if (originalStepId) compact.originalStepId = originalStepId;
   return Object.keys(compact).length > 1 ? compact : undefined;
@@ -2524,16 +2522,12 @@ function mapExpandedStepToState(
   const source =
     nonEmptyRecordValue(step.source) ||
     compactSourceFromPresetProvenance(nonEmptyRecordValue(step.presetProvenance));
-  const normalizedSource = source
-    ? {
-        ...source,
-        ...(!source.presetVersion && source.version
-          ? { presetVersion: source.version }
-          : {}),
-      }
-    : undefined;
+  const normalizedSource = source ? { ...source } : undefined;
   if (normalizedSource && "version" in normalizedSource) {
     delete normalizedSource.version;
+  }
+  if (normalizedSource && "presetVersion" in normalizedSource) {
+    delete normalizedSource.presetVersion;
   }
   const templateAttachments = Array.isArray(step.inputAttachments)
     ? step.inputAttachments
@@ -7099,8 +7093,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           inputValues,
           featureRequestOverride,
         );
-    const version =
-      detail.version || detail.latestVersion || preset.latestVersion || "1.0.0";
     const presetRuntime = runtime.trim().toLowerCase();
     const expandResponse = await fetch(
       withQueryParams(
@@ -7116,7 +7108,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           Accept: "application/json",
         },
         body: JSON.stringify({
-          version,
           inputs,
           context: {
             repository: repository.trim() || defaultRepository,
@@ -7143,7 +7134,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     return {
       presetKey: preset.key,
       presetTitle: preset.title,
-      version,
       expandedSteps,
       inputs,
       assumptions,
@@ -7171,12 +7161,13 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const appliedTemplate = expansion.appliedTemplate || {};
     return {
       slug: String(appliedTemplate.slug || preset.slug),
-      version: String(
-        appliedTemplate.version ||
-          detail.version ||
-          preset.latestVersion ||
-          "1.0.0",
-      ),
+      ...(String(appliedTemplate.presetDigest || detail.presetDigest || preset.presetDigest || "").trim()
+        ? {
+            presetDigest: String(
+              appliedTemplate.presetDigest || detail.presetDigest || preset.presetDigest,
+            ).trim(),
+          }
+        : {}),
       inputs:
         appliedTemplate.inputs && typeof appliedTemplate.inputs === "object"
           ? appliedTemplate.inputs

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2629,17 +2629,16 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/presets/{slug}/versions/{version}": {
+    "/api/presets/{slug}/review": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Template Version */
-        get: operations["get_template_version_api_presets__slug__versions__version__get"];
-        /** Review Template Version */
-        put: operations["review_template_version_api_presets__slug__versions__version__put"];
+        get?: never;
+        /** Review Template */
+        put: operations["review_template_api_presets__slug__review_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -6156,8 +6155,8 @@ export interface components {
         PresetAppliedMetadataSchema: {
             /** Slug */
             slug: string;
-            /** Version */
-            version: string;
+            /** Presetdigest */
+            presetDigest?: string | null;
             /** Inputs */
             inputs?: {
                 [key: string]: unknown;
@@ -6215,8 +6214,6 @@ export interface components {
          * @description Request model for template expansion.
          */
         PresetExpandRequestSchema: {
-            /** Version */
-            version: string;
             /** Inputs */
             inputs?: {
                 [key: string]: unknown;
@@ -6261,7 +6258,7 @@ export interface components {
         };
         /**
          * PresetInputSchema
-         * @description Input definition used by preset versions.
+         * @description Input definition used by presets.
          */
         PresetInputSchema: {
             /** Name */
@@ -6295,7 +6292,7 @@ export interface components {
         };
         /**
          * PresetResponseSchema
-         * @description Detail response model for one template version.
+         * @description Detail response model for one preset.
          */
         PresetResponseSchema: {
             /** Slug */
@@ -6311,10 +6308,8 @@ export interface components {
             title: string;
             /** Description */
             description: string;
-            /** Latestversion */
-            latestVersion: string;
-            /** Version */
-            version: string;
+            /** Presetdigest */
+            presetDigest?: string | null;
             /** Tags */
             tags?: string[];
             /**
@@ -6514,10 +6509,8 @@ export interface components {
             title: string;
             /** Description */
             description: string;
-            /** Latestversion */
-            latestVersion: string;
-            /** Version */
-            version: string;
+            /** Presetdigest */
+            presetDigest?: string | null;
             /** Tags */
             tags?: string[];
             /**
@@ -14390,7 +14383,7 @@ export interface operations {
             };
         };
     };
-    get_template_version_api_presets__slug__versions__version__get: {
+    review_template_api_presets__slug__review_put: {
         parameters: {
             query: {
                 scope: string;
@@ -14399,42 +14392,6 @@ export interface operations {
             header?: never;
             path: {
                 slug: string;
-                version: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PresetResponseSchema"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    review_template_version_api_presets__slug__versions__version__put: {
-        parameters: {
-            query: {
-                scope: string;
-                scopeRef?: string | null;
-            };
-            header?: never;
-            path: {
-                slug: string;
-                version: string;
             };
             cookie?: never;
         };

--- a/moonmind/agents/cli/presets.py
+++ b/moonmind/agents/cli/presets.py
@@ -51,7 +51,6 @@ class PresetClient:
         *,
         slug: str,
         scope: str,
-        version: str,
         inputs: dict[str, Any],
         scope_ref: str | None = None,
         context: dict[str, Any] | None = None,
@@ -64,7 +63,6 @@ class PresetClient:
             headers=self._headers(),
             params=params,
             json={
-                "version": version,
                 "inputs": dict(inputs or {}),
                 "context": dict(context or {}),
                 "options": {"enforceStepLimit": True},

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -173,21 +173,6 @@ def _skill_metadata_required_capabilities(skill_id: object) -> tuple[str, ...]:
     return tuple(required)
 
 
-def _normalize_preset_version_alias(value: object) -> object:
-    if not isinstance(value, Mapping):
-        return value
-    if "version" not in value:
-        return value
-    normalized = dict(value)
-    legacy_version = _clean_optional_str(normalized.pop("version"))
-    current_version = _clean_optional_str(normalized.get("presetVersion"))
-    if legacy_version and current_version and legacy_version != current_version:
-        raise WorkflowContractError("presetVersion conflicts with legacy version")
-    if legacy_version and not current_version:
-        normalized["presetVersion"] = legacy_version
-    return normalized
-
-
 def _contains_data_image_url(value: object) -> bool:
     if isinstance(value, str):
         return _DATA_IMAGE_URL_PATTERN.match(value.strip()) is not None
@@ -1349,17 +1334,12 @@ class WorkflowStepSource(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_legacy_version(cls, value: object) -> object:
-        return _normalize_preset_version_alias(value)
-
     kind: Literal["manual", "preset-derived", "preset-include", "detached"] | None = (
         Field(None, alias="kind")
     )
     preset_id: str | None = Field(None, alias="presetId")
     preset_slug: str | None = Field(None, alias="presetSlug")
-    preset_version: str | None = Field(None, alias="presetVersion")
+    preset_digest: str | None = Field(None, alias="presetDigest")
     include_path: list[str] | None = Field(None, alias="includePath")
     original_step_id: str | None = Field(None, alias="originalStepId")
 
@@ -1367,7 +1347,7 @@ class WorkflowStepSource(BaseModel):
         "kind",
         "preset_id",
         "preset_slug",
-        "preset_version",
+        "preset_digest",
         "original_step_id",
         mode="before",
     )
@@ -1394,14 +1374,9 @@ class AuthoredPresetBinding(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_legacy_version(cls, value: object) -> object:
-        return _normalize_preset_version_alias(value)
-
     preset_id: str | None = Field(None, alias="presetId")
     preset_slug: str | None = Field(None, alias="presetSlug")
-    preset_version: str | None = Field(None, alias="presetVersion")
+    preset_digest: str | None = Field(None, alias="presetDigest")
     alias: str | None = Field(None, alias="alias")
     include_path: list[str] | None = Field(None, alias="includePath")
     input_mapping: dict[str, Any] | None = Field(None, alias="inputMapping")
@@ -1410,7 +1385,7 @@ class AuthoredPresetBinding(BaseModel):
     @field_validator(
         "preset_id",
         "preset_slug",
-        "preset_version",
+        "preset_digest",
         "alias",
         "scope",
         mode="before",
@@ -2605,9 +2580,7 @@ def _include_tree_summary(
         parent_slug = _clean_optional_str(
             template.get("slug") or template.get("presetSlug")
         )
-        parent_version = _clean_optional_str(
-            template.get("version") or template.get("presetVersion")
-        )
+        parent_digest = _clean_optional_str(template.get("presetDigest"))
         composition = template.get("composition")
         candidates: list[Any] = []
         if isinstance(composition, Mapping):
@@ -2619,13 +2592,11 @@ def _include_tree_summary(
             summary.append(
                 {
                     "presetSlug": parent_slug,
-                    "presetVersion": parent_version,
+                    "presetDigest": parent_digest,
                     "includedSlug": _clean_optional_str(
                         include.get("slug") or include.get("presetSlug")
                     ),
-                    "includedVersion": _clean_optional_str(
-                        include.get("version") or include.get("presetVersion")
-                    ),
+                    "includedDigest": _clean_optional_str(include.get("presetDigest")),
                 }
             )
     return summary

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -97,7 +97,6 @@ async def expand_preset_for_child_run(
         template_slug = schedule.slug
         template_payload = {
             "slug": schedule.slug,
-            "version": schedule.version,
             "scope": "global",
         }
         existing_inputs = _coerce_mapping(task_payload.get("inputs"))
@@ -109,7 +108,6 @@ async def expand_preset_for_child_run(
             "source": "goal",
             "reason": schedule.reason,
             "presetSlug": schedule.slug,
-            "presetVersion": schedule.version,
             "jiraIssueKey": schedule.issue_key,
         }
 
@@ -119,7 +117,6 @@ async def expand_preset_for_child_run(
         PresetNotFoundError,
     )
 
-    template_version = str(template_payload.get("version") or "1.0.0").strip()
     template_scope = str(template_payload.get("scope") or "global").strip() or "global"
     template_scope_ref = (
         str(template_payload.get("scopeRef") or template_payload.get("scope_ref") or "")
@@ -149,7 +146,6 @@ async def expand_preset_for_child_run(
         "slug": template_slug,
         "scope": template_scope,
         "scope_ref": template_scope_ref,
-        "version": template_version,
         "inputs": template_inputs,
         "context": template_context,
         "options": ExpandOptions(should_enforce_step_limit=True),
@@ -169,12 +165,14 @@ async def expand_preset_for_child_run(
     applied_template = _coerce_mapping(expanded.get("appliedTemplate"))
     applied_template_payload: dict[str, Any] = {
         "slug": str(applied_template.get("slug") or template_slug),
-        "version": str(applied_template.get("version") or template_version),
         "inputs": _coerce_mapping(applied_template.get("inputs")) or template_inputs,
         "stepIds": list(applied_template.get("stepIds") or []),
         "appliedAt": str(applied_template.get("appliedAt") or ""),
         "capabilities": list(expanded.get("capabilities") or []),
     }
+    preset_digest = str(applied_template.get("presetDigest") or "").strip()
+    if preset_digest:
+        applied_template_payload["presetDigest"] = preset_digest
     composition = applied_template.get("composition") or expanded.get("composition")
     if isinstance(composition, Mapping):
         applied_template_payload["composition"] = dict(composition)
@@ -191,7 +189,6 @@ async def expand_preset_for_child_run(
     task_payload["taskTemplate"] = {
         **template_payload,
         "slug": str(applied_template.get("slug") or template_slug),
-        "version": str(applied_template.get("version") or template_version),
         "scope": template_scope,
     }
     parameters[payload_key] = task_payload

--- a/moonmind/workflows/executions/preset_goal_scheduler.py
+++ b/moonmind/workflows/executions/preset_goal_scheduler.py
@@ -17,7 +17,6 @@ class GoalPresetSchedule:
 
     goal: str
     slug: str
-    version: str
     inputs: dict[str, Any]
     reason: str
     issue_key: str | None = None
@@ -135,7 +134,6 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
         return GoalPresetSchedule(
             goal=normalized_goal,
             slug=slug,
-            version="1.1.0" if slug == "jira-implement" else "1.0.0",
             issue_key=issue_key,
             inputs={
                 "jira_issue_key": issue_key,
@@ -150,7 +148,6 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
         return GoalPresetSchedule(
             goal=normalized_goal,
             slug="github-issue-implement",
-            version="1.0.0",
             issue_key=f"{repository}#{number}",
             inputs={
                 "github_issue": {"repository": repository, "number": number},
@@ -163,7 +160,6 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
         return GoalPresetSchedule(
             goal=normalized_goal,
             slug="jira-breakdown-orchestrate",
-            version="1.0.0",
             inputs={
                 "feature_request": normalized_goal,
                 "jira_project_key": _jira_project_key(normalized_goal),
@@ -179,7 +175,6 @@ def schedule_preset_from_goal(goal: str) -> GoalPresetSchedule | None:
     return GoalPresetSchedule(
         goal=normalized_goal,
         slug="moonspec-orchestrate",
-        version="1.0.0",
         inputs={
             "feature_request": normalized_goal,
             "source_design_path": "",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -46,13 +46,11 @@ _DOWNSTREAM_PRESET_IMPLEMENT = "implement"
 _DOWNSTREAM_PRESETS: dict[str, dict[str, str]] = {
     _DOWNSTREAM_PRESET_ORCHESTRATE: {
         "slug": "jira-orchestrate",
-        "version": "1.0.0",
         "label": "Jira Orchestrate",
         "idempotencyPrefix": "jira-orchestrate",
     },
     _DOWNSTREAM_PRESET_IMPLEMENT: {
         "slug": "jira-implement",
-        "version": "1.1.0",
         "label": "Jira Implement",
         "idempotencyPrefix": "jira-implement",
     },
@@ -1178,7 +1176,6 @@ def _downstream_task_payload(
     preset = _DOWNSTREAM_PRESETS[target_preset]
     preset_label = preset["label"]
     preset_slug = preset["slug"]
-    preset_version = preset["version"]
     issue_key = _string(mapping.get("issueKey") or mapping.get("issue_key"))
     story_id = _string(mapping.get("storyId") or mapping.get("story_id"))
     summary = _string(mapping.get("summary")) or issue_key
@@ -1237,7 +1234,6 @@ def _downstream_task_payload(
         },
         "taskTemplate": {
             "slug": preset_slug,
-            "version": preset_version,
         },
     }
     if runtime:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2224,7 +2224,7 @@ class MoonMindRunWorkflow:
                 if not isinstance(preset, Mapping):
                     continue
                 compact_preset: dict[str, Any] = {}
-                for key in ("id", "name", "version", "source", "presetId"):
+                for key in ("id", "name", "source", "presetId", "presetDigest"):
                     value = self._coerce_text(preset.get(key), max_chars=160)
                     if value:
                         compact_preset[key] = value
@@ -2295,7 +2295,7 @@ class MoonMindRunWorkflow:
             "kind",
             "presetId",
             "presetSlug",
-            "presetVersion",
+            "presetDigest",
             "originalStepId",
         ):
             text = self._coerce_text(value.get(key), max_chars=160)

--- a/scripts/backfill_template_recents.py
+++ b/scripts/backfill_template_recents.py
@@ -15,7 +15,6 @@ from api_service.db.base import get_async_session_context
 from api_service.db.models import (
     Preset,
     PresetRecent,
-    PresetVersion,
 )
 
 _LOOKBACK_DAYS = 30
@@ -32,11 +31,10 @@ def _extract_applied_templates(payload: dict[str, Any]) -> list[dict[str, Any]]:
         if not isinstance(raw, dict):
             continue
         slug = str(raw.get("slug") or "").strip()
-        version = str(raw.get("version") or "").strip()
-        if not slug or not version:
+        if not slug:
             continue
         result.append(
-            {"slug": slug, "version": version, "appliedAt": raw.get("appliedAt")}
+            {"slug": slug, "appliedAt": raw.get("appliedAt")}
         )
     return result
 
@@ -44,21 +42,17 @@ async def backfill_recents(*, lookback_days: int = _LOOKBACK_DAYS) -> int:
     threshold = datetime.now(UTC) - timedelta(days=lookback_days)
 
     async with get_async_session_context() as session:
-        version_rows = (
+        preset_rows = (
             await session.execute(
                 select(
-                    PresetVersion.id,
-                    PresetVersion.version,
+                    Preset.id,
                     Preset.slug,
-                ).join(
-                    Preset,
-                    Preset.id == PresetVersion.template_id,
                 )
             )
         ).all()
-        version_index: dict[tuple[str, str], UUID] = {
-            (str(slug), str(version)): version_id
-            for version_id, version, slug in version_rows
+        preset_index: dict[str, UUID] = {
+            str(slug): preset_id
+            for preset_id, slug in preset_rows
         }
 
         jobs = (
@@ -83,10 +77,8 @@ async def backfill_recents(*, lookback_days: int = _LOOKBACK_DAYS) -> int:
             if not isinstance(payload, dict):
                 continue
             for template_meta in _extract_applied_templates(payload):
-                version_id = version_index.get(
-                    (template_meta["slug"], template_meta["version"])
-                )
-                if version_id is None:
+                preset_id = preset_index.get(template_meta["slug"])
+                if preset_id is None:
                     continue
                 applied_at = created_at
                 raw_applied = template_meta.get("appliedAt")
@@ -99,11 +91,11 @@ async def backfill_recents(*, lookback_days: int = _LOOKBACK_DAYS) -> int:
                     pg_insert(PresetRecent)
                     .values(
                         user_id=user_id,
-                        template_version_id=version_id,
+                        template_id=preset_id,
                         applied_at=applied_at,
                     )
                     .on_conflict_do_nothing(
-                        index_elements=["user_id", "template_version_id"]
+                        index_elements=["user_id", "template_id"]
                     )
                 )
                 inserted += int((result.rowcount or 0) > 0)

--- a/scripts/create_issue_implement_preset_workflows.py
+++ b/scripts/create_issue_implement_preset_workflows.py
@@ -15,8 +15,6 @@ from urllib.parse import quote, urlparse
 
 DEFAULT_REPOSITORY = "MoonLadderStudios/MoonMind"
 DEFAULT_RUNTIME = "codex_cli"
-DEFAULT_PRESET_VERSION = "1.0.0"
-PROVIDER_DEFAULT_PRESET_VERSIONS = {"jira": "1.1.0", "github": "1.0.0"}
 PROVIDER_PRESETS = {"jira": "jira-implement", "github": "github-issue-implement"}
 
 
@@ -44,9 +42,9 @@ def normalize_issue_ref(*, provider: str, issue: str, repository: str) -> tuple[
     return ref, {"github_issue": {"repository": repo, "number": number}, "constraints": ""}
 
 
-def build_idempotency_key(*, provider: str, issue_ref: str, repository: str, runtime: str, preset_version: str, model: str | None = None, effort: str | None = None) -> str:
+def build_idempotency_key(*, provider: str, issue_ref: str, repository: str, runtime: str, model: str | None = None, effort: str | None = None) -> str:
     preset_slug = PROVIDER_PRESETS[provider]
-    parts = [preset_slug, issue_ref, repository.strip(), runtime.strip(), preset_version.strip()]
+    parts = [preset_slug, issue_ref, repository.strip(), runtime.strip()]
     model = (model or "").strip()
     effort = (effort or "").strip()
     if model or effort:
@@ -74,7 +72,7 @@ def build_runtime_block(*, runtime: str, model: str | None = None, effort: str |
     return runtime_block
 
 
-def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: str, expanded_steps: list[dict[str, Any]], applied_template: dict[str, Any] | None = None, preset_version: str = DEFAULT_PRESET_VERSION, model: str | None = None, effort: str | None = None) -> dict[str, Any]:
+def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: str, expanded_steps: list[dict[str, Any]], applied_template: dict[str, Any] | None = None, model: str | None = None, effort: str | None = None) -> dict[str, Any]:
     preset_slug = PROVIDER_PRESETS[provider]
     title_provider = "Jira" if provider == "jira" else "GitHub Issue"
     task: dict[str, Any] = {
@@ -84,12 +82,11 @@ def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: st
         "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}},
         "inputs": normalize_issue_ref(provider=provider, issue=issue_ref, repository=repository)[1],
         "steps": expanded_steps,
-        "taskTemplate": {"slug": preset_slug, "version": preset_version, "scope": "global"},
+        "taskTemplate": {"slug": preset_slug, "scope": "global"},
         "presetSchedule": {
             "source": "batch",
             "reason": f"{provider}_issue_batch",
             "presetSlug": preset_slug,
-            "presetVersion": preset_version,
             "issueProvider": provider,
             "issueRef": issue_ref,
         },
@@ -98,7 +95,10 @@ def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: st
         task["inputs"]["jira_issue_key"] = issue_ref
         task["presetSchedule"]["jiraIssueKey"] = issue_ref
     if applied_template:
-        task["appliedStepTemplates"] = [applied_template]
+        cleaned_applied_template = dict(applied_template)
+        cleaned_applied_template.pop("version", None)
+        cleaned_applied_template.pop("presetVersion", None)
+        task["appliedStepTemplates"] = [cleaned_applied_template]
     return {
         "type": "task",
         "payload": {
@@ -106,17 +106,16 @@ def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: st
             "targetRuntime": runtime,
             "publishMode": "pr",
             "mergeAutomation": {"enabled": True},
-            "idempotencyKey": build_idempotency_key(provider=provider, issue_ref=issue_ref, repository=repository, runtime=runtime, preset_version=preset_version, model=model, effort=effort),
+            "idempotencyKey": build_idempotency_key(provider=provider, issue_ref=issue_ref, repository=repository, runtime=runtime, model=model, effort=effort),
             "integration": provider,
             "task": task,
         },
     }
 
 
-def build_expand_payload(*, provider: str, issue: str, repository: str, runtime: str, preset_version: str = DEFAULT_PRESET_VERSION) -> dict[str, Any]:
+def build_expand_payload(*, provider: str, issue: str, repository: str, runtime: str) -> dict[str, Any]:
     _ref, inputs = normalize_issue_ref(provider=provider, issue=issue, repository=repository)
     return {
-        "version": preset_version,
         "inputs": inputs,
         "context": {"repository": repository, "targetRuntime": runtime},
         "options": {"enforceStepLimit": True},
@@ -136,9 +135,9 @@ def post_json(*, base_url: str, payload: dict[str, Any], timeout: float) -> dict
         return {"status": 0, "error": str(exc)}
 
 
-def expand_issue_implement(*, base_url: str, provider: str, issue: str, repository: str, runtime: str, preset_version: str, timeout: float) -> dict[str, Any]:
+def expand_issue_implement(*, base_url: str, provider: str, issue: str, repository: str, runtime: str, timeout: float) -> dict[str, Any]:
     preset_slug = PROVIDER_PRESETS[provider]
-    payload = build_expand_payload(provider=provider, issue=issue, repository=repository, runtime=runtime, preset_version=preset_version)
+    payload = build_expand_payload(provider=provider, issue=issue, repository=repository, runtime=runtime)
     data = json.dumps(payload).encode("utf-8")
     req = request.Request(f"{base_url.rstrip('/')}/api/presets/{preset_slug}:expand?scope=global", data=data, headers={"Content-Type": "application/json"}, method="POST")
     with request.urlopen(req, timeout=timeout) as response:
@@ -196,7 +195,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--board-id", default=None, help="Discover issues from this Jira board id instead of (or in addition to) positional args.")
     parser.add_argument("--column", default="To Do", help="Board column name to pull issues from when --board-id is set (default: 'To Do').")
     parser.add_argument("--project-key", default=None, help="Optional Jira project key passed as the projectKey query param for board discovery.")
-    parser.add_argument("--preset-version", default=None)
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()
@@ -204,8 +202,6 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    if args.preset_version is None:
-        args.preset_version = PROVIDER_DEFAULT_PRESET_VERSIONS[args.provider]
 
     issues: list[str] = list(args.issues)
     discovery: dict[str, Any] | None = None
@@ -241,10 +237,10 @@ def main() -> int:
             record = {"issue": raw_issue, "status": 0, "error": f"Invalid issue reference: {exc}"}
             failures.append(record); results.append(record); continue
         if args.dry_run:
-            results.append({"issue": issue_ref, "expandPayload": build_expand_payload(provider=args.provider, issue=raw_issue, repository=args.repository, runtime=args.runtime, preset_version=args.preset_version)})
+            results.append({"issue": issue_ref, "expandPayload": build_expand_payload(provider=args.provider, issue=raw_issue, repository=args.repository, runtime=args.runtime)})
             continue
         try:
-            expanded = expand_issue_implement(base_url=args.base_url, provider=args.provider, issue=raw_issue, repository=args.repository, runtime=args.runtime, preset_version=args.preset_version, timeout=args.timeout)
+            expanded = expand_issue_implement(base_url=args.base_url, provider=args.provider, issue=raw_issue, repository=args.repository, runtime=args.runtime, timeout=args.timeout)
         except Exception as exc:
             record = {"issue": issue_ref, "status": 0, "error": f"Expansion failed: {exc}"}
             failures.append(record); results.append(record); continue
@@ -252,14 +248,14 @@ def main() -> int:
         if not isinstance(raw_steps, list) or len(raw_steps) != 8:
             record = {"issue": issue_ref, "error": f"Expected {PROVIDER_PRESETS[args.provider]} expansion to produce 8 steps; got {len(raw_steps) if isinstance(raw_steps, list) else 0}."}
             failures.append(record); results.append(record); continue
-        payload = build_payload(provider=args.provider, issue_ref=issue_ref, repository=args.repository, runtime=args.runtime, expanded_steps=raw_steps, applied_template=expanded.get("appliedTemplate") if isinstance(expanded.get("appliedTemplate"), dict) else None, preset_version=args.preset_version, model=args.model, effort=args.effort)
+        payload = build_payload(provider=args.provider, issue_ref=issue_ref, repository=args.repository, runtime=args.runtime, expanded_steps=raw_steps, applied_template=expanded.get("appliedTemplate") if isinstance(expanded.get("appliedTemplate"), dict) else None, model=args.model, effort=args.effort)
         response = post_json(base_url=args.base_url, payload=payload, timeout=args.timeout)
         body = response.get("body") if isinstance(response.get("body"), dict) else {}
         record = {"issue": issue_ref, "status": response.get("status"), "workflowId": body.get("workflowId") or body.get("id"), "runId": body.get("runId"), "title": body.get("title"), "state": body.get("state") or body.get("status")}
         if response.get("status") != 201:
             record["error"] = response.get("error", ""); failures.append(record)
         results.append(record)
-    print(json.dumps({"submittedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "apiBase": args.base_url, "repository": args.repository, "targetRuntime": args.runtime, "model": args.model, "effort": args.effort, "discovery": discovery, "preset": {"slug": PROVIDER_PRESETS[args.provider], "version": args.preset_version}, "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}}, "results": results, "failures": failures}, indent=2))
+    print(json.dumps({"submittedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "apiBase": args.base_url, "repository": args.repository, "targetRuntime": args.runtime, "model": args.model, "effort": args.effort, "discovery": discovery, "preset": {"slug": PROVIDER_PRESETS[args.provider]}, "publish": {"mode": "pr", "mergeAutomation": {"enabled": True}}, "results": results, "failures": failures}, indent=2))
     return 1 if failures else 0
 
 

--- a/tests/helpers/step_type_payloads.py
+++ b/tests/helpers/step_type_payloads.py
@@ -54,7 +54,6 @@ def preset_step(
     step_id: str = "run-preset",
     title: str = "Run preset",
     slug: str = "child-flow",
-    version: str = "1.0.0",
     inputs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return a valid draft Preset step payload."""
@@ -66,7 +65,6 @@ def preset_step(
         "instructions": "Apply the child preset.",
         "preset": {
             "slug": slug,
-            "version": version,
             "inputs": inputs or {"issue_key": "MM-569"},
         },
     }

--- a/tests/integration/api/test_execution_contract_normalization.py
+++ b/tests/integration/api/test_execution_contract_normalization.py
@@ -165,15 +165,15 @@ def test_mm569_flat_executable_steps_preserve_preset_provenance_without_lookup()
     tool["source"] = {
         "kind": "preset-derived",
         "presetSlug": "mm569-parent",
-        "presetVersion": "1.0.0",
-        "includePath": ["mm569-parent@1.0.0"],
+        "presetDigest": "digest-mm569-parent",
+        "includePath": ["mm569-parent"],
     }
     skill = skill_step()
     skill["source"] = {
         "kind": "preset-derived",
         "presetSlug": "mm569-parent",
-        "presetVersion": "1.0.0",
-        "includePath": ["mm569-parent@1.0.0"],
+        "presetDigest": "digest-mm569-parent",
+        "includePath": ["mm569-parent"],
     }
 
     result = build_canonical_workflow_view(

--- a/tests/integration/temporal/test_task_shaped_submission_normalization.py
+++ b/tests/integration/temporal/test_task_shaped_submission_normalization.py
@@ -238,37 +238,37 @@ def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
     authored_presets = [
         {
             "presetSlug": "parent-flow",
-            "presetVersion": "1.0.0",
+            "presetDigest": "digest-parent",
             "scope": "global",
-            "includePath": ["parent-flow@1.0.0"],
+            "includePath": ["parent-flow"],
         },
         {
             "presetSlug": "child-checks",
-            "presetVersion": "1.0.0",
+            "presetDigest": "digest-child",
             "alias": "quality",
             "scope": "global",
             "includePath": [
-                "parent-flow@1.0.0",
-                "quality:child-checks@1.0.0",
+                "parent-flow",
+                "quality:child-checks",
             ],
             "inputMapping": {"target": "preset composition"},
         },
     ]
     composition = {
         "slug": "parent-flow",
-        "version": "1.0.0",
+        "digest": "digest-parent",
         "scope": "global",
-        "path": ["parent-flow@1.0.0"],
+        "path": ["parent-flow"],
         "stepIds": ["tpl:parent-flow:1.0.0:01"],
         "includes": [
             {
                 "slug": "child-checks",
-                "version": "1.0.0",
+                "digest": "digest-child",
                 "scope": "global",
                 "alias": "quality",
                 "path": [
-                    "parent-flow@1.0.0",
-                    "quality:child-checks@1.0.0",
+                    "parent-flow",
+                    "quality:child-checks",
                 ],
                 "inputMapping": {"target": "preset composition"},
                 "stepIds": ["tpl:parent-flow:1.0.0:01"],
@@ -298,10 +298,10 @@ def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
                                 "source": {
                                     "kind": "preset-derived",
                                     "presetSlug": "child-checks",
-                                    "presetVersion": "1.0.0",
+                                    "presetDigest": "digest-child",
                                     "includePath": [
-                                        "parent-flow@1.0.0",
-                                        "quality:child-checks@1.0.0",
+                                        "parent-flow",
+                                        "quality:child-checks",
                                     ],
                                     "originalStepId": "lint-target",
                                 },
@@ -311,7 +311,7 @@ def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
                         "appliedStepTemplates": [
                             {
                                 "slug": "parent-flow",
-                                "version": "1.0.0",
+                                "presetDigest": "digest-parent",
                                 "stepIds": ["tpl:parent-flow:1.0.0:01"],
                                 "composition": composition,
                                 "authoredPresets": authored_presets,
@@ -328,8 +328,8 @@ def test_task_shaped_submission_boundary_preserves_recursive_preset_metadata(
     assert task["appliedStepTemplates"][0]["composition"] == composition
     assert task["appliedStepTemplates"][0]["authoredPresets"] == authored_presets
     assert task["steps"][0]["source"]["includePath"] == [
-        "parent-flow@1.0.0",
-        "quality:child-checks@1.0.0",
+        "parent-flow",
+        "quality:child-checks",
     ]
     assert task["steps"][0]["source"]["originalStepId"] == "lint-target"
     assert all(step.get("kind") != "include" for step in task["steps"])
@@ -380,8 +380,8 @@ def test_mm569_task_shaped_submission_preserves_flat_tool_skill_provenance(
         step["source"] = {
             "kind": "preset-derived",
             "presetSlug": "mm569-parent",
-            "presetVersion": "1.0.0",
-            "includePath": ["mm569-parent@1.0.0"],
+            "presetDigest": "digest-mm569-parent",
+            "includePath": ["mm569-parent"],
         }
 
     with test_client:

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -40,14 +40,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         template = result.scalar_one_or_none()
         assert template is not None
-        assert template.latest_version is not None
-        assert template.latest_version.release_status.value == "active"
+        assert template.release_status.value == "active"
         seeded_skill_ids = [
-            step["skill"]["id"] for step in template.latest_version.steps
+            step["skill"]["id"] for step in template.steps
         ]
         assert seeded_skill_ids == [
             "moonspec-specify",
@@ -58,13 +57,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "moonspec-verify",
             "moonspec-doc-reconcile",
         ]
-        seeded_step_titles = [step["title"] for step in template.latest_version.steps]
+        seeded_step_titles = [step["title"] for step in template.steps]
         assert "Classify request and resume point" not in seeded_step_titles
         assert "Split broad designs when needed" not in seeded_step_titles
         assert seeded_step_titles[0] == "Create or select Moon Spec"
         assert "moonspec-breakdown" not in seeded_skill_ids
         assert "speckit-analyze" not in seeded_skill_ids
-        specify_step = template.latest_version.steps[0]
+        specify_step = template.steps[0]
         assert "Before running moonspec-specify, validate" in specify_step[
             "instructions"
         ]
@@ -72,7 +71,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "routed through moonspec-breakdown" in specify_step["instructions"]
         tasks_step = next(
             step
-            for step in template.latest_version.steps
+            for step in template.steps
             if step["title"] == "Generate TDD task breakdown"
         )
         assert "/moonspec-verify" in tasks_step["instructions"]
@@ -85,13 +84,12 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         jira_template = result.scalar_one_or_none()
         assert jira_template is not None
-        assert jira_template.latest_version is not None
         assert [
-            step["skill"]["id"] for step in jira_template.latest_version.steps
+            step["skill"]["id"] for step in jira_template.steps
         ] == ["moonspec-breakdown", "story.create_jira_issues"]
 
         result = await session.execute(
@@ -101,12 +99,11 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         jira_orchestrate_template = result.scalar_one_or_none()
         assert jira_orchestrate_template is not None
-        assert jira_orchestrate_template.latest_version is not None
-        annotations = jira_orchestrate_template.latest_version.annotations or {}
+        annotations = jira_orchestrate_template.annotations or {}
         assert annotations["inputSchema"]["required"] == ["jira_issue"]
         assert annotations["inputSchema"]["properties"]["jira_issue"]["required"] == [
             "key"
@@ -118,7 +115,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert annotations["uiSchema"]["jira_issue"]["allowManualKeyEntry"] is True
         jira_orchestrate_steps = [
             (step.get("skill") or step.get("tool"))["id"]
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
         ]
         assert jira_orchestrate_steps[0] == "jira-issue-updater"
         assert jira_orchestrate_steps[1] == "jira.check_blockers"
@@ -130,7 +127,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert jira_orchestrate_steps.count("moonspec-implement") == 7
         assert jira_orchestrate_steps.count("moonspec-verify") == 7
         assert jira_orchestrate_steps.count("moonspec-doc-reconcile") == 1
-        blocker_step = jira_orchestrate_template.latest_version.steps[1]
+        blocker_step = jira_orchestrate_template.steps[1]
         assert blocker_step["title"] == "Check Jira blockers before implementation"
         assert blocker_step["type"] == "tool"
         assert blocker_step["tool"]["id"] == "jira.check_blockers"
@@ -141,13 +138,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "non-blocker" in blocker_step["instructions"]
         assert "status cannot be determined" in blocker_step["instructions"]
         assert "stop the orchestration immediately" in blocker_step["instructions"]
-        brief_step = jira_orchestrate_template.latest_version.steps[2]
+        brief_step = jira_orchestrate_template.steps[2]
         assert brief_step["title"] == "Load Jira preset brief"
         assert brief_step["type"] == "tool"
         assert brief_step["tool"]["id"] == "jira.load_preset_brief"
         remediation_step = next(
             step
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
             if step["title"] == "Remediate verification gaps 1 of 6"
         )
         assert remediation_step["skill"]["id"] == "moonspec-implement"
@@ -155,14 +152,14 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "verification report's gaps" in remediation_step["instructions"]
         remediation_verify_step = next(
             step
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
             if step["title"] == "Verify remediation 6 of 6"
         )
         assert remediation_verify_step["skill"]["id"] == "moonspec-verify"
         assert "controlling verification gate" in remediation_verify_step["instructions"]
         doc_reconcile_step = next(
             step
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
             if step["title"] == "Reconcile declarative docs"
         )
         assert doc_reconcile_step["skill"]["id"] == "moonspec-doc-reconcile"
@@ -173,16 +170,16 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "artifacts/jira-orchestrate-doc-reconcile.json" in doc_reconcile_step[
             "instructions"
         ]
-        doc_reconcile_index = jira_orchestrate_template.latest_version.steps.index(
+        doc_reconcile_index = jira_orchestrate_template.steps.index(
             doc_reconcile_step
         )
         pr_step = next(
             step
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
             if step["title"] == "Create pull request"
         )
         assert (
-            jira_orchestrate_template.latest_version.steps.index(pr_step)
+            jira_orchestrate_template.steps.index(pr_step)
             == doc_reconcile_index + 1
         )
         assert "pull request" in pr_step["instructions"]
@@ -195,10 +192,10 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "artifacts/jira-orchestrate-pr.json" in pr_step["instructions"]
         code_review_step = next(
             step
-            for step in jira_orchestrate_template.latest_version.steps
+            for step in jira_orchestrate_template.steps
             if step["title"] == "Move Jira issue to Review"
         )
-        assert code_review_step == jira_orchestrate_template.latest_version.steps[-1]
+        assert code_review_step == jira_orchestrate_template.steps[-1]
         assert code_review_step["annotations"] == {
             "jiraOrchestrateRole": "code-review-handoff"
         }
@@ -212,13 +209,12 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         jira_implement_template = result.scalar_one_or_none()
         assert jira_implement_template is not None
-        assert jira_implement_template.latest_version is not None
         implement_annotations = (
-            jira_implement_template.latest_version.annotations or {}
+            jira_implement_template.annotations or {}
         )
         assert implement_annotations["inputSchema"]["required"] == ["jira_issue"]
         assert implement_annotations["inputSchema"]["properties"]["jira_issue"][
@@ -235,7 +231,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert (
             implement_annotations.get("postMergeJiraCompletion") == "done_category"
         )
-        raw_jira_implement_steps = jira_implement_template.latest_version.steps
+        raw_jira_implement_steps = jira_implement_template.steps
         assert raw_jira_implement_steps[1]["kind"] == "include"
         assert raw_jira_implement_steps[1]["slug"] == "issue-implement-assessment"
         assert raw_jira_implement_steps[4]["kind"] == "include"
@@ -245,7 +241,6 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             slug="jira-implement",
             scope="global",
             scope_ref=None,
-            version="1.1.0",
             inputs={"jira_issue": {"key": "MM-999"}, "constraints": ""},
             context={"repository": "MoonLadderStudios/MoonMind"},
         )
@@ -344,23 +339,22 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         composite_template = result.scalar_one_or_none()
         assert composite_template is not None
-        assert composite_template.latest_version is not None
         assert [
             step["skill"]["id"]
-            for step in composite_template.latest_version.steps
+            for step in composite_template.steps
         ] == [
             "moonspec-breakdown",
             "story-reconcile-implementation",
             "story.create_jira_issues",
             "story.create_jira_orchestrate_tasks",
         ]
-        reconcile_step = composite_template.latest_version.steps[1]
+        reconcile_step = composite_template.steps[1]
         assert "fully implemented stories" in reconcile_step["instructions"]
-        downstream_step = composite_template.latest_version.steps[3]
+        downstream_step = composite_template.steps[3]
         assert "trusted Jira story output" in downstream_step["instructions"]
         assert "dependsOn" in downstream_step["instructions"]
         assert "orchestrationMode" not in downstream_step["jiraOrchestration"]["task"]
@@ -378,14 +372,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         implement_composite_template = result.scalar_one_or_none()
         assert implement_composite_template is not None
-        assert implement_composite_template.latest_version is not None
         assert [
             step["skill"]["id"]
-            for step in implement_composite_template.latest_version.steps
+            for step in implement_composite_template.steps
         ] == [
             "moonspec-breakdown",
             "story-reconcile-implementation",
@@ -393,7 +386,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "story.create_jira_implement_tasks",
         ]
         implement_downstream_step = (
-            implement_composite_template.latest_version.steps[3]
+            implement_composite_template.steps[3]
         )
         assert (
             "Create one Jira Implement task"
@@ -414,12 +407,11 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         doc_template = result.scalar_one_or_none()
         assert doc_template is not None
-        assert doc_template.latest_version is not None
-        doc_steps = doc_template.latest_version.steps
+        doc_steps = doc_template.steps
         assert len(doc_steps) == 2
         assert doc_steps[0]["type"] == "tool"
         assert doc_steps[0]["tool"]["id"] == "document.discover"
@@ -445,12 +437,11 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),
             )
-            .options(selectinload(Preset.latest_version))
+            
         )
         batch_template = result.scalar_one_or_none()
         assert batch_template is not None
-        assert batch_template.latest_version is not None
-        batch_annotations = batch_template.latest_version.annotations or {}
+        batch_annotations = batch_template.annotations or {}
         assert batch_annotations["runtimeInheritance"] == "caller"
         assert batch_annotations["inputSchema"]["properties"]["source_kind"][
             "enum"
@@ -461,7 +452,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert batch_annotations["bindings"]["github-issue-implement"][
             "github_issue_ref"
         ] == "{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}"
-        batch_steps = batch_template.latest_version.steps
+        batch_steps = batch_template.steps
         assert len(batch_steps) == 1
         assert batch_steps[0]["skill"]["id"] == "batch-workflows"
         assert batch_steps[0]["batchOrchestration"]["runtime"]["inherit"] == "caller"

--- a/tests/unit/agents/test_preset_cli.py
+++ b/tests/unit/agents/test_preset_cli.py
@@ -25,18 +25,17 @@ def test_list_templates_and_expand(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url, headers, params, timeout):
         calls.append(("GET", url, params))
-        return _FakeResponse({"items": [{"slug": "demo", "latestVersion": "1.0.0"}]})
+        return _FakeResponse({"items": [{"slug": "demo"}]})
 
     def fake_post(url, headers, params, json, timeout):
         calls.append(("POST", url, params, json))
         return _FakeResponse(
             {
-                "steps": [{"id": "tpl:demo:1.0.0:01:abcd1234", "instructions": "run"}],
+                "steps": [{"id": "tpl:demo:01:abcd1234", "instructions": "run"}],
                 "appliedTemplate": {
                     "slug": "demo",
-                    "version": "1.0.0",
                     "inputs": {},
-                    "stepIds": ["tpl:demo:1.0.0:01:abcd1234"],
+                    "stepIds": ["tpl:demo:01:abcd1234"],
                 },
                 "capabilities": ["codex"],
                 "warnings": [],
@@ -51,7 +50,6 @@ def test_list_templates_and_expand(monkeypatch: pytest.MonkeyPatch) -> None:
     expanded = client.expand_template(
         slug="demo",
         scope="global",
-        version="1.0.0",
         inputs={},
     )
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -552,13 +552,13 @@ def _mm639_authored_task_payload() -> dict[str, Any]:
         "appliedStepTemplates": [
             {
                 "slug": "jira-orchestrate",
-                "version": "1.0.0",
+                "version": "1",
                 "inputs": {"issueKey": "MM-639"},
                 "stepIds": ["step-1", "step-2"],
                 "composition": {
                     "slug": "jira-orchestrate",
                     "includes": [
-                        {"slug": "jira-fetch", "version": "1.0.0"},
+                        {"slug": "jira-fetch", "version": "1"},
                     ],
                 },
             }
@@ -566,7 +566,7 @@ def _mm639_authored_task_payload() -> dict[str, Any]:
         "authoredPresets": [
             {
                 "presetSlug": "jira-orchestrate",
-                "presetVersion": "1.0.0",
+                "presetDigest": "digest-1",
                 "inputBindings": {"issueKey": "MM-639"},
             }
         ],
@@ -579,7 +579,7 @@ def _mm639_authored_task_payload() -> dict[str, Any]:
                 "templateStepId": "tpl:jira-orchestrate:fetch",
                 "presetProvenance": {
                     "presetSlug": "jira-orchestrate",
-                    "presetVersion": "1.0.0",
+                    "presetDigest": "digest-1",
                 },
             },
             {
@@ -597,7 +597,7 @@ def _mm639_authored_task_payload() -> dict[str, Any]:
                 ],
                 "presetProvenance": {
                     "presetSlug": "jira-orchestrate",
-                    "presetVersion": "1.0.0",
+                    "presetDigest": "digest-1",
                     "sourceStepId": "tpl:jira-orchestrate:implement",
                 },
                 "detachedFromPreset": True,
@@ -634,8 +634,8 @@ async def test_goal_preset_submission_expands_before_planner(tmp_path) -> None:
 
     assert task_payload["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.1.0",
         "scope": "global",
+        "presetDigest": task_payload["appliedStepTemplates"][0]["presetDigest"],
     }
     assert task_payload["inputs"]["jira_issue_key"] == "MM-747"
     assert task_payload["presetSchedule"]["presetSlug"] == "jira-implement"
@@ -2682,7 +2682,7 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_p
                     "publish": {"mode": "pr"},
                     "steps": [
                         {
-                            "id": "tpl:jira-orchestrate:1.0.0:01",
+                            "id": "tpl:jira-orchestrate:1:01",
                             "title": "Move Jira issue",
                             "instructions": "Transition THOR-352 to In Progress.",
                             "skill": {"id": "jira-issue-updater", "args": {}},
@@ -2691,8 +2691,8 @@ def test_create_task_shaped_execution_allows_jira_orchestrate_first_step_skill_p
                     "appliedStepTemplates": [
                         {
                             "slug": "jira-orchestrate",
-                            "version": "1.0.0",
-                            "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
+                            "version": "1",
+                            "stepIds": ["tpl:jira-orchestrate:1:01"],
                         }
                     ],
                 },
@@ -4213,20 +4213,20 @@ def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
                     ],
                     "taskTemplate": {
                         "slug": "jira-implement",
-                        "version": "1.0.0",
+                        "version": "1",
                         "scope": "global",
                     },
                     "presetSchedule": {
                         "source": "goal",
                         "reason": "jira_issue_goal",
                         "presetSlug": "jira-implement",
-                        "presetVersion": "1.0.0",
+                        "presetDigest": "digest-1",
                         "jiraIssueKey": "MM-747",
                     },
                     "appliedStepTemplates": [
                         {
                             "slug": "jira-implement",
-                            "version": "1.0.0",
+                            "version": "1",
                             "stepIds": ["step-1"],
                         }
                     ],
@@ -4242,14 +4242,14 @@ def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
     task = initial_parameters["workflow"]
     assert task["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.0.0",
+        "version": "1",
         "scope": "global",
     }
     assert task["presetSchedule"] == {
         "source": "goal",
         "reason": "jira_issue_goal",
         "presetSlug": "jira-implement",
-        "presetVersion": "1.0.0",
+        "presetDigest": "digest-1",
         "jiraIssueKey": "MM-747",
     }
     assert task["appliedStepTemplates"][0]["slug"] == "jira-implement"
@@ -4273,7 +4273,7 @@ def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaul
                     },
                     "steps": [
                         {
-                            "id": "tpl:demo:1.0.0:01",
+                            "id": "tpl:demo:1:01",
                             "title": "Clarify the create-task recovery plan",
                             "instructions": "Audit the regression and list the missing controls.",
                             "skill": {
@@ -4283,7 +4283,7 @@ def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaul
                             },
                         },
                         {
-                            "id": "tpl:demo:1.0.0:02",
+                            "id": "tpl:demo:1:02",
                             "title": "Implement the restored builder",
                             "instructions": "Restore presets and multi-step submission.",
                             "runtime": {
@@ -4310,7 +4310,7 @@ def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaul
     assert initial_parameters["stepCount"] == 2
     assert initial_parameters["workflow"]["steps"] == [
         {
-            "id": "tpl:demo:1.0.0:01",
+            "id": "tpl:demo:1:01",
             "title": "Clarify the create-task recovery plan",
             "instructions": "Audit the regression and list the missing controls.",
             "skill": {
@@ -4320,7 +4320,7 @@ def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaul
             },
         },
         {
-            "id": "tpl:demo:1.0.0:02",
+            "id": "tpl:demo:1:02",
             "title": "Implement the restored builder",
             "instructions": "Restore presets and multi-step submission.",
             "runtime": {
@@ -4354,46 +4354,46 @@ def test_create_task_shaped_execution_preserves_recursive_preset_metadata(
                     "authoredPresets": [
                         {
                             "presetSlug": "root-preset",
-                            "presetVersion": "1.0.0",
-                            "includePath": ["root-preset@1.0.0"],
+                            "presetDigest": "digest-1",
+                            "includePath": ["root-preset"],
                         },
                         {
                             "presetSlug": "child-preset",
-                            "presetVersion": "1.0.0",
+                            "presetDigest": "digest-1",
                             "alias": "checks",
                             "inputMapping": {"target": "recursive presets"},
                             "includePath": [
-                                "root-preset@1.0.0",
-                                "checks:child-preset@1.0.0",
+                                "root-preset",
+                                "checks:child-preset",
                             ],
                         },
                     ],
                     "appliedStepTemplates": [
                         {
                             "slug": "root-preset",
-                            "version": "1.0.0",
+                            "version": "1",
                             "stepIds": [
-                                "tpl:root-preset:1.0.0:01",
-                                "tpl:child-preset:1.0.0:01",
+                                "tpl:root-preset:1:01",
+                                "tpl:child-preset:1:01",
                             ],
                             "composition": {
                                 "slug": "root-preset",
-                                "version": "1.0.0",
-                                "path": ["root-preset@1.0.0"],
+                                "version": "1",
+                                "path": ["root-preset"],
                                 "stepIds": [
-                                    "tpl:root-preset:1.0.0:01",
-                                    "tpl:child-preset:1.0.0:01",
+                                    "tpl:root-preset:1:01",
+                                    "tpl:child-preset:1:01",
                                 ],
                                 "includes": [
                                     {
                                         "slug": "child-preset",
-                                        "version": "1.0.0",
+                                        "version": "1",
                                         "alias": "checks",
                                         "path": [
-                                            "root-preset@1.0.0",
-                                            "checks:child-preset@1.0.0",
+                                            "root-preset",
+                                            "checks:child-preset",
                                         ],
-                                        "stepIds": ["tpl:child-preset:1.0.0:01"],
+                                        "stepIds": ["tpl:child-preset:1:01"],
                                     }
                                 ],
                             },
@@ -4401,28 +4401,28 @@ def test_create_task_shaped_execution_preserves_recursive_preset_metadata(
                     ],
                     "steps": [
                         {
-                            "id": "tpl:root-preset:1.0.0:01",
+                            "id": "tpl:root-preset:1:01",
                             "title": "Prepare task",
                             "instructions": "Prepare the task context.",
                             "source": {
                                 "kind": "preset-derived",
                                 "presetSlug": "root-preset",
-                                "presetVersion": "1.0.0",
-                                "includePath": ["root-preset@1.0.0"],
+                                "presetDigest": "digest-1",
+                                "includePath": ["root-preset"],
                                 "originalStepId": "prepare-task",
                             },
                         },
                         {
-                            "id": "tpl:child-preset:1.0.0:01",
+                            "id": "tpl:child-preset:1:01",
                             "title": "Run checks",
                             "instructions": "Run recursive preset checks.",
                             "source": {
                                 "kind": "preset-derived",
                                 "presetSlug": "child-preset",
-                                "presetVersion": "1.0.0",
+                                "presetDigest": "digest-1",
                                 "includePath": [
-                                    "root-preset@1.0.0",
-                                    "checks:child-preset@1.0.0",
+                                    "root-preset",
+                                    "checks:child-preset",
                                 ],
                                 "originalStepId": "run-checks",
                             },
@@ -4438,8 +4438,8 @@ def test_create_task_shaped_execution_preserves_recursive_preset_metadata(
     assert task["steps"][0]["source"]["presetSlug"] == "root-preset"
     assert task["steps"][0]["source"]["originalStepId"] == "prepare-task"
     assert task["steps"][1]["source"]["includePath"] == [
-        "root-preset@1.0.0",
-        "checks:child-preset@1.0.0",
+        "root-preset",
+        "checks:child-preset",
     ]
     assert task["steps"][1]["source"]["originalStepId"] == "run-checks"
     assert [preset["presetSlug"] for preset in task["authoredPresets"]] == [
@@ -4472,8 +4472,8 @@ def test_create_task_shaped_execution_preserves_manual_and_preset_step_order(
                     "authoredPresets": [
                         {
                             "presetSlug": "parent-flow",
-                            "presetVersion": "1.0.0",
-                            "includePath": ["parent-flow@1.0.0"],
+                            "presetDigest": "digest-1",
+                            "includePath": ["parent-flow"],
                         }
                     ],
                     "steps": [
@@ -4484,28 +4484,28 @@ def test_create_task_shaped_execution_preserves_manual_and_preset_step_order(
                             "skill": {"id": "auto"},
                         },
                         {
-                            "id": "tpl:parent-flow:1.0.0:01:abcdef12",
+                            "id": "tpl:parent-flow:1:01:abcdef12",
                             "type": "skill",
                             "instructions": "Preset one.",
                             "skill": {"id": "auto"},
                             "source": {
                                 "kind": "preset-derived",
                                 "presetSlug": "parent-flow",
-                                "presetVersion": "1.0.0",
-                                "includePath": ["parent-flow@1.0.0"],
+                                "presetDigest": "digest-1",
+                                "includePath": ["parent-flow"],
                                 "originalStepId": "preset-derived-1",
                             },
                         },
                         {
-                            "id": "tpl:parent-flow:1.0.0:02:abcdef12",
+                            "id": "tpl:parent-flow:1:02:abcdef12",
                             "type": "skill",
                             "instructions": "Preset two.",
                             "skill": {"id": "auto"},
                             "source": {
                                 "kind": "preset-derived",
                                 "presetSlug": "parent-flow",
-                                "presetVersion": "1.0.0",
-                                "includePath": ["parent-flow@1.0.0"],
+                                "presetDigest": "digest-1",
+                                "includePath": ["parent-flow"],
                                 "originalStepId": "preset-derived-2",
                             },
                         },
@@ -4525,8 +4525,8 @@ def test_create_task_shaped_execution_preserves_manual_and_preset_step_order(
     task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
     assert [step["id"] for step in task["steps"]] == [
         "manual-before",
-        "tpl:parent-flow:1.0.0:01:abcdef12",
-        "tpl:parent-flow:1.0.0:02:abcdef12",
+        "tpl:parent-flow:1:01:abcdef12",
+        "tpl:parent-flow:1:02:abcdef12",
         "manual-after",
     ]
     assert task["steps"][0].get("source") in (None, {"kind": "manual"})
@@ -4544,8 +4544,8 @@ def test_create_task_shaped_execution_preserves_detached_edited_step_source(
     detached_source = {
         "kind": "detached",
         "presetSlug": "quality-flow",
-        "presetVersion": "1.0.0",
-        "includePath": ["root-flow@1.0.0", "quality-flow@1.0.0"],
+        "presetDigest": "digest-1",
+        "includePath": ["root-flow", "quality-flow"],
         "originalStepId": "lint-target",
     }
     response = test_client.post(
@@ -4705,7 +4705,7 @@ def _pentest_workflow_payload(
                 "tool": {
                     "type": "skill",
                     "name": "security.pentest.run",
-                    "version": "1.0.0",
+                    "version": "1",
                     "inputs": safe_inputs,
                 },
                 "steps": [
@@ -4716,7 +4716,7 @@ def _pentest_workflow_payload(
                         "tool": {
                             "type": "skill",
                             "name": "security.pentest.run",
-                            "version": "1.0.0",
+                            "version": "1",
                             "inputs": step_safe_inputs,
                         },
                     }
@@ -4760,7 +4760,7 @@ def test_create_task_shaped_execution_accepts_authorized_pentest_roles(
     assert workflow["tool"] == {
         "type": "skill",
         "name": "security.pentest.run",
-        "version": "1.0.0",
+        "version": "1",
         "inputs": {
             "target": "https://lab.example.test",
             "scope_artifact_ref": "art_scope_valid",
@@ -7055,7 +7055,7 @@ def test_serialize_execution_surfaces_task_template_slug_as_primary_skill() -> N
             "instructions": "Use the existing Jira Orchestrate workflow.",
             "taskTemplate": {
                 "slug": "jira-orchestrate",
-                "version": "1.0.0",
+                "version": "1",
             },
         },
     }
@@ -7075,12 +7075,12 @@ def test_serialize_execution_prefers_preset_slug_over_child_skill_display() -> N
             "instructions": "Run Jira Implement for MM-901.",
             "taskTemplate": {
                 "slug": "jira-implement",
-                "version": "1.0.0",
+                "version": "1",
             },
             "tool": {
                 "type": "skill",
                 "name": "jira-issue-updater",
-                "version": "1.0.0",
+                "version": "1",
             },
             "skill": {
                 "id": "jira-issue-updater",
@@ -7089,13 +7089,13 @@ def test_serialize_execution_prefers_preset_slug_over_child_skill_display() -> N
             "appliedStepTemplates": [
                 {
                     "slug": "jira-implement",
-                    "version": "1.0.0",
-                    "stepIds": ["tpl:jira-implement:1.0.0:08"],
+                    "version": "1",
+                    "stepIds": ["tpl:jira-implement:1:08"],
                 }
             ],
             "steps": [
                 {
-                    "id": "tpl:jira-implement:1.0.0:08",
+                    "id": "tpl:jira-implement:1:08",
                     "title": "Finalize Jira status",
                     "instructions": "Update Jira with implementation status.",
                     "skill": {
@@ -7123,7 +7123,7 @@ def test_serialize_execution_surfaces_applied_template_slug_as_primary_skill() -
             "appliedStepTemplates": [
                 {
                     "slug": "jira-orchestrate",
-                    "version": "1.0.0",
+                    "version": "1",
                     "stepIds": ["tpl:jira-orchestrate:1"],
                 }
             ],
@@ -7145,12 +7145,12 @@ def test_serialize_execution_uses_latest_applied_template_as_primary_skill() -> 
             "appliedStepTemplates": [
                 {
                     "slug": "initial-preset",
-                    "version": "1.0.0",
+                    "version": "1",
                     "stepIds": ["tpl:initial-preset:1"],
                 },
                 {
                     "slug": "latest-preset",
-                    "version": "1.0.0",
+                    "version": "1",
                     "stepIds": ["tpl:latest-preset:1"],
                 },
             ],
@@ -7244,7 +7244,7 @@ def test_serialize_execution_preserves_direct_skill_source_provenance() -> None:
                 {"name": "pr-resolver", "version": "1.2.0"},
                 {
                     "name": "fix-ci",
-                    "version": "2.0.0",
+                    "version": "2",
                     "source_kind": "deployment",
                     "source_path": ".agents/skills/fix-ci",
                 },
@@ -8731,7 +8731,7 @@ def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query
                     "id": "fetch-issue",
                     "title": "Fetch issue",
                     "type": "tool",
-                    "tool": {"id": "jira.get_issue", "version": "1.0.0"},
+                    "tool": {"id": "jira.get_issue", "version": "1"},
                 },
                 {
                     "id": "implement",
@@ -8771,7 +8771,7 @@ def test_get_execution_steps_falls_back_to_stored_task_steps_when_temporal_query
     assert payload["steps"][0]["tool"] == {
         "type": "tool",
         "name": "jira.get_issue",
-        "version": "1.0.0",
+        "version": "1",
     }
     assert payload["steps"][1]["tool"]["name"] == "moonspec-implement"
     assert payload["steps"][1]["dependsOn"] == ["fetch-issue"]
@@ -8797,7 +8797,7 @@ def test_get_execution_steps_fallback_prefers_structured_step_order(
                     "id": "fetch-issue",
                     "title": "Fetch issue",
                     "type": "tool",
-                    "tool": {"id": "jira.get_issue", "version": "1.0.0"},
+                    "tool": {"id": "jira.get_issue", "version": "1"},
                 },
                 {
                     "id": "implement",
@@ -9625,9 +9625,9 @@ def test_original_task_input_snapshot_payload_preserves_mm639_authored_fields() 
     assert authored["includeTreeSummary"] == [
         {
             "presetSlug": "jira-orchestrate",
-            "presetVersion": "1.0.0",
+            "presetDigest": None,
             "includedSlug": "jira-fetch",
-            "includedVersion": "1.0.0",
+            "includedDigest": None,
         }
     ]
     assert authored["finalSubmittedOrder"] == [

--- a/tests/unit/api/routers/test_presets.py
+++ b/tests/unit/api/routers/test_presets.py
@@ -58,8 +58,6 @@ def test_list_templates_success() -> None:
             "scopeRef": None,
             "title": "Example",
             "description": "desc",
-            "latestVersion": "1.0.0",
-            "version": "1.0.0",
             "tags": ["demo"],
             "isFavorite": False,
             "recentAppliedAt": None,
@@ -95,14 +93,12 @@ def test_expand_template_success() -> None:
         "steps": [{"id": "tpl:demo:1.0.0:01:abcd1234", "instructions": "do work"}],
         "composition": {
             "slug": "demo",
-            "version": "1.0.0",
             "scope": "global",
             "stepIds": ["tpl:demo:1.0.0:01:abcd1234"],
             "includes": [],
         },
         "appliedTemplate": {
             "slug": "demo",
-            "version": "1.0.0",
             "inputs": {},
             "stepIds": ["tpl:demo:1.0.0:01:abcd1234"],
             "appliedAt": "2026-02-18T00:00:00+00:00",
@@ -114,7 +110,7 @@ def test_expand_template_success() -> None:
     response = client.post(
         "/api/presets/demo:expand",
         params={"scope": "global"},
-        json={"version": "1.0.0", "inputs": {}, "options": {"enforceStepLimit": True}},
+        json={"inputs": {}, "options": {"enforceStepLimit": True}},
     )
 
     assert response.status_code == 200
@@ -131,8 +127,6 @@ def test_save_from_workflow_success() -> None:
         "scopeRef": str(uuid4()),
         "title": "Saved Template",
         "description": "Saved",
-        "latestVersion": "1.0.0",
-        "version": "1.0.0",
         "tags": [],
         "isFavorite": False,
         "recentAppliedAt": None,

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -435,7 +435,7 @@ def test_get_proposal_preview_includes_preset_provenance(
                 "authoredPresets": [
                     {
                         "presetId": "runtime-quality-followup",
-                        "presetVersion": "2026-04-17",
+                        "presetDigest": "digest-2026-04-17",
                         "includePath": ["root", "regression-coverage"],
                     }
                 ],
@@ -445,7 +445,7 @@ def test_get_proposal_preview_includes_preset_provenance(
                         "source": {
                             "kind": "preset-derived",
                             "presetId": "runtime-quality-followup",
-                            "presetVersion": "2026-04-17",
+                            "presetDigest": "digest-2026-04-17",
                             "includePath": ["root", "regression-coverage"],
                             "originalStepId": "add-regression-test",
                         },
@@ -465,12 +465,12 @@ def test_get_proposal_preview_includes_preset_provenance(
     assert preview["authoredPresetCount"] == 1
     assert preview["stepSourceKinds"] == ["preset-derived"]
     assert preview["presetSourceMetadata"] == [
-        {
-            "kind": "preset-derived",
-            "presetId": "runtime-quality-followup",
-            "presetVersion": "2026-04-17",
-            "includePath": ["root", "regression-coverage"],
-            "originalStepId": "add-regression-test",
+            {
+                "kind": "preset-derived",
+                "presetId": "runtime-quality-followup",
+                "presetDigest": "digest-2026-04-17",
+                "includePath": ["root", "regression-coverage"],
+                "originalStepId": "add-regression-test",
         }
     ]
 

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import selectinload, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import Base, Preset, PresetScopeType
 from api_service.services.presets.catalog import PresetCatalogService
@@ -57,10 +57,8 @@ async def _load_preset(session) -> Preset:
             Preset.scope_type == PresetScopeType.GLOBAL,
             Preset.scope_ref.is_(None),
         )
-        .options(selectinload(Preset.latest_version))
     )
     template = result.scalar_one()
-    assert template.latest_version is not None
     return template
 
 
@@ -71,8 +69,7 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
 
             template = await _load_preset(session)
-            version = template.latest_version
-            annotations = version.annotations or {}
+            annotations = template.annotations or {}
 
             assert template.title == "Batch Workflows"
             assert template.scope_type is PresetScopeType.GLOBAL
@@ -105,10 +102,9 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             ):
                 assert name in schema["properties"]
 
-            # Target preset selector (slug/version/scope/scopeRef).
+            # Target preset selector (slug/scope/scopeRef).
             for name in (
                 "target_preset_slug",
-                "target_preset_version",
                 "target_preset_scope",
                 "target_preset_scope_ref",
             ):
@@ -152,14 +148,14 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
             # The board input keeps the existing jira_board input type.
             board_input = next(
                 item
-                for item in version.inputs_schema
+                for item in template.inputs_schema
                 if item["name"] == "jira_board_id"
             )
             assert board_input["type"] == "jira_board"
 
             # Orchestration step references the batch-workflows skill.
-            assert len(version.steps) == 1
-            step = version.steps[0]
+            assert len(template.steps) == 1
+            step = template.steps[0]
             assert step["skill"]["id"] == "batch-workflows"
             # The parent only orchestrates/queues; it must not hard-require the
             # jira capability or GitHub-only batches would be blocked at launch
@@ -181,13 +177,11 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
                 slug="batch-workflows",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "source_kind": "jira_board_column",
                     "jira_board_id": "42",
                     "jira_column": "In Progress",
                     "target_preset_slug": "jira-implement",
-                    "target_preset_version": "1.1.0",
                     "publish_mode": "pr",
                     "constraints": "Be careful",
                     "max_workflows": "10",
@@ -204,7 +198,7 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert orchestration["source"]["jiraBoardColumn"]["boardId"] == "42"
             assert orchestration["source"]["jiraBoardColumn"]["column"] == "In Progress"
             assert orchestration["targetPreset"]["slug"] == "jira-implement"
-            assert orchestration["targetPreset"]["version"] == "1.1.0"
+            assert "version" not in orchestration["targetPreset"]
             assert orchestration["publish"]["mode"] == "pr"
             # Every child inherits the caller runtime.
             assert orchestration["runtime"]["inherit"] == "caller"

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -94,7 +94,6 @@ async def test_create_and_expand_template_deterministic_ids(tmp_path):
                 slug="pr-check",
                 scope="personal",
                 scope_ref=str(user_id),
-                version="1.0.0",
                 inputs={"summary": "fix failing tests"},
                 context={},
                 options=ExpandOptions(should_enforce_step_limit=True),
@@ -155,7 +154,6 @@ async def test_expand_template_normalizes_legacy_orchestrate_mode_to_runtime(
                 slug=slug,
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "Implement MM-600",
                     "orchestration_mode": "docs",
@@ -247,7 +245,6 @@ async def test_expand_template_preserves_literal_placeholders_from_user_input(tm
                 slug="literal-placeholder-input",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": (
                         "Preserve the literal {{ downstream.value }} token."
@@ -287,7 +284,6 @@ async def test_expand_template_rejects_unknown_template_variable(tmp_path):
                     slug="unknown-template-variable",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                 )
@@ -321,7 +317,6 @@ async def test_expand_template_reports_malformed_template_as_validation_error(tm
                     slug="malformed-template",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                 )
@@ -390,7 +385,6 @@ async def test_expand_schema_capability_reports_field_addressable_errors(tmp_pat
                     slug="schema-required",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={"jira_issue": {}},
                     context={},
                 )
@@ -448,7 +442,6 @@ async def test_expand_annotated_schema_capability_reports_field_addressable_erro
                     slug="annotated-schema-required",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={"jira_issue": {}},
                     context={},
                 )
@@ -457,7 +450,6 @@ async def test_expand_annotated_schema_capability_reports_field_addressable_erro
                 slug="annotated-schema-required",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={"jira_issue": {"key": "MM-593"}},
                 context={},
             )
@@ -533,7 +525,6 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
                     {
                         "kind": "include",
                         "slug": "child-checks",
-                        "version": "1.0.0",
                         "alias": "quality",
                         "scope": "global",
                         "inputMapping": {"target": "{{ inputs.feature }}"},
@@ -548,7 +539,6 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
                 slug="parent-flow",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={"feature": "preset composition"},
                 context={},
                 options=ExpandOptions(should_enforce_step_limit=True),
@@ -580,13 +570,11 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["authoredPresets"] == [
         {
             "presetSlug": "parent-flow",
-            "presetVersion": "1.0.0",
             "scope": "global",
             "includePath": ["parent-flow@1.0.0"],
         },
         {
             "presetSlug": "child-checks",
-            "presetVersion": "1.0.0",
             "alias": "quality",
             "scope": "global",
             "includePath": [
@@ -603,7 +591,6 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetSlug": "child-checks",
-        "presetVersion": "1.0.0",
         "includePath": [
             "parent-flow@1.0.0",
             "quality:child-checks@1.0.0",
@@ -616,7 +603,6 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["steps"][1]["source"] == {
         "kind": "preset-derived",
         "presetSlug": "child-checks",
-        "presetVersion": "1.0.0",
         "includePath": [
             "parent-flow@1.0.0",
             "quality:child-checks@1.0.0",
@@ -663,7 +649,6 @@ async def test_expand_template_preserves_explicit_original_step_id_over_step_id(
                 slug="explicit-original-id",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -698,7 +683,6 @@ async def test_expand_template_omits_original_step_id_when_source_step_has_no_id
                 slug="generated-step",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -739,7 +723,6 @@ async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
                     {
                         "kind": "include",
                         "slug": "stable-child",
-                        "version": "1.0.0",
                         "alias": "child",
                         "scope": "global",
                     },
@@ -754,7 +737,6 @@ async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
                 slug="stable-parent",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -762,7 +744,6 @@ async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
                 slug="stable-parent",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -836,7 +817,6 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
                     {
                         "kind": "include",
                         "slug": "deep-child",
-                        "version": "1.0.0",
                         "alias": "deep",
                         "scope": "global",
                         "inputMapping": {"target": "{{ inputs.target }}"},
@@ -873,7 +853,6 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
                     {
                         "kind": "include",
                         "slug": "middle-flow",
-                        "version": "1.0.0",
                         "alias": "middle",
                         "scope": "global",
                         "inputMapping": {"target": "{{ inputs.feature }}"},
@@ -892,7 +871,6 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
                 slug="parent-flow",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={"feature": "recursive provenance"},
                 context={},
             )
@@ -908,7 +886,6 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
     assert deep_step["source"] == {
         "kind": "preset-derived",
         "presetSlug": "deep-child",
-        "presetVersion": "1.0.0",
         "includePath": [
             "parent-flow@1.0.0",
             "middle:middle-flow@1.0.0",
@@ -919,13 +896,11 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
     assert expanded["authoredPresets"] == [
         {
             "presetSlug": "parent-flow",
-            "presetVersion": "1.0.0",
             "scope": "global",
             "includePath": ["parent-flow@1.0.0"],
         },
         {
             "presetSlug": "middle-flow",
-            "presetVersion": "1.0.0",
             "alias": "middle",
             "scope": "global",
             "includePath": [
@@ -936,7 +911,6 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
         },
         {
             "presetSlug": "deep-child",
-            "presetVersion": "1.0.0",
             "alias": "deep",
             "scope": "global",
             "includePath": [
@@ -982,13 +956,11 @@ async def test_expand_template_rejects_duplicate_include_aliases(tmp_path):
                         {
                             "kind": "include",
                             "slug": "duplicate-child",
-                            "version": "1.0.0",
                             "alias": "same",
                         },
                         {
                             "kind": "include",
                             "slug": "duplicate-child",
-                            "version": "1.0.0",
                             "alias": "same",
                         },
                     ],
@@ -1013,7 +985,6 @@ async def test_expand_template_rejects_missing_include_target(tmp_path):
                     {
                         "kind": "include",
                         "slug": "missing-child",
-                        "version": "1.0.0",
                         "alias": "missing",
                     }
                 ],
@@ -1030,7 +1001,6 @@ async def test_expand_template_rejects_missing_include_target(tmp_path):
                     slug="missing-target-parent",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                 )
@@ -1061,45 +1031,30 @@ async def test_expand_template_rejects_include_version_mismatch_with_explicit_er
                 required_capabilities=[],
                 created_by=None,
             )
-            await service.create_template(
-                slug="version-mismatch-parent",
-                title="Version Mismatch Parent",
-                description="Requests unavailable version.",
-                scope="global",
-                scope_ref=None,
-                tags=[],
-                inputs_schema=[],
-                steps=[
-                    {
-                        "kind": "include",
-                        "slug": "child-checks",
-                        "version": "2.0.0",
-                        "alias": "child",
-                        "scope": "global",
-                    }
-                ],
-                annotations={},
-                required_capabilities=[],
-                created_by=None,
-            )
-
             with pytest.raises(PresetValidationError) as excinfo:
-                await service.expand_template(
-                    slug="version-mismatch-parent",
+                await service.create_template(
+                    slug="version-field-parent",
+                    title="Version Field Parent",
+                    description="Rejects versioned preset includes.",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
-                    inputs={},
-                    context={},
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "kind": "include",
+                            "slug": "child-checks",
+                            "version": "2.0.0",
+                            "alias": "child",
+                            "scope": "global",
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
                 )
 
-    assert "version mismatch" in str(excinfo.value).lower()
-    assert "child:child-checks@2.0.0" in str(excinfo.value)
-    assert excinfo.value.errors[0]["code"] == "preset_include_version_mismatch"
-    assert excinfo.value.errors[0]["includePath"] == [
-        "version-mismatch-parent@1.0.0",
-        "child:child-checks@2.0.0",
-    ]
+    assert "slug/scope only" in str(excinfo.value)
 
 async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
     tmp_path,
@@ -1152,7 +1107,6 @@ async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
                     {
                         "kind": "include",
                         "slug": "moonspec-orchestrate",
-                        "version": "1.0.0",
                         "alias": "orchestrate",
                         "scope": "global",
                         "inputMapping": {
@@ -1170,7 +1124,6 @@ async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
                 slug="parent-flow",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={"feature_request": "Implement MM-600"},
                 context={},
                 user_id=user_id,
@@ -1236,7 +1189,6 @@ async def test_create_template_rejects_unsupported_include_fields(tmp_path):
                         {
                             "kind": "include",
                             "slug": "child-checks",
-                            "version": "1.0.0",
                             "alias": "checks",
                             "scope": "global",
                             "instructions": "Override child instructions",
@@ -1264,7 +1216,6 @@ async def test_expand_template_rejects_global_parent_personal_include(tmp_path):
                     {
                         "kind": "include",
                         "slug": "personal-child",
-                        "version": "1.0.0",
                         "alias": "private",
                         "scope": "personal",
                     }
@@ -1282,7 +1233,6 @@ async def test_expand_template_rejects_global_parent_personal_include(tmp_path):
                     slug="global-parent",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(),
@@ -1306,7 +1256,6 @@ async def test_expand_template_rejects_include_cycles_with_path(tmp_path):
                     {
                         "kind": "include",
                         "slug": "preset-b",
-                        "version": "1.0.0",
                         "alias": "b",
                         "scope": "global",
                     }
@@ -1327,7 +1276,6 @@ async def test_expand_template_rejects_include_cycles_with_path(tmp_path):
                     {
                         "kind": "include",
                         "slug": "preset-a",
-                        "version": "1.0.0",
                         "alias": "a",
                         "scope": "global",
                     }
@@ -1345,7 +1293,6 @@ async def test_expand_template_rejects_include_cycles_with_path(tmp_path):
                     slug="preset-a",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(),
@@ -1403,7 +1350,6 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
                     {
                         "kind": "include",
                         "slug": "inactive-child",
-                        "version": "1.0.0",
                         "alias": "inactive",
                         "scope": "global",
                     }
@@ -1424,7 +1370,6 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
                     {
                         "kind": "include",
                         "slug": "input-child",
-                        "version": "1.0.0",
                         "alias": "requires-topic",
                         "scope": "global",
                     }
@@ -1442,7 +1387,6 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
                     slug="bad-parent",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(),
@@ -1456,7 +1400,6 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
                     slug="input-parent",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(),
@@ -1499,7 +1442,6 @@ async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_pa
                     {
                         "kind": "include",
                         "slug": "two-step-child",
-                        "version": "1.0.0",
                         "alias": "two",
                         "scope": "global",
                     }
@@ -1512,11 +1454,10 @@ async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_pa
                 await session.execute(
                     select(Preset)
                     .where(Preset.slug == "limited-parent")
-                    .options(selectinload(Preset.latest_version))
+                    
                 )
             ).scalar_one()
-            assert template.latest_version is not None
-            template.latest_version.max_step_count = 1
+            template.max_step_count = 1
             await session.commit()
 
             with pytest.raises(
@@ -1527,7 +1468,6 @@ async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_pa
                     slug="limited-parent",
                     scope="global",
                     scope_ref=None,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(should_enforce_step_limit=True),
@@ -1608,7 +1548,6 @@ async def test_list_templates_with_favorites_and_recents(tmp_path):
                 slug="second-template",
                 scope="personal",
                 scope_ref=user_str,
-                version="1.0.0",
                 inputs={},
                 context={},
                 options=ExpandOptions(),
@@ -1682,7 +1621,6 @@ async def test_recents_trimmed_to_latest_five_rows(tmp_path):
                     slug=slug,
                     scope="personal",
                     scope_ref=user_str,
-                    version="1.0.0",
                     inputs={},
                     context={},
                     options=ExpandOptions(),
@@ -1719,7 +1657,6 @@ async def test_release_status_sets_reviewer_fields(tmp_path):
                 slug="review-target",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 release_status=PresetReleaseStatus.ACTIVE,
                 reviewer_id=user_id,
             )
@@ -1877,7 +1814,6 @@ async def test_import_seed_templates_success(tmp_path):
         "title": "Seed Test",
         "description": "A test seed template",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [{"instructions": "seed step"}],
     }
     _write_seed_template(seed_dir, seed_data)
@@ -1905,7 +1841,6 @@ async def test_import_seed_templates_skips_existing(tmp_path):
         "slug": "seed-test-conflict",
         "title": "Seed Test Conflict",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [{"instructions": "seed step"}],
     }
     _write_seed_template(seed_dir, seed_data)
@@ -1934,7 +1869,6 @@ async def test_sync_seed_templates_preserves_step_original_step_id(tmp_path):
             "title": "Seeded Preset",
             "description": "Seed carries source ids.",
             "scope": "global",
-            "version": "1.0.0",
             "steps": [
                 {
                     "id": "current-id",
@@ -1954,7 +1888,6 @@ async def test_sync_seed_templates_preserves_step_original_step_id(tmp_path):
                 slug="seeded-preset",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -1990,8 +1923,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 scope_ref=None,
             )
             assert template.title == "Jira Breakdown"
-            assert template.latest_version is not None
-            assert [step["skill"]["id"] for step in template.latest_version.steps] == [
+            assert [step["skill"]["id"] for step in template.steps] == [
                 "moonspec-breakdown",
                 "story.create_jira_issues",
             ]
@@ -2000,7 +1932,6 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
@@ -2051,8 +1982,7 @@ async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
                 scope_ref=None,
             )
             assert template.title == "Document Health Update"
-            assert template.latest_version is not None
-            steps = template.latest_version.steps
+            steps = template.steps
             assert [step["title"] for step in steps] == [
                 "Document health review",
                 "Document health remediate",
@@ -2066,7 +1996,6 @@ async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
                 slug="document-health-update",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={"documentation_scope": "docs/Workflows/"},
                 context={},
             )
@@ -2106,7 +2035,6 @@ async def test_jira_breakdown_uses_single_allowed_project_as_runtime_default(
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
             )
             project_input = next(
                 item
@@ -2119,7 +2047,6 @@ async def test_jira_breakdown_uses_single_allowed_project_as_runtime_default(
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_issue_type": "Story",
@@ -2166,7 +2093,6 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 slug="jira-breakdown-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
             )
             assert "orchestration_mode" not in {
                 item["name"] for item in template["inputs"]
@@ -2182,7 +2108,6 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 slug="jira-breakdown-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
@@ -2254,7 +2179,6 @@ async def test_jira_breakdown_replaces_tool_placeholder_with_single_allowed_proj
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "TOOL",
@@ -2298,7 +2222,6 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
                 slug="jira-breakdown-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "PLAT",
@@ -2345,7 +2268,6 @@ async def test_jira_breakdown_uses_seeded_default_when_multiple_allowed_without_
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
             )
             project_input = next(
                 item
@@ -2358,7 +2280,6 @@ async def test_jira_breakdown_uses_seeded_default_when_multiple_allowed_without_
                 slug="jira-breakdown",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_issue_type": "Story",
@@ -2388,22 +2309,20 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 scope_ref=None,
             )
             assert template.title == "Jira Orchestrate"
-            assert template.latest_version is not None
-            assert template.latest_version.annotations["jiraWorkflow"] == (
+            assert template.annotations["jiraWorkflow"] == (
                 "implementation-to-code-review"
             )
             template_payload = await service.get_template(
                 slug="jira-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
             )
             assert "orchestration_mode" not in {
                 item["name"] for item in template_payload["inputs"]
             }
             assert [
                 (step.get("skill") or step.get("tool"))["id"]
-                for step in template.latest_version.steps
+                for step in template.steps
             ] == [
                 "jira-issue-updater",
                 "jira.check_blockers",
@@ -2421,14 +2340,13 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "auto",
                 "jira-issue-updater",
             ]
-            step_titles = [step["title"] for step in template.latest_version.steps]
+            step_titles = [step["title"] for step in template.steps]
             assert "Return Jira orchestration report" not in step_titles
 
             expanded = await service.expand_template(
                 slug="jira-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "jira_issue_key": "MM-328",
                     "source_design_path": "",
@@ -2563,7 +2481,6 @@ async def test_seed_catalog_jira_implement_flattens_jira_issue_input(tmp_path):
                 slug="jira-implement",
                 scope="global",
                 scope_ref=None,
-                version="1.1.0",
                 inputs={"jira_issue": {"key": "MM-742"}},
                 context={},
             )
@@ -2608,7 +2525,6 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
                 slug="github-issue-implement",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "github_issue": {
                         "repository": "MoonLadderStudios/MoonMind",
@@ -2660,15 +2576,14 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                 scope_ref=None,
             )
             assert template.title == "Jira Breakdown and Orchestrate"
-            assert template.latest_version is not None
-            assert template.latest_version.annotations["sourceSkill"] == (
+            assert template.annotations["sourceSkill"] == (
                 "jira-breakdown"
             )
-            assert template.latest_version.annotations["output"] == (
+            assert template.annotations["output"] == (
                 "dependent-jira-orchestrate-tasks"
             )
             assert [
-                step["skill"]["id"] for step in template.latest_version.steps
+                step["skill"]["id"] for step in template.steps
             ] == [
                 "moonspec-breakdown",
                 "story-reconcile-implementation",
@@ -2680,7 +2595,6 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(tmp_path)
                 slug="jira-breakdown-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
@@ -2742,7 +2656,6 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(tmp_path):
                 slug="jira-breakdown-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
@@ -2786,7 +2699,6 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
                 slug="jira-breakdown-implement",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
@@ -2836,16 +2748,15 @@ async def test_seed_catalog_includes_document_update_orchestrate_preset(tmp_path
                 scope_ref=None,
             )
             assert template.title == "Document Update Orchestrate"
-            assert template.latest_version is not None
-            assert template.latest_version.annotations["sourceSkill"] == (
+            assert template.annotations["sourceSkill"] == (
                 "document-update-orchestrate"
             )
-            assert template.latest_version.annotations["output"] == (
+            assert template.annotations["output"] == (
                 "document-update-tasks"
             )
             assert [
                 step.get("tool", step.get("skill", {})).get("id")
-                for step in template.latest_version.steps
+                for step in template.steps
             ] == [
                 "document.discover",
                 "story.create_document_update_tasks",
@@ -2855,7 +2766,6 @@ async def test_seed_catalog_includes_document_update_orchestrate_preset(tmp_path
                 slug="document-update-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "document_directory": "docs",
                     "publish_mode": "pr_with_merge_automation",
@@ -2901,8 +2811,7 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 scope_ref=None,
             )
             assert template.title == "MoonSpec Orchestrate"
-            assert template.latest_version is not None
-            assert [step["skill"]["id"] for step in template.latest_version.steps] == [
+            assert [step["skill"]["id"] for step in template.steps] == [
                 "moonspec-specify",
                 "moonspec-plan",
                 "moonspec-tasks",
@@ -2911,7 +2820,7 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 "moonspec-verify",
                 "moonspec-doc-reconcile",
             ]
-            step_titles = [step["title"] for step in template.latest_version.steps]
+            step_titles = [step["title"] for step in template.steps]
             assert (
                 "Return orchestration report and defer publish actions"
                 not in step_titles
@@ -2922,7 +2831,6 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 slug="moonspec-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
             )
             assert "orchestration_mode" not in {
                 item["name"] for item in template_payload["inputs"]
@@ -2932,7 +2840,6 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
                 slug="moonspec-orchestrate",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={
                     "feature_request": "MM-366: Simplify Orchestrate Summary",
                     "orchestration_mode": "docs",
@@ -2968,7 +2875,6 @@ async def test_sync_seed_templates_creates_missing_seed(tmp_path):
         "title": "MoonSpec Orchestrate",
         "description": "Seeded preset",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [
             {
                 "title": "Specify",
@@ -3001,8 +2907,7 @@ async def test_sync_seed_templates_creates_missing_seed(tmp_path):
                 scope_ref=None,
             )
             assert template.title == "MoonSpec Orchestrate"
-            assert template.latest_version is not None
-            assert template.latest_version.steps[0]["skill"]["id"] == "moonspec-specify"
+            assert template.steps[0]["skill"]["id"] == "moonspec-specify"
 
 async def test_sync_seed_templates_preserves_default_expansion_limit_for_includes(
     tmp_path,
@@ -3013,12 +2918,10 @@ async def test_sync_seed_templates_preserves_default_expansion_limit_for_include
         "title": "Composed Seed",
         "description": "Seeded preset with child include",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [
             {
                 "kind": "include",
                 "slug": "shared-child",
-                "version": "1.0.0",
                 "alias": "shared",
                 "scope": "global",
             }
@@ -3039,8 +2942,7 @@ async def test_sync_seed_templates_preserves_default_expansion_limit_for_include
                 scope_ref=None,
             )
 
-    assert template.latest_version is not None
-    assert template.latest_version.max_step_count == 25
+    assert template.max_step_count == 25
 
 async def test_sync_seed_templates_updates_existing_include_limit_default(tmp_path):
     seed_dir = tmp_path / "seeds"
@@ -3049,12 +2951,10 @@ async def test_sync_seed_templates_updates_existing_include_limit_default(tmp_pa
         "title": "Composed Seed",
         "description": "Seeded preset with child include",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [
             {
                 "kind": "include",
                 "slug": "shared-child",
-                "version": "1.0.0",
                 "alias": "shared",
                 "scope": "global",
             }
@@ -3085,8 +2985,7 @@ async def test_sync_seed_templates_updates_existing_include_limit_default(tmp_pa
                 scope=PresetScopeType.GLOBAL,
                 scope_ref=None,
             )
-            assert template.latest_version is not None
-            template.latest_version.max_step_count = 1
+            template.max_step_count = 1
             await session.commit()
 
             result = await service.sync_seed_templates(seed_dir=seed_dir)
@@ -3098,8 +2997,7 @@ async def test_sync_seed_templates_updates_existing_include_limit_default(tmp_pa
             )
 
     assert result.updated == 1
-    assert template.latest_version is not None
-    assert template.latest_version.max_step_count == 25
+    assert template.max_step_count == 25
 
 async def test_sync_seed_templates_updates_existing_seed(tmp_path):
     seed_dir = tmp_path / "seeds"
@@ -3108,7 +3006,6 @@ async def test_sync_seed_templates_updates_existing_seed(tmp_path):
         "title": "MoonSpec Orchestrate",
         "description": "Updated seeded preset",
         "scope": "global",
-        "version": "1.0.0",
         "steps": [
             {
                 "title": "Specify",
@@ -3162,10 +3059,9 @@ async def test_sync_seed_templates_updates_existing_seed(tmp_path):
                 scope_ref=None,
             )
             assert template.description == "Updated seeded preset"
-            assert template.latest_version is not None
-            assert len(template.latest_version.steps) == 2
-            assert template.latest_version.steps[0]["skill"]["id"] == "moonspec-specify"
-            assert template.latest_version.annotations["sourceSkill"] == "moonspec-orchestrate"
+            assert len(template.steps) == 2
+            assert template.steps[0]["skill"]["id"] == "moonspec-specify"
+            assert template.annotations["sourceSkill"] == "moonspec-orchestrate"
 
 async def test_mm557_accepts_and_expands_jira_transition_tool_step(tmp_path):
     user_id = uuid4()
@@ -3187,7 +3083,6 @@ async def test_mm557_accepts_and_expands_jira_transition_tool_step(tmp_path):
                         "instructions": "Move MM-557 to In Progress.",
                         "tool": {
                             "id": "jira.transition_issue",
-                            "version": "1.0.0",
                             "inputs": {
                                 "issueKey": "MM-557",
                                 "targetStatus": "In Progress",
@@ -3206,7 +3101,6 @@ async def test_mm557_accepts_and_expands_jira_transition_tool_step(tmp_path):
                 slug="jira-transition-tool",
                 scope="personal",
                 scope_ref=str(user_id),
-                version="1.0.0",
                 inputs={},
                 context={},
                 options=ExpandOptions(should_enforce_step_limit=True),
@@ -3511,7 +3405,6 @@ async def test_mm569_accepts_valid_tool_skill_and_preset_draft_steps(tmp_path):
                 slug="mm569-explicit-step-types",
                 scope="global",
                 scope_ref=None,
-                version="1.0.0",
                 inputs={},
                 context={},
             )
@@ -3530,7 +3423,6 @@ async def test_mm569_accepts_valid_tool_skill_and_preset_draft_steps(tmp_path):
     assert preset["type"] == "preset"
     assert preset["preset"] == {
         "slug": "mm569-child-preset",
-        "version": "1.0.0",
         "inputs": {"issue_key": "MM-569"},
     }
     assert [step["type"] for step in expanded["steps"]] == ["tool", "skill", "skill"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -101,11 +101,11 @@ async def test_create_and_expand_template_deterministic_ids(tmp_path):
             )
 
     assert len(expanded["steps"]) == 1
-    assert expanded["steps"][0]["id"].startswith("tpl:pr-check:1.0.0:01:")
+    assert expanded["steps"][0]["id"].startswith("tpl:pr-check:01:")
     assert "fix failing tests" in expanded["steps"][0]["instructions"]
     assert set(expanded["capabilities"]) >= {"codex", "docker"}
     assert expanded["appliedTemplate"]["slug"] == "pr-check"
-    assert expanded["appliedTemplate"]["version"] == "1.0.0"
+    assert "version" not in expanded["appliedTemplate"]
 
 @pytest.mark.parametrize("slug", ["jira-orchestrate", "moonspec-orchestrate"])
 async def test_expand_template_normalizes_legacy_orchestrate_mode_to_runtime(
@@ -549,19 +549,20 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
         "Lint target",
         "Test target",
     ]
-    assert expanded["steps"][0]["id"].startswith("tpl:parent-flow:1.0.0:01:")
-    assert expanded["steps"][1]["id"].startswith("tpl:parent-flow:1.0.0:02:")
+    assert expanded["steps"][0]["id"].startswith("tpl:parent-flow:01:")
+    assert expanded["steps"][1]["id"].startswith("tpl:parent-flow:02:")
     assert "preset composition" in expanded["steps"][0]["instructions"]
     assert set(expanded["capabilities"]) >= {"codex", "docker"}
     provenance = expanded["steps"][0]["presetProvenance"]
-    assert provenance["root"] == {"slug": "parent-flow", "version": "1.0.0"}
+    assert provenance["root"] == {"slug": "parent-flow"}
     assert provenance["source"]["slug"] == "child-checks"
-    assert provenance["source"]["version"] == "1.0.0"
+    assert "version" not in provenance["source"]
+    assert provenance["source"]["presetDigest"]
     assert provenance["source"]["originalStepId"] == "lint-target"
     assert provenance["alias"] == "quality"
     assert provenance["path"] == [
-        "parent-flow@1.0.0",
-        "quality:child-checks@1.0.0",
+        "parent-flow",
+        "quality:child-checks",
     ]
     assert expanded["composition"]["includes"][0]["alias"] == "quality"
     assert expanded["composition"]["includes"][0]["stepIds"] == [
@@ -570,16 +571,18 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["authoredPresets"] == [
         {
             "presetSlug": "parent-flow",
+            "presetDigest": expanded["composition"]["digest"],
             "scope": "global",
-            "includePath": ["parent-flow@1.0.0"],
+            "includePath": ["parent-flow"],
         },
         {
             "presetSlug": "child-checks",
+            "presetDigest": expanded["composition"]["includes"][0]["digest"],
             "alias": "quality",
             "scope": "global",
             "includePath": [
-                "parent-flow@1.0.0",
-                "quality:child-checks@1.0.0",
+                "parent-flow",
+                "quality:child-checks",
             ],
             "inputMapping": {"target": "preset composition"},
         },
@@ -591,9 +594,10 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetSlug": "child-checks",
+        "presetDigest": expanded["composition"]["includes"][0]["digest"],
         "includePath": [
-            "parent-flow@1.0.0",
-            "quality:child-checks@1.0.0",
+            "parent-flow",
+            "quality:child-checks",
         ],
         "originalStepId": "lint-target",
     }
@@ -603,9 +607,10 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     assert expanded["steps"][1]["source"] == {
         "kind": "preset-derived",
         "presetSlug": "child-checks",
+        "presetDigest": expanded["composition"]["includes"][0]["digest"],
         "includePath": [
-            "parent-flow@1.0.0",
-            "quality:child-checks@1.0.0",
+            "parent-flow",
+            "quality:child-checks",
         ],
         "originalStepId": "test-target",
     }
@@ -886,37 +891,41 @@ async def test_expand_template_flattens_multi_level_include_tree_with_provenance
     assert deep_step["source"] == {
         "kind": "preset-derived",
         "presetSlug": "deep-child",
+        "presetDigest": expanded["composition"]["includes"][0]["includes"][0]["digest"],
         "includePath": [
-            "parent-flow@1.0.0",
-            "middle:middle-flow@1.0.0",
-            "deep:deep-child@1.0.0",
+            "parent-flow",
+            "middle:middle-flow",
+            "deep:deep-child",
         ],
         "originalStepId": "deep-child-step",
     }
     assert expanded["authoredPresets"] == [
         {
             "presetSlug": "parent-flow",
+            "presetDigest": expanded["composition"]["digest"],
             "scope": "global",
-            "includePath": ["parent-flow@1.0.0"],
+            "includePath": ["parent-flow"],
         },
         {
             "presetSlug": "middle-flow",
+            "presetDigest": expanded["composition"]["includes"][0]["digest"],
             "alias": "middle",
             "scope": "global",
             "includePath": [
-                "parent-flow@1.0.0",
-                "middle:middle-flow@1.0.0",
+                "parent-flow",
+                "middle:middle-flow",
             ],
             "inputMapping": {"target": "recursive provenance"},
         },
         {
             "presetSlug": "deep-child",
+            "presetDigest": expanded["composition"]["includes"][0]["includes"][0]["digest"],
             "alias": "deep",
             "scope": "global",
             "includePath": [
-                "parent-flow@1.0.0",
-                "middle:middle-flow@1.0.0",
-                "deep:deep-child@1.0.0",
+                "parent-flow",
+                "middle:middle-flow",
+                "deep:deep-child",
             ],
             "inputMapping": {"target": "recursive provenance"},
         },
@@ -995,7 +1004,7 @@ async def test_expand_template_rejects_missing_include_target(tmp_path):
 
             with pytest.raises(
                 PresetValidationError,
-                match="missing:missing-child@1.0.0",
+                match="missing:missing-child",
             ) as excinfo:
                 await service.expand_template(
                     slug="missing-target-parent",
@@ -1007,12 +1016,12 @@ async def test_expand_template_rejects_missing_include_target(tmp_path):
 
     assert excinfo.value.errors[0]["code"] == "preset_include_missing"
     assert excinfo.value.errors[0]["includePath"] == [
-        "missing-target-parent@1.0.0",
-        "missing:missing-child@1.0.0",
+        "missing-target-parent",
+        "missing:missing-child",
     ]
 
 
-async def test_expand_template_rejects_include_version_mismatch_with_explicit_error(
+async def test_expand_template_rejects_include_version_with_explicit_error(
     tmp_path,
 ):
     async with template_db(tmp_path) as session_maker:
@@ -1044,7 +1053,7 @@ async def test_expand_template_rejects_include_version_mismatch_with_explicit_er
                         {
                             "kind": "include",
                             "slug": "child-checks",
-                            "version": "2.0.0",
+                            "version": "2",
                             "alias": "child",
                             "scope": "global",
                         }
@@ -1138,7 +1147,7 @@ async def test_create_template_rejects_templated_include_version(tmp_path):
 
             with pytest.raises(
                 PresetValidationError,
-                match="include version must be a literal pinned version",
+                match="slug/scope only",
             ):
                 await service.create_template(
                     slug="runtime-selected-parent",
@@ -1227,7 +1236,7 @@ async def test_expand_template_rejects_global_parent_personal_include(tmp_path):
 
             with pytest.raises(
                 PresetValidationError,
-                match="Global presets cannot include personal presets.*private:personal-child@1.0.0",
+                match="Global presets cannot include personal presets.*private:personal-child",
             ) as excinfo:
                 await service.expand_template(
                     slug="global-parent",
@@ -1287,7 +1296,7 @@ async def test_expand_template_rejects_include_cycles_with_path(tmp_path):
 
             with pytest.raises(
                 PresetValidationError,
-                match="Preset include cycle detected.*preset-a@1.0.0.*b:preset-b@1.0.0.*a:preset-a@1.0.0",
+                match="Preset include cycle detected.*preset-a.*b:preset-b.*a:preset-a",
             ) as excinfo:
                 await service.expand_template(
                     slug="preset-a",
@@ -1381,7 +1390,7 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
 
             with pytest.raises(
                 PresetValidationError,
-                match="inactive.*inactive:inactive-child@1.0.0",
+                match="inactive.*inactive:inactive-child",
             ) as inactive_excinfo:
                 await service.expand_template(
                     slug="bad-parent",
@@ -1394,7 +1403,7 @@ async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_pa
 
             with pytest.raises(
                 PresetValidationError,
-                match="requires-topic:input-child@1.0.0.*Missing required template input 'topic'",
+                match="requires-topic:input-child.*Missing required template input 'topic'",
             ) as input_excinfo:
                 await service.expand_template(
                     slug="input-parent",
@@ -1462,7 +1471,7 @@ async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_pa
 
             with pytest.raises(
                 PresetValidationError,
-                match="max_step_count=1.*two:two-step-child@1.0.0",
+                match="max_step_count=1.*two:two-step-child",
             ):
                 await service.expand_template(
                     slug="limited-parent",
@@ -1473,13 +1482,13 @@ async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_pa
                     options=ExpandOptions(should_enforce_step_limit=True),
                 )
 
-async def test_template_recents_declares_unique_user_version_constraint() -> None:
+async def test_template_recents_declares_unique_user_template_constraint() -> None:
     constraint_names = {
         constraint.name
         for constraint in PresetRecent.__table__.constraints
         if isinstance(constraint, UniqueConstraint)
     }
-    assert "uq_preset_recent_user_version" in constraint_names
+    assert "uq_preset_recent_user_template" in constraint_names
 
 async def test_save_from_workflow_rejects_secret_patterns(tmp_path):
     user_id = uuid4()
@@ -1832,8 +1841,13 @@ async def test_import_seed_templates_success(tmp_path):
             )
             assert template.title == "Seed Test"
             assert template.description == "A test seed template"
-            assert len(template.versions) == 1
-            assert template.versions[0].version == "1.0.0"
+            assert template.steps == [
+                {
+                    "type": "skill",
+                        "instructions": "seed step",
+                    "skill": {"id": "auto", "args": {}},
+                }
+            ]
 
 async def test_import_seed_templates_skips_existing(tmp_path):
     seed_dir = tmp_path / "seeds"

--- a/tests/unit/api_service/test_preset_slug_scope_migration.py
+++ b/tests/unit/api_service/test_preset_slug_scope_migration.py
@@ -1,0 +1,45 @@
+"""Regression tests for the MM-912 preset slug/scope migration."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+
+class RecordingOp:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    def __getattr__(self, name: str):
+        def recorder(*args, **kwargs):
+            self.calls.append((name, args[0] if args else kwargs))
+
+        return recorder
+
+
+def test_preset_recents_are_deduplicated_before_template_unique_constraint(
+    monkeypatch,
+) -> None:
+    migration = importlib.import_module(
+        "api_service.migrations.versions.327_mm912_slug_scope_presets"
+    )
+    op = RecordingOp()
+    monkeypatch.setattr(migration, "op", op)
+
+    migration.upgrade()
+
+    duplicate_delete_index = next(
+        index
+        for index, (name, payload) in enumerate(op.calls)
+        if name == "execute"
+        and "delete from preset_recents" in str(payload)
+        and "partition by user_id, template_id" in str(payload)
+    )
+    unique_constraint_index = next(
+        index
+        for index, (name, payload) in enumerate(op.calls)
+        if name == "create_unique_constraint"
+        and payload == "uq_preset_recent_user_template"
+    )
+
+    assert duplicate_delete_index < unique_constraint_index

--- a/tests/unit/scripts/test_create_issue_implement_preset_workflows.py
+++ b/tests/unit/scripts/test_create_issue_implement_preset_workflows.py
@@ -45,8 +45,7 @@ def test_build_payload_uses_jira_implement_pr_with_merge_automation() -> None:
             {"title": "Load Jira preset brief"},
             {"title": "Finalize Jira status"},
         ],
-        applied_template={"slug": "jira-implement", "version": "1.1.0"},
-        preset_version="1.1.0",
+        applied_template={"slug": "jira-implement", "presetDigest": "digest123"},
     )
 
     assert payload["type"] == "task"
@@ -56,7 +55,7 @@ def test_build_payload_uses_jira_implement_pr_with_merge_automation() -> None:
     assert request_payload["publishMode"] == "pr"
     assert request_payload["mergeAutomation"] == {"enabled": True}
     assert request_payload["idempotencyKey"] == (
-        "jira-implement:MM-770:MoonLadderStudios/MoonMind:codex_cli:1.1.0:"
+        "jira-implement:MM-770:MoonLadderStudios/MoonMind:codex_cli:"
         "pr-merge-automation-expanded-steps"
     )
 
@@ -74,20 +73,18 @@ def test_build_payload_uses_jira_implement_pr_with_merge_automation() -> None:
     }
     assert task["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.1.0",
         "scope": "global",
     }
     assert task["presetSchedule"] == {
         "source": "batch",
         "reason": "jira_issue_batch",
         "presetSlug": "jira-implement",
-        "presetVersion": "1.1.0",
         "issueProvider": "jira",
         "issueRef": "MM-770",
         "jiraIssueKey": "MM-770",
     }
     assert task["appliedStepTemplates"] == [
-        {"slug": "jira-implement", "version": "1.1.0"}
+        {"slug": "jira-implement", "presetDigest": "digest123"}
     ]
 
 
@@ -97,7 +94,6 @@ def test_build_payload_idempotency_key_includes_run_shaping_inputs() -> None:
         issue_ref="MM-770",
         repository="MoonLadderStudios/MoonMind",
         runtime="codex_cli",
-        preset_version="1.1.0",
         expanded_steps=[],
     )["payload"]["idempotencyKey"]
     changed_repository = build_payload(
@@ -105,7 +101,6 @@ def test_build_payload_idempotency_key_includes_run_shaping_inputs() -> None:
         issue_ref="MM-770",
         repository="MoonLadderStudios/Other",
         runtime="codex_cli",
-        preset_version="1.1.0",
         expanded_steps=[],
     )["payload"]["idempotencyKey"]
     changed_runtime = build_payload(
@@ -113,21 +108,10 @@ def test_build_payload_idempotency_key_includes_run_shaping_inputs() -> None:
         issue_ref="MM-770",
         repository="MoonLadderStudios/MoonMind",
         runtime="claude_code",
-        preset_version="1.1.0",
         expanded_steps=[],
     )["payload"]["idempotencyKey"]
-    changed_version = build_payload(
-        provider="jira",
-        issue_ref="MM-770",
-        repository="MoonLadderStudios/MoonMind",
-        runtime="codex_cli",
-        preset_version="2.0.0",
-        expanded_steps=[],
-    )["payload"]["idempotencyKey"]
-
     assert base != changed_repository
     assert base != changed_runtime
-    assert base != changed_version
 
 
 def test_build_expand_payload_targets_jira_issue_picker_input() -> None:
@@ -136,11 +120,9 @@ def test_build_expand_payload_targets_jira_issue_picker_input() -> None:
         issue="mm-779",
         repository="MoonLadderStudios/MoonMind",
         runtime="codex_cli",
-        preset_version="1.1.0",
     )
 
     assert payload == {
-        "version": "1.1.0",
         "inputs": {"jira_issue": {"key": "MM-779"}, "constraints": ""},
         "context": {
             "repository": "MoonLadderStudios/MoonMind",
@@ -166,7 +148,7 @@ def test_post_json_returns_failure_for_urlopen_exceptions(monkeypatch) -> None:
 def test_main_continues_after_expand_failure(monkeypatch, capsys) -> None:
     expanded = {
         "steps": [{"title": f"Step {index}"} for index in range(8)],
-        "appliedTemplate": {"slug": "jira-implement", "version": "1.1.0"},
+        "appliedTemplate": {"slug": "jira-implement", "presetDigest": "digest123"},
     }
 
     def fake_expand_issue_implement(**kwargs):
@@ -230,7 +212,6 @@ def test_build_payload_passes_claude_code_model_and_effort() -> None:
         runtime="claude_code",
         model="claude-opus-4-8",
         effort="xhigh",
-        preset_version="1.1.0",
         expanded_steps=[{"title": "Load Jira preset brief"}],
     )
 
@@ -250,7 +231,7 @@ def test_build_payload_passes_claude_code_model_and_effort() -> None:
     expected_token = "rt-" + hashlib.sha256(b"claude-opus-4-8|xhigh").hexdigest()[:10]
     key = request_payload["idempotencyKey"]
     assert key == (
-        f"jira-implement:MM-874:MoonLadderStudios/MoonMind:claude_code:1.1.0:"
+        f"jira-implement:MM-874:MoonLadderStudios/MoonMind:claude_code:"
         f"{expected_token}:pr-merge-automation-expanded-steps"
     )
     assert len(key) <= 128
@@ -262,12 +243,11 @@ def test_build_payload_without_overrides_keeps_runtime_only_and_stable_key() -> 
         issue_ref="MM-770",
         repository="MoonLadderStudios/MoonMind",
         runtime="codex_cli",
-        preset_version="1.1.0",
         expanded_steps=[],
     )["payload"]
     assert payload["task"]["runtime"] == {"mode": "codex_cli"}
     assert payload["idempotencyKey"] == (
-        "jira-implement:MM-770:MoonLadderStudios/MoonMind:codex_cli:1.1.0:"
+        "jira-implement:MM-770:MoonLadderStudios/MoonMind:codex_cli:"
         "pr-merge-automation-expanded-steps"
     )
 
@@ -288,7 +268,7 @@ def test_extract_column_issue_keys_unknown_column_is_empty() -> None:
 def test_main_discovers_board_to_do_issues(monkeypatch, capsys) -> None:
     expanded = {
         "steps": [{"title": f"Step {index}"} for index in range(8)],
-        "appliedTemplate": {"slug": "jira-implement", "version": "1.1.0"},
+        "appliedTemplate": {"slug": "jira-implement", "presetDigest": "digest123"},
     }
     submitted: list[dict] = []
 

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -71,7 +71,6 @@ _GITHUB_TARGET: dict[str, Any] = {
 def _jira_config(module, **overrides):
     defaults = dict(
         preset_slug="jira-implement",
-        preset_version="1.1.0",
         preset_scope="global",
         publish_mode="pr",
         constraints="Be careful",
@@ -83,7 +82,6 @@ def _jira_config(module, **overrides):
 def _github_config(module, **overrides):
     defaults = dict(
         preset_slug="github-issue-implement",
-        preset_version="1.0.0",
         preset_scope="global",
         publish_mode="branch",
         constraints="",
@@ -162,8 +160,8 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     # The selected preset is authored as the child taskTemplate (read by the
     # execution API), not inert batchTargetPreset metadata.
     assert payload["task"]["taskTemplate"]["slug"] == "jira-implement"
-    assert payload["task"]["taskTemplate"]["version"] == "1.1.0"
     assert payload["task"]["taskTemplate"]["scope"] == "global"
+    assert "version" not in payload["task"]["taskTemplate"]
     assert "batchTargetPreset" not in payload["task"]
     # Stable, length-bounded idempotency key.
     key = payload["idempotencyKey"]
@@ -171,16 +169,15 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
 
 
-def test_build_child_request_authors_selected_preset_version_scope_and_ref():
-    # A non-default preset version / personal scope / scopeRef must be carried
-    # into the child taskTemplate so the execution API expands the exact
-    # selected preset instead of the goal scheduler's hard-coded global version.
+def test_build_child_request_authors_selected_preset_scope_and_ref():
+    # Personal scope / scopeRef must be carried into the child taskTemplate so
+    # the execution API expands the exact selected preset instead of the goal
+    # scheduler's global default.
     module = _load_module()
     request = module["build_child_request"](
         _JIRA_TARGET,
         config=_jira_config(
             module,
-            preset_version="2.3.0",
             preset_scope="personal",
             preset_scope_ref="user-123",
         ),
@@ -190,9 +187,9 @@ def test_build_child_request_authors_selected_preset_version_scope_and_ref():
     )
     template = request["payload"]["task"]["taskTemplate"]
     assert template["slug"] == "jira-implement"
-    assert template["version"] == "2.3.0"
     assert template["scope"] == "personal"
     assert template["scopeRef"] == "user-123"
+    assert "version" not in template
     assert "batchTargetPreset" not in request["payload"]["task"]
 
 
@@ -206,6 +203,30 @@ def test_build_child_request_omits_scope_ref_when_blank():
         inherit_runtime_from_caller=True,
     )
     assert "scopeRef" not in request["payload"]["task"]["taskTemplate"]
+
+
+def test_parse_args_accepts_slug_scope_without_preset_version(tmp_path):
+    module = _load_module()
+    targets = tmp_path / "targets.json"
+    targets.write_text("[]", encoding="utf-8")
+
+    args = module["_parse_args"](
+        [
+            "--targets",
+            str(targets),
+            "--target-preset-slug",
+            "jira-implement",
+            "--target-preset-scope",
+            "global",
+            "--publish-mode",
+            "pr",
+            "--max-workflows",
+            "1",
+        ]
+    )
+
+    assert args.target_preset_slug == "jira-implement"
+    assert not hasattr(args, "target_preset_version")
 
 
 def test_build_child_request_without_caller_omits_inheritance_directive():

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -513,7 +513,6 @@ def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
                 "authoredPresets": [
                     {
                         "presetId": "runtime-quality-followup",
-                        "version": "2026-04-17",
                     }
                 ],
                 "steps": [
@@ -524,7 +523,6 @@ def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
                         "source": {
                             "kind": "preset-derived",
                             "presetId": "runtime-quality-followup",
-                            "version": "2026-04-17",
                         },
                     }
                 ],
@@ -536,13 +534,11 @@ def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
     assert task["authoredPresets"] == [
         {
             "presetId": "runtime-quality-followup",
-            "presetVersion": "2026-04-17",
         }
     ]
     assert task["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
-        "presetVersion": "2026-04-17",
     }
 
 def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
@@ -562,7 +558,6 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
                     "source": {
                         "kind": "preset-derived",
                         "presetId": "jira-flow",
-                        "presetVersion": "2026-04-24",
                         "includePath": ["root", "fetch"],
                         "originalStepId": "fetch-jira-issue",
                     },
@@ -588,7 +583,6 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
     assert dumped_steps[0]["source"] == {
         "kind": "preset-derived",
         "presetId": "jira-flow",
-        "presetVersion": "2026-04-24",
         "includePath": ["root", "fetch"],
         "originalStepId": "fetch-jira-issue",
     }
@@ -603,12 +597,10 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
         {
             "kind": "preset-derived",
             "presetId": "stale-preset",
-            "presetVersion": "missing-from-catalog",
         },
         {
             "kind": "preset-include",
             "presetSlug": "parent-flow",
-            "presetVersion": "2026-04-24",
             "includePath": ["root", "child"],
             "originalStepId": "child-step",
         },
@@ -652,7 +644,6 @@ def test_task_steps_preserve_detached_template_source_provenance() -> None:
                     "source": {
                         "kind": "detached",
                         "presetSlug": "quality-flow",
-                        "presetVersion": "1.0.0",
                         "includePath": ["root-flow@1.0.0", "quality-flow@1.0.0"],
                         "originalStepId": "lint-target",
                     },
@@ -665,7 +656,6 @@ def test_task_steps_preserve_detached_template_source_provenance() -> None:
     assert dumped["source"] == {
         "kind": "detached",
         "presetSlug": "quality-flow",
-        "presetVersion": "1.0.0",
         "includePath": ["root-flow@1.0.0", "quality-flow@1.0.0"],
         "originalStepId": "lint-target",
     }
@@ -680,13 +670,11 @@ def test_canonical_task_payload_preserves_recursive_preset_source_original_step_
                 "authoredPresets": [
                     {
                         "presetSlug": "parent-flow",
-                        "presetVersion": "1.0.0",
                         "scope": "global",
                         "includePath": ["parent-flow@1.0.0"],
                     },
                     {
                         "presetSlug": "child-checks",
-                        "presetVersion": "1.0.0",
                         "alias": "quality",
                         "scope": "global",
                         "includePath": [
@@ -705,7 +693,6 @@ def test_canonical_task_payload_preserves_recursive_preset_source_original_step_
                         "source": {
                             "kind": "preset-derived",
                             "presetSlug": "child-checks",
-                            "presetVersion": "1.0.0",
                             "includePath": [
                                 "parent-flow@1.0.0",
                                 "quality:child-checks@1.0.0",
@@ -740,7 +727,6 @@ def test_canonical_task_payload_preserves_detached_template_source_provenance() 
                         "source": {
                             "kind": "detached",
                             "presetSlug": "quality-flow",
-                            "presetVersion": "1.0.0",
                             "includePath": [
                                 "root-flow@1.0.0",
                                 "quality-flow@1.0.0",
@@ -757,7 +743,6 @@ def test_canonical_task_payload_preserves_detached_template_source_provenance() 
     assert task["steps"][0]["source"] == {
         "kind": "detached",
         "presetSlug": "quality-flow",
-        "presetVersion": "1.0.0",
         "includePath": ["root-flow@1.0.0", "quality-flow@1.0.0"],
         "originalStepId": "lint-target",
     }
@@ -771,13 +756,11 @@ def test_task_authored_presets_accept_recursive_bindings() -> None:
                 "authoredPresets": [
                     {
                         "presetSlug": "parent-flow",
-                        "presetVersion": "1.0.0",
                         "scope": "global",
                         "includePath": ["parent-flow@1.0.0"],
                     },
                     {
                         "presetSlug": "child-checks",
-                        "presetVersion": "1.0.0",
                         "alias": "quality",
                         "scope": "global",
                         "includePath": [
@@ -795,7 +778,6 @@ def test_task_authored_presets_accept_recursive_bindings() -> None:
                         "source": {
                             "kind": "preset-derived",
                             "presetSlug": "child-checks",
-                            "presetVersion": "1.0.0",
                             "includePath": [
                                 "parent-flow@1.0.0",
                                 "quality:child-checks@1.0.0",
@@ -810,7 +792,6 @@ def test_task_authored_presets_accept_recursive_bindings() -> None:
     task = payload.model_dump(by_alias=True, exclude_none=True)["workflow"]
     assert task["authoredPresets"][1] == {
         "presetSlug": "child-checks",
-        "presetVersion": "1.0.0",
         "alias": "quality",
         "includePath": [
             "parent-flow@1.0.0",
@@ -1106,7 +1087,7 @@ def test_jira_orchestrate_preset_context_allows_first_step_skill_pr_publish() ->
                 "publish": {"mode": "pr"},
                 "steps": [
                     {
-                        "id": "tpl:jira-orchestrate:1.0.0:01",
+                        "id": "tpl:jira-orchestrate:01",
                         "title": "Move Jira issue",
                         "instructions": "Transition THOR-352 to In Progress.",
                         "skill": {"id": "jira-issue-updater", "args": {}},
@@ -1115,8 +1096,7 @@ def test_jira_orchestrate_preset_context_allows_first_step_skill_pr_publish() ->
                 "appliedStepTemplates": [
                     {
                         "slug": "jira-orchestrate",
-                        "version": "1.0.0",
-                        "stepIds": ["tpl:jira-orchestrate:1.0.0:01"],
+                        "stepIds": ["tpl:jira-orchestrate:01"],
                     }
                 ],
             },

--- a/tests/unit/workflows/executions/test_preset_goal_scheduler.py
+++ b/tests/unit/workflows/executions/test_preset_goal_scheduler.py
@@ -10,7 +10,6 @@ def test_schedule_preset_from_goal_selects_jira_implement_for_issue_goal() -> No
 
     assert schedule is not None
     assert schedule.slug == "jira-implement"
-    assert schedule.version == "1.1.0"
     assert schedule.issue_key == "MM-747"
     assert schedule.inputs["jira_issue_key"] == "MM-747"
 
@@ -31,7 +30,6 @@ def test_schedule_preset_from_goal_selects_github_issue_implement_for_issue_url(
 
     assert schedule is not None
     assert schedule.slug == "github-issue-implement"
-    assert schedule.version == "1.0.0"
     assert schedule.issue_key == "MoonLadderStudios/MoonMind#123"
     assert schedule.inputs["github_issue"] == {
         "repository": "MoonLadderStudios/MoonMind",

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -591,7 +591,6 @@ async def test_promote_proposal_applies_runtime_override() -> None:
                     "authoredPresets": [
                         {
                             "presetId": "runtime-quality-followup",
-                            "presetVersion": "2026-04-17",
                         }
                     ],
                     "steps": [
@@ -602,7 +601,6 @@ async def test_promote_proposal_applies_runtime_override() -> None:
                             "source": {
                                 "kind": "preset-derived",
                                 "presetId": "runtime-quality-followup",
-                                "presetVersion": "2026-04-17",
                             },
                         }
                     ],
@@ -627,13 +625,11 @@ async def test_promote_proposal_applies_runtime_override() -> None:
     assert final_request["payload"]["workflow"]["authoredPresets"] == [
         {
             "presetId": "runtime-quality-followup",
-            "presetVersion": "2026-04-17",
         }
     ]
     assert final_request["payload"]["workflow"]["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
-        "presetVersion": "2026-04-17",
     }
     assert (
         updated_proposal.workflow_create_request["payload"]["workflow"]["runtime"]["mode"]
@@ -728,7 +724,6 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
                     "authoredPresets": [
                         {
                             "presetId": "runtime-quality-followup",
-                            "presetVersion": "2026-04-17",
                             "includePath": ["root", "regression-coverage"],
                         }
                     ],
@@ -744,7 +739,6 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
                             "source": {
                                 "kind": "preset-derived",
                                 "presetId": "runtime-quality-followup",
-                                "presetVersion": "2026-04-17",
                                 "includePath": ["root", "regression-coverage"],
                                 "originalStepId": "add-regression-test",
                             },
@@ -768,14 +762,12 @@ async def test_promote_proposal_preserves_preset_provenance() -> None:
     assert task["authoredPresets"] == [
         {
             "presetId": "runtime-quality-followup",
-            "presetVersion": "2026-04-17",
             "includePath": ["root", "regression-coverage"],
         }
     ]
     assert task["steps"][0]["source"] == {
         "kind": "preset-derived",
         "presetId": "runtime-quality-followup",
-        "presetVersion": "2026-04-17",
         "includePath": ["root", "regression-coverage"],
         "originalStepId": "add-regression-test",
     }
@@ -797,7 +789,6 @@ async def test_promote_proposal_uses_reviewed_flattened_payload_without_reexpans
             "source": {
                 "kind": "preset-derived",
                 "presetSlug": "jira-orchestrate",
-                "presetVersion": "reviewed-version",
                 "originalStepId": "implement-story",
             },
         }
@@ -822,7 +813,6 @@ async def test_promote_proposal_uses_reviewed_flattened_payload_without_reexpans
                     "authoredPresets": [
                         {
                             "presetSlug": "jira-orchestrate",
-                            "presetVersion": "reviewed-version",
                         }
                     ],
                     "steps": reviewed_steps,
@@ -845,7 +835,7 @@ async def test_promote_proposal_uses_reviewed_flattened_payload_without_reexpans
     assert task["steps"][0]["id"] == reviewed_steps[0]["id"]
     assert task["steps"][0]["type"] == reviewed_steps[0]["type"]
     assert task["steps"][0]["skill"] == reviewed_steps[0]["skill"]
-    assert task["steps"][0]["source"]["presetVersion"] == "reviewed-version"
+    assert "presetVersion" not in task["steps"][0]["source"]
     assert task["taskTemplate"]["version"] == "live-version-that-must-not-be-expanded"
 
 
@@ -911,7 +901,6 @@ async def test_promote_proposal_rejects_preset_derived_steps_without_flat_type()
                             "source": {
                                 "kind": "preset-derived",
                                 "presetId": "runtime-quality-followup",
-                                "presetVersion": "2026-04-17",
                             },
                         }
                     ],

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -2105,7 +2105,6 @@ async def test_create_jira_implement_tasks_targets_jira_implement_preset():
     first_task = first_request["initial_parameters"]["workflow"]
     assert first_task["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.1.0",
     }
     assert first_task["title"].startswith("Run Jira Implement for MM-501")
     assert "Run Jira Implement for MM-501" in first_task["instructions"]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -377,14 +377,12 @@ async def test_child_run_auto_sequences_jira_goal_through_implement_preset(tmp_p
     task = expanded_parameters["task"]
     assert task["taskTemplate"] == {
         "slug": "jira-implement",
-        "version": "1.1.0",
         "scope": "global",
     }
     assert task["presetSchedule"] == {
         "source": "goal",
         "reason": "jira_issue_goal",
         "presetSlug": "jira-implement",
-        "presetVersion": "1.1.0",
         "jiraIssueKey": "MM-747",
     }
     assert task["inputs"]["jira_issue_key"] == "MM-747"
@@ -520,7 +518,6 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
                         "source": {
                             "kind": "preset-derived",
                             "presetId": "jira-flow",
-                            "presetVersion": "catalog-version-that-need-not-exist",
                             "includePath": ["root", "fetch"],
                             "originalStepId": "fetch-jira-issue",
                         },
@@ -543,7 +540,6 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
     assert plan["nodes"][0]["inputs"]["source"] == {
         "kind": "preset-derived",
         "presetId": "jira-flow",
-        "presetVersion": "catalog-version-that-need-not-exist",
         "includePath": ["root", "fetch"],
         "originalStepId": "fetch-jira-issue",
     }
@@ -573,7 +569,6 @@ def test_runtime_planner_maps_explicit_skill_step_with_provenance_to_agent_runti
                         "source": {
                             "kind": "preset-derived",
                             "presetSlug": "jira-orchestrate",
-                            "presetVersion": "1.0.0",
                         },
                     }
                 ],
@@ -594,7 +589,6 @@ def test_runtime_planner_maps_explicit_skill_step_with_provenance_to_agent_runti
     assert plan["nodes"][0]["inputs"]["source"] == {
         "kind": "preset-derived",
         "presetSlug": "jira-orchestrate",
-        "presetVersion": "1.0.0",
     }
 
 
@@ -623,7 +617,6 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
                         "source": {
                             "kind": "preset-derived",
                             "presetSlug": "jira-orchestrate",
-                            "presetVersion": "1.0.0",
                         },
                     },
                     {
@@ -638,7 +631,6 @@ def test_runtime_planner_orders_flattened_tool_and_skill_steps_with_provenance()
                         "source": {
                             "kind": "preset-derived",
                             "presetSlug": "jira-orchestrate",
-                            "presetVersion": "1.0.0",
                         },
                     },
                 ],
@@ -1087,7 +1079,6 @@ def test_detect_host_project_dir_returns_none_after_exhausting_retries(
         {
             "kind": "preset-derived",
             "presetId": "removed-preset",
-            "presetVersion": "stale",
         },
     ],
 )
@@ -1940,7 +1931,6 @@ async def test_child_jira_orchestrate_run_expands_seeded_template_steps(tmp_path
     assert task["appliedStepTemplates"][0]["slug"] == "jira-orchestrate"
     assert len(task["appliedStepTemplates"][0]["stepIds"]) == 26
     assert task["authoredPresets"][0]["presetSlug"] == "jira-orchestrate"
-    assert task["authoredPresets"][0]["presetVersion"] == "1.0.0"
     assert "authoredPresets" not in task["appliedStepTemplates"][0]
     assert task["appliedStepTemplates"][0]["composition"]["slug"] == "jira-orchestrate"
     assert all(step["type"] != "preset" for step in task["steps"])
@@ -2005,7 +1995,7 @@ async def test_child_jira_orchestrate_workflow_payload_expands_seeded_template_s
     )
 
     first_node = plan["nodes"][0]
-    assert first_node["id"].startswith("tpl:jira-orchestrate:1.0.0:01")
+    assert first_node["id"].startswith("tpl:jira-orchestrate:01")
     assert first_node["tool"] == {
         "type": "agent_runtime",
         "name": "codex_cli",
@@ -2091,7 +2081,6 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
             "authoredPresets": [
                 {
                     "presetSlug": "jira-orchestrate",
-                    "presetVersion": "1.0.0",
                     "inputBindings": {"issueKey": "MM-501"},
                 }
             ],
@@ -2102,7 +2091,6 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
                     "instructions": "Do the first step.",
                     "presetProvenance": {
                         "presetSlug": "jira-orchestrate",
-                        "presetVersion": "1.0.0",
                     },
                 }
             ],
@@ -2239,9 +2227,7 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
     assert authored["includeTreeSummary"] == [
         {
             "presetSlug": "jira-orchestrate",
-            "presetVersion": "1.0.0",
             "includedSlug": "jira-fetch",
-            "includedVersion": "1.0.0",
         }
     ]
     assert authored["perStepProvenance"] == [
@@ -2250,7 +2236,6 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
             "ordinal": 0,
             "presetProvenance": {
                 "presetSlug": "jira-orchestrate",
-                "presetVersion": "1.0.0",
             },
         }
     ]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2227,7 +2227,9 @@ async def test_child_jira_orchestrate_run_persists_original_task_input_snapshot(
     assert authored["includeTreeSummary"] == [
         {
             "presetSlug": "jira-orchestrate",
+            "presetDigest": None,
             "includedSlug": "jira-fetch",
+            "includedDigest": None,
         }
     ]
     assert authored["perStepProvenance"] == [

--- a/tests/unit/workflows/temporal/workflows/test_run_proposals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_proposals.py
@@ -570,7 +570,6 @@ async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
                     {
                         "id": "preset-1",
                         "name": "Implementation preset",
-                        "version": "2026-06-21",
                         "sourceRef": "artifact://preset-source",
                         "body": "raw preset body should not cross workflow history",
                     }
@@ -605,7 +604,6 @@ async def test_run_proposals_stage_passes_artifact_refs_instead_of_raw_inputs(
                 {
                     "id": "preset-1",
                     "name": "Implementation preset",
-                    "version": "2026-06-21",
                     "sourceRef": "artifact://preset-source",
                     "index": 0,
                 }


### PR DESCRIPTION
Issue reference
- MM-912: https://moonladder.atlassian.net/browse/MM-912

Summary
- Removed semantic-version preset identity from expansion paths, include handling, provenance, request payloads, serializers, CLI output, frontend submission state, and seeded preset definitions.
- Added slug/scope current-definition persistence changes, including a migration that moves active definition fields onto Preset and disables latest-version relationships.
- Updated preset include cycle handling, missing-target behavior, and tests to use slug/scope/scopeRef identity with digest/source provenance.

Tests run
- ./tools/test_unit.sh tests/unit/api/test_presets_service.py tests/unit/api/routers/test_presets.py tests/unit/agents/test_preset_cli.py tests/unit/api/test_batch_workflows_preset.py tests/unit/scripts/test_create_issue_implement_preset_workflows.py

Remaining risks
- Full integration suite was not run in this PR-publication step.
- Existing persisted preset-version data depends on the new migration path during deployment.