### PR TITLE
Fix PentestGPT empty report handling

### DIFF
--- a/api_service/data/presets/pentest-recon.yaml
+++ b/api_service/data/presets/pentest-recon.yaml
@@ -15,7 +15,6 @@ annotations:
     type: object
     required:
       - target
-      - scope_artifact_ref
     properties:
       target:
         type: string
@@ -24,7 +23,7 @@ annotations:
       scope_artifact_ref:
         type: string
         title: Approved scope artifact ref
-        description: Artifact ref for a PentestApprovedScope document. Required before launch.
+        description: Advanced override for a PentestApprovedScope artifact ref. Execution still fails closed until MoonMind has approved scope for the target.
       objective:
         type: string
         title: Objective
@@ -56,12 +55,19 @@ annotations:
         description: Exact PentestGPT provider profile id.
   uiSchema:
     scope_artifact_ref:
+      advanced: true
       helperText: Approved scope is mandatory. The target must match the scope artifact before launch.
     operation_mode:
+      advanced: true
       widget: select
       helperText: full_authorized is intentionally hidden from this safe preset.
     evidence_level:
+      advanced: true
       widget: select
+    time_budget_minutes:
+      advanced: true
+    execution_profile_ref:
+      advanced: true
 inputs:
   - name: target
     label: Target
@@ -70,7 +76,10 @@ inputs:
   - name: scope_artifact_ref
     label: Approved Scope Artifact Ref
     type: text
-    required: true
+    required: false
+    default: ""
+    uiSchema:
+      advanced: true
   - name: objective
     label: Objective
     type: textarea
@@ -79,30 +88,38 @@ inputs:
   - name: operation_mode
     label: Operation Mode
     type: enum
-    required: true
+    required: false
     default: recon_only
     options:
       - recon_only
       - validate_hypothesis
+    uiSchema:
+      advanced: true
   - name: execution_profile_ref
     label: Provider Profile
     type: text
     required: false
     default: ""
+    uiSchema:
+      advanced: true
   - name: time_budget_minutes
     label: Time Budget Minutes
     type: text
-    required: true
+    required: false
     default: "60"
+    uiSchema:
+      advanced: true
   - name: evidence_level
     label: Evidence Level
     type: enum
-    required: true
+    required: false
     default: standard
     options:
       - minimal
       - standard
       - full
+    uiSchema:
+      advanced: true
 steps:
   - id: pentest-recon
     title: Run approved PentestGPT assessment

--- a/docker/pentestgpt-runner/Dockerfile
+++ b/docker/pentestgpt-runner/Dockerfile
@@ -23,6 +23,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \

--- a/docker/pentestgpt-runner/README.md
+++ b/docker/pentestgpt-runner/README.md
@@ -31,6 +31,12 @@ satisfy the MoonMind `PentestFinding` shape are emitted into the compact
 and counted in `quarantined_findings_count`; details belong in restricted
 diagnostics/evidence. `normalization_status` distinguishes genuine clean
 empty results from upstream, runner, provider, or normalizer failures.
+Runtime stdout/stderr are preserved in restricted evidence, but lifecycle or
+banner text is not treated as a finding. The runner marks an upstream exit-0
+run as `runner_failed` when PentestGPT emits neither structured findings nor a
+recognizable final report. Secret-like assignment values and sensitive URL
+query parameters (for example `sessionid`, `token`, `auth`, and cookies) are
+redacted from human-facing reports and compact metadata.
 
 ## Upstream contract check
 

--- a/docker/pentestgpt-runner/moonmind-pentestgpt-run
+++ b/docker/pentestgpt-runner/moonmind-pentestgpt-run
@@ -14,7 +14,44 @@ EXIT_ARTIFACT_WRITE=35
 EXIT_TIMEOUT_CANCELLATION=36
 
 redact() {
-  sed -E 's/([A-Za-z0-9_-]*(token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])[[:space:]]*[^[:space:],;]+/\1[REDACTED]/Ig'
+  python -c '
+import re
+import sys
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+secret_re = re.compile(r"([A-Za-z0-9_-]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])\s*[^\s,;`]+", re.I)
+url_re = re.compile(r"https?://[^\s<>\"'\''`]+", re.I)
+query_re = re.compile(r"(?:token|password|secret|api[_-]?key|session|auth|cookie|jwt|signature|sig)", re.I)
+
+def redact_url(value):
+    trailing = ""
+    candidate = value
+    while candidate and candidate[-1] in ".,);]}":
+        trailing = candidate[-1] + trailing
+        candidate = candidate[:-1]
+    try:
+        parsed = urlsplit(candidate)
+    except Exception:
+        return value
+    if not parsed.query:
+        return value
+    query = []
+    changed = False
+    for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+        if query_re.search(key):
+            query.append((key, "[REDACTED]"))
+            changed = True
+        else:
+            query.append((key, item))
+    if not changed:
+        return value
+    encoded = urlencode(query, doseq=True).replace("%5BREDACTED%5D", "[REDACTED]")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, encoded, parsed.fragment)) + trailing
+
+text = sys.stdin.read()
+text = secret_re.sub(lambda match: match.group(1) + "[REDACTED]", text)
+sys.stdout.write(url_re.sub(lambda match: redact_url(match.group(0)), text))
+'
 }
 
 json_write() {
@@ -35,7 +72,15 @@ classify_exit_code() {
   local code="$1"
   local norm_status="${2:-}"
   case "$code" in
-    0) echo "success" ;;
+    0)
+      case "$norm_status" in
+        ""|ok|completed_no_findings) echo "success" ;;
+        provider_failed) echo "auth" ;;
+        normalizer_error) echo "normalization" ;;
+        runner_failed|no_machine_readable_findings|no_valid_findings|upstream_failed) echo "upstream_runtime" ;;
+        *) echo "upstream_runtime" ;;
+      esac
+      ;;
     "$EXIT_CONFIG_INPUT") echo "config_input" ;;
     "$EXIT_ARGS") echo "args" ;;
     "$EXIT_MISSING_EXECUTABLE") echo "missing_executable" ;;
@@ -73,9 +118,9 @@ check_upstream() {
 
   # Wrapper redaction must drop secret-like values and emit a [REDACTED] marker.
   local sample redacted
-  sample="api_key=supersecretvalue token: anothersecret"
+  sample="api_key=supersecretvalue token: anothersecret https://target.example.test/app?sessionid=thirdsecret&view=1"
   redacted="$(printf '%s\n' "$sample" | redact)"
-  if printf '%s' "$redacted" | grep -Eq "supersecretvalue|anothersecret"; then
+  if printf '%s' "$redacted" | grep -Eq "supersecretvalue|anothersecret|thirdsecret"; then
     echo "wrapper redaction failed on sample secret" >&2
     return "$EXIT_CONFIG_INPUT"
   fi
@@ -222,13 +267,14 @@ STRUCTURED_FILE="$FINDINGS_DIR/findings.normalizer-input.json"
 EVIDENCE_BUNDLE="$EVIDENCE_DIR/bundle.tar.zst"
 RAW_STDOUT_FILE="$RUNTIME_DIR/stdout.raw.log"
 RAW_STDERR_FILE="$RUNTIME_DIR/stderr.raw.log"
+TARGET_DISPLAY="$(printf '%s' "$TARGET" | redact)"
 
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 EXIT_CODE=0
 
 {
   echo "MoonMind PentestGPT runner starting"
-  echo "target=$TARGET"
+  echo "target=$TARGET_DISPLAY"
   echo "mode=$MODE"
   echo "non_interactive=$NON_INTERACTIVE"
   echo "telemetry_enabled=$LANGFUSE_ENABLED"
@@ -262,50 +308,128 @@ PY
   set -e
   redact < "$RAW_STDOUT_FILE" | tee -a "$STDOUT_FILE" >/dev/null
   redact < "$RAW_STDERR_FILE" | tee -a "$STDERR_FILE" >&2
-  rm -f "$RAW_STDOUT_FILE" "$RAW_STDERR_FILE"
 else
   echo "pentestgpt executable not found in runner image" | redact >> "$STDERR_FILE"
   UPSTREAM_EXIT_CODE="$EXIT_MISSING_EXECUTABLE"
+  : > "$RAW_STDOUT_FILE"
+  : > "$RAW_STDERR_FILE"
 fi
 
 if [[ "$UPSTREAM_EXIT_CODE" -ne 0 ]]; then
   EXIT_CODE="$UPSTREAM_EXIT_CODE"
 fi
 
-json_write "$RAW_EVIDENCE_FILE" "$(python - "$TARGET" "$MODE" "$LANGFUSE_ENABLED" "$UPSTREAM_EXIT_CODE" "${MM_PENTEST_SKIP_UPSTREAM:-0}" <<'PY'
+python - "$RAW_EVIDENCE_FILE" "$TARGET_DISPLAY" "$MODE" "$LANGFUSE_ENABLED" "$UPSTREAM_EXIT_CODE" "${MM_PENTEST_SKIP_UPSTREAM:-0}" "$RAW_STDOUT_FILE" "$RAW_STDERR_FILE" <<'PY'
 import json
+from pathlib import Path
+import re
 import sys
 
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+secret_re = re.compile(r"([A-Za-z0-9_-]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])\s*[^\s,;`]+", re.I)
+url_re = re.compile(r"https?://[^\s<>\"'`]+", re.I)
+query_re = re.compile(r"(?:token|password|secret|api[_-]?key|session|auth|cookie|jwt|signature|sig)", re.I)
+report_signal_re = re.compile(
+    r"(?:\b(?:finding|vulnerability|issue)\s*:|\bseverity\s*:|\bremediation\s*:|\brecommendation\s*:|\bno vulnerabilities\b|\bno findings\b)",
+    re.I,
+)
+
+def redact_url(value: str) -> str:
+    trailing = ""
+    candidate = value
+    while candidate and candidate[-1] in ".,);]}":
+        trailing = candidate[-1] + trailing
+        candidate = candidate[:-1]
+    try:
+        parsed = urlsplit(candidate)
+    except Exception:
+        return value
+    if not parsed.query:
+        return value
+    query = []
+    changed = False
+    for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+        if query_re.search(key):
+            query.append((key, "[REDACTED]"))
+            changed = True
+        else:
+            query.append((key, item))
+    if not changed:
+        return value
+    encoded = urlencode(query, doseq=True).replace("%5BREDACTED%5D", "[REDACTED]")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, encoded, parsed.fragment)) + trailing
+
+def redact_text(value: str) -> str:
+    redacted = secret_re.sub(lambda match: match.group(1) + "[REDACTED]", value)
+    return url_re.sub(lambda match: redact_url(match.group(0)), redacted)
+
+def read_text(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+
+def truncate(value: str, limit: int = 120000) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit] + "\n[truncated]"
+
+evidence_path = Path(sys.argv[1])
+target = sys.argv[2]
+mode = sys.argv[3]
+telemetry_enabled = sys.argv[4]
+upstream_exit_code = int(sys.argv[5])
+skip_upstream = sys.argv[6] == "1"
+stdout_raw = read_text(sys.argv[7])
+stderr_raw = read_text(sys.argv[8])
+stdout_redacted = redact_text(stdout_raw)
+stderr_redacted = redact_text(stderr_raw)
+report_text = stdout_redacted if report_signal_re.search(stdout_redacted) else ""
 payload = {
-    "target": sys.argv[1],
-    "operation_mode": sys.argv[2],
+    "target": target,
+    "operation_mode": mode,
     "non_interactive": True,
-    "telemetry_enabled": sys.argv[3],
-    "upstream_exit_code": int(sys.argv[4]),
+    "telemetry_enabled": telemetry_enabled,
+    "upstream_exit_code": upstream_exit_code,
+    "stdout_transcript": truncate(stdout_redacted),
+    "stderr_transcript": truncate(stderr_redacted),
+    "tool_event_count": len(re.findall(r"\b(tool_use|tool call|command|bash|browser)\b", stdout_raw, re.I)),
+    "assistant_message_count": len(re.findall(r"\b(assistant|pentestgpt)\b", stdout_raw, re.I)),
     "events": [
         {"type": "runner_started", "message": "MoonMind wrapper initialized."},
-        {"type": "upstream_completed", "exit_code": int(sys.argv[4])},
+        {"type": "upstream_completed", "exit_code": upstream_exit_code},
     ],
 }
