### PR TITLE
MM-929 add stable canonical claim ID conventions

### DIFF
--- a/docs/DocumentationArchitecture.md
+++ b/docs/DocumentationArchitecture.md
@@ -271,7 +271,7 @@ In both forms: the five viewpoints classify every canonical declarative document
 6. **Resolve same-class conflicts by authority scope.** When two canonical documents disagree, use the precedence ladder (§7.1) and the conflict-handling procedure (§7.2) to determine which document owns the claim; reconcile the non-owning document, and escalate foundational conflicts rather than resolving them unilaterally.
 7. **Keep rationale with its rule.** Embed significant design rationale in the owning canonical document (§8); do not create separate design-rationale journals.
 
-This standard's taxonomy is the foundation. The **authoring conventions** that build directly on it — the metadata headers (§11), naming conventions (§12), and the incremental adoption policy (§13) — are defined below. Integration with tooling, document templates, migration guidance, and validation are defined in further dependent stories that build on this taxonomy.
+This standard's taxonomy is the foundation. The **authoring conventions** that build directly on it — the metadata headers (§11), naming conventions (§12), the incremental adoption policy (§13), and stable canonical claim IDs (§14) — are defined below. Integration with tooling, document templates, migration guidance, and validation are defined in further dependent stories that build on this taxonomy.
 
 ---
 
@@ -373,7 +373,39 @@ Downstream MoonSpec projects may apply **minor local adjustments** to these conv
 
 ---
 
-## 14. Viewpoint Templates
+## 14. Stable Canonical Claim IDs
+
+Stable canonical claim IDs make durable documentation addressable for indexing, slicing, verification, and reconciliation without depending on run-local coverage IDs. This convention is added under **MM-929**, preserving traceability to source issue **MM-927** ("Moon Spec Doc Architecture Alignment") and coverage IDs **DESIGN-REQ-008**, **DESIGN-REQ-009**, and **DESIGN-REQ-011**.
+
+A stable canonical claim ID identifies one durable claim in a canonical declarative document. Place the ID at the start of the smallest heading that owns the claim. Keep the heading concise, then let the following body text explain the rule, contract, invariant, quality bar, non-goal, or test expectation. The ID is durable under normal text edits: editing prose, splitting paragraphs, or clarifying examples must not require a new ID while the same claim remains in force.
+
+Use these ID families:
+
+| Prefix | Use for |
+|---|---|
+| `DOC-REQ` | Documentation or product behavior requirements that a canonical doc owns. |
+| `CONTRACT` | API, payload, interface, workflow/activity, signal/update, or provider-boundary contract clauses. |
+| `INV` | Invariants that must always hold across implementation and operations. |
+| `NON-GOAL` | Explicit exclusions that prevent scope expansion or accidental interpretation as supported behavior. |
+| `QUALITY` | Quality attributes such as reliability, performance, observability, security, maintainability, or operator ergonomics. |
+| `TEST` | Required verification obligations tied to the canonical claim, especially boundary or regression coverage. |
+
+IDs use `PREFIX-NNN`, where `NNN` is a zero-padded three-digit number. Examples:
+
+- `### DOC-REQ-001 One active skill set is resolved per run`
+- `### CONTRACT-001 Activity payloads carry artifact refs for large content`
+- `### INV-001 Workflow code stays deterministic`
+- `### NON-GOAL-001 Plans do not become canonical desired state`
+- `### QUALITY-001 Live-log failure degrades to artifact replay`
+- `### TEST-001 Workflow-boundary tests cover real invocation shape`
+
+Canonical claim IDs are different from temporary `DESIGN-REQ-*` IDs. `DESIGN-REQ-*` IDs are run-local or source-design coverage markers used for traceability while a design is decomposed and implemented; they are not stable canonical anchors and must not be used as claim IDs in durable docs. When a temporary design requirement becomes durable desired state, assign the appropriate canonical claim ID family above and preserve the source `DESIGN-REQ-*` value only as traceability prose.
+
+Adoption is incremental. New canonical docs and substantially edited sections should add stable claim IDs for the claims they introduce or materially revise. Existing docs are not forced through a metadata-only backfill. The advisory documentation-architecture checker warns by default when canonical claim headings use malformed IDs or when one stable ID is reused for multiple canonical claims; those warnings remain advisory unless a caller opts into strict mode.
+
+---
+
+## 15. Viewpoint Templates
 
 Copy the matching template to start a new document. Each template embeds the correct metadata header (§11) and a concise section skeleton drawn from this standard. Templates are starting points, not a heavyweight process: delete sections that do not apply.
 

