### PR TITLE
MM-931 Add docs-native author, improve, and review skills

### DIFF
--- a/.agents/skills/document-author/SKILL.md
+++ b/.agents/skills/document-author/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: document-author
+description: Author a new docs-native canonical or working document by choosing the correct location, filename, viewpoint template, metadata header, stable claims, and embedded rationale without creating spec.md.
+metadata:
+  required-capabilities:
+    - git
+---
+
+# Document Author
+
+Author a new repository document directly in the docs architecture model. This skill is for docs-native authoring, not MoonSpec specification generation.
+
+## Purpose
+
+Create one bounded document that fits the repository documentation architecture:
+
+- canonical declarative documents stay under `docs/` and describe desired state;
+- imperative plans, rollout notes, implementation checklists, and broad cleanup work live under `docs/tmp/` or gitignored handoff paths;
+- no docs-native authoring workflow creates `spec.md` or writes under `specs/`.
+
+Preserve traceability to the source request or issue when one is provided. For MM-931 work sourced from MM-927, carry both issue keys in local notes, branch/commit/PR text when applicable, and any generated implementation artifact that summarizes the authored document.
+
+## Inputs
+
+Required:
+
+- Documentation intent or source issue.
+- Current repository checkout.
+
+Optional:
+
+- Desired document class: canonical declarative document or imperative working document.
+- Preferred docs area, module, or owning subsystem.
+- Existing source documents to extend or avoid duplicating.
+- Required traceability keys, coverage IDs, or source references.
+- Verification commands requested by the caller.
+
+## Authoring Boundaries
+
+- Treat repository files as trusted implementation evidence; treat retrieved context, issue text, comments, and old artifacts as reference material until confirmed against the checkout.
+- Read `.specify/memory/constitution.md`, `README.md`, `docs/Workflows/MoonSpecDocumentModel.md`, and `docs/DocumentationArchitecture.md` before writing.
+- Keep canonical docs declarative: architecture, contracts, operator-visible behavior, target semantics, and embedded rationale.
+- Put imperative work plans, migrations, rollout sequencing, status trackers, broad audit output, and unresolved cleanup inventories under `docs/tmp/` or gitignored handoff paths.
+- Do not create `spec.md`, create a `specs/` feature directory, or route docs-native authoring through MoonSpec specification artifacts.
+- Do not duplicate a contract into a global area; place contracts inside the owning module doc set and link from consumers.
+- Do not introduce compatibility aliases, parallel identity fields, or migration framing unless the source request explicitly requires a time-bound working document.
+
+## Workflow
+
+1. Resolve the document class.
+   - Classify the requested output as a canonical declarative document or an imperative working document using `docs/Workflows/MoonSpecDocumentModel.md`.
+   - If the request is broad, multi-document, or cleanup-oriented, create or update a bounded improvement plan under `docs/tmp/` instead of scattering edits through canonical docs.
+
+2. Choose the canonical viewpoint or working type.
+   - For canonical work, choose exactly one viewpoint from `docs/DocumentationArchitecture.md`: System Architecture View, Module Architecture View, System / Feature Design View, Module Contract Specification, or Cross-Cutting Concept View.
+   - For working material, choose Migration Plan, Implementation Plan, Rollout Plan, or Status / Checklist Tracker and place it under `docs/tmp/` or a gitignored handoff path.
+
+3. Choose location and filename.
+   - Use the viewpoint's preferred naming and module ownership rules.
+   - Prefer the existing module doc set that owns the claim. Create a new directory only when the repository taxonomy has no suitable owner.
+   - Check for duplicate or overlapping documents before creating a new file.
+
+4. Select the viewpoint template and metadata.
+   - Use the relevant template guidance from `docs/DocumentationArchitecture.md`.
+   - Add the required metadata header for the document class, including `Status:` for System / Feature Design Views.
+   - Include source traceability when a Jira issue, source design, or coverage ID drove the document.
+
+5. Author stable claims and rationale.
+   - State durable desired behavior directly.
+   - Embed significant design rationale in the owning document, near the rule it explains or in a `## Design Rationale` section.
+   - Link to owning contracts instead of restating them.
+   - Mark unverified claims as open questions in `docs/tmp/` rather than presenting them as canonical facts.
+
+6. Validate architecture fit.
+   - Confirm the document class, location, filename, viewpoint, metadata, stable claims, and rationale are all explicitly satisfied.
+   - Confirm no `spec.md` file or `specs/` feature directory was created.
+   - Run available documentation checks and any targeted tests required by the repository instructions.
+
+## Output Checklist
+
+Report:
+
+- Document class and viewpoint or working type.
+- Chosen path and filename, with the ownership reason.
+- Metadata header fields added.
+- Stable claims added and evidence used.
+- Rationale placement.
+- Duplicate or authority conflicts checked.
+- Verification commands and results.
+- Confirmation that no docs-native `spec.md` was created.
+
+## Failure Modes
+
+- The correct owner document already exists: update or link to it instead of creating a duplicate.
+- The request is too broad for one canonical document: write a bounded `docs/tmp/` improvement plan and stop there.
+- The authority owner is unclear: report the ambiguity and propose the narrowest `docs/tmp/` investigation plan rather than creating canonical claims.
+- Implementation evidence is missing: keep the claim out of canonical docs, record the gap, and ask the caller to supply evidence or authorize an implementation investigation.
+- Required verification cannot run: report the exact command and blocker.

