### PR TITLE
MM-949: Classify managed runtime cleanup eligibility

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1086,6 +1086,16 @@ def build_default_activity_catalog(
             heartbeat_required=True,
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.cleanup_managed_runtime_files",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(300, 900, heartbeat_timeout_seconds=30),
+            retries=_activity_retries(max_attempts=1, max_interval_seconds=60),
+            heartbeat_required=True,
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.status",
             family="agent_runtime",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8464,11 +8464,15 @@ class TemporalAgentRuntimeActivities:
             docker_reference_provider=(
                 None if docker_state is None else lambda: docker_state
             ),
-            progress_callback=lambda progress: temporal_activity.heartbeat(
-                {
-                    "activityType": "agent_runtime.cleanup_managed_runtime_files",
-                    **dict(progress),
-                }
+            progress_callback=(
+                lambda progress: temporal_activity.heartbeat(
+                    {
+                        "activityType": "agent_runtime.cleanup_managed_runtime_files",
+                        **dict(progress),
+                    }
+                )
+                if temporal_activity.in_activity()
+                else None
             ),
         )
         return result.to_dict()

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1007,6 +1007,9 @@ class ManagedSessionController(Protocol):
     async def reap_orphan_session_containers(self) -> Any:
         pass
 
+    async def collect_managed_runtime_cleanup_docker_references(self) -> Any:
+        pass
+
 def _managed_runtime_artifact_root() -> Path:
     return managed_runtime_artifact_root()
 
@@ -8377,6 +8380,7 @@ class TemporalAgentRuntimeActivities:
         /,
     ) -> dict[str, Any]:
         from moonmind.workflows.temporal.runtime.cleanup import (
+            DockerReferenceState,
             ManagedRuntimeCleanupConfig,
             cleanup_managed_runtime_files,
         )
@@ -8440,10 +8444,29 @@ class TemporalAgentRuntimeActivities:
                 artifact_root=Path(config_payload.get("artifactRoot", config.artifact_root)),
             )
         session_store = ManagedSessionStore(config.runtime_store_root / "managed_sessions")
+        docker_state: DockerReferenceState | Mapping[str, object] | None = None
+        if self._session_controller is not None and hasattr(
+            self._session_controller,
+            "collect_managed_runtime_cleanup_docker_references",
+        ):
+            docker_state = await _await_with_activity_heartbeats(
+                self._session_controller.collect_managed_runtime_cleanup_docker_references(),
+                heartbeat_payload={
+                    "activityType": "agent_runtime.cleanup_managed_runtime_files",
+                },
+            )
+        elif not config.dry_run:
+            docker_state = DockerReferenceState(
+                failed=True,
+                reason="docker reference scan unavailable",
+            )
         result = cleanup_managed_runtime_files(
             run_store=self._run_store,
             session_store=session_store,
             config=config,
+            docker_reference_provider=(
+                None if docker_state is None else lambda: docker_state
+            ),
         )
         return result.to_dict()
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8392,9 +8392,6 @@ class TemporalAgentRuntimeActivities:
             raise TemporalActivityRuntimeError(
                 "run_store is required for agent_runtime.cleanup_managed_runtime_files"
             )
-        runtime_root = Path(
-            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
-        )
         config = ManagedRuntimeCleanupConfig.from_env()
         if isinstance(payload, Mapping) and isinstance(payload.get("config"), Mapping):
             config_payload = payload["config"]
@@ -8466,6 +8463,12 @@ class TemporalAgentRuntimeActivities:
             config=config,
             docker_reference_provider=(
                 None if docker_state is None else lambda: docker_state
+            ),
+            progress_callback=lambda progress: temporal_activity.heartbeat(
+                {
+                    "activityType": "agent_runtime.cleanup_managed_runtime_files",
+                    **dict(progress),
+                }
             ),
         )
         return result.to_dict()

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -21,7 +21,7 @@ import tempfile
 import time
 import tarfile
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
@@ -1306,6 +1306,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "agent_runtime.reconcile_managed_sessions": (
         "agent_runtime",
         "agent_runtime_reconcile_managed_sessions",
+    ),
+    "agent_runtime.cleanup_managed_runtime_files": (
+        "agent_runtime",
+        "agent_runtime_cleanup_managed_runtime_files",
     ),
     "agent_runtime.status": ("agent_runtime", "agent_runtime_status"),
     "agent_runtime.fetch_result": ("agent_runtime", "agent_runtime_fetch_result"),
@@ -8366,6 +8370,82 @@ class TemporalAgentRuntimeActivities:
             "orphanVolumeReapSkippedActive": orphan_volume_reap_skipped_active,
             "orphanVolumeReapSkippedRecent": orphan_volume_reap_skipped_recent,
         }
+
+    async def agent_runtime_cleanup_managed_runtime_files(
+        self,
+        payload: Mapping[str, Any] | None = None,
+        /,
+    ) -> dict[str, Any]:
+        from moonmind.workflows.temporal.runtime.cleanup import (
+            ManagedRuntimeCleanupConfig,
+            cleanup_managed_runtime_files,
+        )
+        from moonmind.workflows.temporal.runtime.managed_session_store import (
+            ManagedSessionStore,
+        )
+
+        if self._run_store is None:
+            raise TemporalActivityRuntimeError(
+                "run_store is required for agent_runtime.cleanup_managed_runtime_files"
+            )
+        runtime_root = Path(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+        )
+        config = ManagedRuntimeCleanupConfig.from_env()
+        if isinstance(payload, Mapping) and isinstance(payload.get("config"), Mapping):
+            config_payload = payload["config"]
+            config = ManagedRuntimeCleanupConfig(
+                enabled=bool(config_payload.get("enabled", config.enabled)),
+                dry_run=bool(config_payload.get("dryRun", config.dry_run)),
+                workspace_retention=timedelta(
+                    days=int(
+                        config_payload.get(
+                            "workspaceRetentionDays",
+                            config.workspace_retention.days,
+                        )
+                    )
+                ),
+                artifact_retention=timedelta(
+                    days=int(
+                        config_payload.get(
+                            "artifactRetentionDays",
+                            config.artifact_retention.days,
+                        )
+                    )
+                ),
+                record_retention=(
+                    None
+                    if config_payload.get("recordRetentionDays") is None
+                    else timedelta(days=int(config_payload["recordRetentionDays"]))
+                ),
+                grace=timedelta(
+                    seconds=int(
+                        config_payload.get(
+                            "graceSeconds", config.grace.total_seconds()
+                        )
+                    )
+                ),
+                max_delete_paths=int(
+                    config_payload.get("maxDeletePaths", config.max_delete_paths)
+                ),
+                max_delete_bytes=(
+                    None
+                    if config_payload.get("maxDeleteBytes") is None
+                    else int(config_payload["maxDeleteBytes"])
+                ),
+                lock_path=Path(config_payload.get("lockPath", config.lock_path)),
+                runtime_store_root=Path(
+                    config_payload.get("runtimeStoreRoot", config.runtime_store_root)
+                ),
+                artifact_root=Path(config_payload.get("artifactRoot", config.artifact_root)),
+            )
+        session_store = ManagedSessionStore(config.runtime_store_root / "managed_sessions")
+        result = cleanup_managed_runtime_files(
+            run_store=self._run_store,
+            session_store=session_store,
+            config=config,
+        )
+        return result.to_dict()
 
     @staticmethod
     def _agent_runtime_request_identifiers(

--- a/moonmind/workflows/temporal/runtime/cleanup.py
+++ b/moonmind/workflows/temporal/runtime/cleanup.py
@@ -6,7 +6,6 @@ Implements MM-949 from source issue MM-940.
 from __future__ import annotations
 
 import os
-import shutil
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -216,6 +215,7 @@ class DockerReferenceState:
 
 
 DockerReferenceProvider = Callable[[], DockerReferenceState | Mapping[str, object]]
+CleanupProgressCallback = Callable[[Mapping[str, object]], None]
 
 
 class ManagedRuntimeWorkspaceJanitor:
@@ -228,12 +228,14 @@ class ManagedRuntimeWorkspaceJanitor:
         session_store: ManagedSessionStore,
         config: ManagedRuntimeCleanupConfig | None = None,
         docker_reference_provider: DockerReferenceProvider | None = None,
+        progress_callback: CleanupProgressCallback | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._run_store = run_store
         self._session_store = session_store
         self._config = config or ManagedRuntimeCleanupConfig.from_env()
         self._docker_reference_provider = docker_reference_provider
+        self._progress_callback = progress_callback
         self._now = now or (lambda: datetime.now(tz=UTC))
 
     def run(self) -> ManagedRuntimeCleanupResult:
@@ -281,16 +283,18 @@ class ManagedRuntimeWorkspaceJanitor:
             errors.append(docker_state.reason or "docker_reference_scan_failed")
         candidates = self._build_candidates(run_records, session_records)
         budget = _CleanupBudget()
-        decisions = tuple(
-            self._classify_candidate(
-                candidate,
-                docker_state=docker_state,
-                budget=budget,
+        decisions: list[ManagedRuntimeCleanupDecision] = []
+        for index, candidate in enumerate(candidates):
+            self._emit_progress("classify", candidate, index=index, total=len(candidates))
+            decisions.append(
+                self._classify_candidate(
+                    candidate,
+                    docker_state=docker_state,
+                    budget=budget,
+                )
             )
-            for candidate in candidates
-        )
         return self._summarize(
-            decisions,
+            tuple(decisions),
             scanned_run_records=len(run_records),
             scanned_session_records=len(session_records),
             errors=tuple(errors),
@@ -478,6 +482,7 @@ class ManagedRuntimeWorkspaceJanitor:
             if relative.parts:
                 return workspaces_root / relative.parts[0]
         except (OSError, ValueError):
+            # Paths outside /workspaces fall through to the per-run root check.
             pass
         try:
             relative = path.absolute().relative_to(runtime_root.absolute())
@@ -489,6 +494,7 @@ class ManagedRuntimeWorkspaceJanitor:
             }:
                 return runtime_root / relative.parts[0]
         except (OSError, ValueError):
+            # Paths outside the runtime root have no cleanup ownership root.
             pass
         return None
 
@@ -568,7 +574,8 @@ class ManagedRuntimeWorkspaceJanitor:
                 return self._decision(
                     candidate, "protected_recent", "grace window has not elapsed", newest
                 )
-            estimated_bytes = _path_size(path)
+            self._emit_progress("size", candidate)
+            estimated_bytes = _path_size(path, progress_callback=self._progress_callback)
             if budget.deleted_paths >= self._config.max_delete_paths:
                 return self._decision(
                     candidate,
@@ -598,6 +605,7 @@ class ManagedRuntimeWorkspaceJanitor:
                     newest,
                     estimated_bytes,
                 )
+            self._emit_progress("delete", candidate)
             self._delete_candidate(candidate)
             budget.deleted_paths += 1
             budget.deleted_bytes += estimated_bytes
@@ -756,10 +764,15 @@ class ManagedRuntimeWorkspaceJanitor:
             )
         except (OSError, ValueError):
             return True
+        docker_state = self._docker_reference_state()
+        if docker_state.failed:
+            return True
         for fresh in current:
             if fresh.kind == candidate.kind and fresh.path == candidate.path:
-                return self._has_active_owner(fresh)
-        return False
+                return self._has_active_owner(fresh) or self._has_live_docker_reference(
+                    fresh, docker_state
+                )
+        return self._has_live_docker_reference(candidate, docker_state)
 
     def _delete_candidate(self, candidate: ManagedRuntimeCleanupCandidate) -> None:
         if candidate.kind == "run_record":
@@ -776,10 +789,28 @@ class ManagedRuntimeWorkspaceJanitor:
             f".gc-{uuid.uuid4().hex}-{candidate.path.name}"
         )
         candidate.path.rename(quarantine)
