### PR TITLE
MM-923 Update PR preparation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,10 @@ When writing code that interacts with skills:
 - Executable tools are identified by **tool-name**.
 - Do not introduce internal ID aliases, display-name matching, provider-specific synonyms, or compatibility translation tables for these identities. Rename by updating every caller, test, mock, seed, and doc reference in the same change.
 
+## Pull Request Preparation
+
+- Create non-draft pull requests by default. Use a draft PR only when the user or task explicitly requests a draft.
+
 ## Testing Instructions
 
 ### Test Taxonomy


### PR DESCRIPTION
Issue: MM-923

Summary:
- Added AGENTS.md guidance that pull requests should be non-draft by default.
- Clarified that draft PRs should only be used when explicitly requested by the user or task.

Tests run:
- Not run; documentation-only change.

Remaining risks:
- Low. This updates agent guidance only and does not affect runtime behavior.
