### PR TITLE
MM-933 Generate implementation packets from doc slices

### DIFF
--- a/.agents/skills/moonspec-plan/SKILL.md
+++ b/.agents/skills/moonspec-plan/SKILL.md
@@ -109,6 +109,7 @@ Validate before planning:
 - `FEATURE_SPEC` has exactly one `## User Story - ...` section.
 - The story has a Summary, Goal, Independent Test, Acceptance Scenarios, Requirements, and Success Criteria.
 - Source design mappings such as `DESIGN-REQ-*` are preserved when present.
+- Source packet provenance is preserved when present: source document path, document class, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and issue traceability such as `MM-933` / `MM-927`.
 - Constitution gates and `MUST` constraints are available for the plan.
 - In-scope requirement IDs and scenario IDs can be identified for planning and traceability.
 
@@ -138,6 +139,7 @@ Fill:
 
 Add a `## Requirement Status` section after `## Summary` with one row per in-scope item that materially affects delivery:
 
+- stable source claim IDs from `## Source Packet`, such as `CLAIM-*`, `DESIGN-REQ-*`, or `DOC-REQ-*`
 - `FR-*`
 - acceptance scenarios or `SCN-*`
 - measurable success criteria or `SC-*` when they drive implementation or testing
@@ -150,6 +152,8 @@ Use this table shape:
 | FR-001         | missing                | none found                  | add code and tests           | unit + integration       |
 | SCN-001        | implemented_unverified | `src/...`, no scenario test | add verification tests first, with implementation contingency if they fail | integration |
 | DESIGN-REQ-004 | implemented_verified   | `src/...`, `tests/...`      | no new implementation        | none beyond final verify |
+
+When a row originates from a stable source claim, include the claim ID in the `ID` cell or in the evidence text so `/speckit.tasks` can map every implementation task back to stable claim provenance. If no stable source claim applies, write `No stable source claim applies: <reason>` in the evidence text.
 
 Allowed `Status` values:
 

--- a/.agents/skills/moonspec-specify/SKILL.md
+++ b/.agents/skills/moonspec-specify/SKILL.md
@@ -23,7 +23,7 @@ Do not use this skill to split a broad design into multiple specs; use `/speckit
 ## Inputs
 
 - Treat the user's request text as the feature description.
-- `spec.md` is a temporary execution artifact derived from the request or its canonical source document. It is never the source of truth for desired state (see `docs/Workflows/MoonSpecDocumentModel.md`).
+- `spec.md` is a temporary execution artifact and downstream adapter derived from the request or its canonical source document. It is never the source of truth for desired state (see `docs/Workflows/MoonSpecDocumentModel.md`).
 - Do not ask the user to repeat the request unless it is empty or no independently testable story can be derived.
 - If the feature description is empty, stop with: `ERROR "No feature description provided"`.
 - Preserve the original feature description verbatim in the generated spec's `**Input**` field. Do not summarize or normalize it; `/speckit.verify` relies on this source request.
@@ -47,11 +47,19 @@ For source-backed requests:
    - Normative terms such as must, shall, required, forbidden, cannot, should when used as a requirement.
    - Behavior tables, acceptance criteria, invariants, limits, failure handling, and compatibility constraints.
    - Explicit non-goals or exclusions that constrain scope.
-4. Assign stable IDs: `DESIGN-REQ-001`, `DESIGN-REQ-002`, and so on.
-5. If the source artifact contains multiple independent stories, do not collapse them into one spec. Ask the user to choose one story, or direct them to `/speckit.breakdown` when the goal is to extract stories from a broader technical or declarative design.
-6. If a source requirement is intentionally out of scope for the selected story, keep it in the source mapping as out of scope with a short rationale. Do not silently drop it.
-7. Record the canonical source document path and its document class (per `docs/Workflows/MoonSpecDocumentModel.md`) in a `**Source Document**` line directly below `**Input**` in `spec.md`.
-8. If drafting reveals a conflict between the feature request and the canonical source document, surface it as a `[NEEDS CLARIFICATION]` marker or an explicitly flagged conflict in the spec. Do not silently resolve the conflict toward either side; the canonical document wins by default, and evidence that the document itself is wrong must flow to doc reconciliation, not be buried in the spec.
+4. Build a source packet from the source artifact. Record the source document path, document class, viewpoint, owning surface, stable claim IDs, and source issue traceability when present. For canonical docs, derive viewpoint and owning surface from the document metadata header, `docs/DocumentationArchitecture.md`, file path, title, and authority text. If the source already has stable IDs, preserve them. If a concrete source claim has no stable ID, assign `CLAIM-001`, `CLAIM-002`, and so on within the generated packet; do not treat line numbers as stable IDs.
+5. Assign source requirement IDs: `DESIGN-REQ-001`, `DESIGN-REQ-002`, and so on. Link each `DESIGN-REQ-*` to its stable claim ID, or state why no stable source claim applies.
+6. If the source artifact contains multiple independent stories, do not collapse them into one spec. Ask the user to choose one story, or direct them to `/speckit.breakdown` when the goal is to extract stories from a broader technical or declarative design.
+7. If a source requirement is intentionally out of scope for the selected story, keep it in the source mapping as out of scope with a short rationale. Do not silently drop it.
+8. Record the packet in `spec.md` immediately below `**Input**` as `## Source Packet`. Include:
+   - `**Artifact Role**`: state that `spec.md` is a temporary adapter derived from the canonical request or source document, not authoritative desired state.
+   - `**Source Document**`: repo-relative source path, or `original request only` when no document exists.
+   - `**Document Class**`: per `docs/Workflows/MoonSpecDocumentModel.md`.
+   - `**Viewpoint**`: canonical documentation viewpoint, or `none` with reason.
+   - `**Owning Surface**`: authority scope, module, feature, contract surface, or `none` with reason.
+   - `**Stable Claim IDs**`: existing source claim IDs and generated `CLAIM-*` IDs used by the selected story, or `none` with reason.
+   - `**Source Issue Traceability**`: preserve issue lineage such as `MM-933` and source issue `MM-927` when present.
+9. If drafting reveals a conflict between the feature request and the canonical source document, surface it as a `[NEEDS CLARIFICATION]` marker or an explicitly flagged conflict in the spec. Do not silently resolve the conflict toward either side; the canonical document wins by default, and evidence that the document itself is wrong must flow to doc reconciliation, not be buried in the spec.
 
 Complete source reading, requirement extraction, and single-story selection before creating the feature directory.
 
