### PR TITLE
[codex] Fix managed session orphan reaping

### DIFF
--- a/docs/ManagedAgents/DockerSidecarRuntime.md
+++ b/docs/ManagedAgents/DockerSidecarRuntime.md
@@ -688,12 +688,15 @@ Default posture: destroy the sidecar and its graph storage at session end; prese
 
 Per-session cleanup runs on the graceful `terminate_session` path. When the owning workflow is terminated or crashes, the managed session child is abandoned (`ParentClosePolicy.ABANDON`), so its agent container, docker sidecar, and sidecar volumes can be left running with no live session behind them.
 
-The recurring managed-session reconcile sweep (`MoonMind.ManagedSessionReconcile`) therefore also reaps orphaned session containers. A container carrying the `moonmind.session_id` label is removed when its session is **not active** in the durable session store, subject to a grace window so a freshly launched session is never reaped before its store record is durable. Reaping is best-effort: a failure never fails the reconcile sweep, and the sweep refuses to remove anything when the session store is unavailable.
+The recurring managed-session reconcile sweep (`MoonMind.ManagedSessionReconcile`) therefore also reaps orphaned session containers. A container carrying the `moonmind.session_id` label is removed when its session is **not active** in the durable session store, subject to a grace window so a freshly launched session is never reaped before its store record is durable.
+
+The sweep also reconciles stale active records against Temporal ownership. If a non-terminal session record points at an owning agent workflow that has reached a terminal Temporal status, the record is marked terminated and the container becomes eligible for orphan reaping in the same sweep. As a final guardrail, an old `ready` session with no `activeTurnId` can be force-reaped after the configured maximum age even if the store still marks it active. Reaping is best-effort: a failure never fails the reconcile sweep, and the sweep refuses to remove anything when the session store is unavailable.
 
 | Env var | Default | Meaning |
 |---|---|---|
 | `MOONMIND_MANAGED_SESSION_REAP_ENABLED` | `1` (enabled) | Set to a falsey value (`0`, `false`, `no`, `off`) to disable orphan reaping entirely. |
 | `MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS` | `900` | Minimum age (seconds) before an orphaned container is eligible for reaping. |
+| `MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS` | `172800` | Maximum age (seconds) for a `ready` active-store session with no `activeTurnId` before the sweep force-reaps it. Set to a falsey value to disable this guardrail. |
 
 ---
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8307,6 +8307,7 @@ class TemporalAgentRuntimeActivities:
         # fail the reconcile activity, whose reattach/degrade work is primary.
         orphan_containers_reaped = 0
         orphan_reap_skipped_recent = 0
+        orphan_reap_forced_stale = 0
         orphan_volumes_scanned = 0
         orphan_volumes_reaped = 0
         orphan_volume_reap_skipped_active = 0
