### PR TITLE
MM-945 correct capability derivation

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16300,6 +16300,73 @@ describe("Task Create governed Tool authoring", () => {
     });
   });
 
+  it("does not derive Git after clearing the repository with a default configured", async () => {
+    toolDiscoveryResponse = {
+      ok: true,
+      json: async () => ({
+        tools: [
+          {
+            name: "jira.get_issue",
+            description: "Fetch a Jira issue.",
+            inputSchema: { type: "object" },
+            requiredCapabilities: ["jira"],
+          },
+        ],
+      }),
+    } as Response;
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    fireEvent.change(await screen.findByLabelText(/GitHub Repo/), {
+      target: { value: "" },
+    });
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Fetch the Jira issue without repository checkout." },
+    });
+    selectStepType(step, "Tool");
+    fireEvent.click(
+      await within(step).findByRole("button", { name: /jira.get_issue/ }),
+    );
+    fireEvent.change(within(step).getByLabelText("Tool Inputs (JSON object)"), {
+      target: { value: '{"issueKey":"MM-945"}' },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest() as {
+      payload: {
+        repository?: string;
+        requiredCapabilities?: string[];
+        task: {
+          git?: Record<string, unknown>;
+          steps: Array<{ tool?: Record<string, unknown> }>;
+        };
+      };
+    };
+    expect(request.payload.repository).toBeUndefined();
+    expect(request.payload.requiredCapabilities).toEqual([
+      "codex_cli",
+      "gh",
+      "jira",
+    ]);
+    expect(request.payload.task.git).toBeUndefined();
+    expect(request.payload.task.steps[0]?.tool).toEqual({
+      type: "tool",
+      id: "jira.get_issue",
+      inputs: { issueKey: "MM-945" },
+      requiredCapabilities: ["jira"],
+    });
+  });
+
   it("submits an authored MM-577 Skill step with agentic controls", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16241,6 +16241,65 @@ describe("Task Create governed Tool authoring", () => {
     });
   });
 