@@ -156,6 +164,7 @@ Fill the template with concrete details derived from the feature description:
 8. Document assumptions in `## Assumptions` only when assumptions are used; remove the section if no assumptions were made.
 9. For source-backed requests, add `## Source Design Requirements` with:
    - Requirement ID.
+   - Stable claim ID from `## Source Packet`, or an explicit `No stable source claim applies: <reason>` entry.
    - Source citation such as heading, table name, or line number when available.
    - Requirement summary in testable, implementation-agnostic language.
    - Scope status: in scope or out of scope with rationale.

--- a/.agents/skills/moonspec-tasks/SKILL.md
+++ b/.agents/skills/moonspec-tasks/SKILL.md
@@ -21,6 +21,7 @@ The generated task list must:
 - Include unit tests and integration tests before production implementation.
 - Include red-first confirmation tasks.
 - Preserve traceability to the original request or source design preserved in `spec.md`.
+- Carry forward docs-native packet provenance from `spec.md`: source document path, document class, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and source issue traceability such as `MM-933` / `MM-927`.
 - Include final `/speckit.verify` work after implementation and tests pass.
 - Include a final doc-reconciliation task (`moonspec-doc-reconcile`) after `/speckit.verify` when `spec.md` records a canonical source document under `docs/`.
 
@@ -101,7 +102,7 @@ If shell arguments contain single quotes, use shell-safe escaping such as `'I'\'
 Read:
 
 - `plan.md`: tech stack, libraries, project structure, unit test tooling, integration test tooling, constraints, validation commands, and any `## Requirement Status` table.
-- `spec.md`: preserved `**Input**`, single user story, goal, independent test, acceptance scenarios, edge cases, functional requirements, success criteria, assumptions, and source design mappings such as `DESIGN-REQ-*` or `DOC-REQ-*`.
+- `spec.md`: preserved `**Input**`, `## Source Packet`, single user story, goal, independent test, acceptance scenarios, edge cases, functional requirements, success criteria, assumptions, and source design mappings such as `CLAIM-*`, `DESIGN-REQ-*` or `DOC-REQ-*`.
 - `.specify/memory/constitution.md`: project constraints and test discipline.
 - `data-model.md` when present: entities, relationships, validation rules, and state transitions.
 - `contracts/` when present: public interfaces and contract or integration test obligations.
