### PR TITLE
MM-936: Add unified "Add to step" capabilities plus button

### DIFF
--- a/frontend/src/entrypoints/workflow-start-step-type.test.tsx
+++ b/frontend/src/entrypoints/workflow-start-step-type.test.tsx
@@ -345,6 +345,45 @@ describe("Task Create Step Type authoring", () => {
     expect(fetchSpy).toHaveBeenCalled();
   });
 
+  it("preserves explicit step capabilities when changing Step Type away from Skill", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+
+    // Add a capability via the always-visible "Add to step" menu while the
+    // step is still the default Skill type.
+    fireEvent.click(
+      within(primaryStep).getByRole("button", { name: "Add to Step 1" }),
+    );
+    fireEvent.click(
+      within(primaryStep).getByRole("menuitem", { name: /Git repository/ }),
+    );
+
+    const removeLabel = "Remove Git repository capability from Step 1";
+    expect(
+      within(primaryStep).getByRole("button", { name: removeLabel }),
+    ).toBeTruthy();
+
+    // Changing the step type away from Skill must not clear the step-level
+    // explicit capability — only skill id/args are skill-specific.
+    selectStepType(primaryStep, "Tool");
+
+    expect(within(primaryStep).queryByLabelText(/Skill \(optional\)/)).toBeNull();
+    expect(
+      within(primaryStep).getByRole("button", { name: removeLabel }),
+    ).toBeTruthy();
+
+    // The chip remains removable through the explicit authoring field.
+    fireEvent.click(
+      within(primaryStep).getByRole("button", { name: removeLabel }),
+    );
+    expect(
+      within(primaryStep).queryByRole("button", { name: removeLabel }),
+    ).toBeNull();
+  });
+
   it("clears Preset configuration after changing Step Type without showing the discard warning", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -21,6 +21,9 @@ import {
 import { renderWithClient } from "../utils/test-utils";
 import {
   ARTIFACT_COMPLETE_RETRY_DELAYS_MS,
+  buildCapabilityChips,
+  CAPABILITY_CATALOG,
+  capabilityChipProvenanceLabel,
   LIQUID_GL_OPTIONS,
   preferredTemplate,
   resolveDefaultProviderProfileId,
@@ -16167,14 +16170,17 @@ describe("Task Create governed Tool authoring", () => {
         target: { value: '{"issueKey":"MM-577","mode":"runtime"}' },
       },
     );
-    fireEvent.change(
-      within(step).getByLabelText(
-        /Step 1 Skill Required Capabilities \(optional CSV\)/,
-      ),
-      {
-        target: { value: "git, jira" },
-      },
+    // MM-936: capabilities are authored through the always-visible "Add to step"
+    // chip menu rather than a freeform CSV field.
+    const addToStep = within(step).getByRole("button", {
+      name: "Add to Step 1",
+    });
+    fireEvent.click(addToStep);
+    fireEvent.click(
+      within(step).getByRole("menuitem", { name: /Git repository/ }),
     );
+    fireEvent.click(addToStep);
+    fireEvent.click(within(step).getByRole("menuitem", { name: /^Jira/ }));
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -16216,6 +16222,124 @@ describe("Task Create governed Tool authoring", () => {
       },
       requiredCapabilities: ["git", "jira"],
     });
+  });
+
+  it("renders an always-visible Add to step menu and submits explicit capabilities without Advanced mode", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Author capabilities through the chip menu." },
+    });
+
+    // The "+" affordance is visible without toggling Advanced mode and the old
+    // CSV authoring field is gone.
+    expect(
+      within(step).queryByLabelText(/Skill Required Capabilities/),
+    ).toBeNull();
+    const addToStep = within(step).getByRole("button", {
+      name: "Add to Step 1",
+    });
+
+    fireEvent.click(addToStep);
+    fireEvent.click(within(step).getByRole("menuitem", { name: /^Docker/ }));
+
+    const chip = await within(step).findByText("Docker");
+    expect(chip).toBeTruthy();
+    expect(
+      within(step).getByText("· docker", { exact: false }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const payload = latestCreateRequest().payload as {
+      requiredCapabilities?: string[];
+    };
+    expect(payload.requiredCapabilities).toContain("docker");
+  });
+
+  it("removes explicit capability chips but keeps derived chips locked", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+
+    // Publishing as a PR contributes a derived, non-removable gh chip.
+    const derivedChip = (
+      await within(step).findByText("GitHub CLI / PRs")
+    ).closest("li") as HTMLElement;
+    expect(within(derivedChip).getByText("· from publish mode")).toBeTruthy();
+    expect(
+      within(derivedChip).queryByRole("button", {
+        name: /Remove GitHub CLI \/ PRs capability/,
+      }),
+    ).toBeNull();
+
+    // The publish-derived gh option is disabled in the menu so the UI never
+    // silently drops a backend-required capability.
+    fireEvent.click(within(step).getByRole("button", { name: "Add to Step 1" }));
+    expect(
+      (
+        within(step).getByRole("menuitem", {
+          name: /GitHub CLI \/ PRs/,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+
+    // An explicitly added capability is removable.
+    fireEvent.click(within(step).getByRole("menuitem", { name: /^Jira/ }));
+    const removeJira = await within(step).findByRole("button", {
+      name: "Remove Jira capability from Step 1",
+    });
+    fireEvent.click(removeJira);
+    await waitFor(() => {
+      expect(within(step).queryByText("Jira")).toBeNull();
+    });
+  });
+
+  it("adds a custom capability token through the prompt", async () => {
+    const promptSpy = vi
+      .spyOn(window, "prompt")
+      .mockImplementationOnce(() => "unity, qdrant");
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Author a custom capability." },
+    });
+    fireEvent.click(within(step).getByRole("button", { name: "Add to Step 1" }));
+    fireEvent.click(
+      within(step).getByRole("menuitem", { name: "Custom capability…" }),
+    );
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+
+    expect(await within(step).findByText("unity")).toBeTruthy();
+    expect(within(step).getByText("qdrant")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const payload = latestCreateRequest().payload as {
+      requiredCapabilities?: string[];
+    };
+    expect(payload.requiredCapabilities).toEqual(
+      expect.arrayContaining(["unity", "qdrant"]),
+    );
+    promptSpy.mockRestore();
   });
 
   it("submits auto skill step attachments without explicit skill type", async () => {
@@ -16823,5 +16947,111 @@ describe("Task Create runtime switch layout stability", () => {
       profileId: "profile:codex-default",
     });
     expect(request.payload.task.runtime).not.toHaveProperty("effort");
+  });
+});
+
+describe("MM-936 capability registry and chip computation", () => {
+  function requireChip(
+    chips: ReturnType<typeof buildCapabilityChips>,
+    token: string,
+  ) {
+    const chip = chips.find((entry) => entry.token === token);
+    if (!chip) {
+      throw new Error(`expected a capability chip for ${token}`);
+    }
+    return chip;
+  }
+
+  it("describes known capability tokens in the frontend catalog", () => {
+    for (const token of ["git", "gh", "jira", "docker", "codex_cli"]) {
+      const entry = CAPABILITY_CATALOG[token];
+      if (!entry) {
+        throw new Error(`expected a catalog entry for ${token}`);
+      }
+      expect(entry.token).toBe(token);
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.shortLabel.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(entry.icon.length).toBeGreaterThan(0);
+      expect(["Code", "Integrations", "Runtime"]).toContain(entry.group);
+    }
+  });
+
+  it("marks explicit-only capabilities removable and labels them from the catalog", () => {
+    const chips = buildCapabilityChips({ explicit: ["gh"] });
+    expect(chips).toHaveLength(1);
+    const chip = requireChip(chips, "gh");
+    expect(chip.label).toBe("GitHub CLI / PRs");
+    expect(chip.removable).toBe(true);
+    expect(chip.sources).toEqual([
+      {
+        token: "gh",
+        sourceKind: "explicit",
+        sourceLabel: "added to this step",
+        removable: true,
+      },
+    ]);
+    expect(capabilityChipProvenanceLabel(chip)).toBeNull();
+  });
+
+  it("keeps derived capabilities non-removable with provenance", () => {
+    const chips = buildCapabilityChips({
+      skill: ["git"],
+      generatedTool: ["docker"],
+      preset: ["jira"],
+      runtime: ["codex_cli"],
+      publish: ["gh"],
+      template: ["unity"],
+    });
+    expect(requireChip(chips, "git").removable).toBe(false);
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "git"))).toBe(
+      "from skill",
+    );
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "docker"))).toBe(
+      "from tool",
+    );
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "jira"))).toBe(
+      "from preset",
+    );
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "codex_cli"))).toBe(
+      "from runtime",
+    );
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "gh"))).toBe(
+      "from publish mode",
+    );
+    expect(capabilityChipProvenanceLabel(requireChip(chips, "unity"))).toBe(
+      "from template",
+    );
+  });
+
+  it("treats a capability with both explicit and derived sources as non-removable", () => {
+    const chips = buildCapabilityChips({ explicit: ["git"], skill: ["git"] });
+    expect(chips).toHaveLength(1);
+    const chip = requireChip(chips, "git");
+    expect(chip.removable).toBe(false);
+    expect(chip.sources.map((source) => source.sourceKind)).toEqual([
+      "explicit",
+      "skill",
+    ]);
+    // The UI must not silently drop a backend-required capability even when the
+    // user also added it explicitly.
+    expect(capabilityChipProvenanceLabel(chip)).toBe("from skill");
+  });
+
+  it("normalizes and de-duplicates tokens while preserving first-seen order", () => {
+    const chips = buildCapabilityChips({
+      explicit: [" GIT ", "jira", "git"],
+      skill: ["JIRA"],
+    });
+    expect(chips.map((chip) => chip.token)).toEqual(["git", "jira"]);
+    // jira is contributed explicitly first, then by the skill -> non-removable.
+    expect(requireChip(chips, "jira").removable).toBe(false);
+  });
+
+  it("synthesizes catalog entries for unknown custom tokens", () => {
+    const chips = buildCapabilityChips({ explicit: ["qdrant"] });
+    const chip = requireChip(chips, "qdrant");
+    expect(chip.label).toBe("qdrant");
+    expect(chip.removable).toBe(true);
   });
 });

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -762,7 +762,10 @@ interface StepState {
   pentestScopeDraft: PentestScopeDraftState;
   skillId: string;
   skillArgs: string;
-  skillRequiredCapabilities: string;
+  // MM-936: explicit, user-authored required capabilities for this step. The
+  // chip selector treats this as the only removable capability source; derived
+  // capabilities (skill/tool/preset/runtime/publish) are computed for display.
+  explicitRequiredCapabilities: string[];
   runtimeMode: string;
   runtimeModel: string;
   runtimeEffort: string;
@@ -1500,7 +1503,7 @@ function createStepStateEntry(
     pentestScopeDraft: createPentestScopeDraftState(),
     skillId: "",
     skillArgs: "",
-    skillRequiredCapabilities: "",
+    explicitRequiredCapabilities: [],
     runtimeMode: "",
     runtimeModel: "",
     runtimeEffort: "",
@@ -1803,7 +1806,9 @@ function createStepStateEntriesFromTemporalDraft(
           : "",
       skillArgs:
         step.stepType === "skill" ? stringifySkillArgs(step.skillArgs) : "",
-      skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
+      explicitRequiredCapabilities: mergeCapabilities(
+        step.skillRequiredCapabilities,
+      ),
       runtimeMode: step.runtime?.mode || "",
       runtimeModel: step.runtime?.model || "",
       runtimeEffort: step.runtime?.effort || "",
@@ -1852,7 +1857,6 @@ function createStepStateEntriesFromTemporalDraft(
 function hasAdvancedStepOptionValues(steps: StepState[]): boolean {
   return steps.some(
     (step) =>
-      Boolean(step.skillRequiredCapabilities.trim()) ||
       Boolean(step.skillArgs.trim()) ||
       Boolean(step.runtimeMode.trim()) ||
       Boolean(step.runtimeModel.trim()) ||
@@ -1949,6 +1953,225 @@ function mergeCapabilities(...groups: Array<string[] | undefined | null>): strin
   );
 }
 
+// MM-936: Capabilities Plus Button.
+//
+// The step authoring surface presents a single "Add to step" affordance that
+// unifies image attachments and required capabilities. `inputAttachments` and
+// `requiredCapabilities` remain separate backend concepts; only the authoring
+// surface is unified. This frontend capability registry controls how known
+// capability tokens are labelled in the menu and chip row. Backend
+// normalization of the `requiredCapabilities` contract remains authoritative.
+type CapabilityGroup = "Code" | "Integrations" | "Runtime";
+
+interface CapabilityCatalogEntry {
+  token: string;
+  label: string;
+  shortLabel: string;
+  description: string;
+  icon: string;
+  group: CapabilityGroup;
+  common?: boolean;
+}
+
+export const CAPABILITY_CATALOG: Record<string, CapabilityCatalogEntry> = {
+  git: {
+    token: "git",
+    label: "Git repository",
+    shortLabel: "Git",
+    description: "Prepare a repository checkout for this step.",
+    icon: "🌱",
+    group: "Code",
+    common: true,
+  },
+  gh: {
+    token: "gh",
+    label: "GitHub CLI / PRs",
+    shortLabel: "GitHub",
+    description:
+      "Allow GitHub repository and PR operations through the runtime path.",
+    icon: "🐙",
+    group: "Integrations",
+    common: true,
+  },
+  jira: {
+    token: "jira",
+    label: "Jira",
+    shortLabel: "Jira",
+    description:
+      "Allow Jira issue access through the trusted integration path.",
+    icon: "📋",
+    group: "Integrations",
+  },
+  docker: {
+    token: "docker",
+    label: "Docker",
+    shortLabel: "Docker",
+    description: "Allow container builds and Docker operations for this step.",
+    icon: "🐳",
+    group: "Runtime",
+  },
+  codex_cli: {
+    token: "codex_cli",
+    label: "Codex CLI",
+    shortLabel: "Codex",
+    description: "Run this step through the Codex CLI runtime.",
+    icon: "✨",
+    group: "Runtime",
+  },
+};
+
+// Capability tokens offered, in order, by the "Add to step" menu.
+const CAPABILITY_MENU_TOKENS: string[] = [
+  "git",
+  "gh",
+  "jira",
+  "docker",
+  "codex_cli",
+];
+
+function normalizeCapabilityToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function capabilityCatalogEntry(token: string): CapabilityCatalogEntry {
+  const normalized = normalizeCapabilityToken(token);
+  const known = CAPABILITY_CATALOG[normalized];
+  if (known) {
+    return known;
+  }
+  return {
+    token: normalized,
+    label: normalized,
+    shortLabel: normalized,
+    description: "Custom capability required before this step launches.",
+    icon: "•",
+    group: "Runtime",
+  };
+}
+
+type CapabilitySourceKind =
+  | "explicit"
+  | "preset"
+  | "skill"
+  | "tool"
+  | "runtime"
+  | "publish"
+  | "template";
+
+const CAPABILITY_SOURCE_LABELS: Record<CapabilitySourceKind, string> = {
+  explicit: "added to this step",
+  preset: "from preset",
+  skill: "from skill",
+  tool: "from tool",
+  runtime: "from runtime",
+  publish: "from publish mode",
+  template: "from template",
+};
+
+interface CapabilityContribution {
+  token: string;
+  sourceKind: CapabilitySourceKind;
+  sourceLabel: string;
+  removable: boolean;
+}
+
+interface StepCapabilityChip {
+  token: string;
+  label: string;
+  description: string;
+  icon: string;
+  sources: CapabilityContribution[];
+  removable: boolean;
+}
+
+interface BuildCapabilityChipsArgs {
+  explicit?: string[] | null | undefined;
+  skill?: string[] | null | undefined;
+  generatedSkill?: string[] | null | undefined;
+  generatedTool?: string[] | null | undefined;
+  preset?: string[] | null | undefined;
+  runtime?: string[] | null | undefined;
+  publish?: string[] | null | undefined;
+  template?: string[] | null | undefined;
+}
+
+// Compute the display chips for a step's required capabilities. Sources are
+// additive and backend normalization is authoritative, so a capability chip is
+// only removable when the sole contribution is the explicit step authoring
+// field. Derived contributions (preset, skill, tool, runtime, publish mode,
+// template) keep the chip non-removable and carry provenance for display.
+export function buildCapabilityChips(
+  args: BuildCapabilityChipsArgs,
+): StepCapabilityChip[] {
+  const contributionGroups: Array<{
+    tokens: string[] | null | undefined;
+    sourceKind: CapabilitySourceKind;
+  }> = [
+    { tokens: args.explicit, sourceKind: "explicit" },
+    { tokens: args.skill, sourceKind: "skill" },
+    { tokens: args.generatedSkill, sourceKind: "skill" },
+    { tokens: args.generatedTool, sourceKind: "tool" },
+    { tokens: args.preset, sourceKind: "preset" },
+    { tokens: args.template, sourceKind: "template" },
+    { tokens: args.runtime, sourceKind: "runtime" },
+    { tokens: args.publish, sourceKind: "publish" },
+  ];
+
+  const chipsByToken = new Map<string, StepCapabilityChip>();
+  const order: string[] = [];
+
+  for (const group of contributionGroups) {
+    for (const rawToken of group.tokens || []) {
+      const token = normalizeCapabilityToken(String(rawToken || ""));
+      if (!token) {
+        continue;
+      }
+      let chip = chipsByToken.get(token);
+      if (!chip) {
+        const entry = capabilityCatalogEntry(token);
+        chip = {
+          token,
+          label: entry.label,
+          description: entry.description,
+          icon: entry.icon,
+          sources: [],
+          removable: false,
+        };
+        chipsByToken.set(token, chip);
+        order.push(token);
+      }
+      if (chip.sources.some((source) => source.sourceKind === group.sourceKind)) {
+        continue;
+      }
+      chip.sources.push({
+        token,
+        sourceKind: group.sourceKind,
+        sourceLabel: CAPABILITY_SOURCE_LABELS[group.sourceKind],
+        removable: group.sourceKind === "explicit",
+      });
+    }
+  }
+
+  return order.map((token) => {
+    const chip = chipsByToken.get(token) as StepCapabilityChip;
+    const removable =
+      chip.sources.length > 0 &&
+      chip.sources.every((source) => source.sourceKind === "explicit");
+    return { ...chip, removable };
+  });
+}
+
+// The provenance label rendered on a derived (non-removable) chip, e.g.
+// "from preset". Returns null for chips whose only source is explicit.
+export function capabilityChipProvenanceLabel(
+  chip: StepCapabilityChip,
+): string | null {
+  const derived = chip.sources.find(
+    (source) => source.sourceKind !== "explicit",
+  );
+  return derived ? derived.sourceLabel : null;
+}
+
 function stringifySkillArgs(
   args: Record<string, unknown> | null | undefined,
 ): string {
@@ -1967,20 +2190,6 @@ function stringifySkillArgs(
   }
 }
 
-function extractCapabilityCsv(value: unknown): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((item) =>
-      String(item || "")
-        .trim()
-        .toLowerCase(),
-    )
-    .filter(Boolean)
-    .join(",");
-}
-
 function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
   if (!step) {
     return true;
@@ -1992,7 +2201,7 @@ function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
     (!step.toolInputs.trim() || step.toolInputs.trim() === "{}") &&
     !step.skillId.trim() &&
     !step.skillArgs.trim() &&
-    !step.skillRequiredCapabilities.trim() &&
+    step.explicitRequiredCapabilities.length === 0 &&
     !step.presetKey.trim() &&
     !step.templateStepId.trim() &&
     !step.templateInstructions.trim() &&
@@ -2338,18 +2547,6 @@ function isImageOnlyPolicy(policy: AttachmentPolicy): boolean {
   );
 }
 
-function attachmentControlLabel(policy: AttachmentPolicy): string {
-  return isImageOnlyPolicy(policy) ? "Images" : "Input Attachments";
-}
-
-function attachmentAddButtonLabel(
-  policy: AttachmentPolicy,
-  stepNumber: number,
-): string {
-  const noun = isImageOnlyPolicy(policy) ? "images" : "attachments";
-  return `Add ${noun} to Step ${stepNumber}`;
-}
-
 function attachmentFilePickerLabel(
   policy: AttachmentPolicy,
   stepNumber: number,
@@ -2512,6 +2709,7 @@ function deriveRequiredCapabilities(args: {
   publishMode: string;
   taskSkillRequiredCapabilities: string[];
   stepSkillRequiredCapabilities: string[];
+  explicitStepCapabilities: string[];
   templateCapabilities: string[];
 }): string[] {
   return Array.from(
@@ -2523,6 +2721,7 @@ function deriveRequiredCapabilities(args: {
         ...(args.publishMode === "pr" ? ["gh"] : []),
         ...args.taskSkillRequiredCapabilities,
         ...args.stepSkillRequiredCapabilities,
+        ...args.explicitStepCapabilities,
         ...args.templateCapabilities
           .map((item) => item.trim().toLowerCase())
           .filter(Boolean),
@@ -2613,7 +2812,10 @@ function mapExpandedStepToState(
       : {},
     skillId: isToolStep ? "" : String(tool.name || tool.id || "").trim(),
     skillArgs: isToolStep ? "" : stringifySkillArgs(inlineInputs),
-    skillRequiredCapabilities: extractCapabilityCsv(tool.requiredCapabilities),
+    // Capabilities declared by an expanded preset's generated tool/skill are
+    // derived (non-removable) chips computed from generatedTool/generatedSkill,
+    // so the explicit authoring field starts empty for expanded steps.
+    explicitRequiredCapabilities: [],
     templateStepId: stepId,
     templateInstructions: instructions,
     templateAttachments,
@@ -4429,6 +4631,148 @@ export const LIQUID_GL_OPTIONS = {
 const DEFAULT_PRIORITY = 0;
 const DEFAULT_MAX_ATTEMPTS = 3;
 
+interface StepContextMenuProps {
+  stepNumber: number;
+  attachmentPolicy: AttachmentPolicy;
+  presentCapabilityTokens: string[];
+  onAddImage: () => void;
+  onAddCapability: (token: string) => void;
+  onAddCustomCapability: () => void;
+}
+
+// MM-936: The single "Add to step" affordance rendered beneath each step's
+// instruction box. It unifies image attachments and required capabilities into
+// one elegant menu without merging the underlying backend concepts.
+function StepContextMenu({
+  stepNumber,
+  attachmentPolicy,
+  presentCapabilityTokens,
+  onAddImage,
+  onAddCapability,
+  onAddCustomCapability,
+}: StepContextMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function handlePointerDown(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const menuLabel = `Add to Step ${stepNumber}`;
+  const imageItemLabel = isImageOnlyPolicy(attachmentPolicy)
+    ? "Image…"
+    : "Attachment…";
+
+  return (
+    <div className="queue-step-context-menu" ref={containerRef}>
+      <button
+        type="button"
+        className="queue-step-attachment-add-button queue-step-context-menu-button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={menuLabel}
+        title={menuLabel}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span aria-hidden="true">+</span>
+        <span className="queue-step-context-menu-button-text">Add to step</span>
+      </button>
+      {open ? (
+        <div
+          className="queue-step-context-menu-popover"
+          role="menu"
+          aria-label={menuLabel}
+        >
+          {attachmentPolicy.enabled ? (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                className="queue-step-context-menu-item"
+                onClick={() => {
+                  setOpen(false);
+                  onAddImage();
+                }}
+              >
+                {imageItemLabel}
+              </button>
+              <div
+                className="queue-step-context-menu-separator"
+                role="separator"
+              />
+            </>
+          ) : null}
+          <p className="queue-step-context-menu-group-label">Capabilities</p>
+          {CAPABILITY_MENU_TOKENS.map((token) => {
+            const entry = capabilityCatalogEntry(token);
+            const alreadyPresent = presentCapabilityTokens.includes(token);
+            return (
+              <button
+                key={token}
+                type="button"
+                role="menuitem"
+                className="queue-step-context-menu-item queue-step-context-menu-capability"
+                disabled={alreadyPresent}
+                aria-disabled={alreadyPresent}
+                title={entry.description}
+                onClick={() => {
+                  setOpen(false);
+                  onAddCapability(token);
+                }}
+              >
+                <span
+                  className="queue-step-context-menu-capability-icon"
+                  aria-hidden="true"
+                >
+                  {entry.icon}
+                </span>
+                <span className="queue-step-context-menu-capability-label">
+                  {entry.label}
+                </span>
+                <span className="queue-step-context-menu-capability-token">
+                  {entry.token}
+                </span>
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            role="menuitem"
+            className="queue-step-context-menu-item"
+            onClick={() => {
+              setOpen(false);
+              onAddCustomCapability();
+            }}
+          >
+            Custom capability…
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   useLiquidGL({ options: LIQUID_GL_OPTIONS });
   const dashboardConfig = readDashboardConfig(payload);
@@ -6207,7 +6551,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       isDefault: Boolean(profile.is_default),
     }));
 
-  const attachmentLabel = attachmentControlLabel(attachmentPolicy);
+  // MM-936: the primary step always carries the publish-mode capability (gh)
+  // when publishing as a PR, surfaced as a non-removable derived chip.
+  const stepPublishModeRequiresGh =
+    normalizePublishModeForSubmit(publishMode) === "pr";
   const attachmentTargetValidation = useMemo(
     () =>
       validateAttachmentTargets(
@@ -6490,6 +6837,55 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         return nextStep;
       }),
     );
+  }
+
+  // MM-936: Append one or more explicit capability tokens to a step. Tokens are
+  // normalized and de-duplicated; existing tokens (including derived ones) are
+  // preserved. The chip selector only ever mutates the explicit field.
+  function addStepCapabilities(localId: string, tokens: string[]) {
+    const normalized = mergeCapabilities(tokens);
+    if (normalized.length === 0) {
+      return;
+    }
+    setSteps((current) =>
+      current.map((step) =>
+        step.localId === localId
+          ? {
+              ...step,
+              explicitRequiredCapabilities: mergeCapabilities(
+                step.explicitRequiredCapabilities,
+                normalized,
+              ),
+            }
+          : step,
+      ),
+    );
+  }
+
+  function removeStepCapability(localId: string, token: string) {
+    const normalized = normalizeCapabilityToken(token);
+    setSteps((current) =>
+      current.map((step) =>
+        step.localId === localId
+          ? {
+              ...step,
+              explicitRequiredCapabilities:
+                step.explicitRequiredCapabilities.filter(
+                  (existing) => existing !== normalized,
+                ),
+            }
+          : step,
+      ),
+    );
+  }
+
+  function promptForCustomStepCapability(localId: string) {
+    const value = window.prompt(
+      "Add a custom capability token (for example: unity, qdrant). Separate multiple tokens with commas.",
+    );
+    if (value) {
+      addStepCapabilities(localId, parseCapabilitiesCsv(value));
+    }
   }
 
   function handleStepInstructionsChange(localId: string, value: string) {
@@ -6844,11 +7240,11 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           step.stepType === "skill" &&
           (step.skillId.trim() ||
             step.skillArgs.trim() ||
-            step.skillRequiredCapabilities.trim())
+            step.explicitRequiredCapabilities.length > 0)
         ) {
           nextStep.skillId = "";
           nextStep.skillArgs = "";
-          nextStep.skillRequiredCapabilities = "";
+          nextStep.explicitRequiredCapabilities = [];
         }
 
         if (
@@ -7474,9 +7870,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       }
       const blueprint: Record<string, unknown> = { instructions };
       const skillId = step.skillId.trim();
-      const caps = showAdvancedStepOptions
-        ? parseCapabilitiesCsv(step.skillRequiredCapabilities)
-        : [];
+      // MM-936: explicit capabilities are authored through the always-visible
+      // chip selector, so they persist into presets regardless of Advanced mode.
+      const caps = step.explicitRequiredCapabilities;
       const skillArgsRaw = showAdvancedStepOptions ? step.skillArgs.trim() : "";
       if (skillId || skillArgsRaw || caps.length > 0) {
         let skillArgs: Record<string, unknown> = {};
@@ -8113,9 +8509,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const taskSkillRequiredCapabilities = primaryStepIsSkill
       ? mergeCapabilities(
           primarySkillDetail?.requiredCapabilities,
-          showAdvancedStepOptions
-            ? parseCapabilitiesCsv(String(primaryStep?.skillRequiredCapabilities || ""))
-            : [],
+          primaryStep?.explicitRequiredCapabilities,
         )
       : [];
     const primarySchemaInputs = primaryStep
@@ -8249,9 +8643,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       const stepSkillCaps = stepIsSkill
         ? mergeCapabilities(
             stepSkillDetail?.requiredCapabilities,
-            showAdvancedStepOptions
-              ? parseCapabilitiesCsv(step.skillRequiredCapabilities)
-              : [],
+            step.explicitRequiredCapabilities,
           )
         : [];
       const stepToolDefinition =
@@ -8812,6 +9204,14 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     const templateCapabilities = submissionAppliedTemplates.flatMap(
       (entry) => entry.capabilities || [],
     );
+    // MM-936: Explicit step capabilities authored via the chip selector bubble
+    // into the task's normalized requiredCapabilities for every step type, not
+    // only skill steps. Skill steps additionally carry them on the step payload.
+    const explicitStepCapabilities = mergeCapabilities(
+      ...submissionSteps.map((step) =>
+        step ? step.explicitRequiredCapabilities : [],
+      ),
+    );
     const mergedCapabilities = deriveRequiredCapabilities({
       runtimeMode: normalizedRuntime,
       stepRuntimeModes: normalizedSteps
@@ -8824,6 +9224,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       publishMode: effectivePublishMode,
       taskSkillRequiredCapabilities,
       stepSkillRequiredCapabilities,
+      explicitStepCapabilities,
       templateCapabilities,
     });
 
@@ -9663,6 +10064,21 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
               )
                 ? Object.entries(schemaProperties(selectedSkillDetail?.inputSchema))
                 : [];
+              // MM-936: derive the capability chip row for this step. Explicit
+              // chips are removable; skill/tool/runtime/publish-derived chips are
+              // non-removable and carry provenance.
+              const stepCapabilityChips = buildCapabilityChips({
+                explicit: step.explicitRequiredCapabilities,
+                skill: selectedSkillDetail?.requiredCapabilities,
+                generatedSkill: step.generatedSkill?.requiredCapabilities,
+                generatedTool: step.generatedTool?.requiredCapabilities,
+                runtime: step.runtimeMode ? [step.runtimeMode] : [],
+                publish:
+                  isPrimaryStep && stepPublishModeRequiresGh ? ["gh"] : [],
+              });
+              const stepCapabilityTokens = stepCapabilityChips.map(
+                (chip) => chip.token,
+              );
               const toolSearchText = toolSearchTextByStep[step.localId] || "";
               const trustedToolDefinitions = trustedToolsQuery.data || [];
               const toolChoiceGroups = groupedToolChoices(
@@ -10354,22 +10770,6 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                           />
                         </label>
                       ) : null}
-                      {showAdvancedStepOptions ? (
-                        <label>
-                          {`Step ${index + 1} Skill Required Capabilities (optional CSV)`}
-                          <input
-                            data-step-field="skillRequiredCapabilities"
-                            data-step-index={String(index)}
-                            value={step.skillRequiredCapabilities}
-                            placeholder="docker,qdrant,unity"
-                            onChange={(event) =>
-                              updateStep(step.localId, {
-                                skillRequiredCapabilities: event.target.value,
-                              })
-                            }
-                          />
-                        </label>
-                      ) : null}
                       {selectedSkillDetail ? (
                         <SchemaCapabilityFields
                           fields={visibleSkillSchemaFields}
@@ -10539,54 +10939,115 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                       }
                     />
                     <RuntimeCommandPreviewMessage preview={instructionPreview} />
+                    <div
+                      className="queue-step-context"
+                      aria-label={`Add to Step ${index + 1}`}
+                    >
+                      <StepContextMenu
+                        stepNumber={index + 1}
+                        attachmentPolicy={attachmentPolicy}
+                        presentCapabilityTokens={stepCapabilityTokens}
+                        onAddImage={() =>
+                          document
+                            .getElementById(
+                              `queue-step-attachments-${step.localId}`,
+                            )
+                            ?.click()
+                        }
+                        onAddCapability={(token) =>
+                          addStepCapabilities(step.localId, [token])
+                        }
+                        onAddCustomCapability={() =>
+                          promptForCustomStepCapability(step.localId)
+                        }
+                      />
+                      {stepCapabilityChips.length > 0 ? (
+                        <ul
+                          className="queue-step-capability-chips"
+                          aria-label={`Step ${index + 1} capabilities`}
+                        >
+                          {stepCapabilityChips.map((chip) => {
+                            const provenance =
+                              capabilityChipProvenanceLabel(chip);
+                            const detailText = chip.removable
+                              ? chip.token
+                              : provenance || chip.token;
+                            return (
+                              <li
+                                key={chip.token}
+                                className={`queue-step-capability-chip${
+                                  chip.removable ? "" : " is-derived"
+                                }`}
+                              >
+                                <span
+                                  className="queue-step-capability-chip-icon"
+                                  aria-hidden="true"
+                                >
+                                  {chip.icon}
+                                </span>
+                                <span className="queue-step-capability-chip-label">
+                                  {chip.label}
+                                </span>
+                                <span className="queue-step-capability-chip-detail">
+                                  {`· ${detailText}`}
+                                </span>
+                                {chip.removable ? (
+                                  <button
+                                    type="button"
+                                    className="queue-step-icon-button destructive queue-step-capability-chip-remove"
+                                    aria-label={`Remove ${chip.label} capability from Step ${index + 1}`}
+                                    title={`Remove ${chip.label} capability from Step ${index + 1}`}
+                                    onClick={() =>
+                                      removeStepCapability(
+                                        step.localId,
+                                        chip.token,
+                                      )
+                                    }
+                                  >
+                                    <CloseIcon />
+                                    <span className="sr-only">{`Remove ${chip.label} capability from Step ${index + 1}`}</span>
+                                  </button>
+                                ) : (
+                                  <span
+                                    className="queue-step-capability-chip-lock"
+                                    aria-label={`${chip.label} capability is required ${
+                                      provenance || "by this step"
+                                    } and cannot be removed here. Change the preset or generated step to remove it.`}
+                                    title={`This capability is required ${
+                                      provenance || "by this step"
+                                    }. Change the preset or generated step to remove it.`}
+                                  >
+                                    🔒
+                                  </span>
+                                )}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : null}
+                    </div>
                     {attachmentPolicy.enabled ? (
                       <div className="queue-step-attachments">
-                        <div className="queue-step-attachment-control">
-                          <span className="queue-step-attachment-label">
-                            {`${attachmentLabel} (optional)`}
-                          </span>
-                          <button
-                            type="button"
-                            className="queue-step-attachment-add-button"
-                            aria-label={attachmentAddButtonLabel(
-                              attachmentPolicy,
-                              index + 1,
-                            )}
-                            title={attachmentAddButtonLabel(
-                              attachmentPolicy,
-                              index + 1,
-                            )}
-                            onClick={() =>
-                              document
-                                .getElementById(
-                                  `queue-step-attachments-${step.localId}`,
-                                )
-                                ?.click()
-                            }
-                          >
-                            +
-                          </button>
-                          <input
-                            id={`queue-step-attachments-${step.localId}`}
-                            className="sr-only"
-                            type="file"
-                            data-step-field="attachments"
-                            data-step-index={String(index)}
-                            accept={attachmentPolicy.allowedContentTypes.join(",")}
-                            multiple
-                            aria-label={attachmentFilePickerLabel(
-                              attachmentPolicy,
-                              index + 1,
-                            )}
-                            onChange={(event) => {
-                              updateStepAttachments(
-                                step.localId,
-                                Array.from(event.currentTarget.files || []),
-                              );
-                              event.currentTarget.value = "";
-                            }}
-                          />
-                        </div>
+                        <input
+                          id={`queue-step-attachments-${step.localId}`}
+                          className="sr-only"
+                          type="file"
+                          data-step-field="attachments"
+                          data-step-index={String(index)}
+                          accept={attachmentPolicy.allowedContentTypes.join(",")}
+                          multiple
+                          aria-label={attachmentFilePickerLabel(
+                            attachmentPolicy,
+                            index + 1,
+                          )}
+                          onChange={(event) => {
+                            updateStepAttachments(
+                              step.localId,
+                              Array.from(event.currentTarget.files || []),
+                            );
+                            event.currentTarget.value = "";
+                          }}
+                        />
                         {attachmentTargetErrors[
                           attachmentTargetKey(step.localId)
                         ] ? (

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6871,7 +6871,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
               ...step,
               explicitRequiredCapabilities:
                 step.explicitRequiredCapabilities.filter(
-                  (existing) => existing !== normalized,
+                  (existing) =>
+                    normalizeCapabilityToken(existing) !== normalized,
                 ),
             }
           : step,
@@ -7236,15 +7237,15 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           stepType: nextType,
         };
 
+        // MM-936: explicitRequiredCapabilities is a step-level field that is
+        // merged for every step type, so it must be preserved across type
+        // changes. Only the skill-specific id/args are cleared here.
         if (
           step.stepType === "skill" &&
-          (step.skillId.trim() ||
-            step.skillArgs.trim() ||
-            step.explicitRequiredCapabilities.length > 0)
+          (step.skillId.trim() || step.skillArgs.trim())
         ) {
           nextStep.skillId = "";
           nextStep.skillArgs = "";
-          nextStep.explicitRequiredCapabilities = [];
         }
 
         if (

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4014,17 +4014,143 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   gap: 0.35rem;
 }
 
-.queue-step-attachment-control {
-  display: inline-flex;
+/* MM-936: unified "Add to step" affordance and capability chip row. */
+.queue-step-context {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
-  width: fit-content;
 }
 
-.queue-step-attachment-label {
-  color: rgb(var(--mm-muted));
+.queue-step-context-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.queue-step-attachment-add-button.queue-step-context-menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: auto;
+  min-width: 0;
+  height: 2rem;
+  padding: 0 0.6rem;
   font-size: 0.86rem;
+}
+
+.queue-step-context-menu-button-text {
   font-weight: 650;
+}
+
+.queue-step-context-menu-popover {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  z-index: 20;
+  min-width: 15rem;
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.35rem;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 10px;
+  background: rgb(var(--mm-panel));
+  box-shadow: 0 12px 30px rgb(0 0 0 / 0.18);
+}
+
+.queue-step-context-menu-group-label {
+  margin: 0.25rem 0.4rem 0.1rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.queue-step-context-menu-separator {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: rgb(var(--mm-border));
+}
+
+.queue-step-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: rgb(var(--mm-text));
+  font-size: 0.88rem;
+  text-align: left;
+}
+
+.queue-step-context-menu-item:hover:not(:disabled),
+.queue-step-context-menu-item:focus-visible:not(:disabled) {
+  background: rgb(var(--mm-accent) / 0.12);
+}
+
+.queue-step-context-menu-item:disabled {
+  opacity: 0.5;
+}
+
+.queue-step-context-menu-capability-label {
+  flex: 1 1 auto;
+}
+
+.queue-step-context-menu-capability-token {
+  color: rgb(var(--mm-muted));
+  font-family: var(--mm-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+}
+
+.queue-step-capability-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.queue-step-capability-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid rgb(var(--mm-accent) / 0.45);
+  border-radius: 999px;
+  background: rgb(var(--mm-accent) / 0.1);
+  font-size: 0.82rem;
+}
+
+.queue-step-capability-chip.is-derived {
+  border-color: rgb(var(--mm-border));
+  background: rgb(var(--mm-muted) / 0.12);
+  color: rgb(var(--mm-muted));
+}
+
+.queue-step-capability-chip-detail {
+  color: rgb(var(--mm-muted));
+  font-size: 0.76rem;
+}
+
+.queue-step-capability-chip-lock {
+  font-size: 0.72rem;
+  cursor: help;
+}
+
+.queue-step-capability-chip-remove {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+}
+
+.queue-step-capability-chip-remove svg {
+  width: 0.85rem;
+  height: 0.85rem;
 }
 
 .queue-step-attachment-add-button {


### PR DESCRIPTION
## Issue

[MM-936: Capabilities Plus Button](https://moonladder.atlassian.net/browse/MM-936)

## Summary

Implements the MM-936 "Capabilities Plus Button" — a single always-visible **"+ Add to step"** affordance beneath each step instruction box that unifies image/attachment context and required capabilities into one ChatGPT-style menu, replacing the old advanced freeform CSV input.

- **Capability registry** — added `CAPABILITY_CATALOG` (`git`, `gh`, `jira`, `docker`, `codex_cli`) mapping tokens to label/shortLabel/description/icon/group, plus `CAPABILITY_MENU_TOKENS` and `capabilityCatalogEntry()` for custom tokens.
- **Provenance-aware chips** — added `CapabilitySourceKind` / `CapabilityContribution` / `StepCapabilityChip` types and `buildCapabilityChips()`, which merges explicit/skill/generatedSkill/generatedTool/preset/runtime/publish/template contributions. Chips are removable only when their sole source is explicit; derived chips render locked with a provenance tooltip and cannot be removed, so the UI never silently drops backend-required capabilities.
- **StepState evolution** — replaced the freeform CSV `skillRequiredCapabilities: string` with `explicitRequiredCapabilities: string[]`, updating all readers/writers (defaults, draft reconstruction, expanded-step mapping, step-type change, empty/advanced detection, preset save, submit). Capabilities now bubble into the task's normalized `requiredCapabilities` for every step type via `deriveRequiredCapabilities(...)` and submit without Advanced mode.
- **New UI** — added the `StepContextMenu` component (always-visible "+ Add to step" with click-outside/escape handling) offering Image/Attachment, the capability catalog, and a Custom capability prompt; rendered a provenance-aware capability chip row beneath the instructions for every step type.
- **Cleanup (delete-don't-deprecate)** — removed the dead `extractCapabilityCsv` / `attachmentControlLabel` / `attachmentAddButtonLabel` helpers, the advanced "Skill Required Capabilities (optional CSV)" input, and the now-unused CSS rules.

Files changed: `frontend/src/entrypoints/workflow-start.tsx`, `frontend/src/entrypoints/workflow-start.test.tsx`, `frontend/src/styles/dashboard.css`.

## Tests run

- **UI unit/component tests** — pass (focused `workflow-start.test.tsx`: 66 passed, 236 pre-existing `describe.skip`). Added coverage for the always-visible menu + submit-without-Advanced, removable explicit chips vs locked derived (publish-mode) chips with a disabled menu option, the custom-capability prompt flow, and pure-function unit coverage for `CAPABILITY_CATALOG`, `buildCapabilityChips` provenance/removability/normalization, and `capabilityChipProvenanceLabel`.
- **Typecheck** — pass (`tsc --noEmit -p frontend/tsconfig.json`).
- **Lint** — pass (`eslint` on the changed frontend sources).
- **Build** — pass (`vite build`).

An independent verification pass against the preset brief found every required behavior present and covered by active tests, with no gaps and no additional code changes required.

## Remaining risks

- **Frontend-only scope.** The backend `requiredCapabilities` normalization contract is unchanged; this is a step-authoring surface change that feeds the existing normalized field. No backend/Temporal payload shapes were modified.
- **Temporal draft compatibility seam.** `temporalTaskEditing.ts` intentionally retains the persisted `skillRequiredCapabilities: string[]` draft contract; draft reconstruction bridges it into `StepState.explicitRequiredCapabilities`. In-flight drafts should rehydrate correctly through this seam, but it is the main compatibility surface to watch.
- **Capability catalog is a static frontend registry.** Per the issue's Phase 1 design, `CAPABILITY_CATALOG` is a frontend constant rather than an API-backed source; custom/unknown tokens fall back to a generated catalog entry. Moving it behind an API is explicitly out of scope.
- The workspace path contains a colon, which breaks PATH-based vitest/tsc/eslint bin resolution; tests were run via the colon-free mirror used by `tools/test_unit.sh`. CI runs in a normal path and is unaffected.
