### PR TITLE
[codex] Compact Codex session result metadata

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -124,6 +124,57 @@ PublishArtifactsFunc = Callable[
 ]
 
 _MAX_AGENT_RUN_RESULT_SUMMARY_CHARS = 4096
+_COMPACT_METADATA_TEXT_CHARS = 1024
+_SESSION_REF_FIELDS = (
+    "latestSummaryRef",
+    "latestCheckpointRef",
+    "latestControlEventRef",
+    "latestResetBoundaryRef",
+)
+_SESSION_STATE_FIELDS = (
+    "sessionId",
+    "sessionEpoch",
+    "containerId",
+    "threadId",
+    "activeTurnId",
+)
+_SESSION_ARTIFACT_METADATA_FIELDS = (
+    "status",
+    "stdoutArtifactRef",
+    "stderrArtifactRef",
+    "diagnosticsRef",
+    "observabilityEventsRef",
+)
+_TURN_METADATA_SCALAR_FIELDS = (
+    "failureCause",
+    "failureClass",
+    "retryRecommendedAction",
+    "selfHealExhausted",
+    "selfHealAction",
+    "selfHealAttempts",
+    "inputTokens",
+    "input_tokens",
+    "promptTokens",
+    "prompt_tokens",
+    "outputTokens",
+    "output_tokens",
+    "completionTokens",
+    "completion_tokens",
+    "totalTokens",
+    "total_tokens",
+    "costEstimateUsd",
+    "cost_estimate_usd",
+    "estimatedCostUsd",
+    "estimated_cost_usd",
+)
+_SESSION_INTERVENTION_FIELDS = (
+    "action",
+    "reason",
+    "fromThreadId",
+    "toThreadId",
+    "fromSessionEpoch",
+    "toSessionEpoch",
+)
 _JIRA_CREATED_ISSUE_KEYS_PATTERN = re.compile(
     r"\b(?:created\s+(?:jira\s+)?(?:issues?|stories?|tickets?)|"
     r"created\s+(?:issue\s+)?keys?|issue\s+keys?\s+created)\b"
@@ -143,6 +194,120 @@ def _result_ref_metadata(
         compact_temporal_ref_metadata("resolvedSkillsetRef", resolved_skillset_ref)
     )
     return metadata
+
+
+def _compact_metadata_scalar(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, bool | int | float):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) > _COMPACT_METADATA_TEXT_CHARS:
+        return f"{text[:_COMPACT_METADATA_TEXT_CHARS]}..."
+    return text
+
+
+def _compact_session_interventions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list | tuple):
+        return []
+    interventions: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        compact: dict[str, Any] = {}
+        for key in _SESSION_INTERVENTION_FIELDS:
+            compact_value = _compact_metadata_scalar(item.get(key))
+            if compact_value is not None:
+                compact[key] = compact_value
+        if compact:
+            interventions.append(compact)
+    return interventions
+
+
+def _compact_turn_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(metadata, Mapping):
+        return {}
+    compact: dict[str, Any] = {}
+    for key in _TURN_METADATA_SCALAR_FIELDS:
+        compact_value = _compact_metadata_scalar(metadata.get(key))
+        if compact_value is not None:
+            compact[key] = compact_value
+    interventions = _compact_session_interventions(metadata.get("sessionInterventions"))
+    if interventions:
+        compact["sessionInterventions"] = interventions
+    return compact
+
+
+def _session_payload_mapping(value: BaseModel | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json", by_alias=True)
+    return dict(value)
+
+
+def _compact_session_ref_payload(
+    value: BaseModel | Mapping[str, Any],
+    *,
+    include_published_refs: bool,
+) -> dict[str, Any]:
+    raw_payload = _session_payload_mapping(value)
+    compact: dict[str, Any] = {}
+
+    raw_state = raw_payload.get("sessionState")
+    if isinstance(raw_state, Mapping):
+        session_state: dict[str, Any] = {}
+        for key in _SESSION_STATE_FIELDS:
+            compact_value = _compact_metadata_scalar(raw_state.get(key))
+            if compact_value is not None:
+                session_state[key] = compact_value
+        if session_state:
+            compact["sessionState"] = session_state
+
+    for key in _SESSION_REF_FIELDS:
+        compact_value = _compact_metadata_scalar(raw_payload.get(key))
+        if compact_value is not None:
+            compact[key] = compact_value
+
+    if include_published_refs:
+        raw_refs = raw_payload.get("publishedArtifactRefs")
+        if isinstance(raw_refs, list | tuple):
+            refs = [
+                ref
+                for ref in (
+                    _compact_metadata_scalar(raw_ref) for raw_ref in raw_refs
+                )
+                if isinstance(ref, str)
+            ]
+            if refs:
+                compact["publishedArtifactRefs"] = refs
+
+    raw_metadata = raw_payload.get("metadata")
+    if isinstance(raw_metadata, Mapping):
+        metadata: dict[str, Any] = {}
+        for key in _SESSION_ARTIFACT_METADATA_FIELDS:
+            compact_value = _compact_metadata_scalar(raw_metadata.get(key))
+            if compact_value is not None:
+                metadata[key] = compact_value
+        if metadata:
+            compact["metadata"] = metadata
+
+    return compact
+
+
+def _compact_session_summary_metadata(
+    summary: CodexManagedSessionSummary,
+) -> dict[str, Any]:
+    return _compact_session_ref_payload(summary, include_published_refs=False)
+
+
+def _compact_session_artifacts_metadata(
+    session_artifacts: CodexManagedSessionArtifactsPublication | Mapping[str, Any],
+) -> dict[str, Any]:
+    return _compact_session_ref_payload(
+        session_artifacts,
+        include_published_refs=True,
+    )
 
 
 def _merge_durable_retrieval_metadata(
@@ -779,19 +944,19 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         instruction_ref=original_instruction_ref,
                         resolved_skillset_ref=original_skillset_ref,
                     ),
-                    "sessionSummary": summary.model_dump(mode="json", by_alias=True),
-                    "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
+                    "sessionSummary": _compact_session_summary_metadata(summary),
+                    "sessionArtifacts": _compact_session_artifacts_metadata(
+                        publication
+                    ),
                     "turnId": turn_id,
                 }
                 if disposition:
                     result_metadata["outcomeDisposition"] = disposition
                     if disposition_reason:
