### PR TITLE
[codex] Fix preset Jira expansion inputs

### DIFF
--- a/api_service/auth_providers.py
+++ b/api_service/auth_providers.py
@@ -24,6 +24,24 @@ logger = logging.getLogger(__name__)
 
 _cached_current_user_dependency = None
 
+
+def _disabled_auth_fallback_user():
+    from types import SimpleNamespace
+
+    user_id_str = settings.oidc.DEFAULT_USER_ID or _DEFAULT_USER_ID
+    return SimpleNamespace(
+        id=uuid.UUID(user_id_str),
+        email=settings.oidc.DEFAULT_USER_EMAIL or "stub@example.com",
+        is_superuser=True,
+    )
+
+
+def _disabled_auth_test_user():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(id=None, email="stub@example.com", is_superuser=True)
+
+
 async def get_default_user_from_db(
     session: AsyncSession = Depends(get_async_session),
 ) -> User:
@@ -64,16 +82,10 @@ def get_current_user():
     if _cached_current_user_dependency is None:
 
         async def _current_user_fallback():  # pragma: no cover – simple helper
-            if (
-                settings.workflow.test_mode
-                or os.getenv("PYTEST_CURRENT_TEST")
-                or os.getenv("MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP") == "1"
-            ):
-                from types import SimpleNamespace as _SimpleNamespace
-
-                return _SimpleNamespace(
-                    id=None, email="stub@example.com", is_superuser=True
-                )
+            if settings.workflow.test_mode or os.getenv("PYTEST_CURRENT_TEST"):
+                return _disabled_auth_test_user()
+            if os.getenv("MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP") == "1":
+                return _disabled_auth_fallback_user()
 
             async def _load_default_user() -> User | None:
                 from api_service.db.base import get_async_session_context
@@ -98,10 +110,8 @@ def get_current_user():
                     exc_info=True,
                 )
 
