### PR TITLE
[codex] Fix compact Codex session result metadata

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -144,6 +144,113 @@ def _result_ref_metadata(
     )
     return metadata
 
+def _validated_agent_run_result_copy(
+    result: AgentRunResult,
+    **updates: Any,
+) -> AgentRunResult:
+    payload = result.model_dump(mode="python")
+    payload.update(updates)
+    return AgentRunResult.model_validate(payload)
+
+
+def _compact_session_state_metadata(session_state: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "sessionId": session_state.session_id,
+        "sessionEpoch": session_state.session_epoch,
+        "containerId": session_state.container_id,
+        "threadId": session_state.thread_id,
+    }
+    active_turn_id = getattr(session_state, "active_turn_id", None)
+    if active_turn_id:
+        metadata["activeTurnId"] = active_turn_id
+    return metadata
+
+
+def _compact_session_summary_metadata(
+    summary: CodexManagedSessionSummary,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "sessionState": _compact_session_state_metadata(summary.session_state)
+    }
+    ref_fields = (
+        ("latestSummaryRef", summary.latest_summary_ref),
+        ("latestCheckpointRef", summary.latest_checkpoint_ref),
+        ("latestControlEventRef", summary.latest_control_event_ref),
+        ("latestResetBoundaryRef", summary.latest_reset_boundary_ref),
+    )
+    for key, value in ref_fields:
+        if value:
+            metadata[key] = value
+    return metadata
+
+
+def _compact_session_artifacts_metadata(
+    publication: CodexManagedSessionArtifactsPublication | Mapping[str, Any],
+) -> dict[str, Any]:
+    if isinstance(publication, CodexManagedSessionArtifactsPublication):
+        metadata: dict[str, Any] = {
+            "sessionState": _compact_session_state_metadata(publication.session_state)
+        }
+        if publication.published_artifact_refs:
+            metadata["publishedArtifactRefs"] = list(
+                publication.published_artifact_refs
+            )
+        ref_fields = (
+            ("latestSummaryRef", publication.latest_summary_ref),
+            ("latestCheckpointRef", publication.latest_checkpoint_ref),
+            ("latestControlEventRef", publication.latest_control_event_ref),
+            ("latestResetBoundaryRef", publication.latest_reset_boundary_ref),
+        )
+        raw_artifact_metadata = publication.metadata
+    else:
+        session_state = publication.get("sessionState")
+        metadata = {}
+        if isinstance(session_state, Mapping):
+            compact_state = {
+                key: session_state[key]
+                for key in (
+                    "sessionId",
+                    "sessionEpoch",
+                    "containerId",
+                    "threadId",
+                    "activeTurnId",
+                )
+                if session_state.get(key)
+            }
+            if compact_state:
+                metadata["sessionState"] = compact_state
+        published_refs = publication.get("publishedArtifactRefs")
+        if isinstance(published_refs, (list, tuple)) and published_refs:
+            metadata["publishedArtifactRefs"] = [
+                str(ref).strip() for ref in published_refs if str(ref).strip()
+            ]
+        ref_fields = (
+            ("latestSummaryRef", publication.get("latestSummaryRef")),
+            ("latestCheckpointRef", publication.get("latestCheckpointRef")),
+            ("latestControlEventRef", publication.get("latestControlEventRef")),
+            ("latestResetBoundaryRef", publication.get("latestResetBoundaryRef")),
+        )
+        raw_artifact_metadata = publication.get("metadata")
+
+    for key, value in ref_fields:
+        if value:
+            metadata[key] = value
+
+    if isinstance(raw_artifact_metadata, Mapping):
+        artifact_refs = {
+            key: raw_artifact_metadata[key]
+            for key in (
+                "stdoutArtifactRef",
+                "stderrArtifactRef",
+                "diagnosticsRef",
+                "observabilityEventsRef",
+            )
+            if raw_artifact_metadata.get(key)
+        }
+        if artifact_refs:
+            metadata["metadata"] = artifact_refs
+    return metadata
+
 
 def _merge_durable_retrieval_metadata(
     request: AgentExecutionRequest,
@@ -779,8 +886,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         instruction_ref=original_instruction_ref,
                         resolved_skillset_ref=original_skillset_ref,
                     ),
-                    "sessionSummary": summary.model_dump(mode="json", by_alias=True),
-                    "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
+                    "sessionSummary": _compact_session_summary_metadata(summary),
+                    "sessionArtifacts": _compact_session_artifacts_metadata(
+                        publication
+                    ),
                     "turnId": turn_id,
                 }
                 if disposition:
@@ -967,12 +1076,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         ):
                             should_apply_derived = True
                         if should_apply_derived:
