### PR TITLE
[codex] Strip capability version identities

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -145,6 +145,7 @@ from moonmind.workflows.executions.execution_contract import (
     is_non_repository_side_effect_skill,
     is_self_managed_publish_skill,
     resolve_publish_mode_for_skill,
+    strip_workflow_capability_identity_versions,
 )
 from api_service.api.schemas import CreateJobRequest
 from moonmind.workflows import get_temporal_artifact_service
@@ -4946,37 +4947,10 @@ def _invalid_workflow_request(message: str) -> HTTPException:
         },
     )
 
-def _reject_submit_version_identity(task_payload: Mapping[str, Any]) -> None:
-    task_template = task_payload.get("taskTemplate") or task_payload.get(
-        "task_template"
-    )
-    if isinstance(task_template, Mapping) and (
-        task_template.get("version") is not None
-        or task_template.get("presetVersion") is not None
-    ):
-        raise _invalid_workflow_request(
-            "payload.workflow.taskTemplate uses slug/scope only; remove version or presetVersion."
-        )
-
-    applied_templates = task_payload.get("appliedStepTemplates") or task_payload.get(
-        "applied_step_templates"
-    )
-    if isinstance(applied_templates, list):
-        for index, item in enumerate(applied_templates):
-            if not isinstance(item, Mapping):
-                continue
-            if item.get("version") is not None or item.get("presetVersion") is not None:
-                raise _invalid_workflow_request(
-                    "payload.workflow.appliedStepTemplates"
-                    f"[{index}] uses slug/scope only; remove version or presetVersion."
-                )
-
-    for field_name in ("tool", "skill"):
-        selected = task_payload.get(field_name)
-        if isinstance(selected, Mapping) and selected.get("version") is not None:
-            raise _invalid_workflow_request(
-                f"payload.workflow.{field_name} uses name-only identity; remove version."
-            )
+def _strip_submit_version_identity(task_payload: dict[str, Any]) -> None:
+    sanitized = strip_workflow_capability_identity_versions(task_payload)
+    task_payload.clear()
+    task_payload.update(sanitized)
 
 def _validation_error_code(message: str) -> str:
     if message.startswith("Dependency not found:"):
