### PR TITLE
MM-948 Run separate dry-run workspace janitor

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1240,6 +1240,27 @@ async def ensure_managed_session_reconcile_schedule_started() -> None:
         schedule_id,
     )
 
+async def ensure_managed_runtime_workspace_cleanup_schedule_started() -> None:
+    """Best-effort startup install for the disabled retained-state janitor schedule."""
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    try:
+        schedule_id = (
+            await TemporalClientAdapter().ensure_managed_runtime_workspace_cleanup_schedule(
+                enabled=False
+            )
+        )
+    except Exception:
+        logger.warning(
+            "Failed to ensure managed runtime workspace cleanup schedule during API startup",
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "Ensured managed runtime workspace cleanup schedule during API startup: %s",
+        schedule_id,
+    )
+
 async def ensure_recurring_workflow_schedules_reconciled() -> None:
     """Best-effort repair for persisted recurring workflow Temporal schedules."""
     from api_service.db.base import get_async_session_context
@@ -1431,6 +1452,7 @@ async def startup_event():
     # Wait for the Temporal client to be available and initialize provider profile managers
     await ensure_provider_profile_managers_started()
     await ensure_managed_session_reconcile_schedule_started()
+    await ensure_managed_runtime_workspace_cleanup_schedule_started()
     await ensure_recurring_workflow_schedules_reconciled()
     logger.info("Application startup events completed.")
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1241,13 +1241,13 @@ async def ensure_managed_session_reconcile_schedule_started() -> None:
     )
 
 async def ensure_managed_runtime_workspace_cleanup_schedule_started() -> None:
-    """Best-effort startup install for the disabled retained-state janitor schedule."""
+    """Best-effort startup install for the retained-state janitor schedule."""
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     try:
         schedule_id = (
             await TemporalClientAdapter().ensure_managed_runtime_workspace_cleanup_schedule(
-                enabled=False
+                enabled=None
             )
         )
     except Exception:

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1086,6 +1086,16 @@ def build_default_activity_catalog(
             heartbeat_required=True,
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.cleanup_managed_runtime_files",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 1800, heartbeat_timeout_seconds=30),
+            retries=_activity_retries(max_attempts=1, max_interval_seconds=60),
+            heartbeat_required=True,
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.status",
             family="agent_runtime",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1307,6 +1307,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "agent_runtime",
         "agent_runtime_reconcile_managed_sessions",
     ),
+    "agent_runtime.cleanup_managed_runtime_files": (
+        "agent_runtime",
+        "agent_runtime_cleanup_managed_runtime_files",
+    ),
     "agent_runtime.status": ("agent_runtime", "agent_runtime_status"),
     "agent_runtime.fetch_result": ("agent_runtime", "agent_runtime_fetch_result"),
     "agent_runtime.cancel": ("agent_runtime", "agent_runtime_cancel"),
@@ -8366,6 +8370,24 @@ class TemporalAgentRuntimeActivities:
             "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,
             "orphanVolumeReapSkippedRecent": orphan_volume_reap_skipped_recent,
         }
+
+    async def agent_runtime_cleanup_managed_runtime_files(
+        self,
+        payload: Mapping[str, Any] | None = None,
+        /,
+    ) -> dict[str, Any]:
+        del payload
+        from moonmind.workflows.temporal.runtime.managed_runtime_cleanup import (
+            ManagedRuntimeWorkspaceJanitor,
+        )
+
+        result = await _await_with_activity_heartbeats(
+            asyncio.to_thread(ManagedRuntimeWorkspaceJanitor().run),
+            heartbeat_payload={
+                "activityType": "agent_runtime.cleanup_managed_runtime_files",
+            },
+        )
+        return result.as_dict()
 
     @staticmethod
     def _agent_runtime_request_identifiers(

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -52,6 +52,12 @@ MANAGED_SESSION_RECONCILE_SCHEDULE_ID = "mm-operational:managed-session-reconcil
 MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE = (
     "mm-operational:managed-session-reconcile:{{.ScheduleTime}}"
 )
+MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID = (
+    "mm-operational:managed-runtime-workspace-cleanup"
+)
+MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE = (
+    "mm-operational:managed-runtime-workspace-cleanup:{{.ScheduleTime}}"
+)
 ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
 
 def _is_rpc_status(exc: BaseException, status_name: str) -> bool:
@@ -636,6 +642,91 @@ class TemporalClientAdapter:
         except Exception as create_exc:
             raise ScheduleOperationError(
                 "Failed to create managed session reconcile schedule: "
+                f"{create_exc}"
+            ) from create_exc
+
+    async def ensure_managed_runtime_workspace_cleanup_schedule(
+        self,
+        *,
+        cron_expression: str = "0 3 * * *",
+        timezone: str = "UTC",
+        enabled: bool = False,
+    ) -> str:
+        """Create or replace the retained managed-runtime cleanup Schedule."""
+
+        from temporalio.client import (
+            Schedule,
+            ScheduleActionStartWorkflow,
+            ScheduleUpdate,
+        )
+
+        from moonmind.workflows.temporal.schedule_errors import ScheduleOperationError
+        from moonmind.workflows.temporal.schedule_mapping import (
+            build_schedule_policy,
+            build_schedule_spec,
+            build_schedule_state,
+        )
+
+        client = await self.get_client()
+        schedule = Schedule(
+            action=ScheduleActionStartWorkflow(
+                "MoonMind.ManagedRuntimeWorkspaceCleanup",
+                {},
+                id=MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
+                task_queue=self._get_task_queue(),
+                typed_search_attributes=_build_typed_search_attributes(
+                    {
+                        "mm_entry": ["operational"],
+                        "mm_state": ["scheduled"],
+                    }
+                ),
+                static_summary="Managed runtime workspace cleanup",
+                static_details=(
+                    "Recurring dry-run retained-state janitor for managed runtime files"
+                ),
+            ),
+            spec=build_schedule_spec(
+                cron=cron_expression,
+                timezone=timezone,
+                jitter_seconds=0,
+            ),
+            policy=build_schedule_policy(
+                overlap_mode="skip",
+                catchup_mode="last",
+            ),
+            state=build_schedule_state(
+                enabled=enabled,
+                note="Managed runtime retained-state workspace cleanup",
+            ),
+        )
+        try:
+            handle = client.get_schedule_handle(
+                MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+            )
+
+            async def _replace_schedule(input: Any) -> ScheduleUpdate:  # noqa: A002
+                del input
+                return ScheduleUpdate(schedule=schedule)
+
+            await handle.update(_replace_schedule)
+            return MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        except Exception as update_exc:
+            if not _is_rpc_status(update_exc, "NOT_FOUND") and "not found" not in str(
+                update_exc
+            ).lower():
+                raise ScheduleOperationError(
+                    "Failed to update managed runtime workspace cleanup schedule: "
+                    f"{update_exc}"
+                ) from update_exc
+        try:
+            handle = await client.create_schedule(
+                MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID,
+                schedule,
+            )
+            return handle.id
+        except Exception as create_exc:
+            raise ScheduleOperationError(
+                "Failed to create managed runtime workspace cleanup schedule: "
                 f"{create_exc}"
             ) from create_exc
 

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -650,9 +650,13 @@ class TemporalClientAdapter:
         *,
         cron_expression: str = "0 3 * * *",
         timezone: str = "UTC",
-        enabled: bool = False,
+        enabled: bool | None = False,
     ) -> str:
-        """Create or replace the retained managed-runtime cleanup Schedule."""
+        """Create or replace the retained managed-runtime cleanup Schedule.
+
+        Pass ``enabled=None`` to preserve an existing schedule's paused state
+        while still creating a missing schedule as disabled.
+        """
 
         from temporalio.client import (
             Schedule,
@@ -668,36 +672,41 @@ class TemporalClientAdapter:
         )
 
         client = await self.get_client()
-        schedule = Schedule(
-            action=ScheduleActionStartWorkflow(
-                "MoonMind.ManagedRuntimeWorkspaceCleanup",
-                {},
-                id=MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
-                task_queue=self._get_task_queue(),
-                typed_search_attributes=_build_typed_search_attributes(
-                    {
-                        "mm_entry": ["operational"],
-                        "mm_state": ["scheduled"],
-                    }
+        def _build_schedule(*, schedule_enabled: bool) -> Schedule:
+            return Schedule(
+                action=ScheduleActionStartWorkflow(
+                    "MoonMind.ManagedRuntimeWorkspaceCleanup",
+                    {},
+                    id=MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
+                    task_queue=self._get_task_queue(),
+                    typed_search_attributes=_build_typed_search_attributes(
+                        {
+                            "mm_entry": ["operational"],
+                            "mm_state": ["scheduled"],
+                        }
+                    ),
+                    static_summary="Managed runtime workspace cleanup",
+                    static_details=(
+                        "Recurring dry-run retained-state janitor for managed runtime files"
+                    ),
                 ),
-                static_summary="Managed runtime workspace cleanup",
-                static_details=(
-                    "Recurring dry-run retained-state janitor for managed runtime files"
+                spec=build_schedule_spec(
+                    cron=cron_expression,
+                    timezone=timezone,
+                    jitter_seconds=0,
                 ),
-            ),
-            spec=build_schedule_spec(
-                cron=cron_expression,
-                timezone=timezone,
-                jitter_seconds=0,
-            ),
-            policy=build_schedule_policy(
-                overlap_mode="skip",
-                catchup_mode="last",
-            ),
-            state=build_schedule_state(
-                enabled=enabled,
-                note="Managed runtime retained-state workspace cleanup",
-            ),
+                policy=build_schedule_policy(
+                    overlap_mode="skip",
+                    catchup_mode="last",
+                ),
+                state=build_schedule_state(
+                    enabled=schedule_enabled,
+                    note="Managed runtime retained-state workspace cleanup",
+                ),
+            )
+
+        schedule = _build_schedule(
+            schedule_enabled=False if enabled is None else enabled
         )
         try:
             handle = client.get_schedule_handle(
@@ -705,8 +714,18 @@ class TemporalClientAdapter:
             )
 
             async def _replace_schedule(input: Any) -> ScheduleUpdate:  # noqa: A002
-                del input
-                return ScheduleUpdate(schedule=schedule)
+                schedule_enabled = enabled
+                if schedule_enabled is None:
+                    existing_schedule = input.description.schedule
+                    existing_paused = (
+                        existing_schedule.state.paused
+                        if existing_schedule.state
+                        else True
+                    )
+                    schedule_enabled = not existing_paused
+                return ScheduleUpdate(
+                    schedule=_build_schedule(schedule_enabled=schedule_enabled)
+                )
 
             await handle.update(_replace_schedule)
             return MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID

--- a/moonmind/workflows/temporal/runtime/managed_runtime_cleanup.py
+++ b/moonmind/workflows/temporal/runtime/managed_runtime_cleanup.py
@@ -1,0 +1,439 @@
+"""Retained-state cleanup for managed-runtime local files."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from moonmind.schemas.agent_runtime_models import (
+    TERMINAL_AGENT_RUN_STATES,
+    ManagedRunRecord,
+)
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    TERMINAL_MANAGED_SESSION_STATUSES,
+    ManagedSessionStore,
+)
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return max(0, int(raw))
+
+
+def _optional_int_env(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return None
+    return max(0, int(raw))
+
+
+@dataclass(frozen=True)
+class ManagedRuntimeCleanupConfig:
+    enabled: bool
+    dry_run: bool
+    workspace_retention: timedelta
+    artifact_retention: timedelta
+    record_retention: timedelta | None
+    grace: timedelta
+    max_delete_paths: int
+    store_root: Path
+    artifact_root: Path
+
+    @classmethod
+    def from_env(cls) -> "ManagedRuntimeCleanupConfig":
+        store_root = Path(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+        ).resolve()
+        return cls(
+            enabled=_bool_env("MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED", False),
+            dry_run=_bool_env("MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN", True),
+            workspace_retention=timedelta(
+                days=_int_env("MOONMIND_MANAGED_RUNTIME_WORKSPACE_RETENTION_DAYS", 30)
+            ),
+            artifact_retention=timedelta(
+                days=_int_env("MOONMIND_MANAGED_RUNTIME_ARTIFACT_RETENTION_DAYS", 90)
+            ),
+            record_retention=(
+                timedelta(days=record_days)
+                if (
+                    record_days := _optional_int_env(
+                        "MOONMIND_MANAGED_RUNTIME_RECORD_RETENTION_DAYS"
+                    )
+                )
+                is not None
+                else None
+            ),
+            grace=timedelta(
+                seconds=_int_env("MOONMIND_MANAGED_RUNTIME_JANITOR_GRACE_SECONDS", 3600)
+            ),
+            max_delete_paths=_int_env(
+                "MOONMIND_MANAGED_RUNTIME_JANITOR_MAX_DELETE_PATHS", 25
+            ),
+            store_root=store_root,
+            artifact_root=managed_runtime_artifact_root().resolve(),
+        )
+
+
+@dataclass
+class ManagedRuntimeCleanupResult:
+    disabled: bool
+    dry_run: bool
+    scanned_run_records: int = 0
+    scanned_session_records: int = 0
+    scanned_workspace_roots: int = 0
+    scanned_artifact_dirs: int = 0
+    protected_roots: int = 0
+    eligible_roots: int = 0
+    deleted_roots: int = 0
+    deleted_artifact_dirs: int = 0
+    deleted_record_files: int = 0
+    estimated_deleted_bytes: int = 0
+    skipped_active: int = 0
+    skipped_recent: int = 0
+    skipped_unsafe_path: int = 0
+    skipped_ambiguous_owner: int = 0
+    errors: tuple[str, ...] = ()
+
+    def add_error(self, message: str) -> None:
+        self.errors = (*self.errors, message)
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class ManagedRuntimeWorkspaceJanitor:
+    """Scan and optionally delete retained managed-runtime state."""
+
+    def __init__(
+        self,
+        config: ManagedRuntimeCleanupConfig | None = None,
+        *,
+        run_store: ManagedRunStore | None = None,
+        session_store: ManagedSessionStore | None = None,
+    ) -> None:
+        self._config = config or ManagedRuntimeCleanupConfig.from_env()
+        self._run_store = run_store or ManagedRunStore(
+            self._config.store_root / "managed_runs"
+        )
+        self._session_store = session_store or ManagedSessionStore(
+            self._config.store_root / "managed_sessions"
+        )
+
+    def run(self) -> ManagedRuntimeCleanupResult:
+        cfg = self._config
+        result = ManagedRuntimeCleanupResult(
+            disabled=not cfg.enabled,
+            dry_run=cfg.dry_run,
+        )
+        if not cfg.enabled:
+            return result
+
+        now = datetime.now(UTC)
+        try:
+            run_records = list(self._run_store.iter_all())
+            session_records = list(self._session_store.iter_all())
+        except Exception as exc:
+            result.add_error(f"store_read_failed:{type(exc).__name__}")
+            return result
+
+        result.scanned_run_records = len(run_records)
+        result.scanned_session_records = len(session_records)
+
+        owner_records = self._records_by_workspace_root(run_records, session_records)
+        artifact_refs = self._referenced_artifact_dir_names(run_records, session_records)
+
+        for path in self._workspace_candidates():
+            result.scanned_workspace_roots += 1
+            self._classify_workspace_candidate(
+                path,
+                owner_records.get(path.resolve(), ()),
+                now,
+                result,
+            )
+
+        for path in self._artifact_candidates():
+            result.scanned_artifact_dirs += 1
+            if path.name in artifact_refs:
+                result.protected_roots += 1
+                continue
+            self._classify_filesystem_candidate(
+                path,
+                now,
+                cfg.artifact_retention,
+                result,
+                artifact=True,
+            )
+
+        if cfg.record_retention is not None:
+            self._delete_old_records(run_records, session_records, now, result)
+
+        return result
+
+    def _workspace_candidates(self) -> list[Path]:
+        cfg = self._config
+        roots: list[Path] = []
+        workspaces_root = cfg.store_root / "workspaces"
+        if workspaces_root.exists():
+            roots.extend(path for path in workspaces_root.iterdir() if path.is_dir())
+        if cfg.store_root.exists():
+            reserved = {"artifacts", "managed_runs", "managed_sessions", "workspaces"}
+            roots.extend(
+                path
+                for path in cfg.store_root.iterdir()
+                if path.is_dir()
+                and path.name not in reserved
+                and not path.name.startswith(".")
+            )
+        return sorted({path.resolve() for path in roots})
+
+    def _artifact_candidates(self) -> list[Path]:
+        artifact_root = self._config.artifact_root
+        if not artifact_root.exists():
+            return []
+        return sorted(path.resolve() for path in artifact_root.iterdir() if path.is_dir())
+
+    def _records_by_workspace_root(
+        self,
+        run_records: list[ManagedRunRecord],
+        session_records: list[object],
+    ) -> dict[Path, tuple[object, ...]]:
+        grouped: dict[Path, list[object]] = {}
+        for record in run_records:
+            if record.workspace_path:
+                root = self._ownership_root(Path(record.workspace_path))
+                if root is not None:
+                    grouped.setdefault(root, []).append(record)
+        for record in session_records:
+            for raw_path in (
+                getattr(record, "workspace_path", None),
+                getattr(record, "session_workspace_path", None),
+            ):
+                if raw_path:
+                    root = self._ownership_root(Path(str(raw_path)))
+                    if root is not None:
+                        grouped.setdefault(root, []).append(record)
+        return {root: tuple(records) for root, records in grouped.items()}
+
+    def _ownership_root(self, path: Path) -> Path | None:
+        cfg = self._config
+        try:
+            resolved = path.resolve()
+            workspaces_root = (cfg.store_root / "workspaces").resolve()
+            if resolved.is_relative_to(workspaces_root):
+                relative = resolved.relative_to(workspaces_root)
+                if relative.parts:
+                    return (workspaces_root / relative.parts[0]).resolve()
+            if resolved.is_relative_to(cfg.store_root):
+                relative = resolved.relative_to(cfg.store_root)
+                if relative.parts and relative.parts[0] not in {
+                    "artifacts",
+                    "managed_runs",
+                    "managed_sessions",
+                    "workspaces",
+                }:
+                    return (cfg.store_root / relative.parts[0]).resolve()
+        except (OSError, ValueError):
+            return None
+        return None
+
+    def _referenced_artifact_dir_names(
+        self,
+        run_records: list[ManagedRunRecord],
+        session_records: list[object],
+    ) -> set[str]:
+        names: set[str] = set()
+        for record in (*run_records, *session_records):
+            for attr in (
+                "log_artifact_ref",
+                "stdout_artifact_ref",
+                "stderr_artifact_ref",
+                "merged_log_artifact_ref",
+                "diagnostics_ref",
+                "observability_events_ref",
+                "latest_summary_ref",
+                "latest_checkpoint_ref",
+                "latest_control_event_ref",
+                "latest_reset_boundary_ref",
+            ):
+                value = getattr(record, attr, None)
+                if isinstance(value, str) and value.strip():
+                    names.add(Path(value).parts[0])
+        return names
+
+    def _classify_workspace_candidate(
+        self,
+        path: Path,
+        owners: tuple[object, ...],
+        now: datetime,
+        result: ManagedRuntimeCleanupResult,
+    ) -> None:
+        if not owners:
+            result.skipped_ambiguous_owner += 1
+            return
+        if any(self._record_is_active(owner) for owner in owners):
+            result.protected_roots += 1
+            result.skipped_active += 1
+            return
+        newest = max(self._record_activity_time(owner) for owner in owners)
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+            newest = max(newest, mtime)
+        except OSError:
+            result.add_error(f"stat_failed:{path.name}")
+            return
+        if now - newest < max(self._config.workspace_retention, self._config.grace):
+            result.protected_roots += 1
+            result.skipped_recent += 1
+            return
+        self._delete_candidate(path, result, artifact=False)
+
+    def _classify_filesystem_candidate(
+        self,
+        path: Path,
+        now: datetime,
+        retention: timedelta,
+        result: ManagedRuntimeCleanupResult,
+        *,
+        artifact: bool,
+    ) -> None:
+        if not self._path_allowed(path, artifact=artifact):
+            result.skipped_unsafe_path += 1
+            return
+        if path.is_symlink():
+            result.skipped_unsafe_path += 1
+            return
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+        except OSError:
+            result.add_error(f"stat_failed:{path.name}")
+            return
+        if now - mtime < max(retention, self._config.grace):
+            result.protected_roots += 1
+            result.skipped_recent += 1
+            return
+        self._delete_candidate(path, result, artifact=artifact)
+
+    def _delete_candidate(
+        self,
+        path: Path,
+        result: ManagedRuntimeCleanupResult,
+        *,
+        artifact: bool,
+    ) -> None:
+        if not self._path_allowed(path, artifact=artifact) or path.is_symlink():
+            result.skipped_unsafe_path += 1
+            return
+        result.eligible_roots += 1
+        result.estimated_deleted_bytes += self._estimate_size(path)
+        if (
+            result.deleted_roots + result.deleted_artifact_dirs
+            >= self._config.max_delete_paths
+        ):
+            result.skipped_recent += 1
+            return
+        if self._config.dry_run:
+            return
+        quarantine = path.with_name(f".gc-{uuid.uuid4().hex}-{path.name}")
+        try:
+            path.rename(quarantine)
+            shutil.rmtree(quarantine)
+        except Exception as exc:
+            result.add_error(f"delete_failed:{path.name}:{type(exc).__name__}")
+            return
+        if artifact:
+            result.deleted_artifact_dirs += 1
+        else:
+            result.deleted_roots += 1
+
+    def _delete_old_records(
+        self,
+        run_records: list[ManagedRunRecord],
+        session_records: list[object],
+        now: datetime,
+        result: ManagedRuntimeCleanupResult,
+    ) -> None:
+        assert self._config.record_retention is not None
+        cutoff = max(self._config.record_retention, self._config.grace)
+        if self._config.dry_run:
+            return
+        for record in run_records:
+            if (
+                self._record_is_active(record)
+                or now - self._record_activity_time(record) < cutoff
+            ):
+                continue
+            self._run_store.delete(record.run_id)
+            result.deleted_record_files += 1
+        for record in session_records:
+            if (
+                self._record_is_active(record)
+                or now - self._record_activity_time(record) < cutoff
+            ):
+                continue
+            self._session_store.delete(str(getattr(record, "session_id")))
+            result.deleted_record_files += 1
+
+    def _path_allowed(self, path: Path, *, artifact: bool) -> bool:
+        try:
+            resolved = path.resolve()
+            if artifact:
+                return resolved.parent == self._config.artifact_root
+            workspaces_root = (self._config.store_root / "workspaces").resolve()
+            if resolved.parent == workspaces_root:
+                return True
+            return resolved.parent == self._config.store_root and resolved.name not in {
+                "artifacts",
+                "managed_runs",
+                "managed_sessions",
+                "workspaces",
+            }
+        except OSError:
+            return False
+
+    def _record_is_active(self, record: object) -> bool:
+        if getattr(record, "active_turn_id", None):
+            return True
+        status = str(getattr(record, "status", "")).lower()
+        if isinstance(record, ManagedRunRecord):
+            return status not in TERMINAL_AGENT_RUN_STATES
+        return status not in TERMINAL_MANAGED_SESSION_STATUSES
+
+    def _record_activity_time(self, record: object) -> datetime:
+        for attr in (
+            "finished_at",
+            "last_heartbeat_at",
+            "last_log_at",
+            "updated_at",
+            "started_at",
+        ):
+            value = getattr(record, attr, None)
+            if isinstance(value, datetime):
+                return value if value.tzinfo else value.replace(tzinfo=UTC)
+        return datetime.now(UTC)
+
+    def _estimate_size(self, path: Path) -> int:
+        if path.is_file():
+            return path.stat().st_size
+        total = 0
+        for child in path.rglob("*"):
+            try:
+                if child.is_file() and not child.is_symlink():
+                    total += child.stat().st_size
+            except OSError:
+                continue
+        return total

--- a/moonmind/workflows/temporal/runtime/managed_session_store.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_store.py
@@ -90,6 +90,14 @@ class ManagedSessionStore:
             return updated
 
     def list_active(self) -> list[CodexManagedSessionRecord]:
+        return [
+            record
+            for record in self.iter_all()
+            if record.status not in TERMINAL_MANAGED_SESSION_STATUSES
+        ]
+
+    def iter_all(self) -> list[CodexManagedSessionRecord]:
+        """Return all readable session records, including terminal records."""
         self.store_root.mkdir(parents=True, exist_ok=True)
         records: list[CodexManagedSessionRecord] = []
         for path in self.store_root.glob("*.json"):
@@ -98,6 +106,13 @@ class ManagedSessionStore:
                 record = CodexManagedSessionRecord(**data)
             except (json.JSONDecodeError, ValueError):
                 continue
-            if record.status not in TERMINAL_MANAGED_SESSION_STATUSES:
-                records.append(record)
+            records.append(record)
         return records
+
+    def delete(self, session_id: str) -> None:
+        """Delete one session record by explicit session id."""
+        path = self._resolve_path(session_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return

--- a/moonmind/workflows/temporal/runtime/store.py
+++ b/moonmind/workflows/temporal/runtime/store.py
@@ -89,17 +89,30 @@ class ManagedRunStore:
 
     def list_active(self) -> list[ManagedRunRecord]:
         """Return all non-terminal run records."""
+        return [
+            record
+            for record in self.iter_all()
+            if record.status not in TERMINAL_AGENT_RUN_STATES
+        ]
+
+    def iter_all(self) -> Iterable[ManagedRunRecord]:
+        """Yield all readable run records, including terminal records."""
         self.store_root.mkdir(parents=True, exist_ok=True)
-        records: list[ManagedRunRecord] = []
         for path in self.store_root.glob("*.json"):
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 record = ManagedRunRecord(**data)
-                if record.status not in TERMINAL_AGENT_RUN_STATES:
-                    records.append(record)
             except (json.JSONDecodeError, ValueError):
                 continue
-        return records
+            yield record
+
+    def delete(self, run_id: str) -> None:
+        """Delete one run record by explicit run id."""
+        path = self._resolve_path(run_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
 
     def find_latest_for_workflow(self, workflow_id: str) -> ManagedRunRecord | None:
         """Return the newest managed run bound to one logical workflow.

--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -19,6 +19,9 @@ from moonmind.workflows.temporal.workflows.agent_session import (
 from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
     MoonMindManagedSessionReconcileWorkflow,
 )
+from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
+    MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
+)
 from moonmind.workflows.temporal.workflows.oauth_session import (
     MoonMindOAuthSessionWorkflow,
 )
@@ -52,6 +55,7 @@ async def main():
                 MoonMindProviderProfileManagerWorkflow,
                 MoonMindAgentSessionWorkflow,
                 MoonMindManagedSessionReconcileWorkflow,
+                MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
                 MoonMindAgentRun,
                 MoonMindOAuthSessionWorkflow,
                 MoonMindMergeAutomationWorkflow,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -106,6 +106,9 @@ from moonmind.workflows.temporal.workflows.agent_session import (
 from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
     MoonMindManagedSessionReconcileWorkflow as MoonMindManagedSessionReconcile,
 )
+from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
+    MoonMindManagedRuntimeWorkspaceCleanupWorkflow as MoonMindManagedRuntimeWorkspaceCleanup,
+)
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     resolve_adapter_metadata,
@@ -2452,6 +2455,7 @@ async def main_async() -> None:
             MoonMindProviderProfileManager,
             MoonMindAgentSession,
             MoonMindManagedSessionReconcile,
+            MoonMindManagedRuntimeWorkspaceCleanup,
             MoonMindAgentRun,
             MoonMindOAuthSession,
             MoonMindMergeAutomation,

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -120,6 +120,7 @@ STATIC_TEMPORAL_WORKFLOW_TYPES = (
     "MoonMind.ProviderProfileManager",
     "MoonMind.AgentSession",
     "MoonMind.ManagedSessionReconcile",
+    "MoonMind.ManagedRuntimeWorkspaceCleanup",
     "MoonMind.AgentRun",
     "MoonMind.OAuthSession",
     "MoonMind.MergeAutomation",

--- a/moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py
+++ b/moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from moonmind.workflows.temporal.activity_catalog import (
+        build_default_activity_catalog,
+    )
+
+DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
+
+
+@workflow.defn(name="MoonMind.ManagedRuntimeWorkspaceCleanup")
+class MoonMindManagedRuntimeWorkspaceCleanupWorkflow:
+    @workflow.run
+    async def run(self, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        del payload
+        workflow.set_current_details("Cleaning retained managed runtime files")
+        workflow.upsert_search_attributes(
+            {
+                "SessionStatus": ["cleanup"],
+                "IsDegraded": [False],
+            }
+        )
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "agent_runtime.cleanup_managed_runtime_files"
+        )
+        try:
+            result = await workflow.execute_activity(
+                "agent_runtime.cleanup_managed_runtime_files",
+                {},
+                task_queue=route.task_queue,
+                start_to_close_timeout=timedelta(
+                    seconds=route.timeouts.start_to_close_seconds
+                ),
+                schedule_to_close_timeout=timedelta(
+                    seconds=route.timeouts.schedule_to_close_seconds
+                ),
+                heartbeat_timeout=timedelta(
+                    seconds=route.timeouts.heartbeat_timeout_seconds or 30
+                ),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=5),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(
+                        seconds=route.retries.max_interval_seconds
+                    ),
+                    maximum_attempts=route.retries.max_attempts,
+                    non_retryable_error_types=list(
+                        route.retries.non_retryable_error_codes
+                    ),
+                ),
+                summary="Clean retained managed runtime files",
+            )
+        except Exception:
+            workflow.set_current_details("Managed runtime file cleanup failed")
+            workflow.upsert_search_attributes(
+                {
+                    "SessionStatus": ["failed"],
+                    "IsDegraded": [True],
+                }
+            )
+            raise
+        normalized = result or {}
+        workflow.set_current_details("Managed runtime file cleanup complete")
+        workflow.upsert_search_attributes(
+            {
+                "SessionStatus": ["completed"],
+                "IsDegraded": [bool(normalized.get("errors"))],
+            }
+        )
+        return normalized

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -58,16 +58,16 @@ async def test_mm870_api_startup_schedule_failure_is_best_effort(
 
 
 @pytest.mark.asyncio
-async def test_mm948_api_startup_ensures_workspace_cleanup_schedule_disabled(
+async def test_mm948_api_startup_preserves_workspace_cleanup_schedule_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[bool] = []
+    calls: list[bool | None] = []
 
     class _Adapter:
         async def ensure_managed_runtime_workspace_cleanup_schedule(
             self,
             *,
-            enabled: bool,
+            enabled: bool | None,
         ) -> str:
             calls.append(enabled)
             return "mm-operational:managed-runtime-workspace-cleanup"
@@ -79,7 +79,7 @@ async def test_mm948_api_startup_ensures_workspace_cleanup_schedule_disabled(
 
     await api_main.ensure_managed_runtime_workspace_cleanup_schedule_started()
 
-    assert calls == [False]
+    assert calls == [None]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -55,3 +55,53 @@ async def test_mm870_api_startup_schedule_failure_is_best_effort(
         await api_main.ensure_managed_session_reconcile_schedule_started()
 
     assert "Failed to ensure managed session reconcile schedule" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mm948_api_startup_ensures_workspace_cleanup_schedule_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+
+    class _Adapter:
+        async def ensure_managed_runtime_workspace_cleanup_schedule(
+            self,
+            *,
+            enabled: bool,
+        ) -> str:
+            calls.append(enabled)
+            return "mm-operational:managed-runtime-workspace-cleanup"
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        _Adapter,
+    )
+
+    await api_main.ensure_managed_runtime_workspace_cleanup_schedule_started()
+
+    assert calls == [False]
+
+
+@pytest.mark.asyncio
+async def test_mm948_api_startup_cleanup_schedule_failure_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _Adapter:
+        async def ensure_managed_runtime_workspace_cleanup_schedule(
+            self,
+            *,
+            enabled: bool,
+        ) -> str:
+            del enabled
+            raise RuntimeError("temporal unavailable")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        _Adapter,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await api_main.ensure_managed_runtime_workspace_cleanup_schedule_started()
+
+    assert "Failed to ensure managed runtime workspace cleanup schedule" in caplog.text

--- a/tests/unit/services/temporal/runtime/test_managed_runtime_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_managed_runtime_cleanup.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.managed_runtime_cleanup import (
+    ManagedRuntimeCleanupConfig,
+    ManagedRuntimeWorkspaceJanitor,
+)
+from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+def _old_time() -> datetime:
+    return datetime.now(tz=UTC) - timedelta(days=120)
+
+
+def _run_record(run_id: str, workspace_path: str, status: str = "completed") -> ManagedRunRecord:
+    return ManagedRunRecord(
+        runId=run_id,
+        workflowId="mm:wf-1",
+        agentId="agent-1",
+        runtimeId="codex-cli",
+        status=status,
+        startedAt=_old_time(),
+        finishedAt=_old_time(),
+        workspacePath=workspace_path,
+    )
+
+
+def _session_record(
+    session_id: str,
+    workspace_path: str,
+    session_workspace_path: str,
+    artifact_spool_path: str,
+    status: str = "terminated",
+) -> CodexManagedSessionRecord:
+    return CodexManagedSessionRecord(
+        sessionId=session_id,
+        sessionEpoch=1,
+        agentRunId="run-1",
+        containerId=f"ctr-{session_id}",
+        threadId=f"thread-{session_id}",
+        runtimeId="codex_cli",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl=f"docker-exec://{session_id}",
+        status=status,
+        workspacePath=workspace_path,
+        sessionWorkspacePath=session_workspace_path,
+        artifactSpoolPath=artifact_spool_path,
+        startedAt=_old_time(),
+        updatedAt=_old_time(),
+    )
+
+
+def _config(tmp_path, *, enabled: bool = True, dry_run: bool = True) -> ManagedRuntimeCleanupConfig:
+    return ManagedRuntimeCleanupConfig(
+        enabled=enabled,
+        dry_run=dry_run,
+        workspace_retention=timedelta(days=30),
+        artifact_retention=timedelta(days=90),
+        record_retention=None,
+        grace=timedelta(seconds=0),
+        max_delete_paths=25,
+        store_root=tmp_path,
+        artifact_root=tmp_path / "artifacts",
+    )
+
+
+def test_mm948_janitor_defaults_to_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED", raising=False)
+    monkeypatch.delenv("MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN", raising=False)
+
+    config = ManagedRuntimeCleanupConfig.from_env()
+
+    assert config.enabled is False
+    assert config.dry_run is True
+
+
+def test_mm948_dry_run_reports_old_terminal_workspace_without_deleting(tmp_path) -> None:
+    workspace_root = tmp_path / "workspaces" / "mm:wf-1"
+    repo = workspace_root / "repo"
+    repo.mkdir(parents=True)
+    (repo / "README.md").write_text("old checkout", encoding="utf-8")
+    old_ts = (_old_time()).timestamp()
+    os.utime(workspace_root, (old_ts, old_ts))
+
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(_run_record("run-1", str(repo)))
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        _config(tmp_path, enabled=True, dry_run=True),
+        run_store=run_store,
+        session_store=ManagedSessionStore(tmp_path / "managed_sessions"),
+    )
+
+    result = janitor.run()
+
+    assert result.disabled is False
+    assert result.dry_run is True
+    assert result.scanned_run_records == 1
+    assert result.scanned_workspace_roots == 1
+    assert result.eligible_roots == 1
+    assert result.deleted_roots == 0
+    assert workspace_root.exists()
+
+
+def test_mm948_delete_requires_enabled_and_non_dry_run_terminal_owners(tmp_path) -> None:
+    run_root = tmp_path / "run-1"
+    repo = run_root / "repo"
+    repo.mkdir(parents=True)
+    (repo / "README.md").write_text("old checkout", encoding="utf-8")
+    old_ts = (_old_time()).timestamp()
+    os.utime(run_root, (old_ts, old_ts))
+
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(_run_record("run-1", str(repo)))
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        _config(tmp_path, enabled=True, dry_run=False),
+        run_store=run_store,
+        session_store=ManagedSessionStore(tmp_path / "managed_sessions"),
+    )
+
+    result = janitor.run()
+
+    assert result.eligible_roots == 1
+    assert result.deleted_roots == 1
+    assert not run_root.exists()
+
+
+def test_mm948_active_owner_protects_workspace(tmp_path) -> None:
+    run_root = tmp_path / "run-1"
+    repo = run_root / "repo"
+    repo.mkdir(parents=True)
+
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(_run_record("run-1", str(repo), status="running"))
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        _config(tmp_path, enabled=True, dry_run=False),
+        run_store=run_store,
+        session_store=ManagedSessionStore(tmp_path / "managed_sessions"),
+    )
+
+    result = janitor.run()
+
+    assert result.skipped_active == 1
+    assert result.deleted_roots == 0
+    assert run_root.exists()
+
+
+def test_mm948_artifact_scan_uses_normalized_artifacts_child_not_agent_jobs_glob(
+    tmp_path,
+) -> None:
+    artifact_dir = tmp_path / "artifacts" / "artifact-job"
+    artifact_dir.mkdir(parents=True)
+    unsafe_sibling = tmp_path / "artifact-job"
+    unsafe_sibling.mkdir()
+    old_ts = (_old_time()).timestamp()
+    os.utime(artifact_dir, (old_ts, old_ts))
+    os.utime(unsafe_sibling, (old_ts, old_ts))
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        _config(tmp_path, enabled=True, dry_run=True),
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        session_store=ManagedSessionStore(tmp_path / "managed_sessions"),
+    )
+
+    result = janitor.run()
+
+    assert result.scanned_artifact_dirs == 1
+    assert result.eligible_roots == 1
+    assert result.scanned_workspace_roots == 1
+    assert result.skipped_ambiguous_owner == 1
+    assert artifact_dir.exists()
+    assert unsafe_sibling.exists()

