### PR TITLE
MM-901 complete name-only capability identity cleanup

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -144,8 +144,8 @@ from moonmind.workflows.executions.execution_contract import (
     build_authoritative_workflow_input_snapshot,
     is_non_repository_side_effect_skill,
     is_self_managed_publish_skill,
+    reject_workflow_capability_identity_versions,
     resolve_publish_mode_for_skill,
-    strip_workflow_capability_identity_versions,
 )
 from api_service.api.schemas import CreateJobRequest
 from moonmind.workflows import get_temporal_artifact_service
@@ -4960,10 +4960,14 @@ def _invalid_workflow_request(message: str) -> HTTPException:
         },
     )
 
-def _strip_submit_version_identity(task_payload: dict[str, Any]) -> None:
-    sanitized = strip_workflow_capability_identity_versions(task_payload)
-    task_payload.clear()
-    task_payload.update(sanitized)
+def _reject_submit_version_identity(task_payload: dict[str, Any]) -> None:
+    try:
+        reject_workflow_capability_identity_versions(
+            task_payload,
+            field_path="payload.workflow",
+        )
+    except WorkflowContractError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
 
 def _validation_error_code(message: str) -> str:
     if message.startswith("Dependency not found:"):
@@ -7058,7 +7062,7 @@ async def _create_execution_from_workflow_request(
         raise _invalid_workflow_request(
             f"{shape_name} Temporal submit requests require {required_field}."
         )
-    _strip_submit_version_identity(task_payload)
+    _reject_submit_version_identity(task_payload)
 
     # Resolve child-agent runtime inheritance before downstream normalization
     # consumes targetRuntime / task.runtime fields.  When inheritance applies,
@@ -7140,7 +7144,7 @@ async def _create_execution_from_workflow_request(
             session=session,
             user_id=user.id,
         )
-        _strip_submit_version_identity(task_payload)
+        _reject_submit_version_identity(task_payload)
 
     (
         objective_attachment_refs,

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -688,25 +688,17 @@ class SecretUsageResponse(BaseModel):
     diagnostics: list[SecretUsageDiagnosticResponse] = Field(default_factory=list)
 
 class AgentSkillSummaryResponse(BaseModel):
-    """List item representing an agent skill definition."""
+    """List item representing current agent skill content evidence."""
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     slug: str
     title: str
     description: Optional[str] = None
     author: Optional[str] = None
-    latest_version: Optional[str] = Field(None, alias="latestVersion")
+    format: Optional[str] = None
+    artifact_ref: Optional[str] = Field(None, alias="artifactRef")
+    content_digest: Optional[str] = Field(None, alias="contentDigest")
     updated_at: Optional[datetime] = Field(None, alias="updatedAt")
-
-class AgentSkillVersionResponse(BaseModel):
-    """Detail response for a specific skill version."""
-    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
-
-    version_string: str = Field(..., alias="versionString")
-    format: str
-    artifact_ref: str = Field(..., alias="artifactRef")
-    content_digest: str = Field(..., alias="contentDigest")
-    created_at: datetime = Field(..., alias="createdAt")
 
 class AgentSkillCreateRequest(BaseModel):
     """Request payload for creating a new agent skill definition."""
@@ -717,19 +709,17 @@ class AgentSkillCreateRequest(BaseModel):
     description: Optional[str] = None
     author: Optional[str] = None
 
-class AgentSkillVersionCreateRequest(BaseModel):
-    """Request payload for pushing a new immutable version to an agent skill."""
+class AgentSkillContentUpdateRequest(BaseModel):
+    """Request payload for updating current content on an agent skill."""
     model_config = ConfigDict(populate_by_name=True)
 
-    version_string: str = Field(..., alias="versionString")
     format: Optional[Literal["markdown", "bundle"]] = Field("markdown")
-    content: str = Field(..., description="The raw skill content to base the version on")
+    content: str = Field(..., description="The raw skill content to store")
 
 class SkillSetEntryResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
 
     skill_slug: str = Field(..., alias="skillSlug")
-    version_constraint: Optional[str] = Field(None, alias="versionConstraint")
 
 class SkillSetSummaryResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, from_attributes=True)
@@ -778,9 +768,8 @@ __all__ = [
     "SecretUsageDiagnosticResponse",
     "SecretUsageResponse",
     "AgentSkillSummaryResponse",
-    "AgentSkillVersionResponse",
     "AgentSkillCreateRequest",
-    "AgentSkillVersionCreateRequest",
+    "AgentSkillContentUpdateRequest",
     "SkillSetEntryResponse",
     "SkillSetSummaryResponse",
     "SkillSetDetailResponse",

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -695,7 +695,7 @@ class AgentSkillSummaryResponse(BaseModel):
     title: str
     description: Optional[str] = None
     author: Optional[str] = None
-    format: Optional[str] = None
+    format: Optional[Literal["markdown", "bundle"]] = None
     artifact_ref: Optional[str] = Field(None, alias="artifactRef")
     content_digest: Optional[str] = Field(None, alias="contentDigest")
     updated_at: Optional[datetime] = Field(None, alias="updatedAt")

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -385,7 +385,6 @@ __all__ = [
     "AgentSkillSourceKind",
     "AgentSkillFormat",
     "AgentSkillDefinition",
-    "AgentSkillVersion",
     "SkillSet",
     "SkillSetEntry",
 ]
@@ -2279,13 +2278,13 @@ class AgentSkillSourceKind(str, enum.Enum):
     LOCAL = "local"
 
 class AgentSkillFormat(str, enum.Enum):
-    """Supported payload formatting inside a given skill version."""
+    """Supported payload formatting for skill content."""
 
     MARKDOWN = "markdown"
     BUNDLE = "bundle"
 
 class AgentSkillDefinition(Base):
-    """Core definition for a reusable agent skill block/bundle."""
+    """Current definition and content evidence for a reusable agent skill."""
 
     __tablename__ = "agent_skill_definitions"
     __table_args__ = (
@@ -2297,44 +2296,6 @@ class AgentSkillDefinition(Base):
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     author: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-        onupdate=func.now(),
-    )
-
-    versions: Mapped[list["AgentSkillVersion"]] = relationship(
-        "AgentSkillVersion",
-        back_populates="skill",
-        cascade="all, delete-orphan",
-        order_by="AgentSkillVersion.created_at",
-    )
-
-    @property
-    def latest_version(self) -> str | None:
-        """Return the version string of the most recently created version."""
-        return self.versions[-1].version_string if self.versions else None
-
-class AgentSkillVersion(Base):
-    """Immutable version release pointing to blob contents in artifact storage."""
-
-    __tablename__ = "agent_skill_versions"
-    __table_args__ = (
-        UniqueConstraint(
-            "skill_id", "version_string", name="uq_agent_skill_version_string"
-        ),
-        Index("ix_agent_skill_versions_skill", "skill_id"),
-    )
-
-    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
-    skill_id: Mapped[UUID] = mapped_column(
-        Uuid, ForeignKey("agent_skill_definitions.id", ondelete="CASCADE"), nullable=False
-    )
-    version_string: Mapped[str] = mapped_column(String(64), nullable=False)
     format: Mapped[AgentSkillFormat] = mapped_column(
         Enum(
             AgentSkillFormat,
@@ -2346,14 +2307,16 @@ class AgentSkillVersion(Base):
         nullable=False,
         default=AgentSkillFormat.MARKDOWN,
     )
-    artifact_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
-    content_digest: Mapped[str] = mapped_column(String(128), nullable=False)
+    artifact_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    content_digest: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-
-    skill: Mapped[AgentSkillDefinition] = relationship(
-        "AgentSkillDefinition", back_populates="versions"
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
 class SkillSet(Base):
@@ -2400,7 +2363,6 @@ class SkillSetEntry(Base):
     skill_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("agent_skill_definitions.id", ondelete="CASCADE"), nullable=False
     )
-    version_constraint: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api_service/migrations/versions/329_mm901_name_only_agent_skills.py
+++ b/api_service/migrations/versions/329_mm901_name_only_agent_skills.py
@@ -42,12 +42,14 @@ def upgrade() -> None:
            set format = v.format,
                artifact_ref = v.artifact_ref,
                content_digest = v.content_digest
-          from agent_skill_versions v
+         from agent_skill_versions v
          where v.skill_id = d.id
-           and v.created_at = (
-               select max(v2.created_at)
+           and v.id = (
+               select v2.id
                  from agent_skill_versions v2
                 where v2.skill_id = d.id
+                order by v2.created_at desc, v2.id desc
+                limit 1
            )
         """
     )

--- a/api_service/migrations/versions/329_mm901_name_only_agent_skills.py
+++ b/api_service/migrations/versions/329_mm901_name_only_agent_skills.py
@@ -1,0 +1,74 @@
+"""Remove active agent skill semantic version storage for MM-901.
+
+Revision ID: 329_mm901_name_only_agent_skills
+Revises: 328_strip_preset_step_versions
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "329_mm901_name_only_agent_skills"
+down_revision: Union[str, None] = "328_strip_preset_step_versions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_skill_definitions",
+        sa.Column(
+            "format",
+            sa.Enum("markdown", "bundle", name="agentskillformat"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "agent_skill_definitions",
+        sa.Column("artifact_ref", sa.String(length=1024), nullable=True),
+    )
+    op.add_column(
+        "agent_skill_definitions",
+        sa.Column("content_digest", sa.String(length=128), nullable=True),
+    )
+
+    op.execute(
+        """
+        update agent_skill_definitions d
+           set format = v.format,
+               artifact_ref = v.artifact_ref,
+               content_digest = v.content_digest
+          from agent_skill_versions v
+         where v.skill_id = d.id
+           and v.created_at = (
+               select max(v2.created_at)
+                 from agent_skill_versions v2
+                where v2.skill_id = d.id
+           )
+        """
+    )
+    op.execute("update agent_skill_definitions set format = 'markdown' where format is null")
+
+    with op.batch_alter_table("agent_skill_definitions") as batch_op:
+        batch_op.alter_column(
+            "format",
+            existing_type=sa.Enum("markdown", "bundle", name="agentskillformat"),
+            nullable=False,
+            server_default="markdown",
+        )
+
+    with op.batch_alter_table("skill_set_entries") as batch_op:
+        batch_op.drop_column("version_constraint")
+
+    op.drop_index("ix_agent_skill_versions_skill", table_name="agent_skill_versions")
+    op.drop_table("agent_skill_versions")
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "MM-901 removes active agent skill semantic versions; downgrade is unsupported."
+    )

--- a/api_service/services/agent_skills_service.py
+++ b/api_service/services/agent_skills_service.py
@@ -8,12 +8,10 @@ from datetime import UTC, datetime
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from api_service.db.models import (
     AgentSkillDefinition,
     AgentSkillFormat,
-    AgentSkillVersion,
     SkillSet,
 )
 from moonmind.services.skill_resolution import (
@@ -29,7 +27,7 @@ class AgentSkillNotFoundError(ValueError):
     """Raised when the requested agent skill definition is not found."""
 
 class AgentSkillsService:
-    """Orchestrates CRUD and version immutable storage for agent skills."""
+    """Orchestrates CRUD and current content storage for agent skills."""
 
     def __init__(
         self,
@@ -43,7 +41,6 @@ class AgentSkillsService:
     async def list_skills(self) -> list[AgentSkillDefinition]:
         stmt = (
             select(AgentSkillDefinition)
-            .options(selectinload(AgentSkillDefinition.versions))
             .order_by(AgentSkillDefinition.slug.asc())
         )
         result = await self._session.execute(stmt)
@@ -52,7 +49,6 @@ class AgentSkillsService:
     async def get_skill(self, slug: str) -> AgentSkillDefinition | None:
         stmt = (
             select(AgentSkillDefinition)
-            .options(selectinload(AgentSkillDefinition.versions))
             .where(AgentSkillDefinition.slug == slug)
         )
         result = await self._session.execute(stmt)
@@ -89,17 +85,16 @@ class AgentSkillsService:
         await self._session.refresh(skill)
         return skill
 
-    async def create_version(
+    async def update_skill_content(
         self,
         *,
         skill_slug: str,
-        version_string: str,
         content: str,
         format_str: str = "markdown",
         principal: str = "system:agent-skills",
-    ) -> AgentSkillVersion:
+    ) -> AgentSkillDefinition:
         if self._artifact_service is None:
-            raise RuntimeError("TemporalArtifactService is required to create an agent skill version.")
+            raise RuntimeError("TemporalArtifactService is required to update agent skill content.")
 
         skill = await self.require_skill(skill_slug)
 
@@ -108,29 +103,18 @@ class AgentSkillsService:
         required_skills = extract_required_skill_names_from_skill_markdown(
             content,
             skill_name=skill_slug,
-            source_label=f"deployment skill '{skill_slug}' version '{version_string}'",
+            source_label=f"deployment skill '{skill_slug}'",
         )
         required_capabilities = extract_required_capabilities_from_skill_markdown(
             content,
             skill_name=skill_slug,
-            source_label=f"deployment skill '{skill_slug}' version '{version_string}'",
+            source_label=f"deployment skill '{skill_slug}'",
         )
-
-        # Check for duplicate version early if possible
-        stmt = select(AgentSkillVersion).where(
-            AgentSkillVersion.skill_id == skill.id,
-            AgentSkillVersion.version_string == version_string,
-        )
-        result = await self._session.execute(stmt)
-        if result.scalars().first() is not None:
-            raise AgentSkillDuplicateError(
-                f"Version '{version_string}' already exists for skill '{skill_slug}'."
-            )
 
         try:
             parsed_format = AgentSkillFormat(format_str)
         except ValueError as exc:
-            raise ValueError(f"Invalid format processing skill version '{version_string}': {exc}") from exc
+            raise ValueError(f"Invalid format processing skill '{skill_slug}': {exc}") from exc
         
         # Store content in artifact storage
         artifact, _upload = await self._artifact_service.create(
@@ -140,7 +124,6 @@ class AgentSkillsService:
             sha256=content_digest.removeprefix("sha256:"),
             metadata_json={
                 "skill_slug": skill_slug,
-                "version_string": version_string,
                 "format": format_str,
                 "required_skills": list(required_skills),
                 "required_capabilities": list(required_capabilities),
@@ -154,27 +137,13 @@ class AgentSkillsService:
         )
         artifact_ref = artifact.artifact_id
 
-        version = AgentSkillVersion(
-            skill_id=skill.id,
-            version_string=version_string,
-            format=parsed_format,
-            artifact_ref=artifact_ref,
-            content_digest=content_digest,
-        )
-        self._session.add(version)
-        try:
-            await self._session.flush()
-        except IntegrityError as exc:
-            await self._session.rollback()
-            raise AgentSkillDuplicateError(
-                f"Version '{version_string}' already exists for skill '{skill_slug}'."
-            ) from exc
-
-        # Keep skill updated_at fresh
+        skill.format = parsed_format
+        skill.artifact_ref = artifact_ref
+        skill.content_digest = content_digest
         skill.updated_at = datetime.now(UTC)
         await self._session.commit()
-        await self._session.refresh(version)
-        return version
+        await self._session.refresh(skill)
+        return skill
 
     async def create_skill_set(
         self,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1361,11 +1361,9 @@ describe.skip("Task Create Entrypoint", () => {
                   tool: {
                     type: "skill",
                     name: "jira-breakdown-orchestrate",
-                    version: "1.0",
                   },
                   skill: {
                     name: "jira-breakdown-orchestrate",
-                    version: "1.0",
                   },
                   steps: [
                     {
@@ -2200,7 +2198,6 @@ describe.skip("Task Create Entrypoint", () => {
                     tool: {
                       type: "skill",
                       name: "jira-breakdown-orchestrate",
-                      version: "1.0",
                       requiredCapabilities: ["git"],
                     },
                     skill: {
@@ -2242,7 +2239,6 @@ describe.skip("Task Create Entrypoint", () => {
                         tool: {
                           type: "skill",
                           name: "moonspec-breakdown",
-                          version: "1.0",
                           requiredCapabilities: ["git"],
                         },
                         skill: {
@@ -2257,7 +2253,6 @@ describe.skip("Task Create Entrypoint", () => {
                         tool: {
                           type: "skill",
                           name: "story.create_jira_issues",
-                          version: "1.0",
                           inputs: {},
                         },
                         skill: {
@@ -2280,7 +2275,6 @@ describe.skip("Task Create Entrypoint", () => {
                         tool: {
                           type: "skill",
                           name: "story.create_jira_orchestrate_tasks",
-                          version: "1.0",
                           inputs: {},
                         },
                         skill: {
@@ -2357,7 +2351,6 @@ describe.skip("Task Create Entrypoint", () => {
                         tool: {
                           type: "skill",
                           name: "moonspec-verify",
-                          version: "1.0",
                         },
                         skill: { id: "moonspec-verify" },
                       },
@@ -5182,7 +5175,6 @@ describe.skip("Task Create Entrypoint", () => {
           tool: {
             type: "skill",
             name: "speckit-orchestrate",
-            version: "1.0",
           },
           runtime: {
             mode: "codex_cli",
@@ -5388,7 +5380,6 @@ describe.skip("Task Create Entrypoint", () => {
     expect(request.payload.task.tool).toEqual({
       type: "skill",
       name: "moonspec-orchestrate",
-      version: "1.0",
       inputs: {
         issueKey: "MM-564",
         mode: "runtime",
@@ -5676,7 +5667,6 @@ describe.skip("Task Create Entrypoint", () => {
     expect(payload.task.tool).toEqual({
       type: "skill",
       name: "auto",
-      version: "1.0",
     });
     expect(payload.requiredCapabilities).toEqual([
       "codex_cli",
@@ -8670,7 +8660,6 @@ describe.skip("Task Create Entrypoint", () => {
       tool: {
         type: "tool",
         id: "jira.get_issue",
-        version: "1.0",
         inputs: { issueKey: "MM-563" },
       },
     });
@@ -9966,7 +9955,6 @@ describe.skip("Task Create Entrypoint", () => {
         tool: {
           type: "skill",
           name: "speckit-clarify",
-          version: "1.0",
           inputs: { feature: "Task Create" },
         },
         skill: {
@@ -10583,7 +10571,6 @@ describe.skip("Task Create Entrypoint", () => {
     expect(savedStep?.tool).toEqual({
       type: "skill",
       name: "auto",
-      version: "1.0",
       inputs: { mode: "advanced" },
       requiredCapabilities: ["docker"],
     });
@@ -16215,7 +16202,6 @@ describe("Task Create governed Tool authoring", () => {
     expect(request.payload.task.tool).toEqual({
       type: "skill",
       name: "moonspec-orchestrate",
-      version: "1.0",
       inputs: {
         issueKey: "MM-577",
         mode: "runtime",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -2596,12 +2596,6 @@ function mapExpandedStepToState(
     nonEmptyRecordValue(step.source) ||
     compactSourceFromPresetProvenance(nonEmptyRecordValue(step.presetProvenance));
   const normalizedSource = source ? { ...source } : undefined;
-  if (normalizedSource && "version" in normalizedSource) {
-    delete normalizedSource.version;
-  }
-  if (normalizedSource && "presetVersion" in normalizedSource) {
-    delete normalizedSource.presetVersion;
-  }
   const templateAttachments = Array.isArray(step.inputAttachments)
     ? step.inputAttachments
     : Array.isArray(step.attachments)
@@ -7507,7 +7501,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         const normalizedTool = {
           type: "skill",
           name: skillId || "auto",
-          version: "1.0",
           inputs: skillArgs,
           ...(caps.length > 0 ? { requiredCapabilities: caps } : {}),
         };
@@ -8203,7 +8196,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const primaryStepTool = {
       type: "skill",
       name: primarySkillId,
-      version: "1.0",
       ...(Object.keys(primarySkillArgs).length > 0
         ? { inputs: primarySkillArgs }
         : {}),
@@ -8645,7 +8637,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         stepPayload.tool = {
           type: "skill",
           name: stepSkillId || primarySkillId,
-          version: "1.0",
           inputs: stepSkillArgs,
           ...(stepSkillCaps.length > 0
             ? { requiredCapabilities: stepSkillCaps }

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -762,7 +762,6 @@ function snapshotDraftTask(
           tool: {
             type: 'skill',
             name: stringValue(primarySkill.name),
-            version: stringValue(primarySkill.version) || '1.0',
             inputs: objectValue(primarySkill.inputs),
           },
           skill: {

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from moonmind.config.settings import settings
 from moonmind.schemas.agent_skill_models import (
@@ -144,34 +143,31 @@ class DeploymentSkillLoader(SkillLoader):
         async with context.async_session_maker() as session:
             stmt = (
                 select(AgentSkillDefinition)
-                .options(selectinload(AgentSkillDefinition.versions))
                 .where(AgentSkillDefinition.slug.in_(requested_names))
             )
 
             res = await session.execute(stmt)
             defs = res.scalars().all()
-            latest_versions_by_artifact: dict[str, typing.Any] = {}
+            artifact_refs: set[str] = set()
             for definition in defs:
-                if definition.versions:
-                    latest_version = definition.versions[-1]
-                    latest_versions_by_artifact[latest_version.artifact_ref] = latest_version
+                if definition.artifact_ref:
+                    artifact_refs.add(definition.artifact_ref)
 
             metadata_by_artifact: dict[str, dict[str, typing.Any]] = {}
-            if latest_versions_by_artifact:
+            if artifact_refs:
                 artifact_stmt = select(
                     TemporalArtifact.artifact_id,
                     TemporalArtifact.metadata_json,
-                ).where(TemporalArtifact.artifact_id.in_(latest_versions_by_artifact))
+                ).where(TemporalArtifact.artifact_id.in_(artifact_refs))
                 artifact_res = await session.execute(artifact_stmt)
                 for artifact_id, metadata_json in artifact_res.all():
                     if isinstance(metadata_json, dict):
                         metadata_by_artifact[str(artifact_id)] = metadata_json
 
             for definition in defs:
-                if not definition.versions:
+                if not definition.artifact_ref:
                     continue
-                latest_version = definition.versions[-1]
-                metadata = metadata_by_artifact.get(latest_version.artifact_ref, {})
+                metadata = metadata_by_artifact.get(definition.artifact_ref, {})
                 required_skills = _required_skill_names_from_artifact_metadata(
                     metadata,
                     owner=definition.slug,
@@ -183,9 +179,9 @@ class DeploymentSkillLoader(SkillLoader):
                 results.append(
                     ResolvedSkillEntry(
                         skill_name=definition.slug,
-                        format=AgentSkillFormat(latest_version.format.value),
-                        content_ref=latest_version.artifact_ref,
-                        content_digest=latest_version.content_digest,
+                        format=AgentSkillFormat(definition.format.value),
+                        content_ref=definition.artifact_ref,
+                        content_digest=definition.content_digest,
                         required_skills=list(required_skills),
                         required_capabilities=list(required_capabilities),
                         provenance=AgentSkillProvenance(

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -161,6 +161,20 @@ def _strip_identity_version_keys(
     return payload
 
 
+def _reject_identity_version_keys(
+    value: Mapping[str, Any],
+    keys: frozenset[str],
+    *,
+    field_path: str,
+) -> None:
+    present = sorted(key for key in keys if key in value)
+    if present:
+        raise WorkflowContractError(
+            f"{field_path} must not include semantic versions for capability selectors: "
+            + ", ".join(present)
+        )
+
+
 def _strip_preset_identity_versions(value: Mapping[str, Any]) -> dict[str, Any]:
     payload = _strip_identity_version_keys(value, _PRESET_IDENTITY_VERSION_KEYS)
     composition = payload.get("composition")
@@ -176,6 +190,33 @@ def _strip_preset_identity_versions(value: Mapping[str, Any]) -> dict[str, Any]:
                 for item in items
             ]
     return payload
+
+
+def _reject_preset_identity_versions(
+    value: Mapping[str, Any],
+    *,
+    field_path: str,
+) -> None:
+    _reject_identity_version_keys(
+        value,
+        _PRESET_IDENTITY_VERSION_KEYS,
+        field_path=field_path,
+    )
+    composition = value.get("composition")
+    if isinstance(composition, Mapping):
+        _reject_preset_identity_versions(
+            composition,
+            field_path=f"{field_path}.composition",
+        )
+    for list_key in ("includes", "authoredPresets", "appliedStepTemplates"):
+        items = value.get(list_key)
+        if isinstance(items, list):
+            for index, item in enumerate(items):
+                if isinstance(item, Mapping):
+                    _reject_preset_identity_versions(
+                        item,
+                        field_path=f"{field_path}.{list_key}[{index}]",
+                    )
 
 
 def strip_workflow_capability_identity_versions(
@@ -236,6 +277,65 @@ def strip_workflow_capability_identity_versions(
             for step in steps
         ]
     return sanitized
+
+
+def reject_workflow_capability_identity_versions(
+    payload: Mapping[str, Any],
+    *,
+    field_path: str = "workflow",
+) -> None:
+    """Reject stale semantic version fields in newly authored capability selectors."""
+
+    for key in ("tool", "skill"):
+        node = payload.get(key)
+        if isinstance(node, Mapping):
+            _reject_identity_version_keys(
+                node,
+                _CAPABILITY_IDENTITY_VERSION_KEYS,
+                field_path=f"{field_path}.{key}",
+            )
+    skills = payload.get("skills")
+    if isinstance(skills, Mapping):
+        for list_key, items in skills.items():
+            if isinstance(items, list):
+                for index, item in enumerate(items):
+                    if isinstance(item, Mapping):
+                        _reject_identity_version_keys(
+                            item,
+                            _SKILL_IDENTITY_VERSION_KEYS,
+                            field_path=f"{field_path}.skills.{list_key}[{index}]",
+                        )
+    for key in (
+        "taskTemplate",
+        "task_template",
+        "presetSchedule",
+        "preset_schedule",
+    ):
+        node = payload.get(key)
+        if isinstance(node, Mapping):
+            _reject_preset_identity_versions(node, field_path=f"{field_path}.{key}")
+    for key in (
+        "appliedStepTemplates",
+        "applied_step_templates",
+        "authoredPresets",
+        "authored_presets",
+    ):
+        items = payload.get(key)
+        if isinstance(items, list):
+            for index, item in enumerate(items):
+                if isinstance(item, Mapping):
+                    _reject_preset_identity_versions(
+                        item,
+                        field_path=f"{field_path}.{key}[{index}]",
+                    )
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for index, step in enumerate(steps):
+            if isinstance(step, Mapping):
+                reject_workflow_capability_identity_versions(
+                    step,
+                    field_path=f"{field_path}.steps[{index}]",
+                )
 
 
 def _skill_metadata_required_capabilities(skill_id: object) -> tuple[str, ...]:
@@ -808,11 +908,12 @@ class WorkflowSkillSelectorExact(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _strip_removed_identity_versions(cls, value: object) -> object:
+    def _reject_removed_identity_versions(cls, value: object) -> object:
         if isinstance(value, Mapping):
-            return _strip_identity_version_keys(
+            _reject_identity_version_keys(
                 value,
                 _SKILL_IDENTITY_VERSION_KEYS,
+                field_path="workflow.skills.include[]",
             )
         return value
 
@@ -987,11 +1088,12 @@ class WorkflowSkillSelection(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _strip_removed_identity_versions(cls, value: object) -> object:
+    def _reject_removed_identity_versions(cls, value: object) -> object:
         if isinstance(value, Mapping):
-            return _strip_identity_version_keys(
+            _reject_identity_version_keys(
                 value,
                 _SKILL_IDENTITY_VERSION_KEYS,
+                field_path="workflow.skill",
             )
         return value
 
@@ -1472,11 +1574,12 @@ class WorkflowStepSource(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _strip_removed_identity_versions(cls, value: object) -> object:
+    def _reject_removed_identity_versions(cls, value: object) -> object:
         if isinstance(value, Mapping):
-            return _strip_identity_version_keys(
+            _reject_identity_version_keys(
                 value,
                 _PRESET_IDENTITY_VERSION_KEYS,
+                field_path="workflow.steps[].source",
             )
         return value
 
@@ -1521,9 +1624,12 @@ class AuthoredPresetBinding(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _strip_removed_identity_versions(cls, value: object) -> object:
+    def _reject_removed_identity_versions(cls, value: object) -> object:
         if isinstance(value, Mapping):
-            return _strip_preset_identity_versions(value)
+            _reject_preset_identity_versions(
+                value,
+                field_path="workflow.authoredPresets[]",
+            )
         return value
 
     @field_validator(
@@ -1599,7 +1705,8 @@ class WorkflowStepSpec(BaseModel):
     def _reject_forbidden_step_overrides(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
-        payload = strip_workflow_capability_identity_versions(value)
+        reject_workflow_capability_identity_versions(value, field_path="workflow.steps[]")
+        payload = dict(value)
         raw_kind = _clean_optional_str(payload.get("kind"))
         if raw_kind is not None and raw_kind.lower() == "include":
             raise WorkflowContractError(
@@ -1883,7 +1990,8 @@ class WorkflowExecutionSpec(BaseModel):
     def _lift_legacy_spec_shape(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
-        payload = strip_workflow_capability_identity_versions(value)
+        reject_workflow_capability_identity_versions(value, field_path="workflow")
+        payload = dict(value)
         runtime_node = payload.get("runtime")
         if isinstance(runtime_node, str):
             payload["runtime"] = {"mode": runtime_node}
@@ -2917,5 +3025,6 @@ __all__ = [
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",
     "resolve_publish_mode_for_skill",
+    "reject_workflow_capability_identity_versions",
     "strip_workflow_capability_identity_versions",
 ]

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -250,6 +250,7 @@ def strip_workflow_capability_identity_versions(
         "task_template",
         "presetSchedule",
         "preset_schedule",
+        "source",
     ):
         node = sanitized.get(key)
         if isinstance(node, Mapping):
@@ -2258,7 +2259,10 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
                 },
             }
         else:
-            body_node = dict(body_node)
+            # Canonical queue payloads may be hydrated from pre-cutover stored
+            # records. Preserve historical read tolerance here while keeping
+            # direct WorkflowExecutionSpec validation strict for new submissions.
+            body_node = strip_workflow_capability_identity_versions(body_node)
             if not body_node.get("instructions"):
                 lifted_instruction = payload.get("instructions") or payload.get(
                     "instruction"

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -180,7 +180,13 @@ def _strip_preset_identity_versions(value: Mapping[str, Any]) -> dict[str, Any]:
     composition = payload.get("composition")
     if isinstance(composition, Mapping):
         payload["composition"] = _strip_preset_identity_versions(composition)
-    for list_key in ("includes", "authoredPresets", "appliedStepTemplates"):
+    for list_key in (
+        "includes",
+        "authoredPresets",
+        "authored_presets",
+        "appliedStepTemplates",
+        "applied_step_templates",
+    ):
         items = payload.get(list_key)
         if isinstance(items, list):
             payload[list_key] = [
@@ -208,7 +214,13 @@ def _reject_preset_identity_versions(
             composition,
             field_path=f"{field_path}.composition",
         )
-    for list_key in ("includes", "authoredPresets", "appliedStepTemplates"):
+    for list_key in (
+        "includes",
+        "authoredPresets",
+        "authored_presets",
+        "appliedStepTemplates",
+        "applied_step_templates",
+    ):
         items = value.get(list_key)
         if isinstance(items, list):
             for index, item in enumerate(items):
@@ -311,6 +323,7 @@ def reject_workflow_capability_identity_versions(
         "task_template",
         "presetSchedule",
         "preset_schedule",
+        "source",
     ):
         node = payload.get(key)
         if isinstance(node, Mapping):

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2000,7 +2000,7 @@ def test_create_task_shaped_execution_rejects_missing_workflow_payload(
     service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_strips_task_template_version(
+def test_create_workflow_execution_rejects_task_template_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -2022,12 +2022,12 @@ def test_create_workflow_execution_strips_task_template_version(
         },
     )
 
-    assert response.status_code == 201
-    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
-    assert task["taskTemplate"] == {"slug": "jira-implement"}
+    assert response.status_code == 422
+    assert "semantic versions" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_strips_applied_template_version(
+def test_create_workflow_execution_rejects_applied_template_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -2051,16 +2051,12 @@ def test_create_workflow_execution_strips_applied_template_version(
         },
     )
 
-    assert response.status_code == 201
-    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
-    assert task["appliedStepTemplates"] == [
-        {
-            "slug": "jira-implement",
-        }
-    ]
+    assert response.status_code == 422
+    assert "semantic versions" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_strips_tool_version(
+def test_create_workflow_execution_rejects_tool_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -2083,13 +2079,12 @@ def test_create_workflow_execution_strips_tool_version(
         },
     )
 
-    assert response.status_code == 201
-    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
-    assert task["tool"] == {"type": "skill", "name": "pr-resolver"}
-    assert task["skill"] == {"name": "pr-resolver"}
+    assert response.status_code == 422
+    assert "semantic versions" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_strips_skill_version(
+def test_create_workflow_execution_rejects_skill_version(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -2111,13 +2106,12 @@ def test_create_workflow_execution_strips_skill_version(
         },
     )
 
-    assert response.status_code == 201
-    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
-    assert task["tool"] == {"type": "skill", "name": "pr-resolver"}
-    assert task["skill"] == {"name": "pr-resolver"}
+    assert response.status_code == 422
+    assert "semantic versions" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
-def test_create_workflow_execution_strips_versions_from_all_capability_selectors(
+def test_create_workflow_execution_rejects_versions_from_all_capability_selectors(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -2197,33 +2191,9 @@ def test_create_workflow_execution_strips_versions_from_all_capability_selectors
         },
     )
 
-    assert response.status_code == 201
-    task = service.create_execution.await_args.kwargs["initial_parameters"]["workflow"]
-    assert task["tool"] == {
-        "type": "skill",
-        "name": "pr-resolver",
-        "inputs": {"pr": "2680"},
-    }
-    assert task["skills"] == {"include": [{"name": "pr-resolver"}]}
-    assert task["taskTemplate"] == {"slug": "jira-implement"}
-    assert task["presetSchedule"] == {"presetSlug": "jira-implement"}
-    assert task["authoredPresets"] == [{"presetSlug": "jira-implement"}]
-    assert task["appliedStepTemplates"] == [
-        {
-            "slug": "jira-implement",
-            "composition": {
-                "includes": [{"presetSlug": "quality-checks"}],
-            },
-        }
-    ]
-    assert task["steps"][0]["tool"] == {
-        "id": "repo.run_tests",
-        "inputs": {"target": "unit"},
-    }
-    assert task["steps"][1]["skill"] == {
-        "id": "fix-ci",
-        "args": {"pr": "2680"},
-    }
+    assert response.status_code == 422
+    assert "semantic versions" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
 
 
 def test_create_task_shaped_execution_rejects_more_than_10_dependencies(

--- a/tests/unit/api/test_agent_skills_service.py
+++ b/tests/unit/api/test_agent_skills_service.py
@@ -84,30 +84,28 @@ async def test_require_skill_not_found(tmp_path):
                 await svc.require_skill("nonexistent")
 
 @pytest.mark.asyncio
-async def test_create_version_success(tmp_path, mock_artifact_service: AsyncMock):
+async def test_update_skill_content_success(tmp_path, mock_artifact_service: AsyncMock):
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as db_session:
             svc = AgentSkillsService(session=db_session, artifact_service=mock_artifact_service)
-            skill = await svc.create_skill(slug="versioned-skill", title="Versioned")
+            skill = await svc.create_skill(slug="docs-skill", title="Docs")
 
-            version = await svc.create_version(
-                skill_slug="versioned-skill",
-                version_string="1.0.0",
+            updated = await svc.update_skill_content(
+                skill_slug="docs-skill",
                 content="some markdown content",
             )
 
-            assert version.skill_id == skill.id
-            assert version.version_string == "1.0.0"
-            assert version.format == AgentSkillFormat.MARKDOWN
-            assert version.artifact_ref == "test-artifact-id"
-            assert version.content_digest.startswith("sha256:")
+            assert updated.id == skill.id
+            assert updated.format == AgentSkillFormat.MARKDOWN
+            assert updated.artifact_ref == "test-artifact-id"
+            assert updated.content_digest.startswith("sha256:")
 
             # Verify that the artifact service was awaited
             mock_artifact_service.create.assert_awaited_once()
             mock_artifact_service.write_complete.assert_awaited_once()
 
 @pytest.mark.asyncio
-async def test_create_second_version_preserves_first_version(
+async def test_update_skill_content_replaces_current_content(
     tmp_path, mock_artifact_service: AsyncMock
 ):
     async with template_db(tmp_path) as session_maker:
@@ -115,49 +113,38 @@ async def test_create_second_version_preserves_first_version(
             svc = AgentSkillsService(
                 session=db_session, artifact_service=mock_artifact_service
             )
-            await svc.create_skill(slug="versioned-skill", title="Versioned")
+            await svc.create_skill(slug="docs-skill", title="Docs")
 
-            first = await svc.create_version(
-                skill_slug="versioned-skill",
-                version_string="1.0.0",
+            first = await svc.update_skill_content(
+                skill_slug="docs-skill",
                 content="first markdown content",
             )
-            second = await svc.create_version(
-                skill_slug="versioned-skill",
-                version_string="1.1.0",
+            first_digest = first.content_digest
+
+            second = await svc.update_skill_content(
+                skill_slug="docs-skill",
                 content="second markdown content",
             )
 
-            fetched = await svc.require_skill("versioned-skill")
+            fetched = await svc.require_skill("docs-skill")
 
-            assert first.id != second.id
-            assert [version.version_string for version in fetched.versions] == [
-                "1.0.0",
-                "1.1.0",
-            ]
-            assert fetched.versions[0].artifact_ref == first.artifact_ref
-            assert fetched.versions[0].content_digest == first.content_digest
-            assert fetched.versions[1].artifact_ref == second.artifact_ref
-            assert fetched.versions[1].content_digest == second.content_digest
+            assert second.id == first.id
+            assert fetched.artifact_ref == second.artifact_ref
+            assert fetched.content_digest == second.content_digest
+            assert fetched.content_digest != first_digest
 
 @pytest.mark.asyncio
-async def test_create_version_duplicate(tmp_path, mock_artifact_service: AsyncMock):
+async def test_update_skill_content_rejects_invalid_format(tmp_path, mock_artifact_service: AsyncMock):
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as db_session:
             svc = AgentSkillsService(session=db_session, artifact_service=mock_artifact_service)
-            await svc.create_skill(slug="dup-ver-skill", title="Dup Ver")
+            await svc.create_skill(slug="docs-skill", title="Docs")
 
-            await svc.create_version(
-                skill_slug="dup-ver-skill",
-                version_string="1.0.0",
-                content="first",
-            )
-
-            with pytest.raises(AgentSkillDuplicateError):
-                await svc.create_version(
-                    skill_slug="dup-ver-skill",
-                    version_string="1.0.0",
+            with pytest.raises(ValueError, match="Invalid format"):
+                await svc.update_skill_content(
+                    skill_slug="docs-skill",
                     content="second",
+                    format_str="invalid",
                 )
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -390,17 +390,12 @@ async def test_deployment_skill_loader_fetches_from_db():
     
     mock_session = AsyncMock()
     
-    class MockVersion:
-        def __init__(self):
-            self.version_string = "1.0.0"
-            self.format = MagicMock(value="markdown")
-            self.artifact_ref = "art_123"
-            self.content_digest = "digest123"
-            
     class MockDef:
         def __init__(self):
             self.slug = "db_skill"
-            self.versions = [MockVersion()]
+            self.format = MagicMock(value="markdown")
+            self.artifact_ref = "art_123"
+            self.content_digest = "digest123"
     
     def _result(definitions=None, artifact_rows=None):
         result = MagicMock()
@@ -607,17 +602,12 @@ async def test_resolver_expands_packaged_pr_resolver_support_skills():
     ]
 
 async def test_resolver_expands_deployment_required_skills_from_artifact_metadata():
-    class MockVersion:
-        def __init__(self, version_string, artifact_ref):
-            self.version_string = version_string
-            self.format = MagicMock(value="markdown")
-            self.artifact_ref = artifact_ref
-            self.content_digest = f"digest-{artifact_ref}"
-
     class MockDef:
         def __init__(self, slug, artifact_ref):
             self.slug = slug
-            self.versions = [MockVersion("1.0.0", artifact_ref)]
+            self.format = MagicMock(value="markdown")
+            self.artifact_ref = artifact_ref
+            self.content_digest = f"digest-{artifact_ref}"
 
     definitions = {
         "primary_skill": MockDef("primary_skill", "art_primary"),

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -85,6 +85,60 @@ def test_workflow_capability_identity_rejector_blocks_nested_skill_versions() ->
         reject_workflow_capability_identity_versions(payload)
 
 
+def test_workflow_capability_identity_rejector_blocks_step_source_versions() -> None:
+    payload = {
+        "steps": [
+            {
+                "instructions": "Run preset-derived step.",
+                "source": {"slug": "jira-implement", "presetVersion": "1.0.0"},
+            },
+        ],
+    }
+
+    with pytest.raises(
+        WorkflowContractError,
+        match=r"workflow\.steps\[0\]\.source",
+    ):
+        reject_workflow_capability_identity_versions(payload)
+
+
+def test_workflow_capability_identity_rejector_blocks_snake_case_nested_presets() -> None:
+    payload = {
+        "task_template": {
+            "slug": "jira-orchestrate",
+            "authored_presets": [
+                {"presetSlug": "jira-implement", "presetVersion": "1.0.0"},
+            ],
+            "applied_step_templates": [
+                {"slug": "jira-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    with pytest.raises(
+        WorkflowContractError,
+        match=r"workflow\.task_template\.authored_presets\[0\]",
+    ):
+        reject_workflow_capability_identity_versions(payload)
+
+
+def test_workflow_capability_identity_rejector_blocks_snake_case_applied_templates() -> None:
+    payload = {
+        "task_template": {
+            "slug": "jira-orchestrate",
+            "applied_step_templates": [
+                {"slug": "jira-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    with pytest.raises(
+        WorkflowContractError,
+        match=r"workflow\.task_template\.applied_step_templates\[0\]",
+    ):
+        reject_workflow_capability_identity_versions(payload)
+
+
 def test_workflow_capability_identity_sanitizer_strips_nested_skill_versions() -> None:
     payload = {
         "skills": {

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -10,6 +10,7 @@ from moonmind.workflows.executions.execution_contract import (
     build_runtime_command_preview_config,
     CanonicalWorkflowExecutionPayload,
     ResumeFromFailedStepRef,
+    reject_workflow_capability_identity_versions,
     resolve_publish_mode_for_skill,
     strip_workflow_capability_identity_versions,
     WorkflowContractError,
@@ -51,18 +52,15 @@ def test_task_skills_accepts_valid_properties() -> None:
     assert spec.skills.exclude == ["legacy"]
     assert spec.skills.materialization_mode == "hybrid"
 
-def test_task_skills_strip_semantic_version_fields() -> None:
-    spec = WorkflowExecutionSpec.model_validate(
-        {
-            "repository": "test/repo",
-            "instructions": "execute",
-            "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
-        }
-    )
-
-    assert spec.skills is not None
-    assert spec.skills.include is not None
-    assert spec.skills.include[0].name == "test-skill"
+def test_task_skills_reject_semantic_version_fields() -> None:
+    with pytest.raises(ValidationError, match="semantic versions"):
+        WorkflowExecutionSpec.model_validate(
+            {
+                "repository": "test/repo",
+                "instructions": "execute",
+                "skills": {"include": [{"name": "test-skill", "version": "1.0.0"}]},
+            }
+        )
 
     with pytest.raises(ValidationError, match="semantic versions"):
         WorkflowExecutionSpec.model_validate(
@@ -72,6 +70,19 @@ def test_task_skills_strip_semantic_version_fields() -> None:
                 "skills": {"include": [{"name": "test-skill:1.0.0"}]},
             }
         )
+
+
+def test_workflow_capability_identity_rejector_blocks_nested_skill_versions() -> None:
+    payload = {
+        "skills": {
+            "include": [
+                {"name": "pr-resolver", "version": "1.0.0", "skillVersion": "1.0.0"},
+            ],
+        },
+    }
+
+    with pytest.raises(WorkflowContractError, match="semantic versions"):
+        reject_workflow_capability_identity_versions(payload)
 
 
 def test_workflow_capability_identity_sanitizer_strips_nested_skill_versions() -> None:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -642,7 +642,6 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
                     "instructions": "Fetch issue.",
                     "tool": {
                         "id": "jira.get_issue",
-                        "version": "1.0.0",
                         "inputs": {"issueKey": "MM-559"},
                     },
                     "source": {
@@ -658,7 +657,6 @@ def test_task_steps_accept_explicit_tool_and_skill_discriminators() -> None:
                     "instructions": "Implement issue.",
                     "skill": {
                         "id": "moonspec-implement",
-                        "skillVersion": "1.0.0",
                         "args": {"issueKey": "MM-559"},
                     },
                 },


### PR DESCRIPTION
Issue reference: MM-901

Summary:
- Removes active agent-skill semantic version storage/service behavior in favor of name-only skill identity.
- Adds the MM-901 migration for name-only agent skills.
- Rejects semantic capability version fields in new execution/task submissions while preserving historical read tolerance where needed.
- Updates affected backend, workflow contract, frontend workflow-start, and unit coverage.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_agent_skills_service.py tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/executions/test_execution_contract.py --ui-args frontend/src/entrypoints/workflow-start.test.tsx

Remaining risks:
- The assessment classified MM-901 as partially implemented before this publication step; review should confirm all remaining active skill-version and new-submission rejection paths are covered.
- Migration behavior should be reviewed against any live database records that still carry legacy agent skill version fields.