### PR TITLE
MM-914 remove semantic skill versions

### DIFF
--- a/moonmind/mcp/skills_on_demand_registry.py
+++ b/moonmind/mcp/skills_on_demand_registry.py
@@ -175,15 +175,12 @@ class SkillsOnDemandToolRegistry:
             return initial_result
 
         requested = service.normalized_requested_skills(request)
-        active_versions = {
-            skill.skill_name: skill.version for skill in active_snapshot.skills
-        }
+        active_names = {skill.skill_name for skill in active_snapshot.skills}
         addition_selector = SkillSelector(
             include=[
-                SkillSelectorEntry(name=name, version=version)
-                for name, version in requested
-                if name not in active_versions
-                or (version is not None and active_versions[name] != version)
+                SkillSelectorEntry(name=name)
+                for name in requested
+                if name not in active_names
             ]
         )
         snapshot_id = f"skillset_mcp_{active_snapshot.snapshot_id}_derived"

--- a/moonmind/schemas/agent_skill_models.py
+++ b/moonmind/schemas/agent_skill_models.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 class AgentSkillSourceKind(str, enum.Enum):
     """Source provenance for a resolved skill."""
@@ -30,9 +30,16 @@ class SkillSelectorEntry(BaseModel):
     """An explicit include rule for a single skill."""
 
     name: str
-    version: str | None = None
     
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("name")
+    @classmethod
+    def _reject_versioned_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if ":" in normalized:
+            raise ValueError("skill selector names must not include semantic versions")
+        return normalized
 
 class SkillSelector(BaseModel):
     """Selection intent expressing which agent skills should be active."""
@@ -48,17 +55,15 @@ class AgentSkillProvenance(BaseModel):
     """Metadata explaining where a resolved skill instance came from."""
 
     source_kind: AgentSkillSourceKind
-    original_version: str | None = None
     source_path: str | None = None
     skill_set_name: str | None = None
     
     model_config = ConfigDict(extra="forbid")
 
 class ResolvedSkillEntry(BaseModel):
-    """An individual agent skill and the immutable version selected for a run."""
+    """An individual agent skill selected for a run."""
 
     skill_name: str
-    version: str | None = None
     format: AgentSkillFormat = AgentSkillFormat.MARKDOWN
     content_ref: str | None = None
     content_digest: str | None = None
@@ -114,7 +119,6 @@ SkillsOnDemandDeniedCode = Literal[
     "invalid_request",
     "snapshot_not_found",
     "skill_not_found",
-    "version_not_found",
     "policy_denied",
     "runtime_incompatible",
     "tool_policy_denied",
@@ -179,7 +183,6 @@ class SkillCatalogSearchResult(BaseModel):
     name: str
     title: str | None = None
     description: str | None = None
-    latest_version: str | None = None
     source_kind: AgentSkillSourceKind
     supported_runtimes: list[str] = Field(default_factory=list)
     required_capabilities: list[str] = Field(default_factory=list)
@@ -221,9 +224,16 @@ class SkillsOnDemandRequestedSkill(BaseModel):
     """A single on-demand Skill requested by a managed runtime."""
 
     name: str
-    version: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("name")
+    @classmethod
+    def _reject_versioned_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if ":" in normalized:
+            raise ValueError("requested skill names must not include semantic versions")
+        return normalized
 
 
 class SkillsOnDemandRequest(BaseModel):

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -13,12 +13,6 @@ from moonmind.schemas.agent_skill_models import (
     RuntimeMaterializationMode,
     RuntimeSkillMaterialization,
 )
-from moonmind.workflows.skills.workspace_links import (
-    SkillWorkspaceLinks,
-    SkillWorkspaceError,
-    ensure_shared_skill_links,
-    is_moonmind_owned_projection,
-)
 
 _CANONICAL_ALIAS = ".agents/skills"
 
@@ -149,6 +143,11 @@ class AgentSkillMaterializer:
                 ) from ex
 
             if self.project_adapter_aliases:
+                from moonmind.workflows.skills.workspace_links import (
+                    SkillWorkspaceError,
+                    ensure_shared_skill_links,
+                )
+
                 try:
                     require_agents_link = not self._is_repo_authored_skills_dir(alias_dir)
                     require_gemini_link = self._runtime_needs_gemini_projection(runtime_id)
@@ -176,6 +175,8 @@ class AgentSkillMaterializer:
                         self._projection_error_message(alias_dir, cause=str(ex))
                     ) from ex
             else:
+                from moonmind.workflows.skills.workspace_links import SkillWorkspaceLinks
+
                 alias_skipped_reason = "adapter_alias_projection_disabled"
                 visible_path = active_dir
                 links = SkillWorkspaceLinks(
@@ -273,7 +274,6 @@ class AgentSkillMaterializer:
             "content_ref": entry.content_ref,
             "name": entry.skill_name,
             "source_kind": entry.provenance.source_kind.value,
-            "version": entry.version,
         }
         if entry.required_by:
             payload["required_by"] = entry.required_by
@@ -309,6 +309,8 @@ class AgentSkillMaterializer:
 
     @staticmethod
     def _preflight_projection(alias_dir: Path, *, active_dir: Path) -> None:
