### PR TITLE
[codex] Track Claude pr-resolver artifact progress

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -15,6 +17,16 @@ from moonmind.workflows.temporal.runtime.strategies.base import (
     ManagedRuntimeStrategy,
 )
 from moonmind.workflows.provider_failures import classify_provider_failure
+
+_CLAUDE_PROGRESS_MTIME_PADDING_SECONDS = 5.0
+_CLAUDE_PR_RESOLVER_PROGRESS_FILES: tuple[Path, ...] = (
+    Path("var/pr_resolver/result.json"),
+    Path("var/pr_resolver/snapshot.json"),
+    Path("artifacts/pr_resolver_result.json"),
+    Path("artifacts/pr_resolver_snapshot.json"),
+    Path("artifacts/pr_resolver_addressed_comments.json"),
+)
+
 
 class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     """Strategy for launching ``claude`` CLI runs."""
@@ -127,6 +139,50 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
 
     def terminate_on_live_rate_limit(self) -> bool:
         return True
+
+    def probe_progress_at(
+        self,
+        *,
+        workspace_path: str | None,
+        run_id: str,
+        started_at: datetime,
+    ) -> datetime | None:
+        """Use MoonMind pr-resolver artifacts as a silent-run progress signal."""
+
+        if not workspace_path:
+            return None
+        workspace_root = Path(workspace_path)
+        if not workspace_root.is_dir():
+            return None
+
+        threshold_ts = started_at.timestamp() - _CLAUDE_PROGRESS_MTIME_PADDING_SECONDS
+        latest_ts: float | None = None
+        for candidate in self._iter_pr_resolver_progress_candidates(workspace_root):
+            try:
+                stat = candidate.stat()
+            except OSError:
+                continue
+            if stat.st_mtime < threshold_ts:
+                continue
+            if latest_ts is None or stat.st_mtime > latest_ts:
+                latest_ts = stat.st_mtime
+
+        if latest_ts is None:
+            return None
+        return datetime.fromtimestamp(latest_ts, tz=UTC)
+
+    @staticmethod
+    def _iter_pr_resolver_progress_candidates(workspace_root: Path) -> Iterator[Path]:
+        for rel_path in _CLAUDE_PR_RESOLVER_PROGRESS_FILES:
+            yield workspace_root / rel_path
+
+        attempts_dir = workspace_root / "var" / "pr_resolver" / "attempts"
+        if attempts_dir.is_dir():
+            yield from attempts_dir.glob("*.json")
+
+        artifacts_dir = workspace_root / "artifacts"
+        if artifacts_dir.is_dir():
+            yield from artifacts_dir.glob("pr_resolver*.json")
 
     async def prepare_workspace(
         self,

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -155,6 +155,9 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         if not workspace_root.is_dir():
             return None
 
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=UTC)
+
         threshold_ts = started_at.timestamp() - _CLAUDE_PROGRESS_MTIME_PADDING_SECONDS
         latest_ts: float | None = None
         for candidate in self._iter_pr_resolver_progress_candidates(workspace_root):

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -233,7 +233,6 @@ class ManagedRunSupervisor:
                 latest = last_output_seen_at
                 if (
                     strategy is None
-                    or progress_timeout_seconds is None
                     or record is None
                     or not record.workspace_path
                 ):

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -755,7 +755,8 @@ async def test_heartbeat_persists_claude_pr_resolver_artifact_progress(
             result = await supervisor.supervise(
                 run_id="run-1", process=process, timeout_seconds=30
             )
-    await progress_writer
+    writer_result = await progress_writer
+    assert writer_result is None
 
     assert result.status == "completed"
     assert any("last_log_at" in update for update in running_updates)

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -703,6 +703,63 @@ async def test_heartbeat_persists_output_progress(supervisor_env):
     )
     assert any(u.get("last_log_offset") for u in progress_updates)
 