+  it("does not derive Git for a Jira-only Tool workflow without repository context", async () => {
+    toolDiscoveryResponse = {
+      ok: true,
+      json: async () => ({
+        tools: [
+          {
+            name: "jira.get_issue",
+            description: "Fetch a Jira issue.",
+            inputSchema: { type: "object" },
+            requiredCapabilities: ["jira"],
+          },
+        ],
+      }),
+    } as Response;
+    renderWithClient(<WorkflowStartPage payload={withoutDefaultRepository()} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Fetch the Jira issue without repository checkout." },
+    });
+    selectStepType(step, "Tool");
+    fireEvent.click(
+      await within(step).findByRole("button", { name: /jira.get_issue/ }),
+    );
+    fireEvent.change(within(step).getByLabelText("Tool Inputs (JSON object)"), {
+      target: { value: '{"issueKey":"MM-945"}' },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest() as {
+      payload: {
+        repository?: string;
+        requiredCapabilities?: string[];
+        task: { steps: Array<{ tool?: Record<string, unknown> }> };
+      };
+    };
+    expect(request.payload.repository).toBeUndefined();
+    expect(request.payload.requiredCapabilities).toEqual([
+      "codex_cli",
+      "gh",
+      "jira",
+    ]);
+    expect(request.payload.task.steps[0]?.tool).toEqual({
+      type: "tool",
+      id: "jira.get_issue",
+      inputs: { issueKey: "MM-945" },
+      requiredCapabilities: ["jira"],
+    });
+  });
+
   it("submits an authored MM-577 Skill step with agentic controls", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -2785,6 +2785,7 @@ function deriveRequiredCapabilities(args: {
   runtimeMode: string;
   stepRuntimeModes: string[];
   publishMode: string;
+  repositoryBacked: boolean;
   taskSkillRequiredCapabilities: string[];
   stepSkillRequiredCapabilities: string[];
   toolRequiredCapabilities: string[];
@@ -2796,7 +2797,7 @@ function deriveRequiredCapabilities(args: {
       [
         args.runtimeMode,
         ...args.stepRuntimeModes,
-        "git",
+        ...(args.repositoryBacked ? ["git"] : []),
         ...(args.publishMode === "pr" ? ["gh"] : []),
         ...args.taskSkillRequiredCapabilities,
         ...args.stepSkillRequiredCapabilities,
@@ -8699,15 +8700,8 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       setIsSubmitting(false);
       releaseSubmitArrowExit();
     };
-    const normalizedRepository = repository.trim() || defaultRepository;
-    if (!normalizedRepository) {
-      setSubmitMessage(
-        "Repository is required because no system default repository is configured.",
-      );
-      clearSubmitBusy();
-      return;
-    }
-    if (!isValidRepositoryInput(normalizedRepository)) {
+    const normalizedRepository = repository.trim();
+    if (normalizedRepository && !isValidRepositoryInput(normalizedRepository)) {
       setSubmitMessage(
         "Repository must be owner/repo, https://<host>/<path>, or git@<host>:<path> (token-free).",
       );
@@ -9594,6 +9588,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       toolRequiredCapabilities,
       explicitStepCapabilities,
       templateCapabilities,
+      repositoryBacked: Boolean(normalizedRepository || effectiveBranch),
     });
 
     const normalizedTaskTool = primaryStepTool;
@@ -9724,7 +9719,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       priority: effectivePriority,
       maxAttempts: effectiveMaxAttempts,
       payload: {
-        repository: normalizedRepository,
+        ...(normalizedRepository ? { repository: normalizedRepository } : {}),
         ...(mergedCapabilities.length > 0
           ? { requiredCapabilities: mergedCapabilities }
           : {}),

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6976,8 +6976,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   const branchLookupEndpoint = normalizeMoonMindApiPath(
     dashboardConfig.sources?.github?.branches,
   );
+  const submittedRepository = repository.trim();
   const selectedRepositoryForBranchLookup =
-    repository.trim() || defaultRepository;
+    submittedRepository || defaultRepository;
   const branchLookupRepository = canLookupRepositoryBranches(
     selectedRepositoryForBranchLookup,
   )
@@ -7007,7 +7008,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   }, [branchOptionsQuery.data?.defaultBranch]);
   const effectiveBranch =
     branch.trim() ||
-    (!branchTouched && pageMode.mode === "create" ? defaultBranch : "");
+    (!branchTouched && pageMode.mode === "create" && submittedRepository
+      ? defaultBranch
+      : "");
   const selectedBranchIsStale = Boolean(
     branch.trim() &&
       branchOptionsQuery.isSuccess &&
@@ -9588,7 +9591,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
       toolRequiredCapabilities,
       explicitStepCapabilities,
       templateCapabilities,
-      repositoryBacked: Boolean(normalizedRepository || effectiveBranch),
+      repositoryBacked: Boolean(normalizedRepository),
     });
 
     const normalizedTaskTool = primaryStepTool;
@@ -9695,7 +9698,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             },
           }
         : {}),
-      ...(effectiveBranch
+      ...(normalizedRepository && effectiveBranch
         ? {
             git: {
               branch: effectiveBranch,

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -11691,10 +11691,6 @@ class CodexWorker:
     ) -> str | None:
         """Fail-closed policy guard for repository + capability requirements."""
 
-        repository = str(canonical_payload.get("repository") or "").strip()
-        if not repository:
-            return "repository is required for task execution"
-
         required_raw = canonical_payload.get("requiredCapabilities")
         if not isinstance(required_raw, list):
             return "requiredCapabilities must be a non-empty list"
@@ -11703,6 +11699,9 @@ class CodexWorker:
         }
         if not required:
             return "requiredCapabilities must include at least one capability"
+        repository = str(canonical_payload.get("repository") or "").strip()
+        if "git" in required and not repository:
+            return "repository is required for git task execution"
 
         available = {
             str(item).strip().lower()

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2520,12 +2520,17 @@ def build_canonical_workflow_view(
             },
         }
 
+    workflow_node = canonical.get("workflow")
+    if not isinstance(workflow_node, dict):
+        workflow_node = {}
+        canonical["workflow"] = workflow_node
+
     target_runtime = (
         _normalize_runtime_value(
             canonical.get("targetRuntime"), field_name="targetRuntime"
         )
         or _normalize_runtime_value(
-            ((canonical.get("workflow") or {}).get("runtime") or {}).get("mode"),
+            (workflow_node.get("runtime") or {}).get("mode"),
             field_name="workflow.runtime.mode",
         )
         or resolved_default_runtime
@@ -2533,10 +2538,10 @@ def build_canonical_workflow_view(
     if target_runtime == "universal":
         target_runtime = resolved_default_runtime
 
-    runtime_node = (canonical.get("workflow") or {}).get("runtime")
+    runtime_node = workflow_node.get("runtime")
     if not isinstance(runtime_node, dict):
         runtime_node = {}
-        canonical.setdefault("workflow", {})["runtime"] = runtime_node
+        workflow_node["runtime"] = runtime_node
     runtime_node["mode"] = target_runtime
     canonical["targetRuntime"] = target_runtime
 
@@ -2549,7 +2554,9 @@ def build_canonical_workflow_view(
         required.extend(canonical_existing)
 
     required.append(target_runtime)
-    workflow_git_node = (canonical.get("workflow") or {}).get("git")
+    workflow_git_node = (
+        workflow_node.get("git") if isinstance(workflow_node, Mapping) else None
+    )
     workflow_git = workflow_git_node if isinstance(workflow_git_node, Mapping) else {}
     has_git_checkout_context = any(
         _clean_optional_str(workflow_git.get(key))
@@ -2578,12 +2585,8 @@ def build_canonical_workflow_view(
     publish_mode_candidate = (
         source_publish_mode
         if normalized_type == CANONICAL_WORKFLOW_JOB_TYPE
-        else ((canonical.get("workflow") or {}).get("publish") or {}).get("mode")
+        else (workflow_node.get("publish") or {}).get("mode")
     )
-    workflow_node = canonical.get("workflow")
-    if not isinstance(workflow_node, dict):
-        workflow_node = {}
-        canonical["workflow"] = workflow_node
     workflow_payload = workflow_node
     publish_node = workflow_payload.get("publish")
     if not isinstance(publish_node, dict):

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -2203,8 +2203,8 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
-    repository: str = Field(
-        ...,
+    repository: str | None = Field(
+        None,
         alias="repository",
         validation_alias=AliasChoices("repository", "repo"),
     )
@@ -2549,7 +2549,21 @@ def build_canonical_workflow_view(
         required.extend(canonical_existing)
 
     required.append(target_runtime)
-    required.append("git")
+    workflow_git_node = (canonical.get("workflow") or {}).get("git")
+    workflow_git = workflow_git_node if isinstance(workflow_git_node, Mapping) else {}
+    has_git_checkout_context = any(
+        _clean_optional_str(workflow_git.get(key))
+        for key in (
+            "repository",
+            "repo",
+            "branch",
+            "startingBranch",
+            "targetBranch",
+            "ref",
+        )
+    )
+    if _clean_optional_str(canonical.get("repository")) or has_git_checkout_context:
+        required.append("git")
 
     source_publish_mode = None
     if normalized_type == CANONICAL_WORKFLOW_JOB_TYPE:

--- a/tests/integration/api/test_execution_contract_normalization.py
+++ b/tests/integration/api/test_execution_contract_normalization.py
@@ -9,6 +9,7 @@ Acceptance scenarios covered:
   SC-002  recover_from_failed_step without resume block → WorkflowContractError
   SC-003  resume block with wrong recovery.kind → WorkflowContractError
   SC-006  workflow.git.targetBranch stripped as active authored branch input
+  MM-945  git capability derived only from repository-backed execution context
 """
 from __future__ import annotations
 
@@ -46,6 +47,12 @@ def _workflow_payload(workflow_overrides: dict) -> dict:
         **_BASE_PAYLOAD,
         "workflow": {**_BASE_PAYLOAD["workflow"], **workflow_overrides},
     }
+
+
+def _workflow_payload_without_repository(workflow_overrides: dict) -> dict:
+    payload = _workflow_payload(workflow_overrides)
+    payload.pop("repository", None)
+    return payload
 
 
 def _workflow_step_payload(*steps: dict) -> dict:
@@ -148,6 +155,72 @@ def test_mm641_task_git_branch_remains_the_active_authored_branch() -> None:
     assert result["workflow"]["git"]["branch"] == "feature/mm-641-create-page"
     assert result["workflow"]["publish"]["mode"] == "branch"
     assert "targetBranch" not in result["workflow"]["git"]
+
+
+def test_mm945_document_only_workflow_without_repository_does_not_derive_git() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload=_workflow_payload_without_repository(
+            {
+                "publish": {"mode": "none"},
+                "reportOutput": {"enabled": True},
+            }
+        ),
+    )
+
+    assert result["repository"] is None
+    assert "git" not in result["requiredCapabilities"]
+    assert result["requiredCapabilities"] == ["codex"]
+
+
+def test_mm945_jira_only_step_without_repository_does_not_derive_git() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload=_workflow_payload_without_repository(
+            {
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "type": "tool",
+                        "instructions": "Fetch Jira issue context.",
+                        "tool": {
+                            "type": "tool",
+                            "id": "jira.get_issue",
+                            "inputs": {"issueKey": "MM-945"},
+                            "requiredCapabilities": ["jira"],
+                        },
+                    }
+                ],
+            }
+        ),
+    )
+
+    assert result["repository"] is None
+    assert result["requiredCapabilities"] == ["codex", "jira"]
+
+
+def test_mm945_pr_publish_without_repository_derives_gh_not_git() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload=_workflow_payload_without_repository({"publish": {"mode": "pr"}}),
+    )
+
+    assert result["repository"] is None
+    assert "git" not in result["requiredCapabilities"]
+    assert result["requiredCapabilities"] == ["codex", "gh"]
+
+
+def test_mm945_explicit_git_capability_remains_authoritative_without_repository() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            **_workflow_payload_without_repository({"publish": {"mode": "none"}}),
+            "requiredCapabilities": ["git"],
+        },
+    )
+
+    assert result["repository"] is None
+    assert result["requiredCapabilities"] == ["git", "codex"]
 
 
 def test_mm569_unresolved_preset_submission_rejected_with_field_path() -> None:

--- a/tests/integration/api/test_execution_contract_normalization.py
+++ b/tests/integration/api/test_execution_contract_normalization.py
@@ -223,6 +223,17 @@ def test_mm945_explicit_git_capability_remains_authoritative_without_repository(
     assert result["requiredCapabilities"] == ["git", "codex"]
 
 
+def test_mm945_malformed_workflow_node_raises_contract_error_not_attribute_error() -> None:
+    with pytest.raises(WorkflowContractError, match="task.instructions is required"):
+        build_canonical_workflow_view(
+            job_type="task",
+            payload={
+                "workflow": "malformed",
+                "requiredCapabilities": ["jira"],
+            },
+        )
+
+
 def test_mm569_unresolved_preset_submission_rejected_with_field_path() -> None:
     with pytest.raises(WorkflowContractError) as excinfo:
         build_canonical_workflow_view(

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -5839,6 +5839,54 @@ async def test_run_once_rejects_when_required_capabilities_missing(
     assert "missing required capabilities" in queue.failed[0]
     assert handler.calls == []
 
+async def test_required_job_policy_allows_repository_less_non_git_work(
+    tmp_path: Path,
+) -> None:
+    worker = CodexWorker.__new__(CodexWorker)
+    worker._config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        worker_capabilities=("codex", "gh", "jira"),
+    )
+
+    error = worker._validate_required_job_policy(
+        {
+            "repository": None,
+            "requiredCapabilities": ["codex", "gh", "jira"],
+        }
+    )
+
+    assert error is None
+
+
+async def test_required_job_policy_requires_repository_for_git_work(
+    tmp_path: Path,
+) -> None:
+    worker = CodexWorker.__new__(CodexWorker)
+    worker._config = CodexWorkerConfig(
+        moonmind_url="http://localhost:8000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        worker_capabilities=("codex", "git"),
+    )
+
+    error = worker._validate_required_job_policy(
+        {
+            "repository": None,
+            "requiredCapabilities": ["codex", "git"],
+        }
+    )
+
+    assert error == "repository is required for git task execution"
+
+
 async def test_run_once_rejects_resolve_pr_publish_none_without_pr_resolver(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1112,6 +1112,83 @@ def test_mm569_tool_step_required_capabilities_aggregate_into_canonical_required
     assert "jira" in result["requiredCapabilities"]
 
 
+def test_required_capabilities_do_not_derive_git_without_repository_context() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "targetRuntime": "codex_cli",
+            "task": {
+                "instructions": "Fetch the Jira issue only.",
+                "publish": {"mode": "none"},
+                "steps": [tool_step()],
+            },
+        },
+    )
+
+    assert result["repository"] is None
+    assert result["requiredCapabilities"] == ["codex_cli", "jira"]
+
+
+def test_pr_publish_derives_gh_without_implicit_git_for_non_repository_workflow() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "targetRuntime": "codex_cli",
+            "task": {
+                "instructions": "Prepare a Jira-only report.",
+                "publish": {"mode": "pr"},
+            },
+        },
+    )
+
+    assert "gh" in result["requiredCapabilities"]
+    assert "git" not in result["requiredCapabilities"]
+
+
+def test_required_capabilities_derive_git_from_repository_or_git_context() -> None:
+    repository_result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex_cli",
+            "task": {
+                "instructions": "Run repository-backed work.",
+                "publish": {"mode": "none"},
+            },
+        },
+    )
+    git_context_result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "targetRuntime": "codex_cli",
+            "task": {
+                "instructions": "Run branch-backed work.",
+                "git": {"branch": "feature/mm-945"},
+                "publish": {"mode": "none"},
+            },
+        },
+    )
+
+    assert "git" in repository_result["requiredCapabilities"]
+    assert "git" in git_context_result["requiredCapabilities"]
+
+
+def test_explicit_git_required_capability_is_preserved_without_repository_context() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "targetRuntime": "codex_cli",
+            "requiredCapabilities": ["git"],
+            "task": {
+                "instructions": "Run explicit Git-capability work.",
+                "publish": {"mode": "none"},
+            },
+        },
+    )
+
+    assert result["requiredCapabilities"] == ["git", "codex_cli"]
+
+
 def test_skill_metadata_required_capabilities_aggregate_into_canonical_required() -> None:
     result = build_canonical_workflow_view(
         job_type="task",


### PR DESCRIPTION
Issue reference: MM-945

Summary:
- Make frontend capability derivation add `git` only when workflow submission includes repository or branch context.
- Allow repository-less task submissions and omit `payload.repository` when no repository is provided.
- Update backend canonical execution normalization so `git` is derived only from repository/git checkout context while preserving explicit capabilities and PR publish `gh` derivation.
- Add regression coverage for repository-less document/Jira workflows, PR publish behavior, explicit Git capability preservation, and frontend Tool submission payloads.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/executions/test_execution_contract.py --ui-args frontend/src/entrypoints/workflow-start.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/integration/api/test_execution_contract_normalization.py`

Remaining risks:
- Integration coverage was run through the local unit runner for the targeted API normalization file; the compose-backed integration suite was not run because this change does not touch Docker, compose, database migrations, or runtime infrastructure.