--- a/.agents/skills/document-author/SKILL.md
+++ b/.agents/skills/document-author/SKILL.md
@@ -18,7 +18,7 @@ Create one bounded document that fits the repository documentation architecture:
 - imperative plans, rollout notes, implementation checklists, and broad cleanup work live under `docs/tmp/` or gitignored handoff paths;
 - no docs-native authoring workflow creates `spec.md` or writes under `specs/`.
 
-Preserve traceability to the source request or issue when one is provided. For MM-931 work sourced from MM-927, carry both issue keys in local notes, branch/commit/PR text when applicable, and any generated implementation artifact that summarizes the authored document.
+Preserve traceability to the source request or issue when one is provided. Carry any provided issue keys in local notes, branch/commit/PR text when applicable, and any generated implementation artifact that summarizes the authored document.
 
 ## Inputs
 

--- a/.agents/skills/document-health-remediate/SKILL.md
+++ b/.agents/skills/document-health-remediate/SKILL.md
@@ -70,6 +70,8 @@ Example invocations:
 - Keep canonical docs under `docs/` focused on desired state: architecture, contracts, operator-visible behavior, and target semantics.
 - Put migration notes, rollout checklists, and temporary investigation details under `docs/tmp/` or in gitignored handoff paths, not as the main framing of canonical docs.
 - Follow the document classes and precedence rules in `docs/Workflows/MoonSpecDocumentModel.md`.
+- When applying documentation architecture findings, fix or explicitly report missing metadata, unclear authority, missing embedded rationale, duplicate contract definitions, imperative leakage in canonical docs, and unverifiable canonical claims.
+- Route broad, multi-document, or uncertain cleanup to a bounded `docs/tmp/` improvement plan instead of expanding the remediation beyond the approved report.
 - When a superseded document is no longer needed, prefer removing or replacing it over leaving compatibility-era ambiguity, but only when its unique content has been preserved or intentionally discarded.
 - Never apply a disallowed action, and never apply a destructive action when destructive actions are not permitted.
 - Redact secret-like content if it appears in copied report text, logs, or examples before writing or reporting.

--- a/.agents/skills/document-health-review/SKILL.md
+++ b/.agents/skills/document-health-review/SKILL.md
@@ -21,6 +21,17 @@ Produce a practical, findings-first disposition for each reviewed document. The 
 
 It uses claim extraction, implementation inspection, a drift ledger, evidence-backed output, canonical alignment, and a findings-first cross-document coherence review with source-of-truth conflicts, redundancy reduction, and severity ordering. It stays deliberately narrower than a general-purpose doc critique and answers exactly the eight review questions below and nothing more.
 