@@ -115,7 +116,7 @@ Build a traceability inventory before writing tasks:
 - One row per acceptance scenario or `SCN-*`.
 - One row per meaningful edge case.
 - One row per measurable success criterion or `SC-*`.
-- One row per in-scope `DESIGN-REQ-*` or `DOC-REQ-*`.
+- One row per in-scope stable source claim ID from `## Source Packet`, such as `CLAIM-*`, `DESIGN-REQ-*` or `DOC-REQ-*`.
 - One row per constitution requirement that affects implementation or testing.
 
 For each row, carry forward the matching `## Requirement Status` entry from `plan.md` when present. Allowed statuses are `missing`, `partial`, `implemented_unverified`, and `implemented_verified`; if a row has no status, treat it as `missing`.
@@ -141,6 +142,7 @@ Fill:
 - Unit test command.
 - Integration test command.
 - Source traceability summary.
+- Source packet summary: source document path, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and source issue traceability when present.
 - Story summary.
 - Independent test.
 - Story traceability IDs.
@@ -169,7 +171,8 @@ Rules:
 - Use sequential task IDs: `T001`, `T002`, `T003`, and so on.
 - Use `[P]` only for tasks that can run in parallel because they touch different files and do not depend on incomplete tasks.
 - Include exact file paths.
-- Include requirement, scenario, or source IDs when the task implements or validates behavior.
+- Include requirement, scenario, or stable source claim IDs when the task implements or validates behavior.
+- Every task must map to stable claim IDs from `## Source Packet`, `DESIGN-REQ-*`, or `DOC-REQ-*`, or state `No source claim applies: <reason>` in the task description.
 - Do not include story labels such as `[US1]`; this task list covers one story.
 
 Good examples:
@@ -268,6 +271,7 @@ Include only work that strengthens the completed story without adding hidden sco
 - Each explicit non-goal or constraint must map to a guardrail test, validation task, or documented scope check when it affects implementation.
 - Each contract must map to a contract or integration test before implementation.
 - Each task that validates behavior must name the file path and requirement/scenario/source IDs.
+- Each implementation task must name stable claim IDs from `## Source Packet`, `DESIGN-REQ-*`, or `DOC-REQ-*`, or state `No source claim applies: <reason>`.
 
 Do not generate tasks for future stories, broad refactors, speculative infrastructure, or implementation layers that are not needed by the single story.
 
@@ -302,9 +306,11 @@ Before reporting, verify:
 - Integration test tasks precede implementation tasks.
 - Red-first confirmation tasks exist before production code tasks.
 - Every traceability inventory row has task coverage.
+- Every task maps to stable claim IDs or explicitly explains why none apply.
 - `## Requirement Status` rows from `plan.md`, when present, are reflected without forcing unnecessary implementation tasks for `implemented_verified` rows.
 - `implemented_unverified` rows include fallback implementation tasks that are conditional on verification failure.
 - Final `/speckit.verify` task exists.
+- Final `moonspec-doc-reconcile` task exists after `/speckit.verify` when `spec.md` records a canonical source document under `docs/`.
 
 If validation fails, update `tasks.md` and validate again before reporting.
 
@@ -318,6 +324,7 @@ Report:
 - Parallel opportunities.
 - Independent test criteria.
 - Source design or original request coverage summary.
+- Source packet provenance summary: source document path, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and source issue traceability.
 - Requirement status coverage summary, including code-and-test, verification-only, conditional fallback, and already-verified counts when `plan.md` provides statuses.
 - Required unit and integration test coverage.
 - Unit and integration test tooling.
@@ -361,7 +368,8 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 - Unit tests and integration tests are required.
 - Red-first confirmation tasks are required before production code.
 - Preserve traceability to `spec.md` `**Input**` and source design mappings.
+- Preserve docs-native packet provenance from `spec.md` without treating generated artifacts as authoritative.
 - Consume `plan.md` `## Requirement Status` when present so tasks match planned code, verification-only, conditional fallback, or already-verified work.
-- Use concrete file paths and requirement/scenario/source IDs.
+- Use concrete file paths and requirement/scenario/stable claim IDs, or explain why no source claim applies.
 - Include final `/speckit.verify`.
 - Do not implement code from this skill.

