### PR TITLE
MM-925 add ops diagnostic stack tool

### DIFF
--- a/moonmind/utils/logging.py
+++ b/moonmind/utils/logging.py
@@ -15,6 +15,9 @@ _GITHUB_TOKEN_PATTERN = re.compile(
     r"(?:ghp|gho|ghu|ghs|ghr|github_pat)[_-][A-Za-z0-9_-]{20,}",
     re.IGNORECASE,
 )
+_CLOUD_TOKEN_PATTERN = re.compile(
+    r"\b(?:AIza[A-Za-z0-9_-]{16,}|AKIA[A-Z0-9]{16})\b"
+)
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
     r"(?i)\b(token|password|secret|api[_-]?key|credential)\s*[:=]\s*"
     r"(?:\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
@@ -73,11 +76,12 @@ def _secret_variants(secret: str) -> set[str]:
     return variants
 
 def scrub_github_tokens(text: str) -> str:
-    """Scrub common GitHub token-like values from diagnostic text."""
+    """Scrub common provider token-like values from diagnostic text."""
 
     if not text:
         return ""
-    return _GITHUB_TOKEN_PATTERN.sub("[REDACTED]", text)
+    redacted = _GITHUB_TOKEN_PATTERN.sub("[REDACTED]", text)
+    return _CLOUD_TOKEN_PATTERN.sub("[REDACTED]", redacted)
 
 def _redact_private_key_blocks(text: str) -> str:
     redacted = text

--- a/moonmind/utils/logging.py
+++ b/moonmind/utils/logging.py
@@ -19,8 +19,8 @@ _CLOUD_TOKEN_PATTERN = re.compile(
     r"\b(?:AIza[A-Za-z0-9_-]{16,}|AKIA[A-Z0-9]{16})\b"
 )
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"(?i)\b([A-Z0-9_.-]*(?:token|password|secret|api[_-]?key|credential)"
-    r"[A-Z0-9_.-]*)\s*[:=]\s*"
+    r"(?i)\b([A-Z0-9_.-]{0,80}(?:token|password|secret|api[_-]?key|credential)"
+    r"[A-Z0-9_.-]{0,80})\s*[:=]\s*"
     r"(?:\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
 )
 _AUTHORIZATION_PATTERN = re.compile(

--- a/moonmind/utils/logging.py
+++ b/moonmind/utils/logging.py
@@ -19,7 +19,8 @@ _CLOUD_TOKEN_PATTERN = re.compile(
     r"\b(?:AIza[A-Za-z0-9_-]{16,}|AKIA[A-Z0-9]{16})\b"
 )
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"(?i)\b(token|password|secret|api[_-]?key|credential)\s*[:=]\s*"
+    r"(?i)\b([A-Z0-9_.-]*(?:token|password|secret|api[_-]?key|credential)"
+    r"[A-Z0-9_.-]*)\s*[:=]\s*"
     r"(?:\"[^\"]*\"|'[^']*'|[^\s,;\"']+)"
 )
 _AUTHORIZATION_PATTERN = re.compile(

--- a/moonmind/workflows/skills/deployment_tools.py
+++ b/moonmind/workflows/skills/deployment_tools.py
@@ -8,6 +8,8 @@ from moonmind.schemas.agent_runtime_models import moonmind_ops_runtime_contract
 
 DEPLOYMENT_UPDATE_TOOL_NAME = "deployment.update_compose_stack"
 DEPLOYMENT_UPDATE_TOOL_VERSION = "1.0.0"
+OPS_DIAGNOSE_STACK_TOOL_NAME = "moonmind.ops_diagnose_stack"
+OPS_DIAGNOSE_STACK_TOOL_VERSION = "1.0.0"
 
 _MOONMIND_REPOSITORY = "ghcr.io/moonladderstudios/moonmind"
 _NON_RETRYABLE_DEPLOYMENT_ERRORS = (
@@ -16,6 +18,31 @@ _NON_RETRYABLE_DEPLOYMENT_ERRORS = (
     "POLICY_VIOLATION",
     "DEPLOYMENT_LOCKED",
 )
+_NON_RETRYABLE_DIAGNOSIS_ERRORS = (
+    "INVALID_INPUT",
+    "PERMISSION_DENIED",
+    "POLICY_VIOLATION",
+)
+_OPS_DIAGNOSIS_INCLUDES = [
+    "compose_ps",
+    "compose_images",
+    "container_health",
+    "container_inspect_summary",
+    "recent_logs",
+    "api_health",
+    "worker_health",
+    "temporal_connectivity",
+    "artifact_store_health",
+    "disk_memory_cpu",
+]
+_DEFAULT_OPS_DIAGNOSIS_INCLUDES = [
+    "compose_ps",
+    "container_health",
+    "recent_logs",
+    "api_health",
+    "worker_health",
+    "temporal_connectivity",
+]
 
 
 def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
@@ -143,8 +170,117 @@ def build_deployment_update_tool_definition_payload() -> dict[str, Any]:
     }
 
 
+def build_ops_diagnose_stack_tool_definition_payload() -> dict[str, Any]:
+    """Build the MM-925 read-only ops diagnosis tool registry definition."""
+
+    ops_runtime = moonmind_ops_runtime_contract().model_copy(
+        update={"allowed_operations": ("status", "logs")}
+    )
+    return {
+        "name": OPS_DIAGNOSE_STACK_TOOL_NAME,
+        "type": "skill",
+        "description": (
+            "Collect read-only, bounded MoonMind Compose stack diagnostics for "
+            "policy-approved remediation workflows."
+        ),
+        "inputs": {
+            "schema": {
+                "type": "object",
+                "required": ["stack", "reason"],
+                "additionalProperties": False,
+                "properties": {
+                    "stack": {"type": "string", "enum": ["moonmind"]},
+                    "include": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": _OPS_DIAGNOSIS_INCLUDES},
+                        "default": _DEFAULT_OPS_DIAGNOSIS_INCLUDES,
+                    },
+                    "services": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "tailLines": {
+                        "type": "integer",
+                        "minimum": 50,
+                        "maximum": 1000,
+                        "default": 300,
+                    },
+                    "targetWorkflowId": {"type": "string"},
+                    "remediationWorkflowId": {"type": "string"},
+                    "reason": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 1000,
+                    },
+                },
+            }
+        },
+        "outputs": {
+            "schema": {
+                "type": "object",
+                "required": ["status", "stack", "summary", "findings", "artifactRefs"],
+                "additionalProperties": False,
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["SUCCEEDED", "FAILED", "PARTIALLY_VERIFIED"],
+                    },
+                    "stack": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "findings": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["kind", "severity", "message"],
+                            "additionalProperties": False,
+                            "properties": {
+                                "kind": {"type": "string"},
+                                "severity": {
+                                    "type": "string",
+                                    "enum": ["info", "warning", "error"],
+                                },
+                                "message": {"type": "string"},
+                                "service": {"type": "string"},
+                                "evidenceRef": {"type": "string"},
+                            },
+                        },
+                    },
+                    "artifactRefs": {
+                        "type": "object",
+                        "additionalProperties": {"type": "string"},
+                    },
+                },
+            }
+        },
+        "executor": {
+            "activity_type": "mm.tool.execute",
+            "selector": {"mode": "by_capability"},
+        },
+        "requirements": {"capabilities": ["deployment_control", "docker_admin"]},
+        "policies": {
+            "timeouts": {
+                "start_to_close_seconds": 300,
+                "schedule_to_close_seconds": 600,
+            },
+            "retries": {
+                "max_attempts": 1,
+                "non_retryable_error_codes": list(_NON_RETRYABLE_DIAGNOSIS_ERRORS),
+            },
+        },
+        "security": {
+            "allowed_roles": ["admin"],
+            "remediationPolicyRequired": True,
+            "exposedToManagedAgents": False,
+            "opsRuntime": ops_runtime.model_dump(by_alias=True, mode="json"),
+        },
+    }
+
+
 __all__ = [
     "DEPLOYMENT_UPDATE_TOOL_NAME",
     "DEPLOYMENT_UPDATE_TOOL_VERSION",
+    "OPS_DIAGNOSE_STACK_TOOL_NAME",
+    "OPS_DIAGNOSE_STACK_TOOL_VERSION",
     "build_deployment_update_tool_definition_payload",
+    "build_ops_diagnose_stack_tool_definition_payload",
 ]

--- a/moonmind/workflows/skills/ops_diagnostics_execution.py
+++ b/moonmind/workflows/skills/ops_diagnostics_execution.py
@@ -8,13 +8,17 @@ import json
 from dataclasses import dataclass, replace
 from typing import Any, Mapping, Protocol, Sequence
 