--- a/docs/DocumentationArchitectureValidation.md
+++ b/docs/DocumentationArchitectureValidation.md
@@ -6,7 +6,7 @@
 **Audience:** Anyone authoring or reviewing durable documentation, or wiring documentation checks into tooling
 **Purpose:** Describe the **advisory, non-blocking** validation that flags obvious drift from the [MoonSpec Documentation Architecture Standard](DocumentationArchitecture.md) and the [MoonSpec Document Model](Workflows/MoonSpecDocumentModel.md), so reviewers catch documentation-architecture problems early.
 
-> **Traceability:** This is the deliverable of **MM-908** (source design **MM-900**, "Implement MoonSpec Documentation Architecture Standard"); it covers **DESIGN-REQ-018**. It builds on the taxonomy authored in **MM-902**.
+> **Traceability:** This is the deliverable of **MM-908** (source design **MM-900**, "Implement MoonSpec Documentation Architecture Standard"); it covers **DESIGN-REQ-018**. It builds on the taxonomy authored in **MM-902**. Stable canonical claim ID validation is added under **MM-929**, preserving source issue **MM-927** traceability.
 
 ---
 
@@ -47,6 +47,8 @@ Each check maps to one acceptance criterion of MM-908 and emits a finding with a
 | `duplicate-canonical-authority` | Two canonical docs sharing an H1 title (overlapping authority), or more than one root-level System Architecture View. | [Standard §3.1](DocumentationArchitecture.md), [Document Model — Precedence](Workflows/MoonSpecDocumentModel.md) |
 | `contract-missing-authority-statement` | A contract doc (`*Contract.md` / `*Contracts.md`) with no authority statement naming its single authoritative owner / source of truth. | [Standard §6.1](DocumentationArchitecture.md) |
 | `discouraged-decision-record` | A separate `decisions/` directory or ADR-style doc, introduced instead of embedding rationale in the owning canonical view. | [Standard §8](DocumentationArchitecture.md) |
+| `malformed-claim-id` | A canonical claim heading using a malformed stable ID. | [Standard §14](DocumentationArchitecture.md) |
+| `duplicate-claim-id` | A stable canonical claim ID reused for multiple canonical claims. | [Standard §14](DocumentationArchitecture.md) |
 
 ## 4. Reviewer checklist
 
@@ -57,6 +59,7 @@ When reviewing a change that adds or moves durable docs, confirm:
 - [ ] No two canonical docs claim the **same authority** (same title / same scope); there is one root-level System Architecture View.
 - [ ] Each **contract** doc states who **owns** it and that it is the **single source of truth** for that interface.
 - [ ] Rationale is **embedded** in the owning canonical view rather than added as a separate `decisions/` or ADR-style doc.
+- [ ] Stable canonical claim headings use `PREFIX-NNN` with one of `DOC-REQ`, `CONTRACT`, `INV`, `NON-GOAL`, `QUALITY`, or `TEST`, and no stable ID is reused for a different canonical claim.
 
 ## 5. Document Class marker convention
 