--- a/.specify/templates/commands/specify.md
+++ b/.specify/templates/commands/specify.md
@@ -132,18 +132,27 @@ Given that feature description, do this:
        - Acceptance Scenarios
        - Edge Cases
        If no clear independent story can be derived: ERROR "Cannot determine a single independently testable story"
-    5. Generate Functional Requirements
+    5. Fill the Source Packet section
+       - Set **Artifact Role** to `Temporary adapter derived from the canonical request or source document; not authoritative desired state.`
+       - Set **Source Document** to the canonical `docs/` path when the user explicitly references one; otherwise set it to `original request only`
+       - Set **Document Class** to the referenced document class when known; otherwise set it to `original request`
+       - Set **Viewpoint** and **Owning Surface** from the referenced source document when known; otherwise set each to `none`
+       - Set **Stable Claim IDs** to the applicable `CLAIM-*`, `DESIGN-REQ-*`, or `DOC-REQ-*` IDs when provided by a source document; otherwise set it to `none - original request has no stable claim IDs`
+       - Set **Source Issue Traceability** to any explicit issue keys in the request or source document; otherwise set it to `none`
+       - Do not leave bracketed Source Packet placeholders in `spec.md`
+    6. Generate Functional Requirements
        Each requirement must be testable
        Use reasonable defaults for unspecified details (document assumptions in the Assumptions section when assumptions are used)
-    6. Define Success Criteria
+    7. Define Success Criteria
        Create measurable, technology-agnostic outcomes
        Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
        Each criterion must be verifiable without implementation details
-    7. Identify Key Entities (if data involved)
-    8. Return: SUCCESS (spec ready for planning)
+    8. Identify Key Entities (if data involved)
+    9. Return: SUCCESS (spec ready for planning)
 
 6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
    - Preserve the original user description verbatim in the `**Input**` field. Do not summarize or normalize it; downstream `/speckit.verify` uses it as the source request.
+   - Replace every `## Source Packet` placeholder with concrete values from the user request or referenced source document. If no source document or stable claim ID is available, use `original request only`, `original request`, `none`, and `none - original request has no stable claim IDs` as appropriate.
    - Produce exactly one `## User Story - ...` section.
 
 7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -5,6 +5,16 @@
 **Status**: Draft
 **Input**: User description: "$ARGUMENTS"
 
+## Source Packet
+
+**Artifact Role**: Temporary adapter derived from the canonical request or source document; not authoritative desired state.
+**Source Document**: [docs/path.md or original request only]
+**Document Class**: [canonical declarative document | temporary execution artifact | imperative working document | original request]
+**Viewpoint**: [System Architecture View | Module Architecture View | System / Feature Design View | Module Contract Specification | Cross-Cutting Concept View | none]
+**Owning Surface**: [document authority scope, module, feature, contract surface, or none]
+**Stable Claim IDs**: [CLAIM-001, DESIGN-REQ-001, DOC-REQ-001, or none with reason]
+**Source Issue Traceability**: [e.g., MM-933 from MM-927, or none]
+
 <!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
 
 ## User Story - [Brief Title]

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -62,11 +62,11 @@ description: "Task list template for single-story Moon Spec implementation"
 
 **Purpose**: Project initialization and basic structure
 
-- [ ] T001 Create project structure in src/ and tests/ per implementation plan
-- [ ] T002 Initialize [language] project with [framework] dependencies in [config file]
-- [ ] T003 [P] Configure linting and formatting tools in [config file]
-- [ ] T004 [P] Configure unit test tooling for `[UNIT TEST COMMAND]` in [test config file]
-- [ ] T005 [P] Configure integration test tooling for `[INTEGRATION TEST COMMAND]` in [test config file]
+- [ ] T001 Create project structure in src/ and tests/ per implementation plan (No source claim applies: setup task)
+- [ ] T002 Initialize [language] project with [framework] dependencies in [config file] (No source claim applies: setup task)
+- [ ] T003 [P] Configure linting and formatting tools in [config file] (No source claim applies: setup task)
+- [ ] T004 [P] Configure unit test tooling for `[UNIT TEST COMMAND]` in [test config file] (No source claim applies: setup task)
+- [ ] T005 [P] Configure integration test tooling for `[INTEGRATION TEST COMMAND]` in [test config file] (No source claim applies: setup task)
 
 ---
 