-                        result_metadata["outcomeReason"] = disposition_reason
-                success_turn_metadata = {
-                    key: value
-                    for key, value in dict(turn_response.metadata or {}).items()
-                    if key in {"sessionInterventions"}
-                }
+                        compact_reason = _compact_metadata_scalar(disposition_reason)
+                        if compact_reason is not None:
+                            result_metadata["outcomeReason"] = compact_reason
+                success_turn_metadata = _compact_turn_metadata(turn_response.metadata)
                 if success_turn_metadata:
                     result_metadata["turnMetadata"] = success_turn_metadata
                 result = AgentRunResult(
@@ -1838,9 +2003,13 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         if turn_status:
             metadata["turnStatus"] = turn_status
         if turn_metadata:
-            metadata["turnMetadata"] = dict(turn_metadata)
+            compact_turn_metadata = _compact_turn_metadata(turn_metadata)
+            if compact_turn_metadata:
+                metadata["turnMetadata"] = compact_turn_metadata
         if session_artifacts is not None:
-            metadata["sessionArtifacts"] = dict(session_artifacts)
+            metadata["sessionArtifacts"] = _compact_session_artifacts_metadata(
+                session_artifacts
+            )
         provider_failure_event = build_provider_failure_event(
             classification=classification,
         )

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -421,7 +422,10 @@ async def test_start_launches_missing_workflow_scoped_session_and_persists_resul
         "artifact:session-checkpoint",
     ]
     assert result.metadata["instructionRef"] == "artifact:instructions"
-    assert result.metadata["sessionSummary"]["latestSummaryRef"] == "artifact:session-summary"
+    assert (
+        result.metadata["sessionSummary"]["latestSummaryRef"]
+        == "artifact:session-summary"
+    )
     assert result.metadata["sessionArtifacts"]["latestCheckpointRef"] == "artifact:session-checkpoint"
 
     assert attach_calls == [{"containerId": "container-1", "threadId": "thread-1"}]
