### PR TITLE
Fix pentest runner Claude CLI

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -60,7 +60,7 @@ MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 # as the operator disable override in deployments that are not approved for
 # pentest operation.
 MOONMIND_PENTEST_ENABLED="true"
-MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+MOONMIND_PENTEST_RUNNER_IMAGE="ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 MOONMIND_PENTEST_ALLOWED_RUNNER_PROFILES="pentestgpt-claude-oauth"
 MOONMIND_PENTEST_DEFAULT_RUNNER_PROFILE="pentestgpt-claude-oauth"
 MOONMIND_PENTEST_ALLOW_CLAUDE_OAUTH_PROFILE="true"

--- a/.github/workflows/pentestgpt-runner.yml
+++ b/.github/workflows/pentestgpt-runner.yml
@@ -49,6 +49,7 @@ env:
   PENTEST_RUNNER_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-pentestgpt
   PENTEST_RUNNER_VULN_SEVERITY_THRESHOLD: "CRITICAL,HIGH"
   PENTESTGPT_DEFAULT_REF: b9869307d028f26660f4615455d3b14b7d976b2e
+  CLAUDE_CODE_NPM_VERSION: "2.1.193"
 
 jobs:
   metadata:
@@ -124,6 +125,7 @@ jobs:
           tags: moonmind-pentestgpt-smoke:${{ needs.metadata.outputs.version_tag }}
           build-args: |
             PENTESTGPT_REF=${{ needs.metadata.outputs.pentestgpt_ref }}
+            CLAUDE_CODE_NPM_VERSION=${{ env.CLAUDE_CODE_NPM_VERSION }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}
@@ -236,6 +238,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             PENTESTGPT_REF=${{ needs.metadata.outputs.pentestgpt_ref }}
+            CLAUDE_CODE_NPM_VERSION=${{ env.CLAUDE_CODE_NPM_VERSION }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.metadata.outputs.version_tag }}

--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -1,7 +1,7 @@
 profiles:
   - id: pentestgpt-claude-oauth
     kind: one_shot
-    image: ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6
+    image: ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0
     workdirTemplate: /work/agent_jobs/${task_run_id}/repo
     requiredMounts:
       - type: volume

--- a/docker/pentestgpt-runner/Dockerfile
+++ b/docker/pentestgpt-runner/Dockerfile
@@ -1,3 +1,15 @@
+FROM node:20-bookworm-slim AS claude-cli
+
+ARG CLAUDE_CODE_NPM_VERSION=2.1.193
+
+ENV NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_FUND=false
+
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_NPM_VERSION}" \
+    && claude --version \
+    && cp "$(readlink -f "$(command -v claude)")" /tmp/claude \
+    && chmod 0755 /tmp/claude
+
 FROM python:3.12-slim AS runtime
 
 ARG PENTESTGPT_REF=b9869307d028f26660f4615455d3b14b7d976b2e
@@ -23,11 +35,13 @@ RUN apt-get update \
 RUN python -m pip install --upgrade pip \
     && python -m pip install "git+https://github.com/GreyDGL/PentestGPT.git@${PENTESTGPT_REF}"
 
+COPY --from=claude-cli /tmp/claude /usr/local/bin/claude
 COPY docker/pentestgpt-runner/moonmind-pentestgpt-run /usr/local/bin/moonmind-pentestgpt-run
 COPY docker/pentestgpt-runner/normalize_findings.py /usr/local/lib/moonmind-pentestgpt/normalize_findings.py
 COPY docker/pentestgpt-runner/selftest_report.py /usr/local/lib/moonmind-pentestgpt/selftest_report.py
 
-RUN chmod 0755 /usr/local/bin/moonmind-pentestgpt-run
+RUN chmod 0755 /usr/local/bin/moonmind-pentestgpt-run \
+    && claude --version
 
 WORKDIR /work/agent_jobs
 ENTRYPOINT ["/usr/local/bin/moonmind-pentestgpt-run"]