@@ -78,13 +78,13 @@ description: "Task list template for single-story Moon Spec implementation"
 
 Examples of foundational tasks (include only what the story truly depends on):
 
-- [ ] T006 Setup database schema and migrations framework in [schema/migrations path]
-- [ ] T007 [P] Implement authentication/authorization framework in src/[auth path]
-- [ ] T008 [P] Setup API routing and middleware structure in src/[routing path]
-- [ ] T009 Create base models/entities that the story depends on in src/models/
-- [ ] T010 Configure error handling and logging infrastructure in src/[infrastructure path]
-- [ ] T011 Setup environment configuration management in [config path]
-- [ ] T012 Configure integration test fixtures, service containers, or emulators needed by SCN-* in tests/integration/
+- [ ] T006 Setup database schema and migrations framework in [schema/migrations path] (No source claim applies: foundational infrastructure task)
+- [ ] T007 [P] Implement authentication/authorization framework in src/[auth path] (No source claim applies: foundational infrastructure task)
+- [ ] T008 [P] Setup API routing and middleware structure in src/[routing path] (No source claim applies: foundational infrastructure task)
+- [ ] T009 Create base models/entities that the story depends on in src/models/ (No source claim applies: foundational infrastructure task)
+- [ ] T010 Configure error handling and logging infrastructure in src/[infrastructure path] (No source claim applies: foundational infrastructure task)
+- [ ] T011 Setup environment configuration management in [config path] (No source claim applies: foundational infrastructure task)
+- [ ] T012 Configure integration test fixtures, service containers, or emulators needed by SCN-* in tests/integration/ (No source claim applies: foundational infrastructure task)
 
 **Checkpoint**: Foundation ready - story test and implementation work can now begin
 
@@ -150,8 +150,8 @@ Examples of foundational tasks (include only what the story truly depends on):
 - [ ] TXXX [P] Expand integration coverage for operational scenarios covering DESIGN-REQ-001 in tests/integration/
 - [ ] TXXX Security hardening for CLAIM-003 in src/[location]/[file].py
 - [ ] TXXX Run quickstart.md validation (No source claim applies: validation task)
-- [ ] TXXX Run `/speckit.verify` to validate the final implementation against the original feature request and Source Packet claims
-- [ ] TXXX Run `moonspec-doc-reconcile` for the canonical source document when `spec.md` names a canonical source under docs/
+- [ ] TXXX Run `/speckit.verify` to validate the final implementation against the original feature request and Source Packet claims (No source claim applies: validation task)
+- [ ] TXXX Run `moonspec-doc-reconcile` for the canonical source document when `spec.md` names a canonical source under docs/ (No source claim applies: documentation reconciliation task)
 
 ---
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -114,26 +114,26 @@ Examples of foundational tasks (include only what the story truly depends on):
 
 > **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
 
-- [ ] T013 [P] Add failing unit test for [domain behavior] covering FR-001 in tests/unit/test_[name].py
-- [ ] T014 [P] Add failing unit test for [edge case] covering FR-002 in tests/unit/test_[name].py
+- [ ] T013 [P] Add failing unit test for [domain behavior] covering CLAIM-001 / FR-001 in tests/unit/test_[name].py
+- [ ] T014 [P] Add failing unit test for [edge case] covering CLAIM-002 / FR-002 in tests/unit/test_[name].py
 - [ ] T015 Run `[UNIT TEST COMMAND]` for tests/unit/test_[name].py to confirm T013-T014 fail for the expected reason
 
 ### Integration Tests (write first) ⚠️
 
-- [ ] T016 [P] Add failing integration test for [user journey] covering SCN-001 in tests/integration/test_[name].py
+- [ ] T016 [P] Add failing integration test for [user journey] covering CLAIM-001 / SCN-001 in tests/integration/test_[name].py
 - [ ] T017 [P] Add failing integration test for [system interaction or contract] covering DESIGN-REQ-001 in tests/integration/test_[name].py
 - [ ] T018 Run `[INTEGRATION TEST COMMAND]` for tests/integration/test_[name].py to confirm T016-T017 fail for the expected reason
 
 ### Implementation
 
