### PR TITLE
[codex] Fix pentest report output completion

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3547,7 +3547,7 @@ class MoonMindRunWorkflow:
         execution_result: Any,
         updated_at: datetime,
     ) -> None:
-        outputs = self._get_from_result(execution_result, "outputs")
+        outputs = self._effective_result_outputs(execution_result)
         if not isinstance(outputs, Mapping):
             return
 
@@ -3638,11 +3638,20 @@ class MoonMindRunWorkflow:
             ),
         }
         artifacts = {
-            "outputSummary": _output_ref("outputSummaryRef", "output_summary_ref")
+            "outputSummary": _output_ref(
+                "outputSummaryRef",
+                "output_summary_ref",
+                "summaryRef",
+                "summary_ref",
+            )
             or _artifact_class_ref("output.summary"),
             "outputPrimary": _output_ref(
                 "outputPrimaryRef",
                 "output_primary_ref",
+                "primaryRef",
+                "primary_ref",
+                "primaryReportRef",
+                "primary_report_ref",
             )
             or _artifact_class_ref("output.primary"),
             "runtimeStdout": _output_ref(
@@ -3665,7 +3674,12 @@ class MoonMindRunWorkflow:
                 "logArtifactRef",
                 "log_artifact_ref",
             ),
-            "runtimeDiagnostics": _output_ref("diagnosticsRef", "diagnostics_ref")
+            "runtimeDiagnostics": _output_ref(
+                "diagnosticsRef",
+                "diagnostics_ref",
+                "diagnosticsArtifactRef",
+                "diagnostics_artifact_ref",
+            )
             or _artifact_class_ref("runtime.diagnostics"),
             "providerSnapshot": _output_ref(
                 "providerSnapshotRef",
@@ -4289,13 +4303,29 @@ class MoonMindRunWorkflow:
         logical_step_id: str,
         execution_result: Any,
     ) -> bool:
-        outputs = self._get_from_result(execution_result, "outputs")
+        outputs = self._effective_result_outputs(execution_result)
         row_outputs = self._step_execution_compact_output_refs(logical_step_id)
         merged_outputs: dict[str, Any] = {}
         if isinstance(outputs, Mapping):
             merged_outputs.update(dict(outputs))
+            self._merge_direct_output_evidence(merged_outputs, outputs)
         merged_outputs.update(row_outputs)
         return logical_step_success_allowed(outputs=merged_outputs)
+
+    @staticmethod
+    def _merge_direct_output_evidence(
+        merged_outputs: dict[str, Any],
+        outputs: Mapping[str, Any],
+    ) -> None:
+        for source_key, target_key in (
+            ("primary_report_ref", "primaryRef"),
+            ("primaryReportRef", "primaryRef"),
+            ("summary_ref", "summaryRef"),
+            ("summaryRef", "summaryRef"),
+        ):
+            value = outputs.get(source_key)
+            if isinstance(value, str) and value.strip():
+                merged_outputs.setdefault(target_key, value.strip())
 
     def _review_gate_active(
         self,
@@ -7547,8 +7577,8 @@ class MoonMindRunWorkflow:
             return outputs
         if not workflow.patched(RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH):
             return None
-        if isinstance(result, Mapping) and any(
-            key in result for key in _DIRECT_EXECUTABLE_OUTPUT_KEYS
+        if isinstance(result, Mapping) and not _DIRECT_EXECUTABLE_OUTPUT_KEYS.isdisjoint(
+            result
         ):
             return result
         return None
@@ -9355,16 +9385,18 @@ class MoonMindRunWorkflow:
                 self._publish_context["mergeAutomationStatus"] = "not_applicable"
             return
 
+        report_not_required_reason = self._report_only_publish_not_required_reason(
+            outputs
+        )
+        if report_not_required_reason is not None:
+            self._publish_status = "not_required"
+            self._publish_reason = report_not_required_reason
+            if self._merge_automation_requested(parameters):
+                self._publish_context["mergeAutomationStatus"] = "not_applicable"
+            return
+
         push_status = self._coerce_text(outputs.get("push_status"))
         if push_status is None:
-            report_not_required_reason = (
-                self._report_only_publish_not_required_reason(outputs)
-            )
-            if report_not_required_reason is not None:
-                self._publish_status = "not_required"
-                self._publish_reason = report_not_required_reason
-                if self._merge_automation_requested(parameters):
-                    self._publish_context["mergeAutomationStatus"] = "not_applicable"
             return
         self._record_publish_metadata_context(outputs)
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -271,6 +271,37 @@ _PUBLISH_NOT_REQUIRED_STATUSES = frozenset(
         "not-applicable",
     }
 )
+_DIRECT_EXECUTABLE_OUTPUT_KEYS = frozenset(
+    {
+        "diagnostics_artifact_ref",
+        "diagnosticsArtifactRef",
+        "evidence_refs",
+        "evidenceRefs",
+        "primary_report_ref",
+        "primaryReportRef",
+        "publish_outcome",
+        "publishOutcome",
+        "push_status",
+        "pushStatus",
+        "report_bundle",
+        "reportBundle",
+        "report_bundle_v",
+        "reportBundleV",
+        "report_scope",
+        "reportScope",
+        "report_type",
+        "reportType",
+        "stderr_artifact_ref",
+        "stderrArtifactRef",
+        "stdout_artifact_ref",
+        "stdoutArtifactRef",
+        "structured_ref",
+        "structuredRef",
+        "summary_ref",
+        "summaryRef",
+    }
+)
+_REPORT_ONLY_PUBLISH_TYPES = frozenset({"security_pentest_report"})
 _JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
 _JIRA_BACKED_AGENT_SKILLS = frozenset(
     {"jira-implement", *JIRA_BACKED_AGENT_SKILLS}
@@ -416,6 +447,7 @@ NATIVE_PR_LEASE_CONFLICT_GATE_PATCH = "native-pr-lease-conflict-gate-v1"
 RUN_STOP_ON_PUBLISH_HANDOFF_FAILURE_PATCH = (
     "run-stop-on-publish-handoff-failure-v1"
 )
+RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH = "run-direct-tool-report-outputs-v1"
 # Assert the producing Step Execution reached the `accepted` terminal
 # disposition before an external handoff runs, in addition to the existing
 # MoonSpec gate verdict block. Guarded for replay safety so in-flight runs keep
@@ -7509,6 +7541,18 @@ class MoonMindRunWorkflow:
             return result.get(key)
         return getattr(result, key, None)
 
+    def _effective_result_outputs(self, result: Any) -> Mapping[str, Any] | None:
+        outputs = self._get_from_result(result, "outputs")
+        if isinstance(outputs, Mapping):
+            return outputs
+        if not workflow.patched(RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH):
+            return None
+        if isinstance(result, Mapping) and any(
+            key in result for key in _DIRECT_EXECUTABLE_OUTPUT_KEYS
+        ):
+            return result
+        return None
+
     def _activity_result_status(self, result: Any) -> str | None:
         raw_status = self._get_from_result(result, "status")
         if raw_status is None:
@@ -9298,7 +9342,7 @@ class MoonMindRunWorkflow:
         if publish_mode not in {"pr", "branch"}:
             return
 
-        outputs = self._get_from_result(execution_result, "outputs")
+        outputs = self._effective_result_outputs(execution_result)
         if not isinstance(outputs, Mapping):
             return
         self._record_no_change_publish_evidence(outputs)
@@ -9313,6 +9357,14 @@ class MoonMindRunWorkflow:
 
         push_status = self._coerce_text(outputs.get("push_status"))
         if push_status is None:
+            report_not_required_reason = (
+                self._report_only_publish_not_required_reason(outputs)
+            )
+            if report_not_required_reason is not None:
+                self._publish_status = "not_required"
+                self._publish_reason = report_not_required_reason
+                if self._merge_automation_requested(parameters):
+                    self._publish_context["mergeAutomationStatus"] = "not_applicable"
             return
         self._record_publish_metadata_context(outputs)
 
@@ -9384,6 +9436,46 @@ class MoonMindRunWorkflow:
         if push_status == "pushed" and publish_mode == "branch":
             self._publish_status = "published"
             self._publish_reason = "published branch"
+
+    def _report_only_publish_not_required_reason(
+        self,
+        outputs: Mapping[str, Any],
+    ) -> str | None:
+        report_type = self._coerce_text(
+            outputs.get("report_type") or outputs.get("reportType"),
+            max_chars=120,
+        )
+        report_bundle = outputs.get("report_bundle") or outputs.get("reportBundle")
+        if not report_type and isinstance(report_bundle, Mapping):
+            report_type = self._coerce_text(
+                report_bundle.get("report_type") or report_bundle.get("reportType"),
+                max_chars=120,
+            )
+        if report_type not in _REPORT_ONLY_PUBLISH_TYPES:
+            return None
+
+        primary_ref = self._coerce_text(
+            outputs.get("primary_report_ref") or outputs.get("primaryReportRef"),
+            max_chars=200,
+        )
+        if not primary_ref and isinstance(report_bundle, Mapping):
+            primary_bundle_ref = report_bundle.get(
+                "primary_report_ref"
+            ) or report_bundle.get("primaryReportRef")
+            if isinstance(primary_bundle_ref, Mapping):
+                primary_ref = self._coerce_text(
+                    primary_bundle_ref.get("artifact_id")
+                    or primary_bundle_ref.get("artifactId"),
+                    max_chars=200,
+                )
+            else:
+                primary_ref = self._coerce_text(primary_bundle_ref, max_chars=200)
+        if not primary_ref:
+            return None
+        return (
+            "security.pentest.run produced a final report artifact; "
+            "PR/branch publication is not applicable"
+        )
 
     def _publish_not_required_reason(self, outputs: Mapping[str, Any]) -> str | None:
         for source in self._publish_outcome_sources(outputs):
@@ -9496,7 +9588,7 @@ class MoonMindRunWorkflow:
         return None
 
     def _record_execution_context(self, *, node_id: str, execution_result: Any) -> None:
-        outputs = self._get_from_result(execution_result, "outputs")
+        outputs = self._effective_result_outputs(execution_result)
         if not isinstance(outputs, Mapping):
             return
 
@@ -9715,7 +9807,7 @@ class MoonMindRunWorkflow:
 
     def _record_report_result(self, execution_result: Any) -> None:
         metadata = self._get_from_result(execution_result, "metadata")
-        outputs = self._get_from_result(execution_result, "outputs")
+        outputs = self._effective_result_outputs(execution_result)
         report_sources = [
             source
             for source in (metadata, outputs)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.workflows.run import (
     NATIVE_PR_LEASE_CONFLICT_GATE_PATCH,
     NATIVE_PR_PUSH_STATUS_GATE_PATCH,
     RUN_CONDITIONAL_REGISTRY_READ_PATCH,
+    RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
@@ -3067,6 +3068,102 @@ def test_record_execution_context_tracks_mapped_agent_run_report(
     assert mock_run_workflow._report_created is True
     assert mock_run_workflow._report_ref == "art_report_2"
     assert status == "success"
+    assert publish_failure is False
+
+
+def test_record_execution_context_tracks_direct_pentest_report_result(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
+    )
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "status": "completed",
+            "primary_report_ref": "art_pentest_report_1",
+            "report_type": "security_pentest_report",
+            "report_scope": "final",
+            "report_bundle": {
+                "report_bundle_v": 1,
+                "primary_report_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": "art_pentest_report_1",
+                },
+                "report_type": "security_pentest_report",
+                "report_scope": "final",
+            },
+        },
+    )
+
+    status, _message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "none",
+            "reportOutput": {"enabled": True, "required": True},
+        }
+    )
+
+    assert mock_run_workflow._report_created is True
+    assert mock_run_workflow._report_ref == "art_pentest_report_1"
+    assert status == "success"
+    assert publish_failure is False
+
+
+def test_pentest_report_result_makes_pr_publish_not_required(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
+    )
+    execution_result = {
+        "status": "completed",
+        "primary_report_ref": "art_pentest_report_1",
+        "report_type": "security_pentest_report",
+        "report_scope": "final",
+        "report_bundle": {
+            "report_bundle_v": 1,
+            "primary_report_ref": {
+                "artifact_ref_v": 1,
+                "artifact_id": "art_pentest_report_1",
+            },
+            "report_type": "security_pentest_report",
+            "report_scope": "final",
+        },
+    }
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result=execution_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters={
+            "publishMode": "pr",
+            "reportOutput": {"enabled": True, "required": True},
+        },
+        execution_result=execution_result,
+    )
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={
+            "publishMode": "pr",
+            "reportOutput": {"enabled": True, "required": True},
+        }
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    assert mock_run_workflow._publish_reason == (
+        "security.pentest.run produced a final report artifact; "
+        "PR/branch publication is not applicable"
+    )
+    assert status == "success"
+    assert "PR/branch publication is not applicable" in message
     assert publish_failure is False
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -3124,6 +3124,7 @@ def test_pentest_report_result_makes_pr_publish_not_required(
     )
     execution_result = {
         "status": "completed",
+        "push_status": "no_commits",
         "primary_report_ref": "art_pentest_report_1",
         "report_type": "security_pentest_report",
         "report_scope": "final",

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1252,6 +1252,56 @@ def test_run_groups_child_lineage_and_evidence_into_step_row(
         "stepExecutionManifestRefs": [],
     }
 
+
+def test_run_records_direct_report_outputs_as_accepted_step_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_DIRECT_TOOL_REPORT_OUTPUTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    execution_result = {
+        "status": "COMPLETED",
+        "primary_report_ref": "art_pentest_report_1",
+        "summary_ref": "art_pentest_summary_1",
+        "diagnostics_artifact_ref": "art_pentest_diag_1",
+        "report_type": "security_pentest_report",
+    }
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "pentest",
+                "tool": {"type": "skill", "name": "security.pentest.run"},
+                "inputs": {"title": "Run pentest"},
+            }
+        ],
+        dependency_map={"pentest": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "pentest",
+        updated_at=now,
+        summary="Running pentest",
+    )
+    workflow._record_step_result_evidence(
+        "pentest",
+        execution_result=execution_result,
+        updated_at=now,
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["artifacts"]["outputPrimary"] == "art_pentest_report_1"
+    assert step["artifacts"]["outputSummary"] == "art_pentest_summary_1"
+    assert step["artifacts"]["runtimeDiagnostics"] == "art_pentest_diag_1"
+    assert workflow._step_has_accepted_output_evidence("pentest", execution_result)
+
+
 def test_run_waiting_state_captures_child_workflow_lineage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Recognize direct `security.pentest.run` report outputs as effective step outputs when the tool result is not wrapped in `outputs`.
- Treat report-only pentest results as publish-not-required when `publishMode` is `pr` or `branch` and a final report artifact exists.
- Add unit coverage for direct pentest report output tracking and PR publish-not-required behavior.

## Root Cause
The pentest executable returned report fields such as `primary_report_ref`, `report_bundle`, and `report_type` at the top level. The parent run workflow only inspected nested `outputs`, so required report output completion failed even though the pentest tool created the report artifact. Selecting PR/branch output also required push metadata for a report-only tool.

## Validation
- `git diff --check`
- `python3 -m py_compile moonmind/workflows/temporal/workflows/run.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py -k 'direct_pentest_report or pentest_report_result_makes_pr or determine_publish_completion_requires_requested_report or record_execution_context_tracks_created_report or record_execution_context_tracks_mapped_agent_run_report'`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py`