### PR TITLE
Prefer declarative path, Jira issue, then instructions for breakdown presets

### DIFF
--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -19,17 +19,20 @@ Good inputs include:
 - A pasted technical design.
 - A declarative design document.
 - A file path to a design artifact.
+- A trusted Jira issue brief or description when no declarative document path is provided.
 - A request to run or reproduce `/speckit.breakdown`.
 
 Do not use this skill for a single natural-language feature request. Use `moonspec-specify` for one clearly scoped story.
 
 ## Inputs
 
-- Treat the user's request text as the source design unless it names a readable file path.
-- If a file path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
-- If no design text or readable design path is provided, stop with: `ERROR "No technical design provided"`.
+- Select breakdown input content using this preference chain:
+  1. Declarative document path: if an explicit source or declarative document path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
+  2. Jira issue description: if no declarative document path is provided and trusted Jira issue context is available from MoonMind previous outputs, use `jiraPresetBrief` or the Jira issue description/acceptance criteria from that trusted context.
+  3. Workflow instructions: if neither of the above is available, use the workflow instructions or user request text as the source design.
+- If no selected input content is available after applying the preference chain, stop with: `ERROR "No technical design provided"`.
 - Preserve the original design text verbatim in the breakdown output so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
-- Preserve the source document reference path whenever the source design came from a file. Use the repo-relative path when possible; otherwise use the absolute path provided by the user. This reference is required downstream so every Jira story can point back to the original declarative document.
+- Preserve the source document reference path whenever the selected source design came from a file. Use the repo-relative path when possible; otherwise use the absolute path provided by the user. If the selected source is trusted Jira context or workflow instructions, set source and story reference paths to `null` and preserve the source title/key instead.
 - The canonical source document, not the breakdown output, remains the source of truth for desired state. Breakdown output is a temporary derived view (see `docs/Workflows/MoonSpecDocumentModel.md`).
 - Do not implement, plan, generate tasks, create Jira issues, create `spec.md`, or create directories under `specs/`.
 