-- [ ] T019 [P] Create or update [Entity1] for FR-001 in src/models/[entity1].py
-- [ ] T020 [P] Create or update [Entity2] for FR-002 in src/models/[entity2].py
-- [ ] T021 Implement [Service] for FR-001/FR-002 in src/services/[service].py (depends on T019, T020)
-- [ ] T022 Implement [endpoint/feature/UI/CLI] for SCN-001 in src/[location]/[file].py
-- [ ] T023 Add validation, error handling, and non-goal guardrails for FR-003 in src/[location]/[file].py
+- [ ] T019 [P] Create or update [Entity1] for CLAIM-001 / FR-001 in src/models/[entity1].py
+- [ ] T020 [P] Create or update [Entity2] for CLAIM-002 / FR-002 in src/models/[entity2].py
+- [ ] T021 Implement [Service] for CLAIM-001 / CLAIM-002 / FR-001 / FR-002 in src/services/[service].py (depends on T019, T020)
+- [ ] T022 Implement [endpoint/feature/UI/CLI] for CLAIM-001 / SCN-001 in src/[location]/[file].py
+- [ ] T023 Add validation, error handling, and non-goal guardrails for CLAIM-003 / FR-003 in src/[location]/[file].py
 - [ ] T024 Wire integration boundary for DESIGN-REQ-001 in src/[location]/[file].py
-- [ ] T025 Add logging/observability for the story flow in src/[location]/[file].py
-- [ ] T026 Run `[UNIT TEST COMMAND]` and `[INTEGRATION TEST COMMAND]` for tests/unit/ and tests/integration/, fix failures, and verify the story passes end-to-end
+- [ ] T025 Add logging/observability for the story flow in src/[location]/[file].py (No source claim applies: operational support task)
+- [ ] T026 Run `[UNIT TEST COMMAND]` and `[INTEGRATION TEST COMMAND]` for tests/unit/ and tests/integration/, fix failures, and verify the story passes end-to-end (No source claim applies: validation task)
 
 **Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently
 
@@ -143,13 +143,13 @@ Examples of foundational tasks (include only what the story truly depends on):
 
 **Purpose**: Improvements that strengthen the completed story without changing its core scope
 
-- [ ] TXXX [P] Documentation updates in docs/
-- [ ] TXXX Code cleanup and refactoring
-- [ ] TXXX Performance optimization for the story path
-- [ ] TXXX [P] Expand unit test edge-case coverage in tests/unit/
-- [ ] TXXX [P] Expand integration coverage for operational scenarios in tests/integration/
-- [ ] TXXX Security hardening
-- [ ] TXXX Run quickstart.md validation
+- [ ] TXXX [P] Documentation updates in docs/ (No source claim applies: optional polish task)
+- [ ] TXXX Code cleanup and refactoring (No source claim applies: optional polish task)
+- [ ] TXXX Performance optimization for the story path covering CLAIM-001 in src/[location]/[file].py
+- [ ] TXXX [P] Expand unit test edge-case coverage for CLAIM-002 in tests/unit/
+- [ ] TXXX [P] Expand integration coverage for operational scenarios covering DESIGN-REQ-001 in tests/integration/
+- [ ] TXXX Security hardening for CLAIM-003 in src/[location]/[file].py
+- [ ] TXXX Run quickstart.md validation (No source claim applies: validation task)
 - [ ] TXXX Run `/speckit.verify` to validate the final implementation against the original feature request and Source Packet claims
 - [ ] TXXX Run `moonspec-doc-reconcile` for the canonical source document when `spec.md` names a canonical source under docs/
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -11,7 +11,9 @@ description: "Task list template for single-story Moon Spec implementation"
 
 **Organization**: Tasks are grouped by phase around a single user story so the work stays focused, traceable, and independently testable.
 
-**Source Traceability**: Each task should reference the relevant `FR-*`, acceptance scenario, success criterion, or `DESIGN-REQ-*`/`DOC-REQ-*` source mapping from `spec.md` when applicable.
+**Source Traceability**: Each task MUST reference the relevant stable claim IDs from `spec.md` (`CLAIM-*`, `DESIGN-REQ-*`, `DOC-REQ-*`), plus `FR-*`, acceptance scenario, or success criterion IDs when applicable. If no stable claim applies, the task MUST state `No source claim applies: <reason>`.
+
+**Source Packet**: Carry forward `spec.md` source document path, viewpoint, owning surface, stable claim IDs, and temporary-adapter role. Preserve source issue traceability such as `MM-933` and `MM-927` when present.
 
 **Test Commands**:
 