-            # Fallback: lightweight stub with the minimal attributes used in code
-            from types import SimpleNamespace
-
-            return SimpleNamespace(id=None, email="stub@example.com", is_superuser=True)
+            # Fallback: lightweight stub with the minimal attributes used in code.
+            return _disabled_auth_fallback_user()
 
         _cached_current_user_dependency = _current_user_fallback
 

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -810,6 +810,48 @@ def _issue_object_from_ref(
     return None
 
 
+def _issue_ref_from_mapping(
+    issue_value: Mapping[str, Any],
+    *,
+    provider: str,
+    ref_path: Sequence[Any] | None,
+) -> str:
+    if isinstance(ref_path, Sequence) and not isinstance(
+        ref_path, (str, bytes, bytearray)
+    ):
+        cursor: Any = issue_value
+        for path_item in ref_path:
+            if not isinstance(cursor, Mapping):
+                cursor = None
+                break
+            cursor = cursor.get(str(path_item or "").strip())
+        issue_ref = str(cursor or "").strip()
+        if issue_ref:
+            return issue_ref
+
+    candidate_keys = (
+        ("repository", "number")
+        if provider == "github"
+        else ("key", "issueKey", "issue_key", "jiraIssueKey")
+    )
+    if provider == "github":
+        repository = str(issue_value.get("repository") or "").strip()
+        number = str(issue_value.get("number") or "").strip()
+        if repository and number:
+            return f"{repository}#{number}"
+        for key in ("url", "ref"):
+            issue_ref = str(issue_value.get(key) or "").strip()
+            if issue_ref:
+                return issue_ref
+        return ""
+
+    for key in candidate_keys:
+        issue_ref = str(issue_value.get(key) or "").strip()
+        if issue_ref:
+            return issue_ref
+    return ""
+
+
 def _apply_issue_input_overrides(
     *,
     annotations: Mapping[str, Any] | None,
@@ -825,32 +867,50 @@ def _apply_issue_input_overrides(
     adjusted = dict(submitted)
     provider = str(issue_input.get("provider") or "").strip().lower()
     issue_value = adjusted.get(object_input)
+    ref_path_raw = issue_input.get("refPath")
+    ref_path = (
+        ref_path_raw
+        if isinstance(ref_path_raw, Sequence)
+        and not isinstance(ref_path_raw, (str, bytes, bytearray))
+        else None
+    )
     if isinstance(issue_value, Mapping):
         ref_template = str(issue_input.get("refTemplate") or "").strip()
-        ref_path = issue_input.get("refPath")
         issue_ref = ""
         if ref_template:
             issue_ref = _render_issue_ref_template(ref_template, issue_value)
-        elif isinstance(ref_path, Sequence) and not isinstance(ref_path, (str, bytes, bytearray)):
-            cursor: Any = issue_value
-            for path_item in ref_path:
-                if not isinstance(cursor, Mapping):
-                    cursor = None
-                    break
-                cursor = cursor.get(str(path_item or "").strip())
-            issue_ref = str(cursor or "").strip()
+        else:
+            issue_ref = _issue_ref_from_mapping(
+                issue_value,
+                provider=provider,
+                ref_path=ref_path,
+            )
+        if issue_ref:
+            if not str(adjusted.get(ref_input) or "").strip():
+                adjusted[ref_input] = issue_ref
+            issue_object = _issue_object_from_ref(
+                provider=provider,
+                ref_value=issue_ref,
+                ref_path=ref_path,
+            )
+            if issue_object is not None:
+                adjusted[object_input] = {**issue_value, **issue_object}
+        return adjusted
+    if isinstance(issue_value, str):
+        issue_ref = issue_value.strip()
         if issue_ref and not str(adjusted.get(ref_input) or "").strip():
             adjusted[ref_input] = issue_ref
+        if issue_ref:
+            issue_object = _issue_object_from_ref(
+                provider=provider,
+                ref_value=issue_ref,
+                ref_path=ref_path,
+            )
+            if issue_object is not None:
+                adjusted[object_input] = issue_object
         return adjusted
     legacy_ref = str(adjusted.get(ref_input) or "").strip()
     if legacy_ref:
-        ref_path_raw = issue_input.get("refPath")
-        ref_path = (
-            ref_path_raw
-            if isinstance(ref_path_raw, Sequence)
-            and not isinstance(ref_path_raw, (str, bytes, bytearray))
-            else None
-        )
         issue_object = _issue_object_from_ref(
             provider=provider,
             ref_value=legacy_ref,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -15795,6 +15795,39 @@ describe("Task Create schema-driven capability inputs", () => {
     });
   });
 
+  it("derives jira.issue-picker expansion inputs from imported-style step instructions", async () => {
+    renderWithClient(<WorkflowStartPage payload={withJiraIntegration()} />);
+    const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText("Preset Template") as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-schema-preset" },
+    });
+    await within(step).findByLabelText("Jira issue");
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Complete Jira issue ENG-202: Build browser shell" },
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url, request]) => {
+          if (!String(url).startsWith("/api/presets/jira-schema-preset:expand")) {
+            return false;
+          }
+          const payload = JSON.parse(String(request?.body || "{}")) as {
+            inputs?: { jira_issue?: { key?: string } };
+          };
+          return payload.inputs?.jira_issue?.key === "ENG-202";
+        }),
+      ).toBe(true);
+    });
+  });
+
 
 
   it("renders github.issue-picker from schema metadata and normalizes manual issue URL", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1373,6 +1373,90 @@ function jiraProjectKeyFromIssueKey(issueKey: string): string {
   );
 }
 