--- a/docker/pentestgpt-runner/README.md
+++ b/docker/pentestgpt-runner/README.md
@@ -19,6 +19,10 @@ Build:
 docker build -f docker/pentestgpt-runner/Dockerfile -t ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0 .
 ```
 
+The image bundles a pinned Claude Code CLI binary, installed in a build stage
+from `@anthropic-ai/claude-code`, because the upstream PentestGPT execution path
+invokes `claude` during its staged analysis.
+
 ## Strict findings normalization
 
 The findings normalizer (`normalize_findings.py`) is strict: only records that
@@ -32,10 +36,11 @@ empty results from upstream, runner, provider, or normalizer failures.
 
 `--check-upstream` verifies the runner image contract before a real run:
 telemetry defaults to disabled, the wrapper redaction drops secret-like values
-and emits `[REDACTED]`, and the upstream `pentestgpt` CLI responds to a `--help`
-(or `--version` fallback) contract probe. Distinct exit codes let CI classify
-the failure: `30` upstream CLI missing, `31` upstream CLI contract probe failed,
-`32` telemetry default invariant failed, `33` redaction invariant failed.
+and emits `[REDACTED]`, the bundled Claude CLI responds to `claude --version`,
+and the upstream `pentestgpt` CLI responds to a `--help` (or `--version`
+fallback) contract probe. Distinct exit codes let CI classify the failure:
+`10` configuration invariant failed, `30` required executable missing, and `33`
+upstream CLI contract probe failed.
 
 Smoke checks:
 

--- a/docker/pentestgpt-runner/moonmind-pentestgpt-run
+++ b/docker/pentestgpt-runner/moonmind-pentestgpt-run
@@ -89,6 +89,15 @@ check_upstream() {
     return "$EXIT_MISSING_EXECUTABLE"
   fi
 
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "Claude CLI executable not found" >&2
+    return "$EXIT_MISSING_EXECUTABLE"
+  fi
+  if ! claude --version >/tmp/moonmind-pentestgpt-claude-version.out 2>&1; then
+    echo "Claude CLI failed contract probe" | redact >&2
+    return "$EXIT_UPSTREAM_RUNTIME"
+  fi
+
   # Probe the CLI contract via --help, falling back to --version when an
   # upstream build does not implement --help parsing.
   if ! pentestgpt --help >/tmp/moonmind-pentestgpt-upstream-help.out 2>&1; then

--- a/docs/Security/PentestOperations.md
+++ b/docs/Security/PentestOperations.md
@@ -113,11 +113,11 @@ The Docker publish workflow builds and publishes this image alongside the main M
 The runner entrypoint is `/usr/local/bin/moonmind-pentestgpt-run`. It runs non-interactively, disables Langfuse telemetry by default, captures redacted stdout/stderr, writes MoonMind report artifacts, and normalizes findings JSON.
 
 CI smoke tests the wrapper with `--version` and `--self-test`, and validates the
-installed upstream PentestGPT CLI contract with `--check-upstream` (the
-`pentestgpt` executable exists, `pentestgpt --help` parses, telemetry defaults
-to off, and wrapper redaction works). Upstream-CLI breakage uses distinct exit
-codes (30–33) so it is classified separately from wrapper/configuration
-failures.
+installed upstream runtime contract with `--check-upstream` (the `pentestgpt`
+executable exists, `pentestgpt --help` parses, the bundled Claude CLI responds
+to `claude --version`, telemetry defaults to off, and wrapper redaction works).
+Upstream-CLI breakage uses distinct exit codes so it is classified separately
+from wrapper/configuration failures.
 
 The runner publish workflow (`.github/workflows/docker-publish.yml`) enforces
 production-rollout gates that **fail the build** when:

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -31,8 +31,7 @@ _PENTEST_APPROVED_RUNNER_IMAGE_REPOSITORY = (
 )
 _PENTEST_APPROVED_RUNNER_IMAGE_TAGS = frozenset(("1.0",))
 _PENTEST_DEFAULT_RUNNER_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
+    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 )
 _PENTEST_RUNNER_IMAGE_PATTERN = re.compile(
     r"^(?P<repository>"
@@ -1469,7 +1468,11 @@ class PentestSettings(BaseSettings):
     runner_image: str = Field(
         _PENTEST_DEFAULT_RUNNER_IMAGE,
         validation_alias=AliasChoices("MOONMIND_PENTEST_RUNNER_IMAGE"),
-        description="Curated PentestGPT runner image digest-pinned production reference.",
+        description=(
+            "Curated PentestGPT runner image reference. Use an explicit "
+            "digest-pinned override for production deployments that require "
+            "immutable image selection."
+        ),
     )
     unsafe_dev_runner_image_override: bool = Field(
         False,

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -127,10 +127,7 @@ _PENTEST_OAUTH_ENV_ALLOWLIST: tuple[str, ...] = (
     "MM_PENTEST_CLAUDE_OAUTH_SOURCE",
     "MM_PENTEST_SEED_CLAUDE_HOME",
 )
-_PENTEST_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
-)
+_PENTEST_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 _PENTEST_ENTRYPOINT = ("/usr/local/bin/moonmind-pentestgpt-run",)
 _PENTEST_WORKDIR_TEMPLATE = "/work/agent_jobs/${agent_run_id}/repo"
 _PENTEST_ENV_ALLOWLIST = (

--- a/tests/integration/temporal/test_pentest_docker_e2e.py
+++ b/tests/integration/temporal/test_pentest_docker_e2e.py
@@ -16,7 +16,7 @@ unless explicitly opted in, so they never run by accident:
 Run locally with, e.g.::
 
     MOONMIND_PENTEST_E2E=1 \
-    MOONMIND_PENTEST_RUNNER_IMAGE=ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6 \
+    MOONMIND_PENTEST_RUNNER_IMAGE=ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0 \
     python -m pytest tests/integration/temporal/test_pentest_docker_e2e.py -m integration
 
 Rather than adding skipped acceptance-test skeletons, the following real-Docker

--- a/tests/integration/temporal/test_pentest_runner_profile_registry.py
+++ b/tests/integration/temporal/test_pentest_runner_profile_registry.py
@@ -18,10 +18,7 @@ import pytest
 from moonmind.workloads.registry import RunnerProfileRegistry
 
 _PROFILES_PATH = Path("config/workloads/default-runner-profiles.yaml")
-_PENTEST_RUNNER_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
-)
+_PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 
 
 @pytest.mark.integration

--- a/tests/unit/integrations/pentest/test_pentest_models.py
+++ b/tests/unit/integrations/pentest/test_pentest_models.py
@@ -46,10 +46,8 @@ from moonmind.integrations.pentest.models import (
     validate_authorized_scope_for_request,
 )
 
-PENTEST_RUNNER_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
-)
+PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
+
 
 def _valid_request_payload() -> dict[str, object]:
     return {

--- a/tests/unit/test_pentestgpt_runner_workflow.py
+++ b/tests/unit/test_pentestgpt_runner_workflow.py
@@ -6,6 +6,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pentestgpt-runner.yml"
+DOCKERFILE_PATH = REPO_ROOT / "docker" / "pentestgpt-runner" / "Dockerfile"
+WRAPPER_PATH = REPO_ROOT / "docker" / "pentestgpt-runner" / "moonmind-pentestgpt-run"
 
 
 def _load_workflow() -> dict:
@@ -111,9 +113,44 @@ def test_runner_publish_validates_selftest_report_output() -> None:
     run = step["run"]
     assert "--self-test" in run
     assert '"self_test"' in run
-    for token in ("report.primary", "report.structured", "no_canary_leak", "redaction_ok"):
+    for token in (
+        "report.primary",
+        "report.structured",
+        "no_canary_leak",
+        "redaction_ok",
+    ):
         assert token in run, f"self-test validation does not check {token}"
     assert "exit 1" in run or "SystemExit(1)" in run
+
+
+def test_runner_image_bundles_and_checks_claude_cli() -> None:
+    # The upstream PentestGPT runner invokes `claude` during real staged
+    # execution. CI must fail before publishing if the curated image lacks it.
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
+    wrapper = WRAPPER_PATH.read_text(encoding="utf-8")
+    workflow = _load_workflow()
+
+    assert workflow["env"]["CLAUDE_CODE_NPM_VERSION"] == "2.1.193"
+    for step_name in ("Build runner smoke image", "Build and push runner by digest"):
+        build_args = _pentest_step(step_name)["with"]["build-args"]
+        assert (
+            "CLAUDE_CODE_NPM_VERSION=${{ env.CLAUDE_CODE_NPM_VERSION }}"
+            in build_args
+        )
+
+    assert "FROM node:20-bookworm-slim AS claude-cli" in dockerfile
+    assert 'ARG CLAUDE_CODE_NPM_VERSION=2.1.193' in dockerfile
+    assert (
+        'npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_NPM_VERSION}"'
+        in dockerfile
+    )
+    assert "COPY --from=claude-cli /tmp/claude /usr/local/bin/claude" in dockerfile
+    assert "claude --version" in dockerfile
+
+    assert "command -v claude" in wrapper
+    assert "Claude CLI executable not found" in wrapper
+    assert "claude --version" in wrapper
+    assert "Claude CLI failed contract probe" in wrapper
 
 
 def test_runner_selftest_report_is_passed_without_clobbering_stdin() -> None:

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -96,10 +96,7 @@ from moonmind.workflows.temporal.artifacts import (
 from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workloads.registry import RunnerProfileRegistry
 
-PENTEST_RUNNER_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
-)
+PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 
 pytestmark = [pytest.mark.asyncio]
 

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -21,10 +21,7 @@ from moonmind.workloads.registry import (
 )
 
 WORKSPACE_ROOT = Path("/work/agent_jobs")
-PENTEST_RUNNER_IMAGE = (
-    "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0@"
-    "sha256:a9e35914533968d4f6e394ea8b08f3c5b885eb136ecfacf4990bfeb04d3a11f6"
-)
+PENTEST_RUNNER_IMAGE = "ghcr.io/moonladderstudios/moonmind-pentestgpt:1.0"
 
 def _profile_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {


### PR DESCRIPTION
## Summary
- Bundle a pinned Claude Code CLI in the PentestGPT runner image and validate it in `--check-upstream`.
- Pass the pinned Claude CLI version through the runner publish workflow and document the runtime contract.
- Stop defaulting to the stale digest-pinned pentest image so the fixed `:1.0` image can roll out; explicit digest-pinned overrides remain supported.

## Root Cause
Workflow `mm:97a351e1-070d-4f8d-8e95-78a742844922` reached the PentestGPT runner, but every staged analysis failed because the runner image did not have `claude` on `PATH`.

## Verification
- `./tools/test_unit.sh tests/unit/test_pentestgpt_runner_workflow.py tests/unit/integrations/pentest/test_pentest_operations_docs.py`
- `./tools/test_unit.sh tests/unit/test_pentestgpt_runner_workflow.py tests/unit/integrations/pentest/test_pentest_operations_docs.py tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workloads/test_workload_contract.py tests/unit/workflows/temporal/test_activity_runtime.py`
- `docker build -f docker/pentestgpt-runner/Dockerfile -t moonmind-pentestgpt-claude-fix:local .`
- `docker run --rm moonmind-pentestgpt-claude-fix:local --check-upstream`
- `docker run --rm moonmind-pentestgpt-claude-fix:local --self-test`
- `docker compose -f docker-compose.test.yaml run --rm pytest bash -lc "pytest tests/integration/temporal/test_pentest_runner_profile_registry.py tests/integration/temporal/test_pentest_tool_contract.py -m 'integration_ci' -q --tb=short"`

## Notes
- `./tools/test_integration.sh tests/integration/temporal/test_pentest_runner_profile_registry.py` ran the full `integration_ci` suite rather than only the requested file. The pentest integration files passed in that run, but the broad suite failed 2 unrelated Codex session task-creation tests.