+        from moonmind.workflows.skills.workspace_links import is_moonmind_owned_projection
+
         if not alias_dir.exists() and not alias_dir.is_symlink():
             return
         if alias_dir.is_symlink() and is_moonmind_owned_projection(

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -83,7 +83,6 @@ class BuiltInSkillLoader(SkillLoader):
         results = _scan_for_skills(
             self.skills_root,
             AgentSkillSourceKind.BUILT_IN,
-            version="1.0.0",
             skip_names={"local"},
         )
         discovered = {entry.skill_name for entry in results}
@@ -104,7 +103,6 @@ class BuiltInSkillLoader(SkillLoader):
             results.append(
                 ResolvedSkillEntry(
                     skill_name=name,
-                    version="1.0.0",
                     provenance=AgentSkillProvenance(
                         source_kind=AgentSkillSourceKind.BUILT_IN
                     ),
@@ -185,7 +183,6 @@ class DeploymentSkillLoader(SkillLoader):
                 results.append(
                     ResolvedSkillEntry(
                         skill_name=definition.slug,
-                        version=latest_version.version_string,
                         format=AgentSkillFormat(latest_version.format.value),
                         content_ref=latest_version.artifact_ref,
                         content_digest=latest_version.content_digest,
@@ -204,7 +201,6 @@ def _scan_for_skills(
     skills_dir: Path,
     source_kind: AgentSkillSourceKind,
     *,
-    version: str = "latest",
     skip_names: set[str] | None = None,
 ) -> list[ResolvedSkillEntry]:
     results = []
@@ -218,7 +214,6 @@ def _scan_for_skills(
             results.append(
                 ResolvedSkillEntry(
                     skill_name=item.name,
-                    version=version,
                     provenance=AgentSkillProvenance(
                         source_kind=source_kind,
                         source_path=str(item),
@@ -579,18 +574,11 @@ class AgentSkillResolver:
 
         excluded_names = {str(name).strip() for name in selector.exclude if str(name).strip()}
 
-        # Pinning strict check
         for include_entry in selector.include:
             if include_entry.name in excluded_names:
                 raise ValueError(
                     f"selected skill '{include_entry.name}' cannot also be excluded"
                 )
-            if include_entry.version:
-                resolved = resolved_map.get(include_entry.name)
-                if not resolved or resolved.version != include_entry.version:
-                    raise ValueError(
-                        f"Could not resolve pinned version '{include_entry.name}@{include_entry.version}' across any active sources"
-                    )
 
         requested_names = {entry.name for entry in selector.include}
         # Note: Future implementation for `sets` would expand skill names here.

--- a/moonmind/services/skills_on_demand.py
+++ b/moonmind/services/skills_on_demand.py
@@ -88,7 +88,6 @@ class SkillsOnDemandService:
                 part
                 for part in [
                     entry.skill_name,
-                    entry.version or "",
                     entry.selection_reason or "",
                 ]
                 if part
@@ -145,13 +144,9 @@ class SkillsOnDemandService:
         requested = self.normalized_requested_skills(request)
         active_snapshot = request.active_snapshot
         assert active_snapshot is not None
-        active_entries = {entry.skill_name: entry for entry in active_snapshot.skills}
-        if all(
-            name in active_entries
-            and (version is None or active_entries[name].version == version)
-            for name, version in requested
-        ):
-            requested_names = [name for name, _version in requested]
+        active_names = {entry.skill_name for entry in active_snapshot.skills}
+        if all(name in active_names for name in requested):
+            requested_names = list(requested)
             return SkillsOnDemandRequestResult(
                 status="no_change",
                 code=SKILLS_ON_DEMAND_ALREADY_ACTIVE_CODE,
@@ -245,7 +240,7 @@ class SkillsOnDemandService:
         materialization: RuntimeSkillMaterialization | None = None,
     ) -> SkillsOnDemandRequestResult:
         requested = self.normalized_requested_skills(request)
-        requested_names = [name for name, _version in requested]
+        requested_names = list(requested)
         active_names = {
             skill.skill_name for skill in (request.active_snapshot.skills if request.active_snapshot else [])
         }
@@ -307,14 +302,13 @@ class SkillsOnDemandService:
 
     def normalized_requested_skills(
         self, request: SkillsOnDemandRequest
-    ) -> list[tuple[str, str | None]]:
-        seen: dict[str, str | None] = {}
+    ) -> list[str]:
+        seen: dict[str, None] = {}
         for skill in request.requested_skills:
             name = skill.name.strip()
-            version = skill.version.strip() if skill.version is not None else None
             if name not in seen:
-                seen[name] = version
-        return [(name, version) for name, version in seen.items()]
+                seen[name] = None
+        return list(seen.keys())
 
     def _validate_activation_request(
         self, request: SkillsOnDemandRequest
@@ -327,17 +321,14 @@ class SkillsOnDemandService:
             return "current_snapshot_ref does not match active_snapshot."
         if not request.requested_skills:
             return "requested_skills must contain at least one Skill."
-        seen_versions: dict[str, str | None] = {}
+        seen_names: set[str] = set()
         for skill in request.requested_skills:
             if not skill.name.strip():
                 return "requested skill name must not be blank."
-            version = skill.version.strip() if skill.version is not None else None
-            if skill.version is not None and not version:
-                return "requested skill version must not be blank when provided."
             name = skill.name.strip()
-            if name in seen_versions and seen_versions[name] != version:
-                return f"requested skill '{name}' has conflicting versions."
-            seen_versions[name] = version
+            if ":" in name:
+                return "requested skill names must not include semantic versions."
+            seen_names.add(name)
         for field_name in ("reason", "runtime_id", "step_id"):
             value = getattr(request, field_name)
             if value is not None and not value.strip():
@@ -424,7 +415,6 @@ class SkillsOnDemandService:
         eligible, summary = self._eligibility_for(entry)
         return SkillCatalogSearchResult(
             name=entry.skill_name,
-            latest_version=entry.version,
             source_kind=entry.provenance.source_kind,
             required_capabilities=list(entry.required_capabilities),
             eligible=eligible,
@@ -499,9 +489,7 @@ class SkillsOnDemandService:
             if request.runtime_id and request.runtime_id.strip()
             else None,
             parent_snapshot_id=parent_snapshot_id,
-            requested_skills=[
-                name for name, _version in self.normalized_requested_skills(request)
-            ],
+            requested_skills=self.normalized_requested_skills(request),
             result=result,
             result_code=result_code,
             derived_snapshot_id=derived_snapshot_id,

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -252,15 +252,12 @@ class AgentSkillsActivities:
 
         try:
             info = activity.info()
-            active_versions = {
-                skill.skill_name: skill.version for skill in active_snapshot.skills
-            }
+            active_names = {skill.skill_name for skill in active_snapshot.skills}
             addition_selector = SkillSelector(
                 include=[
-                    SkillSelectorEntry(name=name, version=version)
-                    for name, version in requested
-                    if name not in active_versions
-                    or (version is not None and active_versions[name] != version)
+                    SkillSelectorEntry(name=name)
+                    for name in requested
+                    if name not in active_names
                 ]
             )
             context = SkillResolutionContext(
@@ -433,28 +430,16 @@ class AgentSkillsActivities:
     ) -> ResolvedSkillSet:
         active_by_name = {skill.skill_name: skill for skill in active_snapshot.skills}
         merged = dict(active_by_name)
-        requested_versions = {}
+        requested_names = set()
         for requested_skill in request.requested_skills:
             name = requested_skill.name.strip()
-            version = (
-                requested_skill.version.strip()
-                if requested_skill.version is not None
-                else None
-            )
-            if name not in requested_versions:
-                requested_versions[name] = version
+            if name:
+                requested_names.add(name)
         for skill in resolved_additions.skills:
             active_skill = active_by_name.get(skill.skill_name)
-            requested_version = requested_versions.get(skill.skill_name)
             if (
                 active_skill is not None
-                and (
-                    skill.skill_name not in requested_versions
-                    or (
-                        requested_version is None
-                        or requested_version == active_skill.version
-                    )
-                )
+                and skill.skill_name not in requested_names
             ):
                 continue
             merged[skill.skill_name] = skill.model_copy(
@@ -496,8 +481,6 @@ class AgentSkillsActivities:
 
     def _skills_on_demand_resolution_code(self, message: str) -> str:
         lowered = message.lower()
-        if "pinned version" in lowered:
-            return "version_not_found"
         if "runtime" in lowered:
             return "runtime_incompatible"
         if "policy" in lowered or "forbidden" in lowered:
@@ -536,8 +519,6 @@ class AgentSkillsActivities:
 
         for skill in resolved_skillset.skills:
             lines.append(f"## Skill: {skill.skill_name}")
-            if skill.version:
-                lines.append(f"Version: {skill.version}")
             if skill.provenance.source_kind:
                 lines.append(f"Source: {skill.provenance.source_kind.value}")
                 

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -696,17 +696,21 @@ def _normalize_secret_ref(value: object, *, field_name: str) -> str | None:
     return f"vault://{mount}/{path}#{field}"
 
 class WorkflowSkillSelectorExact(BaseModel):
-    """Explicitly included skill by name and optional version."""
+    """Explicitly included skill by name."""
 
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     name: str = Field(..., alias="name")
-    version: str | None = Field(None, alias="version")
 
-    @field_validator("name", "version", mode="before")
+    @field_validator("name", mode="before")
     @classmethod
     def _normalize_optional_strings(cls, value: object) -> str | None:
-        return _clean_optional_str(value)
+        normalized = _clean_optional_str(value)
+        if normalized and ":" in normalized:
+            raise WorkflowContractError(
+                "workflow.skills.include names must not include semantic versions"
+            )
+        return normalized
 
 class WorkflowSkillSelectors(BaseModel):
     """Resolved definition for active skills during execution."""
@@ -828,7 +832,6 @@ def build_effective_workflow_skill_selectors(
                 continue
             include_by_name[item.name] = WorkflowSkillSelectorExact(
                 name=item.name,
-                version=item.version,
             )
     for item in excludes:
         include_by_name.pop(item, None)

--- a/moonmind/workflows/skills/materializer.py
+++ b/moonmind/workflows/skills/materializer.py
@@ -62,7 +62,6 @@ class MaterializedSkill:
     """Materialized skill metadata for one run."""
 
     name: str
-    version: str
     source_uri: str
     content_hash: str
     cache_path: Path
@@ -85,7 +84,6 @@ class MaterializedSkillWorkspace:
             "skills": [
                 {
                     "name": skill.name,
-                    "version": skill.version,
                     "sourceUri": skill.source_uri,
                     "contentHash": skill.content_hash,
                     "cachePath": str(skill.cache_path),
@@ -549,7 +547,7 @@ def _ensure_signature(entry: ResolvedSkill, *, verify_signatures: bool) -> None:
     if verify_signatures and not entry.signature:
         raise SkillMaterializationError(
             "signature_missing",
-            f"Skill '{entry.skill_name}:{entry.version}' is missing a required signature",
+            f"Skill '{entry.skill_name}' is missing a required signature",
         )
 
 def _materialize_cache_entry(
@@ -566,7 +564,7 @@ def _materialize_cache_entry(
         if entry.content_hash and entry.content_hash != computed_hash:
             raise SkillMaterializationError(
                 "hash_mismatch",
-                f"Hash mismatch for '{skill_name}:{entry.version}' "
+                f"Hash mismatch for '{skill_name}' "
                 f"(expected {entry.content_hash}, got {computed_hash})",
             )
 
@@ -585,12 +583,11 @@ def _materialize_cache_entry(
         if not (skill_cache_dir / "SKILL.md").is_file():
             raise SkillMaterializationError(
                 "cache_entry_incomplete",
-                f"Cache entry for '{skill_name}:{entry.version}' is incomplete",
+                f"Cache entry for '{skill_name}' is incomplete",
             )
 
     return MaterializedSkill(
         name=skill_name,
-        version=entry.version,
         source_uri=entry.source_uri,
         content_hash=computed_hash,
         cache_path=skill_cache_dir,

--- a/moonmind/workflows/skills/resolver.py
+++ b/moonmind/workflows/skills/resolver.py
@@ -24,7 +24,6 @@ class ResolvedSkill:
     """Resolved runtime metadata for one selected skill."""
 
     skill_name: str
-    version: str
     source_uri: str
     content_hash: str | None = None
     signature: str | None = None
@@ -45,7 +44,6 @@ class RunSkillSelection:
             "skills": [
                 {
                     "name": skill.skill_name,
-                    "version": skill.version,
                     "sourceUri": skill.source_uri,
                     "contentHash": skill.content_hash,
                     "signature": skill.signature,
@@ -76,12 +74,11 @@ def _normalize_skill_entry(raw: object) -> dict[str, str | None]:
         if not text:
             raise SkillResolutionError("Skill entry cannot be blank")
         if ":" in text:
-            skill_name, version = text.split(":", 1)
-        else:
-            skill_name, version = text, "local"
+            raise SkillResolutionError(
+                "Skill entries must use skill names only; semantic versions are not supported"
+            )
         return {
-            "skill_name": validate_skill_name(skill_name),
-            "version": version.strip() or "local",
+            "skill_name": validate_skill_name(text),
             "source_uri": None,
             "content_hash": None,
             "signature": None,
@@ -91,7 +88,10 @@ def _normalize_skill_entry(raw: object) -> dict[str, str | None]:
         skill_name = str(raw.get("skill_name") or raw.get("name") or "")
         if not skill_name.strip():
             raise SkillResolutionError("Skill entry is missing skill_name")
-        version = str(raw.get("version") or "local").strip() or "local"
+        if "version" in raw:
+            raise SkillResolutionError(
+                "Skill entries must not include semantic version fields"
+            )
         source_uri = (
             str(raw.get("source_uri") or raw.get("sourceUri") or "").strip() or None
         )
@@ -101,7 +101,6 @@ def _normalize_skill_entry(raw: object) -> dict[str, str | None]:
         signature = str(raw.get("signature") or "").strip() or None
         return {
             "skill_name": validate_skill_name(skill_name),
-            "version": version,
             "source_uri": source_uri,
             "content_hash": content_hash,
             "signature": signature,
@@ -303,7 +302,6 @@ def list_available_skill_names() -> tuple[str, ...]:
         try:
             _resolve_source_uri(
                 skill_name=skill_name,
-                version="local",
                 declared_source=None,
                 source_overrides=None,
             )
@@ -317,7 +315,6 @@ def list_available_skill_names() -> tuple[str, ...]:
 def _resolve_source_uri(
     *,
     skill_name: str,
-    version: str,
     declared_source: str | None,
     source_overrides: Mapping[str, object] | None,
 ) -> str:
@@ -325,9 +322,7 @@ def _resolve_source_uri(
         return declared_source
 
     if source_overrides:
-        keyed = source_overrides.get(f"{skill_name}:{version}")
-        fallback = source_overrides.get(skill_name)
-        raw = keyed if keyed is not None else fallback
+        raw = source_overrides.get(skill_name)
         if isinstance(raw, str) and raw.strip():
             return raw.strip()
         if isinstance(raw, Mapping):
@@ -340,7 +335,7 @@ def _resolve_source_uri(
         return local_source
 
     raise SkillResolutionError(
-        f"No source URI resolved for skill '{skill_name}:{version}'. "
+        f"No source URI resolved for skill '{skill_name}'. "
         "Provide skill_sources override or configure a local mirror root."
     )
 
@@ -389,7 +384,6 @@ def resolve_run_skill_selection(
 
     for entry in normalized:
         skill_name = validate_skill_name(str(entry["skill_name"] or ""))
-        version = str(entry["version"] or "local").strip() or "local"
         if skill_name in seen_names:
             raise SkillResolutionError(
                 f"Duplicate skill name '{skill_name}' in resolved selection"
@@ -397,7 +391,6 @@ def resolve_run_skill_selection(
 
         source_uri = _resolve_source_uri(
             skill_name=skill_name,
-            version=version,
             declared_source=entry.get("source_uri"),
             source_overrides=(
                 source_overrides if isinstance(source_overrides, Mapping) else None
@@ -415,7 +408,6 @@ def resolve_run_skill_selection(
         resolved.append(
             ResolvedSkill(
                 skill_name=skill_name,
-                version=version,
                 source_uri=source_uri,
                 content_hash=entry.get("content_hash"),
                 signature=entry.get("signature"),

--- a/moonmind/workflows/skills/run_projection.py
+++ b/moonmind/workflows/skills/run_projection.py
@@ -46,6 +46,33 @@ class SkillProjectionError(RuntimeError):
     """
 
 
+def _strip_legacy_skill_version_fields(data: Any) -> Any:
+    """Remove removed skill-version metadata from persisted pre-cutover snapshots."""
+
+    if not isinstance(data, dict):
+        return data
+    normalized = dict(data)
+    raw_skills = normalized.get("skills")
+    if not isinstance(raw_skills, list):
+        return normalized
+
+    skills: list[Any] = []
+    for raw_skill in raw_skills:
+        if not isinstance(raw_skill, dict):
+            skills.append(raw_skill)
+            continue
+        skill = dict(raw_skill)
+        skill.pop("version", None)
+        provenance = skill.get("provenance")
+        if isinstance(provenance, dict):
+            normalized_provenance = dict(provenance)
+            normalized_provenance.pop("original_version", None)
+            skill["provenance"] = normalized_provenance
+        skills.append(skill)
+    normalized["skills"] = skills
+    return normalized
+
+
 async def load_resolved_skillset(
     artifact_service: Any,
     skillset_ref: str,
@@ -64,7 +91,7 @@ async def load_resolved_skillset(
             allow_restricted_raw=True,
         )
         data = json.loads(payload.decode("utf-8"))
-        return ResolvedSkillSet.model_validate(data)
+        return ResolvedSkillSet.model_validate(_strip_legacy_skill_version_fields(data))
     except (
         OSError,
         TemporalArtifactError,

--- a/moonmind/workflows/skills/tool_plan_contracts.py
+++ b/moonmind/workflows/skills/tool_plan_contracts.py
@@ -374,16 +374,17 @@ class ToolDefinition:
 @dataclass(frozen=True, slots=True)
 class StepSkillSelectorExact:
     name: str
-    version: str | None = None
 
     def __post_init__(self) -> None:
-        _ensure_non_empty(self.name, field_name="node.skills.include[].name")
+        name = _ensure_non_empty(self.name, field_name="node.skills.include[].name")
+        if ":" in name:
+            raise ContractValidationError(
+                "invalid_plan",
+                "node.skills.include names must not include semantic versions",
+            )
 
     def to_payload(self) -> dict[str, Any]:
-        payload: dict[str, Any] = {"name": self.name}
-        if self.version is not None:
-            payload["version"] = self.version
-        return payload
+        return {"name": self.name}
 
 @dataclass(frozen=True, slots=True)
 class StepSkillSelectors:
@@ -1021,11 +1022,14 @@ def parse_step(payload: Mapping[str, Any]) -> Step:
                 name = str(item.get("name") or "").strip()
                 if not name:
                     raise ContractValidationError("invalid_plan", "node.skills.include[].name is required")
-                version = item.get("version")
+                if "version" in item:
+                    raise ContractValidationError(
+                        "invalid_plan",
+                        "node.skills.include entries must not include semantic versions",
+                    )
                 parsed_include.append(
                     StepSkillSelectorExact(
                         name=name,
-                        version=val if (val := str(version or "").strip()) else None
                     )
                 )
 

--- a/tests/integration/temporal/test_skills_on_demand_request_activation.py
+++ b/tests/integration/temporal/test_skills_on_demand_request_activation.py
@@ -32,7 +32,6 @@ def _entry(
 ) -> ResolvedSkillEntry:
     return ResolvedSkillEntry(
         skill_name=name,
-        version="1.0.0",
         content_ref=content_ref,
         content_digest=content_digest,
         provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN),

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3591,14 +3591,12 @@ def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
                         "minSeverityForMoonMind": "medium",
                         "defaultRuntime": "gemini_cli",
                     },
-                    "skills": {
-                        "sets": ["deployment-default", "proposal-quality"],
-                        "include": [
-                            {"name": "moonmind-doc-writer", "version": "2.3.0"}
-                        ],
-                        "exclude": ["legacy-proposer"],
-                        "materializationMode": "hybrid",
-                    },
+                        "skills": {
+                            "sets": ["deployment-default", "proposal-quality"],
+                            "include": [{"name": "moonmind-doc-writer"}],
+                            "exclude": ["legacy-proposer"],
+                            "materializationMode": "hybrid",
+                        },
                     "steps": [
                         {
                             "id": "review",
@@ -3630,7 +3628,7 @@ def test_create_task_shaped_execution_preserves_proposal_and_skill_intent(
     }
     assert initial_parameters["workflow"]["skills"] == {
         "sets": ["deployment-default", "proposal-quality"],
-        "include": [{"name": "moonmind-doc-writer", "version": "2.3.0"}],
+        "include": [{"name": "moonmind-doc-writer"}],
         "exclude": ["legacy-proposer"],
         "materializationMode": "hybrid",
     }

--- a/tests/unit/mcp/test_skills_on_demand_registry.py
+++ b/tests/unit/mcp/test_skills_on_demand_registry.py
@@ -21,7 +21,6 @@ pytestmark = [pytest.mark.asyncio]
 def _entry(name: str) -> ResolvedSkillEntry:
     return ResolvedSkillEntry(
         skill_name=name,
-        version="1.0.0",
         content_ref="hidden-content-ref",
         provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN),
     )
@@ -94,7 +93,6 @@ async def test_enabled_query_returns_metadata_without_skill_body_refs() -> None:
             "name": "jira-issue-updater",
             "title": None,
             "description": None,
-            "latest_version": "1.0.0",
             "source_kind": "built_in",
             "supported_runtimes": [],
             "required_capabilities": [],

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2833,7 +2833,6 @@ def _build_skill_snapshot_artifact(
         entries.append(
             ResolvedSkillEntry(
                 skill_name=name,
-                version="1.0.0",
                 content_ref=ref,
                 content_digest="sha256:" + hashlib.sha256(body).hexdigest(),
                 provenance=AgentSkillProvenance(

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -31,7 +31,6 @@ async def test_materializer_projects_selected_skill_to_agents_skills(tmp_path: P
         skills=[
             ResolvedSkillEntry(
                 skill_name="my_skill",
-                version="1.0.0",
                 content_ref="artifact-my-skill",
                 content_digest=_digest(payload),
                 provenance=AgentSkillProvenance(
@@ -73,7 +72,6 @@ async def test_materializer_projects_selected_skill_to_agents_skills(tmp_path: P
                 "content_ref": "artifact-my-skill",
                 "name": "my_skill",
                 "source_kind": "deployment",
-                "version": "1.0.0",
             }
         ],
         "snapshot_id": "test_snap_123",
@@ -152,7 +150,6 @@ async def test_materializer_extracts_skill_bundle_with_companion_files(
         skills=[
             ResolvedSkillEntry(
                 skill_name="bundle_skill",
-                version="1.0.0",
                 format=AgentSkillFormat.BUNDLE,
                 content_ref="artifact-bundle",
                 provenance=AgentSkillProvenance(
@@ -301,7 +298,6 @@ async def test_materializer_rejects_checksum_mismatch_before_projection_switch(
         skills=[
             ResolvedSkillEntry(
                 skill_name="active",
-                version="1.0.0",
                 content_ref="artifact-active",
                 content_digest="sha256:does-not-match",
                 provenance=AgentSkillProvenance(
@@ -346,7 +342,6 @@ async def test_materializer_preserves_previous_projection_on_bundle_failure(
         skills=[
             ResolvedSkillEntry(
                 skill_name="active",
-                version="1.0.0",
                 format=AgentSkillFormat.BUNDLE,
                 content_ref="artifact-bundle",
                 content_digest=_digest(payload),
@@ -602,7 +597,6 @@ async def test_materializer_prompt_bundle_mode(tmp_path: Path):
 def _skill(name: str, content_ref: str) -> ResolvedSkillEntry:
     return ResolvedSkillEntry(
         skill_name=name,
-        version="1.0.0",
         content_ref=content_ref,
         provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT),
     )

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -36,7 +36,6 @@ async def test_resolver_resolves_built_in_skills():
             return [
                 ResolvedSkillEntry(
                     skill_name="read_file",
-                    version="1.0",
                     provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN)
                 )
             ]
@@ -49,7 +48,6 @@ async def test_resolver_resolves_built_in_skills():
         include=[
             {
                 "name": "read_file",
-                "version": "1.0",
             }
         ]
     )
@@ -425,7 +423,6 @@ async def test_deployment_skill_loader_fetches_from_db():
     results = await loader.load_skills(selector, context)
     assert len(results) == 1
     assert results[0].skill_name == "db_skill"
-    assert results[0].version == "1.0.0"
     assert results[0].provenance.source_kind == AgentSkillSourceKind.DEPLOYMENT
     assert mock_session.execute.call_count == 2
     definition_stmt = str(mock_session.execute.call_args_list[0].args[0])
@@ -436,12 +433,12 @@ async def test_resolver_respects_precedence():
 
     built_in = BuiltInSkillLoader()
     built_in.load_skills = AsyncMock(return_value=[
-        ResolvedSkillEntry(skill_name="shared_skill", version="1.0", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN))
+        ResolvedSkillEntry(skill_name="shared_skill", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN))
     ])
 
     deployment = DeploymentSkillLoader()
     deployment.load_skills = AsyncMock(return_value=[
-        ResolvedSkillEntry(skill_name="shared_skill", version="1.0", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT))
+        ResolvedSkillEntry(skill_name="shared_skill", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT))
     ])
 
     resolver = AgentSkillResolver(loaders=[built_in, deployment])
@@ -458,7 +455,7 @@ async def test_resolver_rejects_collisions_within_source():
         async def load_skills(self, sel, ctx):
             return [
                 ResolvedSkillEntry(skill_name="dup_skill", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN)),
-                ResolvedSkillEntry(skill_name="dup_skill", version="2.0", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN))
+                ResolvedSkillEntry(skill_name="dup_skill", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN))
             ]
 
     resolver = AgentSkillResolver(loaders=[CollisionLoader()])
@@ -468,19 +465,12 @@ async def test_resolver_rejects_collisions_within_source():
     with pytest.raises(ValueError, match="Duplicate skill definition"):
         await resolver.resolve(selector, context)
 
-async def test_resolver_fails_on_pinned_version_mismatch():
-    class SingleLoader(BuiltInSkillLoader):
-        async def load_skills(self, sel, ctx):
-            return [
-                ResolvedSkillEntry(skill_name="test_skill", version="1.0", provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.BUILT_IN))
-            ]
+async def test_resolver_rejects_versioned_selector_input():
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        SkillSelector(include=[{"name": "test_skill", "version": "2.0"}])
 
-    resolver = AgentSkillResolver(loaders=[SingleLoader()])
-    context = SkillResolutionContext(snapshot_id="snap")
-    selector = SkillSelector(include=[{"name": "test_skill", "version": "2.0"}])
-    
-    with pytest.raises(ValueError, match="Could not resolve pinned version"):
-        await resolver.resolve(selector, context)
+    with pytest.raises(ValueError, match="semantic versions"):
+        SkillSelector(include=[{"name": "test_skill:2.0"}])
 
 async def test_resolver_produces_deterministic_snapshot_sorting():
     class DisorderLoader(BuiltInSkillLoader):

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -101,7 +101,6 @@ async def test_resolve_skills_activity_persists_file_backed_skill_content(
             skills=[
                 ResolvedSkillEntry(
                     skill_name="pr-resolver",
-                    version="1.0.0",
                     provenance=AgentSkillProvenance(
                         source_kind=AgentSkillSourceKind.BUILT_IN,
                         source_path=str(skill_dir),

--- a/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
+++ b/tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py
@@ -34,13 +34,11 @@ def _entry(
     name: str,
     *,
     source_kind: AgentSkillSourceKind = AgentSkillSourceKind.BUILT_IN,
-    version: str | None = "1.0.0",
     content_ref: str | None = None,
     source_path: str | None = None,
 ) -> ResolvedSkillEntry:
     return ResolvedSkillEntry(
         skill_name=name,
-        version=version,
         content_ref=content_ref,
         content_digest="sha256:secret-digest" if content_ref else None,
         provenance=AgentSkillProvenance(
@@ -113,7 +111,6 @@ async def test_enabled_query_returns_metadata_only_results() -> None:
     assert result.results == [
         SkillCatalogSearchResult(
             name="jira-issue-updater",
-            latest_version="1.0.0",
             source_kind=AgentSkillSourceKind.BUILT_IN,
             eligible=True,
             in_current_snapshot=False,

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -32,7 +32,7 @@ def test_task_skills_accepts_valid_properties() -> None:
         "skills": {
             "sets": ["default", "python"],
             "include": [
-                {"name": "test-skill", "version": "1.0.0"},
+                {"name": "test-skill"},
                 {"name": "unversioned"},
             ],
             "exclude": ["legacy"],
@@ -46,12 +46,28 @@ def test_task_skills_accepts_valid_properties() -> None:
     assert spec.skills.sets == ["default", "python"]
     assert len(spec.skills.include) == 2
     assert spec.skills.include[0].name == "test-skill"
-    assert spec.skills.include[0].version == "1.0.0"
     assert spec.skills.include[1].name == "unversioned"
-    assert spec.skills.include[1].version is None
     assert spec.skills.exclude == ["legacy"]
     assert spec.skills.materialization_mode == "hybrid"
 
+def test_task_skills_rejects_semantic_version_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorkflowExecutionSpec.model_validate(
+            {
+                "repository": "test/repo",
+                "instructions": "execute",
+                "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="semantic versions"):
+        WorkflowExecutionSpec.model_validate(
+            {
+                "repository": "test/repo",
+                "instructions": "execute",
+                "skills": {"include": [{"name": "test-skill:1.0.0"}]},
+            }
+        )
 
 def test_mm842_authoritative_snapshot_omits_authored_step_graph_metadata() -> None:
     snapshot = build_authoritative_workflow_input_snapshot(
@@ -1115,8 +1131,8 @@ def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> 
             "skills": {
                 "sets": ["default"],
                 "include": [
-                    {"name": "baseline", "version": "1.0.0"},
-                    {"name": "remove-me", "version": "2.0.0"},
+                    {"name": "baseline"},
+                    {"name": "remove-me"},
                 ],
                 "exclude": ["legacy"],
                 "materializationMode": "hybrid",
@@ -1139,9 +1155,9 @@ def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> 
 
     assert effective is not None
     assert effective.sets == ["default", "python"]
-    assert [(item.name, item.version) for item in effective.include or []] == [
-        ("baseline", "1.0.0"),
-        ("step-only", None),
+    assert [item.name for item in effective.include or []] == [
+        "baseline",
+        "step-only",
     ]
     assert effective.exclude == ["legacy", "remove-me"]
     assert effective.materialization_mode == "none"
@@ -1181,9 +1197,7 @@ def test_effective_task_step_skills_drops_auto_without_losing_real_includes() ->
     effective = build_effective_workflow_skill_selectors(task_skills, None)
 
     assert effective is not None
-    assert [(item.name, item.version) for item in effective.include or []] == [
-        ("jira-issue-updater", None)
-    ]
+    assert [item.name for item in effective.include or []] == ["jira-issue-updater"]
 
 def test_task_input_attachments_preserve_objective_and_step_targets() -> None:
     """MM-367: objective and step refs remain distinct canonical fields."""

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -435,6 +435,33 @@ async def test_load_resolved_skillset_round_trips() -> None:
 
 
 @pytest.mark.asyncio
+async def test_load_resolved_skillset_strips_legacy_version_metadata() -> None:
+    payload = {
+        "snapshot_id": "snap-legacy",
+        "resolved_at": datetime.now(tz=UTC).isoformat(),
+        "skills": [
+            {
+                "skill_name": "pr-resolver",
+                "version": "1.0.0",
+                "provenance": {
+                    "source_kind": "built_in",
+                    "original_version": "1.0.0",
+                },
+            }
+        ],
+    }
+
+    loaded = await load_resolved_skillset(
+        _StaticArtifactService({"snap-ref": json.dumps(payload).encode("utf-8")}),
+        "snap-ref",
+    )
+
+    assert loaded.snapshot_id == "snap-legacy"
+    assert loaded.skills[0].skill_name == "pr-resolver"
+    assert loaded.skills[0].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+
+
+@pytest.mark.asyncio
 async def test_load_resolved_skillset_raises_on_missing_service() -> None:
     with pytest.raises(SkillProjectionError, match="artifact service is required"):
         await load_resolved_skillset(None, "any-ref")

--- a/tests/unit/workflows/skills/test_run_projection.py
+++ b/tests/unit/workflows/skills/test_run_projection.py
@@ -37,7 +37,6 @@ def _digest(payload: bytes) -> str:
 def _skill_entry(name: str, content_ref: str, payload: bytes) -> ResolvedSkillEntry:
     return ResolvedSkillEntry(
         skill_name=name,
-        version="1.0.0",
         content_ref=content_ref,
         content_digest=_digest(payload),
         provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT),

--- a/tests/unit/workflows/skills/test_tool_plan_contracts.py
+++ b/tests/unit/workflows/skills/test_tool_plan_contracts.py
@@ -19,7 +19,7 @@ def test_step_skills_accepts_valid_properties() -> None:
         "skills": {
             "sets": ["default", "node-specific"],
             "include": [
-                {"name": "test-skill-1", "version": "1.0.0"},
+                {"name": "test-skill-1"},
                 {"name": "test-skill-2"},
             ],
             "exclude": ["legacy"],
@@ -37,9 +37,7 @@ def test_step_skills_accepts_valid_properties() -> None:
     assert step.skills.sets == ("default", "node-specific")
     assert len(step.skills.include) == 2
     assert step.skills.include[0].name == "test-skill-1"
-    assert step.skills.include[0].version == "1.0.0"
     assert step.skills.include[1].name == "test-skill-2"
-    assert step.skills.include[1].version is None
     assert step.skills.exclude == ("legacy",)
     assert step.skills.materialization_mode == "hybrid"
 
@@ -69,4 +67,16 @@ def test_step_skills_rejects_invalid_values() -> None:
         parse_step({
             "id": "node-1", "tool": {"name": "foo"}, "inputs": {},
             "skills": {"materializationMode": "invalid"},
+        })
+
+    with pytest.raises(ContractValidationError, match="semantic versions"):
+        parse_step({
+            "id": "node-1", "tool": {"name": "foo"}, "inputs": {},
+            "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
+        })
+
+    with pytest.raises(ContractValidationError, match="semantic versions"):
+        parse_step({
+            "id": "node-1", "tool": {"name": "foo"}, "inputs": {},
+            "skills": {"include": [{"name": "test-skill:1.0.0"}]},
         })

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -4120,7 +4120,6 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_selected_ski
         skills=[
             ResolvedSkillEntry(
                 skill_name="pr-resolver",
-                version="1.0.0",
                 content_ref="art-pr-resolver-body",
                 content_digest="sha256:" + hashlib.sha256(skill_body).hexdigest(),
                 provenance=AgentSkillProvenance(
@@ -4217,7 +4216,6 @@ async def test_agent_runtime_prepare_turn_instructions_materializes_verifier_ski
         skills=[
             ResolvedSkillEntry(
                 skill_name="moonspec-verify",
-                version="1.0.0",
                 content_ref="art-moonspec-verify-body",
                 content_digest="sha256:" + hashlib.sha256(skill_body).hexdigest(),
                 provenance=AgentSkillProvenance(
@@ -4422,7 +4420,6 @@ async def test_agent_runtime_prepare_turn_instructions_fails_before_launch_when_
         skills=[
             ResolvedSkillEntry(
                 skill_name="pr-resolver",
-                version="1.0.0",
                 content_ref="art-pr-resolver-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4498,7 +4495,6 @@ async def test_agent_runtime_selected_skill_projection_rejects_non_mapping_manif
         skills=[
             ResolvedSkillEntry(
                 skill_name="pr-resolver",
-                version="1.0.0",
                 content_ref="art-pr-resolver-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4534,7 +4530,6 @@ async def test_agent_runtime_selected_skill_projection_enforces_repo_source_poli
                 "skills": [
                     {
                         "name": "repo-skill",
-                        "version": "1.0.0",
                         "source_kind": "repo",
                     }
                 ],
@@ -4548,7 +4543,6 @@ async def test_agent_runtime_selected_skill_projection_enforces_repo_source_poli
         skills=[
             ResolvedSkillEntry(
                 skill_name="repo-skill",
-                version="1.0.0",
                 content_ref="art-repo-skill-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4589,7 +4583,6 @@ async def test_agent_runtime_selected_skill_projection_enforces_local_source_pol
                 "skills": [
                     {
                         "name": "local-skill",
-                        "version": "1.0.0",
                         "source_kind": "local",
                     }
                 ],
@@ -4603,7 +4596,6 @@ async def test_agent_runtime_selected_skill_projection_enforces_local_source_pol
         skills=[
             ResolvedSkillEntry(
                 skill_name="local-skill",
-                version="1.0.0",
                 content_ref="art-local-skill-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4644,7 +4636,6 @@ async def test_agent_runtime_selected_skill_projection_rejects_repo_skill_with_m
                 "skills": [
                     {
                         "name": "repo-skill",
-                        "version": "1.0.0",
                         "source_kind": "repo",
                     }
                 ],
@@ -4658,7 +4649,6 @@ async def test_agent_runtime_selected_skill_projection_rejects_repo_skill_with_m
         skills=[
             ResolvedSkillEntry(
                 skill_name="repo-skill",
-                version="1.0.0",
                 content_ref="art-repo-skill-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4696,7 +4686,6 @@ async def test_agent_runtime_prepare_turn_instructions_enforces_dependency_sourc
         skills=[
             ResolvedSkillEntry(
                 skill_name="pr-resolver",
-                version="1.0.0",
                 content_ref="art-pr-resolver-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4705,7 +4694,6 @@ async def test_agent_runtime_prepare_turn_instructions_enforces_dependency_sourc
             ),
             ResolvedSkillEntry(
                 skill_name="repo-helper",
-                version="1.0.0",
                 content_ref="art-repo-helper-body",
                 content_digest="sha256:test",
                 provenance=AgentSkillProvenance(
@@ -4785,7 +4773,6 @@ async def test_agent_runtime_prepare_turn_instructions_preserves_checked_in_skil
         skills=[
             ResolvedSkillEntry(
                 skill_name="pr-resolver",
-                version="1.0.0",
                 content_ref="art-pr-resolver-body",
                 content_digest="sha256:" + hashlib.sha256(skill_body).hexdigest(),
                 provenance=AgentSkillProvenance(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -197,7 +197,7 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             ref = await wf._resolve_agent_node_skillset_ref(
                 task_skills={
                     "include": [
-                        {"name": "baseline", "version": "1.0.0"},
+                        {"name": "baseline"},
                         {"name": "remove-me"},
                     ],
                     "materializationMode": "hybrid",
@@ -220,8 +220,8 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         activity_args = kwargs["args"]
         selector = activity_args[0]
         self.assertEqual(
-            [(entry.name, entry.version) for entry in selector.include],
-            [("baseline", "1.0.0"), ("step-only", None)],
+            [entry.name for entry in selector.include],
+            ["baseline", "step-only"],
         )
         self.assertEqual(selector.exclude, ["remove-me"])
         self.assertEqual(activity_args[1:], ["owner-1", None, False, False])
@@ -262,8 +262,8 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(activity_args[1:], ["owner-1", None, False, False])
         selector = activity_args[0]
         self.assertEqual(
-            [(entry.name, entry.version) for entry in selector.include],
-            [("baseline", None), ("canonical-step", None)],
+            [entry.name for entry in selector.include],
+            ["baseline", "canonical-step"],
         )
         self.assertEqual(selector.exclude, ["legacy-input-step"])
 
@@ -335,8 +335,8 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args, ("agent_skill.resolve",))
         selector = kwargs["args"][0]
         self.assertEqual(
-            [(entry.name, entry.version) for entry in selector.include],
-            [("moonspec-breakdown", None)],
+            [entry.name for entry in selector.include],
+            ["moonspec-breakdown"],
         )
         self.assertEqual(kwargs["args"][1:], ["owner-1", "/workspace/repo", False, False])
 
@@ -372,8 +372,8 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args, ("agent_skill.resolve",))
         selector = kwargs["args"][0]
         self.assertEqual(
-            [(entry.name, entry.version) for entry in selector.include],
-            [("jira-breakdown-orchestrate", None), ("moonspec-breakdown", None)],
+            [entry.name for entry in selector.include],
+            ["jira-breakdown-orchestrate", "moonspec-breakdown"],
         )
 
     async def test_agent_node_rejects_unresolved_selected_skill_before_launch(self) -> None:
@@ -491,17 +491,17 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         execute_activity.assert_not_called()
 
-    async def test_agent_node_pinned_resolution_failure_happens_before_launch(self) -> None:
+    async def test_agent_node_rejects_versioned_skill_selector_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"
 
         with patch(
             "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
-            new=AsyncMock(side_effect=ValueError("Could not resolve pinned version")),
-        ):
+            new=AsyncMock(),
+        ) as execute_activity:
             with self.assertRaisesRegex(
                 ValueError,
-                "Could not resolve pinned version",
+                "Extra inputs are not permitted",
             ):
                 await wf._resolve_agent_node_skillset_ref(
                     task_skills={"include": [{"name": "baseline", "version": "9.9.9"}]},
@@ -509,6 +509,7 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
                     node_id="step-1",
                     existing_skillset_ref=None,
                 )
+        execute_activity.assert_not_called()
 
     async def test_agent_node_reuses_existing_skillset_ref_without_reresolution(self) -> None:
         wf = MoonMindRunWorkflow()

--- a/tests/unit/workflows/test_skills_materializer.py
+++ b/tests/unit/workflows/test_skills_materializer.py
@@ -45,7 +45,6 @@ def test_materialize_run_skill_workspace_creates_cache_and_links(tmp_path):
         skills=(
             ResolvedSkill(
                 skill_name="speckit",
-                version="1.0.0",
                 source_uri=(source_root / "speckit").resolve().as_uri(),
             ),
         ),
@@ -83,7 +82,6 @@ def test_materialize_run_skill_workspace_rejects_hash_mismatch(tmp_path):
         skills=(
             ResolvedSkill(
                 skill_name="speckit",
-                version="1.0.0",
                 source_uri=(source_root / "speckit").resolve().as_uri(),
                 content_hash="deadbeef",
             ),
@@ -111,7 +109,6 @@ def test_materialize_run_skill_workspace_requires_skill_md(tmp_path):
         skills=(
             ResolvedSkill(
                 skill_name="speckit",
-                version="1.0.0",
                 source_uri=(source_root / "speckit").resolve().as_uri(),
             ),
         ),
@@ -137,8 +134,8 @@ def test_materialize_run_skill_workspace_rejects_duplicate_names(tmp_path):
         run_id="run-4",
         selection_source="job_override",
         skills=(
-            ResolvedSkill(skill_name="speckit", version="1", source_uri=uri),
-            ResolvedSkill(skill_name="speckit", version="2", source_uri=uri),
+            ResolvedSkill(skill_name="speckit", source_uri=uri),
+            ResolvedSkill(skill_name="speckit", source_uri=uri),
         ),
     )
 
@@ -164,7 +161,6 @@ def test_materialize_run_skill_workspace_does_not_touch_global_codex_config(tmp_
         skills=(
             ResolvedSkill(
                 skill_name="speckit",
-                version="1.0.0",
                 source_uri=(source_root / "speckit").resolve().as_uri(),
             ),
         ),
@@ -202,7 +198,6 @@ def test_materialize_run_skill_workspace_rejects_incomplete_cache_entry(
         skills=(
             ResolvedSkill(
                 skill_name="speckit",
-                version="1.0.0",
                 source_uri=(source_root / "speckit").resolve().as_uri(),
             ),
         ),
@@ -376,7 +371,6 @@ def test_resolve_source_root_uses_git_clone_end_of_options_separator(
 
     entry = ResolvedSkill(
         skill_name="speckit",
-        version="1.0.0",
         source_uri="git+https://github.com/example/repo.git",
     )
 
@@ -388,7 +382,6 @@ def test_resolve_source_root_uses_git_clone_end_of_options_separator(
 def test_resolve_source_root_rejects_git_ext_transport(tmp_path):
     entry = ResolvedSkill(
         skill_name="speckit",
-        version="1.0.0",
         source_uri="git+ext::sh -c echo pwned",
     )
 
@@ -408,7 +401,6 @@ def test_resolve_source_root_rejects_git_private_host(tmp_path, monkeypatch):
     )
     entry = ResolvedSkill(
         skill_name="speckit",
-        version="1.0.0",
         source_uri="git+https://internal.example/repo.git",
     )
 

--- a/tests/unit/workflows/test_skills_resolver.py
+++ b/tests/unit/workflows/test_skills_resolver.py
@@ -100,22 +100,21 @@ def test_resolve_run_skill_selection_prefers_job_override(skills_mirror):
     resolved = resolve_run_skill_selection(
         run_id="run-2",
         context={
-            "skill_selection": ["docs-lint:1.2.0"],
-            "queue_skill_selection": ["speckit:1.0.0"],
-            "skill_sources": {"docs-lint:1.2.0": "file:///tmp/custom/docs-lint"},
+            "skill_selection": ["docs-lint"],
+            "queue_skill_selection": ["speckit"],
+            "skill_sources": {"docs-lint": "file:///tmp/custom/docs-lint"},
         },
     )
 
     assert resolved.selection_source == "job_override"
     assert [skill.skill_name for skill in resolved.skills] == ["docs-lint"]
-    assert resolved.skills[0].version == "1.2.0"
     assert resolved.skills[0].source_uri == "file:///tmp/custom/docs-lint"
 
 def test_resolve_run_skill_selection_rejects_duplicates(skills_mirror):
     with pytest.raises(SkillResolutionError, match="Duplicate skill name"):
         resolve_run_skill_selection(
             run_id="run-3",
-            context={"skill_selection": ["docs-lint:1", "docs-lint:2"]},
+            context={"skill_selection": ["docs-lint", "docs-lint"]},
         )
 
 @pytest.mark.parametrize("skill_name", ["../evil", "a/b", "a\\b", "..", "bad name"])
@@ -123,14 +122,27 @@ def test_resolve_run_skill_selection_rejects_unsafe_names(skills_mirror, skill_n
     with pytest.raises(SkillResolutionError, match="Invalid skill name"):
         resolve_run_skill_selection(
             run_id="run-invalid",
-            context={"skill_selection": [f"{skill_name}:1.0.0"]},
+            context={"skill_selection": [skill_name]},
+        )
+
+def test_resolve_run_skill_selection_rejects_versioned_inputs(skills_mirror):
+    with pytest.raises(SkillResolutionError, match="semantic versions"):
+        resolve_run_skill_selection(
+            run_id="run-versioned",
+            context={"skill_selection": ["docs-lint:1.2.0"]},
+        )
+
+    with pytest.raises(SkillResolutionError, match="semantic version fields"):
+        resolve_run_skill_selection(
+            run_id="run-version-field",
+            context={"skill_selection": [{"name": "docs-lint", "version": "1.2.0"}]},
         )
 
 def test_resolve_run_skill_selection_falls_back_to_legacy_root(skills_mirror):
     _, legacy = skills_mirror
     resolved = resolve_run_skill_selection(
         run_id="run-4",
-        context={"skill_selection": ["legacy:0.1.0"]},
+        context={"skill_selection": ["legacy"]},
     )
 
     assert resolved.skills[0].source_uri == (legacy / "legacy").resolve().as_uri()
@@ -163,7 +175,7 @@ def test_resolve_run_skill_selection_resolves_jira_issue_updater_repo_skill(
 
     resolved = resolve_run_skill_selection(
         run_id="run-jira-updater",
-        context={"skill_selection": ["jira-issue-updater:local"]},
+        context={"skill_selection": ["jira-issue-updater"]},
     )
 
     assert resolved.skills[0].skill_name == "jira-issue-updater"
@@ -187,7 +199,7 @@ def test_resolve_run_skill_selection_requires_source(monkeypatch, tmp_path):
     with pytest.raises(SkillResolutionError, match="No source URI resolved"):
         resolve_run_skill_selection(
             run_id="run-5",
-            context={"skill_selection": ["missing:1.0.0"]},
+            context={"skill_selection": ["missing"]},
         )
 
 def test_list_available_skill_names_permissive_mode_discovers_local_roots(
@@ -382,4 +394,3 @@ def test_project_root_fallback_handles_shallow_paths(monkeypatch):
     monkeypatch.setattr(resolver_module, "__file__", "/x.py", raising=False)
 
     assert resolver_module._project_root() == Path("/")
-


### PR DESCRIPTION
Issue reference: MM-914 - https://moonladder.atlassian.net/browse/MM-914

Summary:
- Removes semantic version fields from active agent skill schema models, provenance, resolved entries, catalog/on-demand surfaces, materialized payloads, and execution skill selectors.
- Updates skill resolution and on-demand activation to resolve skills by name only, reject `skill.version` and `skill:version` inputs, and preserve source URI/content hash evidence.
- Adjusts workflow/activity and API contract tests to cover the versionless skill contract.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/test_skills_resolver.py tests/unit/workflows/test_skills_materializer.py tests/unit/api/routers/test_executions.py tests/unit/workflows/executions/test_execution_contract.py tests/unit/mcp/test_skills_on_demand_registry.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/agent_skills/test_skills_on_demand_controls.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- Python: 724 passed, 2 subtests passed.
- Frontend/Vitest phase from the same runner: 29 files passed, 496 passed, 236 skipped.

Remaining risks:
- Full repository unit and compose-backed integration suites were not run in this PR-publication step.