@@ -433,6 +437,145 @@ async def test_start_launches_missing_workflow_scoped_session_and_persists_resul
     assert control_calls[-1]["action"] == "send_turn"
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
+
+async def test_start_compacts_session_result_metadata_for_workflow_payload(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.agent_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    large_summary_text = "s" * 7_800
+    large_publication_detail = "p" * 7_800
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        workspace_path.mkdir(parents=True)
+        (workspace_path / ".git").mkdir()
+        (workspace_path / ".launch-complete").write_text("ready\n", encoding="utf-8")
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_locator: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            last_assistant_text=large_summary_text,
+        )
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return CodexManagedSessionArtifactsPublication(
+            sessionState={
+                "sessionId": binding.session_id,
+                "sessionEpoch": binding.session_epoch,
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+            },
+            publishedArtifactRefs=(
+                "artifact:stdout",
+                "artifact:stderr",
+                "artifact:diagnostics",
+                "artifact:observability.events.jsonl",
+                "artifact:session-summary",
+                "artifact:session-checkpoint",
+            ),
+            latestSummaryRef="artifact:session-summary",
+            latestCheckpointRef="artifact:session-checkpoint",
+            metadata={
+                "status": "completed",
+                "stdoutArtifactRef": "artifact:stdout",
+                "stderrArtifactRef": "artifact:stderr",
+                "diagnosticsRef": "artifact:diagnostics",
+                "observabilityEventsRef": "artifact:observability.events.jsonl",
+                "verboseRuntimeDetail": large_publication_detail,
+            },
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+    result = await adapter.fetch_result(handle.run_id)
+    persisted_record = run_store.load(binding.agent_run_id)
+
+    assert (
+        result.metadata["sessionSummary"]["latestSummaryRef"]
+        == "artifact:session-summary"
+    )
+    assert "metadata" not in result.metadata["sessionSummary"]
+    assert result.metadata["sessionArtifacts"]["publishedArtifactRefs"] == [
+        "artifact:stdout",
+        "artifact:stderr",
+        "artifact:diagnostics",
+        "artifact:observability.events.jsonl",
+        "artifact:session-summary",
+        "artifact:session-checkpoint",
+    ]
+    assert result.metadata["sessionArtifacts"]["metadata"] == {
+        "status": "completed",
+        "stdoutArtifactRef": "artifact:stdout",
+        "stderrArtifactRef": "artifact:stderr",
+        "diagnosticsRef": "artifact:diagnostics",
+        "observabilityEventsRef": "artifact:observability.events.jsonl",
+    }
+    assert "verboseRuntimeDetail" not in result.metadata["sessionArtifacts"]["metadata"]
+    assert len(json.dumps(result.metadata, sort_keys=True)) < 16_384
+    assert persisted_record is not None
+    assert persisted_record.stdout_artifact_ref == "artifact:stdout"
+    assert persisted_record.diagnostics_ref == "artifact:diagnostics"
+    assert (
+        persisted_record.observability_events_ref
+        == "artifact:observability.events.jsonl"
+    )
 
 async def test_start_prepares_turn_instructions_after_cold_session_launch(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Fixes the cause of workflow `mm:736453ad-ec59-4bc6-8dc8-00130de722f4` failing during the Codex managed-session agent step.

The failed parent and child workflow evidence showed the agent step completed with an `execution_error` because `AgentRunResult.metadata` exceeded the 16 KB Temporal payload guard. The oversized payload came from embedding full Codex session summary/publication objects and raw turn metadata in the result metadata even though logs and runtime detail already live in artifacts.

## Changes

- Compact Codex session result metadata to bounded artifact-ref projections.
- Preserve session locator, latest summary/checkpoint/control/reset refs, published artifact refs, and known runtime artifact refs needed by the managed-run store.
- Whitelist compact turn metadata for failure classification, retry/self-heal reporting, interventions, and token/cost fields.
- Add a regression test where individually valid session summary/publication payloads would exceed the final result metadata limit if embedded whole.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/workflows/adapters/test_codex_session_adapter.py tests/schemas/test_temporal_payload_policy.py tests/unit/workflows/adapters/test_managed_session_conformance_boundary.py -q --tb=short -p no:cacheprovider` passed: 69 tests.
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py` could not run in this checkout because the precheck hit root-owned local runtime state at `deploy/state/desired-state.json` before pytest started.