### PR TITLE
MM-946: Route default URL to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For now, MoonMind is focused on software engineering use cases.
 2. Install git
 3. `git clone https://github.com/MoonLadderStudios/MoonMind.git`
 4. Run `docker compose up -d` to start the service
-5. Open [http://localhost:8000/workflows](http://localhost:8000/workflows)
+5. Open [http://localhost:8000](http://localhost:8000)
 6. In Settings:
     - Add a GitHub personal access token
     - Add an API key or click OAuth to authenticate a provider profile

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -368,7 +368,7 @@ app = FastAPI(
     title="MoonMind API",
     description="API for MoonMind - LLM-powered documentation search and chat interface",
     version="0.1.0",
-    docs_url="/docs",
+    docs_url="/openapi",
     openapi_url="/openapi.json",
     lifespan=lifespan,
 )
@@ -417,8 +417,8 @@ async def health_check():
 
 @app.get("/", include_in_schema=False)
 async def docs_redirect() -> RedirectResponse:
-    """Redirect root path to Swagger UI."""
-    return RedirectResponse(url=app.docs_url)
+    """Redirect root path to the dashboard."""
+    return RedirectResponse(url="/workflows")
 
 app.include_router(health_router, tags=["health"])
 

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api_service.main import app as main_app
 from api_service.api.routers.workflow_console import (
     _get_temporal_service,
     _is_allowed_path,
@@ -188,6 +189,21 @@ def test_root_route_renders_dashboard_shell(client: TestClient) -> None:
     boot_payload = _extract_boot_payload(response.text)
     assert boot_payload["page"] == "workflow-list"
     assert boot_payload["initialData"]["dashboardConfig"]["initialPath"] == "/workflows"
+
+def test_default_app_url_redirects_to_dashboard() -> None:
+    response = TestClient(main_app).get("/", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/workflows"
+
+def test_openapi_route_serves_swagger_ui() -> None:
+    client = TestClient(main_app)
+
+    response = client.get("/openapi")
+
+    assert response.status_code == 200
+    assert "swagger-ui" in response.text
+    assert "/openapi.json" in response.text
 
 def test_static_sub_routes_render_react_shell(client: TestClient) -> None:
     for path in (


### PR DESCRIPTION
Issue reference: MM-946

Summary:
- Moves the FastAPI Swagger UI from /docs to /openapi.
- Changes the default root URL on port 8000 to redirect to the dashboard at /workflows.
- Updates the README quick start URL and adds unit coverage for the root redirect and /openapi Swagger route.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_workflow_console.py

Remaining risks:
- Existing clients or bookmarks that used /docs for Swagger UI will need to use /openapi.