-                            result = result.model_copy(
-                                update={
-                                    "failure_class": derived_failure_class,
-                                    "summary": derived_summary or summary,
-                                    "metadata": metadata,
-                                }
+                            result = _validated_agent_run_result_copy(
+                                result,
+                                failure_class=derived_failure_class,
+                                summary=derived_summary or summary,
+                                metadata=metadata,
                             )
                             updated_result = True
                     elif (
@@ -981,18 +1089,20 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         and failure_class in {None, "execution_error"}
                         and _is_generic_process_exit_summary(summary)
                     ):
-                        result = result.model_copy(
-                            update={
-                                "failure_class": None,
-                                "summary": (
-                                    "pr-resolver requested merge automation re-entry."
-                                ),
-                                "metadata": metadata,
-                            }
+                        result = _validated_agent_run_result_copy(
+                            result,
+                            failure_class=None,
+                            summary=(
+                                "pr-resolver requested merge automation re-entry."
+                            ),
+                            metadata=metadata,
                         )
                         updated_result = True
                     if not updated_result and metadata != result.metadata:
-                        result = result.model_copy(update={"metadata": metadata})
+                        result = _validated_agent_run_result_copy(
+                            result,
+                            metadata=metadata,
+                        )
             return result
         return AgentRunResult(
             summary="Managed session result not found.",
@@ -1840,7 +1950,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         if turn_metadata:
             metadata["turnMetadata"] = dict(turn_metadata)
         if session_artifacts is not None:
-            metadata["sessionArtifacts"] = dict(session_artifacts)
+            metadata["sessionArtifacts"] = _compact_session_artifacts_metadata(
+                session_artifacts
+            )
         provider_failure_event = build_provider_failure_event(
             classification=classification,
         )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8768,7 +8768,9 @@ class TemporalAgentRuntimeActivities:
                     meta["pull_request_url"] = pr_url
 
             if meta:
-                result = result.model_copy(update={"metadata": meta})
+                result_payload = result.model_dump(mode="python")
+                result_payload["metadata"] = meta
+                result = AgentRunResult.model_validate(result_payload)
 
             return result
         finally:

--- a/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
@@ -362,9 +362,12 @@ async def test_agent_run_managed_codex_session_recovers_terminal_rollout_without
             summary="Recovered final answer without vendor turn id",
             metadata={
                 "sessionSummary": {
-                    "metadata": {
-                        "lastAssistantText": "Recovered final answer without vendor turn id",
-                    }
+                    "sessionState": {
+                        "sessionId": "sess-test-codex",
+                        "sessionEpoch": 1,
+                        "containerId": "ctr-test-codex",
+                        "threadId": "thread-test-codex",
+                    },
                 }
             },
         )
@@ -459,6 +462,8 @@ async def test_agent_run_managed_codex_session_recovers_terminal_rollout_without
                     assert result.failure_class is None
                     assert result.summary == "Recovered final answer without vendor turn id"
                     assert isinstance(result.metadata, dict)
-                    assert result.metadata["sessionSummary"]["metadata"][
-                        "lastAssistantText"
-                    ] == "Recovered final answer without vendor turn id"
+                    assert (
+                        result.metadata["sessionSummary"]["sessionState"]["threadId"]
+                        == "thread-test-codex"
+                    )
+                    assert "metadata" not in result.metadata["sessionSummary"]

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -16,6 +16,7 @@ from temporalio.exceptions import (
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
+    AgentRunResult,
     ManagedRunRecord,
 )
 from moonmind.schemas.managed_session_models import (
@@ -849,6 +850,99 @@ async def test_start_omits_large_inline_instruction_from_result_metadata(
     assert result.metadata["instructionRefLengthChars"] == len(large_instruction.strip())
     assert len(result.metadata["instructionRefSha256"]) == 64
     assert "instructionRef" not in result.metadata
+
+
+async def test_start_compacts_nested_session_summary_metadata(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    near_limit_summary_metadata = {
+        "firstCompactField": "x" * 7800,
+        "secondCompactField": "y" * 7800,
+    }
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(
+            return_value=_turn_response(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=CodexManagedSessionSummary(
+                sessionState={
+                    "sessionId": binding.session_id,
+                    "sessionEpoch": binding.session_epoch,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                latestSummaryRef="artifact:session-summary",
+                latestCheckpointRef="artifact:session-checkpoint",
+                latestControlEventRef=None,
+                latestResetBoundaryRef=None,
+                metadata=near_limit_summary_metadata,
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(
+        _request(binding, instruction_ref="artifact:instructions")
+    )
+    result = await adapter.fetch_result(handle.run_id)
+
+    assert result.failure_class is None
+    assert (
+        result.metadata["sessionSummary"]["latestSummaryRef"]
+        == "artifact:session-summary"
+    )
+    assert "metadata" not in result.metadata["sessionSummary"]
+    assert (
+        result.metadata["sessionArtifacts"]["latestCheckpointRef"]
+        == "artifact:session-checkpoint"
+    )
+    AgentRunResult.model_validate(result.model_dump(mode="python"))
 
 async def test_start_preserves_completed_codex_turn_with_usage_limit_summary(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Keep Codex managed-session AgentRunResult metadata compact by projecting session summary/publication data down to refs and session identity.
- Revalidate AgentRunResult after metadata enrichment at the adapter/activity boundaries so model_copy cannot bypass compact-payload checks.
- Add regression coverage for near-limit session summary metadata and update the rollout workflow test to expect compact metadata.

## Root cause
The failed resolver workflow produced a valid managed-session summary, but the Codex adapter embedded the whole session summary object inside AgentRunResult.metadata. That nested payload exceeded the 16 KiB metadata contract and converted an otherwise successful turn into an execution_error.

## Validation
- MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest tests/unit/workflows/adapters/test_codex_session_adapter.py -q --tb=short
- MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_fetch_result_exposes_task_run_and_runtime_artifact_metadata tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_fetch_result_adds_managed_session_assistant_text_to_metadata tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_fetch_result_does_not_use_stale_session_text_for_failed_runs tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py::test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference -q --tb=short
- PYTHONDONTWRITEBYTECODE=1 python3 AST parse of touched files
- git diff --check

Note: ./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py -q --tb=short failed before pytest because tools/check_removed_capability_semantics.py could not read deploy/state/desired-state.json in this checkout.