### PR TITLE
MM-919 Implement workflow-level pause/resume overlay

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4717,16 +4717,37 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         settings.temporal_dashboard.temporal_workflow_editing_enabled
     )
     state_actions = {
-        "scheduled": {"can_set_title", "can_update_inputs", "can_cancel"},
-        "initializing": {"can_set_title", "can_update_inputs", "can_cancel"},
+        "scheduled": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_pause",
+            "can_cancel",
+        },
+        "initializing": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_pause",
+            "can_cancel",
+        },
         "waiting_on_dependencies": {
             "can_set_title",
             "can_update_inputs",
+            "can_pause",
             "can_cancel",
             "can_bypass_dependencies",
         },
-        "awaiting_slot": {"can_set_title", "can_update_inputs", "can_cancel"},
-        "planning": {"can_set_title", "can_update_inputs", "can_cancel"},
+        "awaiting_slot": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_pause",
+            "can_cancel",
+        },
+        "planning": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_pause",
+            "can_cancel",
+        },
         "executing": {
             "can_set_title",
             "can_update_inputs",
@@ -4736,6 +4757,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         "proposals": {
             "can_set_title",
             "can_update_inputs",
+            "can_pause",
             "can_cancel",
         },
         "awaiting_external": {
@@ -4746,7 +4768,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
             "can_reject",
             "can_send_message",
         },
-        "finalizing": {"can_cancel"},
+        "finalizing": {"can_pause", "can_cancel"},
         "completed": {"can_edit_for_rerun", "can_rerun"},
         "failed": {"can_edit_for_rerun", "can_rerun"},
         "canceled": {"can_edit_for_rerun", "can_rerun"},

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -4,7 +4,7 @@
 **Doc type:** API contract 
 **Status:** Draft 
 **Owner:** MoonMind Platform 
-**Last updated:** 2026-06-23 (UTC) 
+**Last updated:** 2026-06-25 (UTC)
 **Audience:** backend, dashboard, integrations
 
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
@@ -776,8 +776,8 @@ Required payload fields:
 Behavior:
 
 - may attach `payloadArtifactRef` to `artifactRefs`,
-- clears `awaiting_external`,
-- resumes execution if not paused,
+- records the integration event,
+- clears the external wait only when the execution is not paused,
 - updates the execution summary.
 
 #### `Approve`
@@ -799,13 +799,13 @@ Behavior:
 
 Purpose:
 
-- request that the execution enter an awaiting state.
+- pause automatic progress for a non-terminal execution.
 
 Behavior:
 
 - sets `paused = true`,
-- sets `awaiting_external = true`,
-- moves `state` to `awaiting_external`.
+- preserves the underlying lifecycle `state`,
+- records operator pause waiting metadata so product surfaces can display the paused overlay.
 
 #### `Resume`
 
@@ -815,8 +815,8 @@ Purpose:
 
 Behavior:
 
-- clears pause/external wait flags,
-- moves execution back to `executing`.
+- clears `paused` and operator pause waiting metadata,
+- preserves the underlying lifecycle `state` so scheduled, dependency-waiting, slot-waiting, and active executions resume from the correct gate.
 
 ### 13.4 Success response
 

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1576,7 +1576,6 @@ class TemporalExecutionService:
                 waiting_reason="operator_paused",
                 attention_required=True,
             )
-            self._set_state(record, MoonMindWorkflowState.AWAITING_EXTERNAL)
             self._set_wait_metadata(
                 record,
                 waiting_reason="operator_paused",
@@ -1587,7 +1586,8 @@ class TemporalExecutionService:
         elif update_name == "Resume":
             record.paused = False
             self._clear_waiting_metadata(record)
-            self._set_state(record, MoonMindWorkflowState.EXECUTING)
+            self._clear_wait_metadata(record)
+            self._touch(record)
             self._update_summary(record, "Execution resumed.")
             response = {"accepted": True, "applied": "async"}
         elif update_name == "Approve":
@@ -1715,7 +1715,6 @@ class TemporalExecutionService:
                     waiting_reason="operator_paused",
                     attention_required=True,
                 )
