### PR TITLE
MM-935 expand doc reconciliation conformance

### DIFF
--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonspec-doc-reconcile
-description: Reconcile a canonical declarative document under docs/ with verified implementation discoveries after a FULLY_IMPLEMENTED moonspec-verify verdict. Use when an orchestration run must decide whether implementation discoveries definitely require updating the source design document for function, consistency, or best practices, apply the smallest correct doc update, or escalate a misaligned update as a Jira issue instead of editing.
+description: Reconcile canonical declarative documents under docs/ with verified implementation discoveries after a FULLY_IMPLEMENTED moonspec-verify verdict. Use when an orchestration run must decide whether implementation discoveries definitely require updating the owning canonical document for function, consistency, or best practices, apply the smallest correct doc update, or escalate ambiguous authority conflicts as Jira issues instead of editing.
 metadata:
   required-capabilities:
     - git
@@ -8,24 +8,44 @@ metadata:
 
 # MoonSpec Doc Reconcile
 
-Use this skill as the final doc-reconciliation pass of a MoonSpec orchestration run. It decides whether verified implementation discoveries definitely require updating the canonical source document, applies the smallest correct update when they do, and reports a structured outcome either way.
+Use this skill as the final doc-reconciliation pass of a MoonSpec orchestration run. It decides whether verified implementation discoveries definitely require updating the canonical document that owns the affected claim, applies the smallest correct update when they do, and reports a structured outcome either way.
 
-This skill operationalizes the reconciliation expectation in `docs/Workflows/MoonSpecDocumentModel.md` and Constitution XI ("update the owning `docs/` files first").
+This skill operationalizes the reconciliation expectation in `docs/Workflows/MoonSpecDocumentModel.md`, the authority ladder and module-owned contract policy in `docs/DocumentationArchitecture.md`, and Constitution XI ("update the owning `docs/` files first").
 
 ## Preconditions
 
 - The latest `moonspec-verify` verdict for the active feature is `FULLY_IMPLEMENTED`. If it is not, stop with `NO_UPDATE_REQUIRED` and report that reconciliation only runs after successful verification.
-- A canonical source document exists: `spec.md` records a `**Source Document**` path under `docs/` (or the breakdown `sourceReference.path` points there). If no canonical document exists, stop immediately with `NO_UPDATE_REQUIRED` and the rationale `no canonical source document`.
+- At least one canonical source candidate exists: `spec.md` records a `**Source Document**` path under `docs/`, the breakdown `sourceReference.path` points there, or the orchestration step provides a source design path under `docs/`. If no canonical document candidate exists, stop immediately with `NO_UPDATE_REQUIRED` and the rationale `no canonical source document`.
 
 ## Inputs
 
-- Required: canonical source document path(s) from `spec.md` `**Source Document**` or breakdown `sourceReference.path`.
+- Required: canonical source document path(s) from `spec.md` `**Source Document**`, breakdown `sourceReference.path`, or the orchestration source design path. Treat these as starting candidates, not as the only documents that may be edited.
 - Required: the latest `moonspec-verify` report, including its Source Document Drift section.
 - Optional: the discovery ledger at `artifacts/doc-discoveries/<feature>.json` written by `moonspec-implement`.
 - Optional: doc-drift notes from a `story-reconcile-implementation` report.
 - Optional: explicit scope limits from the orchestration step.
 
 Discoveries are the only valid basis for edits. Do not re-derive drift by auditing the whole document; this skill is intentionally limited to reconciling verified discoveries from the MoonSpec run.
+
+## Authority-Scope Resolution
+
+For each discovery that passes the update gate, identify the canonical document that owns the affected claim before editing. Use `docs/Workflows/MoonSpecDocumentModel.md` for document-class precedence and `docs/DocumentationArchitecture.md` for same-class authority, including the module-owned contract policy.
+
+Apply this bounded procedure:
+
+1. Classify the affected claim: system structure, cross-cutting semantic, module internals, module contract/API/payload shape, feature behavior, rationale, or migration/status text.
+2. Map the claim to the owning authority scope in `docs/DocumentationArchitecture.md`:
+   - system-wide structure and dependency direction: System Architecture View,
+   - cross-module concern semantics: Cross-Cutting Concept View,
+   - module internals: Module Architecture View,
+   - interface, API, activity/signal/update, DTO, schema, or payload shape: Module Contract Specification owned by the providing module,
+   - feature-level behavior: System/Feature Design View,
+   - migration/status text: temporary artifact, never canonical desired state.
+3. Use the source document path, discovery evidence, cited docs, and nearby module ownership to locate the owning canonical document. The owning document may be different from the original source document.
+4. Edit the owning canonical document when the evidence shows that document is incomplete or wrong. Edit a non-owning canonical document only when it conflicts with the owner and must be reconciled to the owner's desired state.
+5. Escalate instead of guessing when ownership is ambiguous, when two plausible owners claim the same contract, when the relevant module-owned contract cannot be identified, or when the required update would alter constitution/document-model/documentation-architecture policy or a published contract without clear authority.
+
+Never downgrade a canonical document to match incomplete or buggy code. Verification must establish that the implementation is correct for the agreed story before this skill updates desired-state documentation.
 
 ## Update Gate
 
