### PR TITLE
The workflow details page body was changed to span the full width of the screen similar to the overview Workflows page. I think it looks a little stra

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -1490,11 +1490,11 @@ def _secret_refs_check(
         status = managed_secret_statuses.get(result.parsed.locator)
         if status is None:
             problems.append(
-                f"{role} binding references managed secret db://{result.parsed.locator} was not found"
+                f"{role}=[REDACTED] binding references managed secret db://{result.parsed.locator} was not found"
             )
         elif status != SecretStatus.ACTIVE.value:
             problems.append(
-                f"{role} binding references managed secret db://{result.parsed.locator} is {status}"
+                f"{role}=[REDACTED] binding references managed secret db://{result.parsed.locator} is {status}"
             )
 
     return _readiness_check(

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -815,7 +815,6 @@ async def workflow_console_route(
         "workflow-detail",
         detail_path,
         initial_data={"dashboardConfig": dashboard_config},
-        data_wide_panel=True,
         session=session,
         user=_user,
     )

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -206,6 +206,14 @@ describe('Dashboard shared entry', () => {
     );
   });
 
+  it('keeps checkbox label hit areas bounded to visible control text', async () => {
+    const checkboxLabelBlock = cssRuleBlock(dashboardCss, 'label.checkbox');
+
+    expect(checkboxLabelBlock).toContain('display: inline-flex');
+    expect(checkboxLabelBlock).toContain('width: fit-content');
+    expect(checkboxLabelBlock).toContain('max-width: 100%');
+  });
+
   it('defines shared visual atmosphere and glass tokens for light and dark themes', async () => {
     const requiredTokens = [
       '--mm-atmosphere-violet',

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -3020,6 +3020,8 @@ label.checkbox {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
+  width: fit-content;
+  max-width: 100%;
 }
 
 input,

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -383,13 +383,15 @@ def test_data_wide_panel_on_selected_react_routes(client: TestClient) -> None:
     for path in (
         "/workflows",
         "/settings",
-        "/workflows/mm:workflow-123",
-        "/workflows/mm:workflow-123/steps",
     ):
         response = client.get(path)
         assert response.status_code == 200
         assert '"dataWidePanel":true' in response.text
-    for path in ("/manifests",):
+    for path in (
+        "/manifests",
+        "/workflows/mm:workflow-123",
+        "/workflows/mm:workflow-123/steps",
+    ):
         response = client.get(path)
         assert response.status_code == 200
         assert '"dataWidePanel":false' in response.text


### PR DESCRIPTION
The workflow details page body was changed to span the full width of the screen similar to the overview Workflows page. I think it looks a little strange now, so I actually want to go back to the normal start workflow style container width.

Additionally, if you click at the same vertical level as the Report or Propose follow-up work checkboxes, but far to the right, it will still select those checkboxes. This should not be possible. You should have to be relatively close to the checkbox to avoid misclicks by accident.