### PR TITLE
[codex] Fix recurring schedule execution and deletion

### DIFF
--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -152,10 +152,7 @@ def _serialize_definition(
     permissions = action_permissions or RecurringWorkflowActionPermissionsModel(
         can_edit=True,
         can_run_now=True,
-        can_delete=False,
-        disabled_reasons={
-            "canDelete": "Schedule deletion is not available yet.",
-        },
+        can_delete=True,
     )
     return RecurringWorkflowDefinitionModel(
         id=definition.id,
@@ -215,17 +212,16 @@ def _action_permissions_for_definition(
         can_manage = is_operator
         manage_reason = "Operator privileges are required to manage this schedule."
 
-    disabled_reasons: dict[str, str] = {
-        "canDelete": "Schedule deletion is not available yet.",
-    }
+    disabled_reasons: dict[str, str] = {}
     if not can_manage:
         disabled_reasons["canEdit"] = manage_reason
         disabled_reasons["canRunNow"] = manage_reason
+        disabled_reasons["canDelete"] = manage_reason
 
     return RecurringWorkflowActionPermissionsModel(
         can_edit=can_manage,
         can_run_now=can_manage,
-        can_delete=False,
+        can_delete=can_manage,
         disabled_reasons=disabled_reasons,
     )
 
@@ -547,6 +543,43 @@ async def run_recurring_workflow_now(
         scope=definition.scope_type.value,
     )
     return _serialize_run(run)
+
+@router.delete("/{definition_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_recurring_workflow(
+    definition_id: UUID,
+    service: RecurringWorkflowsService = Depends(_get_service),
+    user: User = Depends(get_current_user()),
+) -> Response:
+    user_id = getattr(user, "id", None)
+    try:
+        definition = await service.require_authorized_definition(
+            definition_id=definition_id,
+            user_id=user_id if isinstance(user_id, UUID) else None,
+            can_manage_global=bool(getattr(user, "is_superuser", False)),
+        )
+        await service.delete_definition(definition)
+    except Exception as exc:  # pragma: no cover - thin mapping layer
+        _log_route_exception(
+            action="delete_recurring_workflow",
+            definition_id=definition_id,
+            user_id=user_id if isinstance(user_id, UUID) else None,
+            exc=exc,
+        )
+        _audit_schedule_action(
+            action="recurring_schedule.delete",
+            outcome="failure",
+            user_id=user_id if isinstance(user_id, UUID) else None,
+            definition_id=definition_id,
+        )
+        raise _map_error(exc) from exc
+    _audit_schedule_action(
+        action="recurring_schedule.delete",
+        outcome="success",
+        user_id=user_id if isinstance(user_id, UUID) else None,
+        definition_id=definition.id,
+        scope=definition.scope_type.value,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 @router.get("/{definition_id}/runs", response_model=RecurringWorkflowRunListResponse)
 async def list_recurring_workflow_runs(

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -699,6 +699,7 @@ def build_runtime_config(
                 "update": "/api/recurring-workflows/{definitionId}",
                 "runNow": "/api/recurring-workflows/{definitionId}/run",
                 "runs": "/api/recurring-workflows/{definitionId}/runs?limit=200",
+                "delete": "/api/recurring-workflows/{definitionId}",
             },
             "temporal": {
                 "list": temporal_dashboard.list_endpoint,

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -26,7 +26,10 @@ from moonmind.workflows.recurring.cron import (
     parse_cron_expression,
     validate_timezone_name,
 )
-from moonmind.workflows.temporal.client import TemporalClientAdapter
+from moonmind.workflows.temporal.client import (
+    ScheduleTriggerResult,
+    TemporalClientAdapter,
+)
 from moonmind.workflows.temporal.schedule_errors import (
     ScheduleAdapterError,
     ScheduleAlreadyExistsError,
@@ -497,6 +500,88 @@ class RecurringWorkflowsService:
             "mm_owner_id": str(owner_user_id),
         }
 
+    def _expected_task_queue(self, workflow_type: str) -> str | None:
+        resolver = getattr(self._adapter, "resolve_workflow_task_queue", None)
+        if not callable(resolver):
+            return None
+        try:
+            resolved = resolver(workflow_type)
+        except Exception:
+            logger.warning(
+                "Could not resolve expected task queue for recurring workflow %s",
+                workflow_type,
+                exc_info=True,
+            )
+            return None
+        task_queue = str(resolved or "").strip()
+        return task_queue or None
+
+    def _schedule_action_mismatch(
+        self,
+        *,
+        action: object | None,
+        workflow_type: str,
+        workflow_input: Mapping[str, Any],
+    ) -> bool:
+        temporal_workflow_type = _object_value(action, "workflow")
+        temporal_args = _object_value(action, "args") or []
+        try:
+            temporal_args_list = list(temporal_args)
+        except TypeError:
+            temporal_args_list = []
+        temporal_input = temporal_args_list[0] if temporal_args_list else None
+        temporal_task_queue = _object_value(action, "task_queue", "taskQueue")
+        expected_task_queue = self._expected_task_queue(workflow_type)
+        return (
+            temporal_workflow_type != workflow_type
+            or temporal_input != workflow_input
+            or (
+                expected_task_queue is not None
+                and temporal_task_queue != expected_task_queue
+            )
+        )
+
+    async def _ensure_schedule_action_current(
+        self,
+        definition: RecurringWorkflowDefinition,
+    ) -> None:
+        policy_src = (
+            definition.policy if isinstance(definition.policy, Mapping) else None
+        )
+        policy_obj = _normalize_policy(
+            policy_src,
+            global_max_backfill=_DEFAULT_SCHEDULER_MAX_BACKFILL,
+        )
+        workflow_type, workflow_input = self._workflow_bundle_for_definition(
+            definition
+        )
+        try:
+            description = await self._adapter.describe_schedule(
+                definition_id=definition.id
+            )
+        except ScheduleNotFoundError:
+            await self._recreate_temporal_schedule(definition, policy_obj)
+            return
+
+        schedule = _object_value(description, "schedule")
+        action = _object_value(schedule, "action")
+        if not self._schedule_action_mismatch(
+            action=action,
+            workflow_type=workflow_type,
+            workflow_input=workflow_input,
+        ):
+            return
+
+        await self._adapter.update_schedule(
+            definition_id=definition.id,
+            workflow_type=workflow_type,
+            workflow_input=workflow_input,
+            memo={"definitionId": str(definition.id)},
+            search_attributes=self._owner_search_attributes(
+                definition.owner_user_id
+            ),
+        )
+
     async def create_definition(
         self,
         *,
@@ -696,29 +781,72 @@ class RecurringWorkflowsService:
         now = datetime.now(UTC)
 
         try:
-            await self._adapter.trigger_schedule(definition_id=definition.id)
+            await self._ensure_schedule_action_current(definition)
+            trigger_result = await self._adapter.trigger_schedule(
+                definition_id=definition.id
+            )
         except Exception as exc:
-            logger.error(f"Failed to trigger temporal schedule for {definition.id}: {exc}")
+            logger.error(
+                "Failed to trigger temporal schedule for %s: %s",
+                definition.id,
+                exc,
+            )
             raise RecurringWorkflowValidationError(f"Failed to trigger schedule: {exc}")
 
-        # In phase 2, we can just insert a stub run for the manual invocation API
+        if not isinstance(trigger_result, ScheduleTriggerResult):
+            trigger_result = ScheduleTriggerResult()
+        scheduled_for = trigger_result.scheduled_at or now
+        message = "Triggered via Temporal Schedule"
+        if trigger_result.workflow_id:
+            message = f"Triggered Temporal workflow {trigger_result.workflow_id}"
+
         run = RecurringWorkflowRun(
             id=uuid4(),
             definition_id=definition.id,
-            scheduled_for=now,
+            scheduled_for=scheduled_for,
             trigger=RecurringWorkflowRunTrigger.MANUAL,
             outcome=RecurringWorkflowRunOutcome.ENQUEUED,
             dispatch_attempts=1,
             dispatch_after=now,
+            temporal_workflow_id=trigger_result.workflow_id,
+            temporal_run_id=trigger_result.run_id,
             created_at=now,
             updated_at=now,
-            message="Triggered via Temporal Schedule",
+            message=message,
         )
+        definition.last_scheduled_for = scheduled_for
+        definition.last_dispatch_status = RecurringWorkflowRunOutcome.ENQUEUED.value
+        definition.last_dispatch_error = None
+        definition.updated_at = now
         self._session.add(run)
         await self._session.flush()
         await self._session.refresh(run)
         await self._session.commit()
         return run
+
+    async def delete_definition(
+        self,
+        definition: RecurringWorkflowDefinition,
+    ) -> None:
+        try:
+            await self._adapter.delete_schedule(definition_id=definition.id)
+        except ScheduleNotFoundError:
+            logger.info(
+                "Temporal schedule already absent while deleting recurring definition %s",
+                definition.id,
+            )
+        except ScheduleAdapterError as exc:
+            logger.error(
+                "Failed to delete temporal schedule for %s: %s",
+                definition.id,
+                exc,
+            )
+            raise RecurringWorkflowValidationError(
+                f"Failed to delete schedule: {exc}"
+            ) from exc
+
+        await self._session.delete(definition)
+        await self._session.commit()
 
     def _workflow_bundle_for_definition(
         self, dfn: RecurringWorkflowDefinition
@@ -854,12 +982,10 @@ class RecurringWorkflowsService:
                     dfn
                 )
                 action = getattr(sched, "action", None)
-                temporal_workflow_type = _object_value(action, "workflow")
-                temporal_args = _object_value(action, "args") or []
-                temporal_input = temporal_args[0] if temporal_args else None
-                action_mismatch = (
-                    temporal_workflow_type != workflow_type
-                    or temporal_input != workflow_input
+                action_mismatch = self._schedule_action_mismatch(
+                    action=action,
+                    workflow_type=workflow_type,
+                    workflow_input=workflow_input,
                 )
 
                 if mismatch or action_mismatch:

--- a/docs/Temporal/WorkflowSchedulingGuide.md
+++ b/docs/Temporal/WorkflowSchedulingGuide.md
@@ -121,6 +121,7 @@ Temporal Schedules are the authoritative recurring scheduling system for Tempora
 | `PATCH` | `/api/recurring-workflows/{id}` | Update schedule |
 | `POST` | `/api/recurring-workflows/{id}/run` | Trigger immediate manual run |
 | `GET` | `/api/recurring-workflows/{id}/runs` | List run history |
+| `DELETE` | `/api/recurring-workflows/{id}` | Delete schedule and stop future dispatch |
 
 #### Create payload
 

--- a/docs/UI/RecurringScheduleDetailsPage.md
+++ b/docs/UI/RecurringScheduleDetailsPage.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Owner:** MoonMind Engineering
-**Last Updated:** 2026-06-24
+**Last Updated:** 2026-06-26
 **Audience:** UI developers, backend developers, operators
 
 ## 1. Purpose
@@ -129,7 +129,7 @@ The page needs the following schedule data:
 | `temporalScheduleId` | Advanced/debug fact when available |
 | `updatedAt` | Metadata and freshness display |
 
-The page uses the existing schedule endpoints. Delete is a planned contract and should not be surfaced in the UI until the backend route and runtime-config source are available.
+The page uses the existing schedule endpoints. Delete is surfaced only when the runtime config exposes the backend delete route.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -137,7 +137,7 @@ The page uses the existing schedule endpoints. Delete is a planned contract and 
 | `PATCH` | `/api/recurring-workflows/{definitionId}` | Save schedule edits |
 | `POST` | `/api/recurring-workflows/{definitionId}/run` | Trigger immediate manual run |
 | `GET` | `/api/recurring-workflows/{definitionId}/runs` | Load run history |
-| `DELETE` | `/api/recurring-workflows/{definitionId}` | Planned: delete schedule and stop future dispatch |
+| `DELETE` | `/api/recurring-workflows/{definitionId}` | Delete schedule and stop future dispatch |
 
 Runtime config should expose matching endpoint templates under `sources.schedules`:
 
@@ -150,13 +150,14 @@ Runtime config should expose matching endpoint templates under `sources.schedule
       "detail": "/api/recurring-workflows/{definitionId}",
       "update": "/api/recurring-workflows/{definitionId}",
       "runNow": "/api/recurring-workflows/{definitionId}/run",
-      "runs": "/api/recurring-workflows/{definitionId}/runs?limit=200"
+      "runs": "/api/recurring-workflows/{definitionId}/runs?limit=200",
+      "delete": "/api/recurring-workflows/{definitionId}"
     }
   }
 }
 ```
 
-`sources.schedules.delete` should be added only when `DELETE /api/recurring-workflows/{definitionId}` is implemented by the backend.
+`sources.schedules.delete` is required for rendering the destructive delete action.
 
 ---
 
@@ -194,9 +195,9 @@ The edit surface should not require users to return to `/workflows/new` to adjus
 
 ---
 
-## 9. Planned Delete Behavior
+## 9. Delete Behavior
 
-The delete action is destructive and should live in the detail page action area, visually separated from routine actions, once the backend delete route and `sources.schedules.delete` runtime-config template exist.
+The delete action is destructive and should live in the detail page action area, visually separated from routine actions.
 
 Required behavior:
 
@@ -232,7 +233,7 @@ This keeps the recurring schedule page focused on controlling the cadence and re
 - If the schedule no longer exists, show a not-found state with a link back to `/schedules`.
 - If the detail request succeeds but run history fails, keep the schedule controls available and show a localized runs-panel error.
 - If update fails because reconciliation with Temporal failed, present the MoonMind API error and leave the page state unchanged.
-- If delete is unavailable because the backend contract has not been implemented, do not render the delete action.
+- If delete is unavailable because runtime config omits `sources.schedules.delete`, do not render the delete action.
 - If the schedule is disabled, the page should show it as paused/disabled rather than failed.
 - If `lastDispatchStatus` or `lastDispatchError` indicates failure, the page should show an attention state but still allow edit, run now, and available destructive actions when authorized.
 

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -688,7 +688,9 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         credentials: 'include',
       });
       if (!response.ok) {
-        throw new Error(`Failed to delete schedule: ${response.statusText}`);
+        throw new Error(
+          await responseErrorMessage(response, 'Failed to delete schedule'),
+        );
       }
     },
     onSuccess: () => {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2000,7 +2000,8 @@ export interface paths {
         get: operations["get_recurring_workflow_api_recurring_workflows__definition_id__get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Recurring Workflow */
+        delete: operations["delete_recurring_workflow_api_recurring_workflows__definition_id__delete"];
         options?: never;
         head?: never;
         /** Update Recurring Workflow */
@@ -13248,6 +13249,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["RecurringWorkflowDefinitionModel"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_recurring_workflow_api_recurring_workflows__definition_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                definition_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -185,7 +185,13 @@ def _latest_schedule_trigger_result(
     def _sort_key(action_result: object) -> datetime:
         return (
             _schedule_datetime(
+                _schedule_object_value(action_result, "actual_time", "actualTime")
+            )
+            or _schedule_datetime(
                 _schedule_object_value(action_result, "started_at", "startedAt")
+            )
+            or _schedule_datetime(
+                _schedule_object_value(action_result, "schedule_time", "scheduleTime")
             )
             or _schedule_datetime(
                 _schedule_object_value(action_result, "scheduled_at", "scheduledAt")
@@ -195,11 +201,21 @@ def _latest_schedule_trigger_result(
 
     threshold = _schedule_datetime(not_before) if not_before is not None else None
     for action_result in sorted(action_results, key=_sort_key, reverse=True):
-        scheduled_at = _schedule_datetime(
-            _schedule_object_value(action_result, "scheduled_at", "scheduledAt")
+        scheduled_at = (
+            _schedule_datetime(
+                _schedule_object_value(action_result, "schedule_time", "scheduleTime")
+            )
+            or _schedule_datetime(
+                _schedule_object_value(action_result, "scheduled_at", "scheduledAt")
+            )
         )
-        started_at = _schedule_datetime(
-            _schedule_object_value(action_result, "started_at", "startedAt")
+        started_at = (
+            _schedule_datetime(
+                _schedule_object_value(action_result, "actual_time", "actualTime")
+            )
+            or _schedule_datetime(
+                _schedule_object_value(action_result, "started_at", "startedAt")
+            )
         )
         action_time = started_at or scheduled_at
         if (
@@ -208,14 +224,19 @@ def _latest_schedule_trigger_result(
             and action_time < threshold
         ):
             continue
-        action = _schedule_object_value(action_result, "action")
+        action = _schedule_object_value(
+            action_result,
+            "start_workflow_result",
+            "startWorkflowResult",
+            "action",
+        )
         workflow_id = _schedule_object_value(action, "workflow_id", "workflowId")
         run_id = _schedule_object_value(
             action,
-            "first_execution_run_id",
-            "firstExecutionRunId",
             "run_id",
             "runId",
+            "first_execution_run_id",
+            "firstExecutionRunId",
         )
         if workflow_id or run_id:
             return ScheduleTriggerResult(
@@ -925,7 +946,7 @@ class TemporalClientAdapter:
 
         handle, _desc = await self._get_schedule_handle(definition_id)
         try:
-            triggered_after = datetime.now(timezone.utc) - timedelta(seconds=30)
+            triggered_after = datetime.now(timezone.utc)
             await handle.trigger()
         except Exception as exc:
             raise ScheduleOperationError(

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -125,6 +125,107 @@ class WorkflowStartResult:
     workflow_id: str
     run_id: str
 
+@dataclass(frozen=True, slots=True)
+class ScheduleTriggerResult:
+    """Best-effort metadata for a workflow started by a Temporal Schedule."""
+
+    scheduled_at: datetime | None = None
+    started_at: datetime | None = None
+    workflow_id: str | None = None
+    run_id: str | None = None
+
+def _schedule_object_value(source: object, *keys: str) -> Any:
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        for key in keys:
+            if key in source:
+                return source[key]
+        return None
+    for key in keys:
+        value = getattr(source, key, None)
+        if value is not None:
+            return value
+    return None
+
+def _schedule_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return _schedule_datetime(parsed)
+    return None
+
+def _latest_schedule_trigger_result(
+    description: object,
+    *,
+    not_before: datetime | None = None,
+) -> ScheduleTriggerResult:
+    """Extract the latest start-workflow action from a schedule description."""
+
+    info = _schedule_object_value(description, "info")
+    recent_actions = (
+        _schedule_object_value(info, "recent_actions", "recentActions") or []
+    )
+    try:
+        action_results = list(recent_actions)
+    except TypeError:
+        return ScheduleTriggerResult()
+
+    def _sort_key(action_result: object) -> datetime:
+        return (
+            _schedule_datetime(
+                _schedule_object_value(action_result, "started_at", "startedAt")
+            )
+            or _schedule_datetime(
+                _schedule_object_value(action_result, "scheduled_at", "scheduledAt")
+            )
+            or datetime.min.replace(tzinfo=timezone.utc)
+        )
+
+    threshold = _schedule_datetime(not_before) if not_before is not None else None
+    for action_result in sorted(action_results, key=_sort_key, reverse=True):
+        scheduled_at = _schedule_datetime(
+            _schedule_object_value(action_result, "scheduled_at", "scheduledAt")
+        )
+        started_at = _schedule_datetime(
+            _schedule_object_value(action_result, "started_at", "startedAt")
+        )
+        action_time = started_at or scheduled_at
+        if (
+            threshold is not None
+            and action_time is not None
+            and action_time < threshold
+        ):
+            continue
+        action = _schedule_object_value(action_result, "action")
+        workflow_id = _schedule_object_value(action, "workflow_id", "workflowId")
+        run_id = _schedule_object_value(
+            action,
+            "first_execution_run_id",
+            "firstExecutionRunId",
+            "run_id",
+            "runId",
+        )
+        if workflow_id or run_id:
+            return ScheduleTriggerResult(
+                scheduled_at=scheduled_at,
+                started_at=started_at,
+                workflow_id=str(workflow_id) if workflow_id else None,
+                run_id=str(run_id) if run_id else None,
+            )
+    return ScheduleTriggerResult()
+
 async def get_temporal_client(address: str, namespace: str) -> Client:
     """Connect to and return a Temporal client."""
 
@@ -205,6 +306,11 @@ class TemporalClientAdapter:
                 )
             )
         return self._workflow_topology.task_queues[0]
+
+    def resolve_workflow_task_queue(self, workflow_type: str | None) -> str:
+        """Resolve the task queue a schedule/start action should use."""
+
+        return self._get_task_queue(workflow_type)
 
     async def start_workflow(
         self,
@@ -558,7 +664,7 @@ class TemporalClientAdapter:
         client = await self.get_client()
         definition_uuid = _UUID(str(definition_id))
         schedule_id = make_schedule_id(definition_uuid)
-        task_queue = self._get_task_queue()
+        task_queue = self._get_task_queue(workflow_type)
 
         args = [workflow_input] if workflow_input is not None else []
 
@@ -679,7 +785,7 @@ class TemporalClientAdapter:
         """
         from uuid import UUID as _UUID
 
-        from temporalio.client import ScheduleActionStartWorkflow
+        from temporalio.client import ScheduleActionStartWorkflow, ScheduleUpdate
 
         from moonmind.workflows.temporal.schedule_errors import ScheduleOperationError
         from moonmind.workflows.temporal.schedule_mapping import (
@@ -765,7 +871,7 @@ class TemporalClientAdapter:
                     ),
                 )
 
-            return schedule
+            return ScheduleUpdate(schedule=schedule)
 
         try:
             await handle.update(_do_update)
@@ -808,7 +914,7 @@ class TemporalClientAdapter:
                 f"Failed to unpause schedule: {exc}"
             ) from exc
 
-    async def trigger_schedule(self, *, definition_id: Any) -> None:
+    async def trigger_schedule(self, *, definition_id: Any) -> ScheduleTriggerResult:
         """Trigger an immediate run of the schedule.
 
         Raises:
@@ -819,11 +925,24 @@ class TemporalClientAdapter:
 
         handle, _desc = await self._get_schedule_handle(definition_id)
         try:
+            triggered_after = datetime.now(timezone.utc) - timedelta(seconds=30)
             await handle.trigger()
         except Exception as exc:
             raise ScheduleOperationError(
                 f"Failed to trigger schedule: {exc}"
             ) from exc
+        try:
+            description = await handle.describe()
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "Failed to describe schedule after trigger",
+                exc_info=True,
+            )
+            return ScheduleTriggerResult()
+        return _latest_schedule_trigger_result(
+            description,
+            not_before=triggered_after,
+        )
 
     async def delete_schedule(self, *, definition_id: Any) -> None:
         """Delete a Temporal Schedule.

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -132,7 +132,7 @@ async def test_list_recurring_workflows_uses_runtime_schedule_summary() -> None:
     assert response.items[0].last_dispatch_status == "enqueued"
     assert response.items[0].permissions.can_edit is True
     assert response.items[0].permissions.can_run_now is True
-    assert response.items[0].permissions.can_delete is False
+    assert response.items[0].permissions.can_delete is True
     assert response.items[0].actions == response.items[0].permissions
     service.runtime_summaries_for_definitions.assert_awaited_once_with([definition])
 
@@ -173,10 +173,8 @@ async def test_create_recurring_workflow_returns_serialized_definition() -> None
     assert response.temporal_schedule_id == "mm-schedule:test-definition"
     assert response.permissions.can_edit is True
     assert response.permissions.can_run_now is True
-    assert response.permissions.can_delete is False
-    assert response.permissions.disabled_reasons["canDelete"] == (
-        "Schedule deletion is not available yet."
-    )
+    assert response.permissions.can_delete is True
+    assert response.permissions.disabled_reasons == {}
     service.create_definition.assert_awaited_once()
 
 @pytest.mark.asyncio
@@ -195,7 +193,7 @@ async def test_get_recurring_workflow_serializes_action_permissions() -> None:
 
     assert response.permissions.can_edit is True
     assert response.permissions.can_run_now is True
-    assert response.permissions.can_delete is False
+    assert response.permissions.can_delete is True
     assert response.actions == response.permissions
 
 @pytest.mark.asyncio
@@ -220,7 +218,11 @@ async def test_global_recurring_workflow_action_permissions_require_operator() -
     assert operator_permissions.can_run_now is True
     assert viewer_permissions.can_edit is False
     assert viewer_permissions.can_run_now is False
+    assert viewer_permissions.can_delete is False
     assert viewer_permissions.disabled_reasons["canEdit"] == (
+        "Operator privileges are required to manage global schedules."
+    )
+    assert viewer_permissions.disabled_reasons["canDelete"] == (
         "Operator privileges are required to manage global schedules."
     )
 
@@ -246,6 +248,27 @@ async def test_run_recurring_workflow_now_returns_run_row() -> None:
     assert response.outcome == "pending_dispatch"
     assert response.started_at is None
     service.create_manual_run.assert_awaited_once_with(definition)
+
+@pytest.mark.asyncio
+async def test_delete_recurring_workflow_deletes_authorized_definition() -> None:
+    service = AsyncMock()
+    definition = _definition()
+    service.require_authorized_definition.return_value = definition
+    user = SimpleNamespace(id=definition.owner_user_id, is_superuser=False)
+
+    response = await recurring_router.delete_recurring_workflow(
+        definition_id=definition.id,
+        service=service,
+        user=user,
+    )
+
+    assert response.status_code == 204
+    service.require_authorized_definition.assert_awaited_once_with(
+        definition_id=definition.id,
+        user_id=user.id,
+        can_manage_global=False,
+    )
+    service.delete_definition.assert_awaited_once_with(definition)
 
 @pytest.mark.asyncio
 async def test_list_recurring_workflow_runs_hydrates_actual_start_time() -> None:

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -257,7 +257,7 @@ def test_task_create_route_uses_canonical_boot_payload(client: TestClient) -> No
         "/api/"
     )
 
-def test_schedules_runtime_config_exposes_documented_templates_without_delete(
+def test_schedules_runtime_config_exposes_documented_templates(
     client: TestClient,
 ) -> None:
     response = client.get("/schedules")
@@ -273,8 +273,8 @@ def test_schedules_runtime_config_exposes_documented_templates_without_delete(
         "update": "/api/recurring-workflows/{definitionId}",
         "runNow": "/api/recurring-workflows/{definitionId}/run",
         "runs": "/api/recurring-workflows/{definitionId}/runs?limit=200",
+        "delete": "/api/recurring-workflows/{definitionId}",
     }
-    assert "delete" not in schedules
 
 def test_oauth_terminal_route_uses_terminal_boot_payload(client: TestClient) -> None:
     response = client.get("/oauth-terminal?session_id=oas_route_shell")

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2752,7 +2752,6 @@ async def test_seed_catalog_jira_implement_accepts_common_jira_issue_shapes(
                 slug="jira-implement",
                 scope="global",
                 scope_ref=None,
-                version="1.1.0",
                 inputs={"jira_issue": jira_issue_input},
                 context={},
             )

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -25,6 +25,8 @@ from api_service.services.recurring_workflows_service import (
     RecurringWorkflowsService,
     RecurringWorkflowValidationError,
 )
+from moonmind.workflows.temporal.client import ScheduleTriggerResult
+from moonmind.workflows.temporal.schedule_errors import ScheduleNotFoundError
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -53,9 +55,10 @@ def mock_temporal_adapter():
     adapter.update_schedule = AsyncMock()
     adapter.pause_schedule = AsyncMock()
     adapter.unpause_schedule = AsyncMock()
-    adapter.trigger_schedule = AsyncMock()
+    adapter.trigger_schedule = AsyncMock(return_value=ScheduleTriggerResult())
     adapter.delete_schedule = AsyncMock()
     adapter.describe_schedule = AsyncMock()
+    adapter.resolve_workflow_task_queue = MagicMock(return_value="mm.workflow.user.v2")
     return adapter
 
 async def test_create_definition_creates_temporal_schedule(
@@ -363,12 +366,172 @@ async def test_create_manual_run_triggers_temporal_schedule(
                 },
                 policy={},
             )
+            workflow_type, workflow_input = service._workflow_bundle_for_definition(
+                definition
+            )
+            triggered_at = datetime.now(UTC)
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    action=SimpleNamespace(
+                        workflow=workflow_type,
+                        args=[workflow_input],
+                        task_queue="mm.workflow.user.v2",
+                    )
+                )
+            )
+            mock_temporal_adapter.trigger_schedule.return_value = ScheduleTriggerResult(
+                scheduled_at=triggered_at,
+                started_at=triggered_at,
+                workflow_id="workflow-from-trigger",
+                run_id="run-from-trigger",
+            )
 
             run = await service.create_manual_run(definition)
 
             mock_temporal_adapter.trigger_schedule.assert_called_once_with(definition_id=definition.id)
             assert run.outcome == RecurringWorkflowRunOutcome.ENQUEUED
-            assert run.message == "Triggered via Temporal Schedule"
+            assert run.scheduled_for.replace(tzinfo=UTC) == triggered_at
+            assert run.temporal_workflow_id == "workflow-from-trigger"
+            assert run.temporal_run_id == "run-from-trigger"
+            assert run.message == "Triggered Temporal workflow workflow-from-trigger"
+            assert definition.last_scheduled_for.replace(tzinfo=UTC) == triggered_at
+            assert definition.last_dispatch_status == "enqueued"
+            mock_temporal_adapter.update_schedule.assert_not_called()
+
+async def test_create_manual_run_repairs_legacy_task_queue_before_trigger(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            workflow_type, workflow_input = service._workflow_bundle_for_definition(
+                definition
+            )
+            mock_temporal_adapter.update_schedule.reset_mock()
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    action=SimpleNamespace(
+                        workflow=workflow_type,
+                        args=[workflow_input],
+                        task_queue="mm.workflow",
+                    )
+                )
+            )
+
+            await service.create_manual_run(definition)
+
+            mock_temporal_adapter.update_schedule.assert_called_once()
+            call_kwargs = mock_temporal_adapter.update_schedule.call_args.kwargs
+            assert call_kwargs["definition_id"] == definition.id
+            assert call_kwargs["workflow_type"] == workflow_type
+            assert call_kwargs["workflow_input"] == workflow_input
+            mock_temporal_adapter.trigger_schedule.assert_called_once_with(
+                definition_id=definition.id
+            )
+
+async def test_delete_definition_deletes_temporal_schedule_and_db_row(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+
+            await service.delete_definition(definition)
+
+            mock_temporal_adapter.delete_schedule.assert_called_once_with(
+                definition_id=definition.id
+            )
+            result = await session.execute(
+                select(RecurringWorkflowDefinition).where(
+                    RecurringWorkflowDefinition.id == definition.id
+                )
+            )
+            assert result.scalars().first() is None
+
+async def test_delete_definition_removes_db_row_when_temporal_schedule_is_missing(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            mock_temporal_adapter.delete_schedule.side_effect = ScheduleNotFoundError(
+                "missing"
+            )
+
+            await service.delete_definition(definition)
+
+            result = await session.execute(
+                select(RecurringWorkflowDefinition).where(
+                    RecurringWorkflowDefinition.id == definition.id
+                )
+            )
+            assert result.scalars().first() is None
 
 async def test_runtime_summary_uses_temporal_future_and_recent_actions(
     tmp_path: Path, mock_temporal_adapter
@@ -532,6 +695,7 @@ async def test_reconcile_skips_update_when_metadata_and_action_match(
                     action=SimpleNamespace(
                         workflow="MoonMind.UserWorkflow",
                         args=[workflow_input],
+                        task_queue="mm.workflow.user.v2",
                     ),
                 )
             )
@@ -540,6 +704,68 @@ async def test_reconcile_skips_update_when_metadata_and_action_match(
 
             assert reconciled == 0
             mock_temporal_adapter.update_schedule.assert_not_called()
+
+async def test_reconcile_repairs_schedule_action_task_queue(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            _workflow_type, workflow_input = service._workflow_bundle_for_definition(
+                definition
+            )
+            mock_temporal_adapter.create_schedule.reset_mock()
+            mock_temporal_adapter.update_schedule.reset_mock()
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    spec=SimpleNamespace(
+                        cron_expressions=["0 6 * * *"],
+                        time_zone_name="UTC",
+                        jitter=timedelta(seconds=0),
+                    ),
+                    policy=SimpleNamespace(
+                        overlap=SimpleNamespace(name="SKIP"),
+                        catchup_window=timedelta(minutes=15),
+                    ),
+                    state=SimpleNamespace(paused=False, note="Daily Demo"),
+                    action=SimpleNamespace(
+                        workflow="MoonMind.UserWorkflow",
+                        args=[workflow_input],
+                        task_queue="mm.workflow",
+                    ),
+                )
+            )
+
+            reconciled = await service.reconcile_schedules()
+
+            assert reconciled == 1
+            mock_temporal_adapter.update_schedule.assert_called_once()
+            call_kwargs = mock_temporal_adapter.update_schedule.call_args.kwargs
+            assert call_kwargs["definition_id"] == definition.id
+            assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"] == workflow_input
 
 async def test_runtime_summaries_for_definitions_describes_concurrently(
     tmp_path: Path, mock_temporal_adapter

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -6,7 +6,7 @@ and T017 (SDK error wrapping).
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -19,6 +19,7 @@ from temporalio.common import SearchAttributeKey
 from moonmind.workflows.temporal.client import (
     MANAGED_SESSION_RECONCILE_SCHEDULE_ID,
     MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE,
+    ScheduleTriggerResult,
     TemporalClientAdapter,
 )
 from moonmind.workflows.temporal.schedule_errors import (
@@ -51,6 +52,12 @@ def _mock_schedule_handle(*, describe_side_effect: Exception | None = None) -> M
     handle.update = AsyncMock()
     return handle
 
+async def _run_schedule_update_callback(handle: MagicMock, update_input: Any) -> Any:
+    update_callback = handle.update.call_args[0][0]
+    update = await update_callback(update_input)
+    assert isinstance(update, ScheduleUpdate)
+    return update.schedule
+
 # ---------------------------------------------------------------------------
 # T010: create_schedule
 # ---------------------------------------------------------------------------
@@ -79,6 +86,7 @@ class TestCreateSchedule:
         
         schedule_arg = call_args[0][1]
         assert schedule_arg.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
+        assert schedule_arg.action.task_queue == "mm.workflow.user.v2"
 
     @pytest.mark.asyncio
     async def test_does_not_template_scheduled_for_search_attribute(self) -> None:
@@ -335,11 +343,10 @@ class TestUpdateSchedule:
         )
         handle.update.assert_awaited_once()
 
-        # Get the callback passed to update()
-        update_callback = handle.update.call_args[0][0]
-
-        # Call it with our mock input
-        updated_schedule = await update_callback(mock_update_input)
+        updated_schedule = await _run_schedule_update_callback(
+            handle,
+            mock_update_input,
+        )
 
         assert updated_schedule.spec.cron_expressions == ["0 12 * * *"]
         assert updated_schedule.spec.time_zone_name == "America/New_York"
@@ -372,8 +379,10 @@ class TestUpdateSchedule:
         await adapter.update_schedule(definition_id=_TEST_UUID)
 
         handle.update.assert_awaited_once()
-        update_callback = handle.update.call_args[0][0]
-        updated_schedule = await update_callback(mock_update_input)
+        updated_schedule = await _run_schedule_update_callback(
+            handle,
+            mock_update_input,
+        )
 
         # Verify fields are preserved
         assert updated_schedule.spec.cron_expressions == ["0 0 * * *"]
@@ -417,8 +426,10 @@ class TestUpdateSchedule:
             },
         )
 
-        update_callback = handle.update.call_args[0][0]
-        updated_schedule = await update_callback(mock_update_input)
+        updated_schedule = await _run_schedule_update_callback(
+            handle,
+            mock_update_input,
+        )
 
         assert updated_schedule.action.workflow == "MoonMind.UserWorkflow"
         assert updated_schedule.action.args == [workflow_input]
@@ -513,6 +524,40 @@ class TestTriggerSchedule:
         adapter = _make_adapter(mock_client)
         await adapter.trigger_schedule(definition_id=_TEST_UUID)
         handle.trigger.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_triggered_workflow_metadata_from_recent_action(self) -> None:
+        handle = _mock_schedule_handle()
+        scheduled_at = datetime.now(timezone.utc)
+        handle.describe.side_effect = [
+            MagicMock(),
+            SimpleNamespace(
+                info=SimpleNamespace(
+                    recent_actions=[
+                        SimpleNamespace(
+                            scheduled_at=scheduled_at,
+                            started_at=scheduled_at,
+                            action=SimpleNamespace(
+                                workflow_id="workflow-from-trigger",
+                                first_execution_run_id="run-from-trigger",
+                            ),
+                        )
+                    ]
+                )
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle = MagicMock(return_value=handle)
+
+        adapter = _make_adapter(mock_client)
+        result = await adapter.trigger_schedule(definition_id=_TEST_UUID)
+
+        assert result == ScheduleTriggerResult(
+            scheduled_at=scheduled_at,
+            started_at=scheduled_at,
+            workflow_id="workflow-from-trigger",
+            run_id="run-from-trigger",
+        )
 
 class TestDeleteSchedule:
     """DOC-REQ-002: delete schedule."""

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -528,18 +528,18 @@ class TestTriggerSchedule:
     @pytest.mark.asyncio
     async def test_returns_triggered_workflow_metadata_from_recent_action(self) -> None:
         handle = _mock_schedule_handle()
-        scheduled_at = datetime.now(timezone.utc)
+        scheduled_at = datetime.now(timezone.utc) + timedelta(seconds=1)
         handle.describe.side_effect = [
             MagicMock(),
             SimpleNamespace(
                 info=SimpleNamespace(
                     recent_actions=[
                         SimpleNamespace(
-                            scheduled_at=scheduled_at,
-                            started_at=scheduled_at,
-                            action=SimpleNamespace(
+                            schedule_time=scheduled_at,
+                            actual_time=scheduled_at,
+                            start_workflow_result=SimpleNamespace(
                                 workflow_id="workflow-from-trigger",
-                                first_execution_run_id="run-from-trigger",
+                                run_id="run-from-trigger",
                             ),
                         )
                     ]
@@ -558,6 +558,35 @@ class TestTriggerSchedule:
             workflow_id="workflow-from-trigger",
             run_id="run-from-trigger",
         )
+
+    @pytest.mark.asyncio
+    async def test_ignores_recent_action_before_manual_trigger(self) -> None:
+        handle = _mock_schedule_handle()
+        stale_action_time = datetime.now(timezone.utc) - timedelta(minutes=1)
+        handle.describe.side_effect = [
+            MagicMock(),
+            SimpleNamespace(
+                info=SimpleNamespace(
+                    recent_actions=[
+                        SimpleNamespace(
+                            schedule_time=stale_action_time,
+                            actual_time=stale_action_time,
+                            start_workflow_result=SimpleNamespace(
+                                workflow_id="previous-workflow",
+                                run_id="previous-run",
+                            ),
+                        )
+                    ]
+                )
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle = MagicMock(return_value=handle)
+
+        adapter = _make_adapter(mock_client)
+        result = await adapter.trigger_schedule(definition_id=_TEST_UUID)
+
+        assert result == ScheduleTriggerResult()
 
 class TestDeleteSchedule:
     """DOC-REQ-002: delete schedule."""


### PR DESCRIPTION
## Summary
- Route recurring Temporal schedule actions to the workflow-type-specific task queue so `MoonMind.UserWorkflow` schedules dispatch to the active user workflow queue.
- Repair stale schedule actions before startup reconciliation/manual `Run now`, and persist Temporal workflow/run ids from triggered schedule actions when available.
- Add `DELETE /api/recurring-workflows/{definitionId}`, expose the delete source in Mission Control, regenerate OpenAPI types, and update scheduling docs.

## Validation
- `python3 -m pytest tests/unit/workflows/temporal/test_client_schedules.py tests/unit/services/test_recurring_workflows_service.py tests/unit/api/routers/test_recurring_workflows.py tests/unit/api/routers/test_workflow_console.py -k 'client_schedules or recurring_workflows or schedules_runtime_config' -q`
- `npm run ui:test -- frontend/src/entrypoints/schedules.test.tsx`
- `npm run api:types`
- `python3 -m compileall -q ...` for touched Python modules
- `git diff --check`

Note: a broad `./tools/test_unit.sh --ui-args frontend/src/entrypoints/schedules.test.tsx` run reached 7149 passed tests before I interrupted it after two unrelated existing failures in `tests/unit/api/test_presets_service.py::test_seed_catalog_jira_implement_accepts_common_jira_issue_shapes`, where current main rejects `PresetCatalogService.expand_template(version=...)`.