@@ -54,7 +74,7 @@ When no discovery passes the gate, report `NO_UPDATE_REQUIRED` with a one-line r
 
 ## Escalation
 
-If a required update would conflict with the constitution, `README.md`, or the declared architecture direction — or the correct desired state is genuinely uncertain — do not edit. Instead:
+If a required update would conflict with the constitution, `README.md`, the Document Model, `docs/DocumentationArchitecture.md`, a module-owned contract, or the declared architecture direction — or the owning document/correct desired state is genuinely uncertain — do not edit. Instead:
 
 1. Read `.agents/skills/jira-issue-creator/SKILL.md` and follow its workflow.
 2. Create a Jira issue containing the document path, the contradicted claim, the implementation evidence, and why the update may conflict with project direction.
@@ -77,15 +97,18 @@ Write the structured result to the path provided by the orchestration step when 
 {
   "action": "updated | no_update_required | escalated",
   "docPaths": ["docs/Workflows/Example.md"],
+  "updated": [{"docPath": "docs/Workflows/Example.md", "reason": "definite function drift in owning module contract"}],
+  "noUpdateRequired": [{"docPath": "docs/ExampleDesign.md", "reason": "possible drift only"}],
+  "escalated": [{"docPath": "docs/Workflows/Example.md", "reason": "ambiguous module-owned contract authority"}],
   "gateRationale": "which gate criterion each applied discovery met, or why each discovery was rejected",
   "evidence": ["file, test, or report references backing the decision"],
   "jiraIssue": {"key": "MM-000", "url": "https://..."}
 }
 ```
 
-`docPaths` lists edited documents for `updated`, the considered documents otherwise. Include `jiraIssue` only for `escalated`.
+`docPaths` lists edited documents for `updated`, the considered documents otherwise. The `updated`, `noUpdateRequired`, and `escalated` lists are always present; use empty lists for categories that do not apply. Every updated/noUpdateRequired/escalated item must include a reason. Include `jiraIssue` only for `escalated`.
 
-Also return a short markdown summary suitable for inclusion in a pull request body: outcome, edited paths or rejection rationale, and escalation issue key when present.
+Also return a short markdown summary suitable for inclusion in a pull request body: outcome, canonical sources considered, owning canonical docs edited or rejected, temporary artifacts consulted, claim coverage, and escalation issue key when present.
 
 ## Key Rules
 
@@ -95,3 +118,4 @@ Also return a short markdown summary suitable for inclusion in a pull request bo
 - Smallest correct edit; desired-state framing preserved; no imperative content in canonical docs.
 - Misaligned updates become Jira issues, never silent edits or silent drops.
 - The structured outcome is mandatory in every run, including no-ops.
+- Use authority-scope ownership, not original-source-document convenience, to choose what canonical doc to update.

--- a/.agents/skills/moonspec-doc-reconcile/SKILL.md
+++ b/.agents/skills/moonspec-doc-reconcile/SKILL.md
@@ -14,8 +14,8 @@ This skill operationalizes the reconciliation expectation in `docs/Workflows/Moo
 
 ## Preconditions
 
-- The latest `moonspec-verify` verdict for the active feature is `FULLY_IMPLEMENTED`. If it is not, stop with `NO_UPDATE_REQUIRED` and report that reconciliation only runs after successful verification.
-- At least one canonical source candidate exists: `spec.md` records a `**Source Document**` path under `docs/`, the breakdown `sourceReference.path` points there, or the orchestration step provides a source design path under `docs/`. If no canonical document candidate exists, stop immediately with `NO_UPDATE_REQUIRED` and the rationale `no canonical source document`.
+- The latest `moonspec-verify` verdict for the active feature is `FULLY_IMPLEMENTED`. If it is not, stop with `no_update_required` and report that reconciliation only runs after successful verification.
+- At least one canonical source candidate exists: `spec.md` records a `**Source Document**` path under `docs/`, the breakdown `sourceReference.path` points there, or the orchestration step provides a source design path under `docs/`. If no canonical document candidate exists, stop immediately with `no_update_required` and the rationale `no canonical source document`.
 
 ## Inputs
 
