### PR TITLE
[codex] Resolve Jira source design paths deterministically

### DIFF
--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -81,8 +81,11 @@ steps:
       Run moonspec-breakdown using this input preference chain:
 
       1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
-      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
-      3. Otherwise, use Workflow instructions as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
+      3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      4. Otherwise, use Workflow instructions as the source design.
+
+      If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
       Source declarative document path:
       {{ inputs.source_design_path }}
@@ -94,6 +97,7 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -81,8 +81,11 @@ steps:
       Run moonspec-breakdown using this input preference chain:
 
       1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
-      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
-      3. Otherwise, use Workflow instructions as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
+      3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      4. Otherwise, use Workflow instructions as the source design.
+
+      If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
       Source declarative document path:
       {{ inputs.source_design_path }}
@@ -94,6 +97,7 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -72,8 +72,11 @@ steps:
       Run moonspec-breakdown using this input preference chain:
 
       1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
-      2. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
-      3. Otherwise, use Workflow instructions as the source design.
+      2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
+      3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
+      4. Otherwise, use Workflow instructions as the source design.
+
+      If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
       Source declarative document path:
       {{ inputs.source_design_path }}
@@ -85,6 +88,7 @@ steps:
       {{ inputs.feature_request }}
 
       If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1830,6 +1830,8 @@ def _default_registry_skill_payload(*, name: str) -> dict[str, Any]:
                         "jiraIssueKey": {"type": "string"},
                         "jiraPresetBrief": {"type": "string"},
                         "jiraStepInstructions": {"type": "string"},
+                        "resolvedSourceDesignPath": {"type": "string"},
+                        "sourceResolution": {"type": "object"},
                         "jiraIssue": {"type": "object"},
                         "summary": {"type": "string"},
                     },

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -7,7 +7,7 @@ import hashlib
 import inspect
 import json
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Awaitable, Callable, Mapping, Sequence
 from urllib.parse import urlparse
 
@@ -40,6 +40,10 @@ JIRA_STORY_TOOL_NAMES = frozenset(
         JIRA_ORCHESTRATE_TASKS_TOOL_NAME,
         JIRA_IMPLEMENT_TASKS_TOOL_NAME,
     }
+)
+_SOURCE_DOCUMENT_PATH_RE = re.compile(
+    r"(?P<path>(?:docs/(?:[A-Za-z0-9_.@+=-]+/)*[A-Za-z0-9_.@+=-]+|"
+    r"\.specify/memory/constitution)\.md)"
 )
 _DOWNSTREAM_PRESET_ORCHESTRATE = "orchestrate"
 _DOWNSTREAM_PRESET_IMPLEMENT = "implement"
@@ -529,6 +533,22 @@ def _has_explicit_empty_story_list(value: Any) -> bool:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return len(value) == 0
     return False
