### PR TITLE
[codex] Allow inline instruction Jira breakdowns

### DIFF
--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -97,7 +97,11 @@ steps:
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
+      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
+      {% else %}
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      {% endif %}
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -97,7 +97,11 @@ steps:
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
+      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
+      {% else %}
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      {% endif %}
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -88,7 +88,11 @@ steps:
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
+      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
+      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
+      {% else %}
       Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
+      {% endif %}
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2131,6 +2131,15 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "Inline workflow source." in expanded_with_null_optional_sources[
                 "steps"
             ][0]["instructions"]
+            assert "inline workflow-instruction override" in (
+                expanded_with_null_optional_sources["steps"][0]["instructions"]
+            )
+            assert "imperative-override" in (
+                expanded_with_null_optional_sources["steps"][0]["instructions"]
+            )
+            assert "fail fast with the moonspec-breakdown imperative-input error" not in (
+                expanded_with_null_optional_sources["steps"][0]["instructions"]
+            )
 
             expanded_with_path_and_issue = await service.expand_template(
                 slug="jira-breakdown",
@@ -2152,6 +2161,12 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "docs/Designs/RuntimeTypes.md" in expanded_with_path_and_issue[
                 "steps"
             ][0]["instructions"]
+            assert "inline workflow-instruction override" not in (
+                expanded_with_path_and_issue["steps"][0]["instructions"]
+            )
+            assert "fail fast with the moonspec-breakdown imperative-input error" in (
+                expanded_with_path_and_issue["steps"][0]["instructions"]
+            )
 
             with pytest.raises(PresetValidationError) as excinfo:
                 await service.expand_template(
@@ -2176,6 +2191,78 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             "recoverable": True,
         }
     ]
+
+@pytest.mark.parametrize(
+    ("slug", "extra_inputs"),
+    [
+        ("jira-breakdown", {}),
+        (
+            "jira-breakdown-orchestrate",
+            {"publish_mode": "pr_with_merge_automation"},
+        ),
+        (
+            "jira-breakdown-implement",
+            {"publish_mode": "pr_with_merge_automation"},
+        ),
+    ],
+)
+async def test_jira_breakdown_presets_allow_inline_instruction_roadmaps(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    slug: str,
+    extra_inputs: dict[str, str],
+):
+    monkeypatch.setattr(settings.atlassian.jira, "jira_allowed_projects", None)
+    monkeypatch.setattr(
+        settings.atlassian.jira,
+        "jira_project_defaults_by_repository",
+        None,
+    )
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "presets"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            expanded = await service.expand_template(
+                slug=slug,
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "feature_request": (
+                        "Use this recommendation roadmap as breakdown input:\n"
+                        "1. Make the workflow list title-first.\n"
+                        "2. Move advanced filters into a drawer.\n"
+                        "3. Make errors friendly by default."
+                    ),
+                    "source_design_path": "",
+                    "source_issue_key": "",
+                    "jira_project_key": "MM",
+                    "jira_issue_type": "Story",
+                    "jira_dependency_mode": "none",
+                    **extra_inputs,
+                },
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+            )
+
+    breakdown_instructions = expanded["steps"][0]["instructions"]
+    assert "inline workflow-instruction override" in breakdown_instructions
+    assert "decompose the actionable desired system behavior" in (
+        breakdown_instructions
+    )
+    assert "imperative-override" in breakdown_instructions
+    assert "fail fast with the moonspec-breakdown imperative-input error" not in (
+        breakdown_instructions
+    )
 
 async def test_seed_catalog_includes_document_health_update_preset(tmp_path):
     """MM-889: a Document Health Update preset runs review then remediate steps."""


### PR DESCRIPTION
## Summary

Fixes Jira breakdown presets so pasted workflow instructions can be decomposed into Jira-ready MoonSpec stories even when the inline text is roadmap/checklist-shaped.

## Root Cause

The failing workflow selected the `jira-breakdown` preset with only `feature_request` / workflow instructions. The breakdown step prompt told `moonspec-breakdown` to fail fast on primarily imperative checklist, roadmap, or phased-plan input unless an explicit imperative override was present. Because the preset never rendered that override for direct workflow instructions, the agent wrote a zero-story rejection artifact. The deterministic Jira creation step then correctly created no issues from `stories=0`.

## Changes

- Render an explicit inline workflow-instruction override in `jira-breakdown`, `jira-breakdown-orchestrate`, and `jira-breakdown-implement` when no source document path or source Jira issue key is provided.
- Keep the stricter fail-fast imperative-input guard for file-backed source documents and trusted Jira issue descriptions.
- Add preset expansion coverage for inline roadmap/checklist-style workflow instructions across all three Jira breakdown presets.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q tests/unit/api/test_presets_service.py -k jira_breakdown --durations=10` passed: 13 passed, 60 deselected.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_presets_service.py -k jira_breakdown` did not reach pytest because the local checkout contains an ignored root-owned `deploy/state/desired-state.json` that the precheck cannot read.