+const JIRA_ISSUE_KEY_PATTERN = /\b[A-Z][A-Z0-9]+(?:-[A-Z0-9]+)*-\d+\b/;
+
+function extractJiraIssueKeyFromText(text: string): string {
+  return String(text || "").match(JIRA_ISSUE_KEY_PATTERN)?.[0] || "";
+}
+
+function jiraIssueKeyFromValue(value: unknown): string {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    return String(
+      record.key ||
+        record.issueKey ||
+        record.issue_key ||
+        record.jiraIssueKey ||
+        "",
+    ).trim();
+  }
+  return extractJiraIssueKeyFromText(String(value || ""));
+}
+
+function jiraIssuePickerValueFromKey(
+  issueKey: string,
+  issue?: Pick<JiraIssueDetail, "summary" | "url" | "issueKey"> | null,
+): Record<string, unknown> {
+  const key = String(issueKey || issue?.issueKey || "").trim();
+  return {
+    key,
+    ...(issue?.summary ? { summary: issue.summary } : {}),
+    ...(issue?.url ? { url: issue.url } : {}),
+  };
+}
+
+function normalizeJiraIssuePickerValue(value: unknown): unknown {
+  const issueKey = jiraIssueKeyFromValue(value);
+  if (!issueKey) {
+    return value;
+  }
+  return {
+    ...(value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}),
+    key: issueKey,
+  };
+}
+
+function presetJiraIssueInputValuesFromIssue(
+  detail: Pick<PresetDetail, "inputSchema" | "uiSchema" | "inputs"> | null | undefined,
+  currentValues: Record<string, unknown>,
+  issue: JiraIssueDetail,
+): { values: Record<string, unknown>; changedNames: string[] } {
+  const issueKey = String(issue.issueKey || "").trim();
+  if (!issueKey || !detail) {
+    return { values: currentValues, changedNames: [] };
+  }
+  const values = { ...currentValues };
+  const changedNames: string[] = [];
+  const issueValue = jiraIssuePickerValueFromKey(issueKey, issue);
+
+  for (const [name, rawSchema] of Object.entries(schemaProperties(detail.inputSchema))) {
+    const fieldSchema = recordValue(rawSchema);
+    const uiSchema = capabilityFieldUiSchema(detail.uiSchema, name);
+    if (capabilityWidgetName(fieldSchema, uiSchema) !== "jira.issue-picker") {
+      continue;
+    }
+    values[name] = {
+      ...recordValue(values[name]),
+      ...issueValue,
+    };
+    changedNames.push(name);
+  }
+
+  for (const definition of detail.inputs || []) {
+    const name = String(definition.name || "").trim();
+    const normalized = normalizeTemplateInputKey(name);
+    if (!name || (normalized !== "jiraissuekey" && normalized !== "issuekey")) {
+      continue;
+    }
+    values[name] = issueKey;
+    changedNames.push(name);
+  }
+
+  return { values, changedNames };
+}
+
 function JiraProvenanceChip({
   label,
   provenance,
@@ -2844,20 +2928,33 @@ function schemaContractHasFields(detail: Pick<PresetDetail, "inputSchema"> | nul
 }
 
 function resolveSchemaCapabilityValues(
-  detail: Pick<PresetDetail, "inputSchema" | "defaults">,
+  detail: Pick<PresetDetail, "inputSchema" | "uiSchema" | "defaults">,
   explicitValues: Record<string, unknown>,
   featureRequestOverride?: string,
 ): Record<string, unknown> {
   const values: Record<string, unknown> = {};
   const required = schemaRequired(detail.inputSchema);
+  const instructionFeatureRequest = String(featureRequestOverride || "").trim();
+  const instructionJiraIssueKey =
+    extractJiraIssueKeyFromText(instructionFeatureRequest);
   for (const [name, rawSchema] of Object.entries(schemaProperties(detail.inputSchema))) {
     const fieldSchema = recordValue(rawSchema);
-    const instructionFeatureRequest = String(featureRequestOverride || "").trim();
+    const uiSchema = capabilityFieldUiSchema(detail.uiSchema, name);
+    const widget = capabilityWidgetName(fieldSchema, uiSchema);
     const rawExplicit = explicitValues[name];
-    const explicit =
+    let explicit =
       isFeatureRequestInputKey(name) && instructionFeatureRequest
         ? instructionFeatureRequest
         : rawExplicit;
+    if (
+      explicit === undefined &&
+      widget === "jira.issue-picker" &&
+      instructionJiraIssueKey
+    ) {
+      explicit = jiraIssuePickerValueFromKey(instructionJiraIssueKey);
+    } else if (explicit !== undefined && widget === "jira.issue-picker") {
+      explicit = normalizeJiraIssuePickerValue(explicit);
+    }
     const fallback =
       safeCapabilityDefault(detail.defaults, name) ??
       safeCapabilityDefault(fieldSchema, "default");
@@ -2878,7 +2975,7 @@ function resolveSchemaCapabilityValues(
 }
 
 function resolvedPresetInputValues(
-  detail: Pick<PresetDetail, "inputSchema" | "defaults">,
+  detail: Pick<PresetDetail, "inputSchema" | "uiSchema" | "defaults">,
   explicitValues: Record<string, unknown>,
   featureRequestOverride?: string,
 ): Record<string, unknown> {
@@ -5909,12 +6006,35 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     if (!targetStep) {
       return;
     }
+    const nextInstructions = writeJiraImportedText(
+      targetStep.instructions,
+      selectedJiraImportText,
+      jiraWriteMode,
+    );
+    const presetInputUpdate =
+      targetStep.stepType === "preset"
+        ? presetJiraIssueInputValuesFromIssue(
+            targetStep.presetDetail,
+            targetStep.presetInputValues,
+            issue,
+          )
+        : { values: targetStep.presetInputValues, changedNames: [] };
+    const nextPresetInputErrors =
+      presetInputUpdate.changedNames.length > 0
+        ? Object.fromEntries(
+            Object.entries(targetStep.presetInputErrors).filter(
+              ([name]) => !presetInputUpdate.changedNames.includes(name),
+            ),
+          ) as Record<string, string>
+        : targetStep.presetInputErrors;
     updateStep(importTarget.localId, {
-      instructions: writeJiraImportedText(
-        targetStep.instructions,
-        selectedJiraImportText,
-        jiraWriteMode,
-      ),
+      instructions: nextInstructions,
+      ...(presetInputUpdate.changedNames.length > 0
+        ? {
+            presetInputValues: presetInputUpdate.values,
+            presetInputErrors: nextPresetInputErrors,
+          }
+        : {}),
     });
     const provenance = createJiraProvenance(
       issue,

--- a/tests/unit/api/test_auth_providers.py
+++ b/tests/unit/api/test_auth_providers.py
@@ -5,7 +5,8 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_service.auth_providers import get_default_user_from_db
+import api_service.auth_providers as auth_providers
+from api_service.auth_providers import get_current_user, get_default_user_from_db
 from api_service.db.models import User
 from moonmind.config.settings import settings
 
@@ -38,3 +39,21 @@ async def test_get_default_user_invalid_id(monkeypatch):
         await get_default_user_from_db(mock_session)
     assert exc.value.status_code == 500
     assert exc.value.detail == "Default user not found"
+
+
+@pytest.mark.asyncio
+async def test_disabled_auth_fallback_user_has_default_id(monkeypatch):
+    user_id = str(uuid.uuid4())
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled")
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", user_id)
+    monkeypatch.setattr(settings.workflow, "test_mode", False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP", "1")
+    monkeypatch.setattr(auth_providers, "_cached_current_user_dependency", None)
+
+    dependency = get_current_user()
+    user = await dependency()
+
+    assert user.id == uuid.UUID(user_id)
+    assert user.is_superuser is True
+    monkeypatch.setattr(auth_providers, "_cached_current_user_dependency", None)

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2591,6 +2591,41 @@ async def test_seed_catalog_jira_implement_flattens_jira_issue_input(tmp_path):
             ]
 
 
+@pytest.mark.parametrize(
+    "jira_issue_input",
+    [
+        "MM-742",
+        {"issueKey": "MM-742"},
+    ],
+)
+async def test_seed_catalog_jira_implement_accepts_common_jira_issue_shapes(
+    tmp_path, jira_issue_input
+):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "presets"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            expanded = await service.expand_template(
+                slug="jira-implement",
+                scope="global",
+                scope_ref=None,
+                version="1.1.0",
+                inputs={"jira_issue": jira_issue_input},
+                context={},
+            )
+
+            assert expanded["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-742"}
+            assert expanded["appliedTemplate"]["inputs"]["jira_issue_key"] == "MM-742"
+
+
 async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_path):
     seed_dir = (
         Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary

Fixes preset expansion failures where Jira-driven presets could submit incomplete input shapes and receive 422 responses.

## What changed

- Normalize common Jira issue input shapes such as `MM-123`, `{ issueKey: "MM-123" }`, and `{ key: "MM-123" }` into the schema-required Jira issue object.
- Derive Jira issue picker values from imported-style step instructions when a schema-driven preset has not had its Jira field manually edited.
- Populate structured preset input values when importing Jira issues into Preset steps from the Jira browser.
- Keep disabled-auth test stubs unchanged while using the configured default user UUID for real disabled-auth fallback paths, preventing personal preset scope resolution from failing when default-user DB lookup times out.

## Root cause

The backend required the legacy `jira_issue_key` input while the frontend and schema-driven presets could hold only the structured `jira_issue` object, and some object aliases were not flattened. On this deployment, related disabled-auth fallback behavior could also return a stub user without an ID, making personal preset catalog requests fail with 422 when the DB lookup was slow or unavailable.

## Validation

- `./tools/test_unit.sh`
  - Python: 7110 passed, 6 skipped, 1 xpassed
  - Vitest: 29 passed, 488 passed, 236 skipped