--- a/docs/_viewpoints/ModuleArchitectureView.template.md
+++ b/docs/_viewpoints/ModuleArchitectureView.template.md
@@ -29,3 +29,7 @@ The important paths through the module (request handling, background work, error
 ## 5. Constraints & decisions
 
 Invariants the module must uphold and the design decisions behind its structure.
+
+### INV-001 <concise stable invariant heading>
+
+The durable module invariant this document owns.

--- a/docs/_viewpoints/ModuleContractSpecification.template.md
+++ b/docs/_viewpoints/ModuleContractSpecification.template.md
@@ -22,6 +22,10 @@ The operations, inputs, and outputs the module guarantees (signatures, payload s
 
 What callers can rely on: ordering, idempotency, error semantics, compatibility commitments.
 
+### CONTRACT-001 <concise stable contract heading>
+
+The durable interface guarantee this contract owns.
+
 ## 4. Failure modes
 
 How the contract behaves on invalid input, downstream failure, and degraded conditions.
@@ -29,3 +33,7 @@ How the contract behaves on invalid input, downstream failure, and degraded cond
 ## 5. Versioning & compatibility
 
 How changes to this contract are versioned and what compatibility callers can expect. For Temporal-facing contracts (workflows, activities, signals, updates), explicitly address replay safety, in-flight compatibility, and workflow boundary test coverage.
+
+### TEST-001 <concise stable verification heading>
+
+The required boundary or regression coverage for this contract.

--- a/docs/_viewpoints/SystemArchitectureView.template.md
+++ b/docs/_viewpoints/SystemArchitectureView.template.md
@@ -29,3 +29,7 @@ External systems, trust boundaries, and runtime/deployment boundaries.
 ## 5. Constraints & decisions
 
 Non-negotiable constraints and the architecture decisions that shape this system.
+
+### DOC-REQ-001 <concise stable requirement heading>
+
+The durable system-level requirement this document owns.

--- a/docs/_viewpoints/SystemFeatureDesignView.template.md
+++ b/docs/_viewpoints/SystemFeatureDesignView.template.md
@@ -26,6 +26,14 @@ The key entities, states, and interfaces involved in the design.
 
 What this design deliberately does not do.
 
+### NON-GOAL-001 <concise stable non-goal heading>
+
+The durable exclusion this design owns.
+
 ## 5. Constraints & decisions
 
 Constraints that bound the design and the decisions made within them.
+
+### QUALITY-001 <concise stable quality heading>
+
+The durable quality attribute this design owns.

--- a/tests/unit/docs/test_documentation_architecture_standard.py
+++ b/tests/unit/docs/test_documentation_architecture_standard.py
@@ -90,6 +90,29 @@ def test_incremental_adoption_policy_present() -> None:
     assert "no retroactive metadata-only churn PR is mandated" in text
 
 
+def test_stable_canonical_claim_id_families_present() -> None:
+    text = _read()
+    assert "Stable Canonical Claim IDs" in text
+    for prefix in ("DOC-REQ", "CONTRACT", "INV", "NON-GOAL", "QUALITY", "TEST"):
+        assert prefix in text
+    assert "PREFIX-NNN" in text
+
+
+def test_claim_ids_are_distinguished_from_design_req_traceability() -> None:
+    text = _read()
+    assert "DESIGN-REQ-*" in text
+    assert "not stable canonical anchors" in text
+    assert "MM-927" in text
+    assert "MM-929" in text
+
+
+def test_claim_id_validation_is_advisory_and_incremental() -> None:
+    text = _read()
+    assert "malformed IDs" in text
+    assert "reused for multiple canonical claims" in text
+    assert "Adoption is incremental" in text
+
+
 def test_downstream_minor_local_adjustment_path_documented() -> None:
     text = _read()
     assert "minor local adjustments" in text.lower()

--- a/tests/unit/docs/test_viewpoint_templates.py
+++ b/tests/unit/docs/test_viewpoint_templates.py
@@ -47,6 +47,22 @@ def test_plan_template_embeds_imperative_plan_header() -> None:
     assert "Canonical declarative" not in text
 
 
+def test_canonical_templates_show_stable_claim_heading_examples() -> None:
+    expected = {
+        "SystemArchitectureView.template.md": "### DOC-REQ-001",
+        "ModuleArchitectureView.template.md": "### INV-001",
+        "SystemFeatureDesignView.template.md": "### NON-GOAL-001",
+        "ModuleContractSpecification.template.md": "### CONTRACT-001",
+    }
+    for filename, heading in expected.items():
+        assert heading in _read(VIEWPOINTS_DIR / filename)
+
+    feature_text = _read(VIEWPOINTS_DIR / "SystemFeatureDesignView.template.md")
+    assert "### QUALITY-001" in feature_text
+    contract_text = _read(VIEWPOINTS_DIR / "ModuleContractSpecification.template.md")
+    assert "### TEST-001" in contract_text
+
+
 @pytest.mark.parametrize("filename", ALL_TEMPLATES)
 def test_standard_references_each_template(filename: str) -> None:
     standard_text = _read(STANDARD)

--- a/tests/unit/tools/test_check_documentation_architecture.py
+++ b/tests/unit/tools/test_check_documentation_architecture.py
@@ -187,11 +187,13 @@ def test_malformed_canonical_claim_id_heading_is_advisory() -> None:
         _doc(
             "docs/Workflows/Thing.md",
             "# Thing\n\n**Document Class:** Canonical declarative\n\n"
-            "### DOC-REQ-1 Missing zero padding\n",
+            "### DOC-REQ-1 Missing zero padding\n"
+            "### DOC-REQ-001-A Trailing characters\n",
         )
     ]
     findings = mod.check_malformed_claim_ids(docs)
     assert _rules(findings) == {"malformed-claim-id"}
+    assert len(findings) == 2
     assert findings[0].severity == mod.SEVERITY_ADVISORY
 
 
@@ -226,6 +228,24 @@ def test_duplicate_canonical_claim_ids_are_advisory() -> None:
         "docs/A/Thing.md",
         "docs/B/Thing.md",
     }
