### PR TITLE
[codex] Handle managed no-progress quota cooldown

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1712,6 +1712,8 @@ class MoonMindAgentRun:
                 )
                 if self._result_requires_provider_cooldown(result):
                     return result
+                if status_obj.status != RunStatus.cancelled:
+                    return None
 
     async def _ensure_manager_and_signal(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -167,6 +167,9 @@ AGENT_RUN_STRUCTURED_PROVIDER_FAILURE_PATCH_ID = (
 AGENT_RUN_MANAGED_NO_PROGRESS_RECONCILIATION_PATCH_ID = (
     "agent-run-managed-no-progress-reconciliation-v1"
 )
+AGENT_RUN_MANAGED_NO_PROGRESS_CANCEL_FETCH_PATCH_ID = (
+    "agent-run-managed-no-progress-cancel-fetch-v1"
+)
 MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
     "agent-run-managed-session-start-after-slot-v1"
 )
@@ -812,6 +815,21 @@ class MoonMindAgentRun:
     @staticmethod
     def _no_progress_grace_seconds(policy: Mapping[str, Any]) -> int:
         return max(0, int(policy.get("noProgressGraceSeconds") or 0))
+
+    @staticmethod
+    def _result_requires_provider_cooldown(result: AgentRunResult | None) -> bool:
+        if result is None:
+            return False
+        metadata = result.metadata if isinstance(result.metadata, Mapping) else {}
+        provider_failure_event = provider_failure_event_from_metadata(
+            metadata.get("providerFailure")
+        )
+        if provider_failure_event is not None:
+            return provider_failure_event_requires_cooldown(provider_failure_event)
+        return provider_error_requires_cooldown(
+            provider_error_code=result.provider_error_code,
+            retry_recommendation=result.retry_recommendation,
+        )
 
     def _intervention_result(
         self,
@@ -1582,6 +1600,17 @@ class MoonMindAgentRun:
             ).total_seconds()
             remaining = min(remaining_grace, remaining_overall)
             if remaining <= 0:
+                if workflow.patched(
+                    AGENT_RUN_MANAGED_NO_PROGRESS_CANCEL_FETCH_PATCH_ID
+                ):
+                    return await self._cancel_managed_no_progress_and_fetch_cooldown_result(
+                        request=request,
+                        adapter=adapter,
+                        uses_codex_session_adapter=uses_codex_session_adapter,
+                        use_managed_status_activity=use_managed_status_activity,
+                        poll_interval=poll_interval,
+                        remaining_overall=remaining_overall,
+                    )
                 return None
 
             try:
@@ -1601,6 +1630,88 @@ class MoonMindAgentRun:
                 uses_codex_session_adapter=uses_codex_session_adapter,
                 use_managed_status_activity=use_managed_status_activity,
             )