--- a/tests/unit/services/temporal/runtime/test_managed_session_store.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_store.py
@@ -76,3 +76,24 @@ async def test_store_update_revalidates_and_normalizes_mutations(tmp_path) -> No
     assert updated.runtime_id == "codex_cli"
     assert updated.error_message == "temporary failure"
     assert updated.updated_at == datetime(2026, 4, 6, 12, 6, tzinfo=UTC)
+
+def test_iter_all_and_delete_are_explicit_retained_state_apis(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    store.save(_record())
+    store.save(
+        _record().model_copy(
+            update={
+                "session_id": "sess-2",
+                "agent_run_id": "task-2",
+                "status": "terminated",
+            }
+        )
+    )
+
+    assert {record.session_id for record in store.iter_all()} == {"sess-1", "sess-2"}
+    assert {record.session_id for record in store.list_active()} == {"sess-1"}
+
+    store.delete("sess-2")
+
+    assert store.load("sess-2") is None
+    assert {record.session_id for record in store.iter_all()} == {"sess-1"}

--- a/tests/unit/services/temporal/runtime/test_store.py
+++ b/tests/unit/services/temporal/runtime/test_store.py
@@ -72,6 +72,18 @@ def test_list_active(tmp_path):
     active_ids = {r.run_id for r in active}
     assert active_ids == {"run-1", "run-3"}
 
+def test_iter_all_and_delete_are_explicit_retained_state_apis(tmp_path):
+    store = ManagedRunStore(tmp_path)
+    store.save(_make_record("run-1", "running"))
+    store.save(_make_record("run-2", "completed"))
+
+    assert {record.run_id for record in store.iter_all()} == {"run-1", "run-2"}
+
+    store.delete("run-2")
+
+    assert store.load("run-2") is None
+    assert {record.run_id for record in store.iter_all()} == {"run-1"}
+
 def test_find_latest_for_workflow_prefers_newest_active_run(tmp_path):
     store = ManagedRunStore(tmp_path)
     started_at = datetime.now(tz=UTC)

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4741,6 +4741,7 @@ async def test_build_activity_bindings_resolves_agent_runtime_fleet(
             assert "agent_runtime.terminate_session" in bound_types
             assert "agent_runtime.fetch_session_summary" in bound_types
             assert "agent_runtime.publish_session_artifacts" in bound_types
+            assert "agent_runtime.cleanup_managed_runtime_files" in bound_types
             assert "agent_runtime.status" in bound_types
             assert "agent_runtime.fetch_result" in bound_types
             assert "agent_runtime.cancel" in bound_types

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -291,6 +291,35 @@ class TestManagedRuntimeWorkspaceCleanupSchedule:
         assert update.schedule.state.paused is False
 
     @pytest.mark.asyncio
+    async def test_mm948_preserves_existing_cleanup_schedule_enabled_state(
+        self,
+    ) -> None:
+        mock_existing_handle = _mock_schedule_handle()
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle.return_value = mock_existing_handle
+        mock_client.create_schedule = AsyncMock()
+        existing_schedule = MagicMock()
+        existing_schedule.state.paused = False
+
+        adapter = _make_adapter(mock_client)
+        result = await adapter.ensure_managed_runtime_workspace_cleanup_schedule(
+            enabled=None
+        )
+
+        assert result == MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        mock_existing_handle.update.assert_awaited_once()
+        mock_client.create_schedule.assert_not_awaited()
+        updater = mock_existing_handle.update.call_args[0][0]
+        update = await updater(
+            SimpleNamespace(
+                description=SimpleNamespace(schedule=existing_schedule),
+            )
+        )
+        assert isinstance(update, ScheduleUpdate)
+        assert update.schedule.action.workflow == "MoonMind.ManagedRuntimeWorkspaceCleanup"
+        assert update.schedule.state.paused is False
+
+    @pytest.mark.asyncio
     async def test_jitter_passed_through(self) -> None:
         mock_handle = MagicMock()
         mock_handle.id = _SCHEDULE_ID

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -17,6 +17,8 @@ from temporalio.client import ScheduleOverlapPolicy, ScheduleUpdate
 from temporalio.common import SearchAttributeKey
 
 from moonmind.workflows.temporal.client import (
+    MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID,
+    MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
     MANAGED_SESSION_RECONCILE_SCHEDULE_ID,
     MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE,
     ScheduleTriggerResult,
@@ -236,6 +238,57 @@ class TestManagedSessionReconcileSchedule:
         update = await updater(MagicMock())
         assert isinstance(update, ScheduleUpdate)
         assert update.schedule.action.workflow == "MoonMind.ManagedSessionReconcile"
+
+
+class TestManagedRuntimeWorkspaceCleanupSchedule:
+    @pytest.mark.asyncio
+    async def test_mm948_creates_disabled_cleanup_schedule_by_default(self) -> None:
+        mock_created_handle = MagicMock()
+        mock_created_handle.id = MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        mock_existing_handle = _mock_schedule_handle(
+            describe_side_effect=Exception("not found")
+        )
+        mock_existing_handle.update = AsyncMock(side_effect=Exception("not found"))
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle.return_value = mock_existing_handle
+        mock_client.create_schedule = AsyncMock(return_value=mock_created_handle)
+
+        adapter = _make_adapter(mock_client)
+        result = await adapter.ensure_managed_runtime_workspace_cleanup_schedule()
+
+        assert result == MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        schedule_id, schedule = mock_client.create_schedule.call_args[0]
+        assert schedule_id == MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        assert schedule.action.workflow == "MoonMind.ManagedRuntimeWorkspaceCleanup"
+        assert schedule.action.id == (
+            MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE
+        )
+        assert schedule.action.task_queue == "mm.workflow"
+        assert schedule.action.static_summary == "Managed runtime workspace cleanup"
+        assert schedule.spec.cron_expressions == ["0 3 * * *"]
+        assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
+        assert schedule.state.paused is True
+
+    @pytest.mark.asyncio
+    async def test_mm948_updates_existing_cleanup_schedule(self) -> None:
+        mock_existing_handle = _mock_schedule_handle()
+        mock_client = MagicMock()
+        mock_client.get_schedule_handle.return_value = mock_existing_handle
+        mock_client.create_schedule = AsyncMock()
+
+        adapter = _make_adapter(mock_client)
+        result = await adapter.ensure_managed_runtime_workspace_cleanup_schedule(
+            enabled=True
+        )
+
+        assert result == MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
+        mock_existing_handle.update.assert_awaited_once()
+        mock_client.create_schedule.assert_not_awaited()
+        updater = mock_existing_handle.update.call_args[0][0]
+        update = await updater(MagicMock())
+        assert isinstance(update, ScheduleUpdate)
+        assert update.schedule.action.workflow == "MoonMind.ManagedRuntimeWorkspaceCleanup"
+        assert update.schedule.state.paused is False
 
     @pytest.mark.asyncio
     async def test_jitter_passed_through(self) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3436,12 +3436,16 @@ async def test_main_async_workflow_fleet(
     from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
         MoonMindManagedSessionReconcileWorkflow,
     )
+    from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
+        MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
+    )
     assert kwargs["workflows"] == [
         MoonMindUserWorkflow,
         MoonMindManifestIngest,
         MoonMindProviderProfileManagerWorkflow,
         MoonMindAgentSessionWorkflow,
         MoonMindManagedSessionReconcileWorkflow,
+        MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
         MoonMindAgentRun,
         MoonMindOAuthSession,
         MoonMindMergeAutomationWorkflow,

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -100,6 +100,7 @@ def test_registered_workflow_types_include_manifest_ingest():
         "MoonMind.ProviderProfileManager",
         "MoonMind.AgentSession",
         "MoonMind.ManagedSessionReconcile",
+        "MoonMind.ManagedRuntimeWorkspaceCleanup",
         "MoonMind.AgentRun",
         "MoonMind.OAuthSession",
         "MoonMind.MergeAutomation",
@@ -275,6 +276,11 @@ def test_build_worker_activity_bindings_registers_workload_run_on_agent_runtime_
                 for binding in bindings
                 if binding.activity_type == "agent_runtime.reconcile_managed_sessions"
             ]
+            cleanup_bindings = [
+                binding
+                for binding in bindings
+                if binding.activity_type == "agent_runtime.cleanup_managed_runtime_files"
+            ]
             oauth_runner_bindings = [
                 binding
                 for binding in bindings
@@ -282,6 +288,7 @@ def test_build_worker_activity_bindings_registers_workload_run_on_agent_runtime_
             ]
             assert len(workload_bindings) == 1
             assert len(reconcile_bindings) == 1
+            assert len(cleanup_bindings) == 1
             assert len(oauth_runner_bindings) == 1
             assert (
                 workload_bindings[0].task_queue
@@ -289,6 +296,10 @@ def test_build_worker_activity_bindings_registers_workload_run_on_agent_runtime_
             )
             assert (
                 reconcile_bindings[0].task_queue
+                == settings.temporal.activity_agent_runtime_task_queue
+            )
+            assert (
+                cleanup_bindings[0].task_queue
                 == settings.temporal.activity_agent_runtime_task_queue
             )
             assert (

--- a/tests/unit/workflows/temporal/workflows/test_managed_runtime_workspace_cleanup.py
+++ b/tests/unit/workflows/temporal/workflows/test_managed_runtime_workspace_cleanup.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal.workflows import (
+    managed_runtime_workspace_cleanup as cleanup_module,
+)
+from moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup import (
+    MoonMindManagedRuntimeWorkspaceCleanupWorkflow,
+)
+
+
+@pytest.mark.asyncio
+async def test_managed_runtime_workspace_cleanup_invokes_cleanup_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    details: list[str] = []
+    search_attributes: list[dict[str, list[object]]] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        assert activity_name == "agent_runtime.cleanup_managed_runtime_files"
+        assert payload == {}
+        assert kwargs["task_queue"]
+        return {
+            "disabled": False,
+            "dry_run": True,
+            "scanned_run_records": 2,
+            "scanned_session_records": 1,
+            "eligible_roots": 1,
+            "deleted_roots": 0,
+            "errors": (),
+        }
+
+    monkeypatch.setattr(
+        cleanup_module.workflow,
+        "set_current_details",
+        lambda value: details.append(value),
+    )
+    monkeypatch.setattr(
+        cleanup_module.workflow,
+        "upsert_search_attributes",
+        lambda value: search_attributes.append(value),
+    )
+    monkeypatch.setattr(
+        cleanup_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    result = await MoonMindManagedRuntimeWorkspaceCleanupWorkflow().run()
+
+    assert result["dry_run"] is True
+    assert result["eligible_roots"] == 1
+    assert details == [
+        "Cleaning retained managed runtime files",
+        "Managed runtime file cleanup complete",
+    ]
+    assert search_attributes == [
+        {
+            "SessionStatus": ["cleanup"],
+            "IsDegraded": [False],
+        },
+        {
+            "SessionStatus": ["completed"],
+            "IsDegraded": [False],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_managed_runtime_workspace_cleanup_marks_errors_degraded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_attributes: list[dict[str, list[object]]] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        del activity_name, payload, kwargs
+        return {
+            "disabled": False,
+            "dry_run": True,
+            "errors": ("store_read_failed:RuntimeError",),
+        }
+
+    monkeypatch.setattr(
+        cleanup_module.workflow, "set_current_details", lambda value: None
+    )
+    monkeypatch.setattr(
+        cleanup_module.workflow,
+        "upsert_search_attributes",
+        lambda value: search_attributes.append(value),
+    )
+    monkeypatch.setattr(
+        cleanup_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    result = await MoonMindManagedRuntimeWorkspaceCleanupWorkflow().run()
+
+    assert result["errors"] == ("store_read_failed:RuntimeError",)
+    assert search_attributes[-1] == {
+        "SessionStatus": ["completed"],
+        "IsDegraded": [True],
+    }


### PR DESCRIPTION
Issue reference
- MM-948: Run a separate dry-run workspace janitor

Summary
- Adds a separate managed runtime workspace cleanup workflow and activity surface for retained-state janitor runs.
- Adds dry-run/disabled-by-default cleanup behavior, canonical root constrained candidate discovery, and artifact root normalization safeguards.
- Adds all-record iteration and explicit deletion APIs for managed run and session stores, plus worker/client/schedule registration and unit coverage.

Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_runtime_cleanup.py tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_store.py tests/unit/workflows/temporal/workflows/test_managed_runtime_workspace_cleanup.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_client_schedules.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_temporal_workers.py tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
- Result: 287 Python tests passed; UI phase reported 29 files passed, 510 passed, 236 skipped.

Remaining risks
- Integration/compose-backed cleanup behavior was not run in this step; verification is limited to the targeted unit and UI suites selected for the changed runtime and workflow surfaces.