+
+
+def _story_breakdown_failure_reason(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return ""
+    if not isinstance(value, Mapping):
+        return ""
+    error = _mapping(value.get("error"))
+    if not error:
+        return ""
+    code = _string(error.get("code")) or "story_breakdown_failed"
+    message = _string(error.get("message")) or "Story breakdown failed."
+    return f"Story breakdown failed before Jira creation: {code}: {message}"
 
 def _story_summary(story: Mapping[str, Any], *, index: int) -> str:
     for key in ("summary", "title", "name", "userStory", "user_story"):
@@ -2009,6 +2029,7 @@ async def create_jira_issues_from_stories(
     stories = _coerce_story_payload(raw_story_payload)
     artifact_ref_was_read = False
     artifact_payload_had_explicit_empty_stories = False
+    artifact_payload_failure_reason = ""
     artifact_ref = ""
     if not stories:
         artifact_ref = _string(
@@ -2042,6 +2063,9 @@ async def create_jira_issues_from_stories(
                     except json.JSONDecodeError:
                         parsed_payload = artifact_payload
                 breakdown_source_path = _breakdown_source_path(parsed_payload)
+                artifact_payload_failure_reason = _story_breakdown_failure_reason(
+                    parsed_payload
+                )
                 stories = _coerce_story_payload(parsed_payload)
                 artifact_ref_was_read = True
                 artifact_payload_had_explicit_empty_stories = (
@@ -2058,6 +2082,18 @@ async def create_jira_issues_from_stories(
                         dependency_mode=dependency_mode,
                     )
                 raise
+    if (
+        not stories
+        and artifact_ref_was_read
+        and artifact_payload_failure_reason
+    ):
+        if fallback_for_missing_stories:
+            return _fallback_result(
+                reason=artifact_payload_failure_reason,
+                inputs=inputs,
+                dependency_mode=dependency_mode,
+            )
+        raise ValueError(artifact_payload_failure_reason)
     if (
         not stories
         and artifact_ref_was_read
@@ -2597,6 +2633,173 @@ def _load_preset_brief_issue_key(inputs: Mapping[str, Any]) -> str:
         or nested.get("key")
     ).upper()
 
+
+def _source_resolution_root(
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> Path:
+    context_mapping = _mapping(context)
+    root = _string(
+        inputs.get("repositoryRoot")
+        or inputs.get("repository_root")
+        or inputs.get("repoRoot")
+        or inputs.get("repo_root")
+        or context_mapping.get("repositoryRoot")
+        or context_mapping.get("repository_root")
+        or context_mapping.get("repoRoot")
+        or context_mapping.get("repo_root")
+        or context_mapping.get("workspacePath")
+        or context_mapping.get("workspace_path")
+    )
+    return Path(root) if root else Path.cwd()
+
+
+def _normalize_source_document_path(value: object) -> str:
+    candidate = _string(value).strip()
+    if not candidate:
+        return ""
+    candidate = candidate.replace("\\", "/")
+    candidate = candidate.strip("`'\"<>()[]{}")
+    candidate = candidate.rstrip(".,;:!?")
+    while candidate.startswith("./"):
+        candidate = candidate[2:]
+
+    path = PurePosixPath(candidate)
+    if path.is_absolute() or not path.parts:
+        return ""
+    if any(part in {"", ".", ".."} for part in path.parts):
+        return ""
+    normalized = path.as_posix()
+    if normalized == ".specify/memory/constitution.md":
+        return normalized
+    if normalized.startswith("docs/") and normalized.endswith(".md"):
+        return normalized
+    return ""
+
+
+def _source_document_path_exists(
+    repo_root: Path,
+    source_path: str,
+) -> bool:
+    if not source_path:
+        return False
+    try:
+        path = repo_root.joinpath(*PurePosixPath(source_path).parts)
+        return path.is_file()
+    except (OSError, ValueError):
+        return False
+
+
+def _source_path_candidates(
+    *,
+    texts: Sequence[tuple[str, str]],
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    candidates: dict[str, dict[str, Any]] = {}
+    for source_field, text in texts:
+        if not text:
+            continue
+        for match in _SOURCE_DOCUMENT_PATH_RE.finditer(text):
+            source_path = _normalize_source_document_path(match.group("path"))
+            if not source_path:
+                continue
+            candidate = candidates.setdefault(
+                source_path,
+                {
+                    "path": source_path,
+                    "sourceField": source_field,
+                    "sourceFields": [],
+                    "exists": _source_document_path_exists(repo_root, source_path),
+                },
+            )
+            source_fields = candidate["sourceFields"]
+            if source_field not in source_fields:
+                source_fields.append(source_field)
+    return list(candidates.values())
+
+
+def _resolve_source_design_path_from_issue(
+    *,
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    summary: str,
+    description_text: str,
+    acceptance_text: str,
+    preset_brief: str,
+) -> dict[str, Any]:
+    repo_root = _source_resolution_root(inputs, context)
+    explicit_path = _normalize_source_document_path(
+        inputs.get("sourceDesignPath")
+        or inputs.get("source_design_path")
+        or inputs.get("declarativeDocumentPath")
+        or inputs.get("declarative_document_path")
+    )
+    if explicit_path:
+        exists = _source_document_path_exists(repo_root, explicit_path)
+        return {
+            "status": "resolved" if exists else "invalid_explicit_path",
+            "selectedPath": explicit_path if exists else "",
+            "candidatePaths": [
+                {
+                    "path": explicit_path,
+                    "sourceField": "input.source_design_path",
+                    "sourceFields": ["input.source_design_path"],
+                    "exists": exists,
+                }
+            ],
+            "reason": (
+                "explicit source_design_path exists in the repository checkout"
+                if exists
+                else "explicit source_design_path was not found in the repository checkout"
+            ),
+        }
+
+    candidate_paths = _source_path_candidates(
+        texts=(
+            ("jira.summary", summary),
+            ("jira.description", description_text),
+            ("jira.acceptanceCriteria", acceptance_text),
+            ("jira.presetBrief", preset_brief),
+        ),
+        repo_root=repo_root,
+    )
+    existing_paths = [item for item in candidate_paths if item["exists"]]
+    if len(existing_paths) == 1:
+        selected = existing_paths[0]
+        return {
+            "status": "resolved",
+            "selectedPath": selected["path"],
+            "candidatePaths": candidate_paths,
+            "reason": (
+                f"found one existing canonical document path in "
+                f"{selected['sourceField']}"
+            ),
+        }
+    if len(existing_paths) > 1:
+        return {
+            "status": "ambiguous",
+            "selectedPath": "",
+            "candidatePaths": candidate_paths,
+            "reason": "multiple existing canonical document paths were found",
+        }
+    if candidate_paths:
+        return {
+            "status": "invalid_candidates",
+            "selectedPath": "",
+            "candidatePaths": candidate_paths,
+            "reason": (
+                "canonical document path candidates were mentioned, but none "
+                "exist in the repository checkout"
+            ),
+        }
+    return {
+        "status": "not_found",
+        "selectedPath": "",
+        "candidatePaths": [],
+        "reason": "no canonical document path was found in the trusted Jira issue",
+    }
+
+
 async def load_jira_preset_brief(
     inputs: Mapping[str, Any],
     _context: Mapping[str, Any] | None = None,
@@ -2652,27 +2855,44 @@ async def load_jira_preset_brief(
     if acceptance_text:
         step_parts.append(f"Acceptance criteria\n{acceptance_text}")
     step_instructions = "\n\n".join(part for part in step_parts if part)
-
-    return ToolResult(
-        status="COMPLETED",
-        outputs={
-            "trustedSource": "moonmind.jira.get_issue",
-            "jiraIssueKey": resolved_key,
-            "jiraPresetBrief": preset_brief,
-            "jiraStepInstructions": step_instructions,
-            "jiraIssue": {
-                "key": resolved_key,
-                "summary": summary,
-                "descriptionText": description_text,
-                "acceptanceCriteriaText": acceptance_text,
-                "status": _string(status.get("name")),
-                "issueType": _string(issue_type.get("name")),
-                "assignee": _string(assignee.get("displayName")),
-                "url": _issue_url(issue),
-            },
-            "summary": f"Loaded Jira preset brief for {resolved_key} from trusted Jira data.",
-        },
+    source_resolution = _resolve_source_design_path_from_issue(
+        inputs=inputs,
+        context=_context,
+        summary=summary,
+        description_text=description_text,
+        acceptance_text=acceptance_text,
+        preset_brief=preset_brief,
     )
+    resolved_source_path = _string(source_resolution.get("selectedPath"))
+
+    summary_text = f"Loaded Jira preset brief for {resolved_key} from trusted Jira data."
+    if resolved_source_path:
+        summary_text = (
+            f"{summary_text} Resolved source design path {resolved_source_path}."
+        )
+
+    outputs: dict[str, Any] = {
+        "trustedSource": "moonmind.jira.get_issue",
+        "jiraIssueKey": resolved_key,
+        "jiraPresetBrief": preset_brief,
+        "jiraStepInstructions": step_instructions,
+        "sourceResolution": source_resolution,
+        "jiraIssue": {
+            "key": resolved_key,
+            "summary": summary,
+            "descriptionText": description_text,
+            "acceptanceCriteriaText": acceptance_text,
+            "status": _string(status.get("name")),
+            "issueType": _string(issue_type.get("name")),
+            "assignee": _string(assignee.get("displayName")),
+            "url": _issue_url(issue),
+        },
+        "summary": summary_text,
+    }
+    if resolved_source_path:
+        outputs["resolvedSourceDesignPath"] = resolved_source_path
+
+    return ToolResult(status="COMPLETED", outputs=outputs)
 
 
 def _github_issue_inputs(inputs: Mapping[str, Any]) -> tuple[str, int]:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -2637,7 +2637,7 @@ def _load_preset_brief_issue_key(inputs: Mapping[str, Any]) -> str:
 def _source_resolution_root(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
-) -> Path:
+) -> Path | None:
     context_mapping = _mapping(context)
     root = _string(
         inputs.get("repositoryRoot")
@@ -2651,7 +2651,7 @@ def _source_resolution_root(
         or context_mapping.get("workspacePath")
         or context_mapping.get("workspace_path")
     )
-    return Path(root) if root else Path.cwd()
+    return Path(root) if root else None
 
 
 def _normalize_source_document_path(value: object) -> str:
@@ -2678,9 +2678,11 @@ def _normalize_source_document_path(value: object) -> str:
 
 
 def _source_document_path_exists(
-    repo_root: Path,
+    repo_root: Path | None,
     source_path: str,
-) -> bool:
+) -> bool | None:
+    if repo_root is None:
+        return None
     if not source_path:
         return False
     try:
@@ -2693,7 +2695,7 @@ def _source_document_path_exists(
 def _source_path_candidates(
     *,
     texts: Sequence[tuple[str, str]],
-    repo_root: Path,
+    repo_root: Path | None,
 ) -> list[dict[str, Any]]:
     candidates: dict[str, dict[str, Any]] = {}
     for source_field, text in texts:
@@ -2736,9 +2738,10 @@ def _resolve_source_design_path_from_issue(
     )
     if explicit_path:
         exists = _source_document_path_exists(repo_root, explicit_path)
+        resolved = exists is not False
         return {
-            "status": "resolved" if exists else "invalid_explicit_path",
-            "selectedPath": explicit_path if exists else "",
+            "status": "resolved" if resolved else "invalid_explicit_path",
+            "selectedPath": explicit_path if resolved else "",
             "candidatePaths": [
                 {
                     "path": explicit_path,
@@ -2749,8 +2752,13 @@ def _resolve_source_design_path_from_issue(
             ],
             "reason": (
                 "explicit source_design_path exists in the repository checkout"
-                if exists
-                else "explicit source_design_path was not found in the repository checkout"
+                if exists is True
+                else (
+                    "explicit source_design_path selected without repository-root "
+                    "validation"
+                    if exists is None
+                    else "explicit source_design_path was not found in the repository checkout"
+                )
             ),
         }
 
@@ -2763,9 +2771,11 @@ def _resolve_source_design_path_from_issue(
         ),
         repo_root=repo_root,
     )
-    existing_paths = [item for item in candidate_paths if item["exists"]]
-    if len(existing_paths) == 1:
-        selected = existing_paths[0]
+    existing_paths = [item for item in candidate_paths if item["exists"] is True]
+    if len(existing_paths) == 1 or (
+        repo_root is None and len(candidate_paths) == 1
+    ):
+        selected = existing_paths[0] if existing_paths else candidate_paths[0]
         return {
             "status": "resolved",
             "selectedPath": selected["path"],
@@ -2773,6 +2783,11 @@ def _resolve_source_design_path_from_issue(
             "reason": (
                 f"found one existing canonical document path in "
                 f"{selected['sourceField']}"
+                if selected["exists"] is True
+                else (
+                    f"found one canonical document path in "
+                    f"{selected['sourceField']}; repository-root validation not run"
+                )
             ),
         }
     if len(existing_paths) > 1:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4423,6 +4423,8 @@ class MoonMindRunWorkflow:
             "jiraIssueKey",
             "jiraPresetBrief",
             "jiraStepInstructions",
+            "resolvedSourceDesignPath",
+            "sourceResolution",
             "jiraIssue",
             "summary",
         ):
@@ -4459,6 +4461,8 @@ class MoonMindRunWorkflow:
                 "trustedSource",
                 "jiraIssueKey",
                 "summary",
+                "resolvedSourceDesignPath",
+                "sourceResolution",
                 "jiraPresetBrief",
                 "jiraStepInstructions",
             )

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2109,6 +2109,12 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "jiraPresetBrief" in expanded_with_source_issue["steps"][1][
                 "instructions"
             ]
+            assert "resolvedSourceDesignPath" in expanded_with_source_issue["steps"][
+                1
+            ]["instructions"]
+            assert "source-resolution error" in expanded_with_source_issue["steps"][
+                1
+            ]["instructions"]
 
             expanded_with_null_optional_sources = await service.expand_template(
                 slug="jira-breakdown",

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -375,6 +375,73 @@ async def test_load_jira_preset_brief_ignores_criteria_only_custom_fields():
 
 
 @pytest.mark.asyncio
+async def test_load_jira_preset_brief_resolves_existing_source_design_path(tmp_path):
+    source_path = "docs/ManagedAgents/ManagedRuntimeCleanup.md"
+    source_file = tmp_path / source_path
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("# Managed Runtime Cleanup\n", encoding="utf-8")
+    service = _FakeJiraService()
+    service.issue_responses["MM-940"] = {
+        "key": "MM-940",
+        "fields": {
+            "summary": f"Implement {source_path}",
+            "description": "Break the canonical cleanup design into work.",
+        },
+    }
+
+    result = await load_jira_preset_brief(
+        {"issueKey": "MM-940", "repositoryRoot": str(tmp_path)},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["resolvedSourceDesignPath"] == source_path
+    resolution = result.outputs["sourceResolution"]
+    assert resolution["status"] == "resolved"
+    assert resolution["selectedPath"] == source_path
+    assert resolution["candidatePaths"] == [
+        {
+            "path": source_path,
+            "sourceField": "jira.summary",
+            "sourceFields": ["jira.summary", "jira.presetBrief"],
+            "exists": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_jira_preset_brief_reports_ambiguous_source_paths(tmp_path):
+    first_path = "docs/ManagedAgents/ManagedRuntimeCleanup.md"
+    second_path = "docs/ManagedAgents/ManagedAgentArchitecture.md"
+    for source_path in (first_path, second_path):
+        source_file = tmp_path / source_path
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text("# Source\n", encoding="utf-8")
+    service = _FakeJiraService()
+    service.issue_responses["MM-940"] = {
+        "key": "MM-940",
+        "fields": {
+            "summary": "Managed runtime cleanup",
+            "description": f"Use {first_path} and compare {second_path}.",
+        },
+    }
+
+    result = await load_jira_preset_brief(
+        {"issueKey": "MM-940", "repositoryRoot": str(tmp_path)},
+        jira_service_factory=lambda: service,
+    )
+
+    assert "resolvedSourceDesignPath" not in result.outputs
+    resolution = result.outputs["sourceResolution"]
+    assert resolution["status"] == "ambiguous"
+    assert resolution["selectedPath"] == ""
+    assert [item["path"] for item in resolution["candidatePaths"]] == [
+        first_path,
+        second_path,
+    ]
+
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_source():
     service = _FakeJiraService()
     breakdown = {
@@ -675,6 +742,55 @@ async def test_create_jira_issues_noops_for_empty_previous_story_artifact():
     assert artifact_reads == ["art_empty_story_breakdown"]
     assert fetch_calls == []
     assert service.requests == []
+
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_fails_for_failed_empty_story_artifact():
+    service = _FakeJiraService()
+    breakdown = {
+        "error": {
+            "code": "moonspec-breakdown.imperative-input",
+            "message": (
+                "Imperative input: provide the underlying declarative design or "
+                "explicitly confirm imperative input"
+            ),
+        },
+        "stories": [],
+    }
+
+    async def artifact_reader(ref: str) -> bytes:
+        assert ref == "art_failed_story_breakdown"
+        return json.dumps(breakdown).encode("utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="moonspec-breakdown\\.imperative-input",
+    ):
+        await create_jira_issues_from_stories(
+            {
+                "storyOutput": {
+                    "mode": "jira",
+                    "handoff": "artifact",
+                    "requiresStoryBreakdownArtifactRef": True,
+                    "fallback": "fail",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeName": "Story",
+                    },
+                },
+            },
+            {
+                "previousOutputs": {
+                    "storyOutput": {
+                        "storyBreakdownArtifactRef": "art_failed_story_breakdown",
+                    }
+                }
+            },
+            jira_service_factory=lambda: service,
+            artifact_reader=artifact_reader,
+        )
+    assert service.requests == []
+
 
 @pytest.mark.parametrize(
     ("payload", "expected"),

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -410,6 +410,38 @@ async def test_load_jira_preset_brief_resolves_existing_source_design_path(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_load_jira_preset_brief_resolves_single_path_without_worker_cwd_validation():
+    service = _FakeJiraService()
+    source_path = "docs/ExternalProject/DesiredState.md"
+    service.issue_responses["MM-941"] = {
+        "key": "MM-941",
+        "fields": {
+            "summary": f"Implement {source_path}",
+            "description": "Break the external repository design into work.",
+        },
+    }
+
+    result = await load_jira_preset_brief(
+        {"issueKey": "MM-941"},
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["resolvedSourceDesignPath"] == source_path
+    resolution = result.outputs["sourceResolution"]
+    assert resolution["status"] == "resolved"
+    assert resolution["selectedPath"] == source_path
+    assert resolution["candidatePaths"] == [
+        {
+            "path": source_path,
+            "sourceField": "jira.summary",
+            "sourceFields": ["jira.summary", "jira.presetBrief"],
+            "exists": None,
+        }
+    ]
+    assert "repository-root validation not run" in resolution["reason"]
+
+
+@pytest.mark.asyncio
 async def test_load_jira_preset_brief_reports_ambiguous_source_paths(tmp_path):
     first_path = "docs/ManagedAgents/ManagedRuntimeCleanup.md"
     second_path = "docs/ManagedAgents/ManagedAgentArchitecture.md"

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -449,6 +449,11 @@ def test_agent_request_includes_trusted_jira_previous_outputs_in_instruction_ref
                     "trustedSource": "moonmind.jira.get_issue",
                     "jiraIssueKey": "MM-657",
                     "jiraPresetBrief": "MM-657: Settings HTTP API surface",
+                    "resolvedSourceDesignPath": "docs/Designs/RuntimeTypes.md",
+                    "sourceResolution": {
+                        "status": "resolved",
+                        "selectedPath": "docs/Designs/RuntimeTypes.md",
+                    },
                     "jiraIssue": {"status": "In Progress"},
                 },
             },
@@ -462,6 +467,7 @@ def test_agent_request_includes_trusted_jira_previous_outputs_in_instruction_ref
     assert "MoonMind trusted previous step context:" in request.instruction_ref
     assert "moonmind.jira.get_issue" in request.instruction_ref
     assert "MM-657: Settings HTTP API surface" in request.instruction_ref
+    assert "docs/Designs/RuntimeTypes.md" in request.instruction_ref
     assert "Do not use provider-native Jira/Atlassian connectors" in request.instruction_ref
 
 


### PR DESCRIPTION
## What changed

- Added deterministic source-design path extraction to the trusted Jira preset brief loader.
- Carries `resolvedSourceDesignPath` and `sourceResolution` through trusted previous-step context into downstream agent steps.
- Updated Jira breakdown presets to prefer a resolved repo path before falling back to Jira prose, and to fail on ambiguous/invalid source resolution.
- Changed Jira issue creation to fail when an empty story breakdown artifact contains a breakdown error instead of reporting a successful zero-story no-op.

## Why

A Jira issue can reference a declarative document path in its summary or description. Previously, if `source_design_path` was empty, the workflow treated the whole Jira brief as inline text and could fail MoonSpec classification, then still complete with `no_downstream_tasks`. This makes the source selection explicit, auditable, and harder to silently misinterpret.

## Validation

- `python3 -m py_compile moonmind/workflows/temporal/story_output_tools.py moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/workflows/run.py`
- `.venv/bin/python -m pytest tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py tests/unit/api/test_presets_service.py -q --tb=short` passed: 184 passed, 1 pytest cache permission warning.

`./tools/test_unit.sh ...` could not reach pytest because `tools/check_removed_capability_semantics.py` hit `PermissionError` on root-owned `deploy/state/desired-state.json`.