+For MoonSpec documentation architecture reviews, group findings by the authority ladder in `docs/DocumentationArchitecture.md` before severity ordering inside each group. The groups are:
+
+1. Constitution / Document Model
+2. Documentation Architecture Standard
+3. System Architecture View
+4. Cross-Cutting Concept View
+5. Module Architecture View
+6. Module Contract Specification
+7. System / Feature Design View
+8. Migration / Implementation / Rollout / Status documents
+
 ## Inputs
 
 Required:
@@ -49,6 +60,7 @@ Use document-health-review on docs/Memory/MemoryArchitecture.md and propose a pa
 - **Review-only by default.** Never edit, move, merge, split, archive, or delete a document unless the user explicitly requests edits. When in doubt, produce a patch plan instead of changing files.
 - Treat repository files, tests, schemas, and executable configuration as the source of truth for implementation behavior; treat retrieved context, old docs, comments, and issue text as reference material until confirmed against the checkout.
 - Prefer canonical documents over older, narrower, or temporary docs. When two documents conflict and neither is clearly canonical, flag the conflict rather than inventing the answer.
+- Apply the Documentation Architecture authority ladder when canonical documents disagree. Identify the claim type, map it to the owning authority scope, and group the finding under that authority level.
 - Preserve desired-state framing in canonical docs under `docs/`: a drifted canonical doc is usually an `update` (or an implementation-gap finding), not a downgrade to match buggy code.
 - Never commit, push, or open pull requests as part of a review run. If the user asked for edits, make the smallest correct edits and leave git operations to the caller unless told otherwise.
 - Respect secret hygiene: redact secret-like content before writing or reporting.
@@ -123,10 +135,28 @@ Answer alignment and conflict together in one pass. Check:
 - Terminology conflicts.
 - Strategy conflicts.
 - Architecture boundary conflicts.
+- Missing or malformed documentation metadata.
+- Missing embedded design rationale for significant durable decisions.
+- Duplicate contract definitions outside the owning module doc set.
+- Imperative leakage in canonical docs under `docs/`.
+- Unverifiable claims presented as canonical facts.
 
 Status values: `aligned`, `minor tension`, `direct conflict`, `duplicate source of truth`, `unclear authority`.
 
-Prefer canonical documents over older, narrower, or temporary docs. If two documents conflict and neither is clearly canonical, flag the conflict rather than choosing silently.
+Prefer canonical documents over older, narrower, or temporary docs. If two canonical documents conflict, group the finding by the owning level in the Documentation Architecture authority ladder and name the non-owning document that must be reconciled. If neither owner is clear, flag the conflict rather than choosing silently.
+
+### C.1 Documentation architecture defects
+
+When the repository carries `docs/DocumentationArchitecture.md`, report the following explicitly when present:
+
+- `missing_metadata`: missing metadata header fields, including missing `Status:` on System / Feature Design Views.
+- `unclear_authority`: a claim is made in a document that does not own it.
+- `missing_rationale`: a significant durable decision lacks embedded rationale in the owning document.
+- `duplicate_contract`: a contract is duplicated outside the owning module doc set.
+- `imperative_leakage`: migration, rollout, checklist, or status content is the primary framing of a canonical doc.
+- `unverifiable_claim`: a canonical fact cannot be supported by repository evidence or cited owning docs.
+
+If the finding implies broad cleanup across multiple documents, recommend a bounded improvement plan under `docs/tmp/` instead of direct canonical edits.
 
 ### D. Strategy simplification
 

--- a/.agents/skills/document-update/SKILL.md
+++ b/.agents/skills/document-update/SKILL.md
@@ -31,6 +31,8 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
 - Keep canonical docs under `docs/` focused on desired state: architecture, contracts, operator-visible behavior, and target semantics.
 - Put migration notes, rollout checklists, implementation backlogs, and temporary investigation details under `docs/tmp/` or in gitignored handoff paths (for example `artifacts/` for tool handoffs, or run-local `specs/<feature-id>/` packets), not as the main framing of canonical docs.
 - Follow the document classes and precedence rules in `docs/Workflows/MoonSpecDocumentModel.md`.
