### PR TITLE
[codex] Require structured pr-resolver selectors

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6280,48 +6280,71 @@ def _validate_pentest_submission_boundary(
                 f"that are not user-editable: {', '.join(blocked)}."
             )
 
+_PR_RESOLVER_SELECTOR_ERROR = (
+    "pr-resolver workflow requires a structured PR selector: "
+    "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
+    "payload.workflow.tool.inputs.pr/branch, or "
+    "payload.workflow.git.startingBranch."
+)
+
+
+def _pr_resolver_structured_selector(
+    *,
+    task_payload: Mapping[str, Any],
+    normalized_task_for_planner: Mapping[str, Any] | None = None,
+) -> str:
+    normalized_task = (
+        normalized_task_for_planner
+        if isinstance(normalized_task_for_planner, Mapping)
+        else {}
+    )
+    task_inputs = _coerce_mapping(task_payload.get("inputs"))
+    normalized_inputs = _coerce_mapping(normalized_task.get("inputs"))
+    task_git = _coerce_mapping(task_payload.get("git"))
+    normalized_git = _coerce_mapping(normalized_task.get("git"))
+    tool_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
+        task_payload.get("skill")
+    )
+    tool_inputs = _coerce_mapping(
+        tool_payload.get("inputs") or tool_payload.get("args")
+    )
+
+    return str(
+        task_inputs.get("pr")
+        or normalized_inputs.get("pr")
+        or tool_inputs.get("pr")
+        or task_inputs.get("startingBranch")
+        or normalized_inputs.get("startingBranch")
+        or tool_inputs.get("startingBranch")
+        or task_git.get("startingBranch")
+        or normalized_git.get("startingBranch")
+        or task_payload.get("startingBranch")
+        or normalized_task.get("startingBranch")
+        or task_inputs.get("branch")
+        or normalized_inputs.get("branch")
+        or tool_inputs.get("branch")
+        or ""
+    ).strip()
+
+
 def _validate_workflow_runtime_requirements(
     *,
     task_payload: dict[str, Any],
     normalized_tool: dict[str, Any] | None,
     normalized_task_for_planner: dict[str, Any],
 ) -> None:
-    instructions = str(task_payload.get("instructions") or "").strip()
-    if instructions:
-        return
-
     tool_name = str((normalized_tool or {}).get("name") or "").strip().lower()
     if tool_name != "pr-resolver":
         return
 
-    task_inputs = (
-        normalized_task_for_planner.get("inputs")
-        if isinstance(normalized_task_for_planner.get("inputs"), dict)
-        else {}
-    )
-    task_git = (
-        normalized_task_for_planner.get("git")
-        if isinstance(normalized_task_for_planner.get("git"), dict)
-        else {}
-    )
-
-    pr_selector = str(task_inputs.get("pr") or "").strip()
-    branch_selector = str(
-        task_git.get("startingBranch")
-        or normalized_task_for_planner.get("startingBranch")
-        or task_git.get("branch")
-        or normalized_task_for_planner.get("branch")
-        or task_inputs.get("startingBranch")
-        or task_inputs.get("branch")
-        or ""
-    ).strip()
-    if pr_selector or branch_selector:
+    if _pr_resolver_structured_selector(
+        task_payload=task_payload,
+        normalized_task_for_planner=normalized_task_for_planner,
+    ):
         return
 
-    raise _invalid_workflow_request(
-        "pr-resolver workflow requires payload.workflow.instructions, payload.workflow.inputs.pr, "
-        "or payload.workflow.git.startingBranch."
-    )
+    raise _invalid_workflow_request(_PR_RESOLVER_SELECTOR_ERROR)
+
 
 def _derive_task_title(task_payload: dict[str, Any]) -> str | None:
     explicit = str(task_payload.get("title") or "").strip()
@@ -6336,22 +6359,9 @@ def _derive_task_title(task_payload: dict[str, Any]) -> str | None:
             tool_payload.get("name") or tool_payload.get("id") or ""
         ).strip()
     if tool_name.lower() == "pr-resolver":
