### PR TITLE
MM-952 Rework Workflow List into a scan-first dashboard table

### DIFF
--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
@@ -118,7 +118,7 @@ describe('Workflows Entrypoint', () => {
     );
 
     const scheduledHeaderButton = await screen.findByRole('button', {
-      name: /Scheduled\. Sorted descending\. Activate to sort ascending\./i,
+      name: /Updated\. Sorted descending\. Activate to sort ascending\./i,
     });
     expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
 
@@ -137,7 +137,7 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
-  it('renders workflow table dates with two-digit years', async () => {
+  it('exposes the exact updated timestamp with a two-digit year on hover', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -161,25 +161,20 @@ describe('Workflows Entrypoint', () => {
 
     const row = await screen.findByRole('row', { name: /Example task/ });
     const dateCells = row.querySelectorAll('.queue-table-cell-date');
-    expect(dateCells).toHaveLength(3);
-    const expectedDates = [
-      '2026-06-21T12:00:00Z',
-      '2026-06-21T12:01:00Z',
-      '2026-06-21T12:02:00Z',
-    ].map((iso) =>
-      new Date(iso).toLocaleString(undefined, {
-        year: '2-digit',
-        month: 'numeric',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        second: '2-digit',
-      }),
-    );
-    Array.from(dateCells).forEach((cell, index) => {
-      expect(cell.textContent).toBe(expectedDates[index]);
-      expect(cell.textContent).not.toContain('2026');
+    // The scan-first table consolidates raw timestamps into a single Updated column.
+    expect(dateCells).toHaveLength(1);
+    const expectedExact = new Date('2026-06-21T12:02:00Z').toLocaleString(undefined, {
+      year: '2-digit',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
     });
+    const updatedCell = dateCells[0] as HTMLElement;
+    // Visible text is the relative "Updated" signal; the exact timestamp is on hover.
+    expect(updatedCell.getAttribute('title')).toBe(expectedExact);
+    expect(updatedCell.getAttribute('title')).not.toContain('2026');
   });
 
   it('does not query or render operational metrics on the workflow overview', async () => {
@@ -250,8 +245,8 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
 
-    const scheduledHeaderButton = await screen.findByRole('button', {
-      name: /Scheduled\. Sorted descending\. Activate to sort ascending\./i,
+    const updatedHeaderButton = await screen.findByRole('button', {
+      name: /Updated\. Sorted descending\. Activate to sort ascending\./i,
     });
     const repositoryFilterButton = screen.getByRole('button', {
       name: /Filter Repository\. No filter applied\./i,
@@ -261,14 +256,14 @@ describe('Workflows Entrypoint', () => {
 
     expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
     expect(repositoryFilterButton.closest('th')?.classList.contains('is-filter-open')).toBe(true);
-    expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
+    expect(updatedHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
 
-    fireEvent.click(scheduledHeaderButton);
+    fireEvent.click(updatedHeaderButton);
 
     await waitFor(() => {
-      expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
+      expect(updatedHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
     });
-    expect(screen.queryByRole('dialog', { name: 'Scheduled filter' })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: 'Updated filter' })).toBeNull();
   });
 
   it('keeps workflow filters available outside the desktop-only table layout', async () => {
@@ -340,11 +335,16 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('button', { name: 'Runtime filter: not Codex CLI' })).toBeTruthy();
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Skill\. No filter applied\./i }));
-    fireEvent.change(screen.getByLabelText('Skill filter mode'), { target: { value: 'exclude' } });
-    fireEvent.change(screen.getByLabelText('Skill filter value'), { target: { value: 'pr-resolver' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Skill filter' }));
+    // The Skill filter moves out of the default desktop header but stays in the
+    // preserved filter data model via the secondary filter controls, which apply
+    // on change. Select the value first, then flip to exclude mode.
+    fireEvent.change(screen.getByLabelText('Mobile Skill filter value'), { target: { value: 'pr-resolver' } });
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('targetSkillIn=pr-resolver');
+    });
+    await screen.findAllByText('Example task');
 
+    fireEvent.change(screen.getByLabelText('Mobile Skill filter mode'), { target: { value: 'exclude' } });
     await waitFor(() => {
       const url = fetchSpy.mock.calls.at(-1)?.[0];
       expect(url).toContain('targetRuntimeNotIn=codex_cli');
@@ -666,8 +666,10 @@ describe('Workflows Entrypoint', () => {
 
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
-    const earlyLink = await screen.findByRole('link', { name: 'Early scheduled task' });
-    const lateLink = await screen.findByRole('link', { name: 'Late scheduled task' });
+    const lateTitle = (await screen.findAllByText('Late scheduled task'))[0]!;
+    const table = lateTitle.closest('table') as HTMLTableElement;
+    const earlyLink = within(table).getByRole('link', { name: 'Early scheduled task' });
+    const lateLink = within(table).getByRole('link', { name: 'Late scheduled task' });
     expect(
       lateLink.compareDocumentPosition(earlyLink) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -832,8 +834,9 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
+    // The title filter now lives under the scan-first Workflow column header.
     const titleFilterButton = screen.getByRole('button', {
-      name: /Filter Title\. No filter applied\./i,
+      name: /Filter Workflow\. No filter applied\./i,
     });
 
     fireEvent.click(titleFilterButton);
@@ -844,15 +847,15 @@ describe('Workflows Entrypoint', () => {
     });
 
     fireEvent.change(titleInput, { target: { value: 'Example' } });
-    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Title filter' }), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Workflow filter' }), { key: 'Enter' });
 
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&titleContains=Example',
       );
-      expect(screen.queryByRole('dialog', { name: 'Title filter' })).toBeNull();
+      expect(screen.queryByRole('dialog', { name: 'Workflow filter' })).toBeNull();
       expect(
-        screen.getByRole('button', { name: /Filter Title\. Filter active: Example\./i }),
+        screen.getByRole('button', { name: /Filter Workflow\. Filter active: Example\./i }),
       ).toBeTruthy();
     });
   });
@@ -863,7 +866,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
     const baselineCalls = executionListCalls().length;
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Title\. No filter applied\./i }));
+    fireEvent.click(screen.getByRole('button', { name: /Filter Workflow\. No filter applied\./i }));
     fireEvent.change(await screen.findByLabelText('Title filter value'), { target: { value: 'Example' } });
     const clearButton = screen.getByRole('button', { name: 'Clear' });
     clearButton.focus();
@@ -872,7 +875,7 @@ describe('Workflows Entrypoint', () => {
 
     expect(executionListCalls().length).toBe(baselineCalls);
     expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50');
-    expect(screen.getByRole('dialog', { name: 'Title filter' })).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Workflow filter' })).toBeTruthy();
   });
 
   it('keeps mobile filter focus from jumping to a stale desktop trigger', async () => {
@@ -1012,11 +1015,10 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Skill\. No filter applied\./i }));
-    fireEvent.change(screen.getByLabelText('Skill filter value'), {
+    // Skill and Finished filters live in the preserved secondary filter controls.
+    fireEvent.change(screen.getByLabelText('Mobile Skill filter value'), {
       target: { value: 'moonspec-implement' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Skill filter' }));
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('targetSkillIn=moonspec-implement');
@@ -1024,9 +1026,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('button', { name: 'Skill filter: moonspec-implement' })).toBeTruthy();
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Finished\. No filter applied\./i }));
-    fireEvent.change(screen.getByLabelText('Finished blank values'), { target: { value: 'include' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Finished filter' }));
+    fireEvent.change(screen.getByLabelText('Mobile Finished blank values'), { target: { value: 'include' } });
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('finishedBlank=include');
@@ -1439,10 +1439,13 @@ describe('Workflows Entrypoint', () => {
     const table = titleMatches
       .map((element) => element.closest('table'))
       .find((candidate): candidate is HTMLTableElement => Boolean(candidate));
-    expect(table?.querySelectorAll('col.queue-table-column-id')).toHaveLength(1);
-    expect(table?.querySelectorAll('col.queue-table-column-date')).toHaveLength(3);
-    const idCell = table?.querySelector('td.queue-table-cell-id');
-    expect(idCell?.textContent).toBe(longWorkflowId);
+    // The scan-first table leads with the Workflow column and one Updated column.
+    expect(table?.querySelectorAll('col.queue-table-column-workflow')).toHaveLength(1);
+    expect(table?.querySelectorAll('col.queue-table-column-date')).toHaveLength(1);
+    // The compact workflow id stays visible but secondary inside the Workflow cell.
+    const workflowCell = table?.querySelector('td.queue-table-cell-workflow');
+    const compactId = workflowCell?.querySelector('code.workflow-list-row-id');
+    expect(compactId?.textContent).toBe(longWorkflowId);
   });
 
   it('does not render an Actions column when workflow actions are disabled', async () => {
@@ -1476,5 +1479,96 @@ describe('Workflows Entrypoint', () => {
       String(url).endsWith('/executions/task-123'),
     );
     expect(detailCallsBefore).toHaveLength(0);
+  });
+
+  // MM-952: scan-first desktop table information architecture.
+  it('leads the desktop table with a title-first Workflow column and secondary compact id', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'mm:run:scan-first-001',
+            source: 'temporal',
+            title: 'Scan first task',
+            status: 'running',
+            state: 'executing',
+            rawState: 'executing',
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    const titleMatches = await screen.findAllByText('Scan first task');
+    const table = titleMatches
+      .map((element) => element.closest('table'))
+      .find((candidate): candidate is HTMLTableElement => Boolean(candidate)) as HTMLTableElement;
+
+    const headerLabels = Array.from(table.querySelectorAll('thead th')).map((th) => {
+      const sortButton = th.querySelector('.table-sort-button');
+      if (sortButton) return ((sortButton.getAttribute('aria-label') || '').split('.')[0] || '').trim();
+      return th.querySelector('.workflow-list-static-header')?.textContent?.trim() || '';
+    });
+
+    // The first desktop column is Workflow, not ID, and no standalone ID column remains.
+    expect(headerLabels[0]).toBe('Workflow');
+    expect(headerLabels).not.toContain('ID');
+    // Status is visible before any timestamp column.
+    expect(headerLabels.indexOf('Status')).toBeLessThan(headerLabels.indexOf('Updated'));
+
+    const workflowCell = within(table).getAllByText('Scan first task')[0]!.closest(
+      'td.queue-table-cell-workflow',
+    ) as HTMLTableCellElement;
+    // The workflow title is the primary anchor linking to the detail view.
+    const titleLink = workflowCell.querySelector('a.workflow-list-row-title');
+    expect(titleLink?.textContent).toBe('Scan first task');
+    expect(titleLink?.getAttribute('href')).toBe(
+      '/workflows/mm%3Arun%3Ascan-first-001?source=temporal',
+    );
+    // The compact workflow id stays present but secondary.
+    const compactId = workflowCell.querySelector('code.workflow-list-row-id');
+    expect(compactId?.textContent).toBe('mm:run:scan-first-001');
+  });
+
+  it('surfaces dependency and intervention next-action signals in the status/next-action area', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'task-attention',
+            source: 'temporal',
+            title: 'Attention task',
+            status: 'intervention_requested',
+            state: 'intervention_requested',
+            rawState: 'intervention_requested',
+            attentionRequired: true,
+            dependsOn: ['mm:dep-1'],
+            blockedOnDependencies: true,
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Attention task');
+    const nextActionCell = document.querySelector('.queue-table-cell-next-action');
+    expect(nextActionCell?.textContent).toContain('Intervention requested');
+    expect(nextActionCell?.textContent).toContain('Blocked by 1 prerequisite');
+
+    // The signals are no longer buried under the workflow title cell.
+    const workflowCell = document.querySelector('.queue-table-cell-workflow');
+    expect(workflowCell?.textContent).not.toContain('Intervention requested');
+    expect(workflowCell?.textContent).not.toContain('Blocked by 1 prerequisite');
+
+    // Mobile cards mirror the scan-first hierarchy with a dedicated next-action block.
+    const cardNextAction = document.querySelector('.queue-card-next-action');
+    expect(cardNextAction?.textContent).toContain('Intervention requested');
+    expect(cardNextAction?.textContent).toContain('Blocked by 1 prerequisite');
   });
 });

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -177,6 +177,36 @@ describe('Workflows Entrypoint', () => {
     expect(updatedCell.getAttribute('title')).not.toContain('2026');
   });
 
+  it('floors relative Updated values so units roll over at the exact threshold', async () => {
+    // 1h50m before now: Math.floor -> "1h ago"; Math.round would show "2h ago".
+    // Computed against the real clock so the assertion is deterministic.
+    const closedAt = new Date(Date.now() - (1 * 3600 + 50 * 60) * 1000).toISOString();
+    const createdAt = new Date(Date.now() - 3 * 3600 * 1000).toISOString();
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'task-floor',
+            source: 'temporal',
+            title: 'Floor task',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            createdAt,
+            closedAt,
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    const row = await screen.findByRole('row', { name: /Floor task/ });
+    const updatedCell = row.querySelector('.queue-table-cell-date') as HTMLElement;
+    expect(updatedCell.textContent).toBe('1h ago');
+  });
+
   it('does not query or render operational metrics on the workflow overview', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
@@ -271,26 +301,26 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
 
-    expect(screen.getByLabelText('Mobile ID filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Skill filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Title filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Scheduled from')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Created from')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Finished blank values')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary ID filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary Skill filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary Title filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary Scheduled from')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary Created from')).toBeTruthy();
+    expect(screen.getByLabelText('Secondary Finished blank values')).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('Mobile ID filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary ID filter value'), {
       target: { value: 'task-123' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Status filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary Status filter value'), {
       target: { value: 'completed' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Repository filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary Repository filter value'), {
       target: { value: 'owner/repo' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Runtime filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary Runtime filter value'), {
       target: { value: 'codex_cloud' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Title filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary Title filter value'), {
       target: { value: 'Example' },
     });
 
@@ -338,13 +368,13 @@ describe('Workflows Entrypoint', () => {
     // The Skill filter moves out of the default desktop header but stays in the
     // preserved filter data model via the secondary filter controls, which apply
     // on change. Select the value first, then flip to exclude mode.
-    fireEvent.change(screen.getByLabelText('Mobile Skill filter value'), { target: { value: 'pr-resolver' } });
+    fireEvent.change(screen.getByLabelText('Secondary Skill filter value'), { target: { value: 'pr-resolver' } });
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('targetSkillIn=pr-resolver');
     });
     await screen.findAllByText('Example task');
 
-    fireEvent.change(screen.getByLabelText('Mobile Skill filter mode'), { target: { value: 'exclude' } });
+    fireEvent.change(screen.getByLabelText('Secondary Skill filter mode'), { target: { value: 'exclude' } });
     await waitFor(() => {
       const url = fetchSpy.mock.calls.at(-1)?.[0];
       expect(url).toContain('targetRuntimeNotIn=codex_cli');
@@ -676,6 +706,50 @@ describe('Workflows Entrypoint', () => {
     expect((await screen.findAllByText('—')).length).toBeGreaterThan(0);
   });
 
+  it('sorts the Updated column by the displayed updated timestamp, including closedAt', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: 'task-open',
+            source: 'temporal',
+            title: 'Open later task',
+            status: 'queued',
+            state: 'scheduled',
+            rawState: 'scheduled',
+            scheduledFor: '2026-04-15T10:00:00Z',
+            createdAt: '2026-04-15T05:00:00Z',
+          },
+          {
+            taskId: 'task-closed',
+            source: 'temporal',
+            title: 'Closed latest task',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            scheduledFor: '2026-04-15T01:00:00Z',
+            createdAt: '2026-04-15T00:30:00Z',
+            closedAt: '2026-04-15T20:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    const closedTitle = (await screen.findAllByText('Closed latest task'))[0]!;
+    const table = closedTitle.closest('table') as HTMLTableElement;
+    const closedLink = within(table).getByRole('link', { name: 'Closed latest task' });
+    const openLink = within(table).getByRole('link', { name: 'Open later task' });
+    // Default Updated sort is descending by rowUpdatedAt (closedAt || scheduledFor || createdAt),
+    // so the completed row whose closedAt is newest sorts first even though its
+    // scheduledFor is older than the open row's scheduledFor.
+    expect(
+      closedLink.compareDocumentPosition(openLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it('reuses the trimmed repository column filter for both the request and the query key', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
@@ -878,7 +952,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('dialog', { name: 'Workflow filter' })).toBeTruthy();
   });
 
-  it('keeps mobile filter focus from jumping to a stale desktop trigger', async () => {
+  it('keeps secondary filter focus from jumping to a stale desktop trigger', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -888,11 +962,11 @@ describe('Workflows Entrypoint', () => {
     fireEvent.click(desktopStatusFilter);
     fireEvent.click(screen.getByRole('button', { name: 'Cancel Status filter' }));
 
-    const mobileStatusFilter = screen.getByLabelText('Mobile Status filter value') as HTMLSelectElement;
-    mobileStatusFilter.focus();
-    fireEvent.change(mobileStatusFilter, { target: { value: 'completed' } });
+    const secondaryStatusFilter = screen.getByLabelText('Secondary Status filter value') as HTMLSelectElement;
+    secondaryStatusFilter.focus();
+    fireEvent.change(secondaryStatusFilter, { target: { value: 'completed' } });
 
-    expect(document.activeElement).toBe(mobileStatusFilter);
+    expect(document.activeElement).toBe(secondaryStatusFilter);
   });
 
   it('applies status exclude semantics and removes only the selected chip', async () => {
@@ -1016,7 +1090,7 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
     // Skill and Finished filters live in the preserved secondary filter controls.
-    fireEvent.change(screen.getByLabelText('Mobile Skill filter value'), {
+    fireEvent.change(screen.getByLabelText('Secondary Skill filter value'), {
       target: { value: 'moonspec-implement' },
     });
 
@@ -1026,7 +1100,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('button', { name: 'Skill filter: moonspec-implement' })).toBeTruthy();
     await screen.findAllByText('Example task');
 
-    fireEvent.change(screen.getByLabelText('Mobile Finished blank values'), { target: { value: 'include' } });
+    fireEvent.change(screen.getByLabelText('Secondary Finished blank values'), { target: { value: 'include' } });
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('finishedBlank=include');

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { BootPayload } from '../boot/parseBootPayload';
-import { formatRuntimeLabel, formatStatusLabel, formatTaskSkills } from '../utils/formatters';
+import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
 import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
@@ -55,18 +55,6 @@ const TASK_WORKFLOW_TYPE = 'MoonMind.UserWorkflow';
 const TASK_ENTRY = 'user_workflow';
 
 const TIMESTAMP_SORT_FIELDS = new Set(['scheduledFor', 'createdAt', 'closedAt']);
-const TABLE_COLUMNS = [
-  ['workflowId', 'ID'],
-  ['targetRuntime', 'Runtime'],
-  ['targetSkill', 'Skill'],
-  ['repository', 'Repository'],
-  ['status', 'Status'],
-  ['title', 'Title'],
-  ['scheduledFor', 'Scheduled'],
-  ['createdAt', 'Created'],
-  ['closedAt', 'Finished'],
-] as const;
-type TableColumn = (typeof TABLE_COLUMNS)[number];
 type FilterField =
   | 'workflowId'
   | 'status'
@@ -77,7 +65,43 @@ type FilterField =
   | 'scheduledFor'
   | 'createdAt'
   | 'closedAt';
-const VALID_TABLE_SORT_FIELDS = new Set<string>([...TABLE_COLUMNS.map((column) => column[0]), 'integration']);
+
+// Scan-first desktop columns, ordered left-to-right. `field` is the sort/identity
+// key, `filterField` ties an inline header filter button to the preserved column
+// filter data model (null = no inline header filter). Workflow title leads as the
+// primary anchor; raw/debug identifiers move out of the default table.
+type TableColumnDef = {
+  field: string;
+  label: string;
+  sortable: boolean;
+  filterField: FilterField | null;
+  colClassName: string;
+};
+const TABLE_COLUMNS: TableColumnDef[] = [
+  { field: 'title', label: 'Workflow', sortable: true, filterField: 'title', colClassName: 'queue-table-column-workflow' },
+  { field: 'status', label: 'Status', sortable: true, filterField: 'status', colClassName: 'queue-table-column-status' },
+  { field: 'nextAction', label: 'Next action', sortable: false, filterField: null, colClassName: 'queue-table-column-next-action' },
+  { field: 'repository', label: 'Repository', sortable: true, filterField: 'repository', colClassName: 'queue-table-column-repository' },
+  { field: 'targetRuntime', label: 'Runtime', sortable: true, filterField: 'targetRuntime', colClassName: 'queue-table-column-runtime' },
+  { field: 'scheduledFor', label: 'Updated', sortable: true, filterField: null, colClassName: 'queue-table-column-date' },
+];
+
+// All filterable columns. This is the durable filter data model and stays complete
+// even when a column no longer has a dedicated desktop header filter button; those
+// filters remain reachable through the secondary filter panel and active chips.
+const FILTER_FIELDS = [
+  ['workflowId', 'ID'],
+  ['title', 'Title'],
+  ['status', 'Status'],
+  ['repository', 'Repository'],
+  ['targetRuntime', 'Runtime'],
+  ['targetSkill', 'Skill'],
+  ['scheduledFor', 'Scheduled'],
+  ['createdAt', 'Created'],
+  ['closedAt', 'Finished'],
+] as const;
+type FilterColumn = (typeof FILTER_FIELDS)[number];
+const VALID_TABLE_SORT_FIELDS = new Set<string>([...FILTER_FIELDS.map((column) => column[0]), 'integration']);
 const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
   'workflowId',
   'status',
@@ -189,11 +213,6 @@ function formatWhen(iso: string | null | undefined): string {
   });
 }
 
-function summarizeRuntime(runtime: string | null | undefined): string {
-  const label = formatRuntimeLabel(runtime);
-  return label === '—' ? '' : label;
-}
-
 function hasUnsupportedWorkflowScopeState(params: URLSearchParams): boolean {
   const scope = (params.get('scope') || '').trim().toLowerCase();
   const workflowType = (params.get('workflowType') || '').trim();
@@ -222,6 +241,53 @@ function interventionListSummary(row: ExecutionRow): string {
     return 'Intervention requested';
   }
   return '';
+}
+
+// Next-action signals for the scan-first status area. Reuses the dependency and
+// intervention summaries and falls back to a terminal/waiting reason so operators
+// can see what needs attention without opening the workflow.
+function nextActionItems(row: ExecutionRow): string[] {
+  const items: string[] = [];
+  const intervention = interventionListSummary(row);
+  if (intervention) items.push(intervention);
+  const deps = dependencyListSummary(row);
+  if (deps) items.push(deps);
+  if (items.length === 0) {
+    const state = String(row.rawState || row.state || row.status || '').toLowerCase();
+    if (state === 'failed') items.push('Failed — needs review');
+    else if (state === 'awaiting_external') items.push('Waiting on external response');
+  }
+  return items;
+}
+
+function rowUpdatedAt(row: ExecutionRow): string | null | undefined {
+  return row.closedAt || row.scheduledFor || row.createdAt;
+}
+
+const RELATIVE_TIME_UNITS: Array<[string, number]> = [
+  ['y', 31536000],
+  ['mo', 2592000],
+  ['w', 604800],
+  ['d', 86400],
+  ['h', 3600],
+  ['m', 60],
+];
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  const ms = date.getTime();
+  if (Number.isNaN(ms)) return iso;
+  const diffSeconds = Math.round((Date.now() - ms) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+  if (absSeconds < 45) return 'just now';
+  const suffix = diffSeconds >= 0 ? 'ago' : 'from now';
+  for (const [label, unitSeconds] of RELATIVE_TIME_UNITS) {
+    if (absSeconds >= unitSeconds) {
+      return `${Math.round(absSeconds / unitSeconds)}${label} ${suffix}`;
+    }
+  }
+  return `${absSeconds}s ${suffix}`;
 }
 
 function displayTemporalCount(count: number | null | undefined, countMode: string | undefined): string {
@@ -888,12 +954,12 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   );
   const activeFilters = useMemo(
     () =>
-      TABLE_COLUMNS.map(([field, label]) => {
+      FILTER_FIELDS.map(([field, label]) => {
         if (!isFilterField(field)) return null;
         const value = filterSummary(field, filters);
         return value ? { field, label, value } : null;
       }).filter(
-        (filter): filter is { field: FilterField; label: TableColumn[1]; value: string } => Boolean(filter),
+        (filter): filter is { field: FilterField; label: FilterColumn[1]; value: string } => Boolean(filter),
       ),
     [filters],
   );
@@ -1439,7 +1505,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             className={`workflow-list-mobile-filter-controls${mobileFiltersOpen ? ' is-open' : ''}`}
             aria-label="Mobile workflow filters"
           >
-            {TABLE_COLUMNS.map(([field]) =>
+            {FILTER_FIELDS.map(([field]) =>
               isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
             )}
           </div>
@@ -1474,70 +1540,67 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             <div className="queue-table-wrapper" data-layout="table">
                 <table>
                   <colgroup>
-                    <col className="queue-table-column-id" />
-                    <col className="queue-table-column-runtime" />
-                    <col className="queue-table-column-skill" />
-                    <col className="queue-table-column-repository" />
-                    <col className="queue-table-column-status" />
-                    <col className="queue-table-column-title" />
-                    <col className="queue-table-column-date" />
-                    <col className="queue-table-column-date" />
-                    <col className="queue-table-column-date" />
+                    {TABLE_COLUMNS.map((column) => (
+                      <col key={column.field} className={column.colClassName} />
+                    ))}
                     {actionsEnabled ? <col className="queue-table-column-actions" /> : null}
                   </colgroup>
                   <thead>
                     <tr>
-                      {TABLE_COLUMNS.map(([field, label]) => {
+                      {TABLE_COLUMNS.map(({ field, label, sortable, filterField }) => {
                         const { ariaSort, ariaLabel, sortHint } = sortAccessibilityProps(field, label);
-                        const filterField = isFilterField(field) ? field : null;
                         return (
                           <th
                             key={field}
-                            aria-sort={ariaSort}
+                            aria-sort={sortable ? ariaSort : undefined}
                             className={`workflow-list-compound-header-cell${filterField && openFilter === filterField ? " is-filter-open" : ""}`}
                           >
                             <div className="workflow-list-compound-header">
-                              <button
-                                type="button"
-                                className="table-sort-button"
-                                onClick={() => onHeaderClick(field)}
-                                aria-label={ariaLabel}
-                              >
-                                {label}
-                                {sortIndicator(field)}
-                                <span className="sr-only">{sortHint}</span>
-                              </button>
-                              <button
-                                type="button"
-                                className={`workflow-list-column-filter-button${
-                                  filterValueForField(field) ? ' is-active' : ''
-                                }`}
-                                data-filter-field={field}
-                                ref={
-                                  filterField && pendingFocusField === filterField
-                                    ? (node) => node?.focus()
-                                    : undefined
-                                }
-                                onMouseDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  if (filterField) {
+                              {sortable ? (
+                                <button
+                                  type="button"
+                                  className="table-sort-button"
+                                  onClick={() => onHeaderClick(field)}
+                                  aria-label={ariaLabel}
+                                >
+                                  {label}
+                                  {sortIndicator(field)}
+                                  <span className="sr-only">{sortHint}</span>
+                                </button>
+                              ) : (
+                                <span className="workflow-list-static-header">{label}</span>
+                              )}
+                              {filterField ? (
+                                <button
+                                  type="button"
+                                  className={`workflow-list-column-filter-button${
+                                    filterValueForField(field) ? ' is-active' : ''
+                                  }`}
+                                  data-filter-field={field}
+                                  ref={
+                                    pendingFocusField === filterField
+                                      ? (node) => node?.focus()
+                                      : undefined
+                                  }
+                                  onMouseDown={(event) => event.stopPropagation()}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
                                     filterTriggerRef.current = event.currentTarget;
                                     toggleFilter(filterField);
-                                  }
-                                }}
-                                aria-label={filterAccessibilityLabel(field, label)}
-                                aria-expanded={filterField ? openFilter === filterField : false}
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  className="workflow-list-column-filter-icon"
-                                  viewBox="0 0 16 16"
-                                  focusable="false"
+                                  }}
+                                  aria-label={filterAccessibilityLabel(field, label)}
+                                  aria-expanded={openFilter === filterField}
                                 >
-                                  <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
-                                </svg>
-                              </button>
+                                  <svg
+                                    aria-hidden="true"
+                                    className="workflow-list-column-filter-icon"
+                                    viewBox="0 0 16 16"
+                                    focusable="false"
+                                  >
+                                    <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
+                                  </svg>
+                                </button>
+                              ) : null}
                             </div>
                             {filterField ? renderFilterPopover(filterField, label) : null}
                           </th>
@@ -1552,35 +1615,38 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   </thead>
                   <tbody>
                     {sortedItems.map((row) => {
-                      const depsSummary = dependencyListSummary(row);
-                      const interventionSummary = interventionListSummary(row);
+                      const actionItems = nextActionItems(row);
+                      const updatedAt = rowUpdatedAt(row);
                       return (
                         <tr key={rowWorkflowId(row)}>
-                          <td className="queue-table-cell-id">
-                            <a href={`/workflows/${encodeURIComponent(rowWorkflowId(row))}?source=temporal`}>
-                              <code>{rowWorkflowId(row)}</code>
+                          <td className="queue-table-cell-workflow">
+                            <a
+                              href={`/workflows/${encodeURIComponent(rowWorkflowId(row))}?source=temporal`}
+                              className="workflow-list-row-title"
+                            >
+                              {row.title}
                             </a>
+                            <code className="workflow-list-row-id">{rowWorkflowId(row)}</code>
                           </td>
-                          <td className="queue-table-cell-compact">{formatRuntimeLabel(row.targetRuntime)}</td>
-                          <td className="queue-table-cell-compact">
-                            {formatTaskSkills(row.taskSkills, row.targetSkill)}
-                          </td>
-                          <td className="queue-table-cell-compact">{row.repository || '—'}</td>
                           <td className="queue-table-cell-status">
                             <ExecutionStatusPill status={row.rawState || row.state || row.status} />
                           </td>
-                          <td className="queue-table-cell-title">
-                            <div>{row.title}</div>
-                            {interventionSummary ? (
-                              <div className="small">{interventionSummary}</div>
-                            ) : null}
-                            {depsSummary ? (
-                              <div className="small">{depsSummary}</div>
-                            ) : null}
+                          <td className="queue-table-cell-next-action">
+                            {actionItems.length > 0 ? (
+                              actionItems.map((item) => (
+                                <div key={item} className="workflow-list-next-action-item small">
+                                  {item}
+                                </div>
+                              ))
+                            ) : (
+                              <span className="workflow-list-next-action-empty">—</span>
+                            )}
                           </td>
-                          <td className="queue-table-cell-date">{formatWhen(row.scheduledFor)}</td>
-                          <td className="queue-table-cell-date">{formatWhen(row.createdAt)}</td>
-                          <td className="queue-table-cell-date">{formatWhen(row.closedAt)}</td>
+                          <td className="queue-table-cell-compact">{row.repository || '—'}</td>
+                          <td className="queue-table-cell-compact">{formatRuntimeLabel(row.targetRuntime)}</td>
+                          <td className="queue-table-cell-date" title={formatWhen(updatedAt)}>
+                            {formatRelative(updatedAt)}
+                          </td>
                           {actionsEnabled ? (
                             <td className="queue-table-cell-actions">
                               <WorkflowRowActionsMenu
@@ -1599,8 +1665,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               </div>
               <ul className="queue-card-list" data-layout="card" role="list">
                 {sortedItems.map((row) => {
-                      const depsSummary = dependencyListSummary(row);
-                      const interventionSummary = interventionListSummary(row);
+                      const actionItems = nextActionItems(row);
+                      const updatedAt = rowUpdatedAt(row);
                       return (
                   <li key={rowWorkflowId(row)} className="queue-card">
                     <div className="queue-card-header">
@@ -1611,19 +1677,21 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         >
                           {row.title}
                         </a>
-                        <p className="queue-card-meta">
-                          <code>{rowWorkflowId(row)}</code>
-                          {` · ${
-                            [summarizeRuntime(row.targetRuntime), row.targetSkill, row.workflowType]
-                              .filter(Boolean)
-                              .join(' · ') || 'Temporal workflow'
-                          }`}
-                        </p>
                       </div>
                       <div className="queue-card-status">
                         <ExecutionStatusPill status={row.rawState || row.state || row.status} />
                       </div>
                     </div>
+                    {actionItems.length > 0 ? (
+                      <div className="queue-card-next-action">
+                        <span className="queue-card-next-action-label small">Next action</span>
+                        {actionItems.map((item) => (
+                          <p key={item} className="queue-card-next-action-item">
+                            {item}
+                          </p>
+                        ))}
+                      </div>
+                    ) : null}
                     <dl className="queue-card-fields">
                       <div>
                         <dt>ID</dt>
@@ -1636,37 +1704,13 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <dd>{formatRuntimeLabel(row.targetRuntime)}</dd>
                       </div>
                       <div>
-                        <dt>Skill</dt>
-                        <dd>{formatTaskSkills(row.taskSkills, row.targetSkill)}</dd>
-                      </div>
-                      <div>
                         <dt>Repository</dt>
                         <dd>{row.repository || '—'}</dd>
                       </div>
                       <div>
-                        <dt>Scheduled</dt>
-                        <dd>{formatWhen(row.scheduledFor)}</dd>
+                        <dt>Updated</dt>
+                        <dd title={formatWhen(updatedAt)}>{formatRelative(updatedAt)}</dd>
                       </div>
-                      <div>
-                        <dt>Created</dt>
-                        <dd>{formatWhen(row.createdAt)}</dd>
-                      </div>
-                      <div>
-                        <dt>Finished</dt>
-                        <dd>{formatWhen(row.closedAt)}</dd>
-                      </div>
-                      {depsSummary ? (
-                        <div>
-                          <dt>Dependencies</dt>
-                          <dd>{depsSummary}</dd>
-                        </div>
-                      ) : null}
-                      {interventionSummary ? (
-                        <div>
-                          <dt>Intervention</dt>
-                          <dd>{interventionSummary}</dd>
-                        </div>
-                      ) : null}
                     </dl>
                     <div className="queue-card-actions">
                       <a

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -54,7 +54,7 @@ const RUNTIME_FILTER_VALUE_ALIASES: Record<string, string> = {
 const TASK_WORKFLOW_TYPE = 'MoonMind.UserWorkflow';
 const TASK_ENTRY = 'user_workflow';
 
-const TIMESTAMP_SORT_FIELDS = new Set(['scheduledFor', 'createdAt', 'closedAt']);
+const TIMESTAMP_SORT_FIELDS = new Set(['updatedAt', 'scheduledFor', 'createdAt', 'closedAt']);
 type FilterField =
   | 'workflowId'
   | 'status'
@@ -83,7 +83,7 @@ const TABLE_COLUMNS: TableColumnDef[] = [
   { field: 'nextAction', label: 'Next action', sortable: false, filterField: null, colClassName: 'queue-table-column-next-action' },
   { field: 'repository', label: 'Repository', sortable: true, filterField: 'repository', colClassName: 'queue-table-column-repository' },
   { field: 'targetRuntime', label: 'Runtime', sortable: true, filterField: 'targetRuntime', colClassName: 'queue-table-column-runtime' },
-  { field: 'scheduledFor', label: 'Updated', sortable: true, filterField: null, colClassName: 'queue-table-column-date' },
+  { field: 'updatedAt', label: 'Updated', sortable: true, filterField: null, colClassName: 'queue-table-column-date' },
 ];
 
 // All filterable columns. This is the durable filter data model and stays complete
@@ -101,7 +101,7 @@ const FILTER_FIELDS = [
   ['closedAt', 'Finished'],
 ] as const;
 type FilterColumn = (typeof FILTER_FIELDS)[number];
-const VALID_TABLE_SORT_FIELDS = new Set<string>([...FILTER_FIELDS.map((column) => column[0]), 'integration']);
+const VALID_TABLE_SORT_FIELDS = new Set<string>([...FILTER_FIELDS.map((column) => column[0]), 'integration', 'updatedAt']);
 const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
   'workflowId',
   'status',
@@ -196,7 +196,7 @@ function readListDashboardConfig(payload: BootPayload): ListDashboardConfig | un
 
 function normalizeTableSortField(raw: string | null): string {
   const candidate = (raw || '').trim();
-  return VALID_TABLE_SORT_FIELDS.has(candidate) ? candidate : 'scheduledFor';
+  return VALID_TABLE_SORT_FIELDS.has(candidate) ? candidate : 'updatedAt';
 }
 
 function formatWhen(iso: string | null | undefined): string {
@@ -284,7 +284,7 @@ function formatRelative(iso: string | null | undefined): string {
   const suffix = diffSeconds >= 0 ? 'ago' : 'from now';
   for (const [label, unitSeconds] of RELATIVE_TIME_UNITS) {
     if (absSeconds >= unitSeconds) {
-      return `${Math.round(absSeconds / unitSeconds)}${label} ${suffix}`;
+      return `${Math.floor(absSeconds / unitSeconds)}${label} ${suffix}`;
     }
   }
   return `${absSeconds}s ${suffix}`;
@@ -305,6 +305,7 @@ function sortRows(rows: ExecutionRow[], field: string, direction: 'asc' | 'desc'
     let rightVal: string | number;
     if (TIMESTAMP_SORT_FIELDS.has(field)) {
       const getTimestamp = (row: ExecutionRow) => {
+        if (field === 'updatedAt') return rowUpdatedAt(row);
         if (field === 'scheduledFor') return row.scheduledFor || row.createdAt;
         return (row as Record<string, unknown>)[field] as string | undefined;
       };
@@ -689,7 +690,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
   const [hasEditedFilters, setHasEditedFilters] = useState(false);
   const [openFilter, setOpenFilter] = useState<FilterField | null>(null);
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [secondaryFiltersOpen, setSecondaryFiltersOpen] = useState(false);
   const [pendingFocusField, setPendingFocusField] = useState<FilterField | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -717,7 +718,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     appendFilterParams(params, filters);
     params.set('limit', String(pageSize));
     if (listCursor) params.set('nextPageToken', listCursor);
-    if (sortField !== 'scheduledFor' || sortDir !== 'desc') {
+    if (sortField !== 'updatedAt' || sortDir !== 'desc') {
       params.set('sort', sortField);
       params.set('sortDir', sortDir);
     }
@@ -1023,7 +1024,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     setDraftFilters((current) => ({ ...current, [field]: { ...current[field], ...patch } }));
   };
 
-  const applyMobileValues = (
+  const applySecondaryValues = (
     field: 'status' | 'targetRuntime' | 'targetSkill',
     values: string[],
   ) => {
@@ -1038,14 +1039,14 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     });
   };
 
-  const applyMobileRepository = (value: string) => {
+  const applySecondaryRepository = (value: string) => {
     applyFilters({
       ...filters,
       repository: { ...filters.repository, mode: 'include', values: [], exactText: value },
     });
   };
 
-  const applyMobileDate = (field: 'scheduledFor' | 'createdAt' | 'closedAt', patch: DateFilter) => {
+  const applySecondaryDate = (field: 'scheduledFor' | 'createdAt' | 'closedAt', patch: DateFilter) => {
     applyFilters({
       ...filters,
       [field]: { ...filters[field], ...patch },
@@ -1111,10 +1112,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   };
 
   const renderFilterControl = (field: FilterField, labelPrefix = '') => {
-    const isMobile = Boolean(labelPrefix);
+    const isSecondary = Boolean(labelPrefix);
     if (field === 'workflowId' || field === 'title') {
       const label = field === 'workflowId' ? 'ID' : 'Title';
-      const draft = isMobile ? filters[field] : draftFilters[field];
+      const draft = isSecondary ? filters[field] : draftFilters[field];
       return (
         <div className="queue-inline-filter workflow-list-header-filter-control">
           <label>
@@ -1130,7 +1131,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   : 'Word match: finds titles containing this whole word.'
               }
               onChange={(event) => {
-              if (isMobile) applyFilters({ ...filters, [field]: { contains: event.target.value } }, null);
+              if (isSecondary) applyFilters({ ...filters, [field]: { contains: event.target.value } }, null);
                 else updateDraftText(field, event.target.value);
               }}
             />
@@ -1140,7 +1141,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     }
 
     if (field === 'status') {
-      const draft = isMobile ? filters.status : draftFilters.status;
+      const draft = isSecondary ? filters.status : draftFilters.status;
       return (
         <div className="queue-inline-filter workflow-list-header-filter-control">
           <label>
@@ -1150,7 +1151,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               disabled={!listEnabled}
               onChange={(event) => {
                 const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) {
+                if (isSecondary) {
                   applyFilters({ ...filters, status: { ...filters.status, mode } });
                 } else {
                   updateDraftValueMode('status', mode);
@@ -1172,7 +1173,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             emptyMessage="No status filters selected"
             onChange={(next) => {
               const normalized = next.map((value) => value.toLowerCase());
-              if (isMobile) applyMobileValues('status', normalized);
+              if (isSecondary) applySecondaryValues('status', normalized);
               else updateDraftValues('status', normalized);
             }}
           />
@@ -1188,17 +1189,17 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             {labelPrefix}Repository filter value
             <input
               type="text"
-              value={isMobile ? filters.repository.exactText || '' : draftFilters.repository.exactText || ''}
+              value={isSecondary ? filters.repository.exactText || '' : draftFilters.repository.exactText || ''}
               disabled={!listEnabled}
               placeholder="repo starts with…"
               title="Prefix match: finds repository names that start with this text."
               onChange={(event) => {
-                if (isMobile) applyMobileRepository(event.target.value);
+                if (isSecondary) applySecondaryRepository(event.target.value);
                 else updateDraftRepository(event.target.value);
               }}
             />
           </label>
-          {!isMobile && valueOptionsForField('repository').length > 0 ? (
+          {!isSecondary && valueOptionsForField('repository').length > 0 ? (
             <label>
               Repository values
               <select
@@ -1233,7 +1234,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'targetRuntime') {
       const runtimeOptions = valueOptionsForField('targetRuntime');
-      const draft = isMobile ? filters.targetRuntime : draftFilters.targetRuntime;
+      const draft = isSecondary ? filters.targetRuntime : draftFilters.targetRuntime;
       return (
         <div className="queue-inline-filter workflow-list-header-filter-control">
           <label>
@@ -1243,7 +1244,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               disabled={!listEnabled}
               onChange={(event) => {
                 const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetRuntime: { ...filters.targetRuntime, mode } }, null);
+                if (isSecondary) applyFilters({ ...filters, targetRuntime: { ...filters.targetRuntime, mode } }, null);
                 else updateDraftValueMode('targetRuntime', mode);
               }}
             >
@@ -1261,7 +1262,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             addPlaceholder="Add runtime"
             emptyMessage="No runtime filters selected"
             onChange={(next) => {
-              if (isMobile) applyMobileValues('targetRuntime', next);
+              if (isSecondary) applySecondaryValues('targetRuntime', next);
               else updateDraftValues('targetRuntime', next);
             }}
           />
@@ -1272,7 +1273,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'targetSkill') {
       const skillOptions = valueOptionsForField('targetSkill');
-      const draft = isMobile ? filters.targetSkill : draftFilters.targetSkill;
+      const draft = isSecondary ? filters.targetSkill : draftFilters.targetSkill;
       return (
         <div className="queue-inline-filter workflow-list-header-filter-control">
           <label>
@@ -1282,7 +1283,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               disabled={!listEnabled}
               onChange={(event) => {
                 const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetSkill: { ...filters.targetSkill, mode } }, null);
+                if (isSecondary) applyFilters({ ...filters, targetSkill: { ...filters.targetSkill, mode } }, null);
                 else updateDraftValueMode('targetSkill', mode);
               }}
             >
@@ -1299,7 +1300,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             addPlaceholder="Add skill"
             emptyMessage="No skill filters selected"
             onChange={(next) => {
-              if (isMobile) applyMobileValues('targetSkill', next);
+              if (isSecondary) applySecondaryValues('targetSkill', next);
               else updateDraftValues('targetSkill', next);
             }}
           />
@@ -1310,7 +1311,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') {
       const label = field === 'scheduledFor' ? 'Scheduled' : field === 'createdAt' ? 'Created' : 'Finished';
-      const draft = isMobile ? filters[field] : draftFilters[field];
+      const draft = isSecondary ? filters[field] : draftFilters[field];
       return (
         <div className="queue-inline-filter workflow-list-header-filter-control">
           <label>
@@ -1320,7 +1321,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               value={draft.from || ''}
               disabled={!listEnabled}
               onChange={(event) => {
-                if (isMobile) applyMobileDate(field, { from: event.target.value });
+                if (isSecondary) applySecondaryDate(field, { from: event.target.value });
                 else updateDraftDate(field, { from: event.target.value });
               }}
             />
@@ -1332,7 +1333,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               value={draft.to || ''}
               disabled={!listEnabled}
               onChange={(event) => {
-                if (isMobile) applyMobileDate(field, { to: event.target.value });
+                if (isSecondary) applySecondaryDate(field, { to: event.target.value });
                 else updateDraftDate(field, { to: event.target.value });
               }}
             />
@@ -1345,7 +1346,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                 disabled={!listEnabled}
                 onChange={(event) => {
                   const blank = event.target.value as NonNullable<DateFilter['blank']>;
-                  if (isMobile) applyMobileDate(field, { blank });
+                  if (isSecondary) applySecondaryDate(field, { blank });
                   else updateDraftDate(field, { blank });
                 }}
               >
@@ -1489,24 +1490,24 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             </div>
           </div>
         ) : null}
-        <div className="workflow-list-mobile-filter-disclosure">
+        <div className="workflow-list-secondary-filter-disclosure">
           <button
             type="button"
-            className="workflow-list-mobile-filter-toggle"
-            aria-expanded={mobileFiltersOpen}
-            aria-controls="workflow-list-mobile-filter-panel"
-            onClick={() => setMobileFiltersOpen((open) => !open)}
+            className="workflow-list-secondary-filter-toggle"
+            aria-expanded={secondaryFiltersOpen}
+            aria-controls="workflow-list-secondary-filter-panel"
+            onClick={() => setSecondaryFiltersOpen((open) => !open)}
           >
-            {mobileFiltersOpen ? 'Hide filters' : 'Show filters'}
+            {secondaryFiltersOpen ? 'Hide filters' : 'Show filters'}
             {hasActiveFilters ? ` (${activeFilters.length})` : ''}
           </button>
           <div
-            id="workflow-list-mobile-filter-panel"
-            className={`workflow-list-mobile-filter-controls${mobileFiltersOpen ? ' is-open' : ''}`}
-            aria-label="Mobile workflow filters"
+            id="workflow-list-secondary-filter-panel"
+            className={`workflow-list-secondary-filter-controls${secondaryFiltersOpen ? ' is-open' : ''}`}
+            aria-label="Secondary workflow filters"
           >
             {FILTER_FIELDS.map(([field]) =>
-              isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
+              isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Secondary ')}</div> : null,
             )}
           </div>
         </div>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1852,37 +1852,33 @@ tbody tr:hover {
   word-break: break-word;
 }
 
-.queue-table-column-id {
-  width: 13%;
+.queue-table-column-workflow {
+  width: 30%;
 }
 
-.queue-table-column-runtime {
-  width: 8%;
-}
-
-.queue-table-column-skill {
-  width: 9%;
-}
-
-.queue-table-column-repository {
-  width: 10%;
-}
-
-.queue-table-column-status {
-  width: 10%;
-}
-
-.queue-table-column-title {
+.queue-table-column-next-action {
   width: 18%;
 }
 
-.queue-table-column-date {
-  width: 8%;
+.queue-table-column-runtime {
+  width: 10%;
 }
 
-.queue-table-cell-id,
+.queue-table-column-repository {
+  width: 14%;
+}
+
+.queue-table-column-status {
+  width: 12%;
+}
+
+.queue-table-column-date {
+  width: 10%;
+}
+
 .queue-table-cell-compact,
-.queue-table-cell-date {
+.queue-table-cell-date,
+.queue-table-cell-next-action {
   font-size: 0.82rem;
 }
 
@@ -1891,8 +1887,38 @@ tbody tr:hover {
   white-space: normal;
 }
 
-.queue-table-cell-title {
+.queue-table-cell-workflow {
   font-weight: 500;
+}
+
+.workflow-list-row-title {
+  display: block;
+  font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.workflow-list-row-title:hover {
+  text-decoration: underline;
+}
+
+.workflow-list-row-id {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.76rem;
+  font-weight: 400;
+  color: rgb(var(--mm-muted));
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.workflow-list-next-action-empty {
+  color: rgb(var(--mm-muted));
+}
+
+.workflow-list-next-action-item + .workflow-list-next-action-item {
+  margin-top: 0.15rem;
 }
 
 .data-table-slab {
@@ -2128,6 +2154,23 @@ tr[data-proposal-id].proposal-consuming td {
 .queue-card-header > .queue-card-status {
   flex-shrink: 0;
   max-width: 100%;
+}
+
+.queue-card-next-action {
+  margin: 0.4rem 0 0;
+  display: grid;
+  gap: 0.15rem;
+}
+
+.queue-card-next-action-label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgb(var(--mm-muted));
+}
+
+.queue-card-next-action-item {
+  margin: 0;
+  font-weight: 500;
 }
 
 .queue-card-title {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1579,13 +1579,13 @@ h1 {
   flex: 0 0 auto;
 }
 
-.workflow-list-mobile-filter-disclosure {
-  display: none;
+.workflow-list-secondary-filter-disclosure {
+  display: flex;
   flex-direction: column;
   gap: 0.7rem;
 }
 
-.workflow-list-mobile-filter-toggle {
+.workflow-list-secondary-filter-toggle {
   align-self: stretch;
   display: inline-flex;
   align-items: center;
@@ -1602,10 +1602,10 @@ h1 {
   box-shadow: inset 0 1px 0 var(--mm-glass-edge);
 }
 
-.workflow-list-mobile-filter-toggle:hover,
-.workflow-list-mobile-filter-toggle:focus-visible,
-.workflow-list-mobile-filter-toggle:active,
-.workflow-list-mobile-filter-toggle[aria-expanded="true"] {
+.workflow-list-secondary-filter-toggle:hover,
+.workflow-list-secondary-filter-toggle:focus-visible,
+.workflow-list-secondary-filter-toggle:active,
+.workflow-list-secondary-filter-toggle[aria-expanded="true"] {
   background: var(--mm-control-shell-hover);
   background-image: none;
   border-color: rgb(var(--mm-accent) / 0.7);
@@ -1615,13 +1615,17 @@ h1 {
   filter: none;
 }
 
-.workflow-list-mobile-filter-controls {
+.workflow-list-secondary-filter-controls {
   display: none;
   gap: 0.7rem;
   grid-template-columns: minmax(0, 1fr);
 }
 
-.workflow-list-mobile-filter-controls .queue-inline-filter {
+.workflow-list-secondary-filter-controls.is-open {
+  display: grid;
+}
+
+.workflow-list-secondary-filter-controls .queue-inline-filter {
   border-radius: 0.6rem;
   padding: 0.28rem 0.6rem;
 }
@@ -2275,14 +2279,6 @@ tr[data-proposal-id].proposal-consuming td {
 
   .workflow-list-clear-filters {
     width: 100%;
-  }
-
-  .workflow-list-mobile-filter-disclosure {
-    display: flex;
-  }
-
-  .workflow-list-mobile-filter-controls.is-open {
-    display: grid;
   }
 
   .queue-results-toolbar,


### PR DESCRIPTION
## Issue
[MM-952](https://moonladder.atlassian.net/browse/MM-952) — Rework Workflow List into a scan-first dashboard table (Story, Dashboard / Workflows List)

## Summary
Reworks the `/workflows` desktop table and mobile cards to be scan-first, leading with operator-facing signals instead of technical identifiers.

- **Workflow** is now the first desktop column: workflow title is the primary visual anchor, with the compact workflow ID rendered secondary underneath. The workflow detail link is preserved.
- **Status** (normalized `ExecutionStatusPill`) appears before any timestamps.
- A dedicated **Next action** area surfaces dependency / intervention / waiting / failed signals, reusing the existing `dependencyListSummary()` and `interventionListSummary()` helpers, so they are no longer buried under the title.
- **Context** (repository), **Runtime** (compact label), and a consolidated **Updated** time (relative, exact timestamp on hover) follow.
- Raw/debug identifiers (full ID standalone column, target/task skills, scheduled/created/finished timestamps) are moved out of the default table.
- The full filter data model is preserved: filters whose columns left the default header remain reachable via the secondary filter panel and active filter chips (no backend/API changes).
- Mobile cards mirror the scan-first hierarchy (title/status first, then ID/runtime/repository) with a dedicated next-action block.
- Table column CSS classes and widths updated to match the new layout.

Files changed: `frontend/src/entrypoints/workflow-list.tsx`, `frontend/src/entrypoints/workflow-list.test.tsx`, `frontend/src/styles/dashboard.css`.

## Tests run
- Frontend unit suite for the changed area: `vitest run frontend/src/entrypoints/workflow-list.test.tsx` — **50 passed** (run via a colon-free mirror because the managed workspace path contains a colon that breaks vitest path resolution). Added/updated tests cover title-first rendering, compact workflow ID still present, dependency/intervention next-action summary visible, and the actions menu still rendering when enabled.

## Remaining risks
- Out of scope by design (separate issues): server-side sorting, advanced filter drawer, user-configurable columns, backend API changes.
- The full Python unit suite was not run here (pytest unavailable in this workspace); changes are frontend-only (TSX/CSS/test), so backend impact is not expected.
- Visual/layout polish (column widths, responsive breakpoints) verified via tests only, not a live browser render.


[MM-952]: https://moonladder.atlassian.net/browse/MM-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