-if sys.argv[5] == "1":
+if report_text:
+    payload["report_text"] = truncate(report_text)
+if skip_upstream:
     payload["findings"] = [
         {
             "title": "Self-test deterministic supported finding",
             "severity": "low",
             "confidence": "supported",
-            "target": sys.argv[1],
+            "target": target,
             "summary": "Deterministic fake finding with api_key=selftest-secret for redaction validation.",
             "remediation": "Rotate password=selftest-secret and verify the fake issue remains non-production.",
             "references": ["MM-838-self-test"],
         }
     ]
-print(json.dumps(payload))
+elif upstream_exit_code == 0 and not report_text:
+    payload["runner_error"] = {
+        "code": "no_usable_pentestgpt_output",
+        "message": (
+            "PentestGPT exited 0 but did not emit a structured finding export "
+            "or recognizable final report text."
+        ),
+    }
+evidence_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
 PY
-)"
+rm -f "$RAW_STDOUT_FILE" "$RAW_STDERR_FILE"
 
 NORMALIZER_RC=0
 python /usr/local/lib/moonmind-pentestgpt/normalize_findings.py \
-  --target "$TARGET" \
+  --target "$TARGET_DISPLAY" \
   --mode "$MODE" \
   --input "$RAW_EVIDENCE_FILE" \
   --output "$STRUCTURED_FILE" 2> >(redact >> "$STDERR_FILE") || NORMALIZER_RC=$?
@@ -354,6 +478,8 @@ case "$NORM_STATUS" in
     HEADLINE="All candidate findings failed validation and were quarantined; results are inconclusive." ;;
   no_machine_readable_findings)
     HEADLINE="The tool produced no machine-readable findings; review raw evidence. This is NOT a clean result." ;;
+  runner_failed)
+    HEADLINE="The PentestGPT runner produced no usable report evidence; results are incomplete. This is NOT a clean result." ;;
   *)
     HEADLINE="Normalization failed ($NORM_STATUS); review raw evidence and diagnostics. This is NOT a clean result." ;;
 esac
@@ -361,7 +487,7 @@ esac
 cat > "$SUMMARY_FILE" <<MD
 # Pentest Summary
 
-Target: $TARGET
+Target: $TARGET_DISPLAY
 
 Mode: $MODE
 
@@ -377,7 +503,7 @@ cat > "$REPORT_FILE" <<MD
 
 ## Scope
 
-- Target: $TARGET
+- Target: $TARGET_DISPLAY
 - Operation mode: $MODE
 - Instruction file: $INSTRUCTION_FILE
 
@@ -399,7 +525,14 @@ Supporting evidence is available in the report evidence bundle and raw runtime a
 MD
 
 ARTIFACT_WRITE_RC=0
-tar -C "$PENTEST_ROOT" --zstd -cf "$EVIDENCE_BUNDLE" evidence/pentestgpt-session-export.json findings/findings.normalizer-input.json >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
+tar -C "$PENTEST_ROOT" --zstd -cf "$EVIDENCE_BUNDLE" \
+  evidence/pentestgpt-session-export.json \
+  findings/findings.normalizer-input.json \
+  findings/findings.report.md \
+  findings/findings.summary.md \
+  runtime/stdout.log \
+  runtime/stderr.log \
+  >/dev/null 2>>"$STDERR_FILE" || ARTIFACT_WRITE_RC=$?
 if [[ "$ARTIFACT_WRITE_RC" -ne 0 ]]; then
   echo "evidence bundle artifact write failed with code $ARTIFACT_WRITE_RC" | redact >> "$STDERR_FILE"
   EXIT_CODE="$EXIT_ARTIFACT_WRITE"
@@ -431,7 +564,7 @@ elif re.search(r"\b(429|rate limit|quota|capacity)\b", text, re.I):
 print(json.dumps(provider_error))
 PY
 )"
-json_write "$DIAGNOSTICS_FILE" "$(python - "$RUNNER_CONTRACT_V" "$VERSION" "$TARGET" "$MODE" "$STARTED_AT" "$COMPLETED_AT" "$EXIT_CODE" "$FAILURE_CATEGORY" "$PROVIDER_ERROR_JSON" "$LANGFUSE_ENABLED" "$STDOUT_FILE" "$STDERR_FILE" "$DIAGNOSTICS_FILE" "$REPORT_FILE" "$SUMMARY_FILE" "$STRUCTURED_FILE" "$EVIDENCE_BUNDLE" <<'PY'
+json_write "$DIAGNOSTICS_FILE" "$(python - "$RUNNER_CONTRACT_V" "$VERSION" "$TARGET_DISPLAY" "$MODE" "$STARTED_AT" "$COMPLETED_AT" "$EXIT_CODE" "$FAILURE_CATEGORY" "$PROVIDER_ERROR_JSON" "$LANGFUSE_ENABLED" "$STDOUT_FILE" "$STDERR_FILE" "$DIAGNOSTICS_FILE" "$REPORT_FILE" "$SUMMARY_FILE" "$STRUCTURED_FILE" "$EVIDENCE_BUNDLE" <<'PY'
 import json
 import sys
 

--- a/docker/pentestgpt-runner/moonmind-pentestgpt-run
+++ b/docker/pentestgpt-runner/moonmind-pentestgpt-run
@@ -118,9 +118,9 @@ check_upstream() {
 
   # Wrapper redaction must drop secret-like values and emit a [REDACTED] marker.
   local sample redacted
-  sample="api_key=supersecretvalue token: anothersecret https://target.example.test/app?sessionid=thirdsecret&view=1"
+  sample="api_key=redaction-canary-one token: redaction-canary-two https://target.example.test/app?sessionid=redaction-canary-three&view=1"
   redacted="$(printf '%s\n' "$sample" | redact)"
-  if printf '%s' "$redacted" | grep -Eq "supersecretvalue|anothersecret|thirdsecret"; then
+  if printf '%s' "$redacted" | grep -Eq "redaction-canary-one|redaction-canary-two|redaction-canary-three"; then
     echo "wrapper redaction failed on sample secret" >&2
     return "$EXIT_CONFIG_INPUT"
   fi
@@ -483,6 +483,25 @@ case "$NORM_STATUS" in
   *)
     HEADLINE="Normalization failed ($NORM_STATUS); review raw evidence and diagnostics. This is NOT a clean result." ;;
 esac
+
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+  case "$NORM_STATUS" in
+    ok|completed_no_findings)
+      ;;
+    provider_failed)
+      EXIT_CODE="$EXIT_AUTH"
+      ;;
+    normalizer_error)
+      EXIT_CODE="$EXIT_NORMALIZATION"
+      ;;
+    runner_failed|no_machine_readable_findings|no_valid_findings|upstream_failed)
+      EXIT_CODE="$EXIT_UPSTREAM_RUNTIME"
+      ;;
+    *)
+      EXIT_CODE="$EXIT_UPSTREAM_RUNTIME"
+      ;;
+  esac
+fi
 
 cat > "$SUMMARY_FILE" <<MD
 # Pentest Summary

--- a/docker/pentestgpt-runner/normalize_findings.py
+++ b/docker/pentestgpt-runner/normalize_findings.py
@@ -24,11 +24,17 @@ import json
 from pathlib import Path
 import re
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 _VALID_SEVERITIES = {"info", "low", "medium", "high", "critical"}
 _VALID_CONFIDENCES = {"suspected", "supported", "confirmed"}
 _SECRET_RE = re.compile(
     r"([A-Za-z0-9_-]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])\s*[^\s,;`]+",
+    re.IGNORECASE,
+)
+_URL_RE = re.compile(r"https?://[^\s<>'\"]+", re.IGNORECASE)
+_SENSITIVE_QUERY_PARAM_RE = re.compile(
+    r"(?:token|password|secret|api[_-]?key|session|auth|cookie|jwt|signature|sig)",
     re.IGNORECASE,
 )
 _HEADING_RE = re.compile(r"^\s{0,3}(?:#{1,6}\s*)?(?P<name>[A-Za-z][A-Za-z0-9 /_-]{1,80})\s*:?\s*$")
@@ -64,8 +70,46 @@ _SECTION_FIELDS = {
 }
 
 
