### PR TITLE
MM-930 add advisory MoonSpec doc indexer

### DIFF
--- a/tests/unit/tools/test_index_moonspec_docs.py
+++ b/tests/unit/tools/test_index_moonspec_docs.py
@@ -123,3 +123,59 @@ def test_default_cli_is_advisory_only_even_with_warnings(tmp_path: Path, monkeyp
     warning_rules = {warning["rule"] for warning in payload["warnings"]}
     assert "missing-index-document-class" in warning_rules
     assert "missing-index-authority" in warning_rules
+
+
+def test_heading_extraction_skips_fenced_code_and_accepts_indentation(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "docs" / "Indented.md",
+        "# Real Document\n\n"
+        "```bash\n"
+        "# Not A Heading\n"
+        "```\n\n"
+        "   ## Indented Section\n\n"
+        "~~~python\n"
+        "### Also Not A Heading\n"
+        "~~~\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    anchors = {claim["anchor"] for claim in payload["claims"]}
+    assert "docs/Indented.md#real-document" in anchors
+    assert "docs/Indented.md#indented-section" in anchors
+    assert "docs/Indented.md#not-a-heading" not in anchors
+    assert "docs/Indented.md#also-not-a-heading" not in anchors
+
+
+def test_duplicate_headings_get_unique_markdown_style_anchor_suffixes(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "docs" / "Roadmap.md",
+        "# Roadmap\n\n## Remaining Work\n\nFirst.\n\n## Remaining Work\n\nSecond.\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    claims = {claim["anchor"]: claim for claim in payload["claims"]}
+    assert "docs/Roadmap.md#remaining-work" in claims
+    assert "docs/Roadmap.md#remaining-work-1" in claims
+    assert (
+        claims["docs/Roadmap.md#remaining-work"]["id"]
+        != claims["docs/Roadmap.md#remaining-work-1"]["id"]
+    )
+
+
+def test_explicit_paths_are_normalized_relative_to_repo_root(tmp_path: Path) -> None:
+    doc_path = tmp_path / "docs" / "Explicit.md"
+    _write(doc_path, "# Explicit\n\nSome prose.\n")
+
+    payload = mod.build_index(
+        paths=["./docs/Explicit.md", str(doc_path)],
+        root=tmp_path,
+    )
+
+    assert payload["documentCount"] == 1
+    assert payload["documents"][0]["path"] == "docs/Explicit.md"

--- a/tests/unit/tools/test_index_moonspec_docs.py
+++ b/tests/unit/tools/test_index_moonspec_docs.py
@@ -1,0 +1,125 @@
+"""MM-930 advisory MoonSpec documentation index tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "tools" / "index_moonspec_docs.py"
+TOOLS_PATH = str(MODULE_PATH.parent)
+if TOOLS_PATH not in sys.path:
+    sys.path.insert(0, TOOLS_PATH)
+
+SPEC = importlib.util.spec_from_file_location("index_moonspec_docs", MODULE_PATH)
+assert SPEC is not None
+index_moonspec_docs = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = index_moonspec_docs
+SPEC.loader.exec_module(index_moonspec_docs)
+
+mod = index_moonspec_docs
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_build_index_emits_documents_claims_and_advisory_warnings(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs" / "Api" / "WidgetContract.md",
+        "# Widget Contract\n\n"
+        "**Document Class:** Module Contract Specification\n"
+        "**Authority:** Widget API payloads\n"
+        "**Owning Surface:** moonmind/widgets\n"
+        "**Related Docs:** [Architecture](../MoonMindArchitecture.md), docs/Api/Other.md\n"
+        "**Related Implementation:** moonmind/widgets/api.py, WidgetApi\n\n"
+        "## Payload\n\nThe payload has one field.\n",
+    )
+    _write(
+        tmp_path / ".specify" / "memory" / "constitution.md",
+        "# Constitution\n\n## Principle\n\nDo the thing.\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    assert payload["issue"] == "MM-930"
+    assert payload["sourceIssue"] == "MM-927"
+    assert payload["advisoryOnly"] is True
+    assert payload["documentCount"] == 2
+
+    docs = {entry["path"]: entry for entry in payload["documents"]}
+    contract = docs["docs/Api/WidgetContract.md"]
+    assert contract["documentClass"] == "Module Contract Specification"
+    assert contract["viewpoint"] == "Module Contract Specification"
+    assert contract["authority"] == "Widget API payloads"
+    assert contract["owningSurface"] == "moonmind/widgets"
+    assert "../MoonMindArchitecture.md" in contract["relatedDocs"]
+    assert "moonmind/widgets/api.py" in contract["relatedImplementation"]
+
+    claims = {entry["anchor"]: entry for entry in payload["claims"]}
+    assert "docs/Api/WidgetContract.md#widget-contract" in claims
+    assert claims["docs/Api/WidgetContract.md#payload"]["type"] == "section"
+    assert claims["docs/Api/WidgetContract.md#payload"]["digest"].startswith("sha256:")
+    assert claims["docs/Api/WidgetContract.md#payload"]["id"].startswith("claim:")
+
+
+def test_docs_tmp_is_not_treated_as_canonical(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs" / "tmp" / "MigrationPlan.md",
+        "# Migration Plan\n\n**Document Class:** Imperative working document\n",
+    )
+    _write(
+        tmp_path / "docs" / "SystemDesign.md",
+        "# System Design\n\n"
+        "**Document Class:** Canonical declarative\n"
+        "**Authority:** System behavior\n"
+        "**Owning Surface:** moonmind/system\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    paths = {entry["path"] for entry in payload["documents"]}
+    assert "docs/SystemDesign.md" in paths
+    assert "docs/tmp/MigrationPlan.md" not in paths
+    assert all("docs/tmp/" not in claim["anchor"] for claim in payload["claims"])
+
+
+def test_cli_writes_json_under_artifact_path_without_mutating_docs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write(
+        tmp_path / "docs" / "MoonMindArchitecture.md",
+        "# MoonMind Architecture\n\n"
+        "**Document Class:** System Architecture View\n"
+        "**Authority:** System structure\n"
+        "**Owning Surface:** MoonMind\n",
+    )
+    before = (tmp_path / "docs" / "MoonMindArchitecture.md").read_text(encoding="utf-8")
+    output = tmp_path / "artifacts" / "doc-index" / "index.json"
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    rc = mod.main(["--output", str(output)])
+
+    assert rc == 0
+    assert output.is_file()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["documents"][0]["path"] == "docs/MoonMindArchitecture.md"
+    after = (tmp_path / "docs" / "MoonMindArchitecture.md").read_text(encoding="utf-8")
+    assert after == before
+
+
+def test_default_cli_is_advisory_only_even_with_warnings(tmp_path: Path, monkeypatch) -> None:
+    _write(tmp_path / "docs" / "Unclassified.md", "# Unclassified\n\nSome prose.\n")
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    rc = mod.main(["--output", str(tmp_path / "artifacts" / "index.json")])
+
+    assert rc == 0
+    payload = json.loads((tmp_path / "artifacts" / "index.json").read_text(encoding="utf-8"))
+    warning_rules = {warning["rule"] for warning in payload["warnings"]}
+    assert "missing-index-document-class" in warning_rules
+    assert "missing-index-authority" in warning_rules

--- a/tools/index_moonspec_docs.py
+++ b/tools/index_moonspec_docs.py
@@ -36,7 +36,7 @@ ISSUE = "MM-930"
 DEFAULT_OUTPUT = Path("artifacts/moonspec-doc-index/index.json")
 CONSTITUTION_PATH = ".specify/memory/constitution.md"
 
-HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 METADATA_RE = re.compile(r"^\s*\*\*([^*:\n]+):\*\*\s*(.*?)\s*$")
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 IMPLEMENTATION_TOKEN_RE = re.compile(
@@ -154,7 +154,14 @@ def _anchor_for_heading(heading: str) -> str:
 def _heading_sections(text: str) -> list[tuple[int, str, str]]:
     lines = text.splitlines()
     headings: list[tuple[int, int, str]] = []
+    in_fence = False
     for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         match = HEADING_RE.match(line)
         if match:
             headings.append((index, len(match.group(1)), match.group(2).strip()))
@@ -186,6 +193,14 @@ def _claim_digest(path: str, heading: str, section_text: str) -> str:
     return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def _unique_anchor(anchor: str, seen: dict[str, int]) -> str:
+    count = seen.get(anchor, 0)
+    seen[anchor] = count + 1
+    if count == 0:
+        return anchor
+    return f"{anchor}-{count}"
+
+
 def _warning(rule: str, path: str, message: str, detail: str = "") -> Finding:
     return Finding(
         rule=rule,
@@ -205,7 +220,21 @@ def _constitution_doc(root: Path) -> tuple[str, str] | None:
 
 
 def _index_paths(paths: Iterable[str], *, root: Path) -> list[str]:
-    docs = [path for path in paths if is_canonical_doc(path)]
+    resolved_root = root.resolve()
+    docs: list[str] = []
+    for path in paths:
+        path_obj = Path(path)
+        try:
+            candidate = path_obj if path_obj.is_absolute() else root / path_obj
+            resolved_candidate = candidate.resolve()
+            if resolved_candidate.is_relative_to(resolved_root):
+                normalized = resolved_candidate.relative_to(resolved_root).as_posix()
+            else:
+                normalized = path_obj.as_posix()
+        except (OSError, RuntimeError, ValueError):
+            normalized = path_obj.as_posix()
+        if is_canonical_doc(normalized):
+            docs.append(normalized)
     if (root / CONSTITUTION_PATH).is_file():
         docs.append(CONSTITUTION_PATH)
     return sorted(dict.fromkeys(docs))
@@ -306,8 +335,9 @@ def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None)
             )
         )
 
+        seen_anchors: dict[str, int] = {}
         for level, heading, section_text in _heading_sections(doc.text):
-            anchor = _anchor_for_heading(heading)
+            anchor = _unique_anchor(_anchor_for_heading(heading), seen_anchors)
             claim_entries.append(
                 ClaimEntry(
                     id=_claim_id(path, anchor),

--- a/tools/index_moonspec_docs.py
+++ b/tools/index_moonspec_docs.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""MM-930 advisory MoonSpec documentation indexer.
+
+Builds a machine-readable JSON index of canonical MoonSpec documents and stable
+heading claims without mutating checked-in documentation.
+
+Traceability: MM-930 (source issue MM-927, "Moon Spec Doc Architecture
+Alignment"); covers DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-010, and
+DESIGN-REQ-011.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from check_documentation_architecture import (
+    NON_CANONICAL_DOC_DIRS,
+    REPO_ROOT,
+    Finding,
+    all_doc_paths,
+    is_canonical_doc,
+    load_docs,
+    run_checks,
+)
+
+
+ISSUE = "MM-930"
+DEFAULT_OUTPUT = Path("artifacts/moonspec-doc-index/index.json")
+CONSTITUTION_PATH = ".specify/memory/constitution.md"
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+METADATA_RE = re.compile(r"^\s*\*\*([^*:\n]+):\*\*\s*(.*?)\s*$")
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+IMPLEMENTATION_TOKEN_RE = re.compile(
+    r"(?:^|[\s,(])((?:api_service|dashboard|moonmind|scripts|tests|tools|worker|"
+    r"workers|docs|\.agents|\.specify)/[^\s,)`]+|[A-Za-z_][A-Za-z0-9_]*\([^)]*\)|"
+    r"[A-Za-z_][A-Za-z0-9_.]*[A-Za-z0-9_])"
+)
+
+VIEWPOINTS = {
+    "system architecture view",
+    "module architecture view",
+    "system / feature design view",
+    "feature design view",
+    "module contract specification",
+    "cross-cutting concept view",
+}
+
+
+@dataclass(frozen=True)
+class DocumentEntry:
+    path: str
+    documentClass: str
+    viewpoint: str
+    authority: str
+    owningSurface: str
+    relatedDocs: list[str]
+    relatedImplementation: list[str]
+
+
+@dataclass(frozen=True)
+class ClaimEntry:
+    id: str
+    documentPath: str
+    heading: str
+    type: str
+    anchor: str
+    digest: str
+
+
+def _normalize_metadata_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", key.lower())
+
+
+def _metadata(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in text.splitlines()[:80]:
+        match = METADATA_RE.match(line)
+        if match:
+            values[_normalize_metadata_key(match.group(1))] = match.group(2).strip()
+    return values
+
+
+def _strip_markdown(value: str) -> str:
+    value = re.sub(r"`([^`]+)`", r"\1", value)
+    value = re.sub(r"\*\*([^*]+)\*\*", r"\1", value)
+    value = re.sub(r"\*([^*]+)\*", r"\1", value)
+    return value.strip()
+
+
+def _split_metadata_list(value: str) -> list[str]:
+    if not value or value.strip().lower() in {"none", "n/a", "na"}:
+        return []
+    links = [target.strip() for _, target in MARKDOWN_LINK_RE.findall(value)]
+    without_links = MARKDOWN_LINK_RE.sub("", value)
+    parts = [
+        _strip_markdown(part).strip(" .;")
+        for part in re.split(r",|;", without_links)
+        if _strip_markdown(part).strip(" .;")
+    ]
+    return sorted(dict.fromkeys([*links, *parts]))
+
+
+def _related_implementation(value: str) -> list[str]:
+    if not value or value.strip().lower() in {"none", "n/a", "na"}:
+        return []
+    explicit = _split_metadata_list(value)
+    tokens = [
+        token.strip(" .;`")
+        for token in IMPLEMENTATION_TOKEN_RE.findall(value)
+        if token.strip(" .;`")
+    ]
+    return sorted(dict.fromkeys([*explicit, *tokens]))
+
+
+def _infer_viewpoint(path: str, metadata: dict[str, str]) -> str:
+    declared_viewpoint = metadata.get("viewpoint", "")
+    if declared_viewpoint:
+        return declared_viewpoint
+
+    declared_class = metadata.get("documentclass", "")
+    if declared_class.lower() in VIEWPOINTS:
+        return declared_class
+
+    name = path.rsplit("/", 1)[-1].lower()
+    if "contract" in name:
+        return "Module Contract Specification"
+    if name.endswith("architecture.md"):
+        if path.count("/") == 1:
+            return "System Architecture View"
+        return "Module Architecture View"
+    if name.endswith("design.md") or name.endswith("system.md"):
+        return "System / Feature Design View"
+    return "Cross-Cutting Concept View"
+
+
+def _anchor_for_heading(heading: str) -> str:
+    anchor = heading.strip().lower()
+    anchor = re.sub(r"`([^`]+)`", r"\1", anchor)
+    anchor = re.sub(r"<[^>]+>", "", anchor)
+    anchor = re.sub(r"[^\w\s-]", "", anchor)
+    anchor = re.sub(r"\s+", "-", anchor.strip())
+    return anchor
+
+
+def _heading_sections(text: str) -> list[tuple[int, str, str]]:
+    lines = text.splitlines()
+    headings: list[tuple[int, int, str]] = []
+    for index, line in enumerate(lines):
+        match = HEADING_RE.match(line)
+        if match:
+            headings.append((index, len(match.group(1)), match.group(2).strip()))
+
+    sections: list[tuple[int, str, str]] = []
+    for position, (line_index, level, heading) in enumerate(headings):
+        next_index = headings[position + 1][0] if position + 1 < len(headings) else len(lines)
+        section_text = "\n".join(lines[line_index:next_index]).strip()
+        sections.append((level, heading, section_text))
+    return sections
+
+
+def _claim_type(level: int) -> str:
+    if level == 1:
+        return "document"
+    if level == 2:
+        return "section"
+    return "subsection"
+
+
+def _claim_id(path: str, anchor: str) -> str:
+    raw = f"{path}#{anchor}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    return f"claim:{digest}"
+
+
+def _claim_digest(path: str, heading: str, section_text: str) -> str:
+    raw = f"{path}\n{heading}\n{section_text}"
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _warning(rule: str, path: str, message: str, detail: str = "") -> Finding:
+    return Finding(
+        rule=rule,
+        severity="advisory",
+        path=path,
+        message=message,
+        detail=detail,
+    )
+
+
+def _constitution_doc(root: Path) -> tuple[str, str] | None:
+    path = root / CONSTITUTION_PATH
+    try:
+        return CONSTITUTION_PATH, path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _index_paths(paths: Iterable[str], *, root: Path) -> list[str]:
+    docs = [path for path in paths if is_canonical_doc(path)]
+    if (root / CONSTITUTION_PATH).is_file():
+        docs.append(CONSTITUTION_PATH)
+    return sorted(dict.fromkeys(docs))
+
+
+def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None) -> dict:
+    """Build the advisory documentation index payload."""
+
+    root = root or REPO_ROOT
+    input_paths = paths if paths is not None else all_doc_paths(root=root)
+    selected_paths = _index_paths(input_paths, root=root)
+    doc_files = load_docs(
+        [path for path in selected_paths if path != CONSTITUTION_PATH],
+        root=root,
+    )
+
+    constitution = _constitution_doc(root)
+    if constitution is not None and CONSTITUTION_PATH in selected_paths:
+        constitution_path, constitution_text = constitution
+        from check_documentation_architecture import DocFile
+
+        doc_files.append(DocFile(path=constitution_path, text=constitution_text))
+
+    docs_by_path = {doc.path: doc for doc in doc_files}
+    warnings = run_checks(
+        [doc for doc in doc_files if doc.path != CONSTITUTION_PATH],
+        focus_paths=None,
+    )
+
+    document_entries: list[DocumentEntry] = []
+    claim_entries: list[ClaimEntry] = []
+
+    for path in selected_paths:
+        doc = docs_by_path.get(path)
+        if doc is None:
+            warnings.append(
+                _warning(
+                    "document-unreadable",
+                    path,
+                    "Document could not be read as UTF-8 and was skipped.",
+                )
+            )
+            continue
+
+        metadata = _metadata(doc.text)
+        if path == CONSTITUTION_PATH:
+            document_class = "Canonical declarative"
+            viewpoint = "Constitution / Document Model"
+            authority = "Non-negotiable project principles and constraints"
+            owning_surface = "MoonMind"
+            related_docs: list[str] = ["docs/Workflows/MoonSpecDocumentModel.md"]
+            related_implementation: list[str] = []
+        else:
+            document_class = metadata.get("documentclass") or "Canonical declarative"
+            viewpoint = _infer_viewpoint(path, metadata)
+            authority = metadata.get("authority", "")
+            owning_surface = metadata.get("owningsurface", "")
+            related_docs = _split_metadata_list(metadata.get("relateddocs", ""))
+            related_implementation = _related_implementation(
+                metadata.get("relatedimplementation", "")
+            )
+
+        if not metadata.get("documentclass") and path != CONSTITUTION_PATH:
+            warnings.append(
+                _warning(
+                    "missing-index-document-class",
+                    path,
+                    "Document entry uses location-derived `Canonical declarative`; "
+                    "add a Document Class marker for stronger indexing.",
+                )
+            )
+        if not authority:
+            warnings.append(
+                _warning(
+                    "missing-index-authority",
+                    path,
+                    "Document entry has no declared Authority metadata.",
+                )
+            )
+        if not owning_surface:
+            warnings.append(
+                _warning(
+                    "missing-index-owning-surface",
+                    path,
+                    "Document entry has no declared Owning Surface metadata.",
+                )
+            )
+
+        document_entries.append(
+            DocumentEntry(
+                path=path,
+                documentClass=document_class,
+                viewpoint=viewpoint,
+                authority=authority,
+                owningSurface=owning_surface,
+                relatedDocs=related_docs,
+                relatedImplementation=related_implementation,
+            )
+        )
+
+        for level, heading, section_text in _heading_sections(doc.text):
+            anchor = _anchor_for_heading(heading)
+            claim_entries.append(
+                ClaimEntry(
+                    id=_claim_id(path, anchor),
+                    documentPath=path,
+                    heading=heading,
+                    type=_claim_type(level),
+                    anchor=f"{path}#{anchor}",
+                    digest=_claim_digest(path, heading, section_text),
+                )
+            )
+
+    warning_dicts = [
+        asdict(warning)
+        for warning in sorted(warnings, key=lambda w: (w.path, w.rule, w.message))
+    ]
+    return {
+        "tool": "index_moonspec_docs",
+        "issue": ISSUE,
+        "sourceIssue": "MM-927",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "advisoryOnly": True,
+        "canonicalRoots": ["docs", CONSTITUTION_PATH],
+        "excludedCanonicalDocDirs": list(NON_CANONICAL_DOC_DIRS),
+        "documentCount": len(document_entries),
+        "claimCount": len(claim_entries),
+        "warningCount": len(warning_dicts),
+        "documents": [asdict(entry) for entry in document_entries],
+        "claims": [asdict(entry) for entry in claim_entries],
+        "warnings": warning_dicts,
+    }
+
+
+def write_index(payload: dict, output: Path, *, root: Path | None = None) -> Path:
+    root = root or REPO_ROOT
+    output_path = output if output.is_absolute() else root / output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Artifact JSON output path (default: {DEFAULT_OUTPUT.as_posix()}).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Console output format. The artifact file is always JSON.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when advisory warnings exist. Default is advisory-only.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Optional explicit canonical doc paths to index. docs/tmp remains excluded.",
+    )
+    args = parser.parse_args(argv)
+
+    payload = build_index(args.paths or None)
+    output_path = write_index(payload, args.output)
+
+    if args.format == "json":
+        print(json.dumps({"output": str(output_path), **payload}, indent=2, sort_keys=True))
+    else:
+        print(
+            "MM-930 MoonSpec documentation index "
+            f"wrote {payload['documentCount']} document(s), "
+            f"{payload['claimCount']} claim(s), and "
+            f"{payload['warningCount']} advisory warning(s) to {output_path}."
+        )
+
+    if args.strict and payload["warningCount"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Issue reference

- MM-930: https://moonladder.atlassian.net/browse/MM-930

## Summary

- Added `tools/index_moonspec_docs.py`, an advisory MoonSpec documentation indexer that writes JSON under `artifacts/moonspec-doc-index/index.json` by default.
- Indexes canonical docs plus the constitution, excluding `docs/tmp`, and emits document entries with class, viewpoint, authority, owning surface, related docs, and related implementation.
- Emits stable heading claim entries with ids, anchors, types, and SHA-256 digests, while preserving structured advisory warnings.
- Added unit coverage for document/claim output, `docs/tmp` exclusion, artifact output, and advisory-only warning behavior.

## Tests run

- `./tools/test_unit.sh tests/unit/tools/test_index_moonspec_docs.py`
- Python target: `4 passed`
- Frontend unit wrapper portion: `29 passed`; `498 passed | 236 skipped`

## Remaining risks

- The indexer infers missing metadata as advisory warnings; docs without declared metadata may produce sparse authority or owning-surface fields until canonical docs are annotated.
