### PR TITLE
Remove the workflow detail checkbox for live updates and remove the main workflows page checkbox for live updates. Live updates should just always be…

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -420,6 +420,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+      expect(screen.getByText('Live updates enabled. Polling every 0s')).toBeTruthy();
       expect(screen.getByRole('heading', { name: 'Workflow Preview' })).toBeTruthy();
       expect(screen.getByText('Focused route summary')).toBeTruthy();
       expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('aria-current')).toBe('page');

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2746,7 +2746,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     fireEvent.click(trigger);
     const focusMenu = screen.getByRole('menu', { name: 'Workflow actions' });
-    fireEvent.blur(focusMenu, { relatedTarget: screen.getByLabelText('Live updates') });
+    fireEvent.blur(focusMenu, { relatedTarget: document.body });
     expect(screen.queryByRole('menu', { name: 'Workflow actions' })).toBeNull();
     expect(fetchSpy.mock.calls.some(([url, init]) => String(url).includes('/signal') && init?.method === 'POST')).toBe(false);
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4907,7 +4907,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       return null;
     }
   });
-  const [liveUpdates, setLiveUpdates] = useState(true);
   const [expandedSteps, setExpandedSteps] = useState<Record<string, boolean>>({});
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
   const [remediationMode, setRemediationMode] = useState(DEFAULT_REMEDIATION_MODE);
@@ -4930,7 +4929,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     },
     enabled: Boolean(encodedTaskId),
     refetchInterval: (query) => (
-      liveUpdates && !isExecutionTerminal(query.state.data)
+      !isExecutionTerminal(query.state.data)
         ? detailPoll
         : false
     ),
@@ -4980,7 +4979,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     queryKey: ['workflow-detail-steps', workflowId, execution?.stepsHref],
     queryFn: () => fetchStepLedger(String(execution?.stepsHref || '')),
     enabled: Boolean(execution?.stepsHref),
-    refetchInterval: liveUpdates && execution?.stepsHref && !isTerminalExecution ? detailPoll : false,
+    refetchInterval: execution?.stepsHref && !isTerminalExecution ? detailPoll : false,
   });
   const latestRunId = stepsQuery.data?.runId || runId;
   const selectedRecoveryOptions = useMemo(() => {
@@ -5054,7 +5053,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         selectedRecoveryStep?.logicalStepId &&
         selectedRecoveryStep.executionOrdinal > 0,
     ),
-    refetchInterval: liveUpdates && !isTerminalExecution ? detailPoll : false,
+    refetchInterval: !isTerminalExecution ? detailPoll : false,
   });
   const recoveryEligibility =
     execution?.recoveryEligibility ?? stepRecoveryQuery.data?.recoveryEligibility ?? null;
@@ -5072,7 +5071,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     enabled:
       Boolean(namespace && workflowId && latestRunId)
       && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
-    refetchInterval: liveUpdates && namespace && workflowId && latestRunId && !isTerminalExecution
+    refetchInterval: namespace && workflowId && latestRunId && !isTerminalExecution
       ? detailPoll
       : false,
   });
@@ -5090,7 +5089,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     enabled:
       Boolean(namespace && workflowId && latestRunId)
       && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
-    refetchInterval: liveUpdates && namespace && workflowId && latestRunId && !isTerminalExecution
+    refetchInterval: namespace && workflowId && latestRunId && !isTerminalExecution
       ? detailPoll
       : false,
   });
@@ -5099,7 +5098,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     queryKey: ['workflow-detail-run-summary', summaryArtifactRef],
     queryFn: () => fetchRunSummaryArtifact(payload.apiBase, summaryArtifactRef),
     enabled: Boolean(summaryArtifactRef),