@@ -8330,6 +8331,9 @@ class TemporalAgentRuntimeActivities:
             )
             orphan_reap_skipped_recent = int(
                 getattr(reap_result, "skipped_recent", 0) or 0
+            )
+            orphan_reap_forced_stale = int(
+                getattr(reap_result, "forced_stale", 0) or 0
             )
             orphan_volumes_scanned = int(
                 getattr(reap_result, "scanned_volumes", 0) or 0
@@ -8355,6 +8359,7 @@ class TemporalAgentRuntimeActivities:
             "orphanContainersReaped": orphan_containers_reaped,
             "orphanSessionIdsReaped": orphan_session_ids_reaped,
             "orphanReapSkippedRecent": orphan_reap_skipped_recent,
+            "orphanReapForcedStale": orphan_reap_forced_stale,
             "orphanVolumesScanned": orphan_volumes_scanned,
             "orphanVolumesReaped": orphan_volumes_reaped,
             "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -180,6 +180,22 @@ def _parse_docker_timestamp(value: str) -> datetime | None:
     return parsed
 
 
+def _coerce_aware_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        parsed = _parse_docker_timestamp(value)
+    else:
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
 def _normalize_owner_workflow_status(value: Any) -> str:
     """Normalize Temporal workflow status values for terminal-state checks."""
 
@@ -3519,6 +3535,9 @@ class DockerCodexManagedSessionController:
             return None
         try:
             status = await resolver(record.agent_run_id)
+            if not _owner_workflow_status_is_terminal(status):
+                return None
+            return _normalize_owner_workflow_status(status)
         except Exception:
             logger.warning(
                 "Managed session owner workflow status lookup failed for %s",
@@ -3526,9 +3545,6 @@ class DockerCodexManagedSessionController:
                 exc_info=True,
             )
             return None
-        if not _owner_workflow_status_is_terminal(status):
-            return None
-        return _normalize_owner_workflow_status(status)
 
     async def _mark_session_terminated_by_reconcile(
         self,
@@ -3540,7 +3556,7 @@ class DockerCodexManagedSessionController:
         if self._session_store is None:
             return record
         updated_metadata = {
-            **dict(record.metadata),
+            **dict(record.metadata or {}),
             **dict(metadata),
             "terminationSource": "managed_session_reconcile",
             "terminatedAt": datetime.now(tz=UTC).isoformat(),
@@ -3683,6 +3699,9 @@ class DockerCodexManagedSessionController:
             age_anchor = (
                 newest_container_created_at or record.updated_at or record.started_at
             )
+            age_anchor = _coerce_aware_datetime(age_anchor)
+            if age_anchor is None:
+                continue
             if (now - age_anchor).total_seconds() < max_age_seconds:
                 continue
             stale.add(session_id)
@@ -4008,20 +4027,27 @@ class DockerCodexManagedSessionController:
                 skipped_recent += len(session_containers)
                 continue
             if force_stale:
-                forced_stale += 1
                 record = active_records.get(session_id)
                 if record is not None:
-                    await self._mark_session_terminated_by_reconcile(
-                        record,
-                        reason=(
-                            "managed session exceeded reap max age without an "
-                            "active turn"
-                        ),
-                        metadata={
-                            "maxAgeSeconds": max_age_seconds,
-                            "reapReason": "stale_active_session_max_age",
-                        },
-                    )
+                    try:
+                        await self._mark_session_terminated_by_reconcile(
+                            record,
+                            reason=(
+                                "managed session exceeded reap max age without an "
+                                "active turn"
+                            ),
+                            metadata={
+                                "maxAgeSeconds": max_age_seconds,
+                                "reapReason": "stale_active_session_max_age",
+                            },
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to terminate stale active session %s during reap",
+                            session_id,
+                        )
+                        continue
+                forced_stale += 1
                 logger.warning(
                     "Reaping stale active managed session %s after max age %s seconds",
                     session_id,
@@ -4047,19 +4073,28 @@ class DockerCodexManagedSessionController:
                     session_id,
                 )
         for session_id in sorted(stale_active_session_ids - set(by_session)):
-            forced_stale += 1
             record = active_records.get(session_id)
             if record is not None:
-                await self._mark_session_terminated_by_reconcile(
-                    record,
-                    reason=(
-                        "managed session exceeded reap max age without an active turn"
-                    ),
-                    metadata={
-                        "maxAgeSeconds": max_age_seconds,
-                        "reapReason": "stale_active_session_max_age",
-                    },
-                )
+                try:
+                    await self._mark_session_terminated_by_reconcile(
+                        record,
+                        reason=(
+                            "managed session exceeded reap max age without an "
+                            "active turn"
+                        ),
+                        metadata={
+                            "maxAgeSeconds": max_age_seconds,
+                            "reapReason": "stale_active_session_max_age",
+                        },
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to terminate stale active session %s "
+                        "(no containers) during reap",
+                        session_id,
+                    )
+                    continue
+            forced_stale += 1
             logger.warning(
                 "Marked stale active managed session %s terminated after max age "
                 "%s seconds; no labeled containers were present",

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -88,12 +88,24 @@ _SESSION_DOCKER_MODE_DISABLED_VALUES = {"no-docker", "disabled", "none", "off"}
 # window protects against reaping a container whose record is not yet active
 # (mid-launch) or that is being relaunched.
 _DEFAULT_SESSION_REAP_GRACE_SECONDS = 900.0
+_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS = 48 * 60 * 60
 _MANAGED_SESSION_LABEL_KEY = "moonmind.session_id"
 _MANAGED_SESSION_SIDECAR_VOLUME_KIND = "session-docker-sidecar-volume"
 _MANAGED_SESSION_SIDECAR_VOLUME_NAME = re.compile(
     r"^moonmind-session-.+-docker-(graph|socket)$"
 )
 _FALSEY_ENV_VALUES = {"0", "false", "no", "off", ""}
+_TERMINAL_OWNER_WORKFLOW_STATUSES = frozenset(
+    {
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "CANCELLED",
+        "TERMINATED",
+        "TIMED_OUT",
+        "CONTINUED_AS_NEW",
+    }
+)
 logger = logging.getLogger(__name__)
 
 
@@ -127,11 +139,17 @@ class ManagedSessionReapResult:
     reaped_containers: int = 0
     skipped_active: int = 0
     skipped_recent: int = 0
+    forced_stale: int = 0
     scanned_volumes: int = 0
     reaped_volumes: int = 0
     skipped_active_volumes: int = 0
     skipped_recent_volumes: int = 0
     disabled: bool = False
+
+
+class OwnerWorkflowStatusResolver(Protocol):
+    async def __call__(self, workflow_id: str, /) -> Any:
+        """Return a provider-specific workflow status for *workflow_id*."""
 
 
 def _parse_docker_timestamp(value: str) -> datetime | None:
@@ -160,6 +178,28 @@ def _parse_docker_timestamp(value: str) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed
+
+
+def _normalize_owner_workflow_status(value: Any) -> str:
+    """Normalize Temporal workflow status values for terminal-state checks."""
+
+    if value is None:
+        return ""
+    name = getattr(value, "name", None)
+    if isinstance(name, str) and name.strip():
+        return name.strip().upper()
+    raw = getattr(value, "value", value)
+    if isinstance(raw, str):
+        normalized = raw.strip().upper()
+    else:
+        normalized = str(raw).strip().upper()
+    if "." in normalized:
+        normalized = normalized.rsplit(".", 1)[-1]
+    return normalized
+
+
+def _owner_workflow_status_is_terminal(value: Any) -> bool:
+    return _normalize_owner_workflow_status(value) in _TERMINAL_OWNER_WORKFLOW_STATUSES
 
 def _last_assistant_text_metadata(value: str) -> dict[str, Any]:
     normalized = str(value or "").strip()
@@ -319,6 +359,7 @@ class DockerCodexManagedSessionController:
         ),
         command_runner: CommandRunner = _default_command_runner,
         github_auth_brokers: GitHubAuthBrokerManager | Any | None = None,
+        owner_workflow_status_resolver: OwnerWorkflowStatusResolver | None = None,
     ) -> None:
         self._workspace_volume_name = workspace_volume_name
         self._codex_volume_name = codex_volume_name
@@ -335,6 +376,7 @@ class DockerCodexManagedSessionController:
         self._turn_poll_timeout_seconds = turn_poll_timeout_seconds
         self._command_runner = command_runner
         self._github_auth_brokers = github_auth_brokers or GitHubAuthBrokerManager()
+        self._owner_workflow_status_resolver = owner_workflow_status_resolver
 
     @staticmethod
     def _managed_session_user_command_kwargs() -> dict[str, int]:
@@ -3468,12 +3510,83 @@ class DockerCodexManagedSessionController:
             },
         )
 