+- When `docs/DocumentationArchitecture.md` exists, fix or report missing metadata, unclear authority, missing embedded rationale, duplicate contract definitions, imperative leakage in canonical docs, and unverifiable canonical claims.
+- Route broad, multi-document, or uncertain improvement work to a bounded `docs/tmp/` improvement plan instead of making speculative canonical edits.
 - When a superseded behavior is no longer implemented, remove or replace the stale description instead of preserving compatibility-era ambiguity.
 
 ## Workflow
@@ -68,6 +70,7 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
    - Assess whether the drift-correcting update would move the document toward or away from those canonical sources.
    - If the update is clearly aligned with the constitution, README, and architecture, proceed to edit the document.
    - If the update appears to contradict the project's declared direction, or if the correct direction is uncertain, do **not** edit the document. Instead, proceed to step 8 (Jira fallback).
+   - If the needed work spans many documents or cannot be made safely in one bounded edit, write a `docs/tmp/` improvement plan that records the findings, authority owners, and proposed follow-up instead of broadening the update.
 
 6. Edit the document.
    - Update only the sections needed to correct the drift.
@@ -75,6 +78,7 @@ For canonical documentation under `docs/`, do not downgrade the documented desir
    - Remove obsolete compatibility language, stale migration framing, and contradicted examples.
    - Preserve the document's existing voice, heading structure, and terminology where they remain accurate.
    - Add or update cross-references only when they help readers find the canonical contract.
+   - For documentation architecture defects, either fix the local defect directly or report why it needs follow-up: missing metadata, authority mismatch, missing rationale, duplicate contracts, imperative leakage, and unverifiable claims must not be silently ignored.
 
 7. Verify the update.
    - Re-read the changed sections and compare them against the drift ledger.

--- a/api_service/data/presets/document-author.yaml
+++ b/api_service/data/presets/document-author.yaml
@@ -28,7 +28,7 @@ inputs:
     label: Traceability
     type: text
     required: false
-    default: "MM-931 from MM-927"
+    default: ""
   - name: constraints
     label: Constraints
     type: textarea

--- a/api_service/data/presets/document-author.yaml
+++ b/api_service/data/presets/document-author.yaml
@@ -1,0 +1,66 @@
+slug: document-author
+title: Document Author
+description: Author a new docs-native document by selecting its document class, location, filename, viewpoint template, metadata, stable claims, and rationale without creating spec.md.
+scope: global
+tags:
+  - documentation
+  - document-authoring
+  - docs-native
+requiredCapabilities:
+  - git
+annotations:
+  sourceSkill: document-author
+  sourceIssueKey: MM-931
+  sourceReference: MM-927
+  output: authored-document
+inputs:
+  - name: documentation_intent
+    label: Documentation Intent
+    type: textarea
+    required: true
+    default: ""
+  - name: preferred_area
+    label: Preferred Docs Area
+    type: text
+    required: false
+    default: "docs/"
+  - name: traceability
+    label: Traceability
+    type: text
+    required: false
+    default: "MM-931 from MM-927"
+  - name: constraints
+    label: Constraints
+    type: textarea
+    required: false
+    default: ""
+steps:
+  - title: Author docs-native document
+    type: skill
+    annotations:
+      documentAuthoringRole: author
+      sourceIssueKey: MM-931
+      sourceReference: MM-927
+    instructions: |-
+      Author one docs-native document for this intent:
+      {{ inputs.documentation_intent }}
+
+      Preferred docs area:
+      {{ inputs.preferred_area }}
+
+      Traceability:
+      {{ inputs.traceability }}
+
+      Additional constraints:
+      {{ inputs.constraints }}
+
+      Follow the document-author skill. Choose the document class, location, filename, viewpoint template, metadata header, stable claims, and embedded rationale before writing. If the request is broad or cleanup-oriented, write a bounded improvement plan under docs/tmp/ instead of editing canonical docs.
+
+      Keep canonical docs declarative. Put imperative plans under docs/tmp/ or a gitignored handoff path. Do not create spec.md and do not write under specs/.
+
+      Report the chosen path, ownership reason, metadata fields, stable claims, rationale placement, duplicate/authority checks, verification, and confirmation that no docs-native spec.md was created.
+    skill:
+      id: document-author
+      args: {}
+      requiredCapabilities:
+        - git

