### PR TITLE
I see this error text when I select pause from the Workflows page for a workflow that is AWAITING SLOT:

### DIFF
--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -221,8 +221,17 @@ def _get_managed_session_store_root() -> str:
         "managed_sessions",
     )
 
-NON_TERMINAL_STATES: set[MoonMindWorkflowState] = (
-    set(MoonMindWorkflowState) - TERMINAL_STATES
+NON_TERMINAL_STATES: set[MoonMindWorkflowState] = {
+    MoonMindWorkflowState.SCHEDULED,
+    MoonMindWorkflowState.INITIALIZING,
+    MoonMindWorkflowState.PLANNING,
+    MoonMindWorkflowState.EXECUTING,
+    MoonMindWorkflowState.AWAITING_EXTERNAL,
+    MoonMindWorkflowState.FINALIZING,
+}
+
+OPERATOR_SIGNAL_ALLOWED_STATES: set[MoonMindWorkflowState] = (
+    NON_TERMINAL_STATES | {MoonMindWorkflowState.AWAITING_SLOT}
 )
 
 _RUNNING_STATES: set[MoonMindWorkflowState] = {
@@ -1669,7 +1678,7 @@ class TemporalExecutionService:
             "SkipDependencyWait",
             "SendMessage",
         }:
-            self._ensure_non_terminal(record)
+            self._ensure_state_allows_operator_signal(record)
             operator_message = self._extract_operator_message(payload)
             update_arg: dict[str, Any] = {}
             if signal_name == "SendMessage":
@@ -4066,6 +4075,14 @@ class TemporalExecutionService:
 
     def _ensure_non_terminal(self, record: TemporalExecutionCanonicalRecord) -> None:
         if record.state not in NON_TERMINAL_STATES:
+            raise TemporalExecutionValidationError(
+                "Workflow is in a terminal state and cannot be progressed."
+            )
+
+    def _ensure_state_allows_operator_signal(
+        self, record: TemporalExecutionCanonicalRecord
+    ) -> None:
+        if record.state not in OPERATOR_SIGNAL_ALLOWED_STATES:
             raise TemporalExecutionValidationError(
                 "Workflow is in a terminal state and cannot be progressed."
             )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -221,14 +221,9 @@ def _get_managed_session_store_root() -> str:
         "managed_sessions",
     )
 
-NON_TERMINAL_STATES: set[MoonMindWorkflowState] = {
-    MoonMindWorkflowState.SCHEDULED,
-    MoonMindWorkflowState.INITIALIZING,
-    MoonMindWorkflowState.PLANNING,
-    MoonMindWorkflowState.EXECUTING,
-    MoonMindWorkflowState.AWAITING_EXTERNAL,
-    MoonMindWorkflowState.FINALIZING,
-}
+NON_TERMINAL_STATES: set[MoonMindWorkflowState] = (
+    set(MoonMindWorkflowState) - TERMINAL_STATES
+)
 
 _RUNNING_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.PLANNING,

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3923,7 +3923,8 @@ async def test_signal_pause_allows_awaiting_slot(tmp_path, mock_client_adapter):
             initial_parameters=_valid_user_workflow_parameters(),
             idempotency_key=None,
         )
-        created.state = MoonMindWorkflowState.AWAITING_SLOT
+        source = await service._require_source_execution(created.workflow_id)
+        service._set_state(source, MoonMindWorkflowState.AWAITING_SLOT)
         await session.commit()
 
         await service.signal_execution(
@@ -5070,6 +5071,48 @@ async def test_configure_integration_monitoring_persists_visibility_and_callback
         assert configured.integration_state["callback_correlation_key"]
         assert configured.integration_state["external_operation_id"] == "task-123"
         assert "artifact://events/start" in configured.artifact_refs
+
+
+@pytest.mark.asyncio
+async def test_configure_integration_monitoring_rejects_waiting_states(tmp_path):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+
+        for state in (
+            MoonMindWorkflowState.WAITING_ON_DEPENDENCIES,
+            MoonMindWorkflowState.AWAITING_SLOT,
+        ):
+            created = await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=uuid4(),
+                title=f"Run waiting in {state.value}",
+                input_artifact_ref=None,
+                plan_artifact_ref="artifact://plan/1",
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters=_valid_user_workflow_parameters(),
+                idempotency_key=None,
+            )
+            source = await service._require_source_execution(created.workflow_id)
+            service._set_state(source, state)
+            await session.commit()
+
+            with pytest.raises(TemporalExecutionValidationError):
+                await service.configure_integration_monitoring(
+                    workflow_id=created.workflow_id,
+                    integration_name="jules",
+                    correlation_id=None,
+                    external_operation_id=f"task-{state.value}",
+                    normalized_status="running",
+                    provider_status="running",
+                    callback_supported=True,
+                    callback_correlation_key=None,
+                    recommended_poll_seconds=30,
+                    external_url=None,
+                    provider_summary={},
+                    result_refs=[],
+                )
+
 
 @pytest.mark.asyncio
 async def test_configure_integration_monitoring_rejects_blank_external_operation_id(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3905,6 +3905,44 @@ async def test_signal_pause_recovery_and_external_event_transitions(
         assert "artifact://events/1" in (signaled.artifact_refs or [])
         assert signaled.state is MoonMindWorkflowState.EXECUTING
 
+
+@pytest.mark.asyncio
+async def test_signal_pause_allows_awaiting_slot(tmp_path, mock_client_adapter):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.AWAITING_SLOT
+        await session.commit()
+
+        await service.signal_execution(
+            workflow_id=created.workflow_id,
+            signal_name="Pause",
+            payload={},
+            payload_artifact_ref=None,
+        )
+
+        mock_client_adapter.update_workflow.assert_awaited_once_with(
+            created.workflow_id,
+            "Pause",
+        )
+        paused = await service.describe_execution(created.workflow_id)
+        assert paused.state is MoonMindWorkflowState.AWAITING_SLOT
+        assert paused.paused is True
+        assert paused.memo["waiting_reason"] == "operator_paused"
+
+
 @pytest.mark.asyncio
 async def test_signal_resume_forwards_payload_via_workflow_update(
     tmp_path, mock_client_adapter


### PR DESCRIPTION
I see this error text when I select pause from the Workflows page for a workflow that is AWAITING SLOT:

{"detail":{"code":"signal_rejected","message":"Workflow is in a terminal state and cannot be progressed."}}

I should be able to pause AWAITING workflows. Fix this issue.