-        if quarantine.is_dir():
-            shutil.rmtree(quarantine)
-        else:
-            quarantine.unlink(missing_ok=True)
+        _delete_path(quarantine, progress_callback=self._progress_callback)
+
+    def _emit_progress(
+        self,
+        phase: str,
+        candidate: ManagedRuntimeCleanupCandidate,
+        *,
+        index: int | None = None,
+        total: int | None = None,
+    ) -> None:
+        if self._progress_callback is None:
+            return
+        payload: dict[str, object] = {
+            "phase": phase,
+            "kind": candidate.kind,
+            "path": str(candidate.path),
+        }
+        if index is not None:
+            payload["index"] = index
+        if total is not None:
+            payload["total"] = total
+        self._progress_callback(payload)
 
     def _summarize(
         self,
@@ -866,6 +897,7 @@ class _JanitorLock:
         try:
             self._path.unlink()
         except FileNotFoundError:
+            # Another cleanup path already removed the lock; exit remains successful.
             pass
 
 
@@ -875,6 +907,7 @@ def cleanup_managed_runtime_files(
     session_store: ManagedSessionStore,
     config: ManagedRuntimeCleanupConfig | None = None,
     docker_reference_provider: DockerReferenceProvider | None = None,
+    progress_callback: CleanupProgressCallback | None = None,
 ) -> ManagedRuntimeCleanupResult:
     """Run one managed-runtime retained cleanup pass."""
     return ManagedRuntimeWorkspaceJanitor(
@@ -882,6 +915,7 @@ def cleanup_managed_runtime_files(
         session_store=session_store,
         config=config,
         docker_reference_provider=docker_reference_provider,
+        progress_callback=progress_callback,
     ).run()
 
 
@@ -947,12 +981,18 @@ def _artifact_job_id(ref: str) -> str | None:
     return cleaned.split("/", 1)[0]
 
 
-def _path_size(path: Path) -> int:
+def _path_size(
+    path: Path,
+    *,
+    progress_callback: CleanupProgressCallback | None = None,
+) -> int:
     try:
         if path.is_file():
             return path.stat().st_size
         total = 0
         for child in path.rglob("*"):
+            if progress_callback is not None:
+                progress_callback({"phase": "size_walk", "path": str(child)})
             try:
                 if child.is_file():
                     total += child.stat().st_size
@@ -961,3 +1001,34 @@ def _path_size(path: Path) -> int:
         return total
     except OSError:
         return 0
+
+
+def _delete_path(
+    path: Path,
+    *,
+    progress_callback: CleanupProgressCallback | None = None,
+) -> None:
+    if not path.exists():
+        return
+    if path.is_file():
+        if progress_callback is not None:
+            progress_callback({"phase": "delete_path", "path": str(path)})
+        path.unlink(missing_ok=True)
+        return
+    if not path.is_dir():
+        path.unlink(missing_ok=True)
+        return
+    children = sorted(path.rglob("*"), key=lambda child: len(child.parts), reverse=True)
+    for child in children:
+        if progress_callback is not None:
+            progress_callback({"phase": "delete_path", "path": str(child)})
+        try:
+            if child.is_dir() and not child.is_symlink():
+                child.rmdir()
+            else:
+                child.unlink(missing_ok=True)
+        except FileNotFoundError:
+            continue
+    if progress_callback is not None:
+        progress_callback({"phase": "delete_path", "path": str(path)})
+    path.rmdir()

--- a/moonmind/workflows/temporal/runtime/cleanup.py
+++ b/moonmind/workflows/temporal/runtime/cleanup.py
@@ -1,0 +1,952 @@
+"""Retained-state managed runtime cleanup classification.
+
+Implements MM-949 from source issue MM-940.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import uuid
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+from moonmind.schemas.agent_runtime_models import (
+    ManagedRunRecord,
+    TERMINAL_AGENT_RUN_STATES,
+)
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    TERMINAL_MANAGED_SESSION_STATUSES,
+    ManagedSessionStore,
+)
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+ManagedRuntimeCandidateKind = Literal[
+    "workspace",
+    "artifact",
+    "run_record",
+    "session_record",
+]
+ManagedRuntimeCleanupClassification = Literal[
+    "protected_active",
+    "protected_recent",
+    "protected_shared",
+    "eligible",
+    "deleted",
+    "skipped_unsafe_path",
+    "skipped_ambiguous_owner",
+    "error",
+]
+
+_FALSEY = frozenset({"", "0", "false", "no", "off"})
+
+
+@dataclass(frozen=True)
+class ManagedRuntimeCleanupConfig:
+    enabled: bool = False
+    dry_run: bool = True
+    workspace_retention: timedelta = timedelta(days=30)
+    artifact_retention: timedelta = timedelta(days=90)
+    record_retention: timedelta | None = None
+    grace: timedelta = timedelta(hours=1)
+    max_delete_paths: int = 25
+    max_delete_bytes: int | None = None
+    lock_path: Path = Path("/work/agent_jobs/.janitor.lock")
+    runtime_store_root: Path = Path("/work/agent_jobs")
+    artifact_root: Path = Path("/work/agent_jobs/artifacts")
+
+    @classmethod
+    def from_env(
+        cls, env: Mapping[str, str] | None = None
+    ) -> "ManagedRuntimeCleanupConfig":
+        source = env or os.environ
+        runtime_store_root = Path(
+            source.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+            or "/work/agent_jobs"
+        )
+        artifact_root = managed_runtime_artifact_root()
+        if env is not None:
+            raw_artifact_root = source.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS")
+            if raw_artifact_root is not None:
+                artifact_root = Path(raw_artifact_root or str(runtime_store_root))
+                if artifact_root.name != "artifacts":
+                    artifact_root = artifact_root / "artifacts"
+        return cls(
+            enabled=_env_bool(
+                source, "MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED", False
+            ),
+            dry_run=_env_bool(
+                source, "MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN", True
+            ),
+            workspace_retention=timedelta(
+                days=_env_int(
+                    source, "MOONMIND_MANAGED_RUNTIME_WORKSPACE_RETENTION_DAYS", 30
+                )
+            ),
+            artifact_retention=timedelta(
+                days=_env_int(
+                    source, "MOONMIND_MANAGED_RUNTIME_ARTIFACT_RETENTION_DAYS", 90
+                )
+            ),
+            record_retention=_env_optional_days(
+                source, "MOONMIND_MANAGED_RUNTIME_RECORD_RETENTION_DAYS"
+            ),
+            grace=timedelta(
+                seconds=_env_int(
+                    source, "MOONMIND_MANAGED_RUNTIME_JANITOR_GRACE_SECONDS", 3600
+                )
+            ),
+            max_delete_paths=max(
+                0,
+                _env_int(
+                    source, "MOONMIND_MANAGED_RUNTIME_JANITOR_MAX_DELETE_PATHS", 25
+                ),
+            ),
+            max_delete_bytes=_env_optional_int(
+                source, "MOONMIND_MANAGED_RUNTIME_JANITOR_MAX_DELETE_BYTES"
+            ),
+            lock_path=Path(
+                source.get(
+                    "MOONMIND_MANAGED_RUNTIME_JANITOR_LOCK_PATH",
+                    str(runtime_store_root / ".janitor.lock"),
+                )
+            ),
+            runtime_store_root=runtime_store_root,
+            artifact_root=artifact_root,
+        )
+
+
+@dataclass(frozen=True)
+class ManagedRuntimeCleanupCandidate:
+    kind: ManagedRuntimeCandidateKind
+    path: Path
+    ownership_root: Path | None = None
+    run_records: tuple[ManagedRunRecord, ...] = ()
+    session_records: tuple[CodexManagedSessionRecord, ...] = ()
+
+
+@dataclass(frozen=True)
+class ManagedRuntimeCleanupDecision:
+    kind: ManagedRuntimeCandidateKind
+    path: str
+    ownership_root: str | None
+    classification: ManagedRuntimeCleanupClassification
+    reason: str
+    newest_activity_at: datetime | None = None
+    estimated_bytes: int = 0
+
+
+@dataclass(frozen=True)
+class ManagedRuntimeCleanupResult:
+    disabled: bool
+    dry_run: bool
+    scanned_run_records: int
+    scanned_session_records: int
+    scanned_workspace_roots: int
+    scanned_artifact_dirs: int
+    protected_roots: int
+    eligible_roots: int
+    deleted_roots: int
+    deleted_artifact_dirs: int
+    deleted_record_files: int
+    estimated_deleted_bytes: int
+    skipped_active: int
+    skipped_recent: int
+    skipped_unsafe_path: int
+    skipped_ambiguous_owner: int
+    errors: tuple[str, ...]
+    decisions: tuple[ManagedRuntimeCleanupDecision, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "disabled": self.disabled,
+            "dryRun": self.dry_run,
+            "scannedRunRecords": self.scanned_run_records,
+            "scannedSessionRecords": self.scanned_session_records,
+            "scannedWorkspaceRoots": self.scanned_workspace_roots,
+            "scannedArtifactDirs": self.scanned_artifact_dirs,
+            "protectedRoots": self.protected_roots,
+            "eligibleRoots": self.eligible_roots,
+            "deletedRoots": self.deleted_roots,
+            "deletedArtifactDirs": self.deleted_artifact_dirs,
+            "deletedRecordFiles": self.deleted_record_files,
+            "estimatedDeletedBytes": self.estimated_deleted_bytes,
+            "skippedActive": self.skipped_active,
+            "skippedRecent": self.skipped_recent,
+            "skippedUnsafePath": self.skipped_unsafe_path,
+            "skippedAmbiguousOwner": self.skipped_ambiguous_owner,
+            "errors": list(self.errors),
+            "decisions": [
+                {
+                    "kind": decision.kind,
+                    "path": decision.path,
+                    "ownershipRoot": decision.ownership_root,
+                    "classification": decision.classification,
+                    "reason": decision.reason,
+                    "newestActivityAt": (
+                        decision.newest_activity_at.isoformat()
+                        if decision.newest_activity_at
+                        else None
+                    ),
+                    "estimatedBytes": decision.estimated_bytes,
+                }
+                for decision in self.decisions
+            ],
+        }
+
+
+@dataclass
+class _CleanupBudget:
+    deleted_paths: int = 0
+    deleted_bytes: int = 0
+
+
+@dataclass(frozen=True)
+class DockerReferenceState:
+    active_container_refs: frozenset[str] = field(default_factory=frozenset)
+    active_mount_paths: frozenset[str] = field(default_factory=frozenset)
+    failed: bool = False
+    reason: str | None = None
+
+
+DockerReferenceProvider = Callable[[], DockerReferenceState | Mapping[str, object]]
+
+
+class ManagedRuntimeWorkspaceJanitor:
+    """Classify and optionally delete retained managed-runtime filesystem state."""
+
+    def __init__(
+        self,
+        *,
+        run_store: ManagedRunStore,
+        session_store: ManagedSessionStore,
+        config: ManagedRuntimeCleanupConfig | None = None,
+        docker_reference_provider: DockerReferenceProvider | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._run_store = run_store
+        self._session_store = session_store
+        self._config = config or ManagedRuntimeCleanupConfig.from_env()
+        self._docker_reference_provider = docker_reference_provider
+        self._now = now or (lambda: datetime.now(tz=UTC))
+
+    def run(self) -> ManagedRuntimeCleanupResult:
+        config = self._config
+        if not config.enabled:
+            return ManagedRuntimeCleanupResult(
+                disabled=True,
+                dry_run=config.dry_run,
+                scanned_run_records=len(tuple(self._run_store.iter_all())),
+                scanned_session_records=len(tuple(self._session_store.iter_all())),
+                scanned_workspace_roots=0,
+                scanned_artifact_dirs=0,
+                protected_roots=0,
+                eligible_roots=0,
+                deleted_roots=0,
+                deleted_artifact_dirs=0,
+                deleted_record_files=0,
+                estimated_deleted_bytes=0,
+                skipped_active=0,
+                skipped_recent=0,
+                skipped_unsafe_path=0,
+                skipped_ambiguous_owner=0,
+                errors=(),
+            )
+        with _JanitorLock(config.lock_path):
+            return self._run_enabled_pass()
+
+    def _run_enabled_pass(self) -> ManagedRuntimeCleanupResult:
+        errors: list[str] = []
+        try:
+            run_records = tuple(self._run_store.iter_all())
+            session_records = tuple(self._session_store.iter_all())
+        except OSError as exc:
+            return self._empty_enabled_error(f"unreadable_store: {exc}")
+        docker_state = self._docker_reference_state()
+        if docker_state.failed:
+            errors.append(docker_state.reason or "docker_reference_scan_failed")
+        candidates = self._build_candidates(run_records, session_records)
+        budget = _CleanupBudget()
+        decisions = tuple(
+            self._classify_candidate(
+                candidate,
+                docker_state=docker_state,
+                budget=budget,
+            )
+            for candidate in candidates
+        )
+        return self._summarize(
+            decisions,
+            scanned_run_records=len(run_records),
+            scanned_session_records=len(session_records),
+            errors=tuple(errors),
+        )
+
+    def _empty_enabled_error(self, error: str) -> ManagedRuntimeCleanupResult:
+        return ManagedRuntimeCleanupResult(
+            disabled=False,
+            dry_run=self._config.dry_run,
+            scanned_run_records=0,
+            scanned_session_records=0,
+            scanned_workspace_roots=0,
+            scanned_artifact_dirs=0,
+            protected_roots=0,
+            eligible_roots=0,
+            deleted_roots=0,
+            deleted_artifact_dirs=0,
+            deleted_record_files=0,
+            estimated_deleted_bytes=0,
+            skipped_active=0,
+            skipped_recent=0,
+            skipped_unsafe_path=0,
+            skipped_ambiguous_owner=0,
+            errors=(error,),
+        )
+
+    def _build_candidates(
+        self,
+        run_records: Sequence[ManagedRunRecord],
+        session_records: Sequence[CodexManagedSessionRecord],
+    ) -> tuple[ManagedRuntimeCleanupCandidate, ...]:
+        groups: dict[Path, dict[str, list[object]]] = defaultdict(
+            lambda: {"runs": [], "sessions": []}
+        )
+        ambiguous: list[ManagedRuntimeCleanupCandidate] = []
+        for record in run_records:
+            root = self._ownership_root_for_path(record.workspace_path)
+            if root is None:
+                if record.workspace_path:
+                    ambiguous.append(
+                        ManagedRuntimeCleanupCandidate(
+                            kind="workspace",
+                            path=Path(record.workspace_path),
+                            run_records=(record,),
+                        )
+                    )
+                continue
+            groups[root]["runs"].append(record)
+        for record in session_records:
+            roots = {
+                self._ownership_root_for_path(record.workspace_path),
+                self._ownership_root_for_path(record.session_workspace_path),
+            }
+            roots.discard(None)
+            if not roots:
+                ambiguous.append(
+                    ManagedRuntimeCleanupCandidate(
+                        kind="workspace",
+                        path=Path(record.workspace_path),
+                        session_records=(record,),
+                    )
+                )
+                continue
+            for root in roots:
+                assert root is not None
+                groups[root]["sessions"].append(record)
+        candidates = [
+            ManagedRuntimeCleanupCandidate(
+                kind="workspace",
+                path=root,
+                ownership_root=root,
+                run_records=tuple(values["runs"]),  # type: ignore[arg-type]
+                session_records=tuple(values["sessions"]),  # type: ignore[arg-type]
+            )
+            for root, values in sorted(groups.items(), key=lambda item: str(item[0]))
+        ]
+        known_roots = {candidate.path for candidate in candidates}
+        candidates.extend(self._workspace_path_candidates(known_roots))
+        candidates.extend(ambiguous)
+        candidates.extend(self._artifact_candidates(run_records, session_records))
+        candidates.extend(self._record_candidates(run_records, session_records))
+        return tuple(candidates)
+
+    def _workspace_path_candidates(
+        self, known_roots: set[Path]
+    ) -> list[ManagedRuntimeCleanupCandidate]:
+        runtime_root = self._config.runtime_store_root
+        candidates: list[ManagedRuntimeCleanupCandidate] = []
+        workspace_parent = runtime_root / "workspaces"
+        if workspace_parent.exists():
+            for path in sorted(child for child in workspace_parent.iterdir() if child.is_dir()):
+                if path not in known_roots:
+                    candidates.append(
+                        ManagedRuntimeCleanupCandidate(
+                            kind="workspace",
+                            path=path,
+                            ownership_root=path,
+                        )
+                    )
+        if runtime_root.exists():
+            reserved = {"artifacts", "managed_runs", "managed_sessions", "workspaces"}
+            for path in sorted(child for child in runtime_root.iterdir() if child.is_dir()):
+                if path.name in reserved or path in known_roots:
+                    continue
+                candidates.append(
+                    ManagedRuntimeCleanupCandidate(
+                        kind="workspace",
+                        path=path,
+                        ownership_root=path,
+                    )
+                )
+        return candidates
+
+    def _artifact_candidates(
+        self,
+        run_records: Sequence[ManagedRunRecord],
+        session_records: Sequence[CodexManagedSessionRecord],
+    ) -> list[ManagedRuntimeCleanupCandidate]:
+        refs_by_job: dict[str, dict[str, list[object]]] = defaultdict(
+            lambda: {"runs": [], "sessions": []}
+        )
+        for record in run_records:
+            for ref in _run_artifact_refs(record):
+                job = _artifact_job_id(ref)
+                if job:
+                    refs_by_job[job]["runs"].append(record)
+        for record in session_records:
+            for ref in record.published_artifact_refs():
+                job = _artifact_job_id(ref)
+                if job:
+                    refs_by_job[job]["sessions"].append(record)
+        candidates: list[ManagedRuntimeCleanupCandidate] = []
+        root = self._config.artifact_root
+        if root.exists():
+            for path in sorted(child for child in root.iterdir() if child.is_dir()):
+                values = refs_by_job.get(path.name, {"runs": [], "sessions": []})
+                candidates.append(
+                    ManagedRuntimeCleanupCandidate(
+                        kind="artifact",
+                        path=path,
+                        ownership_root=path,
+                        run_records=tuple(values["runs"]),  # type: ignore[arg-type]
+                        session_records=tuple(values["sessions"]),  # type: ignore[arg-type]
+                    )
+                )
+        return candidates
+
+    def _record_candidates(
+        self,
+        run_records: Sequence[ManagedRunRecord],
+        session_records: Sequence[CodexManagedSessionRecord],
+    ) -> list[ManagedRuntimeCleanupCandidate]:
+        if self._config.record_retention is None:
+            return []
+        runtime_root = self._config.runtime_store_root
+        return [
+            *(
+                ManagedRuntimeCleanupCandidate(
+                    kind="run_record",
+                    path=runtime_root / "managed_runs" / f"{record.run_id}.json",
+                    run_records=(record,),
+                )
+                for record in run_records
+            ),
+            *(
+                ManagedRuntimeCleanupCandidate(
+                    kind="session_record",
+                    path=runtime_root
+                    / "managed_sessions"
+                    / f"{record.session_id}.json",
+                    session_records=(record,),
+                )
+                for record in session_records
+            ),
+        ]
+
+    def _ownership_root_for_path(self, raw_path: str | None) -> Path | None:
+        if not raw_path:
+            return None
+        path = Path(raw_path)
+        runtime_root = self._config.runtime_store_root
+        workspaces_root = runtime_root / "workspaces"
+        try:
+            relative = path.absolute().relative_to(workspaces_root.absolute())
+            if relative.parts:
+                return workspaces_root / relative.parts[0]
+        except (OSError, ValueError):
+            pass
+        try:
+            relative = path.absolute().relative_to(runtime_root.absolute())
+            if relative.parts and relative.parts[0] not in {
+                "artifacts",
+                "managed_runs",
+                "managed_sessions",
+                "workspaces",
+            }:
+                return runtime_root / relative.parts[0]
+        except (OSError, ValueError):
+            pass
+        return None
+
+    def _classify_candidate(
+        self,
+        candidate: ManagedRuntimeCleanupCandidate,
+        *,
+        docker_state: DockerReferenceState,
+        budget: _CleanupBudget,
+    ) -> ManagedRuntimeCleanupDecision:
+        path = candidate.path
+        kind = candidate.kind
+        try:
+            if not self._path_allowed(kind, path):
+                return self._decision(candidate, "skipped_unsafe_path", "unsafe path")
+            if path.is_symlink():
+                return self._decision(
+                    candidate, "skipped_unsafe_path", "candidate path is a symlink"
+                )
+            if kind == "workspace" and candidate.ownership_root is None:
+                return self._decision(
+                    candidate,
+                    "skipped_ambiguous_owner",
+                    "ownership root could not be derived",
+                )
+            if (
+                kind == "workspace"
+                and not candidate.run_records
+                and not candidate.session_records
+            ):
+                return self._decision(
+                    candidate,
+                    "skipped_ambiguous_owner",
+                    "no durable owner records reference candidate",
+                )
+            if docker_state.failed:
+                return self._decision(
+                    candidate,
+                    "protected_active",
+                    docker_state.reason or "docker reference scan failed",
+                )
+            if self._has_active_owner(candidate):
+                classification: ManagedRuntimeCleanupClassification = (
+                    "protected_shared"
+                    if kind == "workspace"
+                    and len(candidate.run_records) + len(candidate.session_records) > 1
+                    else "protected_active"
+                )
+                return self._decision(
+                    candidate, classification, "active owner or active turn"
+                )
+            if self._has_live_docker_reference(candidate, docker_state):
+                return self._decision(
+                    candidate, "protected_active", "live Docker reference"
+                )
+            newest = self._newest_activity(candidate)
+            if newest is None:
+                return self._decision(
+                    candidate,
+                    "protected_recent",
+                    "missing owner and filesystem timestamps",
+                )
+            retention = self._retention_for(kind)
+            if retention is None:
+                return self._decision(
+                    candidate, "protected_recent", "record retention disabled", newest
+                )
+            age = self._now() - newest
+            if age < retention:
+                return self._decision(
+                    candidate,
+                    "protected_recent",
+                    "retention window has not elapsed",
+                    newest,
+                )
+            if age < self._config.grace:
+                return self._decision(
+                    candidate, "protected_recent", "grace window has not elapsed", newest
+                )
+            estimated_bytes = _path_size(path)
+            if budget.deleted_paths >= self._config.max_delete_paths:
+                return self._decision(
+                    candidate,
+                    "protected_recent",
+                    "delete path cap reached",
+                    newest,
+                    estimated_bytes,
+                )
+            max_bytes = self._config.max_delete_bytes
+            if max_bytes is not None and budget.deleted_bytes + estimated_bytes > max_bytes:
+                return self._decision(
+                    candidate,
+                    "protected_recent",
+                    "delete byte cap reached",
+                    newest,
+                    estimated_bytes,
+                )
+            if self._config.dry_run:
+                return self._decision(
+                    candidate, "eligible", "dry-run would delete", newest, estimated_bytes
+                )
+            if self._rescan_blocks_delete(candidate):
+                return self._decision(
+                    candidate,
+                    "protected_active",
+                    "failed rescan before delete",
+                    newest,
+                    estimated_bytes,
+                )
+            self._delete_candidate(candidate)
+            budget.deleted_paths += 1
+            budget.deleted_bytes += estimated_bytes
+            return self._decision(candidate, "deleted", "deleted", newest, estimated_bytes)
+        except OSError as exc:
+            return self._decision(candidate, "error", f"filesystem error: {exc}")
+
+    def _decision(
+        self,
+        candidate: ManagedRuntimeCleanupCandidate,
+        classification: ManagedRuntimeCleanupClassification,
+        reason: str,
+        newest: datetime | None = None,
+        estimated_bytes: int = 0,
+    ) -> ManagedRuntimeCleanupDecision:
+        return ManagedRuntimeCleanupDecision(
+            kind=candidate.kind,
+            path=str(candidate.path),
+            ownership_root=(
+                str(candidate.ownership_root) if candidate.ownership_root else None
+            ),
+            classification=classification,
+            reason=reason,
+            newest_activity_at=newest,
+            estimated_bytes=estimated_bytes,
+        )
+
+    def _path_allowed(self, kind: ManagedRuntimeCandidateKind, path: Path) -> bool:
+        roots = {
+            "workspace": (
+                self._config.runtime_store_root,
+                self._config.runtime_store_root / "workspaces",
+            ),
+            "artifact": (self._config.artifact_root,),
+            "run_record": (self._config.runtime_store_root / "managed_runs",),
+            "session_record": (self._config.runtime_store_root / "managed_sessions",),
+        }[kind]
+        try:
+            candidate = path.absolute()
+            return any(candidate.is_relative_to(root.absolute()) for root in roots)
+        except OSError:
+            return False
+
+    def _has_active_owner(self, candidate: ManagedRuntimeCleanupCandidate) -> bool:
+        return any(
+            record.status not in TERMINAL_AGENT_RUN_STATES or record.active_turn_id
+            for record in candidate.run_records
+        ) or any(
+            record.status not in TERMINAL_MANAGED_SESSION_STATUSES
+            or record.active_turn_id
+            for record in candidate.session_records
+        )
+
+    def _has_live_docker_reference(
+        self,
+        candidate: ManagedRuntimeCleanupCandidate,
+        docker_state: DockerReferenceState,
+    ) -> bool:
+        ids = set()
+        paths = {str(candidate.path)}
+        for record in candidate.run_records:
+            ids.update(
+                value
+                for value in (record.run_id, record.session_id, record.container_id)
+                if value
+            )
+            if record.workspace_path:
+                paths.add(str(record.workspace_path))
+        for record in candidate.session_records:
+            ids.update(
+                value
+                for value in (record.session_id, record.agent_run_id, record.container_id)
+                if value
+            )
+            paths.update(
+                (
+                    record.workspace_path,
+                    record.session_workspace_path,
+                    record.artifact_spool_path,
+                )
+            )
+        if ids.intersection(docker_state.active_container_refs):
+            return True
+        return any(
+            mount == path or mount.startswith(f"{path.rstrip('/')}/")
+            for mount in docker_state.active_mount_paths
+            for path in paths
+        )
+
+    def _newest_activity(
+        self, candidate: ManagedRuntimeCleanupCandidate
+    ) -> datetime | None:
+        timestamps: list[datetime] = []
+        for record in candidate.run_records:
+            timestamps.extend(
+                ts
+                for ts in (
+                    record.finished_at,
+                    record.last_heartbeat_at,
+                    record.last_log_at,
+                    record.started_at,
+                )
+                if ts is not None
+            )
+        for record in candidate.session_records:
+            timestamps.extend(
+                ts
+                for ts in (record.updated_at, record.last_log_at, record.started_at)
+                if ts is not None
+            )
+        try:
+            if candidate.path.exists():
+                timestamps.append(
+                    datetime.fromtimestamp(candidate.path.stat().st_mtime, tz=UTC)
+                )
+        except OSError:
+            return None
+        if not timestamps:
+            return None
+        return max(_ensure_aware(ts) for ts in timestamps)
+
+    def _retention_for(self, kind: ManagedRuntimeCandidateKind) -> timedelta | None:
+        if kind == "artifact":
+            return self._config.artifact_retention
+        if kind in {"run_record", "session_record"}:
+            return self._config.record_retention
+        return self._config.workspace_retention
+
+    def _docker_reference_state(self) -> DockerReferenceState:
+        if self._docker_reference_provider is None:
+            return DockerReferenceState()
+        try:
+            raw = self._docker_reference_provider()
+        except Exception as exc:
+            return DockerReferenceState(
+                failed=True, reason=f"docker reference scan failed: {exc}"
+            )
+        if isinstance(raw, DockerReferenceState):
+            return raw
+        return DockerReferenceState(
+            active_container_refs=frozenset(
+                str(v) for v in raw.get("activeContainerRefs", ()) or ()
+            ),
+            active_mount_paths=frozenset(
+                str(v) for v in raw.get("activeMountPaths", ()) or ()
+            ),
+            failed=bool(raw.get("failed", False)),
+            reason=str(raw.get("reason") or "") or None,
+        )
+
+    def _rescan_blocks_delete(self, candidate: ManagedRuntimeCleanupCandidate) -> bool:
+        current = self._build_candidates(
+            tuple(self._run_store.iter_all()),
+            tuple(self._session_store.iter_all()),
+        )
+        for fresh in current:
+            if fresh.kind == candidate.kind and fresh.path == candidate.path:
+                return self._has_active_owner(fresh)
+        return False
+
+    def _delete_candidate(self, candidate: ManagedRuntimeCleanupCandidate) -> None:
+        if candidate.kind == "run_record":
+            for record in candidate.run_records:
+                self._run_store.delete(record.run_id)
+            return
+        if candidate.kind == "session_record":
+            for record in candidate.session_records:
+                self._session_store.delete(record.session_id)
+            return
+        if not candidate.path.exists():
+            return
+        quarantine = candidate.path.with_name(
+            f".gc-{uuid.uuid4().hex}-{candidate.path.name}"
+        )
+        candidate.path.rename(quarantine)
+        if quarantine.is_dir():
+            shutil.rmtree(quarantine)
+        else:
+            quarantine.unlink(missing_ok=True)
+
+    def _summarize(
+        self,
+        decisions: Sequence[ManagedRuntimeCleanupDecision],
+        *,
+        scanned_run_records: int,
+        scanned_session_records: int,
+        errors: tuple[str, ...],
+    ) -> ManagedRuntimeCleanupResult:
+        all_errors = list(errors)
+        all_errors.extend(
+            f"{decision.path}: {decision.reason}"
+            for decision in decisions
+            if decision.classification == "error"
+        )
+        return ManagedRuntimeCleanupResult(
+            disabled=False,
+            dry_run=self._config.dry_run,
+            scanned_run_records=scanned_run_records,
+            scanned_session_records=scanned_session_records,
+            scanned_workspace_roots=sum(1 for d in decisions if d.kind == "workspace"),
+            scanned_artifact_dirs=sum(1 for d in decisions if d.kind == "artifact"),
+            protected_roots=sum(
+                1
+                for d in decisions
+                if d.kind == "workspace"
+                and d.classification
+                in {"protected_active", "protected_recent", "protected_shared"}
+            ),
+            eligible_roots=sum(1 for d in decisions if d.classification == "eligible"),
+            deleted_roots=sum(
+                1
+                for d in decisions
+                if d.kind == "workspace" and d.classification == "deleted"
+            ),
+            deleted_artifact_dirs=sum(
+                1
+                for d in decisions
+                if d.kind == "artifact" and d.classification == "deleted"
+            ),
+            deleted_record_files=sum(
+                1
+                for d in decisions
+                if d.kind in {"run_record", "session_record"}
+                and d.classification == "deleted"
+            ),
+            estimated_deleted_bytes=sum(
+                d.estimated_bytes for d in decisions if d.classification == "deleted"
+            ),
+            skipped_active=sum(
+                1
+                for d in decisions
+                if d.classification in {"protected_active", "protected_shared"}
+            ),
+            skipped_recent=sum(
+                1 for d in decisions if d.classification == "protected_recent"
+            ),
+            skipped_unsafe_path=sum(
+                1 for d in decisions if d.classification == "skipped_unsafe_path"
+            ),
+            skipped_ambiguous_owner=sum(
+                1 for d in decisions if d.classification == "skipped_ambiguous_owner"
+            ),
+            errors=tuple(all_errors),
+            decisions=tuple(decisions),
+        )
+
+
+class _JanitorLock:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._fd: int | None = None
+
+    def __enter__(self) -> "_JanitorLock":
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(self._fd, str(os.getpid()).encode("ascii"))
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+        try:
+            self._path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def cleanup_managed_runtime_files(
+    *,
+    run_store: ManagedRunStore,
+    session_store: ManagedSessionStore,
+    config: ManagedRuntimeCleanupConfig | None = None,
+    docker_reference_provider: DockerReferenceProvider | None = None,
+) -> ManagedRuntimeCleanupResult:
+    """Run one managed-runtime retained cleanup pass."""
+    return ManagedRuntimeWorkspaceJanitor(
+        run_store=run_store,
+        session_store=session_store,
+        config=config,
+        docker_reference_provider=docker_reference_provider,
+    ).run()
+
+
+def _env_bool(source: Mapping[str, str], key: str, default: bool) -> bool:
+    raw = source.get(key)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in _FALSEY
+
+
+def _env_int(source: Mapping[str, str], key: str, default: int) -> int:
+    raw = source.get(key)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_optional_int(source: Mapping[str, str], key: str) -> int | None:
+    raw = source.get(key)
+    if raw is None or not raw.strip():
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _env_optional_days(source: Mapping[str, str], key: str) -> timedelta | None:
+    value = _env_optional_int(source, key)
+    if value is None:
+        return None
+    return timedelta(days=value)
+
+
+def _ensure_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _run_artifact_refs(record: ManagedRunRecord) -> tuple[str, ...]:
+    refs: list[str] = []
+    for ref in (
+        record.log_artifact_ref,
+        record.stdout_artifact_ref,
+        record.stderr_artifact_ref,
+        record.merged_log_artifact_ref,
+        record.diagnostics_ref,
+        record.observability_events_ref,
+    ):
+        if ref and ref not in refs:
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _artifact_job_id(ref: str) -> str | None:
+    cleaned = ref.strip().lstrip("/")
+    if not cleaned:
+        return None
+    return cleaned.split("/", 1)[0]
+
+
+def _path_size(path: Path) -> int:
+    try:
+        if path.is_file():
+            return path.stat().st_size
+        total = 0
+        for child in path.rglob("*"):
+            try:
+                if child.is_file():
+                    total += child.stat().st_size
+            except OSError:
+                continue
+        return total
+    except OSError:
+        return 0

--- a/moonmind/workflows/temporal/runtime/cleanup.py
+++ b/moonmind/workflows/temporal/runtime/cleanup.py
@@ -239,11 +239,19 @@ class ManagedRuntimeWorkspaceJanitor:
     def run(self) -> ManagedRuntimeCleanupResult:
         config = self._config
         if not config.enabled:
+            try:
+                scanned_run_records = len(tuple(self._run_store.iter_all()))
+                scanned_session_records = len(tuple(self._session_store.iter_all()))
+                errors: tuple[str, ...] = ()
+            except (OSError, ValueError) as exc:
+                scanned_run_records = 0
+                scanned_session_records = 0
+                errors = (f"unreadable_store: {exc}",)
             return ManagedRuntimeCleanupResult(
                 disabled=True,
                 dry_run=config.dry_run,
-                scanned_run_records=len(tuple(self._run_store.iter_all())),
-                scanned_session_records=len(tuple(self._session_store.iter_all())),
+                scanned_run_records=scanned_run_records,
+                scanned_session_records=scanned_session_records,
                 scanned_workspace_roots=0,
                 scanned_artifact_dirs=0,
                 protected_roots=0,
@@ -256,7 +264,7 @@ class ManagedRuntimeWorkspaceJanitor:
                 skipped_recent=0,
                 skipped_unsafe_path=0,
                 skipped_ambiguous_owner=0,
-                errors=(),
+                errors=errors,
             )
         with _JanitorLock(config.lock_path):
             return self._run_enabled_pass()
@@ -266,7 +274,7 @@ class ManagedRuntimeWorkspaceJanitor:
         try:
             run_records = tuple(self._run_store.iter_all())
             session_records = tuple(self._session_store.iter_all())
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             return self._empty_enabled_error(f"unreadable_store: {exc}")
         docker_state = self._docker_reference_state()
         if docker_state.failed:
@@ -741,10 +749,13 @@ class ManagedRuntimeWorkspaceJanitor:
         )
 
     def _rescan_blocks_delete(self, candidate: ManagedRuntimeCleanupCandidate) -> bool:
-        current = self._build_candidates(
-            tuple(self._run_store.iter_all()),
-            tuple(self._session_store.iter_all()),
-        )
+        try:
+            current = self._build_candidates(
+                tuple(self._run_store.iter_all()),
+                tuple(self._session_store.iter_all()),
+            )
+        except (OSError, ValueError):
+            return True
         for fresh in current:
             if fresh.kind == candidate.kind and fresh.path == candidate.path:
                 return self._has_active_owner(fresh)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -3911,6 +3911,77 @@ class DockerCodexManagedSessionController:
             raise RuntimeError(f"failed to inspect active docker containers: {details}")
         return {line.strip() for line in inspect_out.splitlines() if line.strip()}
 
+    async def collect_managed_runtime_cleanup_docker_references(self):
+        """Return live Docker references that must protect retained state."""
+        from moonmind.workflows.temporal.runtime.cleanup import DockerReferenceState
+
+        returncode, stdout, stderr = await self._command_runner(
+            (self._docker_binary, "ps", "-q"),
+            env=self._docker_env(),
+        )
+        if returncode != 0:
+            details = stderr.strip() or stdout.strip() or f"exit code {returncode}"
+            return DockerReferenceState(
+                failed=True,
+                reason=f"docker reference scan failed: {details}",
+            )
+        container_ids = [line.strip() for line in stdout.splitlines() if line.strip()]
+        if not container_ids:
+            return DockerReferenceState()
+        inspect_rc, inspect_out, inspect_err = await self._command_runner(
+            (self._docker_binary, "inspect", *container_ids),
+            env=self._docker_env(),
+        )
+        if inspect_rc != 0:
+            details = (
+                inspect_err.strip()
+                or inspect_out.strip()
+                or f"exit code {inspect_rc}"
+            )
+            return DockerReferenceState(
+                failed=True,
+                reason=f"docker reference scan failed: {details}",
+            )
+        try:
+            items = json.loads(inspect_out) if inspect_out.strip() else []
+        except json.JSONDecodeError as exc:
+            return DockerReferenceState(
+                failed=True,
+                reason=f"docker reference scan failed: {exc}",
+            )
+        active_container_refs: set[str] = set()
+        active_mount_paths: set[str] = set()
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for value in (item.get("Id"), item.get("Name")):
+                if value:
+                    active_container_refs.add(str(value).strip().lstrip("/"))
+            config = item.get("Config") or {}
+            labels = config.get("Labels") if isinstance(config, dict) else {}
+            if isinstance(labels, dict):
+                for key in (
+                    "moonmind.session_id",
+                    "moonmind.agent_run_id",
+                    "moonmind.run_id",
+                ):
+                    value = labels.get(key)
+                    if value:
+                        active_container_refs.add(str(value))
+            mounts = item.get("Mounts") or []
+            if isinstance(mounts, list):
+                for mount in mounts:
+                    if not isinstance(mount, dict):
+                        continue
+                    for key in ("Source", "Destination", "Name"):
+                        value = mount.get(key)
+                        if value:
+                            active_mount_paths.add(str(value))
+        return DockerReferenceState(
+            active_container_refs=frozenset(active_container_refs),
+            active_mount_paths=frozenset(active_mount_paths),
+        )
+
     def _active_sidecar_volume_names(self, active_session_ids: set[str]) -> set[str]:
         names: set[str] = set()
         for session_id in active_session_ids:

--- a/moonmind/workflows/temporal/runtime/managed_session_store.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_store.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -101,3 +102,21 @@ class ManagedSessionStore:
             if record.status not in TERMINAL_MANAGED_SESSION_STATUSES:
                 records.append(record)
         return records
+
+    def iter_all(self) -> Iterable[CodexManagedSessionRecord]:
+        """Return all readable session records, including terminal records."""
+        self.store_root.mkdir(parents=True, exist_ok=True)
+        for path in self.store_root.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                yield CodexManagedSessionRecord(**data)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    def delete(self, session_id: str) -> None:
+        """Delete a session record file if it exists."""
+        path = self._resolve_path(session_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return

--- a/moonmind/workflows/temporal/runtime/managed_session_store.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_store.py
@@ -104,14 +104,15 @@ class ManagedSessionStore:
         return records
 
     def iter_all(self) -> Iterable[CodexManagedSessionRecord]:
-        """Return all readable session records, including terminal records."""
+        """Return all session records, including terminal records.
+
+        Unlike active reconciliation, retained-state cleanup must fail closed
+        when any durable owner record is unreadable.
+        """
         self.store_root.mkdir(parents=True, exist_ok=True)
         for path in self.store_root.glob("*.json"):
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-                yield CodexManagedSessionRecord(**data)
-            except (json.JSONDecodeError, ValueError):
-                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            yield CodexManagedSessionRecord(**data)
 
     def delete(self, session_id: str) -> None:
         """Delete a session record file if it exists."""

--- a/moonmind/workflows/temporal/runtime/store.py
+++ b/moonmind/workflows/temporal/runtime/store.py
@@ -101,6 +101,24 @@ class ManagedRunStore:
                 continue
         return records
 
+    def iter_all(self) -> Iterable[ManagedRunRecord]:
+        """Return all readable run records, including terminal records."""
+        self.store_root.mkdir(parents=True, exist_ok=True)
+        for path in self.store_root.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                yield ManagedRunRecord(**data)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    def delete(self, run_id: str) -> None:
+        """Delete a run record file if it exists."""
+        path = self._resolve_path(run_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+
     def find_latest_for_workflow(self, workflow_id: str) -> ManagedRunRecord | None:
         """Return the newest managed run bound to one logical workflow.
 

--- a/moonmind/workflows/temporal/runtime/store.py
+++ b/moonmind/workflows/temporal/runtime/store.py
@@ -102,14 +102,15 @@ class ManagedRunStore:
         return records
 
     def iter_all(self) -> Iterable[ManagedRunRecord]:
-        """Return all readable run records, including terminal records."""
+        """Return all run records, including terminal records.
+
+        Unlike active reconciliation, retained-state cleanup must fail closed
+        when any durable owner record is unreadable.
+        """
         self.store_root.mkdir(parents=True, exist_ok=True)
         for path in self.store_root.glob("*.json"):
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-                yield ManagedRunRecord(**data)
-            except (json.JSONDecodeError, ValueError):
-                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            yield ManagedRunRecord(**data)
 
     def delete(self, run_id: str) -> None:
         """Delete a run record file if it exists."""

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.cleanup import (
+    DockerReferenceState,
+    ManagedRuntimeCleanupConfig,
+    ManagedRuntimeWorkspaceJanitor,
+)
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+NOW = datetime(2026, 6, 27, 12, 0, tzinfo=UTC)
+OLD = NOW - timedelta(days=45)
+RECENT = NOW - timedelta(days=1)
+
+
+def _config(root: Path, *, dry_run: bool = True) -> ManagedRuntimeCleanupConfig:
+    return ManagedRuntimeCleanupConfig(
+        enabled=True,
+        dry_run=dry_run,
+        workspace_retention=timedelta(days=30),
+        artifact_retention=timedelta(days=30),
+        record_retention=timedelta(days=30),
+        grace=timedelta(hours=1),
+        max_delete_paths=25,
+        max_delete_bytes=None,
+        lock_path=root / ".janitor.lock",
+        runtime_store_root=root,
+        artifact_root=root / "artifacts",
+    )
+
+
+def _run(
+    run_id: str,
+    status: str,
+    *,
+    root: Path,
+    workspace_path: str | None = None,
+    active_turn_id: str | None = None,
+    finished_at: datetime | None = OLD,
+    artifact_ref: str | None = None,
+) -> ManagedRunRecord:
+    return ManagedRunRecord(
+        runId=run_id,
+        workflowId=f"mm:{run_id}",
+        agentId="agent-1",
+        runtimeId="codex-cli",
+        status=status,
+        startedAt=OLD - timedelta(hours=1),
+        finishedAt=finished_at,
+        workspacePath=workspace_path or str(root / run_id / "repo"),
+        activeTurnId=active_turn_id,
+        stdoutArtifactRef=artifact_ref,
+    )
+
+
+def _session(
+    session_id: str,
+    status: str,
+    *,
+    root: Path,
+    agent_run_id: str,
+    active_turn_id: str | None = None,
+    updated_at: datetime | None = OLD,
+) -> CodexManagedSessionRecord:
+    return CodexManagedSessionRecord(
+        sessionId=session_id,
+        sessionEpoch=1,
+        agentRunId=agent_run_id,
+        containerId=f"ctr-{session_id}",
+        threadId=f"thread-{session_id}",
+        runtimeId="codex_cli",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl=f"docker-exec://{session_id}",
+        status=status,
+        workspacePath=str(root / agent_run_id / "repo"),
+        sessionWorkspacePath=str(root / agent_run_id / "session"),
+        artifactSpoolPath=str(root / agent_run_id / "artifacts"),
+        activeTurnId=active_turn_id,
+        startedAt=OLD - timedelta(hours=1),
+        updatedAt=updated_at,
+    )
+
+
+def _stores(root: Path) -> tuple[ManagedRunStore, ManagedSessionStore]:
+    return ManagedRunStore(root / "managed_runs"), ManagedSessionStore(
+        root / "managed_sessions"
+    )
+
+
+def _touch_old(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    old_epoch = OLD.timestamp()
+    os.utime(path, (old_epoch, old_epoch))
+
+
+def _janitor(
+    root: Path,
+    run_store: ManagedRunStore,
+    session_store: ManagedSessionStore,
+    *,
+    dry_run: bool = True,
+    docker_state: DockerReferenceState | None = None,
+) -> ManagedRuntimeWorkspaceJanitor:
+    return ManagedRuntimeWorkspaceJanitor(
+        run_store=run_store,
+        session_store=session_store,
+        config=_config(root, dry_run=dry_run),
+        docker_reference_provider=(
+            None if docker_state is None else lambda: docker_state
+        ),
+        now=lambda: NOW,
+    )
+
+
+def test_mm_949_groups_shared_ownership_root_and_protects_active_owner(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    shared = root / "workspaces" / "mm:workflow-123"
+    _touch_old(shared)
+    run_store, session_store = _stores(root)
+    run_store.save(
+        _run(
+            "run-old",
+            "completed",
+            root=root,
+            workspace_path=str(shared / "repo"),
+        )
+    )
+    run_store.save(
+        _run(
+            "run-active",
+            "running",
+            root=root,
+            workspace_path=str(shared / "repo"),
+        )
+    )
+
+    result = _janitor(root, run_store, session_store).run()
+
+    assert result.scanned_workspace_roots == 1
+    assert result.decisions[0].ownership_root == str(shared)
+    assert result.decisions[0].classification == "protected_shared"
+    assert result.decisions[0].reason == "active owner or active turn"
+
+
+def test_mm_949_terminal_old_per_run_workspace_is_eligible_in_dry_run(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+    session_store.save(_session("sess-1", "terminated", root=root, agent_run_id="run-1"))
+
+    result = _janitor(root, run_store, session_store).run()
+
+    workspace_decisions = [d for d in result.decisions if d.kind == "workspace"]
+    assert len(workspace_decisions) == 1
+    assert workspace_decisions[0].classification == "eligible"
+    assert workspace_decisions[0].reason == "dry-run would delete"
+    assert run_root.exists()
+
+def test_mm_949_filesystem_workspace_without_records_is_ambiguous(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    unowned = root / "workspaces" / "mm:unowned"
+    _touch_old(unowned)
+    run_store, session_store = _stores(root)
+
+    result = _janitor(root, run_store, session_store).run()
+
+    workspace_decision = next(d for d in result.decisions if d.kind == "workspace")
+    assert workspace_decision.path == str(unowned)
+    assert workspace_decision.classification == "skipped_ambiguous_owner"
+    assert workspace_decision.reason == "no durable owner records reference candidate"
+
+
+def test_mm_949_recent_filesystem_timestamp_prevents_deletion(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    os.utime(run_root, (RECENT.timestamp(), RECENT.timestamp()))
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root, finished_at=OLD))
+
+    result = _janitor(root, run_store, session_store).run()
+
+    workspace_decision = next(d for d in result.decisions if d.kind == "workspace")
+    assert workspace_decision.classification == "protected_recent"
+    assert workspace_decision.reason == "retention window has not elapsed"
+    assert workspace_decision.newest_activity_at == RECENT
+
+
+def test_mm_949_symlink_and_ambiguous_owner_are_specific_skips(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    target = tmp_path / "target"
+    target.mkdir()
+    symlink_root = root / "run-symlink"
+    symlink_root.parent.mkdir(parents=True, exist_ok=True)
+    symlink_root.symlink_to(target, target_is_directory=True)
+    run_store, session_store = _stores(root)
+    run_store.save(
+        _run("run-symlink", "completed", root=root, workspace_path=str(symlink_root / "repo"))
+    )
+    run_store.save(
+        _run(
+            "run-ambiguous",
+            "completed",
+            root=root,
+            workspace_path=str(root / "managed_runs" / "run-ambiguous.json"),
+        )
+    )
+
+    result = _janitor(root, run_store, session_store).run()
+    workspace_classifications = {
+        Path(d.path).name: d.classification
+        for d in result.decisions
+        if d.kind == "workspace"
+    }
+
+    assert workspace_classifications["run-symlink"] == "skipped_unsafe_path"
+    assert workspace_classifications["run-ambiguous.json"] == "skipped_ambiguous_owner"
+
+
+def test_mm_949_live_docker_reference_prevents_deletion(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+
+    result = _janitor(
+        root,
+        run_store,
+        session_store,
+        docker_state=DockerReferenceState(active_mount_paths=frozenset({str(run_root)})),
+    ).run()
+
+    workspace_decision = next(d for d in result.decisions if d.kind == "workspace")
+    assert workspace_decision.classification == "protected_active"
+    assert workspace_decision.reason == "live Docker reference"
+
+
+def test_mm_949_enabled_delete_uses_rescan_and_deletes_records_after_retention(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+    session_store.save(_session("sess-1", "terminated", root=root, agent_run_id="run-1"))
+    os.utime(root / "managed_runs" / "run-1.json", (OLD.timestamp(), OLD.timestamp()))
+    os.utime(
+        root / "managed_sessions" / "sess-1.json",
+        (OLD.timestamp(), OLD.timestamp()),
+    )
+
+    result = _janitor(root, run_store, session_store, dry_run=False).run()
+
+    classifications = {(d.kind, Path(d.path).name): d.classification for d in result.decisions}
+    assert classifications[("workspace", "run-1")] == "deleted"
+    assert classifications[("run_record", "run-1.json")] == "deleted"
+    assert classifications[("session_record", "sess-1.json")] == "deleted"
+    assert not run_root.exists()
+    assert run_store.load("run-1") is None
+    assert session_store.load("sess-1") is None
+
+
+def test_mm_949_config_from_env_normalizes_artifact_root_and_caps() -> None:
+    root = Path("/tmp/agent_jobs")
+    config = ManagedRuntimeCleanupConfig.from_env(
+        {
+            "MOONMIND_AGENT_RUNTIME_STORE": str(root),
+            "MOONMIND_AGENT_RUNTIME_ARTIFACTS": str(root),
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_ENABLED": "1",
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_DRY_RUN": "0",
+            "MOONMIND_MANAGED_RUNTIME_WORKSPACE_RETENTION_DAYS": "7",
+            "MOONMIND_MANAGED_RUNTIME_ARTIFACT_RETENTION_DAYS": "11",
+            "MOONMIND_MANAGED_RUNTIME_RECORD_RETENTION_DAYS": "13",
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_GRACE_SECONDS": "17",
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_MAX_DELETE_PATHS": "3",
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_MAX_DELETE_BYTES": "19",
+            "MOONMIND_MANAGED_RUNTIME_JANITOR_LOCK_PATH": str(root / "lock"),
+        }
+    )
+
+    assert config.enabled is True
+    assert config.dry_run is False
+    assert config.artifact_root == root / "artifacts"
+    assert config.workspace_retention == timedelta(days=7)
+    assert config.artifact_retention == timedelta(days=11)
+    assert config.record_retention == timedelta(days=13)
+    assert config.grace == timedelta(seconds=17)
+    assert config.max_delete_paths == 3
+    assert config.max_delete_bytes == 19
+    assert config.lock_path == root / "lock"

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -269,6 +269,64 @@ def test_mm_949_live_docker_reference_prevents_deletion(tmp_path: Path) -> None:
     assert workspace_decision.reason == "live Docker reference"
 
 
+def test_mm_949_final_rescan_rechecks_live_docker_reference(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+    docker_states = iter(
+        (
+            DockerReferenceState(),
+            DockerReferenceState(active_mount_paths=frozenset({str(run_root)})),
+        )
+    )
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        run_store=run_store,
+        session_store=session_store,
+        config=_config(root, dry_run=False),
+        docker_reference_provider=lambda: next(docker_states),
+        now=lambda: NOW,
+    )
+
+    result = janitor.run()
+
+    workspace_decision = next(d for d in result.decisions if d.kind == "workspace")
+    assert workspace_decision.classification == "protected_active"
+    assert workspace_decision.reason == "failed rescan before delete"
+    assert run_root.exists()
+
+
+def test_mm_949_cleanup_emits_progress_during_filesystem_walk(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    (run_root / "repo").mkdir()
+    (run_root / "repo" / "README.md").write_text("done\n", encoding="utf-8")
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+    progress: list[dict[str, object]] = []
+
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        run_store=run_store,
+        session_store=session_store,
+        config=_config(root, dry_run=True),
+        progress_callback=lambda payload: progress.append(dict(payload)),
+        now=lambda: NOW,
+    )
+
+    result = janitor.run()
+
+    workspace_decision = next(d for d in result.decisions if d.kind == "workspace")
+    assert workspace_decision.classification == "eligible"
+    assert {"classify", "size", "size_walk"}.issubset(
+        {str(payload["phase"]) for payload in progress}
+    )
+
+
 def test_mm_949_enabled_delete_uses_rescan_and_deletes_records_after_retention(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -186,6 +186,23 @@ def test_mm_949_filesystem_workspace_without_records_is_ambiguous(
     assert workspace_decision.reason == "no durable owner records reference candidate"
 
 
+def test_mm_949_corrupt_owner_record_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    run_root = root / "run-1"
+    _touch_old(run_root)
+    run_store, session_store = _stores(root)
+    run_store.save(_run("run-1", "completed", root=root))
+    corrupt = root / "managed_runs" / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+
+    result = _janitor(root, run_store, session_store, dry_run=False).run()
+
+    assert result.decisions == ()
+    assert result.errors
+    assert result.errors[0].startswith("unreadable_store:")
+    assert run_root.exists()
+
+
 def test_mm_949_recent_filesystem_timestamp_prevents_deletion(tmp_path: Path) -> None:
     root = tmp_path / "agent_jobs"
     run_root = root / "run-1"

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -306,6 +306,7 @@ def test_mm_949_cleanup_emits_progress_during_filesystem_walk(
     _touch_old(run_root)
     (run_root / "repo").mkdir()
     (run_root / "repo" / "README.md").write_text("done\n", encoding="utf-8")
+    os.utime(run_root, (OLD.timestamp(), OLD.timestamp()))
     run_store, session_store = _stores(root)
     run_store.save(_run("run-1", "completed", root=root))
     progress: list[dict[str, object]] = []

--- a/tests/unit/services/temporal/runtime/test_managed_session_store.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_store.py
@@ -94,3 +94,14 @@ def test_iter_all_and_delete_include_terminal_records(tmp_path) -> None:
     store.delete("sess-2")
     assert store.load("sess-2") is None
     assert {record.session_id for record in store.iter_all()} == {"sess-1"}
+
+
+def test_iter_all_raises_for_corrupt_records(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    store.save(_record())
+    (tmp_path / "corrupt.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        tuple(store.iter_all())
+
+    assert {record.session_id for record in store.list_active()} == {"sess-1"}

--- a/tests/unit/services/temporal/runtime/test_managed_session_store.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_store.py
@@ -76,3 +76,21 @@ async def test_store_update_revalidates_and_normalizes_mutations(tmp_path) -> No
     assert updated.runtime_id == "codex_cli"
     assert updated.error_message == "temporary failure"
     assert updated.updated_at == datetime(2026, 4, 6, 12, 6, tzinfo=UTC)
+
+def test_iter_all_and_delete_include_terminal_records(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    store.save(_record())
+    store.save(
+        _record().model_copy(
+            update={
+                "session_id": "sess-2",
+                "status": "terminated",
+            }
+        )
+    )
+
+    assert {record.session_id for record in store.iter_all()} == {"sess-1", "sess-2"}
+
+    store.delete("sess-2")
+    assert store.load("sess-2") is None
+    assert {record.session_id for record in store.iter_all()} == {"sess-1"}

--- a/tests/unit/services/temporal/runtime/test_store.py
+++ b/tests/unit/services/temporal/runtime/test_store.py
@@ -83,6 +83,17 @@ def test_iter_all_and_delete_include_terminal_records(tmp_path):
     assert store.load("run-2") is None
     assert {record.run_id for record in store.iter_all()} == {"run-1"}
 
+
+def test_iter_all_raises_for_corrupt_records(tmp_path):
+    store = ManagedRunStore(tmp_path)
+    store.save(_make_record("run-1", "running"))
+    (tmp_path / "corrupt.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        tuple(store.iter_all())
+
+    assert {record.run_id for record in store.list_active()} == {"run-1"}
+
 def test_find_latest_for_workflow_prefers_newest_active_run(tmp_path):
     store = ManagedRunStore(tmp_path)
     started_at = datetime.now(tz=UTC)

--- a/tests/unit/services/temporal/runtime/test_store.py
+++ b/tests/unit/services/temporal/runtime/test_store.py
@@ -72,6 +72,17 @@ def test_list_active(tmp_path):
     active_ids = {r.run_id for r in active}
     assert active_ids == {"run-1", "run-3"}
 
+def test_iter_all_and_delete_include_terminal_records(tmp_path):
+    store = ManagedRunStore(tmp_path)
+    store.save(_make_record("run-1", "running"))
+    store.save(_make_record("run-2", "completed"))
+
+    assert {record.run_id for record in store.iter_all()} == {"run-1", "run-2"}
+
+    store.delete("run-2")
+    assert store.load("run-2") is None
+    assert {record.run_id for record in store.iter_all()} == {"run-1"}
+
 def test_find_latest_for_workflow_prefers_newest_active_run(tmp_path):
     store = ManagedRunStore(tmp_path)
     started_at = datetime.now(tz=UTC)

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5373,6 +5373,114 @@ async def test_agent_runtime_cleanup_managed_runtime_files_activity_boundary(
     assert result["decisions"][0]["classification"] == "eligible"
     assert result["decisions"][0]["reason"] == "dry-run would delete"
 
+
+async def test_agent_runtime_cleanup_managed_runtime_files_uses_docker_references(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "agent_jobs"
+    run_root = runtime_root / "run-mm-949"
+    run_root.mkdir(parents=True)
+    old = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    os.utime(run_root, (old.timestamp(), old.timestamp()))
+    run_store = ManagedRunStore(runtime_root / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId="run-mm-949",
+            workflowId="mm:workflow-mm-949",
+            agentId="agent-1",
+            runtimeId="codex-cli",
+            status="completed",
+            startedAt=old - timedelta(hours=1),
+            finishedAt=old,
+            workspacePath=str(run_root / "repo"),
+        )
+    )
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(runtime_root))
+
+    class _Controller:
+        async def collect_managed_runtime_cleanup_docker_references(
+            self,
+        ) -> dict[str, object]:
+            return {"activeMountPaths": [str(run_root)]}
+
+    activities = TemporalAgentRuntimeActivities(
+        run_store=run_store,
+        session_controller=_Controller(),
+    )
+
+    result = await activities.agent_runtime_cleanup_managed_runtime_files(
+        {
+            "config": {
+                "enabled": True,
+                "dryRun": False,
+                "runtimeStoreRoot": str(runtime_root),
+                "artifactRoot": str(runtime_root / "artifacts"),
+                "lockPath": str(runtime_root / ".janitor.lock"),
+                "workspaceRetentionDays": 30,
+                "artifactRetentionDays": 30,
+                "recordRetentionDays": None,
+                "graceSeconds": 3600,
+                "maxDeletePaths": 25,
+                "maxDeleteBytes": None,
+            }
+        }
+    )
+
+    assert result["decisions"][0]["classification"] == "protected_active"
+    assert result["decisions"][0]["reason"] == "live Docker reference"
+    assert run_root.exists()
+
+
+async def test_agent_runtime_cleanup_managed_runtime_files_fails_closed_without_docker_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "agent_jobs"
+    run_root = runtime_root / "run-mm-949"
+    run_root.mkdir(parents=True)
+    old = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    os.utime(run_root, (old.timestamp(), old.timestamp()))
+    run_store = ManagedRunStore(runtime_root / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId="run-mm-949",
+            workflowId="mm:workflow-mm-949",
+            agentId="agent-1",
+            runtimeId="codex-cli",
+            status="completed",
+            startedAt=old - timedelta(hours=1),
+            finishedAt=old,
+            workspacePath=str(run_root / "repo"),
+        )
+    )
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(runtime_root))
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+
+    result = await activities.agent_runtime_cleanup_managed_runtime_files(
+        {
+            "config": {
+                "enabled": True,
+                "dryRun": False,
+                "runtimeStoreRoot": str(runtime_root),
+                "artifactRoot": str(runtime_root / "artifacts"),
+                "lockPath": str(runtime_root / ".janitor.lock"),
+                "workspaceRetentionDays": 30,
+                "artifactRetentionDays": 30,
+                "recordRetentionDays": None,
+                "graceSeconds": 3600,
+                "maxDeletePaths": 25,
+                "maxDeleteBytes": None,
+            }
+        }
+    )
+
+    assert result["decisions"][0]["classification"] == "protected_active"
+    assert result["decisions"][0]["reason"] == "docker reference scan unavailable"
+    assert result["errors"] == ["docker reference scan unavailable"]
+    assert run_root.exists()
+
+
 @pytest.mark.asyncio
 async def test_agent_runtime_reconcile_managed_sessions_uses_bounded_heartbeating(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from datetime import UTC, datetime
+import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -5318,6 +5319,59 @@ async def test_agent_runtime_reconcile_orphan_reap_failure_is_best_effort() -> N
     assert result["orphanReapForcedStale"] == 0
     assert result["orphanVolumesScanned"] == 0
     assert result["orphanVolumesReaped"] == 0
+
+async def test_agent_runtime_cleanup_managed_runtime_files_activity_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "agent_jobs"
+    run_root = runtime_root / "run-mm-949"
+    run_root.mkdir(parents=True)
+    old = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    os_epoch = old.timestamp()
+    run_root.joinpath("repo").mkdir()
+    run_root.joinpath("repo", "README.md").write_text("done\n", encoding="utf-8")
+    run_root.touch()
+    os.utime(run_root, (os_epoch, os_epoch))
+    run_store = ManagedRunStore(runtime_root / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId="run-mm-949",
+            workflowId="mm:workflow-mm-949",
+            agentId="agent-1",
+            runtimeId="codex-cli",
+            status="completed",
+            startedAt=old - timedelta(hours=1),
+            finishedAt=old,
+            workspacePath=str(run_root / "repo"),
+        )
+    )
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(runtime_root))
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+
+    result = await activities.agent_runtime_cleanup_managed_runtime_files(
+        {
+            "config": {
+                "enabled": True,
+                "dryRun": True,
+                "runtimeStoreRoot": str(runtime_root),
+                "artifactRoot": str(runtime_root / "artifacts"),
+                "lockPath": str(runtime_root / ".janitor.lock"),
+                "workspaceRetentionDays": 30,
+                "artifactRetentionDays": 30,
+                "recordRetentionDays": None,
+                "graceSeconds": 3600,
+                "maxDeletePaths": 25,
+                "maxDeleteBytes": None,
+            }
+        }
+    )
+
+    assert result["disabled"] is False
+    assert result["dryRun"] is True
+    assert result["scannedRunRecords"] == 1
+    assert result["decisions"][0]["classification"] == "eligible"
+    assert result["decisions"][0]["reason"] == "dry-run would delete"
 
 @pytest.mark.asyncio
 async def test_agent_runtime_reconcile_managed_sessions_uses_bounded_heartbeating(


### PR DESCRIPTION
Issue reference: MM-949 (https://moonladder.atlassian.net/browse/MM-949)

Summary:
- Adds managed runtime cleanup classification for ownership-root grouped workspace/artifact/record candidates.
- Implements terminal-state, retention, grace-window, active owner/turn, Docker reference, volume mount, symlink, unsafe path, unreadable store, ambiguous owner, and rescan safety gates with single final classifications and actionable reasons.
- Adds janitor configuration and Temporal activity/runtime wiring, plus store/controller APIs needed to list and delete retained runtime records.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_cleanup.py tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_store.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`

Remaining risks:
- No compose-backed integration cleanup run was executed in this PR step; verification is limited to targeted unit and Temporal activity boundary coverage.
- Cleanup deletion behavior remains gated by configuration and should be exercised cautiously in operator environments before enabling destructive mode.
