### PR TITLE
MM-920 Reduce nesting and rails between panel edge and Live Logs

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -814,6 +814,7 @@ async def workflow_console_route(
         "workflow-detail",
         detail_path,
         initial_data={"dashboardConfig": dashboard_config},
+        data_wide_panel=True,
         session=session,
         user=_user,
     )

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1944,6 +1944,13 @@ describe('Workflow Detail Entrypoint', () => {
     });
     expect(screen.getAllByText('approval policy: passed')[0]?.className).toContain('check-passed');
 
+    // MM-920: the embedded step logs drop the redundant left rail and the second
+    // "Live Logs" disclosure, so the log content sits directly under the
+    // "Logs & Diagnostics" heading.
+    const logsHeading = screen.getByRole('heading', { name: 'Logs & Diagnostics' });
+    expect(logsHeading.closest('section')?.className).toContain('step-tl-detail-section--logs');
+    expect(screen.queryByText('Live Logs')).toBeNull();
+
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/agent-runs/agent-run-step-1/observability-summary')),
     ).toBe(true);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2745,6 +2745,7 @@ function StepObservabilityGroup({
         agentRunId={agentRunId}
         isTerminal={stepTerminal(row.status)}
         autoExpand
+        disclosure={false}
         routes={routes}
         sessionTimelineEnabled={sessionTimelineEnabled}
         structuredHistoryEnabled={structuredHistoryEnabled}
@@ -3171,7 +3172,7 @@ function StepLedgerRowCard({
                 </ul>
               </section>
             ) : null}
-            <section className="step-tl-detail-section">
+            <section className="step-tl-detail-section step-tl-detail-section--logs">
               <h4>Logs & Diagnostics</h4>
               <StepObservabilityGroup
                 apiBase={apiBase}
@@ -3211,6 +3212,7 @@ function LiveLogsPanel({
   agentRunId,
   isTerminal,
   autoExpand = false,
+  disclosure = true,
   routes,
   sessionTimelineEnabled,
   structuredHistoryEnabled,
@@ -3219,6 +3221,10 @@ function LiveLogsPanel({
   agentRunId: string;
   isTerminal: boolean;
   autoExpand?: boolean;
+  // When false, render the log content directly without the collapsible
+  // "Live Logs" disclosure chrome (used when the panel is embedded under an
+  // existing heading, e.g. the step's "Logs & Diagnostics" section).
+  disclosure?: boolean;
   routes: AgentRunRouteTemplates;
   sessionTimelineEnabled: boolean;
   structuredHistoryEnabled: boolean;
@@ -3491,6 +3497,61 @@ function LiveLogsPanel({
       ].filter(([, value]) => value) as Array<[string, string]>
     : [];
 
+  const panelBody = (
+    <div className="stack live-logs-panel">
+      {summaryErrorMessage ? <div className="notice error">{summaryErrorMessage}</div> : null}
+      {expanded ? (
+        <div className="button-group live-logs-toolbar">
+          <label className="live-logs-wrap-toggle">
+            <input type="checkbox" checked={wrapLines} onChange={(e) => setWrapLines(e.target.checked)} />
+            <span className="small">Wrap lines</span>
+          </label>
+          <button className="secondary small" onClick={handleCopy}>Copy</button>
+          <a className="button secondary small" href={downloadUrl} target="_blank" rel="noreferrer">Download</a>
+        </div>
+      ) : null}
+      <p className="small">
+        Workflow run <code className="text-xs">{agentRunId}</code> — {statusLabel}
+      </p>
+      {sessionTimelineEnabled ? (
+        <p className="small">
+          Timeline shows what happened. Continuity artifacts remain the durable drill-down evidence.
+        </p>
+      ) : null}
+      {sessionBadges.length > 0 ? (
+        <div className="live-logs-session-badges">
+          {sessionBadges.map(([label, value]) => (
+            <span key={`${label}-${value}`} className="card live-logs-session-badge">
+              <strong>{label}:</strong> <code className="text-xs break-all">{value}</code>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div className={`live-logs-viewer-shell ${wrapLines ? 'is-wrapped' : 'is-unwrapped'}`}>
+        {logContent.length === 0 ? (
+          <div className="live-logs-empty">{emptyLabel}</div>
+        ) : sessionTimelineEnabled ? (
+          <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
+            <Virtuoso
+              style={{ height: 400 }}
+              data={logContent}
+              computeItemKey={(_, row) => row.id}
+              itemContent={(_, row) => renderTimelineRow(row, wrapLines, true, apiBase)}
+            />
+          </div>
+        ) : (
+          <div data-testid="live-logs-legacy-viewer" className="live-logs-legacy-viewer">
+            {logContent.map((line) => renderTimelineRow(line, wrapLines, false, apiBase))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  if (!disclosure) {
+    return panelBody;
+  }
+
   return (
     <details
       className="stack"
@@ -3505,54 +3566,7 @@ function LiveLogsPanel({
       >
         <span>Live Logs</span>
       </summary>
-      <div className="stack live-logs-panel">
-        {summaryErrorMessage ? <div className="notice error">{summaryErrorMessage}</div> : null}
-        {expanded ? (
-          <div className="button-group live-logs-toolbar">
-            <label className="live-logs-wrap-toggle">
-              <input type="checkbox" checked={wrapLines} onChange={(e) => setWrapLines(e.target.checked)} />
-              <span className="small">Wrap lines</span>
-            </label>
-            <button className="secondary small" onClick={handleCopy}>Copy</button>
-            <a className="button secondary small" href={downloadUrl} target="_blank" rel="noreferrer">Download</a>
-          </div>
-        ) : null}
-        <p className="small">
-          Workflow run <code className="text-xs">{agentRunId}</code> — {statusLabel}
-        </p>
-        {sessionTimelineEnabled ? (
-          <p className="small">
-            Timeline shows what happened. Continuity artifacts remain the durable drill-down evidence.
-          </p>
-        ) : null}
-        {sessionBadges.length > 0 ? (
-          <div className="live-logs-session-badges">
-            {sessionBadges.map(([label, value]) => (
-              <span key={`${label}-${value}`} className="card live-logs-session-badge">
-                <strong>{label}:</strong> <code className="text-xs break-all">{value}</code>
-              </span>
-            ))}
-          </div>
-        ) : null}
-        <div className={`live-logs-viewer-shell ${wrapLines ? 'is-wrapped' : 'is-unwrapped'}`}>
-          {logContent.length === 0 ? (
-            <div className="live-logs-empty">{emptyLabel}</div>
-          ) : sessionTimelineEnabled ? (
-            <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
-              <Virtuoso
-                style={{ height: 400 }}
-                data={logContent}
-                computeItemKey={(_, row) => row.id}
-                itemContent={(_, row) => renderTimelineRow(row, wrapLines, true, apiBase)}
-              />
-            </div>
-          ) : (
-            <div data-testid="live-logs-legacy-viewer" className="live-logs-legacy-viewer">
-              {logContent.map((line) => renderTimelineRow(line, wrapLines, false, apiBase))}
-            </div>
-          )}
-        </div>
-      </div>
+      {panelBody}
     </details>
   );
 }

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -3231,7 +3231,11 @@ function LiveLogsPanel({
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
-  const [expanded, setExpanded] = useState(false);
+  // When rendered without disclosure chrome the panel is always visible, so it
+  // must start expanded; otherwise honor autoExpand. This avoids delaying the
+  // initial log fetch by a render cycle and prevents the embedded toolbar from
+  // being permanently hidden when autoExpand is not set.
+  const [expanded, setExpanded] = useState(!disclosure || autoExpand);
   const isVisible = usePageVisibility();
   const lastSeqRef = useRef<number | null>(null);
   const esRef = useRef<EventSource | null>(null);

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -3598,6 +3598,18 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   background: rgb(var(--mm-panel) / 0.35);
 }
 
+/*
+ * MM-920: Drop the redundant left rail on the Logs & Diagnostics section so the
+ * only vertical line beside the live logs is the step timeline spine. Removing
+ * the padding/background also lets the log content sit flush under the heading.
+ */
+.step-tl-detail-section--logs {
+  border-left: 0;
+  padding: 0;
+  border-radius: 0;
+  background: none;
+}
+
 .step-tl-detail-section h4 {
   margin: 0 0 0.35rem;
   font-size: 0.78rem;

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -380,7 +380,11 @@ def test_detail_sub_routes_render_dashboard_shell(client: TestClient) -> None:
         assert "/static/workflow_console/dist/assets/" in response.text
 
 def test_data_wide_panel_on_selected_react_routes(client: TestClient) -> None:
-    for path in ("/workflows",):
+    for path in (
+        "/workflows",
+        "/workflows/mm:workflow-123",
+        "/workflows/mm:workflow-123/steps",
+    ):
         response = client.get(path)
         assert response.status_code == 200
         assert '"dataWidePanel":true' in response.text


### PR DESCRIPTION
## Issue

[MM-920](https://moonladder.atlassian.net/browse/MM-920) — Reduce Nesting with Live Logs

## Summary

Reduces nesting and stacked vertical rails between the workflow detail panel edge and the Live Logs content, so the live logs read cleanly with only the step timeline spine as the intentional rail.

- **Widen the workflow detail panel** — pass `data_wide_panel=True` to the `workflow-detail` render call in `api_service/api/routers/workflow_console.py`, matching sibling routes (112rem instead of the 72rem fallback). The shell already applies `panel--data-wide` from the boot flag, so no other backend/frontend wiring was needed.
- **Drop the redundant section rail** — add a scoped `step-tl-detail-section--logs` modifier on the Logs & Diagnostics `<section>` in `frontend/src/entrypoints/workflow-detail.tsx` and neutralize its `border-left`/padding/background in `frontend/src/styles/mission-control.css`. Other detail sections keep their rail; the step timeline spine (`.step-tl-line`) is untouched.
- **Remove the redundant "Live Logs" disclosure and empty wrappers** — add a `disclosure` prop to `LiveLogsPanel` (default `true`). `StepObservabilityGroup` now passes `disclosure={false}` so the embedded panel renders its body directly under the "Logs & Diagnostics" heading, dropping the second `<summary>Live Logs</summary>` header. The shared panel body was extracted so both the standalone (disclosure) and embedded (no-disclosure) paths reuse identical markup.

The standalone Live Logs panel's collapse/expand behavior in the Observation fallback region is preserved (it still renders with the disclosure). Live-log streaming/data behavior and the wrap/copy/download controls are unchanged.

## Tests run

- `./tools/test_unit.sh` (Python + frontend unit suites), including:
  - `tests/unit/api/routers/test_workflow_console.py::test_data_wide_panel_on_selected_react_routes` — extended to assert `"dataWidePanel":true` for the `/workflows/{id}` and `/workflows/{id}/steps` detail routes.
  - `frontend/src/entrypoints/workflow-detail.test.tsx` — extended to assert the Logs & Diagnostics section carries `step-tl-detail-section--logs` and that the redundant "Live Logs" disclosure text is no longer rendered in the embedded step context.

## Remaining risks

- Changes are purely presentational (panel width, CSS rail, DOM structure). No streaming/data path changes.
- The CSS rail removal is scoped to the `--logs` modifier, so other `.step-tl-detail-section` instances are unaffected; visual confirmation on a wide monitor is recommended but low-risk.
- `LiveLogsPanel` now has two render paths (disclosure vs. embedded) sharing one extracted body; both are exercised by unit tests, but full visual parity is best confirmed in the running app.


[MM-920]: https://moonladder.atlassian.net/browse/MM-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