### PR TITLE
MM-916 Remove remaining capability version identity surfaces

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -74,10 +74,10 @@ from moonmind.schemas.temporal_models import (
     ExecutionRefreshEnvelope,
     ExecutionRelatedRunModel,
     ExecutionResumeSummaryModel,
+    ExecutionSkillEvidenceSummaryModel,
     ExecutionSkillLifecycleIntentModel,
     ExecutionSkillProvenanceModel,
     ExecutionSkillRuntimeModel,
-    ExecutionSkillVersionSummaryModel,
     RecoverFromFailedStepRequest,
     RecoverFromFailedStepResponse,
     RecoverFromSelectedStepRequest,
@@ -1188,10 +1188,10 @@ def _mapping_value(raw: Mapping[str, Any], *keys: str) -> object | None:
             return raw[key]
     return None
 
-def _selected_skill_versions(raw: object | None) -> list[ExecutionSkillVersionSummaryModel]:
+def _selected_skill_evidence(raw: object | None) -> list[ExecutionSkillEvidenceSummaryModel]:
     if not isinstance(raw, list):
         return []
-    versions: list[ExecutionSkillVersionSummaryModel] = []
+    evidence: list[ExecutionSkillEvidenceSummaryModel] = []
     for item in raw:
         if not isinstance(item, Mapping):
             continue
@@ -1202,10 +1202,9 @@ def _selected_skill_versions(raw: object | None) -> list[ExecutionSkillVersionSu
         )
         if not name:
             continue
-        versions.append(
-            ExecutionSkillVersionSummaryModel(
+        evidence.append(
+            ExecutionSkillEvidenceSummaryModel(
                 name=name,
-                version=_coerce_temporal_scalar(item.get("version")) or None,
                 sourceKind=(
                     _coerce_temporal_scalar(
                         item.get("sourceKind") or item.get("source_kind")
@@ -1232,13 +1231,13 @@ def _selected_skill_versions(raw: object | None) -> list[ExecutionSkillVersionSu
                 ),
             )
         )
-    return versions
+    return evidence
 
-def _skill_provenance_from_versions(
-    versions: list[ExecutionSkillVersionSummaryModel],
+def _skill_provenance_from_evidence(
+    evidence: list[ExecutionSkillEvidenceSummaryModel],
 ) -> list[ExecutionSkillProvenanceModel]:
     provenance: list[ExecutionSkillProvenanceModel] = []
-    for entry in versions:
+    for entry in evidence:
         if not entry.source_kind and not entry.source_path:
             continue
         provenance.append(
@@ -1252,7 +1251,7 @@ def _skill_provenance_from_versions(
 
 def _skill_source_provenance(
     raw: object | None,
-    versions: list[ExecutionSkillVersionSummaryModel],
+    evidence: list[ExecutionSkillEvidenceSummaryModel],
 ) -> list[ExecutionSkillProvenanceModel]:
     provenance: list[ExecutionSkillProvenanceModel] = []
     seen: set[tuple[str, str | None, str | None]] = set()
@@ -1292,7 +1291,7 @@ def _skill_source_provenance(
                 )
             )
 
-    for entry in _skill_provenance_from_versions(versions):
+    for entry in _skill_provenance_from_evidence(evidence):
         key = (entry.name, entry.source_kind, entry.source_path)
         if key in seen:
             continue
@@ -1394,13 +1393,15 @@ def _skill_runtime_evidence(
     if selected_skills is None:
         selected_skills = task_skills or []
 
-    versions = _selected_skill_versions(
-        materialized.get("selectedVersions") or materialized.get("skills")
+    evidence = _selected_skill_evidence(
+        materialized.get("selectedEvidence")
+        or materialized.get("selectedVersions")
+        or materialized.get("skills")
     )
     provenance = _skill_source_provenance(
         materialized.get("sourceProvenance")
         or materialized.get("source_provenance"),
-        versions,
+        evidence,
     )
     task_skills_payload = _first_mapping(task_payload.get("skills"))
     materialization_mode = (
@@ -1429,13 +1430,13 @@ def _skill_runtime_evidence(
         or resolved_skillset_ref
     )
 
-    if not any([runtime_ref, selected_skills, versions, materialized, lifecycle_intent]):
+    if not any([runtime_ref, selected_skills, evidence, materialized, lifecycle_intent]):
         return None
 
     return ExecutionSkillRuntimeModel(
         resolvedSkillsetRef=runtime_ref,
         selectedSkills=selected_skills,
-        selectedVersions=versions,
+        selectedEvidence=evidence,
         sourceProvenance=provenance,
         materializationMode=materialization_mode,
         visiblePath=(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1387,20 +1387,32 @@ def _skill_runtime_evidence(
         params.get("skillsMaterialized"),
         task_payload.get("skillRuntime"),
     )
-    selected_skills = _skill_selector_names(materialized.get("selectedSkills"))
+    selected_skills = _skill_selector_names(
+        materialized.get("selectedSkills") if materialized else None
+    )
     if selected_skills is None:
-        selected_skills = _skill_selector_names(materialized.get("activeSkills"))
+        selected_skills = _skill_selector_names(
+            materialized.get("activeSkills") if materialized else None
+        )
     if selected_skills is None:
         selected_skills = task_skills or []
 
     evidence = _selected_skill_evidence(
-        materialized.get("selectedEvidence")
-        or materialized.get("selectedVersions")
-        or materialized.get("skills")
+        (
+            materialized.get("selectedEvidence")
+            or materialized.get("selectedVersions")
+            or materialized.get("skills")
+        )
+        if materialized
+        else None
     )
     provenance = _skill_source_provenance(
-        materialized.get("sourceProvenance")
-        or materialized.get("source_provenance"),
+        (
+            materialized.get("sourceProvenance")
+            or materialized.get("source_provenance")
+        )
+        if materialized
+        else None,
         evidence,
     )
     task_skills_payload = _first_mapping(task_payload.get("skills"))

--- a/docs/Steps/JiraIntegration.md
+++ b/docs/Steps/JiraIntegration.md
@@ -280,8 +280,7 @@ Example provenance:
 ```json
 {
   "sourceType": "preset",
-  "presetId": "jira-orchestrate",
-  "presetVersion": "1",
+  "presetSlug": "jira-orchestrate",
   "inputSnapshot": {
     "jira_issue": {
       "key": "MOON-123"
@@ -299,9 +298,8 @@ A Skill may request Jira context directly in its own input schema.
 Example Skill manifest fragment:
 
 ```yaml
-id: code.implementation
+name: code.implementation
 kind: skill
-version: 1
 title: Code Implementation
 entrypoint: SKILL.md
 
@@ -372,8 +370,7 @@ A Tool step may be authored directly:
 {
   "type": "tool",
   "tool": {
-    "id": "jira.transition_issue",
-    "version": "1.0.0",
+    "name": "jira.transition_issue",
     "inputs": {
       "issueKey": "MOON-123",
       "transitionId": "31"

--- a/docs/Steps/StepTypes.md
+++ b/docs/Steps/StepTypes.md
@@ -154,7 +154,7 @@ Examples:
 
 A Tool is not an arbitrary script. Tool definitions must declare their contract:
 
-1. name and version,
+1. name,
 2. input schema,
 3. output schema,
 4. required authorization,
@@ -181,8 +181,7 @@ Desired payload shape:
   "title": "Move Jira issue to In Progress",
   "type": "tool",
   "tool": {
-    "id": "jira.transition_issue",
-    "version": "1.0.0",
+    "name": "jira.transition_issue",
     "inputs": {
       "issueKey": "MM-123",
       "targetStatus": "In Progress"
@@ -236,8 +235,7 @@ Desired payload shape:
   "title": "Implement Jira issue",
   "type": "skill",
   "skill": {
-    "id": "code.implementation",
-    "version": "1.0.0",
+    "name": "code.implementation",
     "inputs": {
       "repository": "MoonLadderStudios/MoonMind",
       "issueKey": "MM-123",
@@ -290,8 +288,7 @@ Temporary draft payload before expansion:
   "title": "Jira Orchestrate",
   "type": "preset",
   "preset": {
-    "id": "jira-orchestrate",
-    "version": "1",
+    "slug": "jira-orchestrate",
     "inputs": {
       "jira_issue": {
         "key": "MM-123",
@@ -311,8 +308,7 @@ After apply or submit-time expansion, generated steps should include provenance:
   "title": "Implement MM-123",
   "type": "skill",
   "skill": {
-    "id": "code.implementation",
-    "version": "1.0.0",
+    "name": "code.implementation",
     "inputs": {
       "repository": "MoonLadderStudios/MoonMind",
       "jira_issue_key": "MM-123"
@@ -320,8 +316,7 @@ After apply or submit-time expansion, generated steps should include provenance:
   },
   "provenance": {
     "sourceType": "preset",
-    "presetId": "jira-orchestrate",
-    "presetVersion": "1",
+    "presetSlug": "jira-orchestrate",
     "inputSnapshot": {
       "jira_issue": {
         "key": "MM-123"
@@ -440,7 +435,7 @@ Apply calls the backend expansion service and inserts generated child steps into
 
 ### 8.2 Reapply
 
-Reapply regenerates steps from the saved preset ID, preset version, and current inputs. If generated child steps were edited, the UI must explain whether reapply replaces, merges, or appends regenerated steps.
+Reapply regenerates steps from the saved preset slug and current inputs. If generated child steps were edited, the UI must explain whether reapply replaces, merges, or appends regenerated steps.
 
 ### 8.3 Submit-time auto-expansion
 
@@ -512,12 +507,11 @@ Every step must have:
 A Tool step is valid only when:
 
 1. the selected tool exists,
-2. the tool version can be resolved or pinned,
-3. inputs validate against the tool schema,
-4. the user has required authorization,
-5. required worker capabilities are available,
-6. forbidden fields are absent,
-7. retry and side-effect policy is known.
+2. inputs validate against the tool schema,
+3. the user has required authorization,
+4. required worker capabilities are available,
+5. forbidden fields are absent,
+6. retry and side-effect policy is known.
 
 Tool validation must reject arbitrary shell snippets unless the selected tool is an explicitly approved typed command tool with bounded inputs and policy.
 
@@ -537,12 +531,11 @@ A Skill step is valid only when:
 A Preset step is valid for apply or submit-time expansion only when:
 
 1. the preset exists,
-2. the preset version is active for authoring,
-3. inputs validate against the preset input schema,
-4. expansion succeeds deterministically,
-5. generated steps validate under their own Tool or Skill rules,
-6. step count and policy limits are enforced,
-7. expansion warnings are visible to the user.
+2. inputs validate against the preset input schema,
+3. expansion succeeds deterministically,
+4. generated steps validate under their own Tool or Skill rules,
+5. step count and policy limits are enforced,
+6. expansion warnings are visible to the user.
 
 Validation errors must be field-addressable:
 
@@ -659,8 +652,7 @@ type StepType = "tool" | "skill" | "preset";
 
 type StepProvenance = {
   sourceType: "preset" | "proposal" | "manual";
-  presetId?: string;
-  presetVersion?: string;
+  presetSlug?: string;
   inputSnapshot?: Record<string, unknown>;
   parentPresetPath?: string[];
 };
@@ -675,8 +667,7 @@ type BaseStep = {
 type ToolStep = BaseStep & {
   type: "tool";
   tool: {
-    id: string;
-    version?: string;
+    name: string;
     inputs: Record<string, unknown>;
   };
 };
@@ -684,8 +675,7 @@ type ToolStep = BaseStep & {
 type SkillStep = BaseStep & {
   type: "skill";
   skill: {
-    id: string;
-    version?: string;
+    name: string;
     inputs: Record<string, unknown>;
   };
 };
@@ -693,8 +683,7 @@ type SkillStep = BaseStep & {
 type PresetStep = BaseStep & {
   type: "preset";
   preset: {
-    id: string;
-    version?: string;
+    slug: string;
     inputs: Record<string, unknown>;
   };
   expansionState?: "not_expanded" | "applied" | "error";
@@ -708,8 +697,7 @@ Preset expansion APIs accept `PresetStep` and return concrete executable steps p
 
 ```ts
 type ExpandPresetRequest = {
-  presetId: string;
-  presetVersion?: string;
+  presetSlug: string;
   inputs: Record<string, unknown>;
   context: Record<string, unknown>;
 };
@@ -729,7 +717,7 @@ Preset management and preset use are separate experiences.
 Preset management lives in the Presets section:
 
 1. catalog browsing,
-2. create/edit/version,
+2. create/edit,
 3. governance and lifecycle,
 4. save-from-workflow,
 5. audit and usage inspection,
@@ -753,7 +741,7 @@ Workflow proposals must preserve executable intent.
 
 When a proposal is created from preset-derived work, it may carry preset provenance, but the stored promotable workflow execution payload should be executable and flattened by default unless the proposal is explicitly still in draft-authoring form.
 
-Promotion must not silently re-expand a live preset catalog entry. If the user wants to refresh a proposal or draft to the latest preset version, that must be an explicit action with validation.
+Promotion must not silently re-expand a live preset catalog entry. If the user wants to refresh a proposal or draft from the current preset definition, that must be an explicit action with validation.
 
 Rules:
 
@@ -827,7 +815,7 @@ The implementation may migrate in phases.
 
 Desired default: no. Presets expand into concrete steps before runtime execution.
 
-A future linked-preset mode may exist, but it must be explicit and visibly different from ordinary preset application. It would need separate rules for version pinning, drift detection, refresh behavior, validation, audit, and runtime lookup.
+A future linked-preset mode may exist, but it must be explicit and visibly different from ordinary preset application. It would need separate rules for snapshot evidence, drift detection, refresh behavior, validation, audit, and runtime lookup.
 
 ### Q2: Should the API use `step.type` or `step.action.kind`?
 

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -297,7 +297,7 @@ Apply calls the backend expansion service and inserts the generated child steps 
 
 ### Reapply
 
-Reapply regenerates steps from the saved preset ID, preset version, and current inputs. If the user edited generated child steps, the UI should make clear that reapplying may replace or update those generated steps.
+Reapply regenerates steps from the saved preset slug and current inputs. If the user edited generated child steps, the UI should make clear that reapplying may replace or update those generated steps.
 
 ## Submit-Time Preset Auto-Expansion
 
@@ -455,8 +455,7 @@ Example:
 ```json
 {
   "sourceType": "preset",
-  "presetId": "jira-orchestrate",
-  "presetVersion": "1",
+  "presetSlug": "jira-orchestrate",
   "inputSnapshot": {
     "jira_issue": {
       "key": "MOON-123"

--- a/frontend/src/components/skills/SkillProvenanceBadge.tsx
+++ b/frontend/src/components/skills/SkillProvenanceBadge.tsx
@@ -1,9 +1,8 @@
 type SkillRuntime = {
   resolvedSkillsetRef?: string | null | undefined;
   selectedSkills?: string[] | undefined;
-  selectedVersions?: Array<{
+  selectedEvidence?: Array<{
     name: string;
-    version?: string | null | undefined;
     sourceKind?: string | null | undefined;
     sourcePath?: string | null | undefined;
     contentRef?: string | null | undefined;
@@ -52,12 +51,16 @@ export function SkillProvenanceBadge({
 }: SkillProvenanceBadgeProps) {
   const hasExplicitSkills = Array.isArray(taskSkills) && taskSkills.length > 0;
   const runtimeRef = skillRuntime?.resolvedSkillsetRef || resolvedSkillsetRef;
-  const selectedVersions = skillRuntime?.selectedVersions ?? [];
+  const selectedEvidence = skillRuntime?.selectedEvidence ?? [];
   const provenance = skillRuntime?.sourceProvenance ?? [];
   const diagnostics = skillRuntime?.diagnostics;
   const lifecycleIntent = skillRuntime?.lifecycleIntent;
-  const selectedVersionText = selectedVersions
-    .map((entry) => `${entry.name}${entry.version ? `@${entry.version}` : ''}`)
+  const selectedEvidenceText = selectedEvidence
+    .map((entry) =>
+      [entry.name, entry.contentRef, entry.contentDigest, entry.sourceKind, entry.sourcePath]
+        .filter(Boolean)
+        .join(' · '),
+    )
     .join(', ');
   const provenanceText = provenance
     .map((entry) => [entry.name, entry.sourceKind, entry.sourcePath].filter(Boolean).join(' · '))
@@ -96,10 +99,10 @@ export function SkillProvenanceBadge({
             )}
           </dd>
         </div>
-        {selectedVersionText ? (
+        {selectedEvidenceText ? (
           <div>
-            <dt>Selected Versions</dt>
-            <dd>{selectedVersionText}</dd>
+            <dt>Selected Skill Evidence</dt>
+            <dd>{selectedEvidenceText}</dd>
           </div>
         ) : null}
         {provenanceText ? (

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -3453,10 +3453,9 @@ describe('Workflow Detail Entrypoint', () => {
       skillRuntime: {
         resolvedSkillsetRef: 'artifact:resolved-skills-1',
         selectedSkills: ['jira-pr-verify'],
-        selectedVersions: [
+        selectedEvidence: [
           {
             name: 'jira-pr-verify',
-            version: '1.2.0',
             sourceKind: 'deployment',
             contentRef: 'artifact:skill-body-1',
             contentDigest: 'sha256:abc',
@@ -3531,8 +3530,11 @@ describe('Workflow Detail Entrypoint', () => {
         'jira-pr-verify, fix-comments',
       );
       expect(screen.getByText('Delegated Skill').closest('div')?.textContent).toContain('jira-pr-verify');
-      expect(screen.getByText('Selected Versions').closest('div')?.textContent).toContain(
-        'jira-pr-verify@1.2.0',
+      expect(screen.getByText('Selected Skill Evidence').closest('div')?.textContent).toContain(
+        'jira-pr-verify',
+      );
+      expect(screen.getByText('Selected Skill Evidence').closest('div')?.textContent).toContain(
+        'artifact:skill-body-1',
       );
       expect(screen.getByText('Source Provenance').closest('div')?.textContent).toContain(
         'deployment',

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -285,12 +285,11 @@ const SkillRuntimeSchema = z
   .object({
     resolvedSkillsetRef: z.string().nullable().optional(),
     selectedSkills: z.array(z.string()).optional().default([]),
-    selectedVersions: z
+    selectedEvidence: z
       .array(
         z
           .object({
             name: z.string(),
-            version: z.string().nullable().optional(),
             sourceKind: z.string().nullable().optional(),
             sourcePath: z.string().nullable().optional(),
             contentRef: z.string().nullable().optional(),

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5077,6 +5077,22 @@ export interface components {
             disabledReason?: string | null;
         };
         /**
+         * ExecutionSkillEvidenceSummaryModel
+         * @description Compact operator-safe evidence for one selected skill.
+         */
+        ExecutionSkillEvidenceSummaryModel: {
+            /** Name */
+            name: string;
+            /** Sourcekind */
+            sourceKind?: string | null;
+            /** Sourcepath */
+            sourcePath?: string | null;
+            /** Contentref */
+            contentRef?: string | null;
+            /** Contentdigest */
+            contentDigest?: string | null;
+        };
+        /**
          * ExecutionSkillLifecycleIntentModel
          * @description How skill intent or snapshot reuse is preserved across lifecycle paths.
          */
@@ -5113,8 +5129,8 @@ export interface components {
             resolvedSkillsetRef?: string | null;
             /** Selectedskills */
             selectedSkills?: string[];
-            /** Selectedversions */
-            selectedVersions?: components["schemas"]["ExecutionSkillVersionSummaryModel"][];
+            /** Selectedevidence */
+            selectedEvidence?: components["schemas"]["ExecutionSkillEvidenceSummaryModel"][];
             /** Sourceprovenance */
             sourceProvenance?: components["schemas"]["ExecutionSkillProvenanceModel"][];
             /** Materializationmode */
@@ -5133,24 +5149,6 @@ export interface components {
             activationSummaryRef?: string | null;
             diagnostics?: components["schemas"]["ExecutionProjectionDiagnosticModel"] | null;
             lifecycleIntent?: components["schemas"]["ExecutionSkillLifecycleIntentModel"] | null;
-        };
-        /**
-         * ExecutionSkillVersionSummaryModel
-         * @description Compact operator-safe summary of one selected skill version.
-         */
-        ExecutionSkillVersionSummaryModel: {
-            /** Name */
-            name: string;
-            /** Version */
-            version?: string | null;
-            /** Sourcekind */
-            sourceKind?: string | null;
-            /** Sourcepath */
-            sourcePath?: string | null;
-            /** Contentref */
-            contentRef?: string | null;
-            /** Contentdigest */
-            contentDigest?: string | null;
         };
         /**
          * ExecutionTargetDiagnosticAttachmentModel

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2487,13 +2487,12 @@ class ExecutionDependencySummaryModel(BaseModel):
     close_status: Optional[str] = Field(None, alias="closeStatus")
     workflow_type: Optional[str] = Field(None, alias="workflowType")
 
-class ExecutionSkillVersionSummaryModel(BaseModel):
-    """Compact operator-safe summary of one selected skill version."""
+class ExecutionSkillEvidenceSummaryModel(BaseModel):
+    """Compact operator-safe evidence for one selected skill."""
 
     model_config = ConfigDict(populate_by_name=True)
 
     name: str = Field(..., alias="name")
-    version: Optional[str] = Field(None, alias="version")
     source_kind: Optional[str] = Field(None, alias="sourceKind")
     source_path: Optional[str] = Field(None, alias="sourcePath")
     content_ref: Optional[str] = Field(None, alias="contentRef")
@@ -2537,8 +2536,8 @@ class ExecutionSkillRuntimeModel(BaseModel):
 
     resolved_skillset_ref: Optional[str] = Field(None, alias="resolvedSkillsetRef")
     selected_skills: list[str] = Field(default_factory=list, alias="selectedSkills")
-    selected_versions: list[ExecutionSkillVersionSummaryModel] = Field(
-        default_factory=list, alias="selectedVersions"
+    selected_evidence: list[ExecutionSkillEvidenceSummaryModel] = Field(
+        default_factory=list, alias="selectedEvidence"
     )
     source_provenance: list[ExecutionSkillProvenanceModel] = Field(
         default_factory=list, alias="sourceProvenance"

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7544,6 +7544,26 @@ def test_serialize_execution_preserves_direct_skill_source_provenance() -> None:
         },
     ]
 
+
+def test_serialize_execution_handles_missing_skill_materialization_metadata() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "workflow": {
+            "instructions": "Inspect skill runtime evidence.",
+            "skills": {"sets": ["operator-default"]},
+        },
+        "skillRuntime": None,
+        "skillsMaterialized": None,
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["taskSkills"] == ["operator-default"]
+    assert payload["skillRuntime"]["selectedSkills"] == ["operator-default"]
+    assert payload["skillRuntime"]["selectedEvidence"] == []
+    assert payload["skillRuntime"]["sourceProvenance"] == []
+
+
 def test_serialize_execution_accepts_snake_case_skill_materialization_metadata() -> None:
     record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
     record.parameters = {

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7475,14 +7475,14 @@ def test_serialize_execution_surfaces_compact_skill_runtime_metadata() -> None:
     skill_runtime = dumped["skillRuntime"]
     assert skill_runtime["resolvedSkillsetRef"] == "artifact:resolved-skills-1"
     assert skill_runtime["selectedSkills"] == ["pr-resolver"]
-    assert skill_runtime["selectedVersions"][0] == {
+    assert skill_runtime["selectedEvidence"][0] == {
         "name": "pr-resolver",
-        "version": "1.2.0",
         "sourceKind": "deployment",
         "sourcePath": None,
         "contentRef": "artifact:skill-body-1",
         "contentDigest": "sha256:abc",
     }
+    assert "selectedVersions" not in skill_runtime
     assert skill_runtime["sourceProvenance"][0] == {
         "name": "pr-resolver",
         "sourceKind": "deployment",

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2752,7 +2752,6 @@ async def test_seed_catalog_jira_implement_accepts_common_jira_issue_shapes(
                 slug="jira-implement",
                 scope="global",
                 scope_ref=None,
-                version="1.1.0",
                 inputs={"jira_issue": jira_issue_input},
                 context={},
             )


### PR DESCRIPTION
Issue: MM-916

Summary:
- Removes semantic capability version identity from remaining desired-state docs and active provenance examples.
- Renames skill runtime output from selectedVersions to selectedEvidence while retaining read-side tolerance for historical selectedVersions inputs.
- Updates the workflow detail skill provenance UI label to Selected Skill Evidence and keeps contentRef/contentDigest/source provenance visible.
- Regenerates OpenAPI types and adjusts API/frontend tests for the name-only identity model.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py -k 'skill_runtime_metadata or direct_skill_source_provenance' (passed)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx (passed)
- Earlier targeted tests exposed tests/unit/api/test_presets_service.py still passing a removed version argument; the branch removes that stale argument.

Remaining risks:
- Historical workflow records may still contain selectedVersions; this branch intentionally reads and normalizes those records without re-emitting selectedVersions.