-    refetchInterval: liveUpdates && summaryArtifactRef && !isTerminalExecution ? detailPoll : false,
+    refetchInterval: summaryArtifactRef && !isTerminalExecution ? detailPoll : false,
   });
   const inboundRemediationsQuery = useQuery({
     queryKey: ['workflow-detail-remediations', workflowId, 'inbound'],
@@ -5618,18 +5617,8 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           </div>
         </div>
         <div className="toolbar-controls">
-          <label className="queue-inline-toggle toolbar-live-toggle">
-            <input
-              type="checkbox"
-              checked={liveUpdates}
-              onChange={(event) => setLiveUpdates(event.target.checked)}
-            />
-            Live updates
-          </label>
           <span className="small">
-            {liveUpdates
-              ? `Polling every ${Math.round(detailPoll / 1000)}s`
-              : 'Updates paused to keep selections stable.'}
+            Live updates enabled. Polling every ${Math.round(detailPoll / 1000)}s
           </span>
         </div>
       </div>
@@ -6047,7 +6036,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                         workflowId={workflowId}
                         runId={latestRunId}
                         sourceTemporal={sourceTemporal}
-                        historyPollInterval={liveUpdates && !isTerminalExecution ? detailPoll : false}
+                        historyPollInterval={!isTerminalExecution ? detailPoll : false}
                         expanded={Boolean(expandedSteps[row.logicalStepId])}
                         onToggle={() => toggleStep(row.logicalStepId)}
                         isLast={idx === stepsQuery.data.steps.length - 1}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5618,7 +5618,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         </div>
         <div className="toolbar-controls">
           <span className="small">
-            Live updates enabled. Polling every ${Math.round(detailPoll / 1000)}s
+            Live updates enabled. Polling every {Math.round(detailPoll / 1000)}s
           </span>
         </div>
       </div>

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -64,7 +64,7 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
-    expect(screen.getByLabelText('Live updates')).toBeTruthy();
+    expect(screen.queryByLabelText('Live updates')).toBeNull();
   });
 
   it('keeps active filter chips visible on an empty first page with active filters', async () => {
@@ -105,7 +105,7 @@ describe('Workflows Entrypoint', () => {
 
     expect(await screen.findByText('No workflows found for the current filters.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
-    expect(screen.getByLabelText('Live updates')).toBeTruthy();
+    expect(screen.queryByLabelText('Live updates')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   }, 10000);
 
@@ -1103,8 +1103,8 @@ describe('Workflows Entrypoint', () => {
     const liveBlock = footer?.querySelector('.workflow-list-footer-live');
     const paginationBlock = footer?.querySelector('.workflow-list-footer-pagination');
     const paginationSummary = footer?.querySelector('.workflow-list-footer-page-summary');
-    expect(liveBlock?.contains(screen.getByLabelText('Live updates'))).toBe(true);
-    expect(liveBlock?.textContent).toContain('Polling every 5s');
+    expect(liveBlock?.querySelector('input[type="checkbox"]')).toBeNull();
+    expect(liveBlock?.textContent).toContain('Live updates enabled. Polling every 5s');
     expect(paginationBlock?.contains(screen.getByLabelText('Show'))).toBe(true);
     expect(getComputedStyle(paginationBlock as Element).flexWrap).toBe('wrap');
     expect(paginationSummary?.textContent).toContain('1 - 1');
@@ -1174,8 +1174,8 @@ describe('Workflows Entrypoint', () => {
 
     expect(controlDeck?.classList.contains('panel--controls')).toBe(false);
     expect(controlDeck?.querySelector('.workflow-list-utility-cluster')).toBeNull();
-    expect(dataSlab?.querySelector('.workflow-list-results-footer')?.contains(screen.getByLabelText('Live updates'))).toBe(
-      true,
+    expect(dataSlab?.querySelector('.workflow-list-results-footer')?.textContent).toContain(
+      'Live updates enabled. Polling every 5s',
     );
     expect(screen.queryByText('Showing all task executions.')).toBeNull();
     expect(dataSlab).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -632,7 +632,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
   );
   const [cursorStack, setCursorStack] = useState<string[]>([]);
-  const [liveUpdates, setLiveUpdates] = useState(true);
   const [sortField, setSortField] = useState<string>(() => normalizeTableSortField(initial.get('sort')));
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(() => {
     const initialSortDir = initial.get('sortDir');
@@ -693,7 +692,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       }
       return ExecutionListResponseSchema.parse(await response.json());
     },
-    refetchInterval: liveUpdates && listEnabled && !openFilter ? listPollMs : false,
+    refetchInterval: listEnabled && !openFilter ? listPollMs : false,
   });
 
   const openFacet = facetForFilterField(openFilter);
@@ -838,19 +837,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const resultsFooter = (
     <div className="queue-results-toolbar workflow-list-results-footer">
       <div className="workflow-list-footer-live">
-        <label className="queue-inline-toggle toolbar-live-toggle workflow-list-footer-live-toggle">
-          <input
-            type="checkbox"
-            checked={liveUpdates}
-            disabled={!listEnabled}
-            onChange={(event) => setLiveUpdates(event.target.checked)}
-          />
-          Live updates
-        </label>
         <span className="small">
-          {liveUpdates && listEnabled
-            ? `Polling every ${Math.round(listPollMs / 1000)}s`
-            : 'Updates paused to keep selections stable.'}
+          {listEnabled
+            ? `Live updates enabled. Polling every ${Math.round(listPollMs / 1000)}s`
+            : 'Live updates unavailable while the list is disabled.'}
         </span>
       </div>
       <div className="queue-pagination workflow-list-footer-pagination">

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -577,13 +577,6 @@ h1 {
   margin-left: auto;
 }
 
-.toolbar-live-toggle {
-  margin: 0;
-}
-
-.toolbar-live-toggle input {
-  margin: 0;
-}
 
 .table-sort-button {
   display: inline-flex;
@@ -1753,9 +1746,6 @@ tbody tr:hover {
   justify-content: flex-start;
 }
 
-.workflow-list-footer-live-toggle {
-  flex: 0 0 auto;
-}
 
 .workflow-list-footer-page-summary {
   justify-content: flex-end;


### PR DESCRIPTION
Remove the workflow detail checkbox for live updates and remove the main workflows page checkbox for live updates. Live updates should just always be enabled if you have the page open.