### PR TITLE
[codex] Fix recurring schedule workflow ID routing

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -64,6 +64,7 @@ TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 _SAFE_DETAIL_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SAFE_WORKFLOW_ID_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$")
 _WORKFLOW_DETAIL_TABS = {"steps", "artifacts", "runs"}
 _RESERVED_WORKFLOW_ROUTE_SEGMENTS = {
     "manifests",
@@ -175,6 +176,14 @@ def _is_safe_detail_segment(segment: str) -> bool:
         return False
     return _SAFE_DETAIL_SEGMENT.fullmatch(text) is not None
 
+def _is_safe_workflow_id_segment(segment: str) -> bool:
+    text = segment.strip()
+    if not text:
+        return False
+    if text in {".", ".."}:
+        return False
+    return _SAFE_WORKFLOW_ID_SEGMENT.fullmatch(text) is not None
+
 def _normalize_workflow_detail_path(workflow_path: str) -> str | None:
     normalized = workflow_path.strip("/")
     if not normalized:
@@ -184,13 +193,13 @@ def _normalize_workflow_detail_path(workflow_path: str) -> str | None:
     parts = normalized.split("/")
     if (
         len(parts) == 1
-        and _is_safe_detail_segment(parts[0])
+        and _is_safe_workflow_id_segment(parts[0])
         and parts[0].lower() not in _RESERVED_WORKFLOW_ROUTE_SEGMENTS
     ):
         return parts[0]
     if (
         len(parts) == 2
-        and _is_safe_detail_segment(parts[0])
+        and _is_safe_workflow_id_segment(parts[0])
         and parts[0].lower() not in _RESERVED_WORKFLOW_ROUTE_SEGMENTS
         and parts[1] in _WORKFLOW_DETAIL_TABS
     ):

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -26,6 +26,9 @@ from moonmind.workflows.recurring.cron import (
     parse_cron_expression,
     validate_timezone_name,
 )
+from moonmind.workflows.temporal.schedule_mapping import (
+    make_scheduled_workflow_id_base,
+)
 from moonmind.workflows.temporal.client import (
     ScheduleTriggerResult,
     TemporalClientAdapter,
@@ -520,10 +523,12 @@ class RecurringWorkflowsService:
         self,
         *,
         action: object | None,
+        definition_id: UUID,
         workflow_type: str,
         workflow_input: Mapping[str, Any],
     ) -> bool:
         temporal_workflow_type = _object_value(action, "workflow")
+        temporal_workflow_id_base = _object_value(action, "id")
         temporal_args = _object_value(action, "args") or []
         try:
             temporal_args_list = list(temporal_args)
@@ -532,8 +537,10 @@ class RecurringWorkflowsService:
         temporal_input = temporal_args_list[0] if temporal_args_list else None
         temporal_task_queue = _object_value(action, "task_queue", "taskQueue")
         expected_task_queue = self._expected_task_queue(workflow_type)
+        expected_workflow_id_base = make_scheduled_workflow_id_base(definition_id)
         return (
             temporal_workflow_type != workflow_type
+            or temporal_workflow_id_base != expected_workflow_id_base
             or temporal_input != workflow_input
             or (
                 expected_task_queue is not None
@@ -567,6 +574,7 @@ class RecurringWorkflowsService:
         action = _object_value(schedule, "action")
         if not self._schedule_action_mismatch(
             action=action,
+            definition_id=definition.id,
             workflow_type=workflow_type,
             workflow_input=workflow_input,
         ):
@@ -984,6 +992,7 @@ class RecurringWorkflowsService:
                 action = getattr(sched, "action", None)
                 action_mismatch = self._schedule_action_mismatch(
                     action=action,
+                    definition_id=dfn.id,
                     workflow_type=workflow_type,
                     workflow_input=workflow_input,
                 )

--- a/docs/Temporal/TemporalScheduling.md
+++ b/docs/Temporal/TemporalScheduling.md
@@ -120,7 +120,7 @@ await client.create_schedule(
  action=ScheduleActionStartWorkflow(
  "MoonMind.UserWorkflow",
  args=[workflow_input],
- id=f"mm:{{{{.ScheduleTime}}}}-{definition_id}",
+ id=f"mm:{definition_id}",
  task_queue="mm.workflow",
  memo={"title": schedule_name},
  search_attributes=TypedSearchAttributes([
@@ -231,13 +231,23 @@ schedule contract.
 mm-schedule:{definition_uuid}
 ```
 
-Workflow IDs spawned by the schedule use a deterministic format that includes the schedule time:
+Workflow IDs spawned by the schedule use a deterministic base ID:
 
 ```
-mm:{definition_uuid}:{schedule_time_epoch}
+mm:{definition_uuid}
 ```
 
-This ensures idempotency — if the schedule fires twice for the same time slot, Temporal prevents a duplicate start.
+Temporal appends the scheduled timestamp to the action ID for each fired
+workflow, producing concrete IDs such as:
+
+```
+mm:{definition_uuid}-{scheduled_time_iso8601}
+```
+
+This ensures idempotency — if the schedule fires twice for the same time slot,
+Temporal prevents a duplicate start. Do not include schedule-time template
+tokens in the action ID; Temporal treats them as literal ID text before adding
+its own scheduled-time suffix.
 
 ### 5.9 API Contract
 

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -49,14 +49,14 @@ _MOONMIND_TASK_QUEUES: tuple[str, ...] = (
     "mm.activity.agent_runtime",
 )
 MANAGED_SESSION_RECONCILE_SCHEDULE_ID = "mm-operational:managed-session-reconcile"
-MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE = (
-    "mm-operational:managed-session-reconcile:{{.ScheduleTime}}"
+MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE = (
+    "mm-operational:managed-session-reconcile"
 )
 MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID = (
     "mm-operational:managed-runtime-workspace-cleanup"
 )
-MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE = (
-    "mm-operational:managed-runtime-workspace-cleanup:{{.ScheduleTime}}"
+MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE = (
+    "mm-operational:managed-runtime-workspace-cleanup"
 )
 ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
 
@@ -590,7 +590,7 @@ class TemporalClientAdapter:
             action=ScheduleActionStartWorkflow(
                 "MoonMind.ManagedSessionReconcile",
                 {},
-                id=MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE,
+                id=MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE,
                 task_queue=self._get_task_queue(),
                 typed_search_attributes=_build_typed_search_attributes(
                     {
@@ -677,7 +677,7 @@ class TemporalClientAdapter:
                 action=ScheduleActionStartWorkflow(
                     "MoonMind.ManagedRuntimeWorkspaceCleanup",
                     {},
-                    id=MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
+                    id=MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE,
                     task_queue=self._get_task_queue(),
                     typed_search_attributes=_build_typed_search_attributes(
                         {
@@ -789,7 +789,7 @@ class TemporalClientAdapter:
             build_schedule_spec,
             build_schedule_state,
             make_schedule_id,
-            make_workflow_id_template,
+            make_scheduled_workflow_id_base,
         )
 
         client = await self.get_client()
@@ -812,7 +812,7 @@ class TemporalClientAdapter:
                     action=ScheduleActionStartWorkflow(
                         workflow_type,
                         *args,
-                        id=make_workflow_id_template(definition_uuid),
+                        id=make_scheduled_workflow_id_base(definition_uuid),
                         task_queue=task_queue,
                         memo=memo,
                         **(
@@ -923,7 +923,7 @@ class TemporalClientAdapter:
             build_schedule_policy,
             build_schedule_spec,
             build_schedule_state,
-            make_workflow_id_template,
+            make_scheduled_workflow_id_base,
         )
 
         definition_uuid = _UUID(str(definition_id))
@@ -992,7 +992,7 @@ class TemporalClientAdapter:
                 schedule.action = ScheduleActionStartWorkflow(
                     workflow_type,
                     args=args,
-                    id=make_workflow_id_template(definition_uuid),
+                    id=make_scheduled_workflow_id_base(definition_uuid),
                     task_queue=task_queue,
                     memo=memo,
                     **(

--- a/moonmind/workflows/temporal/schedule_mapping.py
+++ b/moonmind/workflows/temporal/schedule_mapping.py
@@ -108,20 +108,20 @@ def make_schedule_id(definition_id: UUID) -> str:
     """Return the Temporal Schedule ID for a recurring task definition."""
     return f"mm-schedule:{definition_id}"
 
-def make_workflow_id_template(definition_id: UUID) -> str:
-    """Return a deterministic workflow-ID template for schedule-spawned runs.
+def make_scheduled_workflow_id_base(definition_id: UUID) -> str:
+    """Return the workflow-ID base for schedule-spawned runs.
 
-    Temporal evaluates ``{{.ScheduleTime}}`` server-side when the
-    schedule fires, producing a unique workflow ID per time slot.
+    Temporal appends the scheduled timestamp to this action ID when a Schedule
+    starts a workflow, producing a unique workflow ID per time slot.
     """
-    return f"mm:{definition_id}:{{{{.ScheduleTime}}}}"
+    return f"mm:{definition_id}"
 
 __all__ = [
     "build_schedule_policy",
     "build_schedule_spec",
     "build_schedule_state",
+    "make_scheduled_workflow_id_base",
     "make_schedule_id",
-    "make_workflow_id_template",
     "map_catchup_window",
     "map_overlap_policy",
 ]

--- a/tests/integration/api/test_workflow_console_routes.py
+++ b/tests/integration/api/test_workflow_console_routes.py
@@ -6,6 +6,7 @@ import json
 from html.parser import HTMLParser
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import unquote
 from uuid import uuid4
 
 import pytest
@@ -108,6 +109,11 @@ async def async_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Async
         ("/workflows", "workflow-list"),
         ("/workflows/new", "workflow-start"),
         ("/workflows/mm:workflow-123", "workflow-detail"),
+        (
+            "/workflows/mm%3A5cd204e5-4f32-484a-a2ed-2222b214961c%3A"
+            "%7B%7B.ScheduleTime%7D%7D-2026-06-27T13%3A00%3A00Z",
+            "workflow-detail",
+        ),
         ("/workflows/mm:workflow-123/steps", "workflow-detail"),
         ("/workflows/mm:workflow-123/artifacts", "workflow-detail"),
         ("/workflows/mm:workflow-123/runs", "workflow-detail"),
@@ -126,7 +132,9 @@ async def test_supported_workflow_routes_render_console_shell(
 
     boot_payload = _extract_boot_payload(response.text)
     assert boot_payload["page"] == expected_page
-    assert boot_payload["initialData"]["dashboardConfig"]["initialPath"] == path
+    assert boot_payload["initialData"]["dashboardConfig"]["initialPath"] == unquote(
+        path
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/workflows/temporal/test_schedule_timezone_handling.py
+++ b/tests/integration/workflows/temporal/test_schedule_timezone_handling.py
@@ -36,7 +36,10 @@ async def test_schedule_timezone_handling_dst_boundaries():
             id=schedule_id_spring,
             schedule=Schedule(
                 action=ScheduleActionStartWorkflow(
-                    "MoonMind.UserWorkflow", args=[{"run_input": "dummy"}], id=f"mm:s:{{{{.ScheduleTime}}}}", task_queue="test-queue"
+                    "MoonMind.UserWorkflow",
+                    args=[{"run_input": "dummy"}],
+                    id="mm:s",
+                    task_queue="test-queue",
                 ),
                 spec=ScheduleSpec(
                     cron_expressions=["30 2 * * *"],
@@ -60,7 +63,10 @@ async def test_schedule_timezone_handling_dst_boundaries():
             id=schedule_id_fall,
             schedule=Schedule(
                 action=ScheduleActionStartWorkflow(
-                    "MoonMind.UserWorkflow", args=[{"run_input": "dummy"}], id=f"mm:f:{{{{.ScheduleTime}}}}", task_queue="test-queue"
+                    "MoonMind.UserWorkflow",
+                    args=[{"run_input": "dummy"}],
+                    id="mm:f",
+                    task_queue="test-queue",
                 ),
                 spec=ScheduleSpec(
                     cron_expressions=["30 1 * * *"],

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -163,6 +163,10 @@ def test_allowed_path_helper_accepts_known_routes() -> None:
     assert _is_allowed_path("mm:01JNX7SYH6A3K1V8Q2D7E9F4AB/steps")
     assert _is_allowed_path("mm:01JNX7SYH6A3K1V8Q2D7E9F4AB/artifacts")
     assert _is_allowed_path("mm:01JNX7SYH6A3K1V8Q2D7E9F4AB/runs")
+    assert _is_allowed_path(
+        "mm:5cd204e5-4f32-484a-a2ed-2222b214961c:"
+        "{{.ScheduleTime}}-2026-06-27T13:00:00Z"
+    )
     assert not _is_allowed_path("new")
     assert not _is_allowed_path("new/steps")
     assert not _is_allowed_path("manifests")

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -26,6 +26,7 @@ from api_service.services.recurring_workflows_service import (
     RecurringWorkflowValidationError,
 )
 from moonmind.workflows.temporal.client import ScheduleTriggerResult
+from moonmind.workflows.temporal.schedule_mapping import make_scheduled_workflow_id_base
 from moonmind.workflows.temporal.schedule_errors import ScheduleNotFoundError
 
 pytestmark = [pytest.mark.asyncio]
@@ -374,6 +375,7 @@ async def test_create_manual_run_triggers_temporal_schedule(
                 schedule=SimpleNamespace(
                     action=SimpleNamespace(
                         workflow=workflow_type,
+                        id=make_scheduled_workflow_id_base(definition.id),
                         args=[workflow_input],
                         task_queue="mm.workflow.user.v2",
                     )
@@ -694,6 +696,7 @@ async def test_reconcile_skips_update_when_metadata_and_action_match(
                     state=SimpleNamespace(paused=False, note="Daily Demo"),
                     action=SimpleNamespace(
                         workflow="MoonMind.UserWorkflow",
+                        id=make_scheduled_workflow_id_base(definition.id),
                         args=[workflow_input],
                         task_queue="mm.workflow.user.v2",
                     ),
@@ -754,6 +757,69 @@ async def test_reconcile_repairs_schedule_action_task_queue(
                         workflow="MoonMind.UserWorkflow",
                         args=[workflow_input],
                         task_queue="mm.workflow",
+                    ),
+                )
+            )
+
+            reconciled = await service.reconcile_schedules()
+
+            assert reconciled == 1
+            mock_temporal_adapter.update_schedule.assert_called_once()
+            call_kwargs = mock_temporal_adapter.update_schedule.call_args.kwargs
+            assert call_kwargs["definition_id"] == definition.id
+            assert call_kwargs["workflow_type"] == "MoonMind.UserWorkflow"
+            assert call_kwargs["workflow_input"] == workflow_input
+
+async def test_reconcile_repairs_literal_schedule_time_action_id(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = RecurringWorkflowsService(
+                session, temporal_client_adapter=mock_temporal_adapter
+            )
+            definition = await service.create_definition(
+                name="Daily Demo",
+                description="Nightly schedule",
+                enabled=True,
+                schedule_type="cron",
+                cron="0 6 * * *",
+                timezone="UTC",
+                scope_type="personal",
+                scope_ref=None,
+                owner_user_id=uuid4(),
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "task": {
+                            "instructions": "Queue job",
+                        },
+                    },
+                },
+                policy={},
+            )
+            _workflow_type, workflow_input = service._workflow_bundle_for_definition(
+                definition
+            )
+            mock_temporal_adapter.create_schedule.reset_mock()
+            mock_temporal_adapter.update_schedule.reset_mock()
+            mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    spec=SimpleNamespace(
+                        cron_expressions=["0 6 * * *"],
+                        time_zone_name="UTC",
+                        jitter=timedelta(seconds=0),
+                    ),
+                    policy=SimpleNamespace(
+                        overlap=SimpleNamespace(name="SKIP"),
+                        catchup_window=timedelta(minutes=15),
+                    ),
+                    state=SimpleNamespace(paused=False, note="Daily Demo"),
+                    action=SimpleNamespace(
+                        workflow="MoonMind.UserWorkflow",
+                        id=f"mm:{definition.id}:{{{{.ScheduleTime}}}}",
+                        args=[workflow_input],
+                        task_queue="mm.workflow.user.v2",
                     ),
                 )
             )

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -18,9 +18,9 @@ from temporalio.common import SearchAttributeKey
 
 from moonmind.workflows.temporal.client import (
     MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID,
-    MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE,
+    MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE,
     MANAGED_SESSION_RECONCILE_SCHEDULE_ID,
-    MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE,
+    MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE,
     ScheduleTriggerResult,
     TemporalClientAdapter,
 )
@@ -87,7 +87,7 @@ class TestCreateSchedule:
         assert call_args[0][0] == _SCHEDULE_ID  # first positional arg
         
         schedule_arg = call_args[0][1]
-        assert schedule_arg.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
+        assert schedule_arg.action.id == f"mm:{_TEST_UUID}"
         assert schedule_arg.action.task_queue == "mm.workflow.user.v2"
 
     @pytest.mark.asyncio
@@ -187,7 +187,7 @@ class TestManagedSessionReconcileSchedule:
         schedule_id, schedule = mock_client.create_schedule.call_args[0]
         assert schedule_id == MANAGED_SESSION_RECONCILE_SCHEDULE_ID
         assert schedule.action.workflow == "MoonMind.ManagedSessionReconcile"
-        assert schedule.action.id == MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE
+        assert schedule.action.id == MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE
         assert schedule.action.task_queue == "mm.workflow"
         assert schedule.action.static_summary == "Managed session reconcile"
         assert schedule.spec.cron_expressions == ["*/5 * * * *"]
@@ -215,7 +215,7 @@ class TestManagedSessionReconcileSchedule:
         assert result == MANAGED_SESSION_RECONCILE_SCHEDULE_ID
         schedule_id, schedule = mock_client.create_schedule.call_args[0]
         assert schedule_id == MANAGED_SESSION_RECONCILE_SCHEDULE_ID
-        assert schedule.action.id == MANAGED_SESSION_RECONCILE_WORKFLOW_ID_TEMPLATE
+        assert schedule.action.id == MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE
         assert schedule.spec.cron_expressions == ["*/10 * * * *"]
         assert schedule.spec.time_zone_name == "UTC"
         assert schedule.state.paused is True
@@ -261,7 +261,7 @@ class TestManagedRuntimeWorkspaceCleanupSchedule:
         assert schedule_id == MANAGED_RUNTIME_WORKSPACE_CLEANUP_SCHEDULE_ID
         assert schedule.action.workflow == "MoonMind.ManagedRuntimeWorkspaceCleanup"
         assert schedule.action.id == (
-            MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_TEMPLATE
+            MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE
         )
         assert schedule.action.task_queue == "mm.workflow"
         assert schedule.action.static_summary == "Managed runtime workspace cleanup"
@@ -520,7 +520,7 @@ class TestUpdateSchedule:
 
         assert updated_schedule.action.workflow == "MoonMind.UserWorkflow"
         assert updated_schedule.action.args == [workflow_input]
-        assert updated_schedule.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
+        assert updated_schedule.action.id == f"mm:{_TEST_UUID}"
         assert updated_schedule.action.task_queue == "mm.workflow.user.v2"
         assert updated_schedule.action.memo == {"definitionId": str(_TEST_UUID)}
         typed_search_attributes = updated_schedule.action.typed_search_attributes

--- a/tests/unit/workflows/temporal/test_schedule_mapping.py
+++ b/tests/unit/workflows/temporal/test_schedule_mapping.py
@@ -12,8 +12,8 @@ from moonmind.workflows.temporal.schedule_mapping import (
     build_schedule_policy,
     build_schedule_spec,
     build_schedule_state,
+    make_scheduled_workflow_id_base,
     make_schedule_id,
-    make_workflow_id_template,
     map_catchup_window,
     map_overlap_policy,
 )
@@ -143,10 +143,10 @@ class TestIdConventions:
     def test_make_schedule_id(self) -> None:
         assert make_schedule_id(_TEST_UUID) == "mm-schedule:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
-    def test_make_workflow_id_template(self) -> None:
-        template = make_workflow_id_template(_TEST_UUID)
-        assert template.startswith("mm:a1b2c3d4-e5f6-7890-abcd-ef1234567890:")
-        assert "{{.ScheduleTime}}" in template
+    def test_make_scheduled_workflow_id_base(self) -> None:
+        workflow_id_base = make_scheduled_workflow_id_base(_TEST_UUID)
+        assert workflow_id_base == "mm:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert "{{.ScheduleTime}}" not in workflow_id_base
 
 class TestDSTBoundarySemantics:
     """DOC-REQ-006: DST Boundary tests for schedule spec semantics (5.1: US/Eastern, Europe/London, UTC)."""


### PR DESCRIPTION
## Summary
- Stop configuring Temporal Schedule actions with the literal `{{.ScheduleTime}}` token; MoonMind now uses a stable workflow ID base and lets Temporal append the scheduled timestamp.
- Make recurring schedule reconciliation repair existing Temporal schedules whose action ID still contains the old literal token.
- Allow the dashboard workflow shell to route to already-created workflow IDs containing literal braces, so historical schedule runs remain viewable.
- Update scheduling docs and focused unit/integration coverage for the corrected ID behavior.

## Root Cause
Temporal treats the configured schedule action workflow ID as a base ID and appends the scheduled timestamp. MoonMind was configuring that base as `mm:<definition>:{{.ScheduleTime}}`, so the real workflow IDs became `mm:<definition>:{{.ScheduleTime}}-<scheduled-time>`. The dashboard shell rejected `{}` in workflow route segments, which made those workflow detail links return 404 even though the Temporal execution existed.

## Validation
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_schedule_mapping.py tests/unit/workflows/temporal/test_client_schedules.py tests/unit/services/test_recurring_workflows_service.py tests/unit/api/routers/test_workflow_console.py`
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q tests/integration/api/test_workflow_console_routes.py`
- Live local check: restarted `moonmind-api-1`, confirmed the reported encoded `/workflows/...{{.ScheduleTime}}...` route returns HTTP 200, ran recurring schedule reconciliation once, and confirmed schedule `mm-schedule:5cd204e5-4f32-484a-a2ed-2222b214961c` now has action ID `mm:5cd204e5-4f32-484a-a2ed-2222b214961c`.

## Local Note
`./tools/test_unit.sh` could not reach pytest in this workspace because its preflight scan hit root-owned `deploy/state/desired-state.json`; the targeted pytest commands above were run directly with the same relevant test environment variables.