--- a/api_service/data/presets/document-health-update.yaml
+++ b/api_service/data/presets/document-health-update.yaml
@@ -37,10 +37,13 @@ steps:
     source code, tests, schemas, and executable configuration as the source of truth.
     Identify documentation health issues such as: drift or factual inaccuracy versus
     the implementation, stale or superseded descriptions, broken or outdated cross-references
-    and links, and coverage or structural gaps. For canonical docs under docs/, judge
+    and links, coverage or structural gaps, missing metadata, unclear authority, missing
+    embedded rationale, duplicate contract definitions, imperative leakage in canonical
+    docs, and unverifiable canonical claims. For canonical docs under docs/, judge
     health against the documented desired state and do not treat a buggy or incomplete
     implementation as the target; record an implementation gap instead of downgrading
-    the doc.
+    the doc. Group documentation architecture findings by the authority ladder in
+    docs/DocumentationArchitecture.md before severity ordering inside each group.
 
 
     This is a review-only step. Do not edit documentation in this step.
@@ -53,9 +56,11 @@ steps:
 
     Write a structured health report to artifacts/document-health-review.json. The
     report must include the reviewed scope and a findings list, where each finding
-    records the document path, the issue type, a severity, the supporting evidence,
-    and a recommended remediation. When no health issues are found, record an empty
-    findings list and say so explicitly.
+    records the document path, the issue type, the authority ladder group when applicable,
+    a severity, the supporting evidence, and a recommended remediation. When a finding
+    implies broad cleanup across multiple documents, recommend a bounded docs/tmp/
+    improvement plan rather than direct canonical edits. When no health issues are found,
+    record an empty findings list and say so explicitly.
 
 
     Scope this review strictly to the documentation scope above. Do not broaden scope
@@ -95,6 +100,13 @@ steps:
     scope beyond the documents in the report. Follow the project''s testing standards:
     if a change touches executable content, add or update the covering tests and confirm
     they pass before finishing.