@@ -38,7 +41,7 @@ Do not use this skill for a single natural-language feature request. Use `moonsp
 Classify the source design before extracting coverage points, using the document classes in `docs/Workflows/MoonSpecDocumentModel.md`:
 
 - `canonical-declarative`: a readable repo path under `docs/` (or `.specify/memory/constitution.md`) describing desired state.
-- `declarative-text`: pasted declarative design text, or a file-backed declarative design outside `docs/`.
+- `declarative-text`: pasted declarative design text, trusted Jira issue description, workflow instructions, or a file-backed declarative design outside `docs/`.
 - `imperative-override`: a document whose primary framing is steps, phases, checkboxes, status, or migration sequencing, accepted only with an explicit user override.
 
 A document is declarative when it describes what the system is or should be; it is imperative when its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by their primary framing.
@@ -183,7 +186,7 @@ Never name any breakdown output `spec.md`. Never write to `specs/` during breakd
 
 The JSON file must be an object with:
 
-- `source`: object containing `title`, `path`, `referencePath`, `sourceDocumentClass`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For pasted designs without a file path, set them to `null` and use a clear title such as `inline user request`. `sourceDocumentClass` must be `canonical-declarative`, `declarative-text`, or `imperative-override` per the Input Classification section.
+- `source`: object containing `title`, `path`, `referencePath`, `sourceDocumentClass`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For trusted Jira issue descriptions or pasted workflow instructions without a file path, set paths to `null` and use a clear title such as the Jira issue key/summary or `inline workflow instructions`. `sourceDocumentClass` must be `canonical-declarative`, `declarative-text`, or `imperative-override` per the Input Classification section.
 - `extractedAt`: ISO-8601 timestamp.
 - `coverageGate`: exactly `PASS - every major design point is owned by at least one story.`
 - `stories`: ordered list of story objects.
@@ -194,7 +197,7 @@ Each story object must include:
 - `id`: stable story ID, such as `STORY-001`.
 - `summary`: concise title suitable for a Jira issue summary.
 - `description`: user-story or task narrative.
-- `sourceReference`: object containing `path`, `title`, `sections`, and `coverageIds`. For file-backed designs, `path` must be the same original design document path from `source.referencePath`; do not omit it from any story.
+- `sourceReference`: object containing `path`, `title`, `sections`, and `coverageIds`. For file-backed designs, `path` must be the same original design document path from `source.referencePath`; do not omit it from any story. For trusted Jira issue descriptions or workflow instructions, set `path` to `null` and preserve the selected source title.
 - `independentTest`: how this story can be validated independently.
 - `acceptanceCriteria`: concrete acceptance criteria.
 - `requirements`: functional requirements owned by the story.
@@ -206,7 +209,7 @@ Each story object must include:
 The markdown file must include the same substance for human review:
 
 - Source design title or path.
-- Original source document reference path for the breakdown and for each story.
+- Original source document reference path for the breakdown and for each story when a file path exists; otherwise show the selected Jira issue key/summary or workflow instruction title.
 - Story extraction date.
 - Design summary.
 - Coverage points.
@@ -268,7 +271,7 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 - The canonical source document remains the source of truth for desired state; breakdown output is a temporary derived view and is never cited as authority over its source.
 - Classify the input per `docs/Workflows/MoonSpecDocumentModel.md` and fail fast on imperative inputs without an explicit override.
 - Preserve the original technical or declarative design verbatim in the breakdown output for later specify.
-- Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file.
+- Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file; otherwise it must carry the selected source title/key with `path: null`.
 - Prefer vertical user or operational outcomes over technical-layer slices.
 - Extract stable `DESIGN-REQ-*` coverage points before drafting story candidates.
 - Do not write specs in this skill.

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown-implement
 title: Jira Breakdown and Implement
-description: Break a broad Jira or design input into stories, create Jira issues, then create dependent Jira Implement tasks for each generated issue.
+description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Implement tasks for each generated issue.
 scope: global
 tags:
   - jira
@@ -16,9 +16,15 @@ annotations:
   output: dependent-jira-implement-tasks
 inputs:
   - name: feature_request
-    label: Declarative Design Path or Text
+    label: Workflow Instructions
     type: markdown
-    required: true
+    required: false
+    default: ""
+  - name: source_design_path
+    label: Declarative Document Path
+    type: repo_path
+    required: false
+    default: ""
   - name: jira_project_key
     label: Jira Project Key
     type: text
@@ -56,13 +62,40 @@ inputs:
     required: false
     default: ""
 steps:
-  - title: Break down declarative design
+  - title: Load source Jira issue description
+    type: tool
+    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
     instructions: |-
-      Run moonspec-breakdown for this declarative design:
+      Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+    tool:
+      id: jira.load_preset_brief
+      requiredCapabilities:
+        - jira
+      args: {}
+      inputs:
+        issueKey: "{{ inputs.source_issue_key }}"
+  - title: Break down preferred source input
+    instructions: |-
+      Run moonspec-breakdown using this input preference chain:
+
+      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      3. Otherwise, use Workflow instructions as the source design.
+
+      Source declarative document path:
+      {{ inputs.source_design_path }}
+
+      Source Jira issue key:
+      {{ inputs.source_issue_key }}
+
+      Workflow instructions:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
+      If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
       Record sourceDocumentClass in the breakdown output.
@@ -92,7 +125,7 @@ steps:
       Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each eligible story from the reconciled MoonSpec breakdown.
 
       Use the runtime-provided story breakdown JSON path.
-      Every Jira issue must include the Source Document path from the story breakdown.
+      Every Jira issue must include the Source Document path from the story breakdown when present; otherwise include the source title and Source Jira issue key when present.
       Do not create Jira issues for stories where jiraCreation.action is skip or manual_review.
       For stories where jiraCreation.action is create_remaining_work_issue, create the Jira issue from the story's remainingWork while preserving the original story traceability.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -64,7 +64,7 @@ inputs:
 steps:
   - title: Load source Jira issue description
     type: tool
-    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
+    enabled: "{{ (inputs.source_issue_key or '') | trim != '' and (inputs.source_design_path or '') | trim == '' }}"
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown-orchestrate
 title: Jira Breakdown and Orchestrate
-description: Break a broad Jira or design input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
+description: Break a preferred source input into stories, create Jira issues, then create dependent Jira Orchestrate tasks for each generated issue.
 scope: global
 tags:
   - jira
@@ -16,9 +16,15 @@ annotations:
   output: dependent-jira-orchestrate-tasks
 inputs:
   - name: feature_request
-    label: Declarative Design Path or Text
+    label: Workflow Instructions
     type: markdown
-    required: true
+    required: false
+    default: ""
+  - name: source_design_path
+    label: Declarative Document Path
+    type: repo_path
+    required: false
+    default: ""
   - name: jira_project_key
     label: Jira Project Key
     type: text
@@ -56,13 +62,40 @@ inputs:
     required: false
     default: ""
 steps:
-  - title: Break down declarative design
+  - title: Load source Jira issue description
+    type: tool
+    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
     instructions: |-
-      Run moonspec-breakdown for this declarative design:
+      Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+    tool:
+      id: jira.load_preset_brief
+      requiredCapabilities:
+        - jira
+      args: {}
+      inputs:
+        issueKey: "{{ inputs.source_issue_key }}"
+  - title: Break down preferred source input
+    instructions: |-
+      Run moonspec-breakdown using this input preference chain:
+
+      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      3. Otherwise, use Workflow instructions as the source design.
+
+      Source declarative document path:
+      {{ inputs.source_design_path }}
+
+      Source Jira issue key:
+      {{ inputs.source_issue_key }}
+
+      Workflow instructions:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
+      If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
       Record sourceDocumentClass in the breakdown output.
@@ -92,7 +125,7 @@ steps:
       Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each eligible story from the reconciled MoonSpec breakdown.
 
       Use the runtime-provided story breakdown JSON path.
-      Every Jira issue must include the Source Document path from the story breakdown.
+      Every Jira issue must include the Source Document path from the story breakdown when present; otherwise include the source title and Source Jira issue key when present.
       Do not create Jira issues for stories where jiraCreation.action is skip or manual_review.
       For stories where jiraCreation.action is create_remaining_work_issue, create the Jira issue from the story's remainingWork while preserving the original story traceability.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
@@ -121,7 +154,7 @@ steps:
       Create one Jira Orchestrate task for each Jira issue created from the trusted Jira story output.
 
       Use the ordered issue mappings returned by story.create_jira_issues. Preserve the generated story order when creating downstream tasks.
-      Each downstream task must carry the story's sourceReference.path as its source_design_path input so the downstream Jira Orchestrate doc-reconciliation step knows the canonical source document.
+      Each downstream task must carry the story's sourceReference.path as its source_design_path input when present so the downstream Jira Orchestrate doc-reconciliation step knows the canonical source document. If the source path is absent because the story came from a trusted Jira issue description or workflow instructions, preserve the source title and source Jira issue traceability instead of inventing a document path.
       Do not create downstream tasks for skipped fully implemented stories or manual-review stories that did not produce Jira issue mappings.
       Each downstream task must run Jira Orchestrate on its corresponding Jira story issue and must not run implementation inline inside this breakdown run.
       Create task dependencies with dependsOn so each later generated task waits for the immediately earlier generated task workflow ID.

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -64,7 +64,7 @@ inputs:
 steps:
   - title: Load source Jira issue description
     type: tool
-    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
+    enabled: "{{ (inputs.source_issue_key or '') | trim != '' and (inputs.source_design_path or '') | trim == '' }}"
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -1,6 +1,6 @@
 slug: jira-breakdown
 title: Jira Breakdown
-description: Break a declarative design into MoonSpec story candidates, then create Jira Story issues from the generated breakdown.
+description: Break a preferred source input into MoonSpec story candidates, then create Jira Story issues from the generated breakdown.
 scope: global
 tags:
   - jira
@@ -15,9 +15,20 @@ annotations:
   output: jira
 inputs:
   - name: feature_request
-    label: Declarative Design Path or Text
+    label: Workflow Instructions
     type: markdown
-    required: true
+    required: false
+    default: ""
+  - name: source_design_path
+    label: Declarative Document Path
+    type: repo_path
+    required: false
+    default: ""
+  - name: source_issue_key
+    label: Source Jira Issue Key
+    type: text
+    required: false
+    default: ""
   - name: jira_project_key
     label: Jira Project Key
     type: text
@@ -42,13 +53,40 @@ inputs:
       - linear_blocker_chain
       - none
 steps:
-  - title: Break down declarative design
+  - title: Load source Jira issue description
+    type: tool
+    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
     instructions: |-
-      Run moonspec-breakdown for this declarative design:
+      Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+    tool:
+      id: jira.load_preset_brief
+      requiredCapabilities:
+        - jira
+      args: {}
+      inputs:
+        issueKey: "{{ inputs.source_issue_key }}"
+  - title: Break down preferred source input
+    instructions: |-
+      Run moonspec-breakdown using this input preference chain:
+
+      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      3. Otherwise, use Workflow instructions as the source design.
+
+      Source declarative document path:
+      {{ inputs.source_design_path }}
+
+      Source Jira issue key:
+      {{ inputs.source_issue_key }}
+
+      Workflow instructions:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
+      If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, and set each story's sourceReference.path to null.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
       Record sourceDocumentClass in the breakdown output.
@@ -63,7 +101,8 @@ steps:
       Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each story from the generated MoonSpec breakdown.
 
       Use the runtime-provided story breakdown JSON path.
-      Every Jira issue must include the Source Document path from the story breakdown.
+      Every Jira issue must include the Source Document path from the story breakdown when present; otherwise include the source title and Source Jira issue key when present.
+      {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -55,7 +55,7 @@ inputs:
 steps:
   - title: Load source Jira issue description
     type: tool
-    enabled: "{{ inputs.source_issue_key | trim != '' and inputs.source_design_path | trim == '' }}"
+    enabled: "{{ (inputs.source_issue_key or '') | trim != '' and (inputs.source_design_path or '') | trim == '' }}"
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -82,6 +82,11 @@ _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS = frozenset(
 )
 _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _JIRA_BREAKDOWN_REPLACEABLE_PROJECT_DEFAULTS = frozenset({"TOOL", "MM"})
+_JIRA_BREAKDOWN_SOURCE_INPUTS = (
+    "source_design_path",
+    "source_issue_key",
+    "feature_request",
+)
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
 _NATIVE_BOOLEAN_TEMPLATE_PATTERN = re.compile(r"^\{\{.*\}\}$", re.DOTALL)
@@ -653,15 +658,49 @@ def _render_value(
 
 def _preset_step_enabled(value: Any) -> bool:
     if value is None:
-        return True
+        return False
     if isinstance(value, bool):
         return value
     if isinstance(value, (int, float)):
         return value != 0
-    normalized = str(value or "").strip().lower()
-    if normalized in {"", "0", "false", "no", "off"}:
+    normalized = str(value).strip().lower()
+    if normalized in {
+        "",
+        "0",
+        "false",
+        "no",
+        "off",
+        "none",
+        "null",
+        "nil",
+        "undefined",
+    }:
         return False
     return True
+
+def _validate_jira_breakdown_source_inputs(
+    *,
+    slug: str,
+    inputs: Mapping[str, Any],
+) -> None:
+    if slug not in _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS:
+        return
+    if any(str(inputs.get(name) or "").strip() for name in _JIRA_BREAKDOWN_SOURCE_INPUTS):
+        return
+    raise PresetValidationError(
+        "Jira breakdown presets require a source input.",
+        errors=[
+            {
+                "path": "preset.inputs",
+                "message": (
+                    "Provide a Declarative Document Path, Source Jira Issue Key, "
+                    "or Workflow Instructions."
+                ),
+                "code": "required",
+                "recoverable": True,
+            }
+        ],
+    )
 
 def _single_allowed_jira_project_key() -> str | None:
     projects = settings.atlassian.jira.jira_allowed_projects
@@ -2031,6 +2070,10 @@ class PresetCatalogService:
             slug=template.slug,
             submitted=submitted_inputs,
             resolved=validated_inputs,
+        )
+        _validate_jira_breakdown_source_inputs(
+            slug=template.slug,
+            inputs=validated_inputs,
         )
         variables = {
             "inputs": validated_inputs,

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -650,6 +650,19 @@ def _render_value(
         }
     return value
 
+
+def _preset_step_enabled(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value or "").strip().lower()
+    if normalized in {"", "0", "false", "no", "off"}:
+        return False
+    return True
+
 def _single_allowed_jira_project_key() -> str | None:
     projects = settings.atlassian.jira.jira_allowed_projects
     if not projects:
@@ -1665,6 +1678,8 @@ class PresetCatalogService:
                 raise PresetValidationError(
                     f"Expanded step at {_format_include_path(path)} must be an object."
                 )
+            if not _preset_step_enabled(rendered.pop("enabled", True)):
+                continue
             kind = str(rendered.get("kind") or _STEP_KIND).strip().lower()
             if (
                 kind == _STEP_KIND

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1372,7 +1372,7 @@ describe.skip("Task Create Entrypoint", () => {
                   steps: [
                     {
                       id: "tpl:jira-breakdown-orchestrate:1:01",
-                      title: "Break down declarative design",
+                      title: "Break down preferred source input",
                       instructions: "Break down the Grid UI overlay plan.",
                       skill: {
                         id: "moonspec-breakdown",
@@ -2239,7 +2239,7 @@ describe.skip("Task Create Entrypoint", () => {
                     steps: [
                       {
                         id: "tpl:jira-breakdown-orchestrate:1:01",
-                        title: "Break down declarative design",
+                        title: "Break down preferred source input",
                         instructions: "Break down the Grid UI overlay plan.",
                         tool: {
                           type: "skill",
@@ -14447,7 +14447,7 @@ describe("Task Create MM-578 Preset expansion", () => {
             steps: [
               {
                 id: "tpl:jira-breakdown-orchestrate:1:01",
-                title: "Break down declarative design",
+                title: "Break down preferred source input",
                 instructions: "Break down the feature request.",
                 skill: { id: "moonspec-breakdown", args: {} },
               },
@@ -14602,7 +14602,7 @@ describe("Task Create MM-578 Preset expansion", () => {
             steps: [
               {
                 id: "tpl:jira-breakdown-orchestrate:1:01",
-                title: "Break down declarative design",
+                title: "Break down preferred source input",
                 instructions: "Break down the feature request.",
                 skill: { id: "moonspec-breakdown", args: {} },
               },

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -89,8 +89,13 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         jira_template = result.scalar_one_or_none()
         assert jira_template is not None
         assert [
-            step["skill"]["id"] for step in jira_template.steps
-        ] == ["moonspec-breakdown", "story.create_jira_issues"]
+            (step.get("skill") or step.get("tool"))["id"]
+            for step in jira_template.steps
+        ] == [
+            "jira.load_preset_brief",
+            "moonspec-breakdown",
+            "story.create_jira_issues",
+        ]
 
         result = await session.execute(
             select(Preset)
@@ -344,17 +349,18 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         composite_template = result.scalar_one_or_none()
         assert composite_template is not None
         assert [
-            step["skill"]["id"]
+            (step.get("skill") or step.get("tool"))["id"]
             for step in composite_template.steps
         ] == [
+            "jira.load_preset_brief",
             "moonspec-breakdown",
             "story-reconcile-implementation",
             "story.create_jira_issues",
             "story.create_jira_orchestrate_tasks",
         ]
-        reconcile_step = composite_template.steps[1]
+        reconcile_step = composite_template.steps[2]
         assert "fully implemented stories" in reconcile_step["instructions"]
-        downstream_step = composite_template.steps[3]
+        downstream_step = composite_template.steps[4]
         assert "trusted Jira story output" in downstream_step["instructions"]
         assert "dependsOn" in downstream_step["instructions"]
         assert "orchestrationMode" not in downstream_step["jiraOrchestration"]["task"]
@@ -377,16 +383,17 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         implement_composite_template = result.scalar_one_or_none()
         assert implement_composite_template is not None
         assert [
-            step["skill"]["id"]
+            (step.get("skill") or step.get("tool"))["id"]
             for step in implement_composite_template.steps
         ] == [
+            "jira.load_preset_brief",
             "moonspec-breakdown",
             "story-reconcile-implementation",
             "story.create_jira_issues",
             "story.create_jira_implement_tasks",
         ]
         implement_downstream_step = (
-            implement_composite_template.steps[3]
+            implement_composite_template.steps[4]
         )
         assert (
             "Create one Jira Implement task"

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -1937,7 +1937,11 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 scope_ref=None,
             )
             assert template.title == "Jira Breakdown"
-            assert [step["skill"]["id"] for step in template.steps] == [
+            assert [
+                (step.get("skill") or step.get("tool"))["id"]
+                for step in template.steps
+            ] == [
+                "jira.load_preset_brief",
                 "moonspec-breakdown",
                 "story.create_jira_issues",
             ]
@@ -1956,6 +1960,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
 
             assert len(expanded["steps"]) == 2
             assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
+            assert expanded["steps"][0]["title"] == "Break down preferred source input"
             assert "docs/Designs/RuntimeTypes.md" in expanded["steps"][0]["instructions"]
             assert expanded["steps"][1]["skill"]["id"] == "story.create_jira_issues"
             assert "Jira Story issue in project MM" in expanded["steps"][1]["instructions"]
@@ -1974,6 +1979,53 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert expanded["appliedTemplate"]["inputs"]["jira_dependency_mode"] == (
                 "linear_blocker_chain"
             )
+
+            expanded_with_source_issue = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "source_issue_key": "MM-910",
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Story",
+                },
+                context={},
+            )
+
+            assert len(expanded_with_source_issue["steps"]) == 3
+            assert expanded_with_source_issue["steps"][0]["tool"]["id"] == (
+                "jira.load_preset_brief"
+            )
+            assert expanded_with_source_issue["steps"][0]["tool"]["inputs"] == {
+                "issueKey": "MM-910"
+            }
+            assert expanded_with_source_issue["steps"][1]["skill"]["id"] == (
+                "moonspec-breakdown"
+            )
+            assert "jiraPresetBrief" in expanded_with_source_issue["steps"][1][
+                "instructions"
+            ]
+
+            expanded_with_path_and_issue = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "source_design_path": "docs/Designs/RuntimeTypes.md",
+                    "source_issue_key": "MM-910",
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Story",
+                },
+                context={},
+            )
+
+            assert len(expanded_with_path_and_issue["steps"]) == 2
+            assert expanded_with_path_and_issue["steps"][0]["skill"]["id"] == (
+                "moonspec-breakdown"
+            )
+            assert "docs/Designs/RuntimeTypes.md" in expanded_with_path_and_issue[
+                "steps"
+            ][0]["instructions"]
 
 async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
     """MM-889: a Document Health Update preset runs review then remediate steps."""
@@ -2136,8 +2188,8 @@ async def test_jira_breakdown_orchestrate_uses_repository_policy_defaults(
                 },
             )
 
-            jira_step = expanded["steps"][2]
-            downstream_step = expanded["steps"][3]
+            jira_step = expanded["steps"][3]
+            downstream_step = expanded["steps"][4]
 
             assert "Jira Story issue in project GAME" in jira_step[
                 "instructions"
@@ -2252,11 +2304,11 @@ async def test_jira_breakdown_orchestrate_preserves_explicit_project_input(
                 },
             )
 
-            assert expanded["steps"][2]["storyOutput"]["jira"]["projectKey"] == "PLAT"
-            assert expanded["steps"][3]["jiraOrchestration"]["task"]["repository"] == (
+            assert expanded["steps"][3]["storyOutput"]["jira"]["projectKey"] == "PLAT"
+            assert expanded["steps"][4]["jiraOrchestration"]["task"]["repository"] == (
                 "ExampleOrg/Game"
             )
-            assert expanded["steps"][3]["jiraOrchestration"]["task"]["runtime"] == (
+            assert expanded["steps"][4]["jiraOrchestration"]["task"]["runtime"] == (
                 {"mode": "claude_code"}
             )
 
@@ -2608,8 +2660,10 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
                 "dependent-jira-orchestrate-tasks"
             )
             assert [
-                step["skill"]["id"] for step in template.steps
+                (step.get("skill") or step.get("tool"))["id"]
+                for step in template.steps
             ] == [
+                "jira.load_preset_brief",
                 "moonspec-breakdown",
                 "story-reconcile-implementation",
                 "story.create_jira_issues",
@@ -2635,26 +2689,29 @@ async def test_seed_catalog_includes_jira_breakdown_orchestrate_preset(
                 },
             )
 
-            assert len(expanded["steps"]) == 4
-            assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
-            assert expanded["steps"][1]["skill"]["id"] == (
+            assert len(expanded["steps"]) == 5
+            assert expanded["steps"][0]["tool"]["id"] == "jira.load_preset_brief"
+            assert expanded["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-404"}
+            assert expanded["steps"][1]["skill"]["id"] == "moonspec-breakdown"
+            assert "input preference chain" in expanded["steps"][1]["instructions"]
+            assert expanded["steps"][2]["skill"]["id"] == (
                 "story-reconcile-implementation"
             )
-            assert "fully implemented stories" in expanded["steps"][1]["instructions"]
-            assert expanded["steps"][2]["skill"]["id"] == "story.create_jira_issues"
-            assert expanded["steps"][2]["storyOutput"]["jira"] == {
+            assert "fully implemented stories" in expanded["steps"][2]["instructions"]
+            assert expanded["steps"][3]["skill"]["id"] == "story.create_jira_issues"
+            assert expanded["steps"][3]["storyOutput"]["jira"] == {
                 "projectKey": "MM",
                 "issueTypeName": "Story",
                 "boardId": "84",
                 "sourceIssueKey": "MM-404",
                 "dependencyMode": "linear_blocker_chain",
             }
-            downstream = expanded["steps"][3]
+            downstream = expanded["steps"][4]
             assert downstream["skill"]["id"] == "story.create_jira_orchestrate_tasks"
             assert "Create one Jira Orchestrate task" in downstream["instructions"]
             assert "dependsOn" in downstream["instructions"]
             assert "MM-404" in downstream["instructions"]
-            assert "Selected Jira board ID: 84" in expanded["steps"][2]["instructions"]
+            assert "Selected Jira board ID: 84" in expanded["steps"][3]["instructions"]
             assert downstream["jiraOrchestration"]["task"] == {
                 "repository": "MoonLadderStudios/MoonMind",
                 "runtime": {"mode": "codex_cli"},
@@ -2704,7 +2761,7 @@ async def test_jira_breakdown_orchestrate_can_create_source_subtasks(
                 },
             )
 
-            jira_step = expanded["steps"][2]
+            jira_step = expanded["steps"][3]
             assert "Create each generated Jira issue as a sub-task of MM-404" in (
                 jira_step["instructions"]
             )
@@ -2748,11 +2805,13 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
                 },
             )
 
-    assert len(expanded["steps"]) == 4
-    assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
-    assert expanded["steps"][1]["skill"]["id"] == "story-reconcile-implementation"
-    assert expanded["steps"][2]["skill"]["id"] == "story.create_jira_issues"
-    downstream = expanded["steps"][3]
+    assert len(expanded["steps"]) == 5
+    assert expanded["steps"][0]["tool"]["id"] == "jira.load_preset_brief"
+    assert expanded["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-404"}
+    assert expanded["steps"][1]["skill"]["id"] == "moonspec-breakdown"
+    assert expanded["steps"][2]["skill"]["id"] == "story-reconcile-implementation"
+    assert expanded["steps"][3]["skill"]["id"] == "story.create_jira_issues"
+    downstream = expanded["steps"][4]
     assert downstream["skill"]["id"] == "story.create_jira_implement_tasks"
     assert downstream["jiraOrchestration"]["task"] == {
         "repository": "MoonLadderStudios/MoonMind",

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -767,6 +767,58 @@ async def test_expand_template_repeated_recursive_expansion_is_stable(tmp_path):
     ]
 
 
+async def test_expand_template_skips_steps_with_falsy_enabled_values(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.create_template(
+                slug="conditional-steps",
+                title="Conditional Steps",
+                description="Conditional steps.",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[
+                    {
+                        "name": "switch",
+                        "label": "Switch",
+                        "type": "text",
+                        "required": False,
+                        "default": "null",
+                    }
+                ],
+                steps=[
+                    {
+                        "title": "Null disabled",
+                        "instructions": "Should not run.",
+                        "enabled": None,
+                    },
+                    {
+                        "title": "String null disabled",
+                        "instructions": "Should not run either.",
+                        "enabled": "{{ inputs.switch }}",
+                    },
+                    {
+                        "title": "Enabled step",
+                        "instructions": "Should run.",
+                    },
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            expanded = await service.expand_template(
+                slug="conditional-steps",
+                scope="global",
+                scope_ref=None,
+                inputs={},
+                context={},
+            )
+
+    assert [step["title"] for step in expanded["steps"]] == ["Enabled step"]
+
+
 async def test_expand_template_flattens_multi_level_include_tree_with_provenance(
     tmp_path,
 ):
@@ -2006,6 +2058,28 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
                 "instructions"
             ]
 
+            expanded_with_null_optional_sources = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "feature_request": "Inline workflow source.",
+                    "source_design_path": None,
+                    "source_issue_key": None,
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Story",
+                },
+                context={},
+            )
+
+            assert len(expanded_with_null_optional_sources["steps"]) == 2
+            assert expanded_with_null_optional_sources["steps"][0]["skill"]["id"] == (
+                "moonspec-breakdown"
+            )
+            assert "Inline workflow source." in expanded_with_null_optional_sources[
+                "steps"
+            ][0]["instructions"]
+
             expanded_with_path_and_issue = await service.expand_template(
                 slug="jira-breakdown",
                 scope="global",
@@ -2026,6 +2100,30 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "docs/Designs/RuntimeTypes.md" in expanded_with_path_and_issue[
                 "steps"
             ][0]["instructions"]
+
+            with pytest.raises(PresetValidationError) as excinfo:
+                await service.expand_template(
+                    slug="jira-breakdown",
+                    scope="global",
+                    scope_ref=None,
+                    inputs={
+                        "jira_project_key": "MM",
+                        "jira_issue_type": "Story",
+                    },
+                    context={},
+                )
+
+    assert excinfo.value.errors == [
+        {
+            "path": "preset.inputs",
+            "message": (
+                "Provide a Declarative Document Path, Source Jira Issue Key, "
+                "or Workflow Instructions."
+            ),
+            "code": "required",
+            "recoverable": True,
+        }
+    ]
 
 async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
     """MM-889: a Document Health Update preset runs review then remediate steps."""

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -519,7 +519,7 @@ async def test_child_jira_breakdown_implement_expands_workflow_runtime_context(
             )
 
     task = expanded_parameters["workflow"]
-    downstream_task = task["steps"][3]["jiraOrchestration"]["task"]
+    downstream_task = task["steps"][4]["jiraOrchestration"]["task"]
     assert downstream_task["repository"] == "MoonLadderStudios/MoonMind"
     assert downstream_task["runtime"] == {"mode": "codex_cli"}
     assert downstream_task["publish"] == {
@@ -1809,7 +1809,7 @@ def test_runtime_planner_dedupes_repeated_identical_preset_steps():
     )
     breakdown_step = {
         "id": "tpl:jira-breakdown-orchestrate:1.0.0:01:6bfb1360",
-        "title": "Break down declarative design",
+        "title": "Break down preferred source input",
         "type": "skill",
         "skill": {"id": "moonspec-breakdown", "requiredCapabilities": ["git"]},
         "instructions": "Extract MoonSpec stories.",


### PR DESCRIPTION
## Summary
- Update moonspec-breakdown to select input content by preference: declarative document path, trusted Jira issue description, then workflow instructions.
- Update Jira breakdown presets to expose source_design_path/source_issue_key and conditionally load a trusted Jira issue brief only when no document path is provided.
- Add preset expansion support for optional rendered steps and update unit/integration/runtime/frontend fixtures.

## Tests
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_presets_service.py tests/integration/test_startup_preset_seeding.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
- npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx --reporter=dot
- npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx --reporter=dot
- Full ./tools/test_unit.sh: Python phase passed; UI phase still times out in existing frontend/src/entrypoints/workflow-list.test.tsx filter tests, unrelated to this change.