@@ -7071,7 +7045,7 @@ async def _create_execution_from_workflow_request(
         raise _invalid_workflow_request(
             f"{shape_name} Temporal submit requests require {required_field}."
         )
-    _reject_submit_version_identity(task_payload)
+    _strip_submit_version_identity(task_payload)
 
     # Resolve child-agent runtime inheritance before downstream normalization
     # consumes targetRuntime / task.runtime fields.  When inheritance applies,
@@ -7153,7 +7127,7 @@ async def _create_execution_from_workflow_request(
             session=session,
             user_id=user.id,
         )
-        _reject_submit_version_identity(task_payload)
+        _strip_submit_version_identity(task_payload)
 
     (
         objective_attachment_refs,

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -425,13 +425,12 @@ class PresetStepToolSchema(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def reject_version_identity(cls, value: object) -> object:
-        if isinstance(value, dict) and (
-            value.get("version") is not None or value.get("toolVersion") is not None
-        ):
-            raise ValueError(
-                "Tool steps use tool names only; remove version or toolVersion."
-            )
+    def strip_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict):
+            payload = dict(value)
+            payload.pop("version", None)
+            payload.pop("toolVersion", None)
+            return payload
         return value
 
 class PresetStepBlueprintSchema(BaseModel):
@@ -453,13 +452,12 @@ class PresetStepBlueprintSchema(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def reject_preset_version_identity(cls, value: object) -> object:
-        if isinstance(value, dict) and (
-            value.get("version") is not None or value.get("presetVersion") is not None
-        ):
-            raise ValueError(
-                "Preset includes use slug/scope only; remove version or presetVersion."
-            )
+    def strip_preset_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict):
+            payload = dict(value)
+            payload.pop("version", None)
+            payload.pop("presetVersion", None)
+            return payload
         return value
 
 class PresetSummarySchema(BaseModel):
@@ -520,13 +518,12 @@ class PresetCreateRequestSchema(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def reject_version_identity(cls, value: object) -> object:
-        if isinstance(value, dict) and (
-            value.get("version") is not None or value.get("presetVersion") is not None
-        ):
-            raise ValueError(
-                "Preset definitions use slug/scope only; remove version or presetVersion."
-            )
+    def strip_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict):
+            payload = dict(value)
+            payload.pop("version", None)
+            payload.pop("presetVersion", None)
+            return payload
         return value
 
 class PresetExpandOptionsSchema(BaseModel):
@@ -549,13 +546,12 @@ class PresetExpandRequestSchema(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def reject_version_identity(cls, value: object) -> object:
-        if isinstance(value, dict) and (
-            value.get("version") is not None or value.get("presetVersion") is not None
-        ):
-            raise ValueError(
-                "Preset expansion uses slug/scope only; remove version or presetVersion."
-            )
+    def strip_version_identity(cls, value: object) -> object:
+        if isinstance(value, dict):
+            payload = dict(value)
+            payload.pop("version", None)
+            payload.pop("presetVersion", None)
+            return payload
         return value
 
 class PresetAppliedMetadataSchema(BaseModel):

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -384,10 +384,9 @@ def _normalize_tool_payload(raw_tool: Any, *, index: int) -> dict[str, Any]:
         raise PresetValidationError(
             f"Step {index} Tool step requires a tool payload object."
         )
-    if raw_tool.get("version") is not None or raw_tool.get("toolVersion") is not None:
-        raise PresetValidationError(
-            f"Step {index} Tool steps use tool names only; remove version or toolVersion."
-        )
+    raw_tool = dict(raw_tool)
+    raw_tool.pop("version", None)
+    raw_tool.pop("toolVersion", None)
     tool_id = str(raw_tool.get("id") or raw_tool.get("name") or "").strip()
     if not tool_id:
         raise PresetValidationError(
@@ -479,6 +478,9 @@ def _normalize_preset_payload(raw_preset: Any, *, index: int) -> dict[str, Any]:
             message="Preset steps require a preset payload object.",
             code="required",
         )
+    raw_preset = dict(raw_preset)
+    raw_preset.pop("version", None)
+    raw_preset.pop("presetVersion", None)
     preset_slug = str(raw_preset.get("slug") or raw_preset.get("id") or "").strip()
     if not preset_slug:
         raise _step_validation_error(
@@ -486,14 +488,6 @@ def _normalize_preset_payload(raw_preset: Any, *, index: int) -> dict[str, Any]:
             path="preset.slug",
             message="Preset steps require preset.slug or preset.id.",
             code="required",
-        )
-    if raw_preset.get("version") is not None or raw_preset.get("presetVersion") is not None:
-        raise _step_validation_error(
-            index=index,
-            path="preset.version",
-            message="Preset steps use slug/scope only; remove preset.version or presetVersion.",
-            code="preset_version_not_supported",
-            recoverable=False,
         )
     inputs = raw_preset.get("inputs", raw_preset.get("inputMapping", {}))
     if inputs is None:
@@ -1545,6 +1539,9 @@ class PresetCatalogService:
                 raise PresetValidationError(
                     f"Step {index} must be an object with instructions and optional skill."
                 )
+            raw_step = dict(raw_step)
+            raw_step.pop("version", None)
+            raw_step.pop("presetVersion", None)
             blocked = sorted(
                 key for key in raw_step if str(key).strip() in _FORBIDDEN_STEP_KEYS
             )
@@ -1558,10 +1555,6 @@ class PresetCatalogService:
                     f"Step {index} kind must be one of: {_STEP_KIND}, {_INCLUDE_KIND}."
                 )
             if kind == _INCLUDE_KIND:
-                if raw_step.get("version") is not None:
-                    raise PresetValidationError(
-                        f"Step {index} include uses slug/scope only; remove version."
-                    )
                 unsupported = sorted(
                     key
                     for key in raw_step
@@ -1720,6 +1713,8 @@ class PresetCatalogService:
                 )
             if not _preset_step_enabled(rendered.pop("enabled", True)):
                 continue
+            rendered.pop("version", None)
+            rendered.pop("presetVersion", None)
             kind = str(rendered.get("kind") or _STEP_KIND).strip().lower()
             if (
                 kind == _STEP_KIND
@@ -1727,26 +1722,11 @@ class PresetCatalogService:
                 == _STEP_TYPE_PRESET
             ):
                 rendered = _preset_step_to_include(rendered, index=source_index)
+                rendered.pop("version", None)
+                rendered.pop("presetVersion", None)
                 kind = _INCLUDE_KIND
             if kind == _INCLUDE_KIND:
                 include_slug = _normalize_slug(str(rendered.get("slug") or ""))
-                if rendered.get("version") is not None:
-                    include_path = [
-                        *path,
-                        _template_path_label(
-                            slug=include_slug,
-                            alias=_normalize_slug(str(rendered.get("alias") or "")),
-                        ),
-                    ]
-                    raise _include_tree_error(
-                        message=(
-                            "Preset includes use slug/scope only; remove version at "
-                            f"{_format_include_path(include_path)}."
-                        ),
-                        code="preset_include_version_not_supported",
-                        include_path=include_path,
-                        recoverable=False,
-                    )
                 include_alias = _normalize_slug(str(rendered.get("alias") or ""))
                 include_scope = _normalize_scope(str(rendered.get("scope") or scope.value))
                 include_scope_ref = (
@@ -2047,22 +2027,8 @@ class PresetCatalogService:
             for name in _REMOVED_BATCH_WORKFLOWS_INPUTS
             if template.slug == _BATCH_WORKFLOWS_SLUG and name in submitted_inputs
         )
-        if removed_batch_inputs:
-            raise PresetValidationError(
-                "Batch workflow inputs include removed preset version fields.",
-                errors=[
-                    {
-                        "path": f"preset.inputs.{name}",
-                        "message": (
-                            f"Input '{name}' is no longer supported; select the "
-                            "target preset by slug and scope only."
-                        ),
-                        "code": "invalid_input",
-                        "recoverable": True,
-                    }
-                    for name in removed_batch_inputs
-                ],
-            )
+        for name in removed_batch_inputs:
+            submitted_inputs.pop(name, None)
         validated_inputs = self._resolve_inputs(
             schema=effective_schema,
             submitted=submitted_inputs,
@@ -2504,11 +2470,10 @@ class PresetCatalogService:
 
         created = 0
         for item in loaded:
+            item = dict(item)
+            item.pop("version", None)
+            item.pop("presetVersion", None)
             scope = str(item.get("scope", "global")).strip() or "global"
-            if item.get("version") is not None:
-                raise PresetValidationError(
-                    "Seed presets use slug/scope only; remove version."
-                )
             try:
                 await self.create_template(
                     slug=str(
@@ -2548,16 +2513,15 @@ class PresetCatalogService:
         result = SeedSyncResult()
 
         for item in loaded:
+            item = dict(item)
+            item.pop("version", None)
+            item.pop("presetVersion", None)
             scope = _normalize_scope(str(item.get("scope", "global")).strip() or "global")
             scope_ref = _normalize_scope_ref(scope, item.get("scopeRef"))
             slug = str(item.get("slug") or _slugify_from_title(item.get("title", "")))
             normalized_slug = _normalize_slug(slug)
             title = str(item.get("title") or "").strip()
             description = str(item.get("description") or "").strip() or "Seed template."
-            if item.get("version") is not None:
-                raise PresetValidationError(
-                    "Seed presets use slug/scope only; remove version."
-                )
             validated_inputs = self._validate_inputs_schema(item.get("inputs") or [])
             validated_steps = self._validate_template_steps(item.get("steps") or [])
             annotations = _normalize_seed_annotations(item)

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -122,6 +122,14 @@ _EMBEDDED_ATTACHMENT_DATA_FIELDS = frozenset(
         "rawBytes",
     }
 )
+_TOOL_IDENTITY_VERSION_KEYS = frozenset({"version", "toolVersion"})
+_SKILL_IDENTITY_VERSION_KEYS = frozenset({"version", "skillVersion"})
+_PRESET_IDENTITY_VERSION_KEYS = frozenset({"version", "presetVersion"})
+_CAPABILITY_IDENTITY_VERSION_KEYS = (
+    _TOOL_IDENTITY_VERSION_KEYS
+    | _SKILL_IDENTITY_VERSION_KEYS
+    | _PRESET_IDENTITY_VERSION_KEYS
+)
 _SKILL_METADATA_CAPABILITY_CACHE: dict[str, tuple[str, ...]] = {}
 
 class WorkflowContractError(ValueError):
@@ -141,6 +149,80 @@ def _clean_str(value: object) -> str:
 def _clean_optional_str(value: object) -> str | None:
     cleaned = _clean_str(value)
     return cleaned or None
+
+
+def _strip_identity_version_keys(
+    value: Mapping[str, Any],
+    keys: frozenset[str],
+) -> dict[str, Any]:
+    payload = dict(value)
+    for key in keys:
+        payload.pop(key, None)
+    return payload
+
+
+def _strip_preset_identity_versions(value: Mapping[str, Any]) -> dict[str, Any]:
+    payload = _strip_identity_version_keys(value, _PRESET_IDENTITY_VERSION_KEYS)
+    composition = payload.get("composition")
+    if isinstance(composition, Mapping):
+        payload["composition"] = _strip_preset_identity_versions(composition)
+    for list_key in ("includes", "authoredPresets", "appliedStepTemplates"):
+        items = payload.get(list_key)
+        if isinstance(items, list):
+            payload[list_key] = [
+                _strip_preset_identity_versions(item)
+                if isinstance(item, Mapping)
+                else item
+                for item in items
+            ]
+    return payload
+
+
+def strip_workflow_capability_identity_versions(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Drop stale semantic version fields from authored capability selectors."""
+
+    sanitized = dict(payload)
+    for key in ("tool", "skill"):
+        node = sanitized.get(key)
+        if isinstance(node, Mapping):
+            sanitized[key] = _strip_identity_version_keys(
+                node,
+                _CAPABILITY_IDENTITY_VERSION_KEYS,
+            )
+    for key in (
+        "taskTemplate",
+        "task_template",
+        "presetSchedule",
+        "preset_schedule",
+    ):
+        node = sanitized.get(key)
+        if isinstance(node, Mapping):
+            sanitized[key] = _strip_preset_identity_versions(node)
+    for key in (
+        "appliedStepTemplates",
+        "applied_step_templates",
+        "authoredPresets",
+        "authored_presets",
+    ):
+        items = sanitized.get(key)
+        if isinstance(items, list):
+            sanitized[key] = [
+                _strip_preset_identity_versions(item)
+                if isinstance(item, Mapping)
+                else item
+                for item in items
+            ]
+    steps = sanitized.get("steps")
+    if isinstance(steps, list):
+        sanitized["steps"] = [
+            strip_workflow_capability_identity_versions(step)
+            if isinstance(step, Mapping)
+            else step
+            for step in steps
+        ]
+    return sanitized
 
 
 def _skill_metadata_required_capabilities(skill_id: object) -> tuple[str, ...]:
@@ -711,6 +793,16 @@ class WorkflowSkillSelectorExact(BaseModel):
 
     name: str = Field(..., alias="name")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_removed_identity_versions(cls, value: object) -> object:
+        if isinstance(value, Mapping):
+            return _strip_identity_version_keys(
+                value,
+                _SKILL_IDENTITY_VERSION_KEYS,
+            )
+        return value
+
     @field_validator("name", mode="before")
     @classmethod
     def _normalize_optional_strings(cls, value: object) -> str | None:
@@ -879,6 +971,16 @@ class WorkflowSkillSelection(BaseModel):
         None,
         alias="requiredCapabilities",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_removed_identity_versions(cls, value: object) -> object:
+        if isinstance(value, Mapping):
+            return _strip_identity_version_keys(
+                value,
+                _SKILL_IDENTITY_VERSION_KEYS,
+            )
+        return value
 
     @field_validator("id", mode="before")
     @classmethod
@@ -1355,6 +1457,16 @@ class WorkflowStepSource(BaseModel):
     include_path: list[str] | None = Field(None, alias="includePath")
     original_step_id: str | None = Field(None, alias="originalStepId")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_removed_identity_versions(cls, value: object) -> object:
+        if isinstance(value, Mapping):
+            return _strip_identity_version_keys(
+                value,
+                _PRESET_IDENTITY_VERSION_KEYS,
+            )
+        return value
+
     @field_validator(
         "kind",
         "preset_id",
@@ -1393,6 +1505,13 @@ class AuthoredPresetBinding(BaseModel):
     include_path: list[str] | None = Field(None, alias="includePath")
     input_mapping: dict[str, Any] | None = Field(None, alias="inputMapping")
     scope: str | None = Field(None, alias="scope")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_removed_identity_versions(cls, value: object) -> object:
+        if isinstance(value, Mapping):
+            return _strip_preset_identity_versions(value)
+        return value
 
     @field_validator(
         "preset_id",
@@ -1467,7 +1586,7 @@ class WorkflowStepSpec(BaseModel):
     def _reject_forbidden_step_overrides(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
-        payload = dict(value)
+        payload = strip_workflow_capability_identity_versions(value)
         raw_kind = _clean_optional_str(payload.get("kind"))
         if raw_kind is not None and raw_kind.lower() == "include":
             raise WorkflowContractError(
@@ -1751,7 +1870,7 @@ class WorkflowExecutionSpec(BaseModel):
     def _lift_legacy_spec_shape(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
-        payload = dict(value)
+        payload = strip_workflow_capability_identity_versions(value)
         runtime_node = payload.get("runtime")
         if isinstance(runtime_node, str):
             payload["runtime"] = {"mode": runtime_node}
@@ -2785,4 +2904,5 @@ __all__ = [
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",
     "resolve_publish_mode_for_skill",
+    "strip_workflow_capability_identity_versions",
 ]

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -191,6 +191,19 @@ def strip_workflow_capability_identity_versions(
                 node,
                 _CAPABILITY_IDENTITY_VERSION_KEYS,
             )
+    skills = sanitized.get("skills")
+    if isinstance(skills, Mapping):
+        sanitized["skills"] = {
+            list_key: [
+                _strip_identity_version_keys(item, _SKILL_IDENTITY_VERSION_KEYS)
+                if isinstance(item, Mapping)
+                else item
+                for item in items
+            ]
+            if isinstance(items, list)
+            else items
+            for list_key, items in skills.items()
+        }
     for key in (
         "taskTemplate",
         "task_template",

--- a/moonmind/workflows/executions/payload.py
+++ b/moonmind/workflows/executions/payload.py
@@ -19,11 +19,10 @@ def _normalize_capabilities(values: list[Any] | None) -> list[str]:
     return normalized
 
 def _sanitize_template_application(entry: dict[str, Any]) -> dict[str, Any] | None:
+    entry = dict(entry)
+    entry.pop("version", None)
+    entry.pop("presetVersion", None)
     slug = str(entry.get("slug") or "").strip()
-    if entry.get("version") is not None or entry.get("presetVersion") is not None:
-        raise ValueError(
-            "Applied step templates use slug/scope only; remove version or presetVersion."
-        )
     if not slug:
         return None
     inputs = entry.get("inputs")

--- a/moonmind/workflows/skills/tool_dispatcher.py
+++ b/moonmind/workflows/skills/tool_dispatcher.py
@@ -135,18 +135,8 @@ async def execute_tool_activity(
                     "invalid_payload",
                     "tool.type must be 'skill' for the current runtime contract",
                 )
-            if "version" in tool_payload:
-                raise ToolDispatchError(
-                    "invalid_payload",
-                    "tool.version is not supported; executable tools are identified by name only",
-                )
             selected_payload = tool_payload
         elif isinstance(skill_payload, Mapping):
-            if "version" in skill_payload:
-                raise ToolDispatchError(
-                    "invalid_payload",
-                    "skill.version is not supported; executable tools are identified by name only",
-                )
             selected_payload = skill_payload
         else:
             raise ToolDispatchError(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1973,10 +1973,6 @@ def _iter_requested_registry_tools(
             continue
         if tool_name.lower() in JIRA_AGENT_SKILLS:
             continue
-        if "version" in selected_payload:
-            raise ValueError(
-                "tool.version is not supported; executable tools are identified by name only"
-            )
         if tool_name in seen:
             continue
         seen.add(tool_name)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1048,15 +1048,6 @@ def _dedupe_repeated_step_entries(
 def _selected_step_type(step_entry: Mapping[str, Any]) -> str:
     return str(step_entry.get("type") or "").strip().lower()
 
-def _reject_selected_step_tool_version(step_entry: Mapping[str, Any]) -> None:
-    step_tool = _coerce_mapping(step_entry.get("tool")) or _coerce_mapping(
-        step_entry.get("skill")
-    )
-    if "version" in step_tool:
-        raise RuntimeError(
-            "task step tool.version is not supported; executable tools are identified by name only"
-        )
-
 def _selected_step_tool_type(step_entry: Mapping[str, Any]) -> str:
     if _selected_step_tool_name(step_entry).lower() in _STORY_OUTPUT_TASK_TOOLS:
         return "skill"
@@ -1225,7 +1216,6 @@ def _build_runtime_planner():
         selected_skill_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
             task_payload.get("skill")
         )
-        _reject_selected_step_tool_version({"tool": selected_skill_payload})
         selected_skill_name = str(
             selected_skill_payload.get("name")
             or selected_skill_payload.get("id")
@@ -1508,10 +1498,6 @@ def _build_runtime_planner():
                     if is_legacy_agent_skill_plan_entry
                     else authored_tool_name
                 )
-                if "version" in tool_payload:
-                    raise RuntimeError(
-                        "task.plan tool.version is not supported; executable tools are identified by name only"
-                    )
                 node_inputs = _coerce_mapping(plan_entry.get("inputs"))
                 if not node_inputs:
                     node_inputs = _coerce_mapping(
@@ -1689,7 +1675,6 @@ def _build_runtime_planner():
                 # Per-step tool/skill override
                 step_tool_name = _selected_step_tool_name(step_entry)
                 tool_type = _selected_step_tool_type(step_entry)
-                _reject_selected_step_tool_version(step_entry)
                 is_agent_runtime_step = tool_type == "agent_runtime"
                 step_metadata_inputs = _authored_step_metadata_inputs(
                     step_entry,
@@ -1894,8 +1879,6 @@ def _build_runtime_planner():
             node_tool_name = (
                 selected_skill_name if is_story_output_tool else runtime_mode
             )
-            if is_story_output_tool:
-                _reject_selected_step_tool_version({"tool": selected_skill_payload})
             if is_story_output_tool:
                 node_inputs.pop("selectedSkill", None)
                 node_inputs["publishMode"] = "none"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6123,10 +6123,6 @@ class MoonMindRunWorkflow:
             tool_name = str(
                 tool.get("name") or tool.get("id") or ""
             ).strip()
-            if "version" in tool:
-                raise ValueError(
-                    "plan node tool.version is not supported; executable tools are identified by name only"
-                )
             node_id = str(node.get("id") or "unknown")
             if self._is_preserved_step(node_id):
                 self._record_preserved_step_terminal_state(node_id, node)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2000,10 +2000,11 @@ def test_create_task_shaped_execution_rejects_missing_workflow_payload(
     service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_rejects_task_template_version(
+def test_create_workflow_execution_strips_task_template_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -2021,18 +2022,16 @@ def test_create_workflow_execution_rejects_task_template_version(
         },
     )
 
-    assert response.status_code == 422
-    assert (
-        response.json()["detail"]["message"]
-        == "payload.workflow.taskTemplate uses slug/scope only; remove version or presetVersion."
-    )
-    service.create_execution.assert_not_awaited()
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
+    assert task["taskTemplate"] == {"slug": "jira-implement"}
 
 
-def test_create_workflow_execution_rejects_applied_template_version(
+def test_create_workflow_execution_strips_applied_template_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -2052,18 +2051,20 @@ def test_create_workflow_execution_rejects_applied_template_version(
         },
     )
 
-    assert response.status_code == 422
-    assert (
-        response.json()["detail"]["message"]
-        == "payload.workflow.appliedStepTemplates[0] uses slug/scope only; remove version or presetVersion."
-    )
-    service.create_execution.assert_not_awaited()
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
+    assert task["appliedStepTemplates"] == [
+        {
+            "slug": "jira-implement",
+        }
+    ]
 
 
-def test_create_workflow_execution_rejects_tool_version(
+def test_create_workflow_execution_strips_tool_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -2082,18 +2083,17 @@ def test_create_workflow_execution_rejects_tool_version(
         },
     )
 
-    assert response.status_code == 422
-    assert (
-        response.json()["detail"]["message"]
-        == "payload.workflow.tool uses name-only identity; remove version."
-    )
-    service.create_execution.assert_not_awaited()
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
+    assert task["tool"] == {"type": "skill", "name": "pr-resolver"}
+    assert task["skill"] == {"name": "pr-resolver"}
 
 
-def test_create_workflow_execution_rejects_skill_version(
+def test_create_workflow_execution_strips_skill_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
 
     response = test_client.post(
         "/api/executions",
@@ -2111,12 +2111,119 @@ def test_create_workflow_execution_rejects_skill_version(
         },
     )
 
-    assert response.status_code == 422
-    assert (
-        response.json()["detail"]["message"]
-        == "payload.workflow.skill uses name-only identity; remove version."
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
+    assert task["tool"] == {"type": "skill", "name": "pr-resolver"}
+    assert task["skill"] == {"name": "pr-resolver"}
+
+
+def test_create_workflow_execution_strips_versions_from_all_capability_selectors(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "workflow": {
+                    "instructions": "Run pr-resolver for PR 2680.",
+                    "tool": {
+                        "type": "skill",
+                        "name": "pr-resolver",
+                        "version": "1.0.0",
+                        "inputs": {"pr": "2680"},
+                    },
+                    "skills": {
+                        "include": [
+                            {"name": "pr-resolver", "version": "1.0.0"},
+                        ],
+                    },
+                    "taskTemplate": {
+                        "slug": "jira-implement",
+                        "presetVersion": "1.0.0",
+                    },
+                    "presetSchedule": {
+                        "presetSlug": "jira-implement",
+                        "version": "1.0.0",
+                    },
+                    "authoredPresets": [
+                        {
+                            "presetSlug": "jira-implement",
+                            "presetVersion": "1.0.0",
+                        },
+                    ],
+                    "appliedStepTemplates": [
+                        {
+                            "slug": "jira-implement",
+                            "version": "1.0.0",
+                            "composition": {
+                                "includes": [
+                                    {
+                                        "presetSlug": "quality-checks",
+                                        "presetVersion": "1.0.0",
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "id": "test",
+                            "type": "tool",
+                            "instructions": "Run tests.",
+                            "tool": {
+                                "id": "repo.run_tests",
+                                "toolVersion": "1.0.0",
+                                "inputs": {"target": "unit"},
+                            },
+                        },
+                        {
+                            "id": "fix",
+                            "type": "skill",
+                            "instructions": "Fix CI.",
+                            "skill": {
+                                "id": "fix-ci",
+                                "skillVersion": "1.0.0",
+                                "args": {"pr": "2680"},
+                            },
+                        },
+                    ],
+                },
+            },
+        },
     )
-    service.create_execution.assert_not_awaited()
+
+    assert response.status_code == 201
+    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
+    assert task["tool"] == {
+        "type": "skill",
+        "name": "pr-resolver",
+        "inputs": {"pr": "2680"},
+    }
+    assert task["skills"] == {"include": [{"name": "pr-resolver"}]}
+    assert task["taskTemplate"] == {"slug": "jira-implement"}
+    assert task["presetSchedule"] == {"presetSlug": "jira-implement"}
+    assert task["authoredPresets"] == [{"presetSlug": "jira-implement"}]
+    assert task["appliedStepTemplates"] == [
+        {
+            "slug": "jira-implement",
+            "composition": {
+                "includes": [{"presetSlug": "quality-checks"}],
+            },
+        }
+    ]
+    assert task["steps"][0]["tool"] == {
+        "id": "repo.run_tests",
+        "inputs": {"target": "unit"},
+    }
+    assert task["steps"][1]["skill"] == {
+        "id": "fix-ci",
+        "args": {"pr": "2680"},
+    }
 
 
 def test_create_task_shaped_execution_rejects_more_than_10_dependencies(

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -21,7 +21,6 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import Base, Preset, PresetScopeType
 from api_service.services.presets.catalog import (
     PresetCatalogService,
-    PresetValidationError,
 )
 
 pytestmark = [pytest.mark.asyncio]
@@ -225,35 +224,27 @@ async def test_batch_workflows_expands_orchestration_step(tmp_path):
             assert "jira" not in expanded["capabilities"]
 
 
-async def test_batch_workflows_rejects_removed_target_preset_version_input(tmp_path):
+async def test_batch_workflows_ignores_removed_target_preset_version_input(tmp_path):
     async with _catalog_db(tmp_path) as session_maker:
         async with session_maker() as session:
             service = PresetCatalogService(session)
             await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
 
-            with pytest.raises(PresetValidationError) as excinfo:
-                await service.expand_template(
-                    slug="batch-workflows",
-                    scope="global",
-                    scope_ref=None,
-                    inputs={
-                        "source_kind": "jira_board_column",
-                        "jira_board_id": "42",
-                        "jira_column": "In Progress",
-                        "target_preset_slug": "jira-implement",
-                        "target_preset_version": "1.1.0",
-                        "publish_mode": "pr",
-                    },
-                )
+            expanded = await service.expand_template(
+                slug="batch-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "source_kind": "jira_board_column",
+                    "jira_board_id": "42",
+                    "jira_column": "In Progress",
+                    "target_preset_slug": "jira-implement",
+                    "target_preset_version": "1.1.0",
+                    "publish_mode": "pr",
+                },
+            )
 
-    assert excinfo.value.errors == [
-        {
-            "path": "preset.inputs.target_preset_version",
-            "message": (
-                "Input 'target_preset_version' is no longer supported; select the "
-                "target preset by slug and scope only."
-            ),
-            "code": "invalid_input",
-            "recoverable": True,
-        }
-    ]
+    orchestration = expanded["steps"][0]["batchOrchestration"]
+    assert orchestration["targetPreset"]["slug"] == "jira-implement"
+    assert orchestration["targetPreset"]["scope"] == "global"
+    assert "version" not in orchestration["targetPreset"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -107,36 +107,40 @@ async def test_create_and_expand_template_deterministic_ids(tmp_path):
     assert expanded["appliedTemplate"]["slug"] == "pr-check"
     assert "version" not in expanded["appliedTemplate"]
 
-async def test_create_template_rejects_tool_version_identity(tmp_path):
+async def test_create_template_strips_tool_version_identity(tmp_path):
     user_id = uuid4()
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as session:
             service = PresetCatalogService(session)
-            with pytest.raises(PresetValidationError, match="Tool steps use tool names only"):
-                await service.create_template(
-                    slug="tool-version",
-                    title="Tool Version",
-                    description="Rejects semantic tool versions.",
-                    scope="personal",
-                    scope_ref=str(user_id),
-                    tags=[],
-                    inputs_schema=[],
-                    steps=[
-                        {
-                            "type": "tool",
-                            "title": "Fetch issue",
-                            "instructions": "Fetch issue.",
-                            "tool": {
-                                "id": "jira.get_issue",
-                                "version": "1.0.0",
-                                "inputs": {"issueKey": "MM-916"},
-                            },
-                        }
-                    ],
-                    annotations={},
-                    required_capabilities=[],
-                    created_by=user_id,
-                )
+            created = await service.create_template(
+                slug="tool-version",
+                title="Tool Version",
+                description="Strips semantic tool versions.",
+                scope="personal",
+                scope_ref=str(user_id),
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "type": "tool",
+                        "title": "Fetch issue",
+                        "instructions": "Fetch issue.",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "version": "1.0.0",
+                            "inputs": {"issueKey": "MM-916"},
+                        },
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+    assert created["steps"][0]["tool"] == {
+        "id": "jira.get_issue",
+        "inputs": {"issueKey": "MM-916"},
+    }
 
 @pytest.mark.parametrize("slug", ["jira-orchestrate", "moonspec-orchestrate"])
 async def test_expand_template_normalizes_legacy_orchestrate_mode_to_runtime(
@@ -1104,7 +1108,7 @@ async def test_expand_template_rejects_missing_include_target(tmp_path):
     ]
 
 
-async def test_expand_template_rejects_include_version_with_explicit_error(
+async def test_expand_template_strips_include_version(
     tmp_path,
 ):
     async with template_db(tmp_path) as session_maker:
@@ -1123,30 +1127,42 @@ async def test_expand_template_rejects_include_version_with_explicit_error(
                 required_capabilities=[],
                 created_by=None,
             )
-            with pytest.raises(PresetValidationError) as excinfo:
-                await service.create_template(
-                    slug="version-field-parent",
-                    title="Version Field Parent",
-                    description="Rejects versioned preset includes.",
-                    scope="global",
-                    scope_ref=None,
-                    tags=[],
-                    inputs_schema=[],
-                    steps=[
-                        {
-                            "kind": "include",
-                            "slug": "child-checks",
-                            "version": "2",
-                            "alias": "child",
-                            "scope": "global",
-                        }
-                    ],
-                    annotations={},
-                    required_capabilities=[],
-                    created_by=None,
-                )
+            await service.create_template(
+                slug="version-field-parent",
+                title="Version Field Parent",
+                description="Strips versioned preset includes.",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "child-checks",
+                        "version": "2",
+                        "alias": "child",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            expanded = await service.expand_template(
+                slug="version-field-parent",
+                scope="global",
+                scope_ref=None,
+                inputs={},
+                context={},
+            )
 
-    assert "slug/scope only" in str(excinfo.value)
+    assert len(expanded["steps"]) == 1
+    include = expanded["appliedTemplate"]["composition"]["includes"][0]
+    assert include["slug"] == "child-checks"
+    assert include["alias"] == "child"
+    assert include["scope"] == "global"
+    assert "version" not in include
+    assert "presetVersion" not in include
 
 async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
     tmp_path,
@@ -1223,42 +1239,47 @@ async def test_expand_template_normalizes_legacy_orchestrate_mode_for_include(
 
     assert "Selected mode: runtime." in expanded["steps"][0]["instructions"]
 
-async def test_create_template_rejects_templated_include_version(tmp_path):
+async def test_create_template_strips_templated_include_version(tmp_path):
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as session:
             service = PresetCatalogService(session)
 
-            with pytest.raises(
-                PresetValidationError,
-                match="slug/scope only",
-            ):
-                await service.create_template(
-                    slug="runtime-selected-parent",
-                    title="Runtime Selected Parent",
-                    description="Invalid dynamic child selection",
-                    scope="global",
-                    scope_ref=None,
-                    tags=[],
-                    inputs_schema=[
-                        {
-                            "name": "child_version",
-                            "label": "Child version",
-                            "type": "text",
-                        }
-                    ],
-                    steps=[
-                        {
-                            "kind": "include",
-                            "slug": "child-checks",
-                            "version": "{{ inputs.child_version }}",
-                            "alias": "checks",
-                            "scope": "global",
-                        }
-                    ],
-                    annotations={},
-                    required_capabilities=[],
-                    created_by=None,
-                )
+            created = await service.create_template(
+                slug="runtime-selected-parent",
+                title="Runtime Selected Parent",
+                description="Strips dynamic child version",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[
+                    {
+                        "name": "child_version",
+                        "label": "Child version",
+                        "type": "text",
+                    }
+                ],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "child-checks",
+                        "version": "{{ inputs.child_version }}",
+                        "alias": "checks",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+    assert created["steps"] == [
+        {
+            "kind": "include",
+            "slug": "child-checks",
+            "alias": "checks",
+            "scope": "global",
+        }
+    ]
 
 async def test_create_template_rejects_unsupported_include_fields(tmp_path):
     async with template_db(tmp_path) as session_maker:

--- a/tests/unit/api_service/test_strip_preset_step_versions.py
+++ b/tests/unit/api_service/test_strip_preset_step_versions.py
@@ -2,8 +2,8 @@
 
 Covers both the pure sanitization helper and the real expansion boundary: a
 preset whose persisted steps still carry the now-removed version fields (as the
-327 migration copied them verbatim from ``preset_versions``) must expand once
-the version fields are stripped.
+327 migration copied them verbatim from ``preset_versions``) must expand without
+surfacing those fields.
 """
 
 from __future__ import annotations
@@ -23,7 +23,6 @@ from api_service.db.models import (
 from api_service.services.presets.catalog import (
     ExpandOptions,
     PresetCatalogService,
-    PresetValidationError,
 )
 
 migration = importlib.import_module(
@@ -211,18 +210,18 @@ async def test_expansion_repaired_after_stripping_persisted_versions(tmp_path) -
             )
             await session.commit()
 
-        # Before cleanup: expansion is rejected because of the include version.
+        # Before cleanup: expansion tolerates the legacy include version.
         async with maker() as session:
-            with pytest.raises(PresetValidationError) as exc_info:
-                await PresetCatalogService(session).expand_template(
-                    slug="parent-preset",
-                    scope="global",
-                    scope_ref=None,
-                    inputs={},
-                    context={},
-                    options=ExpandOptions(should_enforce_step_limit=True),
-                )
-            assert "remove version" in str(exc_info.value)
+            expanded = await PresetCatalogService(session).expand_template(
+                slug="parent-preset",
+                scope="global",
+                scope_ref=None,
+                inputs={},
+                context={},
+                options=ExpandOptions(should_enforce_step_limit=True),
+            )
+            assert len(expanded["steps"]) == 2
+            assert "version" not in expanded["appliedTemplate"]
 
         # Apply the migration's sanitization to the persisted steps.
         async with maker() as session:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -50,15 +50,18 @@ def test_task_skills_accepts_valid_properties() -> None:
     assert spec.skills.exclude == ["legacy"]
     assert spec.skills.materialization_mode == "hybrid"
 
-def test_task_skills_rejects_semantic_version_fields() -> None:
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        WorkflowExecutionSpec.model_validate(
-            {
-                "repository": "test/repo",
-                "instructions": "execute",
-                "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
-            }
-        )
+def test_task_skills_strip_semantic_version_fields() -> None:
+    spec = WorkflowExecutionSpec.model_validate(
+        {
+            "repository": "test/repo",
+            "instructions": "execute",
+            "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
+        }
+    )
+
+    assert spec.skills is not None
+    assert spec.skills.include is not None
+    assert spec.skills.include[0].name == "test-skill"
 
     with pytest.raises(ValidationError, match="semantic versions"):
         WorkflowExecutionSpec.model_validate(
@@ -551,6 +554,7 @@ def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
                 "authoredPresets": [
                     {
                         "presetId": "runtime-quality-followup",
+                        "presetVersion": "1.0.0",
                     }
                 ],
                 "steps": [
@@ -561,6 +565,7 @@ def test_canonical_task_payload_accepts_legacy_preset_version_keys() -> None:
                         "source": {
                             "kind": "preset-derived",
                             "presetId": "runtime-quality-followup",
+                            "version": "1.0.0",
                         },
                     }
                 ],
@@ -606,6 +611,7 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
                     "instructions": "Implement issue.",
                     "skill": {
                         "id": "moonspec-implement",
+                        "skillVersion": "1.0.0",
                         "args": {"issueKey": "MM-559"},
                     },
                 },
@@ -617,7 +623,10 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
         step.model_dump(by_alias=True, exclude_none=True) for step in spec.steps
     ]
     assert dumped_steps[0]["type"] == "tool"
-    assert dumped_steps[0]["tool"]["id"] == "jira.get_issue"
+    assert dumped_steps[0]["tool"] == {
+        "id": "jira.get_issue",
+        "inputs": {"issueKey": "MM-559"},
+    }
     assert dumped_steps[0]["source"] == {
         "kind": "preset-derived",
         "presetId": "jira-flow",
@@ -625,7 +634,10 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
         "originalStepId": "fetch-jira-issue",
     }
     assert dumped_steps[1]["type"] == "skill"
-    assert dumped_steps[1]["skill"]["id"] == "moonspec-implement"
+    assert dumped_steps[1]["skill"] == {
+        "id": "moonspec-implement",
+        "args": {"issueKey": "MM-559"},
+    }
 
 @pytest.mark.parametrize(
     "source",
@@ -1106,6 +1118,78 @@ def test_codex_skill_payload_defaults_self_managed_publish_to_none(
     )
 
     assert result["workflow"]["publish"]["mode"] == "none"
+
+
+def test_canonical_workflow_view_strips_capability_identity_versions() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "task": {
+                "instructions": "Run pr-resolver for PR 2680.",
+                "skill": {
+                    "id": "pr-resolver",
+                    "skillVersion": "1.0.0",
+                    "args": {"pr": "2680"},
+                },
+                "tool": {
+                    "type": "skill",
+                    "name": "pr-resolver",
+                    "version": "1.0.0",
+                    "inputs": {"pr": "2680"},
+                },
+                "skills": {
+                    "include": [
+                        {"name": "pr-resolver", "version": "1.0.0"},
+                    ],
+                },
+                "authoredPresets": [
+                    {
+                        "presetSlug": "jira-implement",
+                        "presetVersion": "1.0.0",
+                    },
+                ],
+                "appliedStepTemplates": [
+                    {
+                        "slug": "jira-implement",
+                        "version": "1.0.0",
+                    },
+                ],
+                "steps": [
+                    {
+                        "type": "tool",
+                        "instructions": "Fetch issue.",
+                        "tool": {
+                            "id": "jira.get_issue",
+                            "toolVersion": "1.0.0",
+                            "inputs": {"issueKey": "MM-559"},
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    workflow = result["workflow"]
+    assert workflow["skill"]["id"] == "pr-resolver"
+    assert workflow["skill"]["args"] == {"pr": "2680"}
+    assert "skillVersion" not in workflow["skill"]
+    assert "version" not in workflow["skill"]
+    assert workflow["tool"] == {
+        "type": "skill",
+        "name": "pr-resolver",
+        "inputs": {"pr": "2680"},
+    }
+    assert workflow["skills"]["include"] == [{"name": "pr-resolver"}]
+    assert "version" not in workflow["skills"]["include"][0]
+    assert workflow["authoredPresets"][0]["presetSlug"] == "jira-implement"
+    assert "presetVersion" not in workflow["authoredPresets"][0]
+    assert "version" not in workflow["authoredPresets"][0]
+    assert workflow["appliedStepTemplates"] == [{"slug": "jira-implement"}]
+    assert workflow["steps"][0]["tool"] == {
+        "id": "jira.get_issue",
+        "inputs": {"issueKey": "MM-559"},
+    }
 
 
 def test_jira_issue_updater_allows_explicit_repository_publish_modes() -> None:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -11,6 +11,7 @@ from moonmind.workflows.executions.execution_contract import (
     CanonicalWorkflowExecutionPayload,
     ResumeFromFailedStepRef,
     resolve_publish_mode_for_skill,
+    strip_workflow_capability_identity_versions,
     WorkflowContractError,
     WorkflowExecutionSpec,
     WorkflowRecoveryProvenance,
@@ -71,6 +72,41 @@ def test_task_skills_strip_semantic_version_fields() -> None:
                 "skills": {"include": [{"name": "test-skill:1.0.0"}]},
             }
         )
+
+
+def test_workflow_capability_identity_sanitizer_strips_nested_skill_versions() -> None:
+    payload = {
+        "skills": {
+            "include": [
+                {"name": "pr-resolver", "version": "1.0.0", "skillVersion": "1.0.0"},
+            ],
+            "exclude": [
+                {"name": "legacy", "version": "0.1.0"},
+                "old-skill",
+            ],
+        },
+        "steps": [
+            {
+                "instructions": "Run targeted skill.",
+                "skills": {
+                    "include": [
+                        {
+                            "name": "fix-ci",
+                            "version": "2.0.0",
+                            "skillVersion": "2.0.0",
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+    sanitized = strip_workflow_capability_identity_versions(payload)
+
+    assert sanitized["skills"]["include"] == [{"name": "pr-resolver"}]
+    assert sanitized["skills"]["exclude"] == [{"name": "legacy"}, "old-skill"]
+    assert sanitized["steps"][0]["skills"]["include"] == [{"name": "fix-ci"}]
+
 
 def test_mm842_authoritative_snapshot_omits_authored_step_graph_metadata() -> None:
     snapshot = build_authoritative_workflow_input_snapshot(

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -836,7 +836,8 @@ async def test_promote_proposal_uses_reviewed_flattened_payload_without_reexpans
     assert task["steps"][0]["type"] == reviewed_steps[0]["type"]
     assert task["steps"][0]["skill"] == reviewed_steps[0]["skill"]
     assert "presetVersion" not in task["steps"][0]["source"]
-    assert task["taskTemplate"]["version"] == "live-version-that-must-not-be-expanded"
+    assert task["taskTemplate"]["slug"] == "jira-orchestrate"
+    assert "version" not in task["taskTemplate"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -547,6 +547,7 @@ def test_runtime_planner_maps_explicit_tool_step_to_typed_tool_node():
                         "instructions": "Fetch MM-559.",
                         "tool": {
                             "id": "jira.get_issue",
+                            "toolVersion": "1.0.0",
                             "inputs": {"issueKey": "MM-559"},
                         },
                         "source": {
@@ -596,6 +597,7 @@ def test_runtime_planner_maps_explicit_skill_step_with_provenance_to_agent_runti
                         "instructions": "Implement MM-573.",
                         "skill": {
                             "id": "moonspec-implement",
+                            "skillVersion": "1.0.0",
                             "inputs": {"issueKey": "MM-573"},
                         },
                         "source": {
@@ -710,6 +712,7 @@ def test_runtime_planner_preserves_authored_task_plan_tool_nodes():
                         "tool": {
                             "type": "skill",
                             "name": "deployment.update_compose_stack",
+                            "version": "1.0.0",
                         },
                         "inputs": {
                             "stack": "moonmind",
@@ -1191,6 +1194,7 @@ def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
                 "tool": {
                     "type": "skill",
                     "name": "pr-resolver",
+                    "version": "1.0.0",
                     "inputs": {"pr": "123", "repo": "MoonLadderStudios/MoonMind"},
                 },
                 "runtime": {"mode": "gemini_cli"},

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -491,25 +491,30 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         execute_activity.assert_not_called()
 
-    async def test_agent_node_rejects_versioned_skill_selector_before_launch(self) -> None:
+    async def test_agent_node_strips_versioned_skill_selector_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/baseline",
+            skills=[_resolved_skill("baseline")],
+        )
 
         with patch(
             "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
-            new=AsyncMock(),
+            new=AsyncMock(return_value=resolved),
         ) as execute_activity:
-            with self.assertRaisesRegex(
-                ValueError,
-                "Extra inputs are not permitted",
-            ):
-                await wf._resolve_agent_node_skillset_ref(
-                    task_skills={"include": [{"name": "baseline", "version": "9.9.9"}]},
-                    node_inputs={},
-                    node_id="step-1",
-                    existing_skillset_ref=None,
-                )
-        execute_activity.assert_not_called()
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills={"include": [{"name": "baseline", "version": "9.9.9"}]},
+                node_inputs={},
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/baseline")
+        selector = execute_activity.await_args.kwargs["args"][0]
+        self.assertEqual([entry.name for entry in selector.include], ["baseline"])
 
     async def test_agent_node_reuses_existing_skillset_ref_without_reresolution(self) -> None:
         wf = MoonMindRunWorkflow()

--- a/tests/unit/workflows/test_skill_plan_runtime.py
+++ b/tests/unit/workflows/test_skill_plan_runtime.py
@@ -416,7 +416,7 @@ def test_skill_dispatcher_routes_mm_skill_execute_and_activity_handlers():
         execute_skill_activity(
             invocation_payload={
                 "id": "n1",
-                "skill": {"name": "repo.run_tests"},
+                "skill": {"name": "repo.run_tests", "version": "1.0.0"},
                 "inputs": {"repo_ref": "git:org/repo#branch"},
             },
             registry_snapshot=snapshot,
@@ -459,7 +459,11 @@ def test_skill_dispatcher_accepts_tool_payload_alias():
         execute_skill_activity(
             invocation_payload={
                 "id": "n1",
-                "tool": {"type": "skill", "name": "repo.run_tests"},
+                "tool": {
+                    "type": "skill",
+                    "name": "repo.run_tests",
+                    "version": "1.0.0",
+                },
                 "inputs": {"repo_ref": "git:org/repo#branch"},
             },
             registry_snapshot=snapshot,

--- a/tests/unit/workflows/test_workflow_payload_templates.py
+++ b/tests/unit/workflows/test_workflow_payload_templates.py
@@ -28,7 +28,7 @@ def test_compile_workflow_payload_templates_merges_capabilities_and_metadata() -
     assert "version" not in compiled["task"]["appliedStepTemplates"][0]
     assert "appliedAt" in compiled["task"]["appliedStepTemplates"][0]
 
-def test_compile_workflow_payload_templates_rejects_template_versions() -> None:
+def test_compile_workflow_payload_templates_strips_template_versions() -> None:
     payload = {
         "task": {
             "appliedStepTemplates": [
@@ -40,9 +40,7 @@ def test_compile_workflow_payload_templates_rejects_template_versions() -> None:
         },
     }
 
-    try:
-        compile_workflow_payload_templates(payload)
-    except ValueError as exc:
-        assert "remove version or presetVersion" in str(exc)
-    else:
-        raise AssertionError("Expected semantic preset version rejection.")
+    compiled = compile_workflow_payload_templates(payload)
+
+    assert compiled["task"]["appliedStepTemplates"][0]["slug"] == "pr-code-change"
+    assert "version" not in compiled["task"]["appliedStepTemplates"][0]


### PR DESCRIPTION
## Summary
- Strip stale `version`, `toolVersion`, `skillVersion`, and `presetVersion` fields from workflow tool/skill/preset selectors before submission and canonical payload serialization.
- Stop worker planners, tool dispatch, and root workflow plan execution from failing on legacy selector versions; execution still uses name-only identity.
- Apply the same strip behavior to preset create/expand/catalog paths and deprecated `target_preset_version` batch input handling.
- Add regression coverage for pr-resolver-style workflow submissions plus generic skill, tool, preset, dispatcher, and worker-boundary paths.

## Validation
- `git diff --check`
- `python3 -c "import ast, pathlib; files=[...]; [ast.parse(pathlib.Path(f).read_text(), filename=f) for f in files]; print('ast ok')"`
- `MOONMIND_FORCE_LOCAL_TESTS=1 MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/api/routers/test_executions.py tests/unit/workflows/executions/test_execution_contract.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/test_skill_plan_runtime.py tests/unit/workflows/test_workflow_payload_templates.py` (624 passed, 2 subtests passed)
- `MOONMIND_FORCE_LOCAL_TESTS=1 MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/api/test_presets_service.py tests/unit/api_service/test_strip_preset_step_versions.py tests/unit/api/test_batch_workflows_preset.py` (77 passed)

Note: `./tools/test_unit.sh ...` failed before pytest because local `deploy/state/desired-state.json` is unreadable by this user, so I ran the targeted pytest suites directly with the same test environment flags.