### PR TITLE
MM-943 add step plus menu

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16285,6 +16285,11 @@ describe("Task Create governed Tool authoring", () => {
 
     expect(clickSpy).toHaveBeenCalledTimes(1);
     expect(clickSpy.mock.instances[0]).toBe(picker);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        within(step).getByRole("button", { name: "Add to Step 1" }),
+      );
+    });
     clickSpy.mockRestore();
   });
 
@@ -16348,6 +16353,9 @@ describe("Task Create governed Tool authoring", () => {
     await waitFor(() => {
       expect(within(step).queryByRole("menu", { name: "Add to step" }))
         .toBeNull();
+    });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(addToStep);
     });
   });
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16244,6 +16244,9 @@ describe("Task Create governed Tool authoring", () => {
     });
 
     fireEvent.click(addToStep);
+    const menu = within(step).getByRole("menu", { name: "Add to step" });
+    expect(within(menu).getByText("Add to step")).toBeTruthy();
+    expect(within(menu).getByText("Capabilities")).toBeTruthy();
     fireEvent.click(within(step).getByRole("menuitem", { name: /^Docker/ }));
 
     const chip = await within(step).findByText("Docker");
@@ -16263,6 +16266,89 @@ describe("Task Create governed Tool authoring", () => {
       requiredCapabilities?: string[];
     };
     expect(payload.requiredCapabilities).toContain("docker");
+  });
+
+  it("shows the image action only when step attachments are allowed and uses the existing picker", async () => {
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click");
+    renderWithClient(
+      <WorkflowStartPage payload={withImageOnlyAttachmentPolicy()} />,
+    );
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    const picker = within(step).getByLabelText("Step 1 image file picker");
+    fireEvent.click(within(step).getByRole("button", { name: "Add to Step 1" }));
+
+    const menu = within(step).getByRole("menu", { name: "Add to step" });
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Image…" }));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy.mock.instances[0]).toBe(picker);
+    clickSpy.mockRestore();
+  });
+
+  it("omits image actions from the Add to step menu when attachments are disabled", async () => {
+    renderWithClient(
+      <WorkflowStartPage payload={withDisabledAttachmentPolicy()} />,
+    );
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.click(within(step).getByRole("button", { name: "Add to Step 1" }));
+
+    const menu = within(step).getByRole("menu", { name: "Add to step" });
+    expect(within(menu).queryByRole("menuitem", { name: "Image…" })).toBeNull();
+    expect(
+      within(menu).queryByRole("menuitem", { name: "Attachment…" }),
+    ).toBeNull();
+    expect(
+      within(menu).getByRole("menuitem", { name: /Git repository/ }),
+    ).toBeTruthy();
+  });
+
+  it("supports keyboard navigation and Escape close in the Add to step menu", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    const addToStep = within(step).getByRole("button", {
+      name: "Add to Step 1",
+    });
+
+    fireEvent.click(addToStep);
+    const menu = within(step).getByRole("menu", { name: "Add to step" });
+    const gitItem = within(menu).getByRole("menuitem", {
+      name: /Git repository/,
+    });
+    const jiraItem = within(menu).getByRole("menuitem", { name: /^Jira/ });
+    const customItem = within(menu).getByRole("menuitem", {
+      name: "Custom capability…",
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(gitItem);
+    });
+
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(jiraItem);
+
+    fireEvent.keyDown(document, { key: "End" });
+    expect(document.activeElement).toBe(customItem);
+
+    fireEvent.keyDown(document, { key: "Home" });
+    expect(document.activeElement).toBe(gitItem);
+
+    fireEvent.keyDown(document, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(customItem);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(within(step).queryByRole("menu", { name: "Add to step" }))
+        .toBeNull();
+    });
   });
 
   it("removes explicit capability chips but keeps derived chips locked", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4678,7 +4678,7 @@ export const LIQUID_GL_OPTIONS = {
 const DEFAULT_PRIORITY = 0;
 const DEFAULT_MAX_ATTEMPTS = 3;
 
-interface StepContextMenuProps {
+interface StepAddMenuProps {
   stepNumber: number;
   attachmentPolicy: AttachmentPolicy;
   presentCapabilityTokens: string[];
@@ -4687,19 +4687,43 @@ interface StepContextMenuProps {
   onAddCustomCapability: () => void;
 }
 
-// MM-936: The single "Add to step" affordance rendered beneath each step's
-// instruction box. It unifies image attachments and required capabilities into
-// one elegant menu without merging the underlying backend concepts.
-function StepContextMenu({
+// MM-943: The single "Add to step" affordance rendered beneath each step's
+// instruction box. It unifies image attachments and capabilities without
+// merging the underlying backend concepts.
+function StepAddMenu({
   stepNumber,
   attachmentPolicy,
   presentCapabilityTokens,
   onAddImage,
   onAddCapability,
   onAddCustomCapability,
-}: StepContextMenuProps) {
+}: StepAddMenuProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const focusMenuItem = useCallback((startIndex: number, direction: 1 | -1) => {
+    const itemCount = menuItemRefs.current.length;
+    if (itemCount === 0) {
+      return;
+    }
+    for (let offset = 0; offset < itemCount; offset += 1) {
+      const nextIndex =
+        (startIndex + offset * direction + itemCount) % itemCount;
+      const item = menuItemRefs.current[nextIndex];
+      if (item && !item.disabled) {
+        item.focus();
+        return;
+      }
+    }
+  }, []);
+
+  const registerMenuItem = useCallback(
+    (index: number) => (element: HTMLButtonElement | null) => {
+      menuItemRefs.current[index] = element;
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!open) {
@@ -4716,6 +4740,35 @@ function StepContextMenu({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setOpen(false);
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        const currentIndex = menuItemRefs.current.findIndex(
+          (item) => item === document.activeElement,
+        );
+        focusMenuItem(currentIndex < 0 ? 0 : currentIndex + 1, 1);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        const currentIndex = menuItemRefs.current.findIndex(
+          (item) => item === document.activeElement,
+        );
+        focusMenuItem(
+          currentIndex < 0 ? menuItemRefs.current.length - 1 : currentIndex - 1,
+          -1,
+        );
+        return;
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        focusMenuItem(0, 1);
+        return;
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        focusMenuItem(menuItemRefs.current.length - 1, -1);
       }
     }
     document.addEventListener("mousedown", handlePointerDown);
@@ -4724,12 +4777,22 @@ function StepContextMenu({
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [open]);
+  }, [focusMenuItem, open]);
 
   const menuLabel = `Add to Step ${stepNumber}`;
+  const menuTitleId = `queue-step-add-menu-title-${stepNumber}`;
   const imageItemLabel = isImageOnlyPolicy(attachmentPolicy)
     ? "Image…"
     : "Attachment…";
+  const capabilityStartIndex = attachmentPolicy.enabled ? 1 : 0;
+  const customCapabilityIndex =
+    capabilityStartIndex + CAPABILITY_MENU_TOKENS.length;
+
+  useEffect(() => {
+    if (open) {
+      window.setTimeout(() => focusMenuItem(0, 1), 0);
+    }
+  }, [focusMenuItem, open]);
 
   return (
     <div className="queue-step-context-menu" ref={containerRef}>
@@ -4749,14 +4812,18 @@ function StepContextMenu({
         <div
           className="queue-step-context-menu-popover"
           role="menu"
-          aria-label={menuLabel}
+          aria-labelledby={menuTitleId}
         >
+          <p id={menuTitleId} className="queue-step-context-menu-title">
+            Add to step
+          </p>
           {attachmentPolicy.enabled ? (
             <>
               <button
                 type="button"
                 role="menuitem"
                 className="queue-step-context-menu-item"
+                ref={registerMenuItem(0)}
                 onClick={() => {
                   setOpen(false);
                   onAddImage();
@@ -4771,7 +4838,7 @@ function StepContextMenu({
             </>
           ) : null}
           <p className="queue-step-context-menu-group-label">Capabilities</p>
-          {CAPABILITY_MENU_TOKENS.map((token) => {
+          {CAPABILITY_MENU_TOKENS.map((token, tokenIndex) => {
             const entry = capabilityCatalogEntry(token);
             const alreadyPresent = presentCapabilityTokens.includes(token);
             return (
@@ -4780,6 +4847,7 @@ function StepContextMenu({
                 type="button"
                 role="menuitem"
                 className="queue-step-context-menu-item queue-step-context-menu-capability"
+                ref={registerMenuItem(capabilityStartIndex + tokenIndex)}
                 disabled={alreadyPresent}
                 aria-disabled={alreadyPresent}
                 title={entry.description}
@@ -4807,6 +4875,7 @@ function StepContextMenu({
             type="button"
             role="menuitem"
             className="queue-step-context-menu-item"
+            ref={registerMenuItem(customCapabilityIndex)}
             onClick={() => {
               setOpen(false);
               onAddCustomCapability();
@@ -10991,7 +11060,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
                       className="queue-step-context"
                       aria-label={`Add to Step ${index + 1}`}
                     >
-                      <StepContextMenu
+                      <StepAddMenu
                         stepNumber={index + 1}
                         attachmentPolicy={attachmentPolicy}
                         presentCapabilityTokens={stepCapabilityTokens}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4700,17 +4700,22 @@ function StepAddMenu({
 }: StepAddMenuProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   const focusMenuItem = useCallback((startIndex: number, direction: 1 | -1) => {
-    const itemCount = menuItemRefs.current.length;
+    const items = Array.from(
+      containerRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitem"]',
+      ) || [],
+    );
+    const itemCount = items.length;
     if (itemCount === 0) {
       return;
     }
     for (let offset = 0; offset < itemCount; offset += 1) {
       const nextIndex =
         (startIndex + offset * direction + itemCount) % itemCount;
-      const item = menuItemRefs.current[nextIndex];
+      const item = items[nextIndex];
       if (item && !item.disabled) {
         item.focus();
         return;
@@ -4718,12 +4723,12 @@ function StepAddMenu({
     }
   }, []);
 
-  const registerMenuItem = useCallback(
-    (index: number) => (element: HTMLButtonElement | null) => {
-      menuItemRefs.current[index] = element;
-    },
-    [],
-  );
+  const closeMenu = useCallback((restoreFocus = false) => {
+    setOpen(false);
+    if (restoreFocus) {
+      window.setTimeout(() => triggerRef.current?.focus(), 0);
+    }
+  }, []);
 
   useEffect(() => {
     if (!open) {
@@ -4734,29 +4739,34 @@ function StepAddMenu({
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        setOpen(false);
+        closeMenu();
       }
     }
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
-        setOpen(false);
+        closeMenu(true);
         return;
       }
+      const items = Array.from(
+        containerRef.current?.querySelectorAll<HTMLButtonElement>(
+          '[role="menuitem"]',
+        ) || [],
+      );
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        const currentIndex = menuItemRefs.current.findIndex(
-          (item) => item === document.activeElement,
+        const currentIndex = items.indexOf(
+          document.activeElement as HTMLButtonElement,
         );
         focusMenuItem(currentIndex < 0 ? 0 : currentIndex + 1, 1);
         return;
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
-        const currentIndex = menuItemRefs.current.findIndex(
-          (item) => item === document.activeElement,
+        const currentIndex = items.indexOf(
+          document.activeElement as HTMLButtonElement,
         );
         focusMenuItem(
-          currentIndex < 0 ? menuItemRefs.current.length - 1 : currentIndex - 1,
+          currentIndex < 0 ? items.length - 1 : currentIndex - 1,
           -1,
         );
         return;
@@ -4768,7 +4778,7 @@ function StepAddMenu({
       }
       if (event.key === "End") {
         event.preventDefault();
-        focusMenuItem(menuItemRefs.current.length - 1, -1);
+        focusMenuItem(items.length - 1, -1);
       }
     }
     document.addEventListener("mousedown", handlePointerDown);
@@ -4777,16 +4787,13 @@ function StepAddMenu({
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [focusMenuItem, open]);
+  }, [closeMenu, focusMenuItem, open]);
 
   const menuLabel = `Add to Step ${stepNumber}`;
   const menuTitleId = `queue-step-add-menu-title-${stepNumber}`;
   const imageItemLabel = isImageOnlyPolicy(attachmentPolicy)
     ? "Image…"
     : "Attachment…";
-  const capabilityStartIndex = attachmentPolicy.enabled ? 1 : 0;
-  const customCapabilityIndex =
-    capabilityStartIndex + CAPABILITY_MENU_TOKENS.length;
 
   useEffect(() => {
     if (open) {
@@ -4803,6 +4810,7 @@ function StepAddMenu({
         aria-expanded={open}
         aria-label={menuLabel}
         title={menuLabel}
+        ref={triggerRef}
         onClick={() => setOpen((value) => !value)}
       >
         <span aria-hidden="true">+</span>
@@ -4823,9 +4831,8 @@ function StepAddMenu({
                 type="button"
                 role="menuitem"
                 className="queue-step-context-menu-item"
-                ref={registerMenuItem(0)}
                 onClick={() => {
-                  setOpen(false);
+                  closeMenu(true);
                   onAddImage();
                 }}
               >
@@ -4847,12 +4854,11 @@ function StepAddMenu({
                 type="button"
                 role="menuitem"
                 className="queue-step-context-menu-item queue-step-context-menu-capability"
-                ref={registerMenuItem(capabilityStartIndex + tokenIndex)}
                 disabled={alreadyPresent}
                 aria-disabled={alreadyPresent}
                 title={entry.description}
                 onClick={() => {
-                  setOpen(false);
+                  closeMenu(true);
                   onAddCapability(token);
                 }}
               >
@@ -4875,9 +4881,8 @@ function StepAddMenu({
             type="button"
             role="menuitem"
             className="queue-step-context-menu-item"
-            ref={registerMenuItem(customCapabilityIndex)}
             onClick={() => {
-              setOpen(false);
+              closeMenu(true);
               onAddCustomCapability();
             }}
           >

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4845,7 +4845,7 @@ function StepAddMenu({
             </>
           ) : null}
           <p className="queue-step-context-menu-group-label">Capabilities</p>
-          {CAPABILITY_MENU_TOKENS.map((token, tokenIndex) => {
+          {CAPABILITY_MENU_TOKENS.map((token) => {
             const entry = capabilityCatalogEntry(token);
             const alreadyPresent = presentCapabilityTokens.includes(token);
             return (

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4057,6 +4057,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   box-shadow: 0 12px 30px rgb(0 0 0 / 0.18);
 }
 
+.queue-step-context-menu-title {
+  margin: 0.1rem 0.4rem 0.2rem;
+  color: rgb(var(--mm-text));
+  font-size: 0.88rem;
+  font-weight: 750;
+}
+
 .queue-step-context-menu-group-label {
   margin: 0.25rem 0.4rem 0.1rem;
   color: rgb(var(--mm-muted));


### PR DESCRIPTION
Issue: MM-943

Summary:
- Introduces the StepAddMenu component for each workflow step instruction area.
- Adds a visible "Add to step" menu title, Capabilities section label, and keyboard navigation for menu items.
- Wires image actions through the existing step attachment picker and capability actions through explicitRequiredCapabilities.
- Adds focused coverage for attachment-policy visibility, existing picker usage, and keyboard behavior.

Tests run:
- git diff --check origin/main...HEAD
- npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx (failed: npm script could not resolve vitest from PATH in this runtime)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-start.test.tsx (failed: missing Python pytest dependency before UI setup)
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts (failed: Vitest resolved test modules as /frontend/... in this managed workspace before loading tests)

Remaining risks:
- Focused UI assertions were added, but local Vitest execution is blocked by managed workspace test-resolution/dependency issues; CI should validate the frontend suite in its normal environment.
