### PR TITLE
MM-941 add capability catalog chip readiness semantics

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16950,7 +16950,7 @@ describe("Task Create runtime switch layout stability", () => {
   });
 });
 
-describe("MM-936 capability registry and chip computation", () => {
+describe("MM-936/MM-941 capability registry and chip computation", () => {
   function requireChip(
     chips: ReturnType<typeof buildCapabilityChips>,
     token: string,
@@ -16992,6 +16992,12 @@ describe("MM-936 capability registry and chip computation", () => {
       },
     ]);
     expect(capabilityChipProvenanceLabel(chip)).toBeNull();
+    expect(chip.readiness).toMatchObject({
+      state: "requested",
+      label: "Requested capability",
+      sourceLabels: ["added to this step"],
+      grantsAccess: false,
+    });
   });
 
   it("keeps derived capabilities non-removable with provenance", () => {
@@ -17024,6 +17030,30 @@ describe("MM-936 capability registry and chip computation", () => {
     );
   });
 
+  it("represents derived capability readiness without granting access", () => {
+    const chips = buildCapabilityChips({
+      skill: ["git"],
+      generatedTool: ["git"],
+      publish: ["gh"],
+    });
+    const gitChip = requireChip(chips, "git");
+    expect(gitChip.readiness).toEqual({
+      state: "required_before_launch",
+      label: "Required before launch",
+      description:
+        "This derived capability is required by step configuration before launch. The chip records the requirement; it does not grant access by itself.",
+      sourceLabels: ["from skill", "from tool"],
+      grantsAccess: false,
+    });
+
+    const ghChip = requireChip(chips, "gh");
+    expect(ghChip.readiness).toMatchObject({
+      state: "required_before_launch",
+      sourceLabels: ["from publish mode"],
+      grantsAccess: false,
+    });
+  });
+
   it("treats a capability with both explicit and derived sources as non-removable", () => {
     const chips = buildCapabilityChips({ explicit: ["git"], skill: ["git"] });
     expect(chips).toHaveLength(1);
@@ -17036,6 +17066,11 @@ describe("MM-936 capability registry and chip computation", () => {
     // The UI must not silently drop a backend-required capability even when the
     // user also added it explicitly.
     expect(capabilityChipProvenanceLabel(chip)).toBe("from skill");
+    expect(chip.readiness).toMatchObject({
+      state: "required_before_launch",
+      sourceLabels: ["from skill"],
+      grantsAccess: false,
+    });
   });
 
   it("normalizes and de-duplicates tokens while preserving first-seen order", () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -2049,7 +2049,7 @@ function capabilityCatalogEntry(token: string): CapabilityCatalogEntry {
   };
 }
 
-type CapabilitySourceKind =
+export type CapabilitySourceKind =
   | "explicit"
   | "preset"
   | "skill"
@@ -2068,19 +2068,30 @@ const CAPABILITY_SOURCE_LABELS: Record<CapabilitySourceKind, string> = {
   template: "from template",
 };
 
-interface CapabilityContribution {
+export interface CapabilityContribution {
   token: string;
   sourceKind: CapabilitySourceKind;
   sourceLabel: string;
   removable: boolean;
 }
 
-interface StepCapabilityChip {
+export type CapabilityReadinessState = "requested" | "required_before_launch";
+
+export interface CapabilityReadiness {
+  state: CapabilityReadinessState;
+  label: string;
+  description: string;
+  sourceLabels: string[];
+  grantsAccess: false;
+}
+
+export interface StepCapabilityChip {
   token: string;
   label: string;
   description: string;
   icon: string;
   sources: CapabilityContribution[];
+  readiness: CapabilityReadiness;
   removable: boolean;
 }
 
@@ -2099,7 +2110,8 @@ interface BuildCapabilityChipsArgs {
 // additive and backend normalization is authoritative, so a capability chip is
 // only removable when the sole contribution is the explicit step authoring
 // field. Derived contributions (preset, skill, tool, runtime, publish mode,
-// template) keep the chip non-removable and carry provenance for display.
+// template) keep the chip non-removable and carry provenance plus readiness
+// semantics for display without implying the UI grants backend access.
 export function buildCapabilityChips(
   args: BuildCapabilityChipsArgs,
 ): StepCapabilityChip[] {
@@ -2135,6 +2147,7 @@ export function buildCapabilityChips(
           description: entry.description,
           icon: entry.icon,
           sources: [],
+          readiness: explicitCapabilityReadiness([]),
           removable: false,
         };
         chipsByToken.set(token, chip);
@@ -2157,8 +2170,42 @@ export function buildCapabilityChips(
     const removable =
       chip.sources.length > 0 &&
       chip.sources.every((source) => source.sourceKind === "explicit");
-    return { ...chip, removable };
+    const derivedSourceLabels = chip.sources
+      .filter((source) => source.sourceKind !== "explicit")
+      .map((source) => source.sourceLabel);
+    return {
+      ...chip,
+      readiness:
+        derivedSourceLabels.length > 0
+          ? derivedCapabilityReadiness(derivedSourceLabels)
+          : explicitCapabilityReadiness(
+              chip.sources.map((source) => source.sourceLabel),
+            ),
+      removable,
+    };
   });
+}
+
+function explicitCapabilityReadiness(sourceLabels: string[]): CapabilityReadiness {
+  return {
+    state: "requested",
+    label: "Requested capability",
+    description:
+      "This capability token is requested for the step. Runtime policy and credentials still decide whether access is available.",
+    sourceLabels,
+    grantsAccess: false,
+  };
+}
+
+function derivedCapabilityReadiness(sourceLabels: string[]): CapabilityReadiness {
+  return {
+    state: "required_before_launch",
+    label: "Required before launch",
+    description:
+      "This derived capability is required by step configuration before launch. The chip records the requirement; it does not grant access by itself.",
+    sourceLabels,
+    grantsAccess: false,
+  };
 }
 
 // The provenance label rendered on a derived (non-removable) chip, e.g.


### PR DESCRIPTION
Issue: MM-941 (https://moonladder.atlassian.net/browse/MM-941)

Summary:
- Exports the capability source and chip model types used by the workflow start capability helpers.
- Adds explicit readiness data to capability chips so explicit capabilities are represented as requested and derived capabilities are represented as required before launch.
- Preserves backend token identity and source provenance without adding aliases or implying UI-granted access.
- Extends workflow-start capability chip tests for readiness semantics and mixed explicit/derived provenance.

Tests run:
- `git diff --check origin/main...HEAD` (passed)
- Secret scan of `git diff origin/main...HEAD` for common token/private-key patterns (passed; no matches)
- `npm ci --no-fund --no-audit` (passed)
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx` (failed: local Python environment has no `pytest` module before reaching Vitest)
- `npm run ui:test:workflow-start` (failed before test execution: Vitest could not resolve module `/frontend/src/entrypoints/workflow-start.test.tsx` in this managed workspace)

Remaining risks:
- Focused frontend tests could not complete in this managed workspace because the local test environment fails before executing the suite. The changed tests should be run in CI or a local environment with the expected Python/Vitest path setup.
- The implementation is limited to chip model/helper readiness metadata and does not change backend capability enforcement.
