### PR TITLE
MM-942 Serialize explicit tool capabilities

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16417,6 +16417,11 @@ describe("Task Create governed Tool authoring", () => {
     expect(
       (within(step).getByLabelText("transitionId") as HTMLInputElement).value,
     ).toBe("51");
+    const addToStep = within(step).getByRole("button", {
+      name: "Add to Step 1",
+    });
+    fireEvent.click(addToStep);
+    fireEvent.click(within(step).getByRole("menuitem", { name: /^Jira/ }));
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -16439,6 +16444,7 @@ describe("Task Create governed Tool authoring", () => {
           issueKey: "MM-576",
           transitionId: "51",
         },
+        requiredCapabilities: ["jira"],
       },
     });
     expect(request.payload.task.steps[0]?.["skill"]).toBeUndefined();

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -2294,10 +2294,12 @@ function manualToolPayload(
   if (!toolId) {
     return null;
   }
+  const caps = step.explicitRequiredCapabilities;
   return {
     type: "tool",
     id: toolId,
     inputs,
+    ...(caps.length > 0 ? { requiredCapabilities: caps } : {}),
   };
 }
 


### PR DESCRIPTION
Issue reference
- MM-942: https://moonladder.atlassian.net/browse/MM-942

Summary
- Serializes explicit capability chips from manual Tool steps into tool.requiredCapabilities.
- Extends the trusted Jira Tool submission regression to assert the serialized tool requiredCapabilities payload.

Tests run
- git diff --check origin/main...HEAD
- Secret scan over git diff origin/main...HEAD for common token/private-key patterns: no matches.
- ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx --ui-args -t --ui-args "loads trusted Jira transition statuses into submitted Tool inputs" (blocked: Python pytest is not installed in this container before Vitest runs).
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts -t "loads trusted Jira transition statuses into submitted Tool inputs" (blocked: Vitest resolves suites to /frontend/... absolute paths and fails to load test modules in this checkout).

Remaining risks
- Focused frontend test execution could not complete in this managed container because of local test environment issues, so CI should provide the definitive Vitest result.