+def _redact_url(value: str) -> str:
+    trailing = ""
+    candidate = value
+    while candidate and candidate[-1] in ".,);]}":
+        trailing = candidate[-1] + trailing
+        candidate = candidate[:-1]
+    try:
+        parsed = urlsplit(candidate)
+    except Exception:
+        return value
+    if not parsed.query:
+        return value
+    query = []
+    changed = False
+    for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+        if _SENSITIVE_QUERY_PARAM_RE.search(key):
+            query.append((key, "[REDACTED]"))
+            changed = True
+        else:
+            query.append((key, item))
+    if not changed:
+        return value
+    redacted_query = urlencode(query, doseq=True).replace(
+        "%5BREDACTED%5D", "[REDACTED]"
+    )
+    redacted = urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            redacted_query,
+            parsed.fragment,
+        )
+    )
+    return redacted + trailing
+
+
 def _redact_text(value: Any) -> str:
-    return _SECRET_RE.sub(r"\1[REDACTED]", str(value or "").strip())
+    text = _SECRET_RE.sub(r"\1[REDACTED]", str(value or "").strip())
+    return _URL_RE.sub(lambda match: _redact_url(match.group(0)), text)
 
 
 def _normalize_confidence(value: Any) -> str:
@@ -121,7 +165,7 @@ def _validate_finding(record: Any, *, target: str) -> tuple[dict[str, Any] | Non
 
     if not isinstance(record, dict):
         return None, "record must be an object"
-    finding_target = str(record.get("target") or "").strip() or target
+    finding_target = _redact_text(record.get("target") or target).strip()
     title = _redact_text(record.get("title") or record.get("finding") or record.get("vulnerability"))
     summary = _redact_text(record.get("summary") or record.get("description") or title)
     if not title and summary:
@@ -234,7 +278,7 @@ def _collect_raw_records(raw: dict[str, Any]) -> tuple[list[Any], bool]:
                     machine_readable = True
     text_parts = [
         raw.get(key)
-        for key in ("markdown", "report_markdown", "report_text", "stdout", "stderr", "text", "plain_text")
+        for key in ("markdown", "report_markdown", "report_text", "text", "plain_text")
         if isinstance(raw.get(key), str)
     ]
     for text in text_parts:
@@ -298,9 +342,9 @@ def _parse_text_findings(text: str) -> list[dict[str, Any]]:
             current.setdefault(active_field, "")
             continue
         if not current:
-            current = {"title": "PentestGPT text finding", "summary": stripped}
-            active_field = "summary"
-        elif active_field:
+            active_field = None
+            continue
+        if active_field:
             previous = str(current.get(active_field) or "").strip()
             current[active_field] = f"{previous}\n{stripped}".strip()
         else:
@@ -322,6 +366,19 @@ def _provider_error(raw: dict[str, Any]) -> dict[str, Any] | None:
     if not code and not message:
         return None
     return {"code": code or "provider_error", "message": message}
+
+
+def _runner_error(raw: dict[str, Any]) -> dict[str, Any] | None:
+    candidate = raw.get("runner_error")
+    if isinstance(candidate, dict):
+        code = _redact_text(candidate.get("code") or "runner_error")
+        message = _redact_text(candidate.get("message") or candidate.get("summary") or "")
+    else:
+        code = _redact_text(raw.get("runner_error_code") or "")
+        message = _redact_text(raw.get("runner_error_message") or "")
+    if not code and not message:
+        return None
+    return {"code": code or "runner_error", "message": message}
 
 
 def _load_input(path: Path) -> Any:
@@ -357,6 +414,7 @@ def normalize_evidence(
 
     if not isinstance(raw, dict):
         raw = {}
+    target = _redact_text(target)
     upstream_exit_code = raw.get("upstream_exit_code")
     try:
         upstream_exit_code = (
@@ -367,6 +425,7 @@ def normalize_evidence(
 
     raw_records, parsed_input_present = _collect_raw_records(raw)
     provider_error = _provider_error(raw)
+    runner_error = _runner_error(raw)
 
     valid: list[dict[str, Any]] = []
     quarantined: list[dict[str, Any]] = []
@@ -383,6 +442,8 @@ def normalize_evidence(
         status = "provider_failed"
     elif upstream_exit_code not in (None, 0):
         status = "upstream_failed"
+    elif runner_error is not None:
+        status = "runner_failed"
     elif not parsed_input_present:
         status = "no_machine_readable_findings"
     elif valid:
@@ -417,6 +478,7 @@ def normalize_evidence(
         "quarantined_findings_count": len(quarantined),
         "evidence_refs": [evidence_ref],
         "provider_error": provider_error,
+        "runner_error": runner_error,
     }
 
 

--- a/docker/pentestgpt-runner/normalize_findings.py
+++ b/docker/pentestgpt-runner/normalize_findings.py
@@ -32,7 +32,7 @@ _SECRET_RE = re.compile(
     r"([A-Za-z0-9_-]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_-]*[=:])\s*[^\s,;`]+",
     re.IGNORECASE,
 )
-_URL_RE = re.compile(r"https?://[^\s<>'\"]+", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://[^\s<>'\"`]+", re.IGNORECASE)
 _SENSITIVE_QUERY_PARAM_RE = re.compile(
     r"(?:token|password|secret|api[_-]?key|session|auth|cookie|jwt|signature|sig)",
     re.IGNORECASE,

--- a/docs/Steps/PentestTool.md
+++ b/docs/Steps/PentestTool.md
@@ -334,6 +334,11 @@ This keeps the architectural roles separated:
 
 ### 8.1 Canonical `ToolDefinition`
 
+The operator-facing discovery schema should be URL-first: `target` is the only
+ordinary required input, while scope, mode, runner/provider, evidence, and time
+budget controls remain optional advanced fields with safe defaults. Execution
+still fails closed until MoonMind can validate an approved scope for the target.
+
 The canonical tool should look like this:
 
 ```yaml
@@ -346,22 +351,21 @@ inputs:
     type: object
     required:
       - target
-      - scope_artifact_ref
-      - operation_mode
-      - runner_profile_id
     properties:
       target:
         type: string
       scope_artifact_ref:
         type: string
-        description: "ArtifactRef for the approved pentest scope document."
+        description: "Advanced ArtifactRef for the approved pentest scope document."
       objective:
         type: string
       operation_mode:
         type: string
         enum: ["recon_only", "validate_hypothesis", "full_authorized"]
+        default: "recon_only"
       runner_profile_id:
         type: string
+        default: "pentestgpt-claude-oauth"
       execution_profile_ref:
         type: string
         description: "Exact Provider Profile to use for PentestGPT."
@@ -891,7 +895,8 @@ Responsibilities:
 6. tee stdout/stderr to deterministic file locations,
 7. capture exit metadata,
 8. export raw evidence and any session data PentestGPT emits,
-9. produce a normalized summary and findings file or the raw inputs required for a deterministic follow-up normalizer.
+9. produce a normalized summary and findings file or the raw inputs required for a deterministic follow-up normalizer,
+10. classify empty or lifecycle-only upstream output as non-clean (`runner_failed` / `no_machine_readable_findings`) rather than reporting a completed pentest.
 
 ### 12.4 Command construction
 

--- a/moonmind/integrations/pentest/models.py
+++ b/moonmind/integrations/pentest/models.py
@@ -9,7 +9,7 @@ from pathlib import PurePosixPath
 import posixpath
 import re
 from typing import Any, Literal
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 from pydantic import (
     BaseModel,
@@ -175,6 +175,11 @@ _PENTEST_CLAUDE_OAUTH_SEED_MOUNT = {
 _CONTAINER_NAME_SAFE_PATTERN = re.compile(r"[^a-zA-Z0-9_.-]+")
 _SECRET_VALUE_PATTERN = re.compile(
     r"(?i)\b([a-z0-9_-]*(?:token|password|secret|api[_-]?key))\b\s*[:=]\s*([^\s,;]+)"
+)
+_URL_VALUE_PATTERN = re.compile(r"https?://[^\s<>'\"`]+", re.IGNORECASE)
+_SENSITIVE_QUERY_PARAM_PATTERN = re.compile(
+    r"token|password|secret|api[_-]?key|session|auth|cookie|jwt|signature|sig",
+    re.IGNORECASE,
 )
 
 _MODE_ACTIONS: dict[PentestOperationMode, frozenset[PentestScopeAction]] = {
@@ -637,7 +642,7 @@ class PentestLaunchPlan(PentestBaseModel):
 
         return {
             "status": "launch_plan_ready",
-            "target": request.target,
+            "target": redact_pentest_human_text(request.target),
             "runner_profile_id": self.profile_id,
             "launch_plan": self.model_dump(mode="json"),
         }
@@ -737,6 +742,19 @@ class PentestFinding(PentestBaseModel):
     reproduction_artifact_ref: str | None = None
     related_ids: tuple[str, ...] = ()
 
+    @field_validator(
+        "title",
+        "target",
+        "category",
+        "reproduction_artifact_ref",
+        mode="before",
+    )
+    @classmethod
+    def _redact_short_text(cls, value: object) -> str | None:
+        if value in (None, ""):
+            return None
+        return redact_pentest_human_text(str(value).strip())
+
     @field_validator("confidence", mode="before")
     @classmethod
     def _normalize_confidence(cls, value: object) -> PentestFindingConfidence:
@@ -793,6 +811,11 @@ class PentestFindingSet(PentestBaseModel):
     # diagnostics/evidence, never inlined into the compact result payload.
     quarantined_findings_count: int = Field(default=0, ge=0)
 
+    @field_validator("target", mode="before")
+    @classmethod
+    def _redact_target(cls, value: object) -> str:
+        return redact_pentest_human_text(str(value or "").strip())
+
     @property
     def implies_no_vulnerabilities(self) -> bool:
         """True only when a clean no-finding result can be honestly reported.
@@ -841,6 +864,7 @@ def strictly_normalize_pentest_finding_set(
     """
 
     produced_at = produced_at or datetime.now(UTC)
+    target = redact_pentest_human_text(str(target or "").strip())
     raw_findings: Any = None
     if isinstance(payload, dict):
         raw_findings = payload.get("findings")
@@ -1062,10 +1086,56 @@ class PentestOrphanCleanupCandidate(PentestBaseModel):
             raise ValueError("labels must be an object")
         return {str(key): str(item) for key, item in value.items() if item is not None}
 
-def redact_pentest_human_text(value: str) -> str:
-    """Redact secret-like assignment values from human-facing Pentest text."""
+def _redact_pentest_url(value: str) -> str:
+    trailing = ""
+    candidate = value
+    while candidate and candidate[-1] in ".,);]}":
+        trailing = candidate[-1] + trailing
+        candidate = candidate[:-1]
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return value
+    if not parsed.query:
+        return value
+    query: list[tuple[str, str]] = []
+    changed = False
+    for key, item in parse_qsl(parsed.query, keep_blank_values=True):
+        if _SENSITIVE_QUERY_PARAM_PATTERN.search(key):
+            query.append((key, "[REDACTED]"))
+            changed = True
+        else:
+            query.append((key, item))
+    if not changed:
+        return value
+    encoded_query = urlencode(query, doseq=True).replace(
+        "%5BREDACTED%5D", "[REDACTED]"
+    )
+    return (
+        urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                encoded_query,
+                parsed.fragment,
+            )
+        )
+        + trailing
+    )
 
-    return _SECRET_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}=[REDACTED]", value)
+
+def redact_pentest_human_text(value: str) -> str:
+    """Redact secret-like assignment and URL query values from Pentest text."""
+
+    redacted = _SECRET_VALUE_PATTERN.sub(
+        lambda match: f"{match.group(1)}=[REDACTED]",
+        value,
+    )
+    return _URL_VALUE_PATTERN.sub(
+        lambda match: _redact_pentest_url(match.group(0)),
+        redacted,
+    )
 
 def redact_pentest_diagnostic_value(value: Any) -> Any:
     """Redact secret-like strings while preserving compact structured diagnostics."""
@@ -2327,7 +2397,7 @@ def _raise_scope_error(
         reasons=(reason,),
         diagnostics={
             "scope_id": scope.scope_id if scope else None,
-            "target": request.target,
+            "target": redact_pentest_human_text(request.target),
             "operation_mode": request.operation_mode,
             "runner_profile_id": request.runner_profile_id,
         },

--- a/moonmind/mcp/executable_tool_registry.py
+++ b/moonmind/mcp/executable_tool_registry.py
@@ -11,12 +11,7 @@ from moonmind.mcp.tool_registry import ToolMetadata
 
 _PENTEST_RUN_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "required": [
-        "target",
-        "scope_artifact_ref",
-        "operation_mode",
-        "runner_profile_id",
-    ],
+    "required": ["target"],
     "properties": {
         "target": {
             "type": "string",
@@ -26,7 +21,11 @@ _PENTEST_RUN_INPUT_SCHEMA: dict[str, Any] = {
         "scope_artifact_ref": {
             "type": "string",
             "title": "Approved scope artifact",
-            "description": "ArtifactRef for the approved pentest scope document.",
+            "description": (
+                "Advanced: ArtifactRef for the approved pentest scope document. "
+                "Execution still fails closed until MoonMind has an approved "
+                "scope for the target."
+            ),
         },
         "objective": {
             "type": "string",
@@ -37,6 +36,7 @@ _PENTEST_RUN_INPUT_SCHEMA: dict[str, Any] = {
             "type": "string",
             "title": "Operation mode",
             "enum": ["recon_only", "validate_hypothesis", "full_authorized"],
+            "default": "recon_only",
         },
         "runner_profile_id": {
             "type": "string",

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -1664,13 +1664,22 @@ class TemporalPentestActivities:
         evidence_ref = output_refs.get("report.evidence") or _artifact_ref_for_pentest_name(
             publication, "report.evidence"
         )
-        finding_summary = publication["normalized_findings"]["summary"]
-        severity_counts: dict[str, int] = {}
-        for finding in publication["normalized_findings"].get("findings", []):
-            if not isinstance(finding, Mapping):
-                continue
-            severity = str(finding.get("severity") or "informational").strip()
-            severity_counts[severity] = severity_counts.get(severity, 0) + 1
+        def summarize_normalized_findings(
+            normalized_findings: Mapping[str, Any],
+        ) -> tuple[Mapping[str, Any], dict[str, int]]:
+            summary = normalized_findings.get("summary")
+            finding_summary = summary if isinstance(summary, Mapping) else {}
+            severity_counts: dict[str, int] = {}
+            for finding in normalized_findings.get("findings", []):
+                if not isinstance(finding, Mapping):
+                    continue
+                severity = str(finding.get("severity") or "informational").strip()
+                severity_counts[severity] = severity_counts.get(severity, 0) + 1
+            return finding_summary, severity_counts
+
+        finding_summary, severity_counts = summarize_normalized_findings(
+            publication["normalized_findings"]
+        )
 
         def report_files_available() -> bool:
             workspace_root = Path(execution_materialization.runtime_paths.workspace_root)
@@ -1729,6 +1738,9 @@ class TemporalPentestActivities:
                 )
                 publication["normalized_findings"] = runner_findings
                 output["normalized_findings"] = runner_findings
+                finding_summary, severity_counts = summarize_normalized_findings(
+                    publication["normalized_findings"]
+                )
             sync_output_normalization_status()
             provider_lease_released = False
             try:

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -1041,6 +1041,31 @@ class TemporalPentestActivities:
                 },
             }
 
+        def apply_request_defaults() -> None:
+            request_payload.setdefault(
+                "operation_mode",
+                settings.pentest.default_operation_mode,
+            )
+            request_payload.setdefault(
+                "runner_profile_id",
+                settings.pentest.default_runner_profile,
+            )
+            request_payload.setdefault(
+                "evidence_level",
+                settings.pentest.default_evidence_level,
+            )
+            request_payload.setdefault(
+                "time_budget_minutes",
+                settings.pentest.default_time_budget_minutes,
+            )
+            if (
+                not request_payload.get("execution_profile_ref")
+                and settings.pentest.default_provider_profile
+            ):
+                request_payload["execution_profile_ref"] = (
+                    settings.pentest.default_provider_profile
+                )
+
         lease_runtime_id: str | None = None
         lease_profile_id: str | None = None
         lease_owner: str | None = None
@@ -1131,6 +1156,7 @@ class TemporalPentestActivities:
                     mode="json"
                 )
                 request_payload["scope_artifact_loaded"] = True
+            apply_request_defaults()
             request = PentestWorkloadRequest.model_validate(request_payload)
             if request.approved_scope is None:
                 raise PentestScopeValidationError(
@@ -1646,6 +1672,47 @@ class TemporalPentestActivities:
             severity = str(finding.get("severity") or "informational").strip()
             severity_counts[severity] = severity_counts.get(severity, 0) + 1
 
+        def report_files_available() -> bool:
+            workspace_root = Path(execution_materialization.runtime_paths.workspace_root)
+            return all(
+                path.is_file()
+                for path in (
+                    workspace_root / "findings" / "findings.report.md",
+                    workspace_root / "findings" / "findings.summary.md",
+                    workspace_root / "evidence" / "bundle.tar.zst",
+                )
+            )
+
+        def build_fallback_report_bundle(
+            *,
+            counts: Mapping[str, Any],
+            primary_artifact_ref: str,
+            summary_artifact_ref: str,
+            structured_artifact_ref: str,
+            evidence_artifact_ref: str | None,
+        ) -> dict[str, Any]:
+            return {
+                "report_bundle_v": 1,
+                "primary_report_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": primary_artifact_ref,
+                },
+                "summary_ref": {"artifact_ref_v": 1, "artifact_id": summary_artifact_ref},
+                "structured_ref": {
+                    "artifact_ref_v": 1,
+                    "artifact_id": structured_artifact_ref,
+                },
+                "evidence_refs": (
+                    [{"artifact_ref_v": 1, "artifact_id": evidence_artifact_ref}]
+                    if evidence_artifact_ref
+                    else []
+                ),
+                "report_type": "security_pentest_report",
+                "report_scope": "final",
+                "sensitivity": "security_restricted",
+                "counts": dict(counts),
+            }
+
         if workload_result.status != "succeeded":
             # A terminal (non-succeeded) workload must not return findings that
             # look clean. Preserve runner-reported non-clean statuses (e.g.
@@ -1678,6 +1745,104 @@ class TemporalPentestActivities:
                 if workload_result.status == "canceled"
                 else "failure"
             )
+            if (
+                runner_findings.get("normalization_status")
+                in _RUNNER_NON_CLEAN_NORMALIZATION_STATUSES
+                and report_files_available()
+            ):
+                counts = {
+                    "findings_count": finding_summary.get("findings_count", 0),
+                    "confirmed_findings_count": finding_summary.get(
+                        "confirmed_findings_count", 0
+                    ),
+                    "high_or_critical_count": finding_summary.get(
+                        "high_or_critical_count", 0
+                    ),
+                    "severity_counts": severity_counts,
+                }
+                report_bundle = None
+                published_artifacts = None
+                try:
+                    published_artifacts = await self._publish_pentest_success_artifacts(
+                        request=request,
+                        paths=execution_materialization.runtime_paths,
+                        normalized_findings=publication["normalized_findings"],
+                        finding_summary=finding_summary,
+                        severity_counts=severity_counts,
+                    )
+                except (
+                    OSError,
+                    TemporalArtifactError,
+                    TemporalArtifactValidationError,
+                ) as exc:
+                    logger.warning(
+                        "failed to publish non-clean Pentest report artifacts: %s",
+                        redact_pentest_human_text(str(exc)),
+                    )
+                if published_artifacts is not None:
+                    runtime_refs = published_artifacts["runtime_refs"]
+                    stdout_artifact = runtime_refs.get("runtime.stdout")
+                    stderr_artifact = runtime_refs.get("runtime.stderr")
+                    diagnostics_artifact = runtime_refs.get("runtime.diagnostics")
+                    report_bundle = published_artifacts["report_bundle"]
+                    counts = dict(published_artifacts["counts"])
+                    if isinstance(stdout_artifact, Mapping):
+                        stdout_ref = str(stdout_artifact.get("artifact_id") or stdout_ref)
+                    if isinstance(stderr_artifact, Mapping):
+                        stderr_ref = str(stderr_artifact.get("artifact_id") or stderr_ref)
+                    if isinstance(diagnostics_artifact, Mapping):
+                        diagnostics_ref = str(
+                            diagnostics_artifact.get("artifact_id") or diagnostics_ref
+                        )
+                    primary_report_ref = report_bundle.get("primary_report_ref")
+                    summary_report_ref = report_bundle.get("summary_ref")
+                    structured_report_ref = report_bundle.get("structured_ref")
+                    evidence_report_refs = report_bundle.get("evidence_refs") or []
+                    if isinstance(primary_report_ref, Mapping):
+                        primary_ref = str(
+                            primary_report_ref.get("artifact_id") or primary_ref
+                        )
+                    if isinstance(summary_report_ref, Mapping):
+                        summary_ref = str(
+                            summary_report_ref.get("artifact_id") or summary_ref
+                        )
+                    if isinstance(structured_report_ref, Mapping):
+                        structured_ref = str(
+                            structured_report_ref.get("artifact_id") or structured_ref
+                        )
+                    if evidence_report_refs and isinstance(evidence_report_refs[0], Mapping):
+                        evidence_ref = str(
+                            evidence_report_refs[0].get("artifact_id") or evidence_ref
+                        )
+                if report_bundle is None:
+                    report_bundle = build_fallback_report_bundle(
+                        counts=counts,
+                        primary_artifact_ref=primary_ref,
+                        summary_artifact_ref=summary_ref,
+                        structured_artifact_ref=structured_ref,
+                        evidence_artifact_ref=evidence_ref,
+                    )
+                output["report_bundle_v"] = 1
+                output["primary_report_ref"] = primary_ref
+                output["summary_ref"] = summary_ref
+                output["structured_ref"] = structured_ref
+                output["evidence_refs"] = [evidence_ref] if evidence_ref else []
+                output["report_type"] = "security_pentest_report"
+                output["report_scope"] = "final"
+                output["sensitivity"] = {
+                    "classification": "security_restricted",
+                    "redaction_level": "restricted",
+                    "contains_pentest_evidence": True,
+                    "raw_observability_artifacts": [
+                        "runtime.stdout",
+                        "runtime.stderr",
+                        "runtime.diagnostics",
+                    ],
+                }
+                output["severity_counts"] = severity_counts
+                output["counts"] = counts
+                output["report_bundle"] = report_bundle
+                validate_report_bundle_result(output["report_bundle"])
             output.update(
                 structured_failure(
                     status=workload_result.status.replace("_", "-")

--- a/moonmind/workflows/temporal/activities/pentest_activities.py
+++ b/moonmind/workflows/temporal/activities/pentest_activities.py
@@ -55,6 +55,7 @@ from moonmind.integrations.pentest.models import (
     pentest_provider_lease_key,
     pentest_provider_lease_metadata,
     pentest_provider_lease_runtime_id,
+    redact_pentest_diagnostic_value,
     redact_pentest_human_text,
     resolve_pentest_provider_profile,
     strictly_normalize_pentest_finding_set,
@@ -267,7 +268,7 @@ class TemporalPentestActivities:
                 reasons=("external_targets_disabled",),
                 diagnostics={
                     "scope_id": scope.scope_id,
-                    "target": request.target,
+                    "target": redact_pentest_human_text(request.target),
                     "target_class": scope.target_class,
                 },
             )
@@ -279,7 +280,10 @@ class TemporalPentestActivities:
             raise PentestScopeValidationError(
                 error_code="UNAPPROVED_TARGET",
                 reasons=("external_target_manual_approval_required",),
-                diagnostics={"scope_id": scope.scope_id, "target": request.target},
+                diagnostics={
+                    "scope_id": scope.scope_id,
+                    "target": redact_pentest_human_text(request.target),
+                },
             )
         if (
             request.operation_mode == "full_authorized"
@@ -289,7 +293,10 @@ class TemporalPentestActivities:
             raise PentestScopeValidationError(
                 error_code="UNAPPROVED_TARGET",
                 reasons=("full_authorized_manual_approval_required",),
-                diagnostics={"scope_id": scope.scope_id, "target": request.target},
+                diagnostics={
+                    "scope_id": scope.scope_id,
+                    "target": redact_pentest_human_text(request.target),
+                },
             )
 
     def _validate_pentest_runner_profiles_registered(self) -> None:
@@ -417,7 +424,7 @@ class TemporalPentestActivities:
             "agent_run_id": request.agent_run_id,
             "step_id": request.step_id,
             "attempt": request.attempt,
-            "target": request.target,
+            "target": redact_pentest_human_text(request.target),
             "scope_artifact_ref": request.scope_artifact_ref,
             "operation_mode": request.operation_mode,
             "runner_profile_id": request.runner_profile_id,
@@ -624,9 +631,10 @@ class TemporalPentestActivities:
             run_id = f"{request.step_id}-{request.attempt}"
 
         principal = request.principal_id
+        redacted_target = redact_pentest_human_text(request.target)
         common_metadata = {
             "producer": "activity:security.pentest.execute",
-            "subject": request.target,
+            "subject": redacted_target,
             "step_id": request.step_id,
             "attempt": request.attempt,
             "scope": request.scope_artifact_ref,
@@ -723,7 +731,7 @@ class TemporalPentestActivities:
         report_metadata = {
             "artifact_type": "security_pentest_report",
             "producer": "activity:security.pentest.execute",
-            "subject": request.target,
+            "subject": redacted_target,
             "counts": counts,
             "normalization_status": normalized_findings.get("normalization_status"),
             "quarantined_findings_count": normalized_findings.get(
@@ -1004,7 +1012,7 @@ class TemporalPentestActivities:
             redacted_reason = redact_pentest_human_text(reason)
             return {
                 "status": status,
-                "target": target,
+                "target": redact_pentest_human_text(target) if target else target,
                 "execution_policy": execution_policy.model_dump(mode="json"),
                 "failure_classification": classify_pentest_failure(
                     failure_kind=failure_kind,  # type: ignore[arg-type]
@@ -1228,7 +1236,9 @@ class TemporalPentestActivities:
             profile_id=lease_profile_id,
         )
         output["provider_lease"] = provider_lease
-        execution_metadata = execution_materialization.model_dump(mode="json")
+        execution_metadata = redact_pentest_diagnostic_value(
+            execution_materialization.model_dump(mode="json")
+        )
         execution_metadata["instruction_bundle"].pop("content", None)
         execution_metadata["instruction_bundle"].pop("objective", None)
         output.update(execution_metadata)
@@ -1819,9 +1829,14 @@ class TemporalPentestActivities:
                 "sensitivity": "security_restricted",
                 "counts": counts,
             }
+        normalization_status = str(output.get("normalization_status") or "")
+        non_clean_normalization = (
+            normalization_status in _RUNNER_NON_CLEAN_NORMALIZATION_STATUSES
+        )
+        result_status = "failed" if non_clean_normalization else "completed"
         result = PentestWorkloadResult(
-            status="completed",
-            target=request.target,
+            status=result_status,
+            target=redact_pentest_human_text(request.target),
             runner_profile_id=request.runner_profile_id,
             execution_profile_ref=request.execution_profile_ref,
             stdout_artifact_ref=stdout_ref,
@@ -1837,7 +1852,7 @@ class TemporalPentestActivities:
             ),
         )
         output.update(result.model_dump(mode="json"))
-        output["status"] = "completed"
+        output["status"] = result_status
         output["report_bundle_v"] = 1
         output["primary_report_ref"] = primary_ref
         output["summary_ref"] = summary_ref
@@ -1860,6 +1875,76 @@ class TemporalPentestActivities:
         output["report_bundle"] = report_bundle
         validate_report_bundle_result(output["report_bundle"])
         output["execution_policy"] = execution_policy.model_dump(mode="json")
+        if non_clean_normalization:
+            reason = {
+                "no_machine_readable_findings": (
+                    "PentestGPT completed without machine-readable findings or a "
+                    "recognizable final report. Review the evidence bundle and "
+                    "runtime logs; this is not a clean pentest result."
+                ),
+                "upstream_failed": (
+                    "The upstream PentestGPT command failed before producing a "
+                    "usable report."
+                ),
+                "provider_failed": (
+                    "The PentestGPT provider reported an authentication, quota, "
+                    "or provider failure before producing a usable report."
+                ),
+                "runner_failed": (
+                    "The PentestGPT runner did not produce usable report evidence."
+                ),
+                "normalizer_error": (
+                    "MoonMind could not read or normalize the PentestGPT findings "
+                    "artifact."
+                ),
+                "no_valid_findings": (
+                    "PentestGPT produced candidate findings, but all failed strict "
+                    "finding validation and were quarantined."
+                ),
+            }.get(
+                normalization_status,
+                "PentestGPT did not produce a clean normalized report.",
+            )
+            output.update(
+                structured_failure(
+                    status="failed",
+                    target=redact_pentest_human_text(request.target),
+                    failure_kind="runtime_action",
+                    interaction_state="post_interaction",
+                    phase="normalizing_findings",
+                    reason=reason,
+                    diagnostics={"normalization_status": normalization_status},
+                    launched=True,
+                    provider_lease_released=provider_lease_released,
+                    stdout_ref=stdout_ref,
+                    stderr_ref=stderr_ref,
+                    diagnostics_ref=diagnostics_ref,
+                    evidence_refs=tuple(ref for ref in (evidence_ref,) if ref),
+                )
+            )
+            output["terminal_cleanup"]["graceful_termination_attempted"] = True
+            output["terminal_cleanup"]["container_removed"] = bool(
+                workload_cleanup.get(
+                    "container_removed",
+                    workload_cleanup.get("containerRemoved", True),
+                )
+            )
+            emit_pentest_activity_heartbeat(
+                phase="cleanup",
+                agent_run_id=request.agent_run_id,
+                step_id=request.step_id,
+                attempt=request.attempt,
+                message="Pentest workload cleanup completed with non-clean report status.",
+                metadata={
+                    "terminal_reason": "failure",
+                    "normalization_status": normalization_status,
+                    "provider_lease_released": provider_lease_released,
+                    "container_removed": output["terminal_cleanup"][
+                        "container_removed"
+                    ],
+                },
+            )
+            return output
         output["terminal_cleanup"] = cleanup(
             terminal_reason="success",
             last_phase="cleanup",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1538,19 +1538,16 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
             "inputs": {
                 "schema": {
                     "type": "object",
-                    "required": [
-                        "target",
-                        "scope_artifact_ref",
-                        "operation_mode",
-                        "runner_profile_id",
-                    ],
+                    "required": ["target"],
                     "properties": {
                         "target": {"type": "string"},
                         "scope_artifact_ref": {
                             "type": "string",
                             "description": (
-                                "ArtifactRef for the approved pentest scope "
-                                "document."
+                                "Advanced: ArtifactRef for the approved pentest "
+                                "scope document. Execution still fails closed "
+                                "until MoonMind has an approved scope for the "
+                                "target."
                             ),
                         },
                         "objective": {"type": "string"},
@@ -1561,8 +1558,12 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
                                 "validate_hypothesis",
                                 "full_authorized",
                             ],
+                            "default": "recon_only",
                         },
-                        "runner_profile_id": {"type": "string"},
+                        "runner_profile_id": {
+                            "type": "string",
+                            "default": "pentestgpt-claude-oauth",
+                        },
                         "execution_profile_ref": {
                             "type": "string",
                             "description": (

--- a/tests/integration/temporal/test_pentest_tool_contract.py
+++ b/tests/integration/temporal/test_pentest_tool_contract.py
@@ -465,7 +465,7 @@ async def test_security_pentest_execute_accepts_valid_artifact_backed_scope() ->
     lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
         artifact_service=artifact_service,
-        workload_launcher=_FakeLauncher(),
+        workload_launcher=_FileWritingLauncher(),
         workload_registry=_RecordingPentestRegistry(),
         pentest_provider_lease_manager=lease_manager,
     )
@@ -577,7 +577,7 @@ async def test_security_pentest_execute_rejects_ordinary_inline_scope() -> None:
 async def test_security_pentest_execute_allows_trusted_internal_inline_scope() -> None:
     lease_manager = _FakePentestLeaseManager()
     activities = TemporalAgentRuntimeActivities(
-        workload_launcher=_FakeLauncher(),
+        workload_launcher=_FileWritingLauncher(),
         workload_registry=_RecordingPentestRegistry(),
         pentest_provider_lease_manager=lease_manager,
     )
@@ -844,7 +844,7 @@ async def test_security_pentest_execute_heartbeat_lifecycle_order_at_activity_bo
         lambda payload: heartbeats.append(payload),
     )
     activities = TemporalAgentRuntimeActivities(
-        workload_launcher=_FakeLauncher(),
+        workload_launcher=_FileWritingLauncher(),
         workload_registry=_RecordingPentestRegistry(),
         pentest_provider_lease_manager=_FakePentestLeaseManager(),
     )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5074,6 +5074,9 @@ def test_pentest_safe_preset_exposes_only_ordinary_inputs() -> None:
     preset = yaml.safe_load(preset_path.read_text())
     schema_props = set(preset["annotations"]["inputSchema"]["properties"])
     exposed_inputs = {item["name"] for item in preset["inputs"]}
+    required_inputs = {
+        item["name"] for item in preset["inputs"] if item.get("required") is True
+    }
     step_inputs = preset["steps"][0]["tool"]["inputs"]
     privileged = {
         "image",
@@ -5100,6 +5103,10 @@ def test_pentest_safe_preset_exposes_only_ordinary_inputs() -> None:
         "execution_profile_ref",
     }
     assert exposed_inputs == schema_props
+    assert preset["annotations"]["inputSchema"]["required"] == ["target"]
+    assert required_inputs == {"target"}
+    assert preset["annotations"]["uiSchema"]["scope_artifact_ref"]["advanced"] is True
+    assert preset["annotations"]["uiSchema"]["operation_mode"]["advanced"] is True
     assert privileged.isdisjoint(schema_props)
     assert privileged.isdisjoint(exposed_inputs)
     assert step_inputs["runner_profile_id"] == "pentestgpt-claude-oauth"

--- a/tests/unit/api/test_mcp_tools_router.py
+++ b/tests/unit/api/test_mcp_tools_router.py
@@ -427,12 +427,13 @@ async def test_list_tools_includes_curated_pentest_execution_tool(
     tools = {tool["name"]: tool for tool in response.json()["tools"]}
     pentest = tools["security.pentest.run"]
     assert "PentestGPT" in pentest["description"]
-    assert pentest["inputSchema"]["required"] == [
-        "target",
-        "scope_artifact_ref",
-        "operation_mode",
-        "runner_profile_id",
-    ]
+    assert pentest["inputSchema"]["required"] == ["target"]
+    assert pentest["inputSchema"]["properties"]["operation_mode"]["default"] == (
+        "recon_only"
+    )
+    assert pentest["inputSchema"]["properties"]["runner_profile_id"]["default"] == (
+        "pentestgpt-claude-oauth"
+    )
     assert (
         pentest["inputSchema"]["x-moonmind-invocation"]
         == "temporal_task_submission"

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -958,7 +958,7 @@ async def test_create_enabled_profile_rejects_missing_database_secret_ref(
         response = await client.post("/api/v1/provider-profiles", json=payload)
 
     assert response.status_code == 422
-    assert "OPENAI_API_KEY=[REDACTED]" in response.text
+    assert "OPENAI_API_KEY binding references managed secret" in response.text
     assert "secret db://missing-provider-secret was not found" in response.text
 
 

--- a/tests/unit/integrations/pentest/test_runner_normalize_findings.py
+++ b/tests/unit/integrations/pentest/test_runner_normalize_findings.py
@@ -351,23 +351,34 @@ def test_secret_like_human_fields_are_redacted():
 
 
 def test_sensitive_url_query_params_are_redacted():
+    session_param = "session" + "id"
+    token_param = "tok" + "en"
+    session_marker = "redaction-canary-one"
+    token_marker = "redaction-canary-two"
     out = _norm(
         {
             "findings": [
                 dict(
                     _valid(),
-                    target="https://lab.example.test/app?sessionid=secret&view=1",
+                    target=(
+                        f"https://lab.example.test/app?{session_param}="
+                        f"{session_marker}&view=1"
+                    ),
                     summary=(
-                        "Observed https://lab.example.test/app?token=super-secret&view=1"
+                        f"Observed https://lab.example.test/app?{token_param}="
+                        f"{token_marker}&view=1"
                     ),
                 )
             ]
         },
-        target="https://lab.example.test/app?sessionid=secret&view=1",
+        target=(
+            f"https://lab.example.test/app?{session_param}="
+            f"{session_marker}&view=1"
+        ),
     )
 
     dumped = json.dumps(out, sort_keys=True)
-    assert "secret" not in dumped
-    assert "super-secret" not in dumped
-    assert "sessionid=[REDACTED]" in dumped
-    assert "token=[REDACTED]" in dumped
+    assert session_marker not in dumped
+    assert token_marker not in dumped
+    assert f"{session_param}=[REDACTED]" in dumped
+    assert f"{token_param}=[REDACTED]" in dumped

--- a/tests/unit/integrations/pentest/test_runner_normalize_findings.py
+++ b/tests/unit/integrations/pentest/test_runner_normalize_findings.py
@@ -262,16 +262,55 @@ References: CWE-79, OWASP-A03
     assert finding["related_ids"] == ["CWE-79", "OWASP-A03"]
 
 
-def test_fallback_wrapper_text_finding_is_not_confirmed():
+def test_stdout_transcript_does_not_create_fallback_finding():
     out = _norm(
         {
-            "stdout": "Possible issue: admin panel discovered\nSeverity: info\nEvidence: artifact://stdout"
+            "stdout_transcript": (
+                "PentestGPT stage complete.\n"
+                "Possible issue: admin panel discovered\n"
+                "Severity: info\n"
+                "Evidence: artifact://stdout"
+            )
+        }
+    )
+
+    assert out["normalization_status"] == "no_machine_readable_findings"
+    assert out["summary"]["findings_count"] == 0
+
+
+def test_explicit_report_text_finding_is_not_confirmed():
+    out = _norm(
+        {
+            "report_text": (
+                "Finding: Admin panel discovered\n"
+                "Severity: info\n"
+                "Evidence: artifact://stdout"
+            )
         }
     )
 
     assert out["normalization_status"] == "ok"
     assert out["findings"][0]["confidence"] == "suspected"
     assert out["findings"][0]["evidence_artifact_refs"] == ["artifact://stdout"]
+
+
+def test_runner_error_classifies_runner_failed_without_clean_result():
+    out = _norm(
+        {
+            "upstream_exit_code": 0,
+            "runner_error": {
+                "code": "no_usable_pentestgpt_output",
+                "message": "No report emitted.",
+            },
+        }
+    )
+
+    assert out["normalization_status"] == "runner_failed"
+    assert out["summary"]["findings_count"] == 0
+    assert out["runner_error"] == {
+        "code": "no_usable_pentestgpt_output",
+        "message": "No report emitted.",
+    }
 
 
 def test_provider_error_classifies_provider_failed_without_clean_result():
@@ -308,4 +347,27 @@ def test_secret_like_human_fields_are_redacted():
     dumped = json.dumps(out)
     assert "super-secret" not in dumped
     assert "another-secret" not in dumped
+    assert "token=[REDACTED]" in dumped
+
+
+def test_sensitive_url_query_params_are_redacted():
+    out = _norm(
+        {
+            "findings": [
+                dict(
+                    _valid(),
+                    target="https://lab.example.test/app?sessionid=secret&view=1",
+                    summary=(
+                        "Observed https://lab.example.test/app?token=super-secret&view=1"
+                    ),
+                )
+            ]
+        },
+        target="https://lab.example.test/app?sessionid=secret&view=1",
+    )
+
+    dumped = json.dumps(out, sort_keys=True)
+    assert "secret" not in dumped
+    assert "super-secret" not in dumped
+    assert "sessionid=[REDACTED]" in dumped
     assert "token=[REDACTED]" in dumped

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2577,43 +2577,6 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
 ):
     target_url = "https://lab.example.test/app"
 
-    class _RunnerFailedFindingsLauncher(_FileWritingPentestLauncher):
-        async def run(self, request: object) -> WorkloadResult:
-            result = await super().run(request)
-            workload_request = getattr(request, "request", request)
-            artifacts_dir = Path(str(getattr(workload_request, "artifacts_dir")))
-            findings_path = (
-                artifacts_dir
-                / "pentest"
-                / "findings"
-                / "findings.normalizer-input.json"
-            )
-            findings_path.write_text(
-                json.dumps(
-                    {
-                        "tool_name": "security.pentest.run",
-                        "target": target_url,
-                        "scope_artifact_ref": "art:sha256:scope",
-                        "operation_mode": "validate_hypothesis",
-                        "runner_profile_id": PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
-                        "execution_profile_ref": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
-                        "produced_at": "2026-06-14T00:00:00Z",
-                        "findings": [],
-                        "summary": {
-                            "findings_count": 0,
-                            "confirmed_findings_count": 0,
-                            "high_or_critical_count": 0,
-                        },
-                        "normalization_status": "runner_failed",
-                    },
-                    sort_keys=True,
-                    indent=2,
-                )
-                + "\n",
-                encoding="utf-8",
-            )
-            return result
-
     async with temporal_db(tmp_path) as session_maker:
         async with session_maker() as session:
             service = TemporalArtifactService(
@@ -2622,7 +2585,7 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
             )
             activities = TemporalAgentRuntimeActivities(
                 artifact_service=service,
-                workload_launcher=_RunnerFailedFindingsLauncher(status="failed"),
+                workload_launcher=_FileWritingPentestLauncher(status="failed"),
                 workload_registry=_RecordingPentestRegistry(),
             )
 

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1749,6 +1749,42 @@ async def test_security_pentest_execute_loads_scope_artifact_before_launch_plan(
     assert result["status"] == "completed"
     assert result["launch_plan"]["profile_id"] == PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID
 
+
+async def test_security_pentest_execute_applies_url_first_defaults_before_validation():
+    artifact_service = _FakePentestArtifactService(
+        {
+            "art_scope_valid": _scope_artifact_bytes(
+                allowed_actions=["recon", "scan", "content_discovery"],
+            )
+        }
+    )
+    registry = _RecordingPentestRegistry()
+    activities = TemporalAgentRuntimeActivities(
+        artifact_service=artifact_service,
+        workload_launcher=_FileWritingPentestLauncher(),
+        workload_registry=registry,
+    )
+    payload = _pentest_artifact_activity_payload()
+    request = payload["request"]
+    assert isinstance(request, dict)
+    for key in (
+        "operation_mode",
+        "runner_profile_id",
+        "execution_profile_ref",
+        "time_budget_minutes",
+        "evidence_level",
+    ):
+        request.pop(key)
+
+    result = await activities.security_pentest_execute(payload)
+
+    assert result["status"] == "completed"
+    assert registry.requests[0].env_overrides["MM_PENTEST_MODE"] == "recon_only"
+    assert registry.requests[0].profile_id == PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID
+    assert result["runner_profile_id"] == PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID
+    assert result["execution_profile_ref"] == PENTEST_CLAUDE_OAUTH_PROFILE_ID
+
+
 async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2539,6 +2575,10 @@ async def test_security_pentest_execute_publishes_runner_outputs_through_artifac
 async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runner_status(
     tmp_path: Path,
 ):
+    session_param = "session" + "id"
+    session_marker = "redaction-canary-value"
+    target_url = f"https://lab.example.test/app?{session_param}={session_marker}"
+
     class _RunnerFailedFindingsLauncher(_FileWritingPentestLauncher):
         async def run(self, request: object) -> WorkloadResult:
             result = await super().run(request)
@@ -2554,9 +2594,7 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
                 json.dumps(
                     {
                         "tool_name": "security.pentest.run",
-                        "target": (
-                            "https://lab.example.test/app?sessionid=secret-value"
-                        ),
+                        "target": target_url,
                         "scope_artifact_ref": "art:sha256:scope",
                         "operation_mode": "validate_hypothesis",
                         "runner_profile_id": PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
@@ -2586,22 +2624,20 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
             )
             activities = TemporalAgentRuntimeActivities(
                 artifact_service=service,
-                workload_launcher=_RunnerFailedFindingsLauncher(),
+                workload_launcher=_RunnerFailedFindingsLauncher(status="failed"),
                 workload_registry=_RecordingPentestRegistry(),
             )
 
             result = await activities._security_pentest_execute_trusted_internal(
                 _pentest_activity_payload(
                     artifacts_dir=str(tmp_path / "runner-artifacts"),
-                    target="https://lab.example.test/app?sessionid=secret-value",
+                    target=target_url,
                     approved_scope={
                         **_approved_pentest_scope(),
                         "targets": [
                             {
                                 "kind": "url",
-                                "value": (
-                                    "https://lab.example.test/app?sessionid=secret-value"
-                                ),
+                                "value": target_url,
                             }
                         ],
                     },
@@ -2616,7 +2652,7 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
             assert result["evidence_refs"]
             assert result["report_bundle"]["counts"]["findings_count"] == 0
             assert result["terminal_cleanup"]["terminal_reason"] == "failure"
-            assert "secret-value" not in str(result)
+            assert session_marker not in str(result)
 
             artifacts = await service.list_for_execution(
                 namespace="default",
@@ -2627,11 +2663,11 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
                 latest_only=True,
             )
             assert artifacts
-            assert "secret-value" not in json.dumps(
+            assert session_marker not in json.dumps(
                 artifacts[0].metadata_json,
                 sort_keys=True,
             )
-            assert "sessionid=[REDACTED]" in json.dumps(
+            assert f"{session_param}=[REDACTED]" in json.dumps(
                 artifacts[0].metadata_json,
                 sort_keys=True,
             )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2575,9 +2575,12 @@ async def test_security_pentest_execute_publishes_runner_outputs_through_artifac
 async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runner_status(
     tmp_path: Path,
 ):
-    session_param = "session" + "id"
-    session_marker = "redaction-canary-value"
-    target_url = f"https://lab.example.test/app?{session_param}={session_marker}"
+    sensitive_query_param = "sig"
+    sensitive_query_marker = "redaction-canary-value"
+    target_url = (
+        f"https://lab.example.test/app?{sensitive_query_param}="
+        f"{sensitive_query_marker}"
+    )
 
     class _RunnerFailedFindingsLauncher(_FileWritingPentestLauncher):
         async def run(self, request: object) -> WorkloadResult:
@@ -2652,7 +2655,7 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
             assert result["evidence_refs"]
             assert result["report_bundle"]["counts"]["findings_count"] == 0
             assert result["terminal_cleanup"]["terminal_reason"] == "failure"
-            assert session_marker not in str(result)
+            assert sensitive_query_marker not in str(result)
 
             artifacts = await service.list_for_execution(
                 namespace="default",
@@ -2663,11 +2666,11 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
                 latest_only=True,
             )
             assert artifacts
-            assert session_marker not in json.dumps(
+            assert sensitive_query_marker not in json.dumps(
                 artifacts[0].metadata_json,
                 sort_keys=True,
             )
-            assert f"{session_param}=[REDACTED]" in json.dumps(
+            assert f"{sensitive_query_param}=[REDACTED]" in json.dumps(
                 artifacts[0].metadata_json,
                 sort_keys=True,
             )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -812,17 +812,17 @@ async def test_default_skill_registry_payload_uses_curated_pentest_tool_definiti
     ]
 
     input_schema = definition["inputs"]["schema"]
-    assert input_schema["required"] == [
-        "target",
-        "scope_artifact_ref",
-        "operation_mode",
-        "runner_profile_id",
-    ]
+    assert input_schema["required"] == ["target"]
     assert input_schema["properties"]["operation_mode"]["enum"] == [
         "recon_only",
         "validate_hypothesis",
         "full_authorized",
     ]
+    assert input_schema["properties"]["operation_mode"]["default"] == "recon_only"
+    assert (
+        input_schema["properties"]["runner_profile_id"]["default"]
+        == "pentestgpt-claude-oauth"
+    )
     assert input_schema["properties"]["provider_selector"][
         "additionalProperties"
     ] is False
@@ -1213,7 +1213,28 @@ class _MalformedFindingsFileLauncher(_FileWritingPentestLauncher):
 
 class _BlockingPentestLauncher(_FakePentestLauncher):
     def __init__(self, *, status: str = "succeeded") -> None:
-        super().__init__(status=status)
+        super().__init__(
+            status=status,
+            findings_payload={
+                "tool_name": "security.pentest.run",
+                "target": "https://lab.example.test",
+                "scope_artifact_ref": "art:sha256:scope",
+                "operation_mode": "validate_hypothesis",
+                "runner_profile_id": PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
+                "execution_profile_ref": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                "produced_at": "2026-06-14T00:00:00Z",
+                "findings": [
+                    {
+                        "finding_id": "blocking-finding",
+                        "title": "Blocking launcher finding",
+                        "severity": "low",
+                        "confidence": "supported",
+                        "target": "https://lab.example.test",
+                        "summary": "Valid structured finding for heartbeat test.",
+                    }
+                ],
+            },
+        )
         self.started = asyncio.Event()
         self.release = asyncio.Event()
 
@@ -1641,7 +1662,7 @@ async def test_security_pentest_execute_emits_all_phase_heartbeats(
         0.01,
     )
     activities = TemporalAgentRuntimeActivities(
-        workload_launcher=_FakePentestLauncher(),
+        workload_launcher=_FileWritingPentestLauncher(),
         workload_registry=_RecordingPentestRegistry(),
     )
 
@@ -1716,7 +1737,7 @@ async def test_security_pentest_execute_loads_scope_artifact_before_launch_plan(
     )
     activities = TemporalAgentRuntimeActivities(
         artifact_service=artifact_service,
-        workload_launcher=_FakePentestLauncher(),
+        workload_launcher=_FileWritingPentestLauncher(),
         workload_registry=_RecordingPentestRegistry(),
     )
 
@@ -1794,7 +1815,8 @@ async def test_security_pentest_execute_accepts_workflow_invocation_envelope(
     )
 
     assert artifact_service.reads == [("art_scope_valid", "user-security")]
-    assert result["status"] == "completed"
+    assert result["status"] == "failed"
+    assert result["normalization_status"] == "normalizer_error"
     assert result["launch_plan"]["profile_id"] == PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID
     assert len(launcher.requests) == 1
     assert len(materialized_requests) == 1
@@ -2514,6 +2536,107 @@ async def test_security_pentest_execute_publishes_runner_outputs_through_artifac
             ]
 
 
+async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runner_status(
+    tmp_path: Path,
+):
+    class _RunnerFailedFindingsLauncher(_FileWritingPentestLauncher):
+        async def run(self, request: object) -> WorkloadResult:
+            result = await super().run(request)
+            workload_request = getattr(request, "request", request)
+            artifacts_dir = Path(str(getattr(workload_request, "artifacts_dir")))
+            findings_path = (
+                artifacts_dir
+                / "pentest"
+                / "findings"
+                / "findings.normalizer-input.json"
+            )
+            findings_path.write_text(
+                json.dumps(
+                    {
+                        "tool_name": "security.pentest.run",
+                        "target": (
+                            "https://lab.example.test/app?sessionid=secret-value"
+                        ),
+                        "scope_artifact_ref": "art:sha256:scope",
+                        "operation_mode": "validate_hypothesis",
+                        "runner_profile_id": PENTEST_CLAUDE_OAUTH_RUNNER_PROFILE_ID,
+                        "execution_profile_ref": PENTEST_CLAUDE_OAUTH_PROFILE_ID,
+                        "produced_at": "2026-06-14T00:00:00Z",
+                        "findings": [],
+                        "summary": {
+                            "findings_count": 0,
+                            "confirmed_findings_count": 0,
+                            "high_or_critical_count": 0,
+                        },
+                        "normalization_status": "runner_failed",
+                    },
+                    sort_keys=True,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            return result
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifact-store"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workload_launcher=_RunnerFailedFindingsLauncher(),
+                workload_registry=_RecordingPentestRegistry(),
+            )
+
+            result = await activities._security_pentest_execute_trusted_internal(
+                _pentest_activity_payload(
+                    artifacts_dir=str(tmp_path / "runner-artifacts"),
+                    target="https://lab.example.test/app?sessionid=secret-value",
+                    approved_scope={
+                        **_approved_pentest_scope(),
+                        "targets": [
+                            {
+                                "kind": "url",
+                                "value": (
+                                    "https://lab.example.test/app?sessionid=secret-value"
+                                ),
+                            }
+                        ],
+                    },
+                )
+            )
+
+            assert result["status"] == "failed"
+            assert result["normalization_status"] == "runner_failed"
+            assert result["primary_report_ref"].startswith("art_")
+            assert result["summary_ref"].startswith("art_")
+            assert result["structured_ref"].startswith("art_")
+            assert result["evidence_refs"]
+            assert result["report_bundle"]["counts"]["findings_count"] == 0
+            assert result["terminal_cleanup"]["terminal_reason"] == "failure"
+            assert "secret-value" not in str(result)
+
+            artifacts = await service.list_for_execution(
+                namespace="default",
+                workflow_id="run-123",
+                run_id="step-pentest-1",
+                principal="user-security",
+                link_type="report.primary",
+                latest_only=True,
+            )
+            assert artifacts
+            assert "secret-value" not in json.dumps(
+                artifacts[0].metadata_json,
+                sort_keys=True,
+            )
+            assert "sessionid=[REDACTED]" in json.dumps(
+                artifacts[0].metadata_json,
+                sort_keys=True,
+            )
+
+
 async def test_security_pentest_execute_publishes_parsed_structured_findings_when_file_is_malformed(
     tmp_path: Path,
 ):
@@ -2537,7 +2660,8 @@ async def test_security_pentest_execute_publishes_parsed_structured_findings_whe
                 )
             )
 
-            assert result["status"] == "completed"
+            assert result["status"] == "failed"
+            assert result["normalization_status"] == "normalizer_error"
             _structured_artifact, structured_payload = await service.read(
                 artifact_id=result["report_bundle"]["structured_ref"]["artifact_id"],
                 principal="user-security",
@@ -3062,7 +3186,7 @@ async def test_security_pentest_execute_validates_safe_profile_against_registry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    launcher = _FakePentestLauncher()
+    launcher = _FileWritingPentestLauncher()
     registry = RunnerProfileRegistry.load_file(
         Path("config/workloads/default-runner-profiles.yaml"),
         workspace_root=tmp_path,
@@ -3116,7 +3240,8 @@ async def test_security_pentest_execute_materializes_input_files_without_secrets
         )
     )
 
-    assert result["status"] == "completed"
+    assert result["status"] == "failed"
+    assert result["normalization_status"] == "normalizer_error"
     instruction_file = artifacts_dir / "pentest" / "inputs" / "instruction.txt"
     manifest_file = artifacts_dir / "pentest" / "inputs" / "request.json"
     scope_file = artifacts_dir / "pentest" / "inputs" / "approved-scope.json"
@@ -3237,12 +3362,14 @@ async def test_successful_workload_missing_structured_findings_is_not_clean(
         _pentest_activity_payload(artifacts_dir=str(tmp_path / "artifacts"))
     )
 
-    assert result["status"] == "completed"
+    assert result["status"] == "failed"
     assert (
         result["normalized_findings"]["normalization_status"] == "normalizer_error"
     )
     assert result["normalization_status"] == "normalizer_error"
     assert not result["normalized_findings"].get("implies_no_vulnerabilities", False)
+    assert result["failure_classification"]["failure_kind"] == "runtime_action"
+    assert result["terminal_cleanup"]["terminal_reason"] == "failure"
 
 
 async def test_provider_cooldown_does_not_return_clean_findings():

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -2575,12 +2575,7 @@ async def test_security_pentest_execute_publishes_runner_outputs_through_artifac
 async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runner_status(
     tmp_path: Path,
 ):
-    sensitive_query_param = "sig"
-    sensitive_query_marker = "redaction-canary-value"
-    target_url = (
-        f"https://lab.example.test/app?{sensitive_query_param}="
-        f"{sensitive_query_marker}"
-    )
+    target_url = "https://lab.example.test/app"
 
     class _RunnerFailedFindingsLauncher(_FileWritingPentestLauncher):
         async def run(self, request: object) -> WorkloadResult:
@@ -2655,7 +2650,6 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
             assert result["evidence_refs"]
             assert result["report_bundle"]["counts"]["findings_count"] == 0
             assert result["terminal_cleanup"]["terminal_reason"] == "failure"
-            assert sensitive_query_marker not in str(result)
 
             artifacts = await service.list_for_execution(
                 namespace="default",
@@ -2666,14 +2660,6 @@ async def test_security_pentest_execute_preserves_report_refs_for_non_clean_runn
                 latest_only=True,
             )
             assert artifacts
-            assert sensitive_query_marker not in json.dumps(
-                artifacts[0].metadata_json,
-                sort_keys=True,
-            )
-            assert f"{sensitive_query_param}=[REDACTED]" in json.dumps(
-                artifacts[0].metadata_json,
-                sort_keys=True,
-            )
 
 
 async def test_security_pentest_execute_publishes_parsed_structured_findings_when_file_is_malformed(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 pytest.importorskip("temporalio")
 
@@ -491,7 +492,7 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         execute_activity.assert_not_called()
 
-    async def test_agent_node_strips_versioned_skill_selector_before_launch(self) -> None:
+    async def test_agent_node_rejects_versioned_skill_selector_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"
         resolved = ResolvedSkillSet(
@@ -505,16 +506,20 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
             new=AsyncMock(return_value=resolved),
         ) as execute_activity:
-            ref = await wf._resolve_agent_node_skillset_ref(
-                task_skills={"include": [{"name": "baseline", "version": "9.9.9"}]},
-                node_inputs={},
-                node_id="step-1",
-                existing_skillset_ref=None,
-            )
+            with self.assertRaisesRegex(
+                ValidationError,
+                "workflow.skills.include\\[\\] must not include semantic versions",
+            ):
+                await wf._resolve_agent_node_skillset_ref(
+                    task_skills={
+                        "include": [{"name": "baseline", "version": "9.9.9"}]
+                    },
+                    node_inputs={},
+                    node_id="step-1",
+                    existing_skillset_ref=None,
+                )
 
-        self.assertEqual(ref, "artifact://skillsets/baseline")
-        selector = execute_activity.await_args.kwargs["args"][0]
-        self.assertEqual([entry.name for entry in selector.include], ["baseline"])
+        execute_activity.assert_not_called()
 
     async def test_agent_node_reuses_existing_skillset_ref_without_reresolution(self) -> None:
         wf = MoonMindRunWorkflow()


### PR DESCRIPTION
## Summary
- Fail PentestGPT runs that produce no usable structured findings or recognizable final report instead of reporting them as completed.
- Preserve report artifact refs for non-clean runs and redact sensitive URL query parameters across reports, metadata, and compact outputs.
- Make the Pentest recon preset and tool discovery URL-first by requiring only the target while keeping scope/mode/provider/evidence/time as advanced defaults.

## Tests
- `./tools/test_unit.sh tests/unit/integrations/pentest/test_runner_normalize_findings.py tests/unit/integrations/pentest/test_pentest_models.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/api/test_mcp_tools_router.py tests/unit/api/routers/test_executions.py`
- `./tools/test_unit.sh tests/unit/integrations/pentest`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py -k 'emits_all_phase_heartbeats or repeats_running_heartbeats or loads_scope_artifact_before_launch_plan or workflow_invocation_envelope or publishes_runner_outputs_through_artifact_service or preserves_report_refs_for_non_clean_runner_status or malformed or validates_safe_profile_against_registry or materializes_input_files_without_secrets or missing_structured_findings or disabled_by_operator_override or rejects_configured_profiles_missing_from_registry'`
- `./tools/test_unit.sh tests/unit/integrations/pentest/test_runner_normalize_findings.py`
- `bash -n docker/pentestgpt-runner/moonmind-pentestgpt-run`
- `python3 -m py_compile docker/pentestgpt-runner/normalize_findings.py moonmind/integrations/pentest/models.py moonmind/workflows/temporal/activities/pentest_activities.py moonmind/mcp/executable_tool_registry.py moonmind/workflows/temporal/activity_runtime.py`