### PR TITLE
MM-938 Complete stable canonical documentation claim indexing

### DIFF
--- a/tests/unit/tools/test_index_moonspec_docs.py
+++ b/tests/unit/tools/test_index_moonspec_docs.py
@@ -220,6 +220,14 @@ def test_stable_claim_prefixes_are_first_class_claim_identities(tmp_path: Path) 
     assert by_id["INV-001"]["summary"] == "Invariant summary"
 
 
+def test_stable_claim_prefix_without_class_mapping_falls_back_to_claim(monkeypatch) -> None:
+    monkeypatch.delitem(mod.CLAIM_PREFIX_CLASS, "TEST")
+
+    stable_claim = mod._parse_stable_claim_heading("TEST-001 Future prefix")
+
+    assert stable_claim == ("TEST-001", "claim", "Future prefix")
+
+
 def test_missing_stable_claims_are_reported_without_inventing_ids(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/tools/test_index_moonspec_docs.py
+++ b/tests/unit/tools/test_index_moonspec_docs.py
@@ -1,4 +1,4 @@
-"""MM-930 advisory MoonSpec documentation index tests."""
+"""MM-938 advisory MoonSpec documentation index tests."""
 
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ def test_build_index_emits_documents_claims_and_advisory_warnings(tmp_path: Path
         "**Owning Surface:** moonmind/widgets\n"
         "**Related Docs:** [Architecture](../MoonMindArchitecture.md), docs/Api/Other.md\n"
         "**Related Implementation:** moonmind/widgets/api.py, WidgetApi\n\n"
-        "## Payload\n\nThe payload has one field.\n",
+        "## CONTRACT-001 Payload\n\nThe payload has one field.\n",
     )
     _write(
         tmp_path / ".specify" / "memory" / "constitution.md",
@@ -47,7 +47,9 @@ def test_build_index_emits_documents_claims_and_advisory_warnings(tmp_path: Path
     payload = mod.build_index(root=tmp_path)
 
     assert payload["issue"] == "MM-930"
+    assert payload["implementationIssue"] == "MM-938"
     assert payload["sourceIssue"] == "MM-927"
+    assert "MM-938" in payload["traceability"]
     assert payload["advisoryOnly"] is True
     assert payload["documentCount"] == 2
 
@@ -62,9 +64,21 @@ def test_build_index_emits_documents_claims_and_advisory_warnings(tmp_path: Path
 
     claims = {entry["anchor"]: entry for entry in payload["claims"]}
     assert "docs/Api/WidgetContract.md#widget-contract" in claims
-    assert claims["docs/Api/WidgetContract.md#payload"]["type"] == "section"
-    assert claims["docs/Api/WidgetContract.md#payload"]["digest"].startswith("sha256:")
-    assert claims["docs/Api/WidgetContract.md#payload"]["id"].startswith("claim:")
+    payload_claim = claims["docs/Api/WidgetContract.md#contract-001-payload"]
+    assert payload_claim["id"] == "CONTRACT-001"
+    assert payload_claim["identityKind"] == "stable"
+    assert payload_claim["type"] == "section"
+    assert payload_claim["claimClass"] == "contract"
+    assert payload_claim["summary"] == "Payload"
+    assert payload_claim["section"] == "docs/Api/WidgetContract.md#contract-001-payload"
+    assert payload_claim["sourcePath"] == "docs/Api/WidgetContract.md"
+    assert payload_claim["authority"] == "Widget API payloads"
+    assert payload_claim["owningSurface"] == "moonmind/widgets"
+    assert "../MoonMindArchitecture.md" in payload_claim["relatedDocs"]
+    assert "moonmind/widgets/api.py" in payload_claim["relatedImplementation"]
+    assert payload_claim["digest"].startswith("sha256:")
+    assert claims["docs/Api/WidgetContract.md#widget-contract"]["id"].startswith("claim:")
+    assert claims["docs/Api/WidgetContract.md#widget-contract"]["identityKind"] == "generated"
 
 
 def test_docs_tmp_is_not_treated_as_canonical(tmp_path: Path) -> None:
@@ -123,6 +137,7 @@ def test_default_cli_is_advisory_only_even_with_warnings(tmp_path: Path, monkeyp
     warning_rules = {warning["rule"] for warning in payload["warnings"]}
     assert "missing-index-document-class" in warning_rules
     assert "missing-index-authority" in warning_rules
+    assert "missing-stable-claim-id" in warning_rules
 
 
 def test_heading_extraction_skips_fenced_code_and_accepts_indentation(
@@ -166,6 +181,111 @@ def test_duplicate_headings_get_unique_markdown_style_anchor_suffixes(
         claims["docs/Roadmap.md#remaining-work"]["id"]
         != claims["docs/Roadmap.md#remaining-work-1"]["id"]
     )
+
+
+def test_stable_claim_prefixes_are_first_class_claim_identities(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs" / "Claims.md",
+        "# Claims\n\n"
+        "**Document Class:** Feature Design View\n"
+        "**Authority:** Claim behavior\n"
+        "**Owning Surface:** docs/index\n\n"
+        "### DOC-REQ-001 Requirement summary\n\nRequirement body.\n"
+        "### CONTRACT-001: Contract summary\n\nContract body.\n"
+        "### INV-001 - Invariant summary\n\nInvariant body.\n"
+        "### NON-GOAL-001 Non-goal summary\n\nNon-goal body.\n"
+        "### QUALITY-001 Quality summary\n\nQuality body.\n"
+        "### TEST-001 Test summary\n\nTest body.\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    by_id = {claim["id"]: claim for claim in payload["claims"]}
+    stable_ids = [
+        "DOC-REQ-001",
+        "CONTRACT-001",
+        "INV-001",
+        "NON-GOAL-001",
+        "QUALITY-001",
+        "TEST-001",
+    ]
+    assert by_id["DOC-REQ-001"]["claimClass"] == "requirement"
+    assert by_id["CONTRACT-001"]["claimClass"] == "contract"
+    assert by_id["INV-001"]["claimClass"] == "invariant"
+    assert by_id["NON-GOAL-001"]["claimClass"] == "non-goal"
+    assert by_id["QUALITY-001"]["claimClass"] == "quality"
+    assert by_id["TEST-001"]["claimClass"] == "test"
+    assert all(by_id[claim_id]["identityKind"] == "stable" for claim_id in stable_ids)
+    assert by_id["CONTRACT-001"]["summary"] == "Contract summary"
+    assert by_id["INV-001"]["summary"] == "Invariant summary"
+
+
+def test_missing_stable_claims_are_reported_without_inventing_ids(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / "docs" / "NeedsClaims.md",
+        "# Needs Claims\n\n"
+        "**Document Class:** Feature Design View\n"
+        "**Authority:** Claim behavior\n"
+        "**Owning Surface:** docs/index\n\n"
+        "## Behavior\n\nBody.\n",
+    )
+
+    payload = mod.build_index(root=tmp_path)
+
+    assert payload["missingStableClaimPolicy"] == "report"
+    assert payload["missingStableClaimDocuments"] == ["docs/NeedsClaims.md"]
+    warning_rules = {warning["rule"] for warning in payload["warnings"]}
+    assert "missing-stable-claim-id" in warning_rules
+    assert all(claim["identityKind"] == "generated" for claim in payload["claims"])
+    assert all(claim["id"].startswith("claim:") for claim in payload["claims"])
+
+
+def test_missing_stable_claim_fail_policy_returns_nonzero_after_writing_artifact(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write(
+        tmp_path / "docs" / "NeedsClaims.md",
+        "# Needs Claims\n\n"
+        "**Document Class:** Feature Design View\n"
+        "**Authority:** Claim behavior\n"
+        "**Owning Surface:** docs/index\n",
+    )
+    output = tmp_path / "artifacts" / "index.json"
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+
+    rc = mod.main(
+        [
+            "--missing-stable-claim-policy",
+            "fail",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert rc == 1
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["missingStableClaimPolicy"] == "fail"
+    assert payload["missingStableClaimDocuments"] == ["docs/NeedsClaims.md"]
+
+
+def test_non_file_sources_are_reported_and_do_not_receive_claim_ids(
+    tmp_path: Path,
+) -> None:
+    payload = mod.build_index(
+        paths=[
+            "jira://MM-927",
+            "inline:### DOC-REQ-001 Fabricated",
+        ],
+        root=tmp_path,
+    )
+
+    assert payload["documentCount"] == 0
+    assert payload["claimCount"] == 0
+    warnings = {warning["path"]: warning for warning in payload["warnings"]}
+    assert warnings["jira:/MM-927"]["rule"] == "non-file-source-skipped"
+    assert warnings["inline:### DOC-REQ-001 Fabricated"]["rule"] == "non-file-source-skipped"
 
 
 def test_explicit_paths_are_normalized_relative_to_repo_root(tmp_path: Path) -> None:

--- a/tools/index_moonspec_docs.py
+++ b/tools/index_moonspec_docs.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""MM-930 advisory MoonSpec documentation indexer.
+"""MM-938 advisory MoonSpec documentation indexer.
 
 Builds a machine-readable JSON index of canonical MoonSpec documents and stable
 heading claims without mutating checked-in documentation.
 
-Traceability: MM-930 (source issue MM-927, "Moon Spec Doc Architecture
+Traceability: MM-938, MM-930 (source issue MM-927, "Moon Spec Doc Architecture
 Alignment"); covers DESIGN-REQ-001, DESIGN-REQ-008, DESIGN-REQ-010, and
 DESIGN-REQ-011.
 """
@@ -22,6 +22,8 @@ from pathlib import Path
 from typing import Iterable
 
 from check_documentation_architecture import (
+    CANONICAL_CLAIM_ID_RE,
+    CANONICAL_CLAIM_PREFIXES,
     NON_CANONICAL_DOC_DIRS,
     REPO_ROOT,
     Finding,
@@ -33,10 +35,26 @@ from check_documentation_architecture import (
 
 
 ISSUE = "MM-930"
+IMPLEMENTATION_ISSUE = "MM-938"
 DEFAULT_OUTPUT = Path("artifacts/moonspec-doc-index/index.json")
 CONSTITUTION_PATH = ".specify/memory/constitution.md"
+CLAIM_PREFIX_CLASS = {
+    "DOC-REQ": "requirement",
+    "CONTRACT": "contract",
+    "INV": "invariant",
+    "NON-GOAL": "non-goal",
+    "QUALITY": "quality",
+    "TEST": "test",
+}
 
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
+STABLE_CLAIM_PREFIX_RE = "|".join(
+    re.escape(prefix) for prefix in CANONICAL_CLAIM_PREFIXES
+)
+STABLE_CLAIM_HEADING_RE = re.compile(
+    rf"^(?P<id>(?:{STABLE_CLAIM_PREFIX_RE})-\d{{3}})"
+    r"(?P<separator>\s+|:\s*| -\s*|$)(?P<summary>.*)$"
+)
 METADATA_RE = re.compile(r"^\s*\*\*([^*:\n]+):\*\*\s*(.*?)\s*$")
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 IMPLEMENTATION_TOKEN_RE = re.compile(
@@ -69,11 +87,20 @@ class DocumentEntry:
 @dataclass(frozen=True)
 class ClaimEntry:
     id: str
+    identityKind: str
     documentPath: str
+    sourcePath: str
+    section: str
     heading: str
+    summary: str
     type: str
+    claimClass: str
     anchor: str
     digest: str
+    authority: str
+    owningSurface: str
+    relatedDocs: list[str]
+    relatedImplementation: list[str]
 
 
 def _normalize_metadata_key(key: str) -> str:
@@ -188,6 +215,19 @@ def _claim_id(path: str, anchor: str) -> str:
     return f"claim:{digest}"
 
 
+def _parse_stable_claim_heading(heading: str) -> tuple[str, str, str] | None:
+    normalized = _strip_markdown(heading)
+    match = STABLE_CLAIM_HEADING_RE.match(normalized)
+    if not match:
+        return None
+    claim_id = match.group("id")
+    if not CANONICAL_CLAIM_ID_RE.fullmatch(claim_id):
+        return None
+    prefix = claim_id.rsplit("-", 1)[0]
+    summary = match.group("summary").strip(" -:\t") or claim_id
+    return claim_id, CLAIM_PREFIX_CLASS[prefix], summary
+
+
 def _claim_digest(path: str, heading: str, section_text: str) -> str:
     raw = f"{path}\n{heading}\n{section_text}"
     return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
@@ -240,8 +280,47 @@ def _index_paths(paths: Iterable[str], *, root: Path) -> list[str]:
     return sorted(dict.fromkeys(docs))
 
 
-def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None) -> dict:
+def _input_source_warnings(paths: Iterable[str], *, root: Path) -> list[Finding]:
+    resolved_root = root.resolve()
+    warnings: list[Finding] = []
+    for path in paths:
+        path_obj = Path(path)
+        try:
+            candidate = path_obj if path_obj.is_absolute() else root / path_obj
+            resolved_candidate = candidate.resolve()
+            if resolved_candidate.is_relative_to(resolved_root):
+                normalized = resolved_candidate.relative_to(resolved_root).as_posix()
+            else:
+                normalized = path_obj.as_posix()
+        except (OSError, RuntimeError, ValueError):
+            normalized = path_obj.as_posix()
+        if is_canonical_doc(normalized):
+            continue
+        if normalized == CONSTITUTION_PATH:
+            continue
+        warnings.append(
+            _warning(
+                "non-file-source-skipped",
+                normalized,
+                "Input is not a canonical repository markdown file and was not indexed.",
+                "The doc index never fabricates stable canonical claim IDs for Jira text, inline text, or other non-file sources.",
+            )
+        )
+    return warnings
+
+
+def build_index(
+    paths: Iterable[str] | None = None,
+    *,
+    root: Path | None = None,
+    missing_stable_claim_policy: str = "report",
+) -> dict:
     """Build the advisory documentation index payload."""
+
+    if missing_stable_claim_policy not in {"report", "fail", "ignore"}:
+        raise ValueError(
+            "missing_stable_claim_policy must be one of: report, fail, ignore"
+        )
 
     root = root or REPO_ROOT
     input_paths = paths if paths is not None else all_doc_paths(root=root)
@@ -263,9 +342,12 @@ def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None)
         [doc for doc in doc_files if doc.path != CONSTITUTION_PATH],
         focus_paths=None,
     )
+    if paths is not None:
+        warnings.extend(_input_source_warnings(paths, root=root))
 
     document_entries: list[DocumentEntry] = []
     claim_entries: list[ClaimEntry] = []
+    missing_stable_claim_paths: list[str] = []
 
     for path in selected_paths:
         doc = docs_by_path.get(path)
@@ -336,16 +418,49 @@ def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None)
         )
 
         seen_anchors: dict[str, int] = {}
+        stable_claim_count = 0
         for level, heading, section_text in _heading_sections(doc.text):
             anchor = _unique_anchor(_anchor_for_heading(heading), seen_anchors)
+            stable_claim = _parse_stable_claim_heading(heading)
+            claim_id = _claim_id(path, anchor)
+            identity_kind = "generated"
+            claim_class = _claim_type(level)
+            summary = _strip_markdown(heading)
+            if stable_claim is not None:
+                claim_id, claim_class, summary = stable_claim
+                identity_kind = "stable"
+                stable_claim_count += 1
             claim_entries.append(
                 ClaimEntry(
-                    id=_claim_id(path, anchor),
+                    id=claim_id,
+                    identityKind=identity_kind,
                     documentPath=path,
+                    sourcePath=path,
+                    section=f"{path}#{anchor}",
                     heading=heading,
+                    summary=summary,
                     type=_claim_type(level),
+                    claimClass=claim_class,
                     anchor=f"{path}#{anchor}",
                     digest=_claim_digest(path, heading, section_text),
+                    authority=authority,
+                    owningSurface=owning_surface,
+                    relatedDocs=related_docs,
+                    relatedImplementation=related_implementation,
+                )
+            )
+        if (
+            missing_stable_claim_policy != "ignore"
+            and path != CONSTITUTION_PATH
+            and stable_claim_count == 0
+        ):
+            missing_stable_claim_paths.append(path)
+            warnings.append(
+                _warning(
+                    "missing-stable-claim-id",
+                    path,
+                    "Canonical doc has no stable DOC-REQ, CONTRACT, INV, NON-GOAL, QUALITY, or TEST claim headings.",
+                    "Assign stable claim IDs to durable canonical claims, or run with --missing-stable-claim-policy ignore for exploratory indexing.",
                 )
             )
 
@@ -356,9 +471,14 @@ def build_index(paths: Iterable[str] | None = None, *, root: Path | None = None)
     return {
         "tool": "index_moonspec_docs",
         "issue": ISSUE,
+        "implementationIssue": IMPLEMENTATION_ISSUE,
         "sourceIssue": "MM-927",
+        "traceability": [IMPLEMENTATION_ISSUE, ISSUE, "MM-927"],
         "generatedAt": datetime.now(timezone.utc).isoformat(),
         "advisoryOnly": True,
+        "missingStableClaimPolicy": missing_stable_claim_policy,
+        "missingStableClaimDocumentCount": len(missing_stable_claim_paths),
+        "missingStableClaimDocuments": missing_stable_claim_paths,
         "canonicalRoots": ["docs", CONSTITUTION_PATH],
         "excludedCanonicalDocDirs": list(NON_CANONICAL_DOC_DIRS),
         "documentCount": len(document_entries),
@@ -401,25 +521,42 @@ def main(argv: list[str] | None = None) -> int:
         help="Exit non-zero when advisory warnings exist. Default is advisory-only.",
     )
     parser.add_argument(
+        "--missing-stable-claim-policy",
+        choices=("report", "fail", "ignore"),
+        default="report",
+        help=(
+            "How to handle canonical docs with no stable claim headings: report "
+            "advisory findings, fail after writing the artifact, or ignore."
+        ),
+    )
+    parser.add_argument(
         "paths",
         nargs="*",
         help="Optional explicit canonical doc paths to index. docs/tmp remains excluded.",
     )
     args = parser.parse_args(argv)
 
-    payload = build_index(args.paths or None)
+    payload = build_index(
+        args.paths or None,
+        missing_stable_claim_policy=args.missing_stable_claim_policy,
+    )
     output_path = write_index(payload, args.output)
 
     if args.format == "json":
         print(json.dumps({"output": str(output_path), **payload}, indent=2, sort_keys=True))
     else:
         print(
-            "MM-930 MoonSpec documentation index "
+            "MM-938 MoonSpec documentation index "
             f"wrote {payload['documentCount']} document(s), "
             f"{payload['claimCount']} claim(s), and "
             f"{payload['warningCount']} advisory warning(s) to {output_path}."
         )
 
+    if (
+        args.missing_stable_claim_policy == "fail"
+        and payload["missingStableClaimDocumentCount"]
+    ):
+        return 1
     if args.strict and payload["warningCount"]:
         return 1
     return 0

--- a/tools/index_moonspec_docs.py
+++ b/tools/index_moonspec_docs.py
@@ -225,7 +225,7 @@ def _parse_stable_claim_heading(heading: str) -> tuple[str, str, str] | None:
         return None
     prefix = claim_id.rsplit("-", 1)[0]
     summary = match.group("summary").strip(" -:\t") or claim_id
-    return claim_id, CLAIM_PREFIX_CLASS[prefix], summary
+    return claim_id, CLAIM_PREFIX_CLASS.get(prefix, "claim"), summary
 
 
 def _claim_digest(path: str, heading: str, section_text: str) -> str:


### PR DESCRIPTION
Issue reference
- MM-938: Complete stable canonical documentation claim indexing

Summary
- Parses explicit DOC-REQ, CONTRACT, INV, NON-GOAL, QUALITY, and TEST headings as stable claim identities in the MoonSpec doc index.
- Adds portable claim metadata including source path, section, summary, claim class, authority, owning surface, related docs, and related implementation.
- Adds missing-stable-claim reporting/fail/ignore policy and reports non-file inputs without fabricating canonical IDs.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/tools/test_index_moonspec_docs.py

Remaining risks
- Existing canonical docs without stable claim headings will now be reported by default; callers that want exploratory indexing may need to choose the ignore policy explicitly.