+
+    async def _cancel_managed_no_progress_and_fetch_cooldown_result(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        adapter: AgentAdapter,
+        uses_codex_session_adapter: bool,
+        use_managed_status_activity: bool,
+        poll_interval: int,
+        remaining_overall: float,
+    ) -> AgentRunResult | None:
+        """Force silent managed runtimes to surface quota/capacity failures.
+
+        Claude Code can remain silent while blocked on provider/session quota and
+        emit the 429/session-limit line only after the process is interrupted.
+        Before converting no-progress into human intervention, cancel the owned
+        process and briefly reconcile the canonical runtime result so provider
+        cooldown handling can take over when the supervisor classifies a 429.
+        """
+
+        if not self.run_id or remaining_overall <= 0:
+            return None
+
+        try:
+            await self._execute_routed_activity(
+                "agent_runtime.cancel",
+                AgentRuntimeCancelInput(
+                    agentKind=request.agent_kind,
+                    runId=str(self.run_id or ""),
+                ),
+                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            )
+        except Exception:
+            self._get_logger().warning(
+                "Failed to cancel managed runtime during no-progress reconciliation.",
+                exc_info=True,
+            )
+            return None
+
+        reconcile_seconds = min(
+            max(float(poll_interval) * 2.0, 10.0),
+            max(1.0, float(remaining_overall)),
+        )
+        deadline = workflow.now() + timedelta(seconds=reconcile_seconds)
+
+        while True:
+            if self._result_requires_provider_cooldown(self.final_result):
+                return self.final_result
+
+            remaining = (deadline - workflow.now()).total_seconds()
+            if remaining <= 0:
+                return None
+
+            try:
+                completed = await workflow.wait_condition(
+                    lambda: self.completion_event.is_set(),
+                    timeout=timedelta(seconds=min(float(poll_interval), remaining)),
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                completed = False
+
+            if completed or self.completion_event.is_set():
+                if self._result_requires_provider_cooldown(self.final_result):
+                    return self.final_result
+                return None
+
+            status_obj = await self._poll_managed_status(
+                request=request,
+                adapter=adapter,
+                uses_codex_session_adapter=uses_codex_session_adapter,
+                use_managed_status_activity=use_managed_status_activity,
+            )
+            self.run_status = status_obj.status
+            if status_obj.status in _TERMINAL_RUN_STATUSES:
+                result = await self._fetch_managed_result(
+                    request=request,
+                    adapter=adapter,
+                    uses_codex_session_adapter=uses_codex_session_adapter,
+                    use_managed_status_activity=use_managed_status_activity,
+                )
+                if self._result_requires_provider_cooldown(result):
+                    return result
 
     async def _ensure_manager_and_signal(
         self,

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -26,18 +26,46 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 # (the standalone stubs were removed in favor of catalog routing).
 from temporalio import activity as _activity
 
+
 @_activity.defn(name="agent_runtime.publish_artifacts")
-async def mock_publish_artifacts(result: AgentRunResult | None = None) -> AgentRunResult | None:
+async def mock_publish_artifacts(
+    result: AgentRunResult | None = None,
+) -> AgentRunResult | None:
     return result
+
+
+_managed_cancel_count = 0
+
+
+def _request_get(request: object, *keys: str, default: Any = None) -> Any:
+    if isinstance(request, dict):
+        for key in keys:
+            if key in request:
+                return request[key]
+        return default
+    for key in keys:
+        value = getattr(request, key, None)
+        if value is not None:
+            return value
+    return default
+
 
 @_activity.defn(name="agent_runtime.cancel")
 async def mock_cancel(request: dict) -> AgentRunStatus:
+    global _managed_cancel_count
+    _managed_cancel_count += 1
     return AgentRunStatus(
-        runId=request.get("run_id", "unknown"),
-        agentKind=request.get("agent_kind", "unknown"),
+        runId=_request_get(request, "run_id", "runId", default="unknown"),
+        agentKind=_request_get(
+            request,
+            "agent_kind",
+            "agentKind",
+            default="unknown",
+        ),
         agentId="managed",
-        status="canceled"
+        status="canceled",
     )
+
 
 @_activity.defn(name="provider_profile.list")
 async def mock_provider_profile_list(request: dict) -> dict:
@@ -162,6 +190,23 @@ async def mock_agent_runtime_status(request: dict) -> dict:
             "status": status,
             "metadata": metadata,
         }
+    if _managed_status_mode == "silent_then_rate_limited_after_cancel":
+        status = "failed" if _managed_cancel_count else "running"
+        metadata = {"runtimeId": "claude_code"}
+        if status == "failed":
+            metadata["finishedAt"] = datetime.now(tz=UTC).isoformat()
+            metadata["exitCode"] = -9
+        return {
+            "runId": request.get("runId")
+            or request.get("run_id")
+            or "test-managed-run",
+            "agentKind": "managed",
+            "agentId": request.get("agentId")
+            or request.get("agent_id")
+            or "claude_code",
+            "status": status,
+            "metadata": metadata,
+        }
     return {
         "status": "running",
         "container_id": request.get("container_id", "test-container-001"),
@@ -178,6 +223,26 @@ async def mock_agent_runtime_fetch_result(request: dict) -> dict:
             "metadata": {
                 "normalizedStatus": "completed",
                 "fetchRunId": request.get("runId") or request.get("run_id"),
+            },
+        }
+    if _managed_status_mode == "silent_then_rate_limited_after_cancel":
+        return {
+            "summary": "Provider rate limit reached; retry after cooldown.",
+            "failureClass": "integration_error",
+            "providerErrorCode": "429",
+            "retryRecommendation": "retry_after_cooldown",
+            "metadata": {
+                "normalizedStatus": "failed",
+                "fetchRunId": request.get("runId") or request.get("run_id"),
+                "providerFailure": {
+                    "providerErrorClass": "rate_limit",
+                    "providerErrorCode": "429",
+                    "retryRecommendation": "retry_after_cooldown",
+                    "sanitizedSummary": (
+                        "Provider rate limit reached; the run will retry "
+                        "after a profile cooldown."
+                    ),
+                },
             },
         }
     return {
@@ -1241,6 +1306,139 @@ async def test_agent_run_reconciles_managed_completion_during_no_progress_grace(
         )
     finally:
         _managed_status_mode = "default"
+
+@pytest.mark.asyncio
+async def test_agent_run_reconciles_managed_quota_after_no_progress_cancel(
+    monkeypatch,
+):
+    global _managed_status_mode, _managed_status_poll_count
+    global _managed_fetch_result_count, _managed_cancel_count
+    _managed_launch_requests.clear()
+    _managed_status_mode = "silent_then_rate_limited_after_cancel"
+    _managed_status_poll_count = 0
+    _managed_fetch_result_count = 0
+    _managed_cancel_count = 0
+
+    def test_policy(request: AgentExecutionRequest) -> dict[str, Any]:
+        return {
+            "runtime": request.agent_id,
+            "noProgressTimeoutSeconds": 1,
+            "noProgressGraceSeconds": 1,
+            "stuckAction": "request_intervention",
+            "retryPolicy": "test_managed_cancel_fetch_rate_limit",
+        }
+
+    monkeypatch.setattr(
+        MoonMindAgentRun,
+        "_resiliency_policy_for_request",
+        staticmethod(test_policy),
+    )
+
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with (
+                Worker(
+                    env.client,
+                    task_queue="agent-run-task-queue",
+                    workflows=[
+                        MoonMindAgentRun,
+                        MockProviderProfileManager,
+                        TestAgentRunParent,
+                    ],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.artifacts",
+                    activities=[
+                        mock_provider_profile_list,
+                        mock_provider_profile_ensure_manager,
+                        mock_provider_profile_reset_manager,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.agent_runtime",
+                    activities=[
+                        mock_agent_runtime_build_launch_context,
+                        mock_agent_runtime_launch,
+                        mock_agent_runtime_status,
+                        mock_agent_runtime_fetch_result,
+                        mock_publish_artifacts,
+                        mock_cancel,
+                    ],
+                ),
+            ):
+                manager_id = "provider-profile-manager:claude_code"
+                await env.client.start_workflow(
+                    MockProviderProfileManager.run,
+                    {"runtime_id": "claude_code"},
+                    id=manager_id,
+                    task_queue="agent-run-task-queue",
+                )
+                manager_handle = env.client.get_workflow_handle(manager_id)
+
+                parent_handle = await env.client.start_workflow(
+                    TestAgentRunParent.run,
+                    AgentExecutionRequest(
+                        agent_kind="managed",
+                        agent_id="claude_code",
+                        execution_profile_ref="default-managed",
+                        correlation_id="managed-quota-after-cancel:corr",
+                        idempotency_key="managed-quota-after-cancel:idem",
+                    ),
+                    id="test-parent-managed-quota-after-cancel",
+                    task_queue="agent-run-task-queue",
+                )
+
+                await env.sleep(35)
+
+                manager_state = {}
+                parent_state = {}
+                for _ in range(20):
+                    manager_state = await manager_handle.query(
+                        MockProviderProfileManager.get_state
+                    )
+                    parent_state = await parent_handle.query(
+                        TestAgentRunParent.get_state
+                    )
+                    if manager_state.get("cooldown_reports") and any(
+                        "retry scheduled" in change["reason"].lower()
+                        for change in parent_state.get("state_changes", [])
+                    ):
+                        break
+                    await asyncio.sleep(0.1)
+
+                debug_state = {
+                    "cancel_count": _managed_cancel_count,
+                    "fetch_count": _managed_fetch_result_count,
+                    "status_polls": _managed_status_poll_count,
+                    "manager_state": manager_state,
+                    "parent_state": parent_state,
+                }
+                assert _managed_cancel_count >= 1, debug_state
+                assert _managed_fetch_result_count >= 1, debug_state
+                assert manager_state["cooldown_reports"], debug_state
+                assert (
+                    manager_state["cooldown_reports"][-1]["cooldown_seconds"]
+                    == 900
+                )
+                assert not any(
+                    change["state"] == "intervention_requested"
+                    for change in parent_state["state_changes"]
+                )
+                assert any(
+                    "retry scheduled" in change["reason"].lower()
+                    and "900s cooldown" in change["reason"].lower()
+                    for change in parent_state["state_changes"]
+                )
+
+                await parent_handle.cancel()
+                with pytest.raises(WorkflowFailureError):
+                    await parent_handle.result()
+    finally:
+        _managed_status_mode = "default"
+        _managed_cancel_count = 0
 
 @pytest.mark.asyncio
 async def test_agent_run_external_agent_workflow():

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -191,9 +191,14 @@ async def mock_agent_runtime_status(request: dict) -> dict:
             "metadata": metadata,
         }
     if _managed_status_mode == "silent_then_rate_limited_after_cancel":
-        status = "failed" if _managed_cancel_count else "running"
+        if not _managed_cancel_count:
+            status = "running"
+        elif _managed_fetch_result_count == 0:
+            status = "canceled"
+        else:
+            status = "failed"
         metadata = {"runtimeId": "claude_code"}
-        if status == "failed":
+        if status in {"canceled", "failed"}:
             metadata["finishedAt"] = datetime.now(tz=UTC).isoformat()
             metadata["exitCode"] = -9
         return {
@@ -226,6 +231,15 @@ async def mock_agent_runtime_fetch_result(request: dict) -> dict:
             },
         }
     if _managed_status_mode == "silent_then_rate_limited_after_cancel":
+        if _managed_fetch_result_count == 1:
+            return {
+                "summary": "Managed run canceled before provider classification.",
+                "failureClass": "execution_error",
+                "metadata": {
+                    "normalizedStatus": "canceled",
+                    "fetchRunId": request.get("runId") or request.get("run_id"),
+                },
+            }
         return {
             "summary": "Provider rate limit reached; retry after cooldown.",
             "failureClass": "integration_error",
@@ -1391,7 +1405,7 @@ async def test_agent_run_reconciles_managed_quota_after_no_progress_cancel(
                     task_queue="agent-run-task-queue",
                 )
 
-                await env.sleep(35)
+                await env.sleep(50)
 
                 manager_state = {}
                 parent_state = {}
@@ -1417,7 +1431,7 @@ async def test_agent_run_reconciles_managed_quota_after_no_progress_cancel(
                     "parent_state": parent_state,
                 }
                 assert _managed_cancel_count >= 1, debug_state
-                assert _managed_fetch_result_count >= 1, debug_state
+                assert _managed_fetch_result_count >= 2, debug_state
                 assert manager_state["cooldown_reports"], debug_state
                 assert (
                     manager_state["cooldown_reports"][-1]["cooldown_seconds"]


### PR DESCRIPTION
## Summary

This fixes a managed AgentRun failure mode where a silent Claude Code runtime could be marked `intervention_requested` for no observable progress before the runtime surfaced a provider quota/session-limit error.

## What changed

- Added a Temporal patch-gated no-progress reconciliation path for managed runs.
- When no-progress grace expires, AgentRun now cancels the owned managed runtime and briefly reconciles the final runtime result.
- If that result is a provider cooldown class such as `429` or capacity, the existing provider-profile cooldown path handles slot release and retry instead of failing as human intervention.
- Added a workflow-boundary regression test for a silent managed runtime that surfaces `429` only after cancellation.

## Root cause

The failed workflow showed Temporal polling and runtime heartbeat were healthy, but Claude Code produced no observable log/status progress until after AgentRun had already converted the run to `intervention_requested`. The later runtime diagnostics showed the actual provider condition was a session/quota limit.

## Validation

- `.venv/bin/python -m py_compile moonmind/workflows/temporal/workflows/agent_run.py tests/integration/services/temporal/workflows/test_agent_run.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/integration/services/temporal/workflows/test_agent_run.py -q -k 'reconciles_managed_completion_during_no_progress_grace or reconciles_managed_quota_after_no_progress_cancel'`
- `.venv/bin/python -m pytest tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py -q`

Note: `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py` could not run because its precheck hit a local permission error reading `deploy/state/desired-state.json`; the targeted pytest command passed directly.