### PR TITLE
[codex] Fix merge automation resolver gate owner

### DIFF
--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -557,8 +557,10 @@ a silent stalled agent.
 A continuation disposition (`reenter_gate`) only has meaning when a
 `MoonMind.MergeAutomation` gate owns the next cycle: re-enter `awaiting_external`,
 poll CI on the new head, and finalize the merge. Merge automation marks the
-resolver child it launches by injecting a `mergeGate` block
-(`mergeGate.parentWorkflowId`) into the resolver's `initial_parameters`.
+resolver child it launches by injecting a `mergeGate` block into the resolver's
+`initial_parameters`. `mergeGate.parentWorkflowId` MUST be the
+`MoonMind.MergeAutomation` workflow ID that is the resolver child's actual
+Temporal parent, not the root user workflow that launched merge automation.
 
 When `pr-resolver` is instead submitted as a **standalone top-level
 `MoonMind.UserWorkflow`** (no `mergeGate` owner), there is no gate to re-enter. A

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -58,6 +58,10 @@ MAX_PUBLISHED_ARTIFACT_REFS = 20
 MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH = (
     "merge-automation-workflow-child-task-queue-v2"
 )
+MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH = (
+    "merge-automation-resolver-parent-gate-id-v1"
+)
+
 
 @workflow.defn(name=WORKFLOW_NAME)
 class MoonMindMergeAutomationWorkflow:
@@ -68,6 +72,10 @@ class MoonMindMergeAutomationWorkflow:
         if workflow.patched(MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH):
             return settings.temporal.user_workflow_v2_task_queue
         return WORKFLOW_TASK_QUEUE
+
+    @staticmethod
+    def _resolver_parent_workflow_id() -> str:
+        return str(workflow.info().workflow_id).strip()
 
     def __init__(self) -> None:
         self._status = STATE_WAITING
@@ -616,8 +624,11 @@ class MoonMindMergeAutomationWorkflow:
             if evidence.ready:
                 self._status = STATE_EXECUTING
                 self._publish_visibility()
+                resolver_parent_workflow_id = self._input.parent_workflow_id
+                if workflow.patched(MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH):
+                    resolver_parent_workflow_id = self._resolver_parent_workflow_id()
                 resolver_request = build_resolver_run_request(
-                    parent_workflow_id=self._input.parent_workflow_id,
+                    parent_workflow_id=resolver_parent_workflow_id,
                     pull_request=self._input.pull_request,
                     jira_issue_key=self._input.jira_issue_key,
                     merge_method=self._input.config.resolver.merge_method,

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -10,6 +10,7 @@ from temporalio.workflow import ChildWorkflowCancellationType
 
 from moonmind.workflows.temporal.workflows import merge_automation as merge_automation_module
 from moonmind.workflows.temporal.workflows.merge_automation import (
+    MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH,
     MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
     MoonMindMergeAutomationWorkflow,
 )
@@ -47,6 +48,7 @@ def _payload() -> dict[str, Any]:
         "idempotencyKey": "merge-automation:wf-parent:MoonLadderStudios/MoonMind:350:abc123",
     }
 
+
 def _payload_with_post_merge_jira(**post_merge_overrides: Any) -> dict[str, Any]:
     payload = _payload()
     payload["mergeAutomationConfig"]["postMergeJira"] = {
@@ -57,6 +59,9 @@ def _payload_with_post_merge_jira(**post_merge_overrides: Any) -> dict[str, Any]
     }
     return payload
 
+MERGE_AUTOMATION_WORKFLOW_ID = "merge-automation:wf-parent"
+
+
 @pytest.fixture(autouse=True)
 def _default_temporal_patch_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
@@ -64,6 +69,12 @@ def _default_temporal_patch_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "patched",
         lambda _patch_id: True,
     )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "info",
+        lambda: SimpleNamespace(workflow_id=MERGE_AUTOMATION_WORKFLOW_ID),
+    )
+
 
 def test_merge_automation_extracts_artifact_id_from_ref_shapes() -> None:
     assert (
@@ -396,6 +407,10 @@ async def test_merge_automation_tracks_current_head_when_checks_are_still_runnin
     assert result["latestHeadSha"] == "def456"
     assert result["blockers"] == []
     assert child_workflow_ids == [f"{expected_resolver_id}:1"]
+    assert (
+        child_payloads[0]["initial_parameters"]["mergeGate"]["parentWorkflowId"]
+        == MERGE_AUTOMATION_WORKFLOW_ID
+    )
     assert child_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
 
 @pytest.mark.asyncio
@@ -493,6 +508,7 @@ async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marke
 ) -> None:
     workflow = MoonMindMergeAutomationWorkflow()
     child_workflow_ids: list[str] = []
+    child_payloads: list[dict[str, Any]] = []
 
     async def fake_execute_activity(
         activity_type: str,
@@ -513,10 +529,11 @@ async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marke
 
     async def fake_execute_child_workflow(
         workflow_type: str,
-        _payload: dict[str, Any],
+        payload: dict[str, Any],
         **kwargs: Any,
     ) -> dict[str, Any]:
         assert workflow_type == "MoonMind.UserWorkflow"
+        child_payloads.append(payload)
         child_workflow_ids.append(str(kwargs["id"]))
         return {"status": "success", "mergeAutomationDisposition": "merged"}
 
@@ -561,6 +578,83 @@ async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marke
         head_sha="abc123",
     )
     assert child_workflow_ids == [f"{legacy_resolver_id}:1"]
+    assert (
+        child_payloads[0]["initial_parameters"]["mergeGate"]["parentWorkflowId"]
+        == "wf-parent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_automation_resolver_child_uses_actual_parent_gate_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    child_payloads: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert activity_type == "merge_automation.evaluate_readiness"
+        return {
+            "headSha": "abc123",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.UserWorkflow"
+        child_payloads.append(payload)
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert result["status"] == "merged"
+    assert (
+        child_payloads[0]["initial_parameters"]["mergeGate"]["parentWorkflowId"]
+        == MERGE_AUTOMATION_WORKFLOW_ID
+    )
 
 @pytest.mark.asyncio
 async def test_merge_automation_launches_resolver_when_checks_are_failing_but_complete(


### PR DESCRIPTION
## Summary

Fix merge automation resolver children so their `mergeGate.parentWorkflowId` points at the `MoonMind.MergeAutomation` workflow that is the child workflow's actual Temporal parent. This lets gated `reenter_gate` resolver results pass the ownership check instead of being rejected as ungated continuation requests.

The change is guarded by a Temporal patch marker so histories that already scheduled the old child command keep their previous payload shape. It also updates the merge automation documentation to state the owner contract explicitly.

## Validation

- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q --durations=25 tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py` passed: 55 tests.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py` did not reach pytest because the local wrapper precheck cannot read root-owned `deploy/state/desired-state.json` in this checkout.