@@ -61,7 +61,7 @@ The following never pass the gate:
 - Stylistic preferences, wording improvements, or speculative future work.
 - Drift in temporary artifacts (`spec.md`, `plan.md`, `tasks.md`); those are disposable and are never reconciled into docs.
 
-When no discovery passes the gate, report `NO_UPDATE_REQUIRED` with a one-line rationale per rejected discovery. A no-op outcome is a correct and common result.
+When no discovery passes the gate, report `no_update_required` with a one-line rationale per rejected discovery. A no-op outcome is a correct and common result.
 
 ## Editing Rules
 
@@ -113,7 +113,7 @@ Also return a short markdown summary suitable for inclusion in a pull request bo
 ## Key Rules
 
 - Run only after `FULLY_IMPLEMENTED` verification.
-- No canonical source document means an immediate `NO_UPDATE_REQUIRED`.
+- No canonical source document means an immediate `no_update_required`.
 - Only `definite`, evidence-backed discoveries that meet the function, consistency, or best-practices test justify edits.
 - Smallest correct edit; desired-state framing preserved; no imperative content in canonical docs.
 - Misaligned updates become Jira issues, never silent edits or silent drops.

--- a/.agents/skills/moonspec-orchestrate/SKILL.md
+++ b/.agents/skills/moonspec-orchestrate/SKILL.md
@@ -101,8 +101,8 @@ Use these gates before advancing:
   - Verdict is not `NO_DETERMINATION`.
   - Completion is claimed only when verdict is `FULLY_IMPLEMENTED`.
 - Doc Reconcile gate:
-  - `moonspec-doc-reconcile` has run after a `FULLY_IMPLEMENTED` verdict when `spec.md` records a canonical source document.
-  - Its result is exactly one of `UPDATED`, `NO_UPDATE_REQUIRED`, or `ESCALATED`, with rationale.
+  - `moonspec-doc-reconcile` has run after a `FULLY_IMPLEMENTED` verdict when at least one canonical source candidate exists: `spec.md` records a canonical source document, the breakdown `sourceReference.path` points under `docs/`, or the orchestration step provides a source design path under `docs/`.
+  - Its result is exactly one of `updated`, `no_update_required`, or `escalated`, with rationale.
 
 If a gate fails, stop or run the appropriate upstream skill. Do not continue on a claimed success without artifacts or evidence.
 
@@ -160,12 +160,12 @@ This replaces the old manual analyze remediation flow. Do not provide scripted "
 
 ### 7. Reconcile Declarative Docs
 
-Run only when the final verdict is `FULLY_IMPLEMENTED` and `spec.md` records a canonical source document under `docs/`:
+Run only when the final verdict is `FULLY_IMPLEMENTED` and at least one canonical source candidate exists: `spec.md` records a canonical source document, the breakdown `sourceReference.path` points under `docs/`, or the orchestration step provides a source design path under `docs/`:
 
 1. Run `moonspec-doc-reconcile` with the canonical document path(s), the latest verification report (including its Source Document Drift section), and `artifacts/doc-discoveries/<feature>.json` when present.
-2. Accept exactly one outcome: `UPDATED` (canonical doc edited), `NO_UPDATE_REQUIRED` (gate not met), or `ESCALATED` (Jira issue created for a misaligned update).
-3. `ESCALATED` does not retroactively fail verification; report the issue key alongside the outcome.
-4. Skip this stage with outcome `NO_UPDATE_REQUIRED` when no canonical source document exists.
+2. Accept exactly one outcome: `updated` (canonical doc edited), `no_update_required` (gate not met), or `escalated` (Jira issue created for a misaligned update).
+3. `escalated` does not retroactively fail verification; report the issue key alongside the outcome.
+4. Skip this stage with outcome `no_update_required` when no canonical source candidate exists.
 
 ## Multi-Spec Designs
 
@@ -194,7 +194,7 @@ Stages:
 - Align: PASS/FAIL/SKIPPED
 - Implement: PASS/FAIL/SKIPPED
 - Verify: FULLY_IMPLEMENTED/ADDITIONAL_WORK_NEEDED/NO_DETERMINATION/SKIPPED