+    async def _terminal_owner_workflow_status(
+        self,
+        record: CodexManagedSessionRecord,
+    ) -> str | None:
+        resolver = self._owner_workflow_status_resolver
+        if resolver is None:
+            return None
+        try:
+            status = await resolver(record.agent_run_id)
+        except Exception:
+            logger.warning(
+                "Managed session owner workflow status lookup failed for %s",
+                record.session_id,
+                exc_info=True,
+            )
+            return None
+        if not _owner_workflow_status_is_terminal(status):
+            return None
+        return _normalize_owner_workflow_status(status)
+
+    async def _mark_session_terminated_by_reconcile(
+        self,
+        record: CodexManagedSessionRecord,
+        *,
+        reason: str,
+        metadata: Mapping[str, Any],
+    ) -> CodexManagedSessionRecord:
+        if self._session_store is None:
+            return record
+        updated_metadata = {
+            **dict(record.metadata),
+            **dict(metadata),
+            "terminationSource": "managed_session_reconcile",
+            "terminatedAt": datetime.now(tz=UTC).isoformat(),
+        }
+        updated = await self._session_store.update(
+            record.session_id,
+            status="terminated",
+            active_turn_id=None,
+            error_message=reason,
+            metadata=updated_metadata,
+            updated_at=datetime.now(tz=UTC),
+        )
+        await self._github_auth_brokers.stop(record.session_id)
+        self._cleanup_skill_projections_for_session(updated)
+        return updated
+
     async def reconcile(self) -> list[CodexManagedSessionRecord]:
         if self._session_store is None:
             return []
         reconciled: list[CodexManagedSessionRecord] = []
         for record in self._session_store.list_active():
             try:
+                terminal_owner_status = await self._terminal_owner_workflow_status(
+                    record
+                )
+                if terminal_owner_status is not None:
+                    updated = await self._mark_session_terminated_by_reconcile(
+                        record,
+                        reason=(
+                            "managed session owner workflow is terminal during "
+                            f"reconcile: {terminal_owner_status}"
+                        ),
+                        metadata={
+                            "ownerWorkflowId": record.agent_run_id,
+                            "ownerWorkflowStatus": terminal_owner_status,
+                        },
+                    )
+                    reconciled.append(updated)
+                    logger.warning(
+                        "Marked managed session %s terminated because owner "
+                        "workflow %s is terminal: %s",
+                        record.session_id,
+                        record.agent_run_id,
+                        terminal_owner_status,
+                    )
+                    continue
                 container_exists = await self._container_exists(record.container_id)
                 if not container_exists:
                     updated = await self._session_store.update(
@@ -3520,6 +3633,60 @@ class DockerCodexManagedSessionController:
             return max(0.0, float(raw))
         except ValueError:
             return _DEFAULT_SESSION_REAP_GRACE_SECONDS
+
+    @staticmethod
+    def _reap_max_age_seconds() -> float | None:
+        raw = os.environ.get("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS")
+        if raw is None:
+            return float(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS)
+        normalized = raw.strip().lower()
+        if normalized in _FALSEY_ENV_VALUES:
+            return None
+        try:
+            value = float(normalized)
+        except ValueError:
+            return float(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS)
+        if value <= 0:
+            return None
+        return value
+
+    @staticmethod
+    def _newest_container_created_at(
+        containers: Sequence[_ManagedSessionContainer],
+    ) -> datetime | None:
+        return max(
+            (
+                container.created_at
+                for container in containers
+                if container.created_at is not None
+            ),
+            default=None,
+        )
+
+    def _stale_active_session_ids(
+        self,
+        *,
+        active_records: Mapping[str, CodexManagedSessionRecord],
+        by_session: Mapping[str, Sequence[_ManagedSessionContainer]],
+        max_age_seconds: float | None,
+        now: datetime,
+    ) -> set[str]:
+        if max_age_seconds is None:
+            return set()
+        stale: set[str] = set()
+        for session_id, record in active_records.items():
+            if record.status != "ready" or record.active_turn_id:
+                continue
+            newest_container_created_at = self._newest_container_created_at(
+                by_session.get(session_id, ())
+            )
+            age_anchor = (
+                newest_container_created_at or record.updated_at or record.started_at
+            )
+            if (now - age_anchor).total_seconds() < max_age_seconds:
+                continue
+            stale.add(session_id)
+        return stale
 
     async def _list_managed_session_containers(
         self,
@@ -3802,19 +3969,28 @@ class DockerCodexManagedSessionController:
             # so refuse to remove anything rather than guess.
             return ManagedSessionReapResult(disabled=True)
 
-        active_session_ids = {
-            record.session_id for record in self._session_store.list_active()
-        }
         grace_seconds = self._reap_grace_seconds()
+        max_age_seconds = self._reap_max_age_seconds()
         now = datetime.now(tz=UTC)
 
         containers = await self._list_managed_session_containers()
         by_session: dict[str, list[_ManagedSessionContainer]] = {}
         for container in containers:
             by_session.setdefault(container.session_id, []).append(container)
+        active_records = {
+            record.session_id: record for record in self._session_store.list_active()
+        }
+        stale_active_session_ids = self._stale_active_session_ids(
+            active_records=active_records,
+            by_session=by_session,
+            max_age_seconds=max_age_seconds,
+            now=now,
+        )
+        active_session_ids = set(active_records) - stale_active_session_ids
 
         skipped_active = 0
         skipped_recent = 0
+        forced_stale = 0
         reaped_containers = 0
         reaped_session_ids: list[str] = []
 
@@ -3822,17 +3998,35 @@ class DockerCodexManagedSessionController:
             if session_id in active_session_ids:
                 skipped_active += len(session_containers)
                 continue
-            newest = max(
-                (
-                    container.created_at
-                    for container in session_containers
-                    if container.created_at is not None
-                ),
-                default=None,
-            )
-            if newest is not None and (now - newest).total_seconds() < grace_seconds:
+            newest = self._newest_container_created_at(session_containers)
+            force_stale = session_id in stale_active_session_ids
+            if (
+                not force_stale
+                and newest is not None
+                and (now - newest).total_seconds() < grace_seconds
+            ):
                 skipped_recent += len(session_containers)
                 continue
+            if force_stale:
+                forced_stale += 1
+                record = active_records.get(session_id)
+                if record is not None:
+                    await self._mark_session_terminated_by_reconcile(
+                        record,
+                        reason=(
+                            "managed session exceeded reap max age without an "
+                            "active turn"
+                        ),
+                        metadata={
+                            "maxAgeSeconds": max_age_seconds,
+                            "reapReason": "stale_active_session_max_age",
+                        },
+                    )
+                logger.warning(
+                    "Reaping stale active managed session %s after max age %s seconds",
+                    session_id,
+                    max_age_seconds,
+                )
             removed_any = False
             for container in session_containers:
                 if await self._remove_container(
@@ -3852,6 +4046,26 @@ class DockerCodexManagedSessionController:
                     "Reaped orphaned managed session containers for session %s",
                     session_id,
                 )
+        for session_id in sorted(stale_active_session_ids - set(by_session)):
+            forced_stale += 1
+            record = active_records.get(session_id)
+            if record is not None:
+                await self._mark_session_terminated_by_reconcile(
+                    record,
+                    reason=(
+                        "managed session exceeded reap max age without an active turn"
+                    ),
+                    metadata={
+                        "maxAgeSeconds": max_age_seconds,
+                        "reapReason": "stale_active_session_max_age",
+                    },
+                )
+            logger.warning(
+                "Marked stale active managed session %s terminated after max age "
+                "%s seconds; no labeled containers were present",
+                session_id,
+                max_age_seconds,
+            )
 
         (
             scanned_volumes,
@@ -3870,6 +4084,7 @@ class DockerCodexManagedSessionController:
             reaped_containers=reaped_containers,
             skipped_active=skipped_active,
             skipped_recent=skipped_recent,
+            forced_stale=forced_stale,
             scanned_volumes=scanned_volumes,
             reaped_volumes=reaped_volumes,
             skipped_active_volumes=skipped_active_volumes,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2123,6 +2123,14 @@ def _build_agent_runtime_deps(
     session_network_name = _managed_session_docker_network(
         {"MOONMIND_URL": session_moonmind_url or ""}
     )
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    temporal_client_adapter = TemporalClientAdapter()
+
+    async def _owner_workflow_status_resolver(workflow_id: str) -> object | None:
+        description = await temporal_client_adapter.describe_workflow(workflow_id)
+        return getattr(description, "status", None)
+
     session_controller = DockerCodexManagedSessionController(
         workspace_volume_name=workspace_volume_name,
         codex_volume_name=codex_volume_name,
@@ -2133,6 +2141,7 @@ def _build_agent_runtime_deps(
         session_supervisor=session_supervisor,
         docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
         docker_host=docker_host,
+        owner_workflow_status_resolver=_owner_workflow_status_resolver,
     )
     workload_registry_path = os.environ.get("MOONMIND_WORKLOAD_PROFILE_REGISTRY", "")
     allowed_image_registries = _csv_env_tuple(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -4781,6 +4781,86 @@ async def test_controller_reconcile_marks_terminal_owner_session_terminated(
     session_supervisor.start.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_controller_terminal_owner_lookup_handles_bad_status_value(
+    tmp_path: Path,
+) -> None:
+    record = CodexManagedSessionRecord(
+        sessionId="sess-bad-status",
+        sessionEpoch=1,
+        agentRunId="task-bad-status",
+        containerId="ctr-bad-status",
+        threadId="thread-bad-status",
+        runtimeId="codex_cli",
+        imageRef="img",
+        controlUrl="docker-exec://bad-status",
+        status="ready",
+        workspacePath="/work/repo",
+        sessionWorkspacePath="/work/session",
+        artifactSpoolPath="/work/artifacts",
+        startedAt="2026-04-06T12:00:00Z",
+    )
+
+    class _BadStatus:
+        @property
+        def name(self) -> str:
+            raise RuntimeError("unexpected status shape")
+
+    async def _owner_workflow_status(_workflow_id: str) -> object:
+        return _BadStatus()
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=ManagedSessionStore(tmp_path / "session-store"),
+        owner_workflow_status_resolver=_owner_workflow_status,
+    )
+
+    assert await controller._terminal_owner_workflow_status(record) is None
+
+
+@pytest.mark.asyncio
+async def test_controller_reconcile_termination_allows_nullable_record_metadata(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    record = CodexManagedSessionRecord(
+        sessionId="sess-null-metadata",
+        sessionEpoch=1,
+        agentRunId="task-null-metadata",
+        containerId="ctr-null-metadata",
+        threadId="thread-null-metadata",
+        runtimeId="codex_cli",
+        imageRef="img",
+        controlUrl="docker-exec://null-metadata",
+        status="ready",
+        workspacePath="/work/repo",
+        sessionWorkspacePath="/work/session",
+        artifactSpoolPath="/work/artifacts",
+        startedAt="2026-04-06T12:00:00Z",
+    )
+    store.save(record)
+    record.metadata = None
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+    )
+
+    updated = await controller._mark_session_terminated_by_reconcile(
+        record,
+        reason="owner workflow completed",
+        metadata={"ownerWorkflowStatus": "COMPLETED"},
+    )
+
+    assert updated.status == "terminated"
+    assert updated.metadata["ownerWorkflowStatus"] == "COMPLETED"
+    assert updated.metadata["terminationSource"] == "managed_session_reconcile"
+
+
 def _reap_active_record(session_id: str) -> CodexManagedSessionRecord:
     return CodexManagedSessionRecord(
         sessionId=session_id,
@@ -4996,6 +5076,101 @@ async def test_controller_reaps_stale_ready_session_after_max_age(
     assert stale_record.metadata["reapReason"] == "stale_active_session_max_age"
     assert store.load("sess-recent").status == "ready"
     assert store.load("sess-busy").status == "busy"
+
+
+def test_controller_stale_ready_ids_skip_missing_age_and_accept_naive_age(
+    tmp_path: Path,
+) -> None:
+    missing_age = _reap_active_record("sess-missing-age")
+    missing_age.started_at = None
+    missing_age.updated_at = None
+    naive_age = _reap_active_record("sess-naive-age")
+    naive_age.started_at = datetime(2020, 1, 1, 0, 0, 0)
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(tmp_path / "agent_jobs"),
+    )
+
+    stale = controller._stale_active_session_ids(
+        active_records={
+            missing_age.session_id: missing_age,
+            naive_age.session_id: naive_age,
+        },
+        by_session={},
+        max_age_seconds=3600,
+        now=datetime.now(tz=UTC),
+    )
+
+    assert stale == {"sess-naive-age"}
+
+
+@pytest.mark.asyncio
+async def test_controller_reap_continues_when_stale_session_termination_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", "3600")
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(_reap_active_record("sess-fail"))
+    store.save(_reap_active_record("sess-ok"))
+    original_update = store.update
+
+    async def _update(session_id: str, **kwargs: object) -> CodexManagedSessionRecord:
+        if session_id == "sess-fail":
+            raise RuntimeError("database unavailable")
+        return await original_update(session_id, **kwargs)
+
+    store.update = _update
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:2] == ("docker", "ps"):
+            return 0, "c-fail\nc-ok\n", ""
+        if command[:3] == ("docker", "inspect", "--format"):
+            return (
+                0,
+                "c-fail|sess-fail|managed-session|2020-01-01T00:00:00Z\n"
+                "c-ok|sess-ok|managed-session|2020-01-01T00:00:00Z\n",
+                "",
+            )
+        if command[:3] == ("docker", "rm", "-f"):
+            if command[-1].startswith("moonmind-session-"):
+                return 1, "", "No such container"
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert result.forced_stale == 1
+    assert result.reaped_session_ids == ("sess-ok",)
+    assert result.reaped_containers == 1
+    removed = {cmd[-1] for cmd in commands if cmd[:3] == ("docker", "rm", "-f")}
+    assert "c-ok" in removed
+    assert "c-fail" not in removed
+    assert store.load("sess-fail").status == "ready"
+    assert store.load("sess-ok").status == "terminated"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -46,6 +46,7 @@ def _clear_managed_session_docker_policy_env(
 ) -> None:
     monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", raising=False)
 
 
 class _LocalArtifactStorage:
@@ -4718,6 +4719,68 @@ async def test_controller_reconcile_degrades_when_container_inspect_fails(
     )
 
 
+@pytest.mark.asyncio
+async def test_controller_reconcile_marks_terminal_owner_session_terminated(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-terminal-owner",
+            sessionEpoch=1,
+            agentRunId="task-terminal",
+            containerId="ctr-terminal",
+            threadId="thread-terminal",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://terminal",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _owner_workflow_status(workflow_id: str) -> str:
+        assert workflow_id == "task-terminal"
+        return "TERMINATED"
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        raise AssertionError(f"terminal owner should skip docker inspect: {command}")
+
+    session_supervisor = AsyncMock()
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+        owner_workflow_status_resolver=_owner_workflow_status,
+    )
+
+    reconciled = await controller.reconcile()
+
+    assert [record.session_id for record in reconciled] == ["sess-terminal-owner"]
+    updated = store.load("sess-terminal-owner")
+    assert updated is not None
+    assert updated.status == "terminated"
+    assert updated.active_turn_id is None
+    assert updated.metadata["ownerWorkflowId"] == "task-terminal"
+    assert updated.metadata["ownerWorkflowStatus"] == "TERMINATED"
+    assert updated.metadata["terminationSource"] == "managed_session_reconcile"
+    assert updated.error_message == (
+        "managed session owner workflow is terminal during reconcile: TERMINATED"
+    )
+    session_supervisor.start.assert_not_awaited()
+
+
 def _reap_active_record(session_id: str) -> CodexManagedSessionRecord:
     return CodexManagedSessionRecord(
         sessionId=session_id,
@@ -4754,6 +4817,7 @@ async def test_controller_reaps_orphan_session_containers_and_skips_active(
 ) -> None:
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", "0")
     store = ManagedSessionStore(tmp_path / "session-store")
     store.save(_reap_active_record("sess-active"))
 
@@ -4816,6 +4880,125 @@ async def test_controller_reaps_orphan_session_containers_and_skips_active(
 
 
 @pytest.mark.asyncio
+async def test_controller_reaps_stale_ready_session_after_max_age(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", "3600")
+    store = ManagedSessionStore(tmp_path / "session-store")
+    old_started_at = "2020-01-01T00:00:00Z"
+    recent = datetime.now(tz=UTC).isoformat()
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-stale",
+            sessionEpoch=1,
+            agentRunId="task-stale",
+            containerId="ctr-sess-stale",
+            threadId="thread-stale",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://stale",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt=old_started_at,
+        )
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-recent",
+            sessionEpoch=1,
+            agentRunId="task-recent",
+            containerId="ctr-sess-recent",
+            threadId="thread-recent",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://recent",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt=recent,
+        )
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-busy",
+            sessionEpoch=1,
+            agentRunId="task-busy",
+            containerId="ctr-sess-busy",
+            threadId="thread-busy",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://busy",
+            status="busy",
+            activeTurnId="turn-busy",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt=old_started_at,
+        )
+    )
+
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:2] == ("docker", "ps"):
+            return 0, "c-stale\nc-recent\nc-busy\n", ""
+        if command[:3] == ("docker", "inspect", "--format"):
+            return (
+                0,
+                "c-stale|sess-stale|managed-session|2020-01-01T00:00:00Z\n"
+                f"c-recent|sess-recent|managed-session|{recent}\n"
+                "c-busy|sess-busy|managed-session|2020-01-01T00:00:00Z\n",
+                "",
+            )
+        if command[:3] == ("docker", "rm", "-f"):
+            if command[-1].startswith("moonmind-session-"):
+                return 1, "", "No such container"
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "rm", "-f"):
+            return 0, "", ""
+        if command[:4] == ("docker", "volume", "ls", "--format"):
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    result = await controller.reap_orphan_session_containers()
+
+    assert result.forced_stale == 1
+    assert result.reaped_session_ids == ("sess-stale",)
+    assert result.reaped_containers == 1
+    assert result.skipped_active == 2
+    removed = {cmd[-1] for cmd in commands if cmd[:3] == ("docker", "rm", "-f")}
+    assert "c-stale" in removed
+    assert "c-recent" not in removed
+    assert "c-busy" not in removed
+    stale_record = store.load("sess-stale")
+    assert stale_record is not None
+    assert stale_record.status == "terminated"
+    assert stale_record.metadata["reapReason"] == "stale_active_session_max_age"
+    assert store.load("sess-recent").status == "ready"
+    assert store.load("sess-busy").status == "busy"
+
+
+@pytest.mark.asyncio
 async def test_controller_reap_skips_orphans_within_grace_window(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -4865,6 +5048,7 @@ async def test_mm870_controller_reaps_orphan_sidecar_volumes_and_skips_boundarie
 ) -> None:
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_ENABLED", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_GRACE_SECONDS", raising=False)
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", "0")
     store = ManagedSessionStore(tmp_path / "session-store")
     store.save(_reap_active_record("sess-active"))
     recent = datetime.now(tz=UTC).isoformat()

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5267,6 +5267,7 @@ async def test_agent_runtime_reconcile_managed_sessions_returns_bounded_summary(
                 reaped_containers=2,
                 skipped_active=1,
                 skipped_recent=1,
+                forced_stale=1,
                 scanned_volumes=5,
                 reaped_volumes=3,
                 skipped_active_volumes=1,
@@ -5289,6 +5290,7 @@ async def test_agent_runtime_reconcile_managed_sessions_returns_bounded_summary(
         "orphanContainersReaped": 2,
         "orphanSessionIdsReaped": ["sess-orphaned-container"],
         "orphanReapSkippedRecent": 1,
+        "orphanReapForcedStale": 1,
         "orphanVolumesScanned": 5,
         "orphanVolumesReaped": 3,
         "orphanVolumeReapSkippedActive": 1,
@@ -5313,6 +5315,7 @@ async def test_agent_runtime_reconcile_orphan_reap_failure_is_best_effort() -> N
     assert result["orphanContainersReaped"] == 0
     assert result["orphanSessionIdsReaped"] == []
     assert result["orphanReapSkippedRecent"] == 0
+    assert result["orphanReapForcedStale"] == 0
     assert result["orphanVolumesScanned"] == 0
     assert result["orphanVolumesReaped"] == 0
 

--- a/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
+++ b/tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py
@@ -88,6 +88,7 @@ async def test_managed_session_reconcile_passes_orphan_reap_summary_through(
             "orphanContainersReaped": 4,
             "orphanSessionIdsReaped": ["sess-orphan-a", "sess-orphan-b"],
             "orphanReapSkippedRecent": 1,
+            "orphanReapForcedStale": 2,
             "orphanVolumesScanned": 6,
             "orphanVolumesReaped": 2,
             "orphanVolumeReapSkippedActive": 3,
@@ -112,6 +113,7 @@ async def test_managed_session_reconcile_passes_orphan_reap_summary_through(
     assert result["orphanContainersReaped"] == 4
     assert result["orphanSessionIdsReaped"] == ["sess-orphan-a", "sess-orphan-b"]
     assert result["orphanReapSkippedRecent"] == 1
+    assert result["orphanReapForcedStale"] == 2
     assert result["orphanVolumesScanned"] == 6
     assert result["orphanVolumesReaped"] == 2
     assert result["orphanVolumeReapSkippedActive"] == 3


### PR DESCRIPTION
## Summary

- Treat managed sessions whose owner workflow has reached a terminal status as orphaned and eligible for cleanup.
- Add a bounded stale-ready reaper for sessions that never receive an active turn, controlled by `MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS`.
- Expose forced stale cleanup counts through the reconcile activity result and document the operator-facing setting.

## Root Cause

Managed session reconciliation only considered active turn ownership and container state. Sessions could remain marked active when the owning workflow had already completed, or when a ready session never advanced to an active turn.

## Validation

- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python -m compileall -q moonmind/workflows/temporal/runtime/managed_session_controller.py moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/worker_runtime.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_managed_session_reconcile.py`