### PR TITLE
I want to hide the Manifests and Index Health navigation pages in the UI until they are more fully implemented

### DIFF
--- a/api_service/templates/_navigation.html
+++ b/api_service/templates/_navigation.html
@@ -1,8 +1,6 @@
 <nav class="route-nav" id="dashboard-nav" aria-label="MoonMind navigation">
   <a href="/workflows" data-nav {% if current_path == '/workflows' or (current_path.startswith('/workflows/') and current_path != '/workflows/new') %}class="active" aria-current="page"{% endif %}>🛰️ Workflows</a>
   <a href="/workflows/new" data-nav {% if current_path == '/workflows/new' %}class="active" aria-current="page"{% endif %}>🚀 Start Workflow</a>
-  <a href="/manifests" data-nav {% if current_path == '/manifests' %}class="active" aria-current="page"{% endif %}>💽 Manifests</a>
-  <a href="/index-health" data-nav {% if current_path == '/index-health' %}class="active" aria-current="page"{% endif %}>📈 Index Health</a>
   <a href="/schedules" data-nav {% if current_path == '/schedules' %}class="active" aria-current="page"{% endif %}>🌒 Schedules</a>
   <a href="/skills" data-nav {% if current_path == '/skills' %}class="active" aria-current="page"{% endif %}>🛠️ Skills</a>
   <a href="/settings" data-nav {% if current_path == '/settings' %}class="active" aria-current="page"{% endif %}>⚙️ Settings</a>

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -334,11 +334,15 @@ def test_legacy_manifest_submit_route_openapi_documents_redirect(
     assert "200" not in route["responses"]
     assert "application/json" not in route["responses"]["307"].get("content", {})
 
-def test_navigation_exposes_single_manifest_destination(client: TestClient) -> None:
+def test_navigation_hides_incomplete_manifest_and_index_health_pages(
+    client: TestClient,
+) -> None:
     response = client.get("/manifests")
 
     assert response.status_code == 200
-    assert 'href="/manifests"' in response.text
+    assert 'href="/manifests"' not in response.text
+    assert 'href="/index-health"' not in response.text
+    assert "Index Health" not in response.text
     assert "Manifest Submit" not in response.text
     assert 'href="/manifests/new"' not in response.text
 


### PR DESCRIPTION
I want to hide the Manifests and Index Health navigation pages in the UI until they are more fully implemented