+
+
+def test_template_claim_ids_are_not_validated() -> None:
+    docs = [
+        _doc(
+            "docs/_viewpoints/SystemArchitectureView.template.md",
+            "# <System Name> -- System Architecture View\n\n"
+            "**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ-001 <concise stable requirement heading>\n",
+        ),
+        _doc(
+            "docs/Workflows/Thing.md",
+            "# Thing\n\n**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ-001 Stable claim\n",
+        ),
+    ]
+    assert mod.check_duplicate_claim_ids(docs) == []
+    assert mod.check_malformed_claim_ids(docs) == []
 
 
 def test_design_req_traceability_is_not_a_canonical_claim_id() -> None:

--- a/tests/unit/tools/test_check_documentation_architecture.py
+++ b/tests/unit/tools/test_check_documentation_architecture.py
@@ -182,13 +182,84 @@ def test_decision_record_directory_and_adr_file_are_discouraged() -> None:
     }
 
 
+def test_malformed_canonical_claim_id_heading_is_advisory() -> None:
+    docs = [
+        _doc(
+            "docs/Workflows/Thing.md",
+            "# Thing\n\n**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ-1 Missing zero padding\n",
+        )
+    ]
+    findings = mod.check_malformed_claim_ids(docs)
+    assert _rules(findings) == {"malformed-claim-id"}
+    assert findings[0].severity == mod.SEVERITY_ADVISORY
+
+
+def test_claim_heading_prefix_without_number_is_malformed() -> None:
+    docs = [
+        _doc(
+            "docs/Workflows/Thing.md",
+            "# Thing\n\n**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ Missing number\n",
+        )
+    ]
+    findings = mod.check_malformed_claim_ids(docs)
+    assert _rules(findings) == {"malformed-claim-id"}
+
+
+def test_duplicate_canonical_claim_ids_are_advisory() -> None:
+    docs = [
+        _doc(
+            "docs/A/Thing.md",
+            "# Thing A\n\n**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ-001 One claim\n",
+        ),
+        _doc(
+            "docs/B/Thing.md",
+            "# Thing B\n\n**Document Class:** Canonical declarative\n\n"
+            "### DOC-REQ-001 Another claim\n",
+        ),
+    ]
+    findings = mod.check_duplicate_claim_ids(docs)
+    assert _rules(findings) == {"duplicate-claim-id"}
+    assert {finding.path for finding in findings} == {
+        "docs/A/Thing.md",
+        "docs/B/Thing.md",
+    }
+
+
+def test_design_req_traceability_is_not_a_canonical_claim_id() -> None:
+    docs = [
+        _doc(
+            "docs/Workflows/Thing.md",
+            "# Thing\n\n**Document Class:** Canonical declarative\n\n"
+            "Traceability: DESIGN-REQ-008\n\n"
+            "### DOC-REQ-001 Stable claim\n",
+        )
+    ]
+    assert mod.check_malformed_claim_ids(docs) == []
+    assert mod.check_duplicate_claim_ids(docs) == []
+
+
+def test_claim_ids_in_fenced_examples_are_not_validated() -> None:
+    docs = [
+        _doc(
+            "docs/Workflows/Thing.md",
+            "# Thing\n\n**Document Class:** Canonical declarative\n\n"
+            "```markdown\n### DOC-REQ-1 Example only\n```\n",
+        )
+    ]
+    assert mod.check_malformed_claim_ids(docs) == []
+
+
 def test_clean_canonical_doc_produces_no_findings() -> None:
     docs = [
         _doc(
             "docs/Workflows/CleanContract.md",
             "# Clean Contract\n\n**Document Class:** Module Contract Specification\n\n"
             "This document is the authoritative source of truth, owned by the "
-            "workflows module.\n",
+            "workflows module.\n\n"
+            "### CONTRACT-001 Stable guarantee\n",
         )
     ]
     assert mod.run_checks(docs) == []

