### PR TITLE
[codex] Remove pr-resolver skill payload versions

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -590,7 +590,6 @@ def _build_queue_request(
     max_iterations: int,
     priority: int,
     max_attempts: int,
-    skill_version: str = "1.0",
     inherit_runtime_from_caller: bool = False,
 ) -> dict[str, Any]:
     publish_mode = resolve_publish_mode_for_skill("pr-resolver", "none")
@@ -612,7 +611,6 @@ def _build_queue_request(
             "instructions": f"Resolve PR #{pr_number} on branch `{branch}`.",
             "skill": {
                 "name": "pr-resolver",
-                "version": skill_version,
             },
             "inputs": {
                 "repo": repo,
@@ -707,7 +705,6 @@ def _build_request_records(
             max_iterations=args.max_iterations,
             priority=args.priority,
             max_attempts=args.max_attempts,
-            skill_version=args.skill_version,
             inherit_runtime_from_caller=inherit_from_caller,
         )
         queue_requests.append(
@@ -936,7 +933,6 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--runtime-effort", default=None)
     parser.add_argument("--runtime-provider-profile", default=None)
     parser.add_argument("--task-context-path", default=None)
-    parser.add_argument("--skill-version", default="1.0")
     parser.add_argument("--artifacts-dir", default="artifacts")
     args = parser.parse_args(argv)
     args.package_managers = _flatten_package_managers(args.package_managers)

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -484,7 +484,6 @@ def _build_queue_request(
     priority: int,
     max_attempts: int,
     batch_scope: str | None = None,
-    skill_version: str = "1.0",
     inherit_runtime_from_caller: bool = False,
 ) -> dict[str, Any]:
     publish_mode = resolve_publish_mode_for_skill("pr-resolver", "none")
@@ -506,7 +505,6 @@ def _build_queue_request(
             "instructions": f"Resolve PR #{pr_number} on branch `{branch}`.",
             "skill": {
                 "name": "pr-resolver",
-                "version": skill_version,
             },
             "inputs": {
                 "repo": repo,
@@ -611,11 +609,6 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--merge-method", default="squash")
     parser.add_argument("--max-iterations", type=int, default=3)
-    parser.add_argument(
-        "--skill-version",
-        default="1.0",
-        help="Skill registry version for the pr-resolver skill (default: 1.0).",
-    )
     parser.add_argument(
         "--artifacts-dir",
         default="artifacts",
@@ -771,7 +764,6 @@ def _build_request_records(
             priority=args.priority,
             max_attempts=args.max_attempts,
             batch_scope=batch_scope,
-            skill_version=args.skill_version,
             inherit_runtime_from_caller=inherit_from_caller,
         )
         queue_requests.append(

--- a/docs/Temporal/TemporalAgentExecution.md
+++ b/docs/Temporal/TemporalAgentExecution.md
@@ -164,10 +164,10 @@ _run_execution_stage()
 ```
 
 For **generic LLM text instructions** (no specific tool), planning produces
-`tool = { type: "agent_runtime", name: "auto", version: "1.0" }` and the
-workflow dispatches it as a `MoonMind.AgentRun` child workflow. The `runtime.mode`
-field (e.g. `codex`, `gemini_cli`, `jules`) determines which `AgentAdapter`
-implementation handles the run.
+`tool = { type: "agent_runtime", name: "auto" }` and the workflow dispatches it
+as a `MoonMind.AgentRun` child workflow. The `runtime.mode` field (e.g. `codex`,
+`gemini_cli`, `jules`) determines which `AgentAdapter` implementation handles
+the run.
 
 For the full agent execution model including managed runtime supervision, external
 agent callbacks, and auth-profile controls, see
@@ -192,8 +192,7 @@ agent callbacks, and auth-profile controls, see
       "instructions": "Resolve PR #42 on branch `feature/test`.",
       "tool": {
         "type": "skill",
-        "name": "pr-resolver",
-        "version": "1.0"
+        "name": "pr-resolver"
       },
       "inputs": {
         "repo": "owner/repo",
@@ -223,12 +222,11 @@ From `moonmind/workflows/skills/skill_plan_contracts.py`:
 |-------|------|----------|-------------|
 | `id` | string | ✅ | Unique node identifier within the plan |
 | `tool_name` | string | ✅ | Registered tool name (e.g. `"pr-resolver"`) |
-| `tool_version` | string | ✅ | Registry version (e.g. `"1.0"`) |
 | `inputs` | object | ✅ | Tool-specific input parameters |
 | `options` | object | ❌ | Optional execution options |
 
-Serialized payload form (canonical): `{ id, tool: { type, name, version }, inputs: {...} }`
-Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inputs: {...} }`
+Serialized payload form (canonical): `{ id, tool: { type, name }, inputs: {...} }`
+Serialized payload form (legacy accepted): `{ id, skill: { name }, inputs: {...} }`
 
 ### 3.3 Activity catalog
 
@@ -274,7 +272,7 @@ Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inpu
 | **Activity catalog** | ✅ Implemented | 18 activities, 5 fleets, correct routing |
 | **Worker runtime bindings** | ✅ Implemented | `build_activity_bindings` wires handlers to catalog |
 | **Temporal↔DB state sync** | ✅ Implemented | Projection sync from Temporal visibility |
-| **Batch-PR-resolver payload** | ✅ Fixed | Now sends `skill.name` + `skill.version` + `inputs` |
+| **Batch-PR-resolver payload** | ✅ Fixed | Now sends name-only `skill.name` + `inputs` |
 | **Integration polling** (Jules) | ✅ Implemented | Durable waiting loop with status polling |
 | **Pause/Resume/Cancel signals** | ✅ Implemented | Workflow signal handlers |
 | **`plan.validate` activity** | ✅ Implemented | Registry-aware plan validation |

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -314,6 +314,7 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
             branch="codex/session-child-task",
         )
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
+        assert "version" not in body["payload"]["task"]["skill"]
         assert body["payload"]["task"]["inputs"]["pr"] == "1337"
     finally:
         await asyncio.to_thread(server.shutdown)

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -184,6 +184,7 @@ def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
     for body in _FakeAsyncClient.submissions:
         assert body["payload"]["task"]["publish"]["mode"] == "none"
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
+        assert "version" not in body["payload"]["task"]["skill"]
         assert body["payload"]["idempotencyKey"].startswith(
             "batch-dependabot-resolver:MoonLadderStudios/MoonMind:pr:"
         )

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -56,7 +56,6 @@ def _args(**overrides: Any) -> Any:
         "runtime_effort": None,
         "runtime_provider_profile": None,
         "task_context_path": None,
-        "skill_version": "1.0",
         "artifacts_dir": "artifacts",
     }
     base.update(overrides)
@@ -244,8 +243,9 @@ def test_build_queue_request_child_payload_shape() -> None:
     )
     payload = request["payload"]
     task = payload["task"]
-    assert task["skill"] == {"name": "pr-resolver", "version": "1.0"}
+    assert task["skill"] == {"name": "pr-resolver"}
     assert "id" not in task["skill"] and "args" not in task["skill"]
+    assert "version" not in task["skill"]
     assert payload["requiredCapabilities"] == ["gh"]
     assert task["inputs"] == {
         "repo": "MoonLadderStudios/MoonMind",

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -766,7 +766,7 @@ def _build_request(module: dict[str, Any], **overrides: Any) -> dict[str, Any]:
     return build("MoonLadderStudios/MoonMind", 42, "feature/test", **kwargs)
 
 def test_build_queue_request_skill_contract() -> None:
-    """skill.name + skill.version are present; legacy skill.id and skill.args are absent."""
+    """skill.name is present; legacy identity fields and args are absent."""
     module = _load_module()
     req = _build_request(module)
     task = req["payload"]["task"]
@@ -774,9 +774,9 @@ def test_build_queue_request_skill_contract() -> None:
 
     # Correct fields per SkillInvocation contract
     assert skill.get("name") == "pr-resolver", "skill.name must be 'pr-resolver'"
-    assert skill.get("version") == "1.0", "skill.version must default to '1.0'"
 
     # Legacy / wrong fields must NOT be present
+    assert "version" not in skill, "skill.version must not be sent to Temporal"
     assert (
         "id" not in skill
     ), "skill.id is the legacy field; must not be sent to Temporal"
@@ -808,13 +808,6 @@ def test_build_queue_request_required_capabilities_toplevel() -> None:
     assert (
         "requiredCapabilities" not in skill
     ), "requiredCapabilities must not be nested inside skill"
-
-def test_build_queue_request_skill_version_passthrough() -> None:
-    """--skill-version value is forwarded to the payload."""
-    module = _load_module()
-    req = _build_request(module, skill_version="2.3")
-    skill = req["payload"]["task"]["skill"]
-    assert skill.get("version") == "2.3"
 
 def test_write_run_artifacts_emits_no_op_when_zero_queued_no_errors(tmp_path: Path) -> None:
     """A genuine no-op run writes skill_outcome.json declaring status=no_op."""


### PR DESCRIPTION
## Summary
- Remove `version` from batch `pr-resolver` child task skill payloads.
- Delete the stale `--skill-version` plumbing from batch PR and Dependabot resolvers.
- Update regression tests and the Temporal agent execution doc to reflect name-only skill/tool identity.

## Validation
- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/test_batch_pr_resolver.py tests/unit/test_batch_dependabot_resolver.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/integration/skills/test_batch_dependabot_resolver_e2e.py tests/integration/services/temporal/test_codex_session_task_creation.py`

Note: `./tools/test_unit.sh ...` failed before pytest because local `deploy/state/desired-state.json` is root-owned and unreadable by this user, so I ran the exact pytest targets directly with the same test environment flags.