+from moonmind.utils.logging import redact_sensitive_payload
+
 from .deployment_execution import (
     DEPLOYMENT_FINAL_STATUSES,
     HostDockerComposeRunner,
     InMemoryEvidenceWriter,
     TemporalDeploymentEvidenceWriter,
     _compact_mapping,
+    _ensure_command_succeeded,
     _execution_ref_from_context,
+    _parse_json_records,
     _redact_sensitive,
     _tail_text,
     _utc_now,
@@ -52,9 +56,14 @@ DEFAULT_MOONMIND_SERVICES = frozenset(
         "postgres",
         "temporal",
         "temporal-ui",
-        "temporal-worker",
+        "temporal-worker-artifacts",
         "temporal-worker-agent-runtime",
         "temporal-worker-deployment-control",
+        "temporal-worker-integrations",
+        "temporal-worker-llm",
+        "temporal-worker-sandbox",
+        "temporal-worker-workflow",
+        "temporal-worker-workflow-merge-automation",
         "qdrant",
         "minio",
         "docker-proxy",
@@ -221,36 +230,46 @@ class HostDockerComposeOpsDiagnosisRunner(HostDockerComposeRunner):
         self, *, services: tuple[str, ...]
     ) -> Mapping[str, Any]:
         ps = await self._run_compose_json(("ps", "--format", "json", *services))
-        summaries = []
-        for item in ps:
+
+        async def inspect_one(item: Mapping[str, Any]) -> Mapping[str, Any] | None:
             container = str(item.get("ID") or item.get("Name") or "").strip()
             service = str(item.get("Service") or item.get("Name") or "").strip()
             if not container:
-                continue
-            result = await self._run_docker_json(
-                ("docker", "inspect", container),
-                failure_class="container_inspect_failure",
-            )
-            inspect = result[0] if result else {}
-            state = inspect.get("State") if isinstance(inspect, Mapping) else {}
-            config = inspect.get("Config") if isinstance(inspect, Mapping) else {}
-            summaries.append(
-                _compact_mapping(
+                return None
+            try:
+                result = await self._run_docker_json(
+                    ("docker", "inspect", container),
+                    failure_class="container_inspect_failure",
+                )
+            except Exception as exc:
+                return _compact_mapping(
                     {
                         "service": service or None,
                         "container": container,
-                        "state": state if isinstance(state, Mapping) else None,
-                        "image": (
-                            config.get("Image")
-                            if isinstance(config, Mapping)
-                            else None
-                        ),
-                        "restartCount": inspect.get("RestartCount")
-                        if isinstance(inspect, Mapping)
-                        else None,
+                        "status": "FAILED",
+                        "reason": _redact_sensitive(_failure_reason(exc)),
                     }
                 )
+            inspect = result[0] if result else {}
+            state = inspect.get("State") if isinstance(inspect, Mapping) else {}
+            config = inspect.get("Config") if isinstance(inspect, Mapping) else {}
+            return _compact_mapping(
+                {
+                    "service": service or None,
+                    "container": container,
+                    "status": "SUCCEEDED",
+                    "state": state if isinstance(state, Mapping) else None,
+                    "image": (
+                        config.get("Image") if isinstance(config, Mapping) else None
+                    ),
+                    "restartCount": inspect.get("RestartCount")
+                    if isinstance(inspect, Mapping)
+                    else None,
+                }
             )
+
+        inspected = await asyncio.gather(*(inspect_one(item) for item in ps))
+        summaries = [item for item in inspected if item is not None]
         return {"containers": summaries}
 
     async def _docker_system_df(self) -> Mapping[str, Any]:
@@ -269,6 +288,7 @@ class HostDockerComposeOpsDiagnosisRunner(HostDockerComposeRunner):
             max_stdout_chars=8000,
             max_stderr_chars=2000,
         )
+        _ensure_command_succeeded(kind, result)
         return {"kind": kind, "result": result}
 
     async def _run_docker_json(
@@ -314,12 +334,19 @@ class HostDockerComposeOpsDiagnosisRunner(HostDockerComposeRunner):
         text = stdout.decode("utf-8", errors="replace").strip()
         if not text:
             return []
-        parsed = json.loads(text)
-        if isinstance(parsed, list):
-            return [item for item in parsed if isinstance(item, Mapping)]
-        if isinstance(parsed, Mapping):
-            return [parsed]
-        return []
+        try:
+            return _parse_json_records(text)
+        except json.JSONDecodeError as exc:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Ops diagnosis Docker command returned invalid JSON.",
+                retryable=False,
+                details={
+                    "command": list(command),
+                    "stdout": _tail_text(stdout, max_chars=2000),
+                    "failureClass": failure_class,
+                },
+            ) from exc
 
 
 @dataclass(slots=True)
@@ -355,20 +382,23 @@ class OpsStackDiagnosisExecutor:
                     "reason": _redact_sensitive(_failure_reason(exc)),
                 }
                 continue
-            redacted = _redact_sensitive(payload)
+            redacted = _redact_ops_diagnosis_payload(payload)
             evidence[include] = {"status": "SUCCEEDED", "payload": redacted}
             findings.extend(_findings_for_evidence(include, redacted))
 
-        if not evidence:
+        succeeded_count = sum(
+            1 for item in evidence.values() if item.get("status") == "SUCCEEDED"
+        )
+        if succeeded_count == 0:
             status = "FAILED"
-        elif all(item.get("status") == "SUCCEEDED" for item in evidence.values()):
+        elif succeeded_count == len(evidence):
             status = "SUCCEEDED"
         else:
             status = "PARTIALLY_VERIFIED"
         if status not in DEPLOYMENT_FINAL_STATUSES:
             status = "FAILED"
 
-        diagnosis_payload = _redact_sensitive(
+        diagnosis_payload = _redact_ops_diagnosis_payload(
             {
                 "schemaVersion": "v1",
                 "artifactType": OPS_DIAGNOSIS_ARTIFACT_TYPE,
@@ -637,6 +667,10 @@ def _failure_reason(exc: Exception) -> str:
     if isinstance(exc, ToolFailure):
         return exc.message
     return str(exc) or exc.__class__.__name__
+
+
+def _redact_ops_diagnosis_payload(payload: Any) -> Any:
+    return redact_sensitive_payload(_redact_sensitive(payload))
 
 
 def _finding_for_failure(include: str, exc: Exception) -> dict[str, Any]:

--- a/moonmind/workflows/skills/ops_diagnostics_execution.py
+++ b/moonmind/workflows/skills/ops_diagnostics_execution.py
@@ -1,0 +1,718 @@
+"""Read-only ops diagnosis execution for remediation workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Protocol, Sequence
+
+from .deployment_execution import (
+    DEPLOYMENT_FINAL_STATUSES,
+    HostDockerComposeRunner,
+    InMemoryEvidenceWriter,
+    TemporalDeploymentEvidenceWriter,
+    _compact_mapping,
+    _execution_ref_from_context,
+    _redact_sensitive,
+    _tail_text,
+    _utc_now,
+)
+from .deployment_tools import OPS_DIAGNOSE_STACK_TOOL_NAME
+from .tool_plan_contracts import ToolFailure, ToolResult
+
+OPS_DIAGNOSIS_ARTIFACT_TYPE = "remediation.ops_diagnosis"
+OPS_DIAGNOSIS_STACKS = frozenset({"moonmind"})
+OPS_DIAGNOSIS_INCLUDES = frozenset(
+    {
+        "compose_ps",
+        "compose_images",
+        "container_health",
+        "container_inspect_summary",
+        "recent_logs",
+        "api_health",
+        "worker_health",
+        "temporal_connectivity",
+        "artifact_store_health",
+        "disk_memory_cpu",
+    }
+)
+DEFAULT_OPS_DIAGNOSIS_INCLUDES = (
+    "compose_ps",
+    "container_health",
+    "recent_logs",
+    "api_health",
+    "worker_health",
+    "temporal_connectivity",
+)
+DEFAULT_MOONMIND_SERVICES = frozenset(
+    {
+        "api",
+        "postgres",
+        "temporal",
+        "temporal-ui",
+        "temporal-worker",
+        "temporal-worker-agent-runtime",
+        "temporal-worker-deployment-control",
+        "qdrant",
+        "minio",
+        "docker-proxy",
+    }
+)
+OPS_DIAGNOSIS_TAIL_LINES_MIN = 50
+OPS_DIAGNOSIS_TAIL_LINES_MAX = 1000
+OPS_DIAGNOSIS_TAIL_LINES_DEFAULT = 300
+
+
+class OpsDiagnosisEvidenceWriter(Protocol):
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        """Write redacted diagnosis evidence and return an artifact ref."""
+
+
+class OpsDiagnosisRunner(Protocol):
+    async def collect(
+        self,
+        *,
+        stack: str,
+        include: str,
+        services: tuple[str, ...],
+        tail_lines: int,
+    ) -> Mapping[str, Any]:
+        """Collect one allowlisted evidence class using fixed read-only commands."""
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalOpsDiagnosisEvidenceWriter(TemporalDeploymentEvidenceWriter):
+    """Ops diagnosis evidence writer backed by Temporal artifacts."""
+
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        encoded = (
+            json.dumps(payload, sort_keys=True, default=str, indent=2) + "\n"
+        ).encode("utf-8")
+        artifact, _upload = await self.artifact_service.create(
+            principal=self.principal,
+            content_type="application/json",
+            link=self.execution_ref,
+            metadata_json={
+                "artifact_type": OPS_DIAGNOSIS_ARTIFACT_TYPE,
+                "artifactType": OPS_DIAGNOSIS_ARTIFACT_TYPE,
+                "artifactClass": OPS_DIAGNOSIS_ARTIFACT_TYPE,
+                "opsDiagnosisKind": kind,
+            },
+        )
+        completed = await self.artifact_service.write_complete(
+            artifact_id=artifact.artifact_id,
+            principal=self.principal,
+            payload=encoded,
+            content_type="application/json",
+        )
+        return str(getattr(completed, "artifact_id", artifact.artifact_id))
+
+
+class DisabledOpsDiagnosisRunner:
+    """Fail-closed runner used when deployment-control diagnostics are unavailable."""
+
+    async def collect(
+        self,
+        *,
+        stack: str,
+        include: str,
+        services: tuple[str, ...],
+        tail_lines: int,
+    ) -> Mapping[str, Any]:
+        raise ToolFailure(
+            error_code="POLICY_VIOLATION",
+            message="Ops diagnosis runner is not configured for this worker.",
+            retryable=False,
+            details={
+                "stack": stack,
+                "include": include,
+                "failureClass": "policy_violation",
+            },
+        )
+
+
+class HostDockerComposeOpsDiagnosisRunner(HostDockerComposeRunner):
+    """Read-only Docker Compose diagnosis runner for deployment-control workers."""
+
+    async def collect(
+        self,
+        *,
+        stack: str,
+        include: str,
+        services: tuple[str, ...],
+        tail_lines: int,
+    ) -> Mapping[str, Any]:
+        if include == "compose_ps":
+            return {"services": await self._run_compose_json(("ps", "--format", "json"))}
+        if include == "compose_images":
+            return {
+                "images": await self._run_compose_json(("images", "--format", "json"))
+            }
+        if include == "container_health":
+            return await self._container_health(services=services)
+        if include == "container_inspect_summary":
+            return await self._container_inspect_summary(services=services)
+        if include == "recent_logs":
+            return await self._recent_logs(services=services, tail_lines=tail_lines)
+        if include == "api_health":
+            return await self._run_service_command(
+                "api_health", ("docker", "compose", "ps", "--format", "json", "api")
+            )
+        if include == "worker_health":
+            return await self._run_service_command(
+                "worker_health",
+                ("docker", "compose", "ps", "--format", "json", *services),
+            )
+        if include == "temporal_connectivity":
+            return await self._run_service_command(
+                "temporal_connectivity",
+                ("docker", "compose", "ps", "--format", "json", "temporal"),
+            )
+        if include == "artifact_store_health":
+            return await self._run_service_command(
+                "artifact_store_health",
+                ("docker", "compose", "ps", "--format", "json", "minio"),
+            )
+        if include == "disk_memory_cpu":
+            return await self._docker_system_df()
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"Unsupported ops diagnosis include '{include}'.",
+            retryable=False,
+            details={"include": include, "failureClass": "invalid_input"},
+        )
+
+    async def _recent_logs(
+        self, *, services: tuple[str, ...], tail_lines: int
+    ) -> Mapping[str, Any]:
+        command = ("docker", "compose", "logs", "--no-color", "--tail", str(tail_lines), *services)
+        result = await self._run_compose_command(
+            command,
+            max_stdout_chars=tail_lines * 500,
+            max_stderr_chars=2000,
+        )
+        return {"tailLines": tail_lines, "services": list(services), "result": result}
+
+    async def _container_health(self, *, services: tuple[str, ...]) -> Mapping[str, Any]:
+        records = []
+        ps = await self._run_compose_json(("ps", "--format", "json", *services))
+        for item in ps:
+            name = str(
+                item.get("Name") or item.get("ContainerName") or item.get("ID") or ""
+            ).strip()
+            service = str(item.get("Service") or item.get("Name") or "").strip()
+            state = str(item.get("State") or item.get("Status") or "").strip()
+            health = str(item.get("Health") or item.get("health") or "").strip()
+            records.append(
+                _compact_mapping(
+                    {
+                        "service": service or None,
+                        "container": name or None,
+                        "state": state or None,
+                        "health": health or None,
+                    }
+                )
+            )
+        return {"containers": records}
+
+    async def _container_inspect_summary(
+        self, *, services: tuple[str, ...]
+    ) -> Mapping[str, Any]:
+        ps = await self._run_compose_json(("ps", "--format", "json", *services))
+        summaries = []
+        for item in ps:
+            container = str(item.get("ID") or item.get("Name") or "").strip()
+            service = str(item.get("Service") or item.get("Name") or "").strip()
+            if not container:
+                continue
+            result = await self._run_docker_json(
+                ("docker", "inspect", container),
+                failure_class="container_inspect_failure",
+            )
+            inspect = result[0] if result else {}
+            state = inspect.get("State") if isinstance(inspect, Mapping) else {}
+            config = inspect.get("Config") if isinstance(inspect, Mapping) else {}
+            summaries.append(
+                _compact_mapping(
+                    {
+                        "service": service or None,
+                        "container": container,
+                        "state": state if isinstance(state, Mapping) else None,
+                        "image": (
+                            config.get("Image")
+                            if isinstance(config, Mapping)
+                            else None
+                        ),
+                        "restartCount": inspect.get("RestartCount")
+                        if isinstance(inspect, Mapping)
+                        else None,
+                    }
+                )
+            )
+        return {"containers": summaries}
+
+    async def _docker_system_df(self) -> Mapping[str, Any]:
+        return {
+            "dockerSystemDf": await self._run_docker_json(
+                ("docker", "system", "df", "--format", "json"),
+                failure_class="docker_system_df_failure",
+            )
+        }
+
+    async def _run_service_command(
+        self, kind: str, command: Sequence[str]
+    ) -> Mapping[str, Any]:
+        result = await self._run_compose_command(
+            command,
+            max_stdout_chars=8000,
+            max_stderr_chars=2000,
+        )
+        return {"kind": kind, "result": result}
+
+    async def _run_docker_json(
+        self, command: Sequence[str], *, failure_class: str
+    ) -> list[Mapping[str, Any]]:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(self._local_dir()),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.command_timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Ops diagnosis Docker command timed out.",
+                retryable=False,
+                details={
+                    "command": list(command),
+                    "timeoutSeconds": self.command_timeout_seconds,
+                    "failureClass": failure_class,
+                },
+            ) from exc
+        if process.returncode != 0:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_COMMAND_FAILED",
+                message="Ops diagnosis Docker command failed.",
+                retryable=False,
+                details={
+                    "command": list(command),
+                    "exitCode": process.returncode,
+                    "stderr": _tail_text(stderr, max_chars=2000),
+                    "failureClass": failure_class,
+                },
+            )
+        text = stdout.decode("utf-8", errors="replace").strip()
+        if not text:
+            return []
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, Mapping)]
+        if isinstance(parsed, Mapping):
+            return [parsed]
+        return []
+
+
+@dataclass(slots=True)
+class OpsStackDiagnosisExecutor:
+    evidence_writer: OpsDiagnosisEvidenceWriter
+    runner: OpsDiagnosisRunner
+
+    async def execute(
+        self,
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        context = dict(context or {})
+        _require_remediation_policy(context)
+        parsed = _parse_diagnosis_inputs(inputs)
+        started_at = _utc_now()
+        findings: list[dict[str, Any]] = []
+        evidence: dict[str, Any] = {}
+        artifact_ref: str | None = None
+
+        for include in parsed["include"]:
+            try:
+                payload = await self.runner.collect(
+                    stack=parsed["stack"],
+                    include=include,
+                    services=parsed["services"],
+                    tail_lines=parsed["tailLines"],
+                )
+            except Exception as exc:
+                findings.append(_finding_for_failure(include, exc))
+                evidence[include] = {
+                    "status": "FAILED",
+                    "reason": _redact_sensitive(_failure_reason(exc)),
+                }
+                continue
+            redacted = _redact_sensitive(payload)
+            evidence[include] = {"status": "SUCCEEDED", "payload": redacted}
+            findings.extend(_findings_for_evidence(include, redacted))
+
+        if not evidence:
+            status = "FAILED"
+        elif all(item.get("status") == "SUCCEEDED" for item in evidence.values()):
+            status = "SUCCEEDED"
+        else:
+            status = "PARTIALLY_VERIFIED"
+        if status not in DEPLOYMENT_FINAL_STATUSES:
+            status = "FAILED"
+
+        diagnosis_payload = _redact_sensitive(
+            {
+                "schemaVersion": "v1",
+                "artifactType": OPS_DIAGNOSIS_ARTIFACT_TYPE,
+                "toolName": OPS_DIAGNOSE_STACK_TOOL_NAME,
+                "status": status,
+                "stack": parsed["stack"],
+                "include": list(parsed["include"]),
+                "services": list(parsed["services"]),
+                "tailLines": parsed["tailLines"],
+                "targetWorkflowId": parsed.get("targetWorkflowId"),
+                "remediationWorkflowId": parsed.get("remediationWorkflowId"),
+                "reason": parsed["reason"],
+                "startedAt": started_at,
+                "completedAt": _utc_now(),
+                "evidence": evidence,
+                "findings": findings,
+            }
+        )
+        artifact_ref = await self.evidence_writer.write("diagnosis", diagnosis_payload)
+        summary = _summary(status=status, evidence=evidence, findings=findings)
+        outputs = {
+            "status": status,
+            "stack": parsed["stack"],
+            "summary": summary,
+            "findings": _findings_with_ref(findings, artifact_ref),
+            "artifactRefs": {"diagnosis": artifact_ref},
+        }
+        return ToolResult(
+            status="COMPLETED" if status == "SUCCEEDED" else "FAILED",
+            outputs=outputs,
+            progress={
+                "percent": 100,
+                "state": status,
+                "message": summary,
+            },
+        )
+
+
+def build_ops_diagnose_stack_handler(
+    executor: OpsStackDiagnosisExecutor | None = None,
+):
+    resolved_executor = executor or OpsStackDiagnosisExecutor(
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=DisabledOpsDiagnosisRunner(),
+    )
+
+    async def _handler(
+        inputs: Mapping[str, Any], context: Mapping[str, Any] | None = None
+    ) -> ToolResult:
+        context = dict(context or {})
+        context_executor = None
+        candidate = context.get("ops_diagnosis_executor")
+        if isinstance(candidate, OpsStackDiagnosisExecutor):
+            context_executor = candidate
+        active_executor = context_executor or resolved_executor
+        artifact_service = context.get("temporal_artifact_service")
+        if artifact_service is not None and context_executor is None:
+            active_executor = replace(
+                active_executor,
+                evidence_writer=TemporalOpsDiagnosisEvidenceWriter(
+                    artifact_service=artifact_service,
+                    principal=str(
+                        context.get("deployment_evidence_principal")
+                        or "system:deployment"
+                    ),
+                    execution_ref=_execution_ref_from_context(context),
+                ),
+            )
+        return await active_executor.execute(inputs, context)
+
+    return _handler
+
+
+def register_ops_diagnose_stack_tool_handler(
+    dispatcher: Any,
+    *,
+    executor: OpsStackDiagnosisExecutor | None = None,
+) -> None:
+    dispatcher.register_skill(
+        skill_name=OPS_DIAGNOSE_STACK_TOOL_NAME,
+        handler=build_ops_diagnose_stack_handler(executor),
+    )
+
+
+def _parse_diagnosis_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(inputs, Mapping):
+        raise ToolFailure(
+            "INVALID_INPUT",
+            "Ops diagnosis inputs must be an object.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
+    forbidden = {
+        "command",
+        "dockerCommand",
+        "shell",
+        "composeFile",
+        "hostPath",
+        "path",
+        "exec",
+    }
+    found_forbidden = sorted(forbidden.intersection(inputs.keys()))
+    if found_forbidden:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message="Ops diagnosis inputs contain forbidden fields.",
+            retryable=False,
+            details={"fields": found_forbidden, "failureClass": "invalid_input"},
+        )
+    stack = _required_string(inputs.get("stack"), "stack")
+    if stack not in OPS_DIAGNOSIS_STACKS:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=f"Unsupported ops diagnosis stack '{stack}'.",
+            retryable=False,
+            details={"stack": stack, "failureClass": "invalid_input"},
+        )
+    reason = _required_string(inputs.get("reason"), "reason")
+    if len(reason) > 1000:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message="Ops diagnosis reason must be at most 1000 characters.",
+            retryable=False,
+            details={"failureClass": "invalid_input"},
+        )
+    include = _parse_include(inputs.get("include"))
+    services = _parse_services(inputs.get("services"))
+    tail_lines = _parse_tail_lines(inputs.get("tailLines"))
+    return {
+        "stack": stack,
+        "reason": reason,
+        "include": include,
+        "services": services,
+        "tailLines": tail_lines,
+        "targetWorkflowId": _optional_string(inputs.get("targetWorkflowId")),
+        "remediationWorkflowId": _optional_string(inputs.get("remediationWorkflowId")),
+    }
+
+
+def _require_remediation_policy(context: Mapping[str, Any]) -> None:
+    remediation = context.get("remediation")
+    remediation_policy = context.get("remediation_policy") or context.get(
+        "remediationPolicy"
+    )
+    is_remediation = bool(context.get("is_remediation_workflow")) or isinstance(
+        remediation, Mapping
+    )
+    policy_allows = bool(context.get("remediation_policy_allows_ops_diagnostics"))
+    if isinstance(remediation_policy, Mapping):
+        policy_allows = policy_allows or bool(
+            remediation_policy.get("allowOpsDiagnostics")
+            or remediation_policy.get("opsDiagnosticsAllowed")
+        )
+    if not is_remediation:
+        raise ToolFailure(
+            error_code="PERMISSION_DENIED",
+            message="Ops diagnosis is only available to remediation workflows.",
+            retryable=False,
+            details={"failureClass": "permission_denied"},
+        )
+    if not policy_allows:
+        raise ToolFailure(
+            error_code="PERMISSION_DENIED",
+            message="Remediation policy does not allow ops diagnostics.",
+            retryable=False,
+            details={"failureClass": "permission_denied"},
+        )
+
+
+def _parse_include(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return DEFAULT_OPS_DIAGNOSIS_INCLUDES
+    if not isinstance(value, list | tuple):
+        raise ToolFailure(
+            "INVALID_INPUT",
+            "Ops diagnosis include must be an array.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        include = _required_string(item, "include")
+        if include not in OPS_DIAGNOSIS_INCLUDES:
+            raise ToolFailure(
+                error_code="INVALID_INPUT",
+                message=f"Unsupported ops diagnosis include '{include}'.",
+                retryable=False,
+                details={"include": include, "failureClass": "invalid_input"},
+            )
+        if include not in seen:
+            normalized.append(include)
+            seen.add(include)
+    return tuple(normalized or DEFAULT_OPS_DIAGNOSIS_INCLUDES)
+
+
+def _parse_services(value: Any) -> tuple[str, ...]:
+    if value is None or value == []:
+        return tuple(sorted(DEFAULT_MOONMIND_SERVICES))
+    if not isinstance(value, list | tuple):
+        raise ToolFailure(
+            "INVALID_INPUT",
+            "Ops diagnosis services must be an array.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
+    services: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        service = _required_string(item, "services[]")
+        if service not in DEFAULT_MOONMIND_SERVICES:
+            raise ToolFailure(
+                error_code="INVALID_INPUT",
+                message=f"Unsupported MoonMind service '{service}'.",
+                retryable=False,
+                details={"service": service, "failureClass": "invalid_input"},
+            )
+        if service not in seen:
+            services.append(service)
+            seen.add(service)
+    return tuple(services)
+
+
+def _parse_tail_lines(value: Any) -> int:
+    if value is None:
+        return OPS_DIAGNOSIS_TAIL_LINES_DEFAULT
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ToolFailure(
+            "INVALID_INPUT",
+            "Ops diagnosis tailLines must be an integer.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
+    if value < OPS_DIAGNOSIS_TAIL_LINES_MIN or value > OPS_DIAGNOSIS_TAIL_LINES_MAX:
+        raise ToolFailure(
+            error_code="INVALID_INPUT",
+            message=(
+                "Ops diagnosis tailLines must be between "
+                f"{OPS_DIAGNOSIS_TAIL_LINES_MIN} and "
+                f"{OPS_DIAGNOSIS_TAIL_LINES_MAX}."
+            ),
+            retryable=False,
+            details={"tailLines": value, "failureClass": "invalid_input"},
+        )
+    return value
+
+
+def _required_string(value: Any, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ToolFailure(
+            "INVALID_INPUT",
+            f"Ops diagnosis {field_name} is required.",
+            False,
+            details={"failureClass": "invalid_input"},
+        )
+    return normalized
+
+
+def _optional_string(value: Any) -> str | None:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _failure_reason(exc: Exception) -> str:
+    if isinstance(exc, ToolFailure):
+        return exc.message
+    return str(exc) or exc.__class__.__name__
+
+
+def _finding_for_failure(include: str, exc: Exception) -> dict[str, Any]:
+    return {
+        "kind": include,
+        "severity": "error",
+        "message": _redact_sensitive(_failure_reason(exc)),
+    }
+
+
+def _findings_for_evidence(include: str, payload: Any) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if include == "container_health" and isinstance(payload, Mapping):
+        for item in payload.get("containers") or []:
+            if not isinstance(item, Mapping):
+                continue
+            state = str(item.get("state") or "").lower()
+            health = str(item.get("health") or "").lower()
+            service = str(item.get("service") or "").strip() or None
+            if state and "running" not in state:
+                findings.append(
+                    {
+                        "kind": "container_health",
+                        "severity": "error",
+                        "message": f"Service {service or 'unknown'} is not running.",
+                        "service": service,
+                    }
+                )
+            elif health and health not in {"healthy", "none"}:
+                findings.append(
+                    {
+                        "kind": "container_health",
+                        "severity": "warning",
+                        "message": (
+                            f"Service {service or 'unknown'} health is {health}."
+                        ),
+                        "service": service,
+                    }
+                )
+    return findings
+
+
+def _findings_with_ref(
+    findings: list[dict[str, Any]], artifact_ref: str
+) -> list[dict[str, Any]]:
+    return [
+        {**_compact_mapping(finding), "evidenceRef": artifact_ref}
+        for finding in findings
+    ]
+
+
+def _summary(
+    *,
+    status: str,
+    evidence: Mapping[str, Mapping[str, Any]],
+    findings: Sequence[Mapping[str, Any]],
+) -> str:
+    succeeded = sum(1 for item in evidence.values() if item.get("status") == "SUCCEEDED")
+    failed = sum(1 for item in evidence.values() if item.get("status") == "FAILED")
+    errors = sum(1 for item in findings if item.get("severity") == "error")
+    warnings = sum(1 for item in findings if item.get("severity") == "warning")
+    return (
+        f"Ops diagnosis {status}: {succeeded} evidence class(es) collected, "
+        f"{failed} failed, {errors} error finding(s), {warnings} warning finding(s)."
+    )
+
+
+__all__ = [
+    "DEFAULT_OPS_DIAGNOSIS_INCLUDES",
+    "OPS_DIAGNOSIS_ARTIFACT_TYPE",
+    "OPS_DIAGNOSIS_INCLUDES",
+    "OPS_DIAGNOSIS_STACKS",
+    "OpsStackDiagnosisExecutor",
+    "DisabledOpsDiagnosisRunner",
+    "HostDockerComposeOpsDiagnosisRunner",
+    "TemporalOpsDiagnosisEvidenceWriter",
+    "build_ops_diagnose_stack_handler",
+    "register_ops_diagnose_stack_tool_handler",
+]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -119,7 +119,9 @@ from moonmind.services.skill_materialization import AgentSkillMaterializer
 from moonmind.workflows.temporal.jira_agent_skills import JIRA_AGENT_SKILLS
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
+    OPS_DIAGNOSE_STACK_TOOL_NAME,
     build_deployment_update_tool_definition_payload,
+    build_ops_diagnose_stack_tool_definition_payload,
 )
 
 from moonmind.schemas.agent_runtime_models import (
@@ -1520,6 +1522,9 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
 
     if name == DEPLOYMENT_UPDATE_TOOL_NAME:
         return build_deployment_update_tool_definition_payload()
+
+    if name == OPS_DIAGNOSE_STACK_TOOL_NAME:
+        return build_ops_diagnose_stack_tool_definition_payload()
 
     if name == "security.pentest.run":
         return {

--- a/moonmind/workflows/temporal/remediation_context.py
+++ b/moonmind/workflows/temporal/remediation_context.py
@@ -1224,6 +1224,7 @@ def build_remediation_final_summary(
     summary: Mapping[str, Any],
     repair: Mapping[str, Any],
     prevention: Mapping[str, Any],
+    ops_diagnostic_artifact_refs: Mapping[str, Any] | None = None,
     decision_log_ref: str | None = None,
     final_audit_ref: str | None = None,
     lock_release: str,
@@ -1241,6 +1242,8 @@ def build_remediation_final_summary(
     payload = _safe_lifecycle_payload(summary)
     payload["repair"] = _safe_lifecycle_payload(repair)
     payload["prevention"] = _safe_lifecycle_payload(prevention)
+    if refs := _artifact_refs_mapping(ops_diagnostic_artifact_refs):
+        payload["opsDiagnosticArtifactRefs"] = refs
     if ref := _artifact_ref_string(decision_log_ref, "decision_log_ref"):
         payload["decisionLogRef"] = ref
     if ref := _artifact_ref_string(final_audit_ref, "final_audit_ref"):

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -54,6 +54,11 @@ from moonmind.workflows.skills.deployment_execution import (
     InMemoryEvidenceWriter,
     register_deployment_update_tool_handler,
 )
+from moonmind.workflows.skills.ops_diagnostics_execution import (
+    HostDockerComposeOpsDiagnosisRunner,
+    OpsStackDiagnosisExecutor,
+    register_ops_diagnose_stack_tool_handler,
+)
 from moonmind.workflows.skills.skill_dispatcher import SkillActivityDispatcher
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
@@ -596,6 +601,28 @@ def _build_deployment_update_executor() -> DeploymentUpdateExecutor | None:
         ),
         excluded_services=excluded_services,
     )
+
+
+def _build_ops_diagnosis_executor() -> OpsStackDiagnosisExecutor | None:
+    update_executor = _build_deployment_update_executor()
+    if update_executor is None:
+        return None
+    runner = update_executor.runner
+    if not isinstance(runner, HostDockerComposeRunner):
+        return None
+    return OpsStackDiagnosisExecutor(
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=HostDockerComposeOpsDiagnosisRunner(
+            project_dir=runner.project_dir,
+            compose_file=runner.compose_file,
+            project_name=runner.project_name,
+            command_timeout_seconds=runner.command_timeout_seconds,
+            local_project_dir=runner.local_project_dir,
+            env_file=runner.env_file,
+            excluded_services=runner.excluded_services,
+        ),
+    )
+
 
 def _coerce_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
@@ -2255,6 +2282,10 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
             register_deployment_update_tool_handler(
                 dispatcher,
                 executor=_build_deployment_update_executor(),
+            )
+            register_ops_diagnose_stack_tool_handler(
+                dispatcher,
+                executor=_build_ops_diagnosis_executor(),
             )
 
         bindings = build_worker_activity_bindings(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -894,6 +894,8 @@ class MoonMindRunWorkflow:
         # operator diagnosis even after the prerequisite later succeeds.
         self._dependency_failure_counts: dict[str, int] = {}
         self._dependency_last_failed_at: dict[str, str] = {}
+        self._remediation_context: dict[str, Any] = {}
+        self._remediation_policy: dict[str, Any] = {}
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -5589,6 +5591,7 @@ class MoonMindRunWorkflow:
         if not task_parameters:
             task_parameters = self._mapping_value(parameters, "task")
         self._record_bounded_story_loop_context(parameters, task_parameters)
+        self._record_remediation_context(parameters, task_parameters)
         self._declared_dependencies = normalize_dependency_ids(
             task_parameters.get("dependsOn")
         )
@@ -5633,6 +5636,36 @@ class MoonMindRunWorkflow:
             self._scheduled_for = scheduled_for
 
         return workflow_type, parameters, input_ref, plan_ref, scheduled_for
+
+    def _record_remediation_context(
+        self,
+        parameters: Mapping[str, Any],
+        task_parameters: Mapping[str, Any],
+    ) -> None:
+        remediation = task_parameters.get("remediation")
+        self._remediation_context = (
+            dict(remediation) if isinstance(remediation, Mapping) else {}
+        )
+
+        policy = (
+            task_parameters.get("remediationPolicy")
+            or task_parameters.get("remediation_policy")
+            or parameters.get("remediationPolicy")
+            or parameters.get("remediation_policy")
+        )
+        self._remediation_policy = dict(policy) if isinstance(policy, Mapping) else {}
+
+    def _skill_remediation_context(self) -> dict[str, Any]:
+        if not self._remediation_context and not self._remediation_policy:
+            return {}
+        context: dict[str, Any] = {
+            "is_remediation_workflow": bool(self._remediation_context),
+        }
+        if self._remediation_context:
+            context["remediation"] = dict(self._remediation_context)
+        if self._remediation_policy:
+            context["remediation_policy"] = dict(self._remediation_policy)
+        return context
 
     def _has_recurrence_metadata(self, parameters: Mapping[str, Any]) -> bool:
         system_payload = parameters.get("system")
@@ -6547,6 +6580,7 @@ class MoonMindRunWorkflow:
                                 "workflow_id": workflow.info().workflow_id,
                                 "run_id": workflow.info().run_id,
                                 "node_id": node_id,
+                                **self._skill_remediation_context(),
                             },
                             "idempotency_key": step_execution_operation_idempotency_key(
                                 workflow_id=workflow.info().workflow_id,

--- a/tests/integration/temporal/test_ops_diagnostics_execution_contract.py
+++ b/tests/integration/temporal/test_ops_diagnostics_execution_contract.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.skills.ops_diagnostics_execution import (
+    OPS_DIAGNOSIS_ARTIFACT_TYPE,
+    OpsStackDiagnosisExecutor,
+    register_ops_diagnose_stack_tool_handler,
+)
+from moonmind.workflows.skills.deployment_tools import (
+    OPS_DIAGNOSE_STACK_TOOL_NAME,
+    build_ops_diagnose_stack_tool_definition_payload,
+)
+from moonmind.workflows.skills.tool_dispatcher import (
+    ToolActivityDispatcher,
+    execute_tool_activity,
+)
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure, ToolResult
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.tool_registry import create_registry_snapshot
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+class RecordingEvidenceWriter:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        self.records.append((kind, dict(payload)))
+        return f"art:sha256:{kind:0<64}"[:75]
+
+
+class FakeDeploymentControlDiagnosisRunner:
+    def __init__(self, *, fail_include: str | None = None) -> None:
+        self.fail_include = fail_include
+        self.calls: list[dict[str, Any]] = []
+
+    async def collect(
+        self,
+        *,
+        stack: str,
+        include: str,
+        services: tuple[str, ...],
+        tail_lines: int,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            {
+                "stack": stack,
+                "include": include,
+                "services": services,
+                "tailLines": tail_lines,
+            }
+        )
+        if include == self.fail_include:
+            raise RuntimeError("collector failed")
+        if include == "container_health":
+            return {
+                "containers": [
+                    {"service": "api", "state": "running", "health": "healthy"},
+                    {
+                        "service": "temporal-worker-agent-runtime",
+                        "state": "running",
+                        "health": "unhealthy",
+                    },
+                ]
+            }
+        if include == "recent_logs":
+            return {
+                "tailLines": tail_lines,
+                "logs": "\n".join(f"line {i}" for i in range(tail_lines)),
+            }
+        return {"ok": True}
+
+
+def _snapshot():
+    return create_registry_snapshot(
+        skills=(
+            parse_tool_definition(build_ops_diagnose_stack_tool_definition_payload()),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+
+
+def _payload(**input_overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "stack": "moonmind",
+        "reason": "MM-925 remediation diagnostics",
+        "include": ["container_health", "recent_logs"],
+        "services": ["api", "temporal-worker-agent-runtime"],
+        "tailLines": 80,
+        "targetWorkflowId": "mm:target",
+        "remediationWorkflowId": "mm:remediation",
+    }
+    inputs.update(input_overrides)
+    return {
+        "id": "diagnose-moonmind",
+        "tool": {"type": "skill", "name": OPS_DIAGNOSE_STACK_TOOL_NAME},
+        "inputs": inputs,
+    }
+
+
+def _context(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "is_remediation_workflow": True,
+        "remediation_policy": {"allowOpsDiagnostics": True},
+        "workflow_id": "mm:remediation",
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_ops_diagnosis_tool_dispatch_returns_summary_and_artifact_refs() -> None:
+    writer = RecordingEvidenceWriter()
+    runner = FakeDeploymentControlDiagnosisRunner()
+    dispatcher = ToolActivityDispatcher()
+    register_ops_diagnose_stack_tool_handler(
+        dispatcher,
+        executor=OpsStackDiagnosisExecutor(evidence_writer=writer, runner=runner),
+    )
+
+    result = await execute_tool_activity(
+        invocation_payload=_payload(),
+        registry_snapshot=_snapshot(),
+        dispatcher=dispatcher,
+        context=_context(),
+    )
+
+    assert isinstance(result, ToolResult)
+    assert result.status == "COMPLETED"
+    assert result.outputs["status"] == "SUCCEEDED"
+    assert result.outputs["stack"] == "moonmind"
+    assert result.outputs["artifactRefs"]["diagnosis"].startswith("art:sha256:")
+    assert "Ops diagnosis SUCCEEDED" in result.outputs["summary"]
+    assert writer.records[0][1]["artifactType"] == OPS_DIAGNOSIS_ARTIFACT_TYPE
+    assert writer.records[0][1]["targetWorkflowId"] == "mm:target"
+    assert runner.calls[1]["tailLines"] == 80
+    assert any(
+        finding["kind"] == "container_health"
+        and finding["service"] == "temporal-worker-agent-runtime"
+        and finding["severity"] == "warning"
+        for finding in result.outputs["findings"]
+    )
+
+    definition = parse_tool_definition(
+        build_ops_diagnose_stack_tool_definition_payload()
+    )
+    output_properties = set(definition.output_schema["properties"])
+    assert set(result.outputs) - output_properties == set()
+
+
+async def test_ops_diagnosis_tool_dispatch_denies_non_remediation_workflow() -> None:
+    dispatcher = ToolActivityDispatcher()
+    register_ops_diagnose_stack_tool_handler(
+        dispatcher,
+        executor=OpsStackDiagnosisExecutor(
+            evidence_writer=RecordingEvidenceWriter(),
+            runner=FakeDeploymentControlDiagnosisRunner(),
+        ),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await execute_tool_activity(
+            invocation_payload=_payload(),
+            registry_snapshot=_snapshot(),
+            dispatcher=dispatcher,
+            context={"remediation_policy": {"allowOpsDiagnostics": True}},
+        )
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+
+
+async def test_ops_diagnosis_tool_dispatch_denies_policy_without_ops_diagnostics() -> None:
+    dispatcher = ToolActivityDispatcher()
+    register_ops_diagnose_stack_tool_handler(
+        dispatcher,
+        executor=OpsStackDiagnosisExecutor(
+            evidence_writer=RecordingEvidenceWriter(),
+            runner=FakeDeploymentControlDiagnosisRunner(),
+        ),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await execute_tool_activity(
+            invocation_payload=_payload(),
+            registry_snapshot=_snapshot(),
+            dispatcher=dispatcher,
+            context=_context(remediation_policy={"allowOpsDiagnostics": False}),
+        )
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+
+
+async def test_ops_diagnosis_tool_dispatch_rejects_arbitrary_command_input() -> None:
+    dispatcher = ToolActivityDispatcher()
+    register_ops_diagnose_stack_tool_handler(
+        dispatcher,
+        executor=OpsStackDiagnosisExecutor(
+            evidence_writer=RecordingEvidenceWriter(),
+            runner=FakeDeploymentControlDiagnosisRunner(),
+        ),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await execute_tool_activity(
+            invocation_payload=_payload(dockerCommand="docker ps"),
+            registry_snapshot=_snapshot(),
+            dispatcher=dispatcher,
+            context=_context(),
+        )
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+
+
+async def test_ops_diagnosis_tool_dispatch_partial_diagnostics_are_structured() -> None:
+    writer = RecordingEvidenceWriter()
+    dispatcher = ToolActivityDispatcher()
+    register_ops_diagnose_stack_tool_handler(
+        dispatcher,
+        executor=OpsStackDiagnosisExecutor(
+            evidence_writer=writer,
+            runner=FakeDeploymentControlDiagnosisRunner(fail_include="recent_logs"),
+        ),
+    )
+
+    result = await execute_tool_activity(
+        invocation_payload=_payload(),
+        registry_snapshot=_snapshot(),
+        dispatcher=dispatcher,
+        context=_context(),
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "PARTIALLY_VERIFIED"
+    assert writer.records[0][1]["evidence"]["recent_logs"]["status"] == "FAILED"
+    assert any(
+        finding["kind"] == "recent_logs" and finding["severity"] == "error"
+        for finding in result.outputs["findings"]
+    )

--- a/tests/unit/workflows/skills/test_deployment_tool_contracts.py
+++ b/tests/unit/workflows/skills/test_deployment_tool_contracts.py
@@ -5,7 +5,9 @@ import pytest
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
+    OPS_DIAGNOSE_STACK_TOOL_NAME,
     build_deployment_update_tool_definition_payload,
+    build_ops_diagnose_stack_tool_definition_payload,
 )
 from moonmind.workflows.skills.plan_validation import (
     PlanValidationError,
@@ -140,6 +142,138 @@ def test_deployment_update_tool_definition_matches_mm519_contract() -> None:
     ]
     assert "verificationArtifactRef" in output_schema["properties"]
     assert "audit" in output_schema["properties"]
+
+
+def test_ops_diagnose_stack_tool_definition_matches_mm925_contract() -> None:
+    definition = parse_tool_definition(
+        build_ops_diagnose_stack_tool_definition_payload()
+    )
+
+    assert definition.name == OPS_DIAGNOSE_STACK_TOOL_NAME
+    assert definition.executor.activity_type == "mm.tool.execute"
+    assert definition.executor.selector_mode == "by_capability"
+    assert definition.required_capabilities == (
+        "deployment_control",
+        "docker_admin",
+    )
+    assert definition.allowed_roles == ("admin",)
+    assert definition.ops_runtime is not None
+    raw_payload = build_ops_diagnose_stack_tool_definition_payload()
+    assert raw_payload["security"]["remediationPolicyRequired"] is True
+    assert raw_payload["security"]["exposedToManagedAgents"] is False
+    assert raw_payload["security"]["opsRuntime"] == {
+        "kind": "MoonMindOpsRuntime",
+        "name": "docker-admin-runtime",
+        "purpose": "moonmind-application-operations",
+        "backend": "docker",
+        "exposedToManagedAgents": False,
+        "allowedOperations": ["status", "logs"],
+        "dockerBackend": {
+            "hostDockerAccess": True,
+            "component": "moonmind-ops-runner",
+        },
+    }
+    assert definition.policies.retries.max_attempts == 1
+    assert definition.policies.retries.non_retryable_error_codes == (
+        "INVALID_INPUT",
+        "PERMISSION_DENIED",
+        "POLICY_VIOLATION",
+    )
+
+    input_schema = definition.input_schema
+    assert input_schema["required"] == ["stack", "reason"]
+    assert input_schema["additionalProperties"] is False
+    assert input_schema["properties"]["stack"]["enum"] == ["moonmind"]
+    assert input_schema["properties"]["tailLines"]["minimum"] == 50
+    assert input_schema["properties"]["tailLines"]["maximum"] == 1000
+    assert "command" not in input_schema["properties"]
+    assert "hostPath" not in input_schema["properties"]
+    assert input_schema["properties"]["include"]["items"]["enum"] == [
+        "compose_ps",
+        "compose_images",
+        "container_health",
+        "container_inspect_summary",
+        "recent_logs",
+        "api_health",
+        "worker_health",
+        "temporal_connectivity",
+        "artifact_store_health",
+        "disk_memory_cpu",
+    ]
+
+    output_schema = definition.output_schema
+    assert output_schema["required"] == [
+        "status",
+        "stack",
+        "summary",
+        "findings",
+        "artifactRefs",
+    ]
+    assert output_schema["properties"]["status"]["enum"] == [
+        "SUCCEEDED",
+        "FAILED",
+        "PARTIALLY_VERIFIED",
+    ]
+
+
+@pytest.mark.parametrize("stack", ["other", "", "default"])
+def test_ops_diagnose_stack_plan_rejects_unknown_stack(stack: str) -> None:
+    snapshot = create_registry_snapshot(
+        skills=(
+            parse_tool_definition(build_ops_diagnose_stack_tool_definition_payload()),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+    payload = _valid_plan_payload(snapshot)
+    payload["nodes"][0]["tool"]["name"] = OPS_DIAGNOSE_STACK_TOOL_NAME
+    payload["nodes"][0]["inputs"] = {
+        "stack": stack,
+        "reason": "MM-925 diagnosis",
+    }
+
+    with pytest.raises(PlanValidationError):
+        validate_plan_payload(payload=payload, registry_snapshot=snapshot)
+
+
+def test_ops_diagnose_stack_plan_rejects_unknown_include_value() -> None:
+    snapshot = create_registry_snapshot(
+        skills=(
+            parse_tool_definition(build_ops_diagnose_stack_tool_definition_payload()),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+    payload = _valid_plan_payload(snapshot)
+    payload["nodes"][0]["tool"]["name"] = OPS_DIAGNOSE_STACK_TOOL_NAME
+    payload["nodes"][0]["inputs"] = {
+        "stack": "moonmind",
+        "reason": "MM-925 diagnosis",
+        "include": ["compose_ps", "raw_docker"],
+    }
+
+    with pytest.raises(PlanValidationError):
+        validate_plan_payload(payload=payload, registry_snapshot=snapshot)
+
+
+@pytest.mark.parametrize("field", ["command", "dockerCommand", "hostPath", "path"])
+def test_ops_diagnose_stack_plan_rejects_arbitrary_command_inputs(
+    field: str,
+) -> None:
+    snapshot = create_registry_snapshot(
+        skills=(
+            parse_tool_definition(build_ops_diagnose_stack_tool_definition_payload()),
+        ),
+        artifact_store=InMemoryArtifactStore(),
+    )
+    payload = _valid_plan_payload(snapshot)
+    payload["nodes"][0]["tool"]["name"] = OPS_DIAGNOSE_STACK_TOOL_NAME
+    payload["nodes"][0]["inputs"] = {
+        "stack": "moonmind",
+        "reason": "MM-925 diagnosis",
+        field: "docker ps",
+    }
+
+    with pytest.raises(PlanValidationError, match=f"Unexpected field '{field}'"):
+        validate_plan_payload(payload=payload, registry_snapshot=snapshot)
 
 
 def test_deployment_update_tool_definition_rejects_agent_exposed_ops_runtime() -> None:

--- a/tests/unit/workflows/skills/test_ops_diagnostics_execution.py
+++ b/tests/unit/workflows/skills/test_ops_diagnostics_execution.py
@@ -5,9 +5,11 @@ from typing import Any, Mapping
 import pytest
 
 from moonmind.workflows.skills.ops_diagnostics_execution import (
+    HostDockerComposeOpsDiagnosisRunner,
     OPS_DIAGNOSIS_ARTIFACT_TYPE,
     OpsStackDiagnosisExecutor,
 )
+from moonmind.workflows.skills.deployment_execution import _parse_json_records
 from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
 
 
@@ -61,9 +63,23 @@ class RecordingDiagnosisRunner:
         if include == "recent_logs":
             return {
                 "tailLines": tail_lines,
-                "logs": "starting\npassword=hunter2\nready",
+                "logs": (
+                    "starting\n"
+                    "password=hunter2\n"
+                    "OPENAI_API_KEY=sk-test-secret\n"
+                    "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                    "github_pat_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                    "AIzaSyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                    "AKIAAAAAAAAAAAAAAAAA\n"
+                    "ready"
+                ),
             }
         return {"ok": True, "authorization": "Bearer raw-secret"}
+
+
+class FailingComposeCommandRunner(HostDockerComposeOpsDiagnosisRunner):
+    async def _run_compose_command(self, *args: Any, **kwargs: Any) -> Mapping[str, Any]:
+        return {"exitCode": 1, "stderr": "compose failed"}
 
 
 def _context(**overrides: object) -> dict[str, object]:
@@ -159,6 +175,11 @@ async def test_ops_diagnosis_publishes_redacted_artifact_and_findings() -> None:
     serialized = str(payload)
     assert "secret-token" not in serialized
     assert "hunter2" not in serialized
+    assert "sk-test-secret" not in serialized
+    assert "ghp_" not in serialized
+    assert "github_pat_" not in serialized
+    assert "AIza" not in serialized
+    assert "AKIA" not in serialized
     assert "[REDACTED]" in serialized
     assert runner.calls[1]["tailLines"] == 75
 
@@ -184,6 +205,24 @@ async def test_ops_diagnosis_returns_partial_for_failed_evidence_class() -> None
 
 
 @pytest.mark.asyncio
+async def test_ops_diagnosis_reports_failed_when_all_evidence_classes_fail() -> None:
+    writer = RecordingEvidenceWriter()
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=writer,
+        runner=RecordingDiagnosisRunner(fail_include="recent_logs"),
+    )
+
+    result = await executor.execute(
+        _inputs(include=["recent_logs"]),
+        context=_context(),
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "FAILED"
+    assert "0 evidence class(es) collected" in result.outputs["summary"]
+
+
+@pytest.mark.asyncio
 async def test_ops_diagnosis_rejects_unknown_service_and_unbounded_tail() -> None:
     executor = OpsStackDiagnosisExecutor(
         evidence_writer=RecordingEvidenceWriter(),
@@ -197,3 +236,55 @@ async def test_ops_diagnosis_rejects_unknown_service_and_unbounded_tail() -> Non
     with pytest.raises(ToolFailure) as tail_exc:
         await executor.execute(_inputs(tailLines=1001), context=_context())
     assert "tailLines" in tail_exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_allows_real_worker_service_names() -> None:
+    runner = RecordingDiagnosisRunner()
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=RecordingEvidenceWriter(),
+        runner=runner,
+    )
+
+    await executor.execute(
+        _inputs(
+            include=["container_health"],
+            services=[
+                "temporal-worker-workflow",
+                "temporal-worker-artifacts",
+                "temporal-worker-llm",
+                "temporal-worker-sandbox",
+                "temporal-worker-integrations",
+            ],
+        ),
+        context=_context(),
+    )
+
+    assert runner.calls[0]["services"] == (
+        "temporal-worker-workflow",
+        "temporal-worker-artifacts",
+        "temporal-worker-llm",
+        "temporal-worker-sandbox",
+        "temporal-worker-integrations",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_service_command_rejects_nonzero_exit() -> None:
+    runner = FailingComposeCommandRunner(project_dir=".")
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await runner._run_service_command(
+            "api_health",
+            ("docker", "compose", "ps", "--format", "json", "api"),
+        )
+
+    assert exc_info.value.error_code == "DEPLOYMENT_COMMAND_FAILED"
+    assert "exit code 1" in exc_info.value.message
+
+
+def test_ops_diagnosis_uses_shared_json_record_parser_for_ndjson() -> None:
+    assert _parse_json_records('{"Service":"api"}\n{"Service":"temporal"}') == [
+        {"Service": "api"},
+        {"Service": "temporal"},
+    ]

--- a/tests/unit/workflows/skills/test_ops_diagnostics_execution.py
+++ b/tests/unit/workflows/skills/test_ops_diagnostics_execution.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from moonmind.workflows.skills.ops_diagnostics_execution import (
+    OPS_DIAGNOSIS_ARTIFACT_TYPE,
+    OpsStackDiagnosisExecutor,
+)
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+
+
+class RecordingEvidenceWriter:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def write(self, kind: str, payload: Mapping[str, Any]) -> str:
+        self.records.append((kind, dict(payload)))
+        return f"art:sha256:{kind:0<64}"[:75]
+
+
+class RecordingDiagnosisRunner:
+    def __init__(self, *, fail_include: str | None = None) -> None:
+        self.fail_include = fail_include
+        self.calls: list[dict[str, Any]] = []
+
+    async def collect(
+        self,
+        *,
+        stack: str,
+        include: str,
+        services: tuple[str, ...],
+        tail_lines: int,
+    ) -> Mapping[str, Any]:
+        self.calls.append(
+            {
+                "stack": stack,
+                "include": include,
+                "services": services,
+                "tailLines": tail_lines,
+            }
+        )
+        if include == self.fail_include:
+            raise RuntimeError("collector failed with token=secret-token")
+        if include == "container_health":
+            return {
+                "containers": [
+                    {
+                        "service": "api",
+                        "state": "running",
+                        "health": "healthy",
+                        "environment": {"API_TOKEN": "token=secret-token"},
+                    },
+                    {
+                        "service": "temporal-worker-agent-runtime",
+                        "state": "exited",
+                    },
+                ]
+            }
+        if include == "recent_logs":
+            return {
+                "tailLines": tail_lines,
+                "logs": "starting\npassword=hunter2\nready",
+            }
+        return {"ok": True, "authorization": "Bearer raw-secret"}
+
+
+def _context(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "is_remediation_workflow": True,
+        "remediation_policy": {"allowOpsDiagnostics": True},
+        "workflow_id": "mm:remediation",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _inputs(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "stack": "moonmind",
+        "reason": "MM-925 diagnose failed remediation target",
+        "include": ["container_health", "recent_logs"],
+        "services": ["api", "temporal-worker-agent-runtime"],
+        "tailLines": 75,
+        "targetWorkflowId": "mm:target",
+        "remediationWorkflowId": "mm:remediation",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_denies_non_remediation_workflow() -> None:
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=RecordingEvidenceWriter(),
+        runner=RecordingDiagnosisRunner(),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(), context={"remediation_policy": {"allowOpsDiagnostics": True}})
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert "remediation workflows" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_denies_when_policy_disallows() -> None:
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=RecordingEvidenceWriter(),
+        runner=RecordingDiagnosisRunner(),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(), context=_context(remediation_policy={}))
+
+    assert exc_info.value.error_code == "PERMISSION_DENIED"
+    assert "policy" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_rejects_arbitrary_command_input() -> None:
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=RecordingEvidenceWriter(),
+        runner=RecordingDiagnosisRunner(),
+    )
+
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_inputs(command="docker ps"), context=_context())
+
+    assert exc_info.value.error_code == "INVALID_INPUT"
+    assert exc_info.value.details["fields"] == ["command"]
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_publishes_redacted_artifact_and_findings() -> None:
+    writer = RecordingEvidenceWriter()
+    runner = RecordingDiagnosisRunner()
+    executor = OpsStackDiagnosisExecutor(evidence_writer=writer, runner=runner)
+
+    result = await executor.execute(_inputs(), context=_context())
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["status"] == "SUCCEEDED"
+    assert result.outputs["artifactRefs"]["diagnosis"].startswith("art:sha256:")
+    assert result.outputs["findings"] == [
+        {
+            "kind": "container_health",
+            "severity": "error",
+            "message": "Service temporal-worker-agent-runtime is not running.",
+            "service": "temporal-worker-agent-runtime",
+            "evidenceRef": result.outputs["artifactRefs"]["diagnosis"],
+        }
+    ]
+    assert len(writer.records) == 1
+    kind, payload = writer.records[0]
+    assert kind == "diagnosis"
+    assert payload["artifactType"] == OPS_DIAGNOSIS_ARTIFACT_TYPE
+    serialized = str(payload)
+    assert "secret-token" not in serialized
+    assert "hunter2" not in serialized
+    assert "[REDACTED]" in serialized
+    assert runner.calls[1]["tailLines"] == 75
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_returns_partial_for_failed_evidence_class() -> None:
+    writer = RecordingEvidenceWriter()
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=writer,
+        runner=RecordingDiagnosisRunner(fail_include="recent_logs"),
+    )
+
+    result = await executor.execute(_inputs(), context=_context())
+
+    assert result.status == "FAILED"
+    assert result.outputs["status"] == "PARTIALLY_VERIFIED"
+    assert any(
+        finding["kind"] == "recent_logs" and finding["severity"] == "error"
+        for finding in result.outputs["findings"]
+    )
+    assert writer.records[0][1]["evidence"]["recent_logs"]["status"] == "FAILED"
+    assert "secret-token" not in str(writer.records[0][1])
+
+
+@pytest.mark.asyncio
+async def test_ops_diagnosis_rejects_unknown_service_and_unbounded_tail() -> None:
+    executor = OpsStackDiagnosisExecutor(
+        evidence_writer=RecordingEvidenceWriter(),
+        runner=RecordingDiagnosisRunner(),
+    )
+
+    with pytest.raises(ToolFailure) as service_exc:
+        await executor.execute(_inputs(services=["host-root"]), context=_context())
+    assert "Unsupported MoonMind service" in service_exc.value.message
+
+    with pytest.raises(ToolFailure) as tail_exc:
+        await executor.execute(_inputs(tailLines=1001), context=_context())
+    assert "tailLines" in tail_exc.value.message

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -1189,6 +1189,10 @@ def test_remediation_lifecycle_repair_prevention_and_decision_log_are_bounded():
         summary=base_summary,
         repair=repair,
         prevention=prevention,
+        ops_diagnostic_artifact_refs={
+            "diagnosis": "art_ops_diagnosis",
+            "token": "art_secret",
+        },
         decision_log_ref="art_decision_log",
         final_audit_ref="art_audit",
         lock_release="released",
@@ -1196,6 +1200,9 @@ def test_remediation_lifecycle_repair_prevention_and_decision_log_are_bounded():
     )
     assert final_summary["repair"]["repairOutcome"] == "repaired"
     assert final_summary["prevention"]["status"] == "findings_reported"
+    assert final_summary["opsDiagnosticArtifactRefs"] == {
+        "diagnosis": "art_ops_diagnosis"
+    }
     assert final_summary["decisionLogRef"] == "art_decision_log"
     assert final_summary["finalAuditRef"] == "art_audit"
     assert final_summary["lockRelease"] == "released"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -149,6 +149,24 @@ def test_run_workflow_child_task_queue_is_replay_patched(
     assert workflow._workflow_child_task_queue() == "mm.workflow"
 
 
+def test_run_workflow_skill_context_includes_remediation_policy() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    workflow._record_remediation_context(
+        {},
+        {
+            "remediation": {"target": {"workflowId": "mm:target"}},
+            "remediationPolicy": {"allowOpsDiagnostics": True},
+        },
+    )
+
+    assert workflow._skill_remediation_context() == {
+        "is_remediation_workflow": True,
+        "remediation": {"target": {"workflowId": "mm:target"}},
+        "remediation_policy": {"allowOpsDiagnostics": True},
+    }
+
+
 @pytest.fixture
 def mock_run_workflow(monkeypatch: pytest.MonkeyPatch) -> MoonMindRunWorkflow:
     workflow = MoonMindRunWorkflow()


### PR DESCRIPTION
Issue reference: MM-925

Summary:
- Adds the read-only `moonmind.ops_diagnose_stack` tool contract with deployment-control and docker-admin capabilities.
- Implements typed, allowlisted MoonMind stack diagnostics with bounded evidence collection, redaction, artifact publication, and structured partial/failure handling.
- Wires remediation context/runtime support so ops diagnostics are available only for remediation flows when policy allows them.
- Adds unit and integration coverage for schema validation, gating, redaction, artifact publication, bounded logs, degraded diagnostics, and dispatch behavior.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/skills/test_deployment_tool_contracts.py tests/unit/workflows/skills/test_ops_diagnostics_execution.py tests/unit/workflows/temporal/test_remediation_context.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/temporal/test_ops_diagnostics_execution_contract.py -q --tb=short`

Remaining risks:
- Live deployment-control execution against a real Compose host was not exercised in this managed runtime; coverage uses fake runners and contract-level integration tests.