--- a/tools/check_documentation_architecture.py
+++ b/tools/check_documentation_architecture.py
@@ -27,6 +27,10 @@ Enumerated advisory checks:
                                      statement.
   5. ``discouraged-decision-record`` separate ``decisions/`` or ADR-style docs
                                      introduced instead of embedded rationale.
+  6. ``malformed-claim-id``          canonical claim headings with malformed
+                                     stable IDs.
+  7. ``duplicate-claim-id``          stable canonical claim IDs reused across
+                                     canonical docs.
 """
 
 from __future__ import annotations
@@ -100,6 +104,26 @@ ADR_FILE_RE = re.compile(r"(?:^|/)(?:adr[-_].+|\d{3,4}[-_].+-decision|.*\bADR\b.
 # (the standard, this validation doc) are not miscounted as views.
 SYSTEM_ARCH_DECLARATION_RE = re.compile(
     r"document\s+class\s*[:|]\s*\**\s*system architecture view", re.IGNORECASE
+)
+
+CANONICAL_CLAIM_PREFIXES = (
+    "DOC-REQ",
+    "CONTRACT",
+    "INV",
+    "NON-GOAL",
+    "QUALITY",
+    "TEST",
+)
+CANONICAL_CLAIM_PREFIX_RE = "|".join(
+    re.escape(prefix) for prefix in CANONICAL_CLAIM_PREFIXES
+)
+CANONICAL_CLAIM_ID_RE = re.compile(
+    rf"^(?:{CANONICAL_CLAIM_PREFIX_RE})-\d{{3}}$"
+)
+CLAIM_HEADING_RE = re.compile(
+    rf"^\s{{0,3}}#{{1,6}}\s+(?:`|\*\*)?"
+    rf"(?P<id>(?:{CANONICAL_CLAIM_PREFIX_RE})(?:-[A-Za-z0-9_]+)?)"
+    rf"(?:`|\*\*)?(?=\s|:|-|$)"
 )
 
 SEVERITY_ADVISORY = "advisory"
@@ -312,12 +336,89 @@ def check_discouraged_decision_record(docs: Sequence[DocFile]) -> list[Finding]:
     return findings
 
 
+def _claim_heading_ids(doc: DocFile) -> list[str]:
+    ids: list[str] = []
+    in_fence = False
+    for line in doc.text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = CLAIM_HEADING_RE.match(line)
+        if match:
+            ids.append(match.group("id"))
+    return ids
+
+
+def check_malformed_claim_ids(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for doc in docs:
+        if not is_canonical_doc(doc.path):
+            continue
+        for claim_id in _claim_heading_ids(doc):
+            if CANONICAL_CLAIM_ID_RE.fullmatch(claim_id):
+                continue
+            findings.append(
+                Finding(
+                    rule="malformed-claim-id",
+                    severity=SEVERITY_ADVISORY,
+                    path=doc.path,
+                    message=(
+                        f"Canonical claim heading uses malformed ID `{claim_id}`. "
+                        "Use PREFIX-NNN with one of DOC-REQ, CONTRACT, INV, "
+                        "NON-GOAL, QUALITY, or TEST "
+                        "(see docs/DocumentationArchitecture.md §14)."
+                    ),
+                )
+            )
+    return findings
+
+
+def check_duplicate_claim_ids(docs: Sequence[DocFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    by_id: dict[str, list[str]] = {}
+    for doc in docs:
+        if not is_canonical_doc(doc.path):
+            continue
+        for claim_id in _claim_heading_ids(doc):
+            if CANONICAL_CLAIM_ID_RE.fullmatch(claim_id):
+                by_id.setdefault(claim_id, []).append(doc.path)
+
+    for claim_id, paths in sorted(by_id.items()):
+        unique_paths = sorted(set(paths))
+        if len(paths) < 2:
+            continue
+        for path in unique_paths:
+            others = [other for other in unique_paths if other != path]
+            detail = "duplicate occurrences in this document"
+            if others:
+                detail = "also used by: " + ", ".join(others)
+            findings.append(
+                Finding(
+                    rule="duplicate-claim-id",
+                    severity=SEVERITY_ADVISORY,
+                    path=path,
+                    message=(
+                        f"Stable canonical claim ID `{claim_id}` is reused. "
+                        "Assign one durable ID to one canonical claim "
+                        "(see docs/DocumentationArchitecture.md §14)."
+                    ),
+                    detail=detail,
+                )
+            )
+    return findings
+
+
 ALL_CHECKS = (
     check_missing_document_class,
     check_imperative_plan_in_canonical_area,
     check_duplicate_canonical_authority,
     check_contract_missing_authority_statement,
     check_discouraged_decision_record,
+    check_malformed_claim_ids,
+    check_duplicate_claim_ids,
 )
 
 

--- a/tools/check_documentation_architecture.py
+++ b/tools/check_documentation_architecture.py
@@ -122,7 +122,7 @@ CANONICAL_CLAIM_ID_RE = re.compile(
 )
 CLAIM_HEADING_RE = re.compile(
     rf"^\s{{0,3}}#{{1,6}}\s+(?:`|\*\*)?"
-    rf"(?P<id>(?:{CANONICAL_CLAIM_PREFIX_RE})(?:-[A-Za-z0-9_]+)?)"
+    rf"(?P<id>(?:{CANONICAL_CLAIM_PREFIX_RE})(?:-[^\s:|`*]*)?)"
     rf"(?:`|\*\*)?(?=\s|:|-|$)"
 )
 
@@ -165,6 +165,8 @@ def is_canonical_doc(path: str) -> bool:
     """True for canonical declarative docs (``docs/**.md`` minus excluded trees)."""
 
     if not path.endswith(".md"):
+        return False
+    if path.endswith(".template.md"):
         return False
     if not _is_under(path, CANONICAL_DOCS_ROOT):
         return False


### PR DESCRIPTION
Issue reference: MM-929

Summary:
- Adds stable canonical claim ID conventions for DOC-REQ, CONTRACT, INV, NON-GOAL, QUALITY, and TEST IDs.
- Updates canonical viewpoint templates with concise stable claim heading examples.
- Extends the documentation architecture checker with advisory malformed and duplicate claim ID warnings.
- Adds focused unit coverage for the guidance, templates, and validator behavior.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/docs/test_documentation_architecture_standard.py tests/unit/docs/test_viewpoint_templates.py tests/unit/tools/test_check_documentation_architecture.py
- git diff --check origin/main...HEAD
- secret-pattern scan over git diff origin/main...HEAD

Remaining risks:
- Existing canonical docs are not backfilled with claim IDs; adoption remains incremental by design.