-                self._set_state(record, MoonMindWorkflowState.AWAITING_EXTERNAL)
                 self._set_wait_metadata(
                     record,
                     waiting_reason="operator_paused",
@@ -1731,7 +1730,8 @@ class TemporalExecutionService:
             elif signal_name == "Resume":
                 record.paused = False
                 self._clear_waiting_metadata(record)
-                self._set_state(record, MoonMindWorkflowState.EXECUTING)
+                self._clear_wait_metadata(record)
+                self._touch(record)
                 self._append_intervention_audit(
                     record,
                     action="resume",

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2595,6 +2595,10 @@ class MoonMindAgentRun:
                     )
 
                 manager_handle = None
+                if self._paused:
+                    await workflow.wait_condition(lambda: not self._paused)
+                    overall_start = workflow.now()
+
                 # Acquire provider-profile slot if managed
                 if request.agent_kind == "managed":
                     runtime_id = self._managed_runtime_id(request.agent_id)
@@ -2818,14 +2822,15 @@ class MoonMindAgentRun:
                                 lambda: self.slot_assigned_event.is_set(),
                             )
 
-                    # Reset the execution clock so the timeout budget starts
-                    # from slot acquisition, not from workflow start.
-                    overall_start = workflow.now()
                     self._awaiting_slot_reason_override = None
                     self._slot_wait_timeout_override_seconds = None
 
                     if self._paused:
                         await workflow.wait_condition(lambda: not self._paused)
+
+                    # Reset the execution clock so the timeout budget starts
+                    # from launch readiness, excluding slot and pause waits.
+                    overall_start = workflow.now()
 
                     self.run_status = RunStatus.launching
                     if parent_info:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -416,6 +416,7 @@ class MoonMindAgentRun:
         self._skip_default_profile_pin_once: bool = False
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
+        self._paused: bool = False
 
     @staticmethod
     def _safe_callback_key(*parts: str) -> str:
@@ -1876,6 +1877,28 @@ class MoonMindAgentRun:
         self._assigned_profile_id = payload.get("profile_id")
         self.slot_assigned_event.set()
 
+    @workflow.update(name="Pause")
+    def pause(self) -> None:
+        self._paused = True
+
+    @pause.validator
+    def validate_pause(self) -> None:
+        if self._paused:
+            raise ValueError("Agent run is already paused.")
+        if self.run_status in _TERMINAL_RUN_STATUSES:
+            raise ValueError("Cannot pause a terminal agent run.")
+
+    @workflow.update(name="Resume")
+    def resume(self) -> None:
+        self._paused = False
+
+    @resume.validator
+    def validate_resume(self) -> None:
+        if not self._paused:
+            raise ValueError("Agent run is not paused.")
+        if self.run_status in _TERMINAL_RUN_STATUSES:
+            raise ValueError("Cannot resume a terminal agent run.")
+
     @workflow.signal
     def update_runtime_selection(self, payload: dict[str, Any] | None = None) -> None:
         payload = payload or {}
@@ -2800,7 +2823,10 @@ class MoonMindAgentRun:
                     overall_start = workflow.now()
                     self._awaiting_slot_reason_override = None
                     self._slot_wait_timeout_override_seconds = None