+
+@pytest.mark.asyncio
+async def test_heartbeat_persists_claude_pr_resolver_artifact_progress(
+    supervisor_env,
+    tmp_path,
+):
+    store, _, _, supervisor = supervisor_env
+    workspace_path = tmp_path / "repo"
+    result_path = workspace_path / "var" / "pr_resolver" / "result.json"
+    workspace_path.mkdir(parents=True)
+    record = ManagedRunRecord(
+        run_id="run-1",
+        agent_id="agent-1",
+        runtime_id="claude_code",
+        status="launching",
+        started_at=datetime.now(tz=UTC),
+        workspace_path=str(workspace_path),
+    )
+    store.save(record)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "1",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    async def _write_pr_resolver_result() -> None:
+        await asyncio.sleep(0.1)
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text(
+            '{"mergeAutomationDisposition":"reenter_gate"}',
+            encoding="utf-8",
+        )
+
+    progress_writer = asyncio.create_task(_write_pr_resolver_result())
+    running_updates: list[dict] = []
+    original_update = store.update_status
+
+    def _spy_update(run_id, status, **kwargs):
+        if status == "running":
+            running_updates.append(dict(kwargs))
+        return original_update(run_id, status, **kwargs)
+
+    with patch(
+        "moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL",
+        0.1,
+    ):
+        with patch.object(store, "update_status", side_effect=_spy_update):
+            result = await supervisor.supervise(
+                run_id="run-1", process=process, timeout_seconds=30
+            )
+    await progress_writer
+
+    assert result.status == "completed"
+    assert any("last_log_at" in update for update in running_updates)
+
 # ---------------------------------------------------------------------------
 # Completion callback tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -142,6 +142,29 @@ class TestClaudeCodeProgressProbe:
 
         assert observed == expected_progress_at
 
+    def test_probe_progress_treats_naive_started_at_as_utc(self, tmp_path) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        result_path = workspace_path / "var" / "pr_resolver" / "result.json"
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text(
+            '{"mergeAutomationDisposition":"reenter_gate"}',
+            encoding="utf-8",
+        )
+
+        started_at = datetime(2026, 6, 26, 17, 49, 38)
+        expected_progress_at = datetime(2026, 6, 26, 18, 17, 0, tzinfo=UTC)
+        ts = expected_progress_at.timestamp()
+        os.utime(result_path, (ts, ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-naive-started-at",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
+
     def test_probe_progress_uses_pr_resolver_attempt_artifacts(self, tmp_path) -> None:
         strategy = ClaudeCodeStrategy()
         workspace_path = tmp_path / "repo"

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -117,6 +117,73 @@ class TestClaudeCodeProperties:
     def test_default_auth_mode(self) -> None:
         assert ClaudeCodeStrategy().default_auth_mode == "api_key"
 
+
+class TestClaudeCodeProgressProbe:
+    def test_probe_progress_uses_pr_resolver_result_artifact(self, tmp_path) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        result_path = workspace_path / "var" / "pr_resolver" / "result.json"
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text(
+            '{"mergeAutomationDisposition":"reenter_gate"}',
+            encoding="utf-8",
+        )
+
+        started_at = datetime(2026, 6, 26, 17, 49, 38, tzinfo=UTC)
+        expected_progress_at = datetime(2026, 6, 26, 18, 17, 0, tzinfo=UTC)
+        ts = expected_progress_at.timestamp()
+        os.utime(result_path, (ts, ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-1",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
+
+    def test_probe_progress_uses_pr_resolver_attempt_artifacts(self, tmp_path) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        attempt_path = (
+            workspace_path / "var" / "pr_resolver" / "attempts" / "1.json"
+        )
+        attempt_path.parent.mkdir(parents=True)
+        attempt_path.write_text('{"status":"blocked"}', encoding="utf-8")
+
+        started_at = datetime(2026, 6, 26, 17, 49, 38, tzinfo=UTC)
+        expected_progress_at = datetime(2026, 6, 26, 18, 16, 47, tzinfo=UTC)
+        ts = expected_progress_at.timestamp()
+        os.utime(attempt_path, (ts, ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-2",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
+
+    def test_probe_progress_ignores_pre_run_pr_resolver_artifact(self, tmp_path) -> None:
+        strategy = ClaudeCodeStrategy()
+        workspace_path = tmp_path / "repo"
+        result_path = workspace_path / "var" / "pr_resolver" / "result.json"
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text("{}", encoding="utf-8")
+
+        started_at = datetime(2026, 6, 26, 17, 49, 38, tzinfo=UTC)
+        stale_ts = datetime(2026, 6, 26, 17, 40, 0, tzinfo=UTC).timestamp()
+        os.utime(result_path, (stale_ts, stale_ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-3",
+            started_at=started_at,
+        )
+
+        assert observed is None
+
+
 _RUNTIME_MODEL_ENV_KEYS = (
     "MOONMIND_CODEX_MODEL",
     "CODEX_MODEL",


### PR DESCRIPTION
## Summary
- Treat Claude Code pr-resolver artifacts as managed-run progress signals.
- Let supervisor progress probes update heartbeat metadata even when supervisor-level stall termination is disabled.
- Add strategy and supervisor regressions for silent pr-resolver artifact progress.

## Validation
- MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_supervisor.py

## Notes
- ./tools/test_unit.sh was blocked before pytest by a local root-owned deploy/state/desired-state.json permission error.