### PR TITLE
I don't believe the sub-sections within the Workflow Detail page need an added encircling border / card format. Since the entire Workflow Detail div i

### DIFF
--- a/frontend/src/components/skills/SkillProvenanceBadge.tsx
+++ b/frontend/src/components/skills/SkillProvenanceBadge.tsx
@@ -78,7 +78,7 @@ export function SkillProvenanceBadge({
     : '';
   
   return (
-    <div className="card mt-4 bg-gray-50 border border-gray-200 p-4 rounded-lg">
+    <div className="mt-4">
       <h3 className="mt-0 text-base">Agent Skill Provenance</h3>
       <dl className="queue-card-fields mb-0">
         <div>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5874,11 +5874,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 .td-evidence-region {
   min-width: 0;
-  padding: 0.85rem;
-  border: 1px solid rgb(var(--mm-border) / 0.58);
-  border-radius: 0.8rem;
-  background: rgb(var(--mm-panel) / 0.9);
-  box-shadow: 0 16px 36px -30px rgb(var(--mm-ink) / 0.48);
 }
 
 .td-facts-region,


### PR DESCRIPTION
I don't believe the sub-sections within the Workflow Detail page need an added encircling border / card format. Since the entire Workflow Detail div is already wrapped in a border and many of the objects have natural dividers as well like table structures, it creates an excessive number of borders having the secondary card border. Please remove it from Workflow Preview, Agent Skill Provenance, Workflow Steps, Timeline, Remediation Evidence, Workflow Artifacts, Execution History, etc.