@@ -23,7 +25,8 @@ description: "Task list template for single-story Moon Spec implementation"
 
 - **[P]**: Can run in parallel (different files, no dependencies)
 - Include exact file paths in descriptions
-- Include requirement, scenario, or source IDs when the task implements or validates behavior
+- Include requirement, scenario, or stable source claim IDs when the task implements or validates behavior
+- Include `No source claim applies: <reason>` when a setup, validation, or polish task has no applicable source claim
 
 ## Path Conventions
 
@@ -39,7 +42,7 @@ description: "Task list template for single-story Moon Spec implementation"
   The /speckit.tasks command MUST replace these with actual tasks based on:
   - The single user story from spec.md
   - The original request/design preserved in spec.md Input
-  - Source design mappings such as DESIGN-REQ-* or DOC-REQ-*
+  - Stable source claim mappings such as CLAIM-*, DESIGN-REQ-* or DOC-REQ-*
   - Feature requirements from plan.md
   - Entities from data-model.md
   - Endpoints from contracts/
@@ -93,7 +96,14 @@ Examples of foundational tasks (include only what the story truly depends on):
 
 **Independent Test**: [How to verify this story works on its own]
 
-**Traceability**: [FR-001, FR-002, SCN-001, SC-001, DESIGN-REQ-001]
+**Traceability**: [FR-001, FR-002, SCN-001, SC-001, CLAIM-001, DESIGN-REQ-001]
+
+**Source Packet**:
+
+- Source document: [docs/path.md or original request only]
+- Viewpoint: [viewpoint or none]
+- Owning surface: [surface or none]
+- Stable claim IDs: [CLAIM-001, DESIGN-REQ-001, DOC-REQ-001, or none with reason]
 
 **Test Plan**:
 
@@ -140,7 +150,8 @@ Examples of foundational tasks (include only what the story truly depends on):
 - [ ] TXXX [P] Expand integration coverage for operational scenarios in tests/integration/
 - [ ] TXXX Security hardening
 - [ ] TXXX Run quickstart.md validation
-- [ ] TXXX Run `/speckit.verify` to validate the final implementation against the original feature request
+- [ ] TXXX Run `/speckit.verify` to validate the final implementation against the original feature request and Source Packet claims
+- [ ] TXXX Run `moonspec-doc-reconcile` for the canonical source document when `spec.md` names a canonical source under docs/
 
 ---
 
@@ -209,7 +220,8 @@ Task: "Create [Entity2] model in src/models/[entity2].py"
 - [P] tasks = different files, no dependencies
 - The task list should cover one story only
 - The story should be independently completable and testable
-- Each in-scope requirement, scenario, success criterion, and source design mapping should have task coverage
+- Each in-scope requirement, scenario, success criterion, and stable source claim mapping must have task coverage
+- Each task must map to stable claim IDs or state `No source claim applies: <reason>`
 - Verify unit and integration tests fail before implementing
 - Run `/speckit.verify` after implementation to check the final result against the original request
 - Commit after each task or logical group

--- a/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
+++ b/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
@@ -72,6 +72,7 @@ def test_moonspec_specify_skill_marks_specs_derived_from_claims() -> None:
         encoding="utf-8"
     )
 
-    assert "`**Derived From Canonical Claims**`" in text
+    assert "`**Stable Claim IDs**`" in text
+    assert "list those claim IDs exactly as supplied" in text
     assert "sourceReference" in text
     assert "claimIds" in text

--- a/tests/unit/agents/test_moonspec_packet_provenance.py
+++ b/tests/unit/agents/test_moonspec_packet_provenance.py
@@ -72,6 +72,12 @@ def test_mm933_tasks_require_claim_mapping_or_explicit_explanation() -> None:
 def test_mm933_task_template_examples_map_implementation_tasks_to_claims() -> None:
     template = (TEMPLATES_DIR / "tasks-template.md").read_text(encoding="utf-8")
 
+    assert (
+        "### Implementation" in template
+    ), "tasks-template.md is missing '### Implementation' section"
+    assert (
+        "**Checkpoint**" in template
+    ), "tasks-template.md is missing '**Checkpoint**' marker"
     implementation_section = template.split("### Implementation", 1)[1].split(
         "**Checkpoint**", 1
     )[0]