-- Doc Reconcile: UPDATED/NO_UPDATE_REQUIRED/ESCALATED/SKIPPED
+- Doc Reconcile: updated/no_update_required/escalated/SKIPPED
 
 Changed files:
 - [paths]
@@ -220,4 +220,4 @@ Mention source design coverage and `DOC-REQ-*`/`DESIGN-REQ-*` status when presen
 - Enforce one story per spec.
 - Keep TDD, unit tests, integration tests, and `/speckit.verify` in the pipeline.
 - Treat verification as the final authority for completion.
-- Run doc reconciliation after a `FULLY_IMPLEMENTED` verdict when a canonical source document exists; never let derived artifacts silently override canonical docs.
+- Run doc reconciliation after a `FULLY_IMPLEMENTED` verdict when a canonical source candidate exists; never let derived artifacts silently override canonical docs.

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -1483,18 +1483,18 @@ def _secret_refs_check(
     problems: list[str] = []
     for role, result in secret_ref_results.items():
         if result.error:
-            problems.append(f"{role}: invalid SecretRef ({result.error})")
+            problems.append(f"{role} binding has invalid SecretRef ({result.error})")
             continue
         if not result.parsed or result.parsed.backend != SecretBackend.DB_ENCRYPTED:
             continue
         status = managed_secret_statuses.get(result.parsed.locator)
         if status is None:
             problems.append(
-                f"{role}: managed secret db://{result.parsed.locator} was not found"
+                f"{role} binding references managed secret db://{result.parsed.locator} was not found"
             )
         elif status != SecretStatus.ACTIVE.value:
             problems.append(
-                f"{role}: managed secret db://{result.parsed.locator} is {status}"
+                f"{role} binding references managed secret db://{result.parsed.locator} is {status}"
             )
 
     return _readiness_check(

--- a/api_service/data/presets/jira-orchestrate.yaml
+++ b/api_service/data/presets/jira-orchestrate.yaml
@@ -451,13 +451,13 @@ steps:
 
       Run moonspec-doc-reconcile for {{ inputs.jira_issue_key }} only when the controlling post-remediation verdict is FULLY_IMPLEMENTED. If the latest verdict is not FULLY_IMPLEMENTED, make no changes and report that doc reconciliation is skipped because publication is already blocked.
 
-      Use the canonical source document recorded in spec.md (Source Document){% if inputs.source_design_path %} or the provided source design path {{ inputs.source_design_path }}{% endif %}. If no canonical source document under docs/ exists, write the structured no_update_required outcome and continue.
+      Use the canonical source document recorded in spec.md (Source Document){% if inputs.source_design_path %} or the provided source design path {{ inputs.source_design_path }}{% endif %} as the starting authority candidate. Reconcile by authority scope, not original-source convenience: apply docs/Workflows/MoonSpecDocumentModel.md plus the docs/DocumentationArchitecture.md authority ladder and module-owned contract policy to identify the canonical document that owns each affected claim. The owning canonical doc may be different from the original source doc. If no canonical source candidate under docs/ exists, write the structured no_update_required outcome and continue.
 
       Consume the latest moonspec-verify report, including its Source Document Drift section, plus artifacts/doc-discoveries/<feature>.json when present. Apply the moonspec-doc-reconcile update gate strictly: edit canonical docs only for definite, evidence-backed discoveries showing the document is functionally wrong, internally inconsistent, or correctly diverged from for verified best-practice reasons. Otherwise report no_update_required; a no-op outcome is a correct result.
 
-      If a required update conflicts with the constitution, README, or architecture direction, do not edit the document; create the Jira escalation issue per the skill and continue. Escalation does not block pull request creation.
+      If a required update conflicts with the constitution, README, Document Model, Documentation Architecture Standard, module-owned contract policy, or architecture direction, or if ownership is ambiguous between multiple canonical documents, do not edit the document; create the Jira escalation issue per the skill and continue. Escalation does not block pull request creation.
 
-      Write the structured outcome to artifacts/jira-orchestrate-doc-reconcile.json with keys action, docPaths, gateRationale, evidence, and jiraIssue when escalated. Do not commit, push, or create a pull request from this step; any canonical doc edits remain in the working tree so the pull request step publishes them together with the implementation.
+      Write the structured outcome to artifacts/jira-orchestrate-doc-reconcile.json with keys action, docPaths, updated, noUpdateRequired, escalated, gateRationale, evidence, and jiraIssue when escalated. Every updated/noUpdateRequired/escalated item must include a reason. Do not commit, push, or create a pull request from this step; any canonical doc edits remain in the working tree so the pull request step publishes them together with the implementation.
     skill:
       id: moonspec-doc-reconcile
       args: {}
@@ -486,6 +486,7 @@ steps:
       - tests run
       - remaining risks
       - the doc reconciliation outcome from artifacts/jira-orchestrate-doc-reconcile.json when present: updated canonical doc paths, the no-update rationale, or the escalation Jira issue key
+      - a Documentation Conformance section listing canonical sources, temporary artifacts consulted, claim coverage, and reconciliation outcomes
 
       Canonical doc edits produced by the doc reconciliation step are intentional changes for this issue and must be committed in the same pull request.
 

--- a/api_service/data/presets/moonspec-orchestrate.yaml
+++ b/api_service/data/presets/moonspec-orchestrate.yaml
@@ -91,8 +91,8 @@ steps:
       args: {}
   - title: Reconcile declarative docs
     instructions: |-
-      Run moonspec-doc-reconcile only when the final moonspec-verify verdict is FULLY_IMPLEMENTED and spec.md records a canonical source document under docs/{% if inputs.source_design_path %} (source design path: {{ inputs.source_design_path }}){% endif %}.
-      If no canonical source document exists, report no_update_required and finish.
+      Run moonspec-doc-reconcile only when the final moonspec-verify verdict is FULLY_IMPLEMENTED and at least one canonical source candidate exists: spec.md records a canonical source document, the breakdown sourceReference.path points under docs/, or the orchestration step provides a source design path under docs/{% if inputs.source_design_path %} (source design path: {{ inputs.source_design_path }}){% endif %}.
+      If no canonical source candidate exists, report no_update_required and finish.
       Consume the latest verification report, including its Source Document Drift section, plus artifacts/doc-discoveries/<feature>.json when present.
       Apply the update gate strictly: edit canonical docs only for definite, evidence-backed discoveries showing the document is functionally wrong, internally inconsistent, or correctly diverged from for verified best-practice reasons. A no-op outcome is a correct result.
       Report exactly one outcome: updated, no_update_required, or escalated. Escalation creates a Jira issue per the skill and does not retroactively fail verification.

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -172,6 +172,17 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             "jiraOrchestrateRole": "doc-reconciliation"
         }
         assert "FULLY_IMPLEMENTED" in doc_reconcile_step["instructions"]
+        assert "starting authority candidate" in doc_reconcile_step["instructions"]
+        assert "authority ladder and module-owned contract policy" in doc_reconcile_step[
+            "instructions"
+        ]
+        assert "owning canonical doc may be different" in doc_reconcile_step[
+            "instructions"
+        ]
+        assert "ownership is ambiguous" in doc_reconcile_step["instructions"]
+        assert "updated, noUpdateRequired, escalated" in doc_reconcile_step[
+            "instructions"
+        ]
         assert "artifacts/jira-orchestrate-doc-reconcile.json" in doc_reconcile_step[
             "instructions"
         ]
@@ -194,6 +205,11 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert "explicit PR-publication step" in pr_step["instructions"]
         assert "controlling instruction for this step only" in pr_step["instructions"]
         assert "merge automation" in pr_step["instructions"]
+        assert "Documentation Conformance section" in pr_step["instructions"]
+        assert "canonical sources" in pr_step["instructions"]
+        assert "temporary artifacts consulted" in pr_step["instructions"]
+        assert "claim coverage" in pr_step["instructions"]
+        assert "reconciliation outcomes" in pr_step["instructions"]
         assert "artifacts/jira-orchestrate-pr.json" in pr_step["instructions"]
         code_review_step = next(
             step

--- a/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
+++ b/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
@@ -15,7 +15,16 @@ def test_moonspec_doc_reconcile_skill_defines_gate_and_output_contract() -> None
     assert "**Function**" in text
     assert "**Consistency**" in text
     assert "**Best practices**" in text
+    assert "## Authority-Scope Resolution" in text
+    assert "docs/DocumentationArchitecture.md" in text
+    assert "module-owned contract policy" in text
+    assert "The owning document may be different from the original source document" in text
+    assert "Escalate instead of guessing when ownership is ambiguous" in text
     assert "no_update_required" in text
+    assert "noUpdateRequired" in text
+    assert '"updated": [' in text
+    assert '"escalated": [' in text
+    assert "Every updated/noUpdateRequired/escalated item must include a reason" in text
     assert "escalated" in text
     assert "docs/Workflows/MoonSpecDocumentModel.md" in text
     assert "Never commit, push, or create pull requests" in text

--- a/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
+++ b/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
@@ -22,6 +22,9 @@ def test_moonspec_doc_reconcile_skill_defines_gate_and_output_contract() -> None
     assert "Escalate instead of guessing when ownership is ambiguous" in text
     assert "no_update_required" in text
     assert "noUpdateRequired" in text
+    assert "stop with `NO_UPDATE_REQUIRED`" not in text
+    assert "report `NO_UPDATE_REQUIRED`" not in text
+    assert "immediate `NO_UPDATE_REQUIRED`" not in text
     assert '"updated": [' in text
     assert '"escalated": [' in text
     assert "Every updated/noUpdateRequired/escalated item must include a reason" in text
@@ -39,6 +42,17 @@ def test_moonspec_implement_skill_defines_discovery_ledger() -> None:
     assert "artifacts/doc-discoveries/<feature>.json" in text
     assert '"severity": "definite | possible"' in text
     assert "moonspec-doc-reconcile" in text
+
+
+def test_moonspec_orchestrate_skill_honors_source_design_path_for_doc_reconcile() -> None:
+    text = (_SKILLS_DIR / "moonspec-orchestrate" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "at least one canonical source candidate exists" in text
+    assert "the orchestration step provides a source design path under `docs/`" in text
+    assert "Skip this stage with outcome `no_update_required`" in text
+    assert "when `spec.md` records a canonical source document" not in text
 
 
 def test_moonspec_verify_skill_reports_source_document_drift() -> None:

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3139,11 +3139,32 @@ async def test_seed_catalog_includes_moonspec_orchestrate_without_report_step(
             assert "moonspec-verify" == expanded["steps"][-2]["skill"]["id"]
             assert expanded["steps"][-1]["title"] == "Reconcile declarative docs"
             assert "moonspec-doc-reconcile" == expanded["steps"][-1]["skill"]["id"]
+            assert "at least one canonical source candidate exists" in expanded[
+                "steps"
+            ][-1]["instructions"]
+            assert "orchestration step provides a source design path under docs/" in expanded[
+                "steps"
+            ][-1]["instructions"]
             assert "no_update_required" in expanded["steps"][-1]["instructions"]
             assert all(
                 step["title"] != "Return orchestration report and defer publish actions"
                 for step in expanded["steps"]
             )
+
+            expanded_with_source_design = await service.expand_template(
+                slug="moonspec-orchestrate",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "feature_request": "MM-366: Simplify Orchestrate Summary",
+                    "source_design_path": "docs/Designs/RuntimeTypes.md",
+                    "constraints": "Keep the scope narrow.",
+                },
+                context={},
+            )
+            assert "source design path: docs/Designs/RuntimeTypes.md" in expanded_with_source_design[
+                "steps"
+            ][-1]["instructions"]
 
 async def test_sync_seed_templates_creates_missing_seed(tmp_path):
     seed_dir = tmp_path / "seeds"


### PR DESCRIPTION
Issue reference: MM-935

## Summary
- Expanded `moonspec-doc-reconcile` from original-source-document reconciliation to authority-scope reconciliation using the Document Model, Documentation Architecture authority ladder, and module-owned contract policy.
- Updated Jira Orchestrate preset instructions so reconciliation can choose the owning canonical document, escalates ambiguous ownership conflicts, and writes structured `updated`, `noUpdateRequired`, and `escalated` outcomes with reasons.
- Added/updated tests covering the reconciliation skill contract and preset PR-publication instructions.

## Documentation Conformance
- Canonical sources: `.agents/skills/moonspec-doc-reconcile/SKILL.md`, `api_service/data/presets/jira-orchestrate.yaml`, `docs/Workflows/MoonSpecDocumentModel.md`, `docs/DocumentationArchitecture.md`.
- Temporary artifacts consulted: `artifacts/jira-implement-assessment.json`.
- Claim coverage: covers authority-scope owning document selection, ambiguous ownership escalation, structured reconciliation outcome lists with reasons, and PR documentation conformance reporting.
- Reconciliation outcomes: this implementation updates the reconciliation skill and Jira Orchestrate preset; no run-specific canonical docs were produced by a doc-reconciliation step in this handoff.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/agents/test_moonspec_doc_reconcile_skill.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest -q tests/integration/test_startup_preset_seeding.py`

## Remaining risks
- Assessment recorded `PARTIALLY_IMPLEMENTED` before this PR-publication step; review should confirm the final instruction text fully satisfies MM-935 authority-scope semantics.