-        git_payload = _coerce_mapping(task_payload.get("git"))
-        inputs_payload = _coerce_mapping(task_payload.get("inputs"))
-        tool_inputs_payload = _coerce_mapping(
-            tool_payload.get("inputs") or tool_payload.get("args")
+        starting_branch = _pr_resolver_structured_selector(
+            task_payload=task_payload,
         )
-        starting_branch = str(
-            git_payload.get("startingBranch")
-            or task_payload.get("startingBranch")
-            or git_payload.get("branch")
-            or task_payload.get("branch")
-            or inputs_payload.get("startingBranch")
-            or inputs_payload.get("branch")
-            or tool_inputs_payload.get("startingBranch")
-            or tool_inputs_payload.get("branch")
-            or ""
-        ).strip()
         if starting_branch:
             return starting_branch[:_MAX_TASK_TITLE_LENGTH]
     raw_steps = task_payload.get("steps")

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6290,41 +6290,49 @@ _PR_RESOLVER_SELECTOR_ERROR = (
 
 def _pr_resolver_structured_selector(
     *,
-    task_payload: Mapping[str, Any],
-    normalized_task_for_planner: Mapping[str, Any] | None = None,
+    task_payload: dict[str, Any],
+    normalized_task_for_planner: dict[str, Any] | None = None,
 ) -> str:
     normalized_task = (
         normalized_task_for_planner
-        if isinstance(normalized_task_for_planner, Mapping)
+        if isinstance(normalized_task_for_planner, dict)
         else {}
     )
     task_inputs = _coerce_mapping(task_payload.get("inputs"))
     normalized_inputs = _coerce_mapping(normalized_task.get("inputs"))
     task_git = _coerce_mapping(task_payload.get("git"))
     normalized_git = _coerce_mapping(normalized_task.get("git"))
-    tool_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
-        task_payload.get("skill")
-    )
+    tool_payload = _coerce_mapping(task_payload.get("tool"))
+    skill_payload = _coerce_mapping(task_payload.get("skill"))
     tool_inputs = _coerce_mapping(
         tool_payload.get("inputs") or tool_payload.get("args")
     )
+    skill_inputs = _coerce_mapping(
+        skill_payload.get("inputs") or skill_payload.get("args")
+    )
 
-    return str(
-        task_inputs.get("pr")
-        or normalized_inputs.get("pr")
-        or tool_inputs.get("pr")
-        or task_inputs.get("startingBranch")
-        or normalized_inputs.get("startingBranch")
-        or tool_inputs.get("startingBranch")
-        or task_git.get("startingBranch")
-        or normalized_git.get("startingBranch")
-        or task_payload.get("startingBranch")
-        or normalized_task.get("startingBranch")
-        or task_inputs.get("branch")
-        or normalized_inputs.get("branch")
-        or tool_inputs.get("branch")
-        or ""
-    ).strip()
+    for value in (
+        task_inputs.get("pr"),
+        normalized_inputs.get("pr"),
+        tool_inputs.get("pr"),
+        skill_inputs.get("pr"),
+        task_inputs.get("startingBranch"),
+        normalized_inputs.get("startingBranch"),
+        tool_inputs.get("startingBranch"),
+        skill_inputs.get("startingBranch"),
+        task_git.get("startingBranch"),
+        normalized_git.get("startingBranch"),
+        task_payload.get("startingBranch"),
+        normalized_task.get("startingBranch"),
+        task_inputs.get("branch"),
+        normalized_inputs.get("branch"),
+        tool_inputs.get("branch"),
+        skill_inputs.get("branch"),
+    ):
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
 
 
 def _validate_workflow_runtime_requirements(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -750,12 +750,46 @@ def _derive_pr_branch_prefix(
         return _slugify_branch_prefix(selected_skill_name)
     return ""
 
+
+_PR_RESOLVER_SELECTOR_ERROR = (
+    "pr-resolver workflow requires workflow.tool.inputs.pr, "
+    "workflow.tool.inputs.branch, or workflow.git.startingBranch"
+)
+
+
+def _pr_resolver_structured_selector(
+    *,
+    task_payload: Mapping[str, Any],
+    selected_skill_inputs: Mapping[str, Any],
+) -> str:
+    git_payload = _coerce_mapping(task_payload.get("git"))
+    selected_skill_payload = (
+        _coerce_mapping(task_payload.get("tool"))
+        or _coerce_mapping(task_payload.get("skill"))
+    )
+    selected_skill_payload_inputs = _coerce_mapping(
+        selected_skill_payload.get("inputs")
+        or selected_skill_payload.get("args")
+    )
+    return _first_non_empty_text(
+        selected_skill_inputs.get("pr"),
+        selected_skill_payload_inputs.get("pr"),
+        selected_skill_inputs.get("startingBranch"),
+        selected_skill_payload_inputs.get("startingBranch"),
+        git_payload.get("startingBranch"),
+        task_payload.get("startingBranch"),
+        selected_skill_inputs.get("branch"),
+        selected_skill_payload_inputs.get("branch"),
+    )
+
+
 def _derive_pr_resolver_title(
     task_payload: Mapping[str, Any],
     selected_skill_inputs: Mapping[str, Any],
 ) -> str:
-    selected_skill_payload = _coerce_mapping(task_payload.get("tool")) or _coerce_mapping(
-        task_payload.get("skill")
+    selected_skill_payload = (
+        _coerce_mapping(task_payload.get("tool"))
+        or _coerce_mapping(task_payload.get("skill"))
     )
     selected_skill_name = str(
         selected_skill_payload.get("name")
@@ -764,22 +798,10 @@ def _derive_pr_resolver_title(
     ).strip()
     if selected_skill_name.lower() != "pr-resolver":
         return ""
-    git_payload = _coerce_mapping(task_payload.get("git"))
-    selected_skill_payload_inputs = _coerce_mapping(
-        selected_skill_payload.get("inputs")
-        or selected_skill_payload.get("args")
+    return _pr_resolver_structured_selector(
+        task_payload=task_payload,
+        selected_skill_inputs=selected_skill_inputs,
     )
-    return str(
-        git_payload.get("startingBranch")
-        or task_payload.get("startingBranch")
-        or git_payload.get("branch")
-        or task_payload.get("branch")
-        or selected_skill_inputs.get("startingBranch")
-        or selected_skill_inputs.get("branch")
-        or selected_skill_payload_inputs.get("startingBranch")
-        or selected_skill_payload_inputs.get("branch")
-        or ""
-    ).strip()
 
 def _normalize_runtime_mode(raw_mode: Any) -> str:
     normalized = str(raw_mode or "").strip().lower()
@@ -1285,35 +1307,31 @@ def _build_runtime_planner():
                     "workflow.instructions, inputs.instructions, or parameters.instructions"
                 )
 
-        if (
-            not has_explicit_instructions
-            and selected_skill_name.lower() == "pr-resolver"
-        ):
+        if selected_skill_name.lower() == "pr-resolver":
             pr_selector = str(selected_skill_inputs.get("pr") or "").strip()
-            branch_selector = str(
-                git_payload.get("startingBranch")
-                or task_payload.get("startingBranch")
-                or git_payload.get("branch")
-                or task_payload.get("branch")
-                or selected_skill_inputs.get("startingBranch")
-                or selected_skill_inputs.get("branch")
-                or ""
-            ).strip()
-            if not pr_selector and not branch_selector:
-                raise RuntimeError(
-                    "pr-resolver workflow requires workflow.tool.inputs.pr or "
-                    "workflow.git.startingBranch when workflow.instructions is not explicitly provided"
-                )
+            pr_resolver_selector = _pr_resolver_structured_selector(
+                task_payload=task_payload,
+                selected_skill_inputs=selected_skill_inputs,
+            )
+            if not pr_resolver_selector:
+                raise RuntimeError(_PR_RESOLVER_SELECTOR_ERROR)
             # Ensure the auto-generated instruction includes the PR/branch
             # selector so the agent knows which PR to target.  The selector
             # may come from git_payload rather than selected_skill_inputs, so
             # the generic " with inputs:" block above can miss it.
-            effective_selector = pr_selector or branch_selector
-            if effective_selector and not pr_selector:
-                merged_inputs = dict(selected_skill_inputs) if selected_skill_inputs else {}
+            effective_selector = pr_selector or pr_resolver_selector
+            if (
+                not has_explicit_instructions
+                and effective_selector
+                and not pr_selector
+            ):
+                merged_inputs = (
+                    dict(selected_skill_inputs) if selected_skill_inputs else {}
+                )
                 merged_inputs["pr"] = effective_selector
-                instructions = f"Execute skill '{selected_skill_name}' with inputs:\n" + json.dumps(
-                    merged_inputs, indent=2, sort_keys=True,
+                instructions = (
+                    f"Execute skill '{selected_skill_name}' with inputs:\n"
+                    + json.dumps(merged_inputs, indent=2, sort_keys=True)
                 )
 
         # --- Resolve runtime mode ---

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -763,23 +763,26 @@ def _pr_resolver_structured_selector(
     selected_skill_inputs: Mapping[str, Any],
 ) -> str:
     git_payload = _coerce_mapping(task_payload.get("git"))
-    selected_skill_payload = (
-        _coerce_mapping(task_payload.get("tool"))
-        or _coerce_mapping(task_payload.get("skill"))
+    tool_payload = _coerce_mapping(task_payload.get("tool"))
+    skill_payload = _coerce_mapping(task_payload.get("skill"))
+    tool_inputs = _coerce_mapping(
+        tool_payload.get("inputs") or tool_payload.get("args")
     )
-    selected_skill_payload_inputs = _coerce_mapping(
-        selected_skill_payload.get("inputs")
-        or selected_skill_payload.get("args")
+    skill_inputs = _coerce_mapping(
+        skill_payload.get("inputs") or skill_payload.get("args")
     )
     return _first_non_empty_text(
-        selected_skill_inputs.get("pr"),
-        selected_skill_payload_inputs.get("pr"),
-        selected_skill_inputs.get("startingBranch"),
-        selected_skill_payload_inputs.get("startingBranch"),
-        git_payload.get("startingBranch"),
-        task_payload.get("startingBranch"),
-        selected_skill_inputs.get("branch"),
-        selected_skill_payload_inputs.get("branch"),
+        str(selected_skill_inputs.get("pr") or "").strip(),
+        str(tool_inputs.get("pr") or "").strip(),
+        str(skill_inputs.get("pr") or "").strip(),
+        str(selected_skill_inputs.get("startingBranch") or "").strip(),
+        str(tool_inputs.get("startingBranch") or "").strip(),
+        str(skill_inputs.get("startingBranch") or "").strip(),
+        str(git_payload.get("startingBranch") or "").strip(),
+        str(task_payload.get("startingBranch") or "").strip(),
+        str(selected_skill_inputs.get("branch") or "").strip(),
+        str(tool_inputs.get("branch") or "").strip(),
+        str(skill_inputs.get("branch") or "").strip(),
     )
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4793,7 +4793,7 @@ def test_create_task_shaped_execution_does_not_fabricate_manual_preset_metadata(
     assert "appliedStepTemplates" not in task
     assert "source" not in task["steps"][0]
 
-def test_create_task_shaped_execution_rejects_pr_resolver_without_selector_or_instructions(
+def test_create_task_shaped_execution_rejects_pr_resolver_without_structured_selector(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
     test_client, service, _user = client
@@ -4804,11 +4804,13 @@ def test_create_task_shaped_execution_rejects_pr_resolver_without_selector_or_in
             "type": "workflow",
             "payload": {
                 "workflow": {
+                    "instructions": "Verify MM-940 and move to DONE if it is a PASS",
                     "runtime": {"mode": "gemini_cli"},
                     "tool": {
                         "type": "skill",
                         "name": "pr-resolver",
                     },
+                    "git": {"branch": "main"},
                 }
             },
         },
@@ -4817,8 +4819,10 @@ def test_create_task_shaped_execution_rejects_pr_resolver_without_selector_or_in
     assert response.status_code == 422
     assert (
         response.json()["detail"]["message"]
-        == "pr-resolver workflow requires payload.workflow.instructions, payload.workflow.inputs.pr, "
-        "or payload.workflow.git.startingBranch."
+        == "pr-resolver workflow requires a structured PR selector: "
+        "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
+        "payload.workflow.tool.inputs.pr/branch, or "
+        "payload.workflow.git.startingBranch."
     )
     service.create_execution.assert_not_awaited()
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4860,6 +4860,37 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
         "startingBranch": "feature/resolve-pr"
     }
 
+
+def test_create_task_shaped_execution_allows_pr_resolver_with_numeric_pr_selector(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "runtime": {"mode": "gemini_cli"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "pr-resolver",
+                    },
+                    "inputs": {"pr": 2733},
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["workflow"]["inputs"] == {"pr": 2733}
+
+
 def _pentest_workflow_payload(
     *,
     tool_inputs: dict[str, object] | None = None,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2586,8 +2586,8 @@ def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions(
     with pytest.raises(
         RuntimeError,
         match=(
-            "pr-resolver workflow requires workflow.tool.inputs.pr or "
-            "workflow.git.startingBranch"
+            "pr-resolver workflow requires workflow.tool.inputs.pr, "
+            "workflow.tool.inputs.branch, or workflow.git.startingBranch"
         ),
     ):
         planner(
@@ -3239,6 +3239,36 @@ def test_runtime_planner_mm669_pr_head_uses_workspace_metadata_before_generated_
     )
 
     assert plan["nodes"][-1]["inputs"]["targetBranch"] == "workspace-head"
+
+def test_runtime_planner_rejects_pr_resolver_with_only_jira_instructions_and_base_branch():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "pr-resolver workflow requires workflow.tool.inputs.pr, "
+            "workflow.tool.inputs.branch, or workflow.git.startingBranch"
+        ),
+    ):
+        planner(
+            inputs={
+                "task": {
+                    "instructions": "Verify MM-940 and move to DONE if it is a PASS",
+                    "tool": {
+                        "type": "skill",
+                        "name": "pr-resolver",
+                    },
+                    "git": {"branch": "main"},
+                    "runtime": {"mode": "gemini_cli"},
+                }
+            },
+            parameters={},
+            snapshot=snapshot,
+        )
 
 def test_runtime_planner_mm669_pr_head_ignores_legacy_top_level_target_branch():
     planner = _build_runtime_planner()

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2576,6 +2576,38 @@ def test_runtime_planner_pr_resolver_title_uses_case_insensitive_tool_inputs():
     assert '"pr": "fix/from-tool-inputs"' in node_inputs["instructions"]
     assert plan["metadata"]["title"] == "fix/from-tool-inputs"
 
+
+def test_runtime_planner_pr_resolver_reads_skill_args_when_tool_is_present():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Resolve and merge pull request 2733.",
+                "tool": {
+                    "type": "skill",
+                    "name": "pr-resolver",
+                },
+                "skill": {
+                    "id": "pr-resolver",
+                    "args": {"pr": 2733, "branch": "codex/pr-resolver-selector-guard"},
+                },
+                "runtime": {"mode": "gemini_cli"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["selectedSkill"] == "pr-resolver"
+    assert plan["metadata"]["title"] == "2733"
+
+
 def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Require selected pr-resolver submissions to include a structured PR/head-branch selector instead of treating free-form instructions or workflow.git.branch as sufficient.
- Apply the same guard in the runtime planner so non-API planning paths fail before launching a managed agent.
- Add regression coverage for the misrouted Jira-instruction shape and valid pr-resolver selectors.

## Root Cause
A Jira verification request was submitted with tool=pr-resolver and git.branch=main. The run completed its Jira work but failed because AgentRun correctly expected pr-resolver result artifacts for a selected pr-resolver run.

## Validation
- MOONMIND_FORCE_LOCAL_TESTS=1 PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache .venv/bin/python -m pytest -q -p no:cacheprovider tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_pr_resolver_without_structured_selector tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_derives_pr_resolver_title_from_tool_inputs tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_pr_resolver_injects_branch_selector_into_instruction tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_pr_resolver_title_uses_case_insensitive_tool_inputs tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_requires_selector_for_pr_resolver_without_instructions tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_rejects_pr_resolver_with_only_jira_instructions_and_base_branch tests/unit/workflows/temporal/test_temporal_worker_runtime.py::test_runtime_planner_mm669_pr_head_uses_workspace_metadata_before_generated_branch
- git diff --check -- api_service/api/routers/executions.py moonmind/workflows/temporal/worker_runtime.py tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py