--- a/tests/unit/agents/test_moonspec_packet_provenance.py
+++ b/tests/unit/agents/test_moonspec_packet_provenance.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_DIR = REPO_ROOT / ".agents" / "skills"
+TEMPLATES_DIR = REPO_ROOT / ".specify" / "templates"
+
+
+def test_mm933_specify_records_docs_native_source_packet() -> None:
+    text = (SKILLS_DIR / "moonspec-specify" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    template = (TEMPLATES_DIR / "spec-template.md").read_text(encoding="utf-8")
+
+    for required in (
+        "## Source Packet",
+        "**Artifact Role**",
+        "**Source Document**",
+        "**Document Class**",
+        "**Viewpoint**",
+        "**Owning Surface**",
+        "**Stable Claim IDs**",
+        "**Source Issue Traceability**",
+    ):
+        assert required in text
+        assert required in template
+
+    assert "temporary adapter" in text
+    assert "CLAIM-001" in text
+    assert "MM-933" in text
+    assert "MM-927" in text
+
+
+def test_mm933_plan_preserves_source_packet_for_task_generation() -> None:
+    text = (SKILLS_DIR / "moonspec-plan" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "source document path" in text
+    assert "document class" in text
+    assert "viewpoint" in text
+    assert "owning surface" in text
+    assert "stable claim IDs" in text
+    assert "temporary-adapter role" in text
+    assert "MM-933" in text
+    assert "MM-927" in text
+    assert "No stable source claim applies: <reason>" in text
+
+
+def test_mm933_tasks_require_claim_mapping_or_explicit_explanation() -> None:
+    text = (SKILLS_DIR / "moonspec-tasks" / "SKILL.md").read_text(encoding="utf-8")
+    template = (TEMPLATES_DIR / "tasks-template.md").read_text(encoding="utf-8")
+
+    for required in (
+        "source document path",
+        "viewpoint",
+        "owning surface",
+        "stable claim IDs",
+        "temporary-adapter role",
+        "MM-933",
+        "MM-927",
+        "Every task must map to stable claim IDs",
+        "No source claim applies: <reason>",
+        "moonspec-doc-reconcile",
+    ):
+        assert required in text
+
+    assert "Each task MUST reference the relevant stable claim IDs" in template
+    assert "No source claim applies: <reason>" in template
+    assert "Source Packet" in template
+    assert "moonspec-doc-reconcile" in template

--- a/tests/unit/agents/test_moonspec_packet_provenance.py
+++ b/tests/unit/agents/test_moonspec_packet_provenance.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -66,3 +67,20 @@ def test_mm933_tasks_require_claim_mapping_or_explicit_explanation() -> None:
     assert "No source claim applies: <reason>" in template
     assert "Source Packet" in template
     assert "moonspec-doc-reconcile" in template
+
+
+def test_mm933_task_template_examples_map_implementation_tasks_to_claims() -> None:
+    template = (TEMPLATES_DIR / "tasks-template.md").read_text(encoding="utf-8")
+
+    implementation_section = template.split("### Implementation", 1)[1].split(
+        "**Checkpoint**", 1
+    )[0]
+    task_lines = [
+        line for line in implementation_section.splitlines() if line.startswith("- [ ]")
+    ]
+
+    assert task_lines
+    for line in task_lines:
+        has_claim_id = re.search(r"\b(?:CLAIM|DESIGN-REQ|DOC-REQ)-\d{3}\b", line)
+        has_explanation = "No source claim applies:" in line
+        assert has_claim_id or has_explanation, line


### PR DESCRIPTION
Issue reference: MM-933

Summary:
- Adds docs-native source packet provenance to MoonSpec specify/plan/tasks skill instructions.
- Extends spec and task templates with source document path, document class, viewpoint, owning surface, stable claim IDs, temporary-adapter role, and issue traceability.
- Adds unit coverage that checks MM-933 packet provenance requirements across the skill and template artifacts.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/agents/test_moonspec_packet_provenance.py`
  - Python target: 4 passed
  - UI phase: 29 files passed, 498 tests passed, 236 skipped

Remaining risks:
- This updates instruction and template contracts only; downstream generated artifacts still depend on agents following these instructions consistently.
- Existing in-flight generated specs/tasks are not rewritten by this change.