-                    
+
+                    if self._paused:
+                        await workflow.wait_condition(lambda: not self._paused)
+
                     self.run_status = RunStatus.launching
                     if parent_info:
                         parent_handle = workflow.get_external_workflow_handle(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -954,6 +954,7 @@ class MoonMindRunWorkflow:
 
         # State tracking
         self._paused: bool = False
+        self._pause_resume_transition_in_progress: bool = False
         self._awaiting_external: bool = False
         self._waiting_reason: Optional[str] = None
         self._attention_required: bool = False
@@ -5173,9 +5174,8 @@ class MoonMindRunWorkflow:
         try:
             await self._reconcile_dependencies(dependency_ids)
             while not self._cancel_requested and (
-                self._unresolved_dependency_ids
+                (self._dependency_failure is None and self._unresolved_dependency_ids)
                 or self._paused
-                or (self._dependency_failure is not None and self._paused)
             ):
                 try:
                     await workflow.wait_condition(
@@ -13966,13 +13966,25 @@ class MoonMindRunWorkflow:
 
     @workflow.update(name="Pause")
     async def pause(self) -> None:
-        self._paused = True
-        self._waiting_reason = "Paused by user"
-        await self._forward_lifecycle_update_to_active_child("Pause")
-        self._update_search_attributes()
+        self._pause_resume_transition_in_progress = True
+        previous_waiting_reason = self._waiting_reason
+        try:
+            self._paused = True
+            self._waiting_reason = "Paused by user"
+            if not await self._forward_lifecycle_update_to_active_child("Pause"):
+                self._paused = False
+                self._waiting_reason = previous_waiting_reason
+                raise RuntimeError(
+                    "Failed to forward Pause update to active child workflow."
+                )
+            self._update_search_attributes()
+        finally:
+            self._pause_resume_transition_in_progress = False
 
     @pause.validator
     def validate_pause(self) -> None:
+        if self._pause_resume_transition_in_progress:
+            raise ValueError("Pause/Resume transition already in progress.")
         if self._paused:
             raise ValueError("Workflow is already paused.")
         if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
@@ -13980,16 +13992,29 @@ class MoonMindRunWorkflow:
 
     @workflow.update(name="Resume")
     async def resume(self, payload: dict[str, Any] | None = None) -> None:
-        self._paused = False
-        self._waiting_reason = None
-        await self._forward_lifecycle_update_to_active_child("Resume")
-        await self._forward_operator_message_to_active_child(payload)
-        if self._awaiting_external:
-            self._recovery_requested = True
-        self._update_search_attributes()
+        self._pause_resume_transition_in_progress = True
+        previous_paused = self._paused
+        previous_waiting_reason = self._waiting_reason
+        try:
+            self._paused = False
+            self._waiting_reason = None
+            if not await self._forward_lifecycle_update_to_active_child("Resume"):
+                self._paused = previous_paused
+                self._waiting_reason = previous_waiting_reason
+                raise RuntimeError(
+                    "Failed to forward Resume update to active child workflow."
+                )
+            await self._forward_operator_message_to_active_child(payload)
+            if self._awaiting_external:
+                self._recovery_requested = True
+            self._update_search_attributes()
+        finally:
+            self._pause_resume_transition_in_progress = False
 
     @resume.validator
     def validate_resume(self, payload: dict[str, Any] | None = None) -> None:
+        if self._pause_resume_transition_in_progress:
+            raise ValueError("Pause/Resume transition already in progress.")
         if not self._paused and not self._awaiting_external:
             raise ValueError("Workflow is not paused or awaiting external completion.")
         if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
@@ -14184,7 +14209,7 @@ class MoonMindRunWorkflow:
 
     async def _forward_lifecycle_update_to_active_child(self, update_name: str) -> bool:
         if not self._active_agent_child_workflow_id:
-            return False
+            return True
         handle = workflow.get_external_workflow_handle(
             self._active_agent_child_workflow_id
         )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -13965,9 +13965,10 @@ class MoonMindRunWorkflow:
         return None
 
     @workflow.update(name="Pause")
-    def pause(self) -> None:
+    async def pause(self) -> None:
         self._paused = True
         self._waiting_reason = "Paused by user"
+        await self._forward_lifecycle_update_to_active_child("Pause")
         self._update_search_attributes()
 
     @pause.validator
@@ -13981,6 +13982,7 @@ class MoonMindRunWorkflow:
     async def resume(self, payload: dict[str, Any] | None = None) -> None:
         self._paused = False
         self._waiting_reason = None
+        await self._forward_lifecycle_update_to_active_child("Resume")
         await self._forward_operator_message_to_active_child(payload)
         if self._awaiting_external:
             self._recovery_requested = True
@@ -14178,6 +14180,24 @@ class MoonMindRunWorkflow:
         await handle.signal("operator_message", {"message": message})
         self._summary = "Operator clarification sent to Jules."
         self._update_memo()
+        return True
+
+    async def _forward_lifecycle_update_to_active_child(self, update_name: str) -> bool:
+        if not self._active_agent_child_workflow_id:
+            return False
+        handle = workflow.get_external_workflow_handle(
+            self._active_agent_child_workflow_id
+        )
+        try:
+            await handle.execute_update(update_name)
+        except Exception as exc:
+            self._get_logger().warning(
+                "Failed to forward %s update to active child workflow %s: %s",
+                update_name,
+                self._active_agent_child_workflow_id,
+                exc,
+            )
+            return False
         return True
 
     @staticmethod

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -5172,15 +5172,15 @@ class MoonMindRunWorkflow:
 
         try:
             await self._reconcile_dependencies(dependency_ids)
-            while (
-                not self._cancel_requested
-                and self._dependency_failure is None
-                and (self._unresolved_dependency_ids or self._paused)
+            while not self._cancel_requested and (
+                self._unresolved_dependency_ids
+                or self._paused
+                or (self._dependency_failure is not None and self._paused)
             ):
                 try:
                     await workflow.wait_condition(
                         lambda: self._cancel_requested
-                        or self._dependency_failure is not None
+                        or (self._dependency_failure is not None and not self._paused)
                         or (
                             not self._paused
                             and not self._unresolved_dependency_ids
@@ -5291,12 +5291,19 @@ class MoonMindRunWorkflow:
                 now = workflow.now()
                 delay = target_dt - now
                 if delay.total_seconds() <= 0:
-                    break
+                    if not self._paused:
+                        break
+                    await self._wait_if_paused_at_safe_boundary()
+                    if self._cancel_requested:
+                        break
+                    continue
 
                 self._reschedule_requested = False
                 try:
                     await workflow.wait_condition(
-                        lambda: self._reschedule_requested or self._cancel_requested,
+                        lambda: self._reschedule_requested
+                        or self._cancel_requested
+                        or self._paused,
                         timeout=delay,
                     )
                 except asyncio.TimeoutError:
@@ -5307,6 +5314,11 @@ class MoonMindRunWorkflow:
 
                 if self._cancel_requested:
                     break
+                if self._paused:
+                    await self._wait_if_paused_at_safe_boundary()
+                    if self._cancel_requested:
+                        break
+                    continue
 
         if self._cancel_requested:
             await self._run_finalizing_stage(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10198,6 +10198,39 @@ def test_describe_execution_exposes_dependency_bypass_action(
     assert body["actions"]["canBypassDependencies"] is True
     assert "canBypassDependencies" not in body["actions"]["disabledReasons"]
 
+@pytest.mark.parametrize(
+    "state",
+    [
+        MoonMindWorkflowState.SCHEDULED,
+        MoonMindWorkflowState.WAITING_ON_DEPENDENCIES,
+        MoonMindWorkflowState.AWAITING_SLOT,
+        MoonMindWorkflowState.PLANNING,
+        MoonMindWorkflowState.PROPOSALS,
+        MoonMindWorkflowState.FINALIZING,
+    ],
+)
+def test_describe_execution_exposes_pause_for_non_terminal_pause_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    state: MoonMindWorkflowState,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record(state=state)
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == state.value
+    assert body["actions"]["canPause"] is True
+    assert "canPause" not in body["actions"]["disabledReasons"]
+
 def test_describe_execution_exposes_lifecycle_resume_for_operator_paused_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3877,7 +3877,8 @@ async def test_signal_pause_recovery_and_external_event_transitions(
             payload_artifact_ref=None,
         )
         paused = await service.describe_execution(created.workflow_id)
-        assert paused.state is MoonMindWorkflowState.AWAITING_EXTERNAL
+        assert paused.state is MoonMindWorkflowState.INITIALIZING
+        assert paused.paused is True
         assert paused.memo["waiting_reason"] == "operator_paused"
         assert paused.memo["attention_required"] is True
         assert paused.memo["intervention_audit"][-1]["transport"] == "temporal_update"
@@ -3889,7 +3890,8 @@ async def test_signal_pause_recovery_and_external_event_transitions(
             payload_artifact_ref=None,
         )
         resumed = await service.describe_execution(created.workflow_id)
-        assert resumed.state is MoonMindWorkflowState.EXECUTING
+        assert resumed.state is MoonMindWorkflowState.INITIALIZING
+        assert resumed.paused is False
         assert "waiting_reason" not in resumed.memo
         assert resumed.memo["intervention_audit"][-1]["transport"] == "temporal_update"
 
@@ -3936,7 +3938,8 @@ async def test_signal_resume_forwards_payload_via_workflow_update(
             {"message": "Use the Provider Profiles label."},
         )
         resumed = await service.describe_execution(created.workflow_id)
-        assert resumed.state is MoonMindWorkflowState.EXECUTING
+        assert resumed.state is MoonMindWorkflowState.INITIALIZING
+        assert resumed.paused is False
         assert resumed.memo.get("waiting_reason") is None
         assert resumed.memo["intervention_audit"][-1]["transport"] == "temporal_update"
         assert (

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -14,6 +14,7 @@ import textwrap
 from moonmind.workflows.temporal.workflows.agent_run import (
     MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID,
     MoonMindAgentRun,
+    RunStatus,
     _SLOT_WAIT_TIMEOUT_SECONDS,
     _SLOT_WAIT_MAX_RESETS,
 )
@@ -95,6 +96,25 @@ class TestSlotWaitRetryBehavior:
             "the slot_assigned_event wait_condition so that awaiting time "
             "does not count against the execution timeout"
         )
+
+    def test_pause_gate_blocks_launch_after_slot_acquisition(self):
+        """A paused AgentRun must not cross from slot assignment into launch."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+        slot_wait_index = source.index("slot_assigned_event.is_set()")
+        pause_gate_index = source.index("await workflow.wait_condition(lambda: not self._paused)")
+        launch_index = source.index("self.run_status = RunStatus.launching")
+
+        assert slot_wait_index < pause_gate_index < launch_index
+
+    def test_pause_resume_update_toggles_agent_run_overlay(self):
+        run = MoonMindAgentRun()
+        run.run_status = RunStatus.awaiting_slot
+
+        run.pause()
+        assert run._paused is True
+
+        run.resume()
+        assert run._paused is False
 
     def test_slot_wait_constants_are_sane(self):
         """Verify the slot wait constants have reasonable values."""

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -101,10 +101,33 @@ class TestSlotWaitRetryBehavior:
         """A paused AgentRun must not cross from slot assignment into launch."""
         source = inspect.getsource(MoonMindAgentRun.run)
         slot_wait_index = source.index("slot_assigned_event.is_set()")
-        pause_gate_index = source.index("await workflow.wait_condition(lambda: not self._paused)")
+        pause_gate_index = source.rindex(
+            "await workflow.wait_condition(lambda: not self._paused)"
+        )
         launch_index = source.index("self.run_status = RunStatus.launching")
 
         assert slot_wait_index < pause_gate_index < launch_index
+
+    def test_pause_gate_runs_before_slot_acquisition(self):
+        """A paused AgentRun should not acquire a provider slot before resume."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+        pre_slot_pause_index = source.index(
+            "await workflow.wait_condition(lambda: not self._paused)"
+        )
+        slot_request_index = source.index("request_slot=True")
+
+        assert pre_slot_pause_index < slot_request_index
+
+    def test_overall_start_reset_after_paused_slot_wait(self):
+        """Paused time after slot assignment must not consume execution budget."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+        pause_gate_index = source.rindex(
+            "await workflow.wait_condition(lambda: not self._paused)"
+        )
+        reset_index = source.index("overall_start = workflow.now()", pause_gate_index)
+        launch_index = source.index("self.run_status = RunStatus.launching")
+
+        assert pause_gate_index < reset_index < launch_index
 
     def test_pause_resume_update_toggles_agent_run_overlay(self):
         run = MoonMindAgentRun()

--- a/tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py
@@ -583,7 +583,7 @@ async def test_run_workflow_multi_dep_fan_in_via_signals(
             assert result["status"] == "success"
 
 # ---------------------------------------------------------------------------
-# 9. Dependent pause → prerequisite failure → immediate fail on resume
+# 9. Dependent pause → prerequisite failure → fail after resume
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -592,7 +592,7 @@ async def test_run_workflow_pause_then_prerequisite_failure(
     monkeypatch,
 ):
     """While the dependent run is paused during dependency wait, a
-    prerequisite fails. On resume, the workflow must fail immediately."""
+    prerequisite fails. The failure is recorded but not raised until resume."""
 
     async def fake_reconcile(self, dependency_ids):
         pass
@@ -636,8 +636,11 @@ async def test_run_workflow_pause_then_prerequisite_failure(
                 ),
             )
 
-            # The current workflow logic fails immediately on dependency
-            # failure, even while paused, so no Resume update is required.
+            status = await handle.query("get_status")
+            assert status["state"] == "waiting_on_dependencies"
+            assert status["paused"] is True
+
+            await handle.execute_update("Resume")
 
             with pytest.raises(WorkflowFailureError):
                 await handle.result()

--- a/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
@@ -153,6 +153,46 @@ async def test_run_workflow_scheduled(mock_run_environment):
             assert result["status"] == "success"
 
 @pytest.mark.asyncio
+async def test_run_workflow_scheduled_pause_blocks_due_dispatch(mock_run_environment):
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-sched-pause",
+            workflows=[MoonMindUserWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            future_time = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+            handle = await env.client.start_workflow(
+                MoonMindUserWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.UserWorkflow",
+                    "initial_parameters": {},
+                    "plan_artifact_ref": "ref-123",
+                    "scheduled_for": future_time,
+                },
+                id="test-wf-sched-pause",
+                task_queue="test-task-queue-sched-pause",
+            )
+
+            for _ in range(20):
+                status = await handle.query("get_status")
+                if status.get("state") == "scheduled":
+                    break
+                await env.sleep(1)
+            assert status.get("state") == "scheduled"
+
+            await handle.execute_update("Pause")
+            await env.sleep(timedelta(hours=2))
+
+            status = await handle.query("get_status")
+            assert status.get("state") == "scheduled"
+            assert status.get("paused") is True
+
+            await handle.execute_update("Resume")
+            result = await handle.result()
+            assert result["status"] == "success"
+
+@pytest.mark.asyncio
 async def test_run_workflow_rescheduled(mock_run_environment):
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -364,6 +364,29 @@ async def test_recovery_forwards_operator_message_to_active_jules_child(monkeypa
         {"message": "Please rename it to Provider Profiles."},
     )
     assert workflow_instance._recovery_requested is True
+
+@pytest.mark.asyncio
+async def test_pause_resume_forwards_lifecycle_updates_to_active_child(monkeypatch):
+    workflow_instance = MoonMindUserWorkflow()
+    workflow_instance._active_agent_child_workflow_id = "wf:agent:implement"
+    workflow_instance._active_agent_id = "codex"
+
+    mock_handle = type("MockHandle", (), {"execute_update": AsyncMock()})()
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: mock_handle,
+    )
+    monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
+
+    await workflow_instance.pause()
+    await workflow_instance.resume()
+
+    assert workflow_instance._paused is False
+    assert mock_handle.execute_update.await_args_list == [
+        call("Pause"),
+        call("Resume"),
+    ]
 
 @pytest.mark.asyncio
 async def test_send_message_forwards_operator_message_without_resuming(monkeypatch):

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 from unittest.mock import AsyncMock, call
 from datetime import datetime, timedelta, timezone
 
@@ -346,7 +347,11 @@ async def test_recovery_forwards_operator_message_to_active_jules_child(monkeypa
     workflow_instance._active_agent_id = "jules"
     workflow_instance._awaiting_external = True
 
-    mock_handle = type("MockHandle", (), {"signal": AsyncMock()})()
+    mock_handle = type(
+        "MockHandle",
+        (),
+        {"execute_update": AsyncMock(), "signal": AsyncMock()},
+    )()
     monkeypatch.setattr(
         workflow,
         "get_external_workflow_handle",
@@ -359,6 +364,7 @@ async def test_recovery_forwards_operator_message_to_active_jules_child(monkeypa
         {"message": "Please rename it to Provider Profiles."}
     )
 
+    mock_handle.execute_update.assert_awaited_once_with("Resume")
     mock_handle.signal.assert_awaited_once_with(
         "operator_message",
         {"message": "Please rename it to Provider Profiles."},
@@ -387,6 +393,55 @@ async def test_pause_resume_forwards_lifecycle_updates_to_active_child(monkeypat
         call("Pause"),
         call("Resume"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_pause_reverts_and_fails_when_active_child_update_fails(monkeypatch):
+    workflow_instance = MoonMindUserWorkflow()
+    workflow_instance._active_agent_child_workflow_id = "wf:agent:implement"
+    workflow_instance._active_agent_id = "codex"
+
+    mock_handle = type(
+        "MockHandle",
+        (),
+        {"execute_update": AsyncMock(side_effect=RuntimeError("child gone"))},
+    )()
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: mock_handle,
+    )
+    monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Failed to forward Pause"):
+        await workflow_instance.pause()
+
+    assert workflow_instance._paused is False
+    assert workflow_instance._waiting_reason is None
+    assert workflow_instance._pause_resume_transition_in_progress is False
+
+
+def test_pause_resume_validators_block_concurrent_transition() -> None:
+    workflow_instance = MoonMindUserWorkflow()
+    workflow_instance._pause_resume_transition_in_progress = True
+
+    with pytest.raises(ValueError, match="transition already in progress"):
+        workflow_instance.validate_pause()
+    with pytest.raises(ValueError, match="transition already in progress"):
+        workflow_instance.validate_resume()
+
+
+def test_dependency_wait_loop_exits_after_unpaused_dependency_failure() -> None:
+    source = inspect.getsource(MoonMindUserWorkflow._wait_for_dependencies)
+
+    assert (
+        "(self._dependency_failure is None and self._unresolved_dependency_ids)"
+        in source
+    )
+    assert (
+        "or (self._dependency_failure is not None and self._paused)"
+        not in source
+    )
 
 @pytest.mark.asyncio
 async def test_send_message_forwards_operator_message_without_resuming(monkeypatch):


### PR DESCRIPTION
Issue reference: MM-919

Summary:
- Preserve workflow lifecycle state when Pause/Resume is applied by treating paused as an overlay.
- Expand pause/resume capabilities for scheduled, dependency-waiting, slot-waiting, and active workflow states.
- Gate scheduled waits, dependency waits, slot acquisition, and active safe boundaries while paused, with tests and API contract updates.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py tests/unit/workflows/temporal/workflows/test_run_scheduling.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py

Remaining risks:
- Verification was limited to targeted unit and selected UI tests from the unit runner; no compose-backed integration suite was run for this publication step.