+
+
+    Fix or explicitly report missing metadata, unclear authority, missing embedded rationale,
+    duplicate contract definitions, imperative leakage in canonical docs, and unverifiable
+    canonical claims when those findings appear in the report. Route broad, multi-document,
+    or uncertain cleanup to a bounded docs/tmp/ improvement plan instead of expanding
+    remediation beyond the approved findings.
 
 
     Report which findings were remediated, which were intentionally left for follow-up,

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -440,6 +440,25 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         result = await session.execute(
             select(Preset)
             .where(
+                Preset.slug == "document-author",
+                Preset.scope_type == PresetScopeType.GLOBAL,
+                Preset.scope_ref.is_(None),
+            )
+
+        )
+        doc_author_template = result.scalar_one_or_none()
+        assert doc_author_template is not None
+        assert doc_author_template.annotations["sourceIssueKey"] == "MM-931"
+        assert doc_author_template.annotations["sourceReference"] == "MM-927"
+        assert len(doc_author_template.steps) == 1
+        assert doc_author_template.steps[0]["type"] == "skill"
+        assert doc_author_template.steps[0]["skill"]["id"] == "document-author"
+        assert "Do not create spec.md" in doc_author_template.steps[0]["instructions"]
+        assert "docs/tmp/" in doc_author_template.steps[0]["instructions"]
+
+        result = await session.execute(
+            select(Preset)
+            .where(
                 Preset.slug == "batch-workflows",
                 Preset.scope_type == PresetScopeType.GLOBAL,
                 Preset.scope_ref.is_(None),

--- a/tests/unit/agents/test_document_author_skill.py
+++ b/tests/unit/agents/test_document_author_skill.py
@@ -1,4 +1,4 @@
-"""Content contract tests for the MM-931 document-author skill."""
+"""Content contract tests for the document-author skill."""
 
 from pathlib import Path
 
@@ -57,8 +57,8 @@ def test_document_author_never_creates_docs_native_spec() -> None:
     assert "Confirmation that no docs-native `spec.md` was created" in text
 
 
-def test_document_author_preserves_mm_931_and_mm_927_traceability() -> None:
+def test_document_author_defines_traceability_guidance() -> None:
     text = _read_skill()
 
-    assert "MM-931" in text
-    assert "MM-927" in text
+    assert "traceability" in text
+    assert "issue keys" in text

--- a/tests/unit/agents/test_document_author_skill.py
+++ b/tests/unit/agents/test_document_author_skill.py
@@ -1,0 +1,64 @@
+"""Content contract tests for the MM-931 document-author skill."""
+
+from pathlib import Path
+
+import yaml
+
+_SKILLS_DIR = Path(__file__).resolve().parents[3] / ".agents" / "skills"
+_SKILL_PATH = _SKILLS_DIR / "document-author" / "SKILL.md"
+
+
+def _read_skill() -> str:
+    return _SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _front_matter(text: str) -> dict:
+    assert text.startswith("---\n"), "SKILL.md must begin with YAML front matter"
+    _, raw, _ = text.split("---\n", 2)
+    return yaml.safe_load(raw)
+
+
+def test_document_author_skill_exists_with_front_matter() -> None:
+    meta = _front_matter(_read_skill())
+
+    assert meta["name"] == "document-author"
+    assert "location, filename, viewpoint template, metadata header" in meta["description"]
+    assert meta["metadata"]["required-capabilities"] == ["git"]
+
+
+def test_document_author_chooses_docs_architecture_fields() -> None:
+    text = _read_skill()
+
+    for expected in (
+        "document class",
+        "location",
+        "filename",
+        "viewpoint template",
+        "metadata header",
+        "stable claims",
+        "embedded rationale",
+    ):
+        assert expected in text
+
+
+def test_document_author_routes_broad_work_to_docs_tmp() -> None:
+    text = _read_skill()
+
+    assert "If the request is broad" in text
+    assert "docs/tmp/" in text
+    assert "improvement plan" in text
+
+
+def test_document_author_never_creates_docs_native_spec() -> None:
+    text = _read_skill()
+
+    assert "Do not create `spec.md`" in text
+    assert "or writes under `specs/`" in text
+    assert "Confirmation that no docs-native `spec.md` was created" in text
+
+
+def test_document_author_preserves_mm_931_and_mm_927_traceability() -> None:
+    text = _read_skill()
+
+    assert "MM-931" in text
+    assert "MM-927" in text

--- a/tests/unit/agents/test_document_health_remediate_skill.py
+++ b/tests/unit/agents/test_document_health_remediate_skill.py
@@ -82,6 +82,22 @@ def test_supported_action_types_and_safety_rules_documented() -> None:
     assert "most conservative action" in text
 
 
+def test_remediation_handles_docs_architecture_defects_and_broad_work() -> None:
+    text = _read_skill()
+
+    for expected in (
+        "missing metadata",
+        "unclear authority",
+        "missing embedded rationale",
+        "duplicate contract",
+        "imperative leakage",
+        "unverifiable canonical claims",
+    ):
+        assert expected in text
+    assert "docs/tmp/" in text
+    assert "improvement plan" in text
+
+
 def test_high_level_workflow_has_thirteen_safe_ordered_steps() -> None:
     text = _read_skill()
 

--- a/tests/unit/agents/test_document_health_review_skill.py
+++ b/tests/unit/agents/test_document_health_review_skill.py
@@ -106,3 +106,36 @@ def test_document_health_review_declares_document_update_dependency() -> None:
     assert (_SKILLS_DIR / "document-update" / "SKILL.md").is_file()
     # It still inlines the drift-analysis mechanics it relies on.
     assert "drift" in text.lower()
+
+
+def test_document_health_review_groups_findings_by_authority_ladder() -> None:
+    text = _skill_text()
+
+    assert "group findings by the authority ladder" in text
+    for level in (
+        "Constitution / Document Model",
+        "Documentation Architecture Standard",
+        "System Architecture View",
+        "Cross-Cutting Concept View",
+        "Module Architecture View",
+        "Module Contract Specification",
+        "System / Feature Design View",
+        "Migration / Implementation / Rollout / Status documents",
+    ):
+        assert level in text
+
+
+def test_document_health_review_reports_docs_architecture_defects() -> None:
+    text = _skill_text()
+
+    for defect in (
+        "missing_metadata",
+        "unclear_authority",
+        "missing_rationale",
+        "duplicate_contract",
+        "imperative_leakage",
+        "unverifiable_claim",
+    ):
+        assert defect in text
+    assert "docs/tmp/" in text
+    assert "improvement plan" in text

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2224,11 +2224,67 @@ async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
                 "artifacts/document-health-review.json"
                 in review_step["instructions"]
             )
+            assert "missing metadata" in review_step["instructions"]
+            assert "authority ladder" in review_step["instructions"]
+            assert "docs/tmp/" in review_step["instructions"]
             assert (
                 "artifacts/document-health-review.json"
                 in remediate_step["instructions"]
             )
             assert "remediate ONLY" in remediate_step["instructions"]
+            assert "missing embedded rationale" in remediate_step["instructions"]
+            assert "unverifiable canonical claims" in remediate_step["instructions"]
+            assert "docs/tmp/" in remediate_step["instructions"]
+
+
+async def test_seed_catalog_includes_document_author_preset(tmp_path):
+    """MM-931: docs-native authoring chooses docs architecture fields."""
+
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "presets"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="document-author",
+                scope=PresetScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            assert template.title == "Document Author"
+            assert template.annotations["sourceIssueKey"] == "MM-931"
+            assert template.annotations["sourceReference"] == "MM-927"
+            assert template.steps[0]["skill"]["id"] == "document-author"
+            assert template.steps[0]["annotations"]["documentAuthoringRole"] == "author"
+
+            expanded = await service.expand_template(
+                slug="document-author",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "documentation_intent": "Document a new runtime contract.",
+                    "preferred_area": "docs/Workflows/",
+                    "traceability": "MM-931 from MM-927",
+                    "constraints": "Canonical only.",
+                },
+                context={},
+            )
+
+            assert len(expanded["steps"]) == 1
+            step = expanded["steps"][0]
+            assert step["type"] == "skill"
+            assert step["skill"]["id"] == "document-author"
+            assert "Document a new runtime contract." in step["instructions"]
+            assert "docs/Workflows/" in step["instructions"]
+            assert "MM-931 from MM-927" in step["instructions"]
+            assert "Do not create spec.md" in step["instructions"]
+            assert "docs/tmp/" in step["instructions"]
 
 async def test_jira_breakdown_uses_single_allowed_project_as_runtime_default(
     tmp_path,

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -958,7 +958,8 @@ async def test_create_enabled_profile_rejects_missing_database_secret_ref(
         response = await client.post("/api/v1/provider-profiles", json=payload)
 
     assert response.status_code == 422
-    assert "managed secret db://missing-provider-secret was not found" in response.text
+    assert "OPENAI_API_KEY=[REDACTED]" in response.text
+    assert "secret db://missing-provider-secret was not found" in response.text
 
 
 @pytest.mark.asyncio
@@ -1164,7 +1165,9 @@ async def test_provider_profile_readiness_reports_invalid_stored_secret_ref(
     checks = {check["id"]: check for check in readiness["checks"]}
     assert checks["secret_refs"]["status"] == "error"
     assert "provider_api_key" in checks["secret_refs"]["message"]
-    assert "invalid SecretRef" in checks["secret_refs"]["message"]
+    assert "SecretRef (secret reference must use <backend>://<locator> format)" in checks[
+        "secret_refs"
+    ]["message"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue: MM-931

Summary:
- Adds a docs-native document-author skill that creates canonical docs without centering spec.md.
- Adds the document-author preset and startup seeding coverage.
- Tightens document health review/remediation/update skill guidance for metadata, authority, rationale, imperative leakage, duplicate contracts, unverifiable claims, docs/tmp routing, and authority-ladder grouping.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/agents/test_document_author_skill.py tests/unit/agents/test_document_health_remediate_skill.py tests/unit/agents/test_document_health_review_skill.py tests/unit/api/test_presets_service.py
- ./tools/test_integration.sh tests/integration/test_startup_preset_seeding.py

Remaining risks:
- The integration wrapper selected the full integration_ci subset rather than only the named file, but it passed.
