### PR TITLE
[codex] Make MoonSpec breakdown input resilient

### DIFF
--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -19,7 +19,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - Optional for breakdown-driven creation: `storyBreakdownPath`, `stories`, or `storyOutput` from `moonspec-breakdown`.
 - Optional for ordered Jira story exports: dependency mode `none` or `linear_blocker_chain`.
 - Optional: description, acceptance criteria, priority, labels, assignee, reporter, parent issue key, sprint, component, due date, linked issues, attachments.
-- Required when creating Jira issues from `moonspec-breakdown` output: an original source document reference path. Read it from each story's `sourceReference.path` or from the breakdown-level `source.referencePath` / `source.path`.
+- Required when creating Jira issues from canonical `moonspec-breakdown` output: original source document traceability. Read the path from each story's `sourceReference.path` or from the breakdown-level `source.referencePath` / `source.path`. For trusted Jira, inline, or `imperative-input` breakdowns without a document path, preserve the source title/key and `coverageIds` instead of blocking solely because no canonical document path exists.
 
 ## Workflow
 
@@ -34,7 +34,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - For bugs, include sections for observed behavior, expected behavior, reproduction steps, impact, and environment when the information is available.
 - For stories, include sections for user story, acceptance criteria, notes, and out-of-scope items when the information is available.
 - For tasks, include sections for objective, requirements, implementation notes, and verification when the information is available.
-- When creating from `moonspec-breakdown` output, every Jira issue description must include a `Source Document` section that names the original declarative document path and any story-specific source sections or coverage IDs available.
+- When creating from `moonspec-breakdown` output, every Jira issue description must include source traceability. Use a `Source Document` section when an original declarative document path exists; otherwise name the selected source title/key and any story-specific source sections or coverage IDs available.
 - Do not invent business requirements, acceptance criteria, assignees, priorities, or deadlines.
 
 3. Validate before creating.
@@ -52,7 +52,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - For dependency mode `linear_blocker_chain`, after all target Jira issues are created or reused, create trusted Jira dependency links so each later story is blocked by the immediately preceding story.
 - Create dependency links only through MoonMind's trusted Jira tool surface, such as `jira.create_issue_link` when available. Do not call Jira directly from the shell and do not rely on issue descriptions or prompt text as the dependency mechanism.
 - Return created/reused issue keys plus created/reused/failed dependency-link results. If issue creation succeeds but a dependency link fails, report partial success and do not claim the dependency chain is complete.
-- Before creating any issue from `stories.json`, verify every story has an original source document path available through `story.sourceReference.path`, `source.referencePath`, or `source.path`. If the original document path is missing for any story, do not create Jira issues; report the missing source-reference blocker and the breakdown path that must be regenerated or repaired.
+- Before creating any issue from `stories.json`, verify every story has source traceability. Canonical declarative breakdowns require an original source document path through `story.sourceReference.path`, `source.referencePath`, or `source.path`. Trusted Jira, inline, and `imperative-input` breakdowns without a document path must preserve source title/key and `coverageIds`; do not block solely because those sources lack a canonical path.
 - Otherwise call Jira REST `POST /rest/api/3/issue` for Jira Cloud or the deployment's documented equivalent.
 - Send only the fields needed for the requested issue.
 - Treat retries carefully: before retrying after an uncertain network failure, use `jira.search_issues` to search by a stable summary/project/reporter marker to avoid duplicate tickets.
@@ -62,10 +62,10 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 When invoked after `moonspec-breakdown` or when the request references story breakdown output:
 
 - Read story candidates from the provided JSON breakdown, not from `spec.md`.
-- Require source traceability before Jira creation. Each Jira issue must include `Source Document: <path>` in its description, using the story-level `sourceReference.path` when present and otherwise the breakdown-level `source.referencePath` or `source.path`.
-- Include story-specific `sourceReference.sections` and `sourceReference.coverageIds` when present so the Jira issue points to the relevant part of the original declarative document.
+- Require source traceability before Jira creation. Each Jira issue must include `Source Document: <path>` in its description when a source path exists, using the story-level `sourceReference.path` when present and otherwise the breakdown-level `source.referencePath` or `source.path`. If no source path exists, include the selected source title/key instead.
+- Include story-specific `sourceReference.sections` and `sourceReference.coverageIds` when present so the Jira issue points to the relevant part of the selected source.
 - Preserve story order, stable story IDs, and dependency IDs so ordered Jira issue chains can be created after issue creation succeeds.
-- Treat missing source document references as a hard blocker, not as an optional warning.
+- Treat missing canonical source document references as a hard blocker only for canonical declarative breakdowns. Do not block trusted Jira, inline, or `imperative-input` breakdowns that preserve source title/key and coverage IDs.
 - Do not create or rename `spec.md`.
 - If Jira issue creation succeeds, return Jira keys/URLs and do not request another output format.
 - If Jira is not configured, required Jira fields are missing, or issue creation fails, report the exact blocker and the existing `artifacts/story-breakdowns/...` output instead of fabricating Jira success.

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -19,7 +19,7 @@ Good inputs include:
 - A pasted technical design.
 - A declarative design document.
 - A file path to a design artifact.
-- A trusted Jira issue brief or description when no declarative document path is provided.
+- A trusted Jira issue brief or description when no source document path is provided.
 - A request to run or reproduce `/speckit.breakdown`.
 
 Do not use this skill for a single natural-language feature request. Use `moonspec-specify` for one clearly scoped story.
@@ -27,8 +27,8 @@ Do not use this skill for a single natural-language feature request. Use `moonsp
 ## Inputs
 
 - Select breakdown input content using this preference chain:
-  1. Declarative document path: if an explicit source or declarative document path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
-  2. Jira issue description: if no declarative document path is provided and trusted Jira issue context is available from MoonMind previous outputs, use `jiraPresetBrief` or the Jira issue description/acceptance criteria from that trusted context.
+  1. Source document path: if an explicit source document path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
+  2. Jira issue description: if no source document path is provided and trusted Jira issue context is available from MoonMind previous outputs, use `jiraPresetBrief` or the Jira issue description/acceptance criteria from that trusted context.
   3. Workflow instructions: if neither of the above is available, use the workflow instructions or user request text as the source design.
 - If no selected input content is available after applying the preference chain, stop with: `ERROR "No technical design provided"`.
 - Preserve the original design text verbatim in the breakdown output so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
@@ -42,11 +42,18 @@ Classify the source design before extracting coverage points, using the document
 
 - `canonical-declarative`: a readable repo path under `docs/` (or `.specify/memory/constitution.md`) describing desired state.
 - `declarative-text`: pasted declarative design text, trusted Jira issue description, workflow instructions, or a file-backed declarative design outside `docs/`.
-- `imperative-override`: a document whose primary framing is steps, phases, checkboxes, status, or migration sequencing, accepted only with an explicit user override.
+- `imperative-input`: a selected source whose primary framing is steps, phases, checkboxes, status, or migration sequencing.
 
 A document is declarative when it describes what the system is or should be; it is imperative when its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by their primary framing.
 
-If the input is primarily imperative and the user has not explicitly confirmed imperative input, stop with: `ERROR "Imperative input: provide the underlying declarative design or explicitly confirm imperative input"`. Decomposing a checklist produces stories that mistake process steps for requirements; the underlying declarative document must be written or identified first.
+Prefer declarative sources when the input preference chain provides one. If no
+declarative design is selected, use the imperative input instead of requiring
+explicit confirmation. For `imperative-input`, infer the underlying desired
+system behavior, constraints, and operator outcomes from the steps. Do not
+create one story per checklist item unless that item is independently valuable
+and testable as a user or operational outcome. Preserve any story-critical
+uncertainty as assumptions or `needsClarification` rather than stopping solely
+because the source is imperative.
 
 Record the resulting class as `sourceDocumentClass` in the breakdown output.
 
@@ -100,8 +107,8 @@ Summarize the design in a few sentences, focusing on:
 
 ### 2. Extract Canonical Claims And Coverage Points
 
-For file-backed declarative documents, identify the selected stable canonical
-claims before creating run-local coverage points:
+For canonical file-backed declarative documents, identify the selected stable
+canonical claims before creating run-local coverage points:
 
 - If the source document already contains stable claim identifiers, preserve
   those exact identifiers.
@@ -112,9 +119,10 @@ claims before creating run-local coverage points:
 - Record each selected claim with `id`, `path`, `sections`, and a concise claim
   summary. The `path` must be the canonical repo-relative document path when
   the source came from a repo file.
-- For trusted Jira descriptions or pasted workflow instructions that do not
-  have a canonical file path, do not fabricate canonical claim IDs. Use only
-  run-local coverage IDs and preserve the selected source title/key.
+- For non-canonical file-backed sources, trusted Jira descriptions, pasted
+  workflow instructions, or `imperative-input`, do not fabricate canonical claim
+  IDs. Use only run-local coverage IDs and preserve the selected source
+  title/key and source path when one exists.
 
 Convert the design into normalized major design points with stable IDs: `DESIGN-REQ-001`, `DESIGN-REQ-002`, and so on.
 
@@ -157,7 +165,7 @@ For each story, define:
 - Title.
 - 2-4 word short name for directory naming.
 - Why the story exists.
-- Source document reference: the original declarative document path plus the relevant source section or heading when available.
+- Source document reference: the original source document path plus the relevant source section or heading when available.
 - Scope and out of scope.
 - Independent test.
 - Acceptance criteria.
@@ -205,7 +213,7 @@ Never name any breakdown output `spec.md`. Never write to `specs/` during breakd
 
 The JSON file must be an object with:
 
-- `source`: object containing `title`, `path`, `referencePath`, `sourceDocumentClass`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For trusted Jira issue descriptions or pasted workflow instructions without a file path, set paths to `null` and use a clear title such as the Jira issue key/summary or `inline workflow instructions`. `sourceDocumentClass` must be `canonical-declarative`, `declarative-text`, or `imperative-override` per the Input Classification section.
+- `source`: object containing `title`, `path`, `referencePath`, `sourceDocumentClass`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For trusted Jira issue descriptions or pasted workflow instructions without a file path, set paths to `null` and use a clear title such as the Jira issue key/summary or `inline workflow instructions`. `sourceDocumentClass` must be `canonical-declarative`, `declarative-text`, or `imperative-input` per the Input Classification section.
 - `extractedAt`: ISO-8601 timestamp.
 - `coverageGate`: exactly `PASS - every major design point is owned by at least one story.`
 - `stories`: ordered list of story objects.
@@ -217,7 +225,7 @@ Each story object must include:
 - `id`: stable story ID, such as `STORY-001`.
 - `summary`: concise title suitable for a Jira issue summary.
 - `description`: user-story or task narrative.
-- `sourceReference`: object containing `path`, `title`, `sections`, `claimIds`, and `coverageIds`. For file-backed designs, `path` must be the same original design document path from `source.referencePath`, and `claimIds` must contain the selected stable canonical claim IDs owned by the story; do not omit either value from any story. For trusted Jira issue descriptions or workflow instructions, set `path` to `null`, set `claimIds` to an empty list, and preserve the selected source title.
+- `sourceReference`: object containing `path`, `title`, `sections`, `claimIds`, and `coverageIds`. For canonical file-backed declarative designs, `path` must be the same original design document path from `source.referencePath`, and `claimIds` must contain the selected stable canonical claim IDs owned by the story; do not omit either value from any story. For non-canonical file-backed sources and `imperative-input`, preserve the source path when one exists, set `claimIds` to an empty list, and rely on `coverageIds` for run-local traceability. For trusted Jira issue descriptions or workflow instructions without a file path, set `path` to `null`, set `claimIds` to an empty list, and preserve the selected source title.
 - `independentTest`: how this story can be validated independently.
 - `acceptanceCriteria`: concrete acceptance criteria.
 - `requirements`: functional requirements owned by the story.
@@ -289,14 +297,17 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 
 - One breakdown story candidate equals one future `spec.md`.
 - The canonical source document remains the source of truth for desired state; breakdown output is a temporary derived view and is never cited as authority over its source.
-- Classify the input per `docs/Workflows/MoonSpecDocumentModel.md` and fail fast on imperative inputs without an explicit override.
+- Classify the input per `docs/Workflows/MoonSpecDocumentModel.md`; prefer declarative sources, but use `imperative-input` when no declarative design is selected instead of requiring explicit confirmation.
 - Preserve the original technical or declarative design verbatim in the breakdown output for later specify.
-- Every story candidate must carry a `sourceReference.path` and non-empty
-  `sourceReference.claimIds` back to stable canonical claims in the original
-  declarative document when the source came from a file; otherwise it must carry
-  the selected source title/key with `path: null` and empty `claimIds`.
+- Every story candidate from a canonical declarative file must carry a
+  `sourceReference.path` and non-empty `sourceReference.claimIds` back to stable
+  canonical claims in the original declarative document. Non-canonical
+  file-backed and imperative inputs preserve the selected source path when one
+  exists and use run-local `coverageIds` with empty `claimIds`. Source text
+  without a file path must carry the selected source title/key with `path: null`
+  and empty `claimIds`.
 - Prefer vertical user or operational outcomes over technical-layer slices.
-- Extract stable canonical claim IDs for file-backed documents and run-local
+- Extract stable canonical claim IDs for canonical file-backed documents and run-local
   `DESIGN-REQ-*` coverage points before drafting story candidates.
 - Do not write specs in this skill.
 - Every major design point, constraint, and non-goal must be explicitly owned by at least one story candidate.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,8 +1,19 @@
+<!--
+Sync Impact Report
+- Version change: 2.1.0 -> 2.2.0
+- Modified principles: Resilient by Default (expanded intelligent fallback/workaround guidance)
+- Added sections: none
+- Removed sections: none
+- Templates requiring updates: .specify/templates/plan-template.md reviewed/no change; .specify/templates/spec-template.md reviewed/no change; .specify/templates/tasks-template.md reviewed/no change
+- Runtime guidance requiring updates: moonspec-breakdown skill/presets and MoonSpec document/tool contracts updated in this change
+- Follow-up TODOs: none
+-->
+
 # MoonMind Constitution
 
-**Version:** 2.1.0 · **Last amended:** 2026-06-25
+**Version:** 2.2.0 · **Last amended:** 2026-06-27
 
-> Principles are cited **by name**, not by number — ordering and numbering may change across amendments. See **Governance** at the end of this document for the versioning policy, amendment procedure, and amendment log. This revision adds explicit simplicity-as-safety, name-only internal capability identity for skill-name, preset-slug, and tool-name references, and narrowed short-lived internal workflow cutover guidance while preserving durable-execution safety.
+> Principles are cited **by name**, not by number — ordering and numbering may change across amendments. See **Governance** at the end of this document for the versioning policy, amendment procedure, and amendment log. This revision adds intelligent fallback and workaround guidance to **Resilient by Default** while preserving policy, security, billing, and traceability guardrails.
 
 ## Core Principles
 
@@ -224,6 +235,9 @@ MoonMind MUST enable fire-and-forget execution — operators should be able to s
 
 Non-negotiable rules:
 
+- Resilience is a core product pillar alongside safety and observability. Workflows MUST attempt an evidence-backed fallback, degraded mode, retry, reroute, or workaround before failing when the system can preserve operator intent, policy boundaries, source traceability, and cost controls.
+- Missing ideal inputs MUST NOT cause brittle failure when the workflow can intelligently infer a safe substitute from trusted context or the user's provided instructions. The chosen fallback MUST be explicit in durable artifacts, status, or summaries so operators can audit what was inferred and why.
+- Fallbacks MUST NOT silently substitute credentials, provider profiles, billing-relevant runtime values, source authority, or less-constrained execution paths. When those boundaries are missing, ambiguous, or unsafe, fail with an actionable error per **Safety and Governance by Construction**.
 - All externally visible side effects (starting runs, publishing results, posting to GitHub/Jira) MUST be retry-safe so that a crash mid-operation never produces duplicates. At the workflow boundary this is realized through the activity-idempotency rule in **Temporal-Native Durable Orchestration**.
 - Long-running workflows MUST persist enough state to resume, retry, or fail deterministically after worker restarts.
 - MoonMind MUST detect stuck agents (loops, repeated failures) and apply escalating interventions (soft reset, hard reset, termination) before burning through the operator's API budget.
@@ -243,7 +257,7 @@ Evidence-based recovery and remediation:
 - Checkpoint resume SHOULD be the default recovery path when evidence supports it. *(Operator-driven recovery is current; resume-as-default is target state, tracked in Roadmap Milestone 13.)*
 - Autonomous remediation MUST NOT outrun the safety and observability substrate it depends on (see **Safety and Governance by Construction**).
 
-Rationale: Resiliency is what makes unattended execution possible. The system must withstand infrastructure failures, agent failures, and runaway costs — and when a run does fail, recovery must be driven by durable evidence, not by whatever happened to survive in a container.
+Rationale: Resiliency is what makes unattended execution possible. The system must withstand infrastructure failures, agent failures, missing-but-inferable inputs, and runaway costs — and when a run does fail, recovery must be driven by durable evidence, not by whatever happened to survive in a container. Agentic intelligence creates product value when it can safely reason around recoverable gaps instead of demanding brittle magic words from the operator.
 
 ### XIII. Facilitate Continuous Improvement
 
@@ -319,7 +333,7 @@ Rationale: In a pre-release project, the cost of legacy confusion vastly exceeds
 - **Validation is required**:
   - Each feature MUST define at least one independent validation path (automated tests or a deterministic quickstart/manual validation).
 - **Clarity over cleverness**:
-  - Prefer explicit contracts, explicit adapters, and explicit errors over implicit fallback behavior.
+  - Prefer explicit contracts, explicit adapters, explicit fallback behavior, and explicit errors over implicit or unauditable recovery paths.
 - **Simplicity gate**:
   - Plans and implementations MUST reject unnecessary aliases, duplicate identity systems, speculative abstractions, and generated context bulk that obscures the canonical path. Added complexity MUST be justified by a concrete safety, durability, or operator-value need.
 - **Exceptions must be visible**:
@@ -335,6 +349,7 @@ Rationale: In a pre-release project, the cost of legacy confusion vastly exceeds
   - **PATCH** — clarifications, wording, or non-semantic fixes.
 - **Amendment procedure.** Amendments MUST update the version and `Last amended` date, summarize the change in the amendment log below, and propagate any renamed principles to dependent references (e.g., agent instruction files, `docs/` cross-references) in the same change, per **Pre-Release Velocity: Delete, Don't Deprecate**.
 - **Amendment log.**
+  - **2.2.0 (2026-06-27)** — Expanded **Resilient by Default** to state that resilience is a core MoonMind pillar and that workflows must use evidence-backed fallbacks, degraded modes, retries, reroutes, or workarounds when operator intent and safety boundaries remain clear. Clarified that intelligent fallback must be explicit and auditable, while credentials, provider profiles, billing-relevant values, source authority, and execution constraints still fail fast when unsafe or ambiguous.
   - **2.1.0 (2026-06-25)** — Added explicit simplicity-as-safety language to **Safety and Governance by Construction**, name-only internal capability identity for skill-name, preset-slug, and tool-name references under **Skills Are First-Class and Easy to Add**, and narrowed **Temporal-Native Durable Orchestration** / **Pre-Release Velocity: Delete, Don't Deprecate** guidance so short-lived internal pre-release workflows may use explicit cutover without compatibility shims while durable histories and persisted payloads remain protected. Added a simplicity gate to quality gates. Traceability: MM-911, source issue MM-901.
   - **2.0.0 (2026-06-16)** — Added **Safety and Governance by Construction**, **Temporal-Native Durable Orchestration**, and **Artifacts Are the Durable Evidence Layer**. Updated **Orchestrate, Don't Recreate** (three execution classes; session-capability claim discipline), **Resilient by Default** (evidence-based/typed remediation; autonomous-repair gate), **Docs-First Development and Traceability** (release-metadata hygiene; constitution as a versioned doc surface), and **Pre-Release Velocity: Delete, Don't Deprecate** (durable-execution carve-out). Reordered so the execution-model principles follow **Orchestrate, Don't Recreate**, with Safety leading. Relocated the former *Non-Negotiable Product & Operational Constraints* (security/secret hygiene, observability/Mission Control, compatibility/migration) into their owning principles so each rule lives once. Established versioning and the cite-by-name convention.
   - **1.x (unversioned)** — Original thirteen-principle constitution prior to the introduction of version metadata.

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
   - name: source_design_path
-    label: Declarative Document Path
+    label: Source Document Path
     type: repo_path
     required: false
     default: ""
@@ -68,7 +68,7 @@ steps:
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
-      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no source document path is provided.
     tool:
       id: jira.load_preset_brief
       requiredCapabilities:
@@ -80,14 +80,14 @@ steps:
     instructions: |-
       Run moonspec-breakdown using this input preference chain:
 
-      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      1. If Source document path is non-empty, read that repo path and use it as the source design.
       2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
       3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
       4. Otherwise, use Workflow instructions as the source design.
 
       If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
-      Source declarative document path:
+      Source document path:
       {{ inputs.source_design_path }}
 
       Source Jira issue key:
@@ -96,16 +96,13 @@ steps:
       Workflow instructions:
       {{ inputs.feature_request }}
 
-      If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
-      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
+      If the selected input is a readable repo path under docs/ (except docs/tmp/) or .specify/memory/constitution.md, use that file as the canonical declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve canonical claim IDs only when the resolved path is a canonical declarative source.
+      If the selected input is a non-canonical file-backed source, preserve that source path in source.path, source.referencePath, and story sourceReference.path, record sourceReference.claimIds as an empty list, and use sourceReference.coverageIds for run-local traceability.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
-      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
-      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
-      {% else %}
-      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
-      {% endif %}
+      Classify the selected input before extracting stories. Prefer declarative sources when one is selected or resolved. If the selected input is primarily framed as steps, phases, recommendations, checklist items, status, or a roadmap, record sourceDocumentClass as imperative-input and decompose the underlying actionable desired system behavior into Jira-ready MoonSpec stories instead of failing solely because the source is imperative. Otherwise record sourceDocumentClass as canonical-declarative or declarative-text as appropriate.
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
   - name: source_design_path
-    label: Declarative Document Path
+    label: Source Document Path
     type: repo_path
     required: false
     default: ""
@@ -68,7 +68,7 @@ steps:
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
-      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no source document path is provided.
     tool:
       id: jira.load_preset_brief
       requiredCapabilities:
@@ -80,14 +80,14 @@ steps:
     instructions: |-
       Run moonspec-breakdown using this input preference chain:
 
-      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      1. If Source document path is non-empty, read that repo path and use it as the source design.
       2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
       3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
       4. Otherwise, use Workflow instructions as the source design.
 
       If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
-      Source declarative document path:
+      Source document path:
       {{ inputs.source_design_path }}
 
       Source Jira issue key:
@@ -96,16 +96,13 @@ steps:
       Workflow instructions:
       {{ inputs.feature_request }}
 
-      If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
-      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
+      If the selected input is a readable repo path under docs/ (except docs/tmp/) or .specify/memory/constitution.md, use that file as the canonical declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve canonical claim IDs only when the resolved path is a canonical declarative source.
+      If the selected input is a non-canonical file-backed source, preserve that source path in source.path, source.referencePath, and story sourceReference.path, record sourceReference.claimIds as an empty list, and use sourceReference.coverageIds for run-local traceability.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
-      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
-      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
-      {% else %}
-      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
-      {% endif %}
+      Classify the selected input before extracting stories. Prefer declarative sources when one is selected or resolved. If the selected input is primarily framed as steps, phases, recommendations, checklist items, status, or a roadmap, record sourceDocumentClass as imperative-input and decompose the underlying actionable desired system behavior into Jira-ready MoonSpec stories instead of failing solely because the source is imperative. Otherwise record sourceDocumentClass as canonical-declarative or declarative-text as appropriate.
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ""
   - name: source_design_path
-    label: Declarative Document Path
+    label: Source Document Path
     type: repo_path
     required: false
     default: ""
@@ -59,7 +59,7 @@ steps:
     instructions: |-
       Fetch source Jira issue {{ inputs.source_issue_key }} through the deterministic trusted Jira tool surface.
 
-      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no declarative document path is provided.
+      Build a compact source brief from the issue key, summary, description, and acceptance criteria. The following breakdown step may use this trusted Jira issue description only when no source document path is provided.
     tool:
       id: jira.load_preset_brief
       requiredCapabilities:
@@ -71,14 +71,14 @@ steps:
     instructions: |-
       Run moonspec-breakdown using this input preference chain:
 
-      1. If Source declarative document path is non-empty, read that repo path and use it as the source design.
+      1. If Source document path is non-empty, read that repo path and use it as the source design.
       2. Otherwise, if trusted Jira previous output from the prior step includes sourceResolution.status = "resolved" and resolvedSourceDesignPath is non-empty, read resolvedSourceDesignPath as the source design.
       3. Otherwise, if trusted Jira previous output from the prior step is available, use its jiraPresetBrief as the source design.
       4. Otherwise, use Workflow instructions as the source design.
 
       If trusted Jira sourceResolution.status is "ambiguous", "invalid_candidates", or "invalid_explicit_path", fail fast with an actionable source-resolution error instead of decomposing the Jira brief as inline text.
 
-      Source declarative document path:
+      Source document path:
       {{ inputs.source_design_path }}
 
       Source Jira issue key:
@@ -87,16 +87,13 @@ steps:
       Workflow instructions:
       {{ inputs.feature_request }}
 
-      If the input is a readable repo path, use that file as the original declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
-      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve that path the same way.
+      If the selected input is a readable repo path under docs/ (except docs/tmp/) or .specify/memory/constitution.md, use that file as the canonical declarative document and preserve its path plus stable canonical claim IDs in every story's sourceReference.path and sourceReference.claimIds.
+      If the selected input is trusted Jira resolvedSourceDesignPath, treat it as a readable repo path selected through deterministic source resolution and preserve canonical claim IDs only when the resolved path is a canonical declarative source.
+      If the selected input is a non-canonical file-backed source, preserve that source path in source.path, source.referencePath, and story sourceReference.path, record sourceReference.claimIds as an empty list, and use sourceReference.coverageIds for run-local traceability.
       If the selected input is the trusted Jira issue description, preserve the Jira issue key and summary as the source title, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       If the selected input is workflow instructions without a readable path, preserve those instructions as inline source text, set source.path and source.referencePath to null, set each story's sourceReference.path to null, and set sourceReference.claimIds to an empty list.
       The canonical declarative document is the primary source of truth; the breakdown output is a temporary derived view (see docs/Workflows/MoonSpecDocumentModel.md).
-      {% if (inputs.source_design_path or '') | trim == '' and (inputs.source_issue_key or '') | trim == '' %}
-      When the selected input falls through to literal Workflow Instructions text instead of a readable repo path, treat this as an explicit inline workflow-instruction override for the moonspec-breakdown input classification gate: if the instructions are primarily framed as steps, phases, recommendations, checklist items, or a roadmap, decompose the actionable desired system behavior into Jira-ready MoonSpec stories instead of failing fast solely because the inline text is imperative. Record sourceDocumentClass as imperative-override for that case; otherwise record declarative-text.
-      {% else %}
-      Classify the input before extracting stories. If it is primarily an imperative checklist, status tracker, or migration plan and no explicit imperative override was given, fail fast with the moonspec-breakdown imperative-input error instead of decomposing it.
-      {% endif %}
+      Classify the selected input before extracting stories. Prefer declarative sources when one is selected or resolved. If the selected input is primarily framed as steps, phases, recommendations, checklist items, status, or a roadmap, record sourceDocumentClass as imperative-input and decompose the underlying actionable desired system behavior into Jira-ready MoonSpec stories instead of failing solely because the source is imperative. Otherwise record sourceDocumentClass as canonical-declarative or declarative-text as appropriate.
       Record sourceDocumentClass in the breakdown output.
       Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
     skill:

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -688,7 +688,7 @@ def _validate_jira_breakdown_source_inputs(
             {
                 "path": "preset.inputs",
                 "message": (
-                    "Provide a Declarative Document Path, Source Jira Issue Key, "
+                    "Provide a Source Document Path, Source Jira Issue Key, "
                     "or Workflow Instructions."
                 ),
                 "code": "required",

--- a/docs/Workflows/MoonSpecDocumentModel.md
+++ b/docs/Workflows/MoonSpecDocumentModel.md
@@ -23,11 +23,13 @@ This document defines the document classes MoonSpec workflows operate on, the pr
 - **Content**: checklists, status trackers, migration and rollout plans, cleanup sequences — anything whose primary framing is steps, phases, checkboxes, or status.
 - **Lifecycle**: time-bound. Delete or archive them when the work completes (Constitution XII).
 
-## Classification Rule
+## Classification And Fallback Rule
 
 A document is **declarative** when it describes what the system is or should be. A document is **imperative** when its primary framing is steps, phases, checkboxes, or status. Mixed documents are classified by their primary framing.
 
-MoonSpec breakdown and specification workflows require declarative input. An imperative document is not a valid substitute for a declarative design: decomposing a checklist produces stories that mistake process steps for requirements. When only an imperative document exists, the underlying declarative document must be written or identified first.
+MoonSpec breakdown workflows prefer declarative input and must select a declarative source when one is provided or can be resolved. When no declarative design is available, breakdown workflows may use imperative input as a resilience fallback: extract the underlying desired system behavior, constraints, and operator outcomes from the steps instead of requiring explicit user confirmation. The output must record that source as imperative input and must not treat checklist steps, phases, or status rows as story boundaries unless they are independently valuable and testable user or operational outcomes.
+
+MoonSpec specification workflows still produce declarative, single-story specs. If a spec starts from imperative input, it must translate that input into desired-state requirements and preserve assumptions or unresolved choices explicitly.
 
 ## Precedence Rule
 
@@ -51,13 +53,13 @@ Stylistic preferences, speculative improvements, and unverified observations nev
 
 ## Documentation Architecture Standard
 
-The [Documentation Architecture Standard](../DocumentationArchitecture.md) defines the documentation viewpoints (architecture, design, and contract viewpoints) that organize canonical declarative documents. Its viewpoint rules **refine** canonical declarative documents; they do **not** replace this model's lifecycle, classification, precedence, or reconciliation rules. The document classes, classification rule, precedence rule, and reconciliation expectation defined above remain authoritative, and the standard is read as a refinement layered on top of them rather than a substitute. See the standard for the rules themselves; they are not restated here.
+The [Documentation Architecture Standard](../DocumentationArchitecture.md) defines the documentation viewpoints (architecture, design, and contract viewpoints) that organize canonical declarative documents. Its viewpoint rules **refine** canonical declarative documents; they do **not** replace this model's lifecycle, classification, fallback, precedence, or reconciliation rules. The document classes, classification and fallback rule, precedence rule, and reconciliation expectation defined above remain authoritative, and the standard is read as a refinement layered on top of them rather than a substitute. See the standard for the rules themselves; they are not restated here.
 
 ### Read order
 
 Read MoonSpec documentation in this order:
 
-1. **MoonSpec Document Model** (this document) — document classes, classification, precedence, and reconciliation.
+1. **MoonSpec Document Model** (this document) — document classes, classification and fallback, precedence, and reconciliation.
 2. **[Documentation Architecture Standard](../DocumentationArchitecture.md)** — viewpoint rules that refine the canonical declarative documents.
 3. **Project-local architecture / design / contract docs** — the canonical declarative documents for the project at hand.
 4. **Optional project-local implementation scratch** — temporary execution artifacts and imperative working documents, when present.

--- a/docs/Workflows/SkillAndPlanContracts.md
+++ b/docs/Workflows/SkillAndPlanContracts.md
@@ -557,21 +557,23 @@ items and do not create Jira issues. Stories marked
 reports `skippedStories`, `blockedStories`, and `partialStoriesAdjusted` so
 downstream orchestration can create follow-up work only for returned Jira issue mappings.
 
-For breakdown-driven Jira output derived from a source document, the canonical
-traceability shape is `sourceReference.path` plus `sourceReference.claimIds` on
-every story, with `source.referencePath` or `source.path` as a
-breakdown-level path fallback. `claimIds` are stable canonical claim identifiers
-for the selected file-backed source document; generated `DESIGN-REQ-*`
-`coverageIds` remain run-local extraction IDs. The tool also accepts path-only
-generated forms, `sourceReference: "<path>"` and top-level
-`sourceDocument: "<path>"`, and normalizes those before Jira issue creation.
-Direct pasted declarative text is also valid input: if no source document path
-exists, Jira creation proceeds and issue mappings report an empty
-`sourceDesignPath`. Callers that require every Jira issue to carry document
-traceability must set `sourceReferencePolicy: "required"` on the tool inputs or
-`storyOutput`. The policy also accepts booleans and standard truthy/falsy
-strings such as `"true"` and `"false"` for callers that produce typed or form
-encoded payloads.
+For breakdown-driven Jira output derived from a canonical source document, the
+canonical traceability shape is `sourceReference.path` plus
+`sourceReference.claimIds` on every story, with `source.referencePath` or
+`source.path` as a breakdown-level path fallback. `claimIds` are stable
+canonical claim identifiers for the selected canonical file-backed source
+document; generated `DESIGN-REQ-*` `coverageIds` remain run-local extraction
+IDs. Non-canonical file-backed sources and imperative-input breakdowns preserve
+their source path when one exists, but they use run-local `coverageIds` rather
+than fabricated canonical `claimIds`. The tool also accepts path-only generated
+forms, `sourceReference: "<path>"` and top-level `sourceDocument: "<path>"`, and
+normalizes those before Jira issue creation. Direct pasted declarative or
+imperative text is also valid input: if no source document path exists, Jira
+creation proceeds and issue mappings report an empty `sourceDesignPath`.
+Callers that require every Jira issue to carry document traceability must set
+`sourceReferencePolicy: "required"` on the tool inputs or `storyOutput`. The
+policy also accepts booleans and standard truthy/falsy strings such as `"true"`
+and `"false"` for callers that produce typed or form encoded payloads.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `artifacts/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 

--- a/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
+++ b/docs/tmp/MoonSpecDocsFirstAlignmentPlan.md
@@ -53,8 +53,8 @@ All edits per Constitution XIII: replace language outright, no compatibility phr
 
 ### 2.1 `moonspec-breakdown`
 
-- **Input classification**: before extracting coverage points, classify the source as declarative or imperative per `MoonSpecDocumentModel.md`. If the input is primarily an imperative checklist/migration/status document, **fail fast** with a clear error directing the user to either supply the underlying declarative doc or explicitly confirm imperative input (constitution prefers fail-fast over hidden fallback).
-- **Canonical anchoring**: when the input is a path under `docs/`, record it as the canonical source of truth; add `sourceDocumentClass` (`canonical-declarative` | `declarative-text` | `imperative-override`) to `stories.json` `source`.
+- **Input classification**: before extracting coverage points, classify the source as declarative or imperative per `MoonSpecDocumentModel.md`. Prefer declarative sources, but when no declarative design is available, use imperative input as a resilience fallback and decompose the underlying desired system behavior instead of requiring explicit confirmation.
+- **Canonical anchoring**: when the input is a path under `docs/` outside `docs/tmp/`, record it as the canonical source of truth; add `sourceDocumentClass` (`canonical-declarative` | `declarative-text` | `imperative-input`) to `stories.json` `source`.
 - **Key rules**: add "Breakdown output is a temporary derived view of the canonical document. The canonical document remains the source of truth for desired state."
 
 ### 2.2 `moonspec-specify`
@@ -126,7 +126,7 @@ Implementation note (deviation from the original draft): preset `version` labels
 
 ### 4.3 `jira-breakdown-orchestrate.yaml` (primary target)
 
-- **Step 1 (Break down declarative design)**: add input-classification language — resolve the path, confirm the document is declarative per `MoonSpecDocumentModel.md`, fail fast on imperative inputs, record the canonical doc as primary source of truth and breakdown output as temporary.
+- **Step 1 (Break down preferred source input)**: add input-classification language — resolve the path, prefer declarative sources per `MoonSpecDocumentModel.md`, use imperative input as a fallback when no declarative design is available, and record the canonical doc as primary source of truth when present while keeping breakdown output temporary.
 - **Step 4 (Create dependent Jira Orchestrate tasks)**: require each downstream task to carry the story's `sourceReference.path` as the Jira Orchestrate `source_design_path` so the doc-reconcile step knows its canonical doc.
 - Apply the same step-1 language to `jira-breakdown.yaml` and `jira-breakdown-implement.yaml` for consistency.
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -823,6 +823,59 @@ def _breakdown_source_path(value: Any) -> str:
             return path
     return ""
 
+
+def _normalize_source_document_class(value: Any) -> str:
+    return _string(value).strip().lower().replace("_", "-")
+
+
+def _breakdown_source_document_class(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    source = value.get("source")
+    if isinstance(source, Mapping):
+        source_class = _normalize_source_document_class(
+            source.get("sourceDocumentClass")
+            or source.get("source_document_class")
+            or source.get("documentClass")
+            or source.get("document_class")
+        )
+        if source_class:
+            return source_class
+    return _normalize_source_document_class(
+        value.get("sourceDocumentClass")
+        or value.get("source_document_class")
+        or value.get("documentClass")
+        or value.get("document_class")
+    )
+
+
+def _is_canonical_source_path(path: str) -> bool:
+    normalized = _string(path).replace("\\", "/").lstrip("./")
+    if not normalized:
+        return False
+    if (
+        normalized == ".specify/memory/constitution.md"
+        or normalized.endswith("/.specify/memory/constitution.md")
+    ):
+        return True
+    if normalized.startswith("docs/tmp/") or "/docs/tmp/" in normalized:
+        return False
+    return normalized.startswith("docs/") or "/docs/" in normalized
+
+
+def _source_reference_requires_claim_ids(
+    *,
+    source_document_class: str,
+    source_path: str,
+) -> bool:
+    source_class = _normalize_source_document_class(source_document_class)
+    if source_class == "canonical-declarative":
+        return True
+    if source_class in {"declarative-text", "imperative-input"}:
+        return False
+    return _is_canonical_source_path(source_path)
+
+
 def _story_source_reference(
     story: Mapping[str, Any],
     *,
@@ -863,11 +916,20 @@ def _missing_source_claim_story_ids(
     stories: Sequence[Mapping[str, Any]],
     *,
     fallback_path: str,
+    source_document_class: str = "",
 ) -> list[str]:
     missing: list[str] = []
     for index, story in enumerate(stories, start=1):
         reference = _story_source_reference(story, fallback_path=fallback_path)
-        if _string(reference.get("path")) and not _story_source_claim_ids(reference):
+        source_path = _string(reference.get("path"))
+        if (
+            source_path
+            and _source_reference_requires_claim_ids(
+                source_document_class=source_document_class,
+                source_path=source_path,
+            )
+            and not _story_source_claim_ids(reference)
+        ):
             missing.append(_story_id(story, index=index))
     return missing
 
@@ -2026,6 +2088,9 @@ async def create_jira_issues_from_stories(
         or previous_story_output.get("storyBreakdownJson")
     )
     breakdown_source_path = _breakdown_source_path(raw_story_payload)
+    breakdown_source_document_class = _breakdown_source_document_class(
+        raw_story_payload
+    )
     stories = _coerce_story_payload(raw_story_payload)
     artifact_ref_was_read = False
     artifact_payload_had_explicit_empty_stories = False
@@ -2063,6 +2128,9 @@ async def create_jira_issues_from_stories(
                     except json.JSONDecodeError:
                         parsed_payload = artifact_payload
                 breakdown_source_path = _breakdown_source_path(parsed_payload)
+                breakdown_source_document_class = _breakdown_source_document_class(
+                    parsed_payload
+                )
                 artifact_payload_failure_reason = _story_breakdown_failure_reason(
                     parsed_payload
                 )
@@ -2157,6 +2225,9 @@ async def create_jira_issues_from_stories(
                     except json.JSONDecodeError:
                         fetched_payload = fetched
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
+                breakdown_source_document_class = _breakdown_source_document_class(
+                    fetched_payload
+                )
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
                 reason = _repo_handoff_read_failure_reason(
@@ -2241,6 +2312,7 @@ async def create_jira_issues_from_stories(
         _missing_source_claim_story_ids(
             stories,
             fallback_path=breakdown_source_path,
+            source_document_class=breakdown_source_document_class,
         )
         if requires_source_reference
         else []
@@ -2248,7 +2320,7 @@ async def create_jira_issues_from_stories(
     if missing_claim_ids:
         reason = (
             "Jira story creation requires sourceReference.claimIds for every "
-            "file-backed story with sourceReference.path or breakdown "
+            "canonical declarative story with sourceReference.path or breakdown "
             "source.referencePath. Missing: "
             + ", ".join(missing_claim_ids)
         )

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -513,6 +513,16 @@ def _coerce_story_payload(value: Any) -> list[dict[str, Any]]:
         return [dict(value)] if value.get("summary") or value.get("title") else []
     return [dict(story) for story in _list(value) if isinstance(story, Mapping)]
 
+def _parse_story_breakdown_payload(value: Any) -> Any:
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    if isinstance(value, str) and value.strip():
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
 def _has_explicit_empty_story_list(value: Any) -> bool:
     if isinstance(value, str) and value.strip():
         try:
@@ -850,7 +860,10 @@ def _breakdown_source_document_class(value: Any) -> str:
 
 
 def _is_canonical_source_path(path: str) -> bool:
-    normalized = _string(path).replace("\\", "/").lstrip("./")
+    normalized = _string(path).replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.lstrip("/")
     if not normalized:
         return False
     if (
@@ -869,6 +882,8 @@ def _source_reference_requires_claim_ids(
     source_path: str,
 ) -> bool:
     source_class = _normalize_source_document_class(source_document_class)
+    if _is_canonical_source_path(source_path):
+        return True
     if source_class == "canonical-declarative":
         return True
     if source_class in {"declarative-text", "imperative-input"}:
@@ -2087,11 +2102,12 @@ async def create_jira_issues_from_stories(
         or previous_story_output.get("story_breakdown")
         or previous_story_output.get("storyBreakdownJson")
     )
-    breakdown_source_path = _breakdown_source_path(raw_story_payload)
+    parsed_story_payload = _parse_story_breakdown_payload(raw_story_payload)
+    breakdown_source_path = _breakdown_source_path(parsed_story_payload)
     breakdown_source_document_class = _breakdown_source_document_class(
-        raw_story_payload
+        parsed_story_payload
     )
-    stories = _coerce_story_payload(raw_story_payload)
+    stories = _coerce_story_payload(parsed_story_payload)
     artifact_ref_was_read = False
     artifact_payload_had_explicit_empty_stories = False
     artifact_payload_failure_reason = ""
@@ -2117,16 +2133,7 @@ async def create_jira_issues_from_stories(
                 artifact_payload = artifact_reader(artifact_ref)
                 if inspect.isawaitable(artifact_payload):
                     artifact_payload = await artifact_payload  # type: ignore[assignment]
-                if isinstance(artifact_payload, bytes):
-                    artifact_payload = artifact_payload.decode(
-                        "utf-8", errors="replace"
-                    )
-                parsed_payload: Any = artifact_payload
-                if isinstance(artifact_payload, str) and artifact_payload.strip():
-                    try:
-                        parsed_payload = json.loads(artifact_payload)
-                    except json.JSONDecodeError:
-                        parsed_payload = artifact_payload
+                parsed_payload = _parse_story_breakdown_payload(artifact_payload)
                 breakdown_source_path = _breakdown_source_path(parsed_payload)
                 breakdown_source_document_class = _breakdown_source_document_class(
                     parsed_payload
@@ -2218,17 +2225,12 @@ async def create_jira_issues_from_stories(
                 fetched = story_fetcher(repo, ref, path)
                 if inspect.isawaitable(fetched):
                     fetched = await fetched  # type: ignore[assignment]
-                fetched_payload: Any = fetched
-                if isinstance(fetched, str) and fetched.strip():
-                    try:
-                        fetched_payload = json.loads(fetched)
-                    except json.JSONDecodeError:
-                        fetched_payload = fetched
+                fetched_payload = _parse_story_breakdown_payload(fetched)
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
                 breakdown_source_document_class = _breakdown_source_document_class(
                     fetched_payload
                 )
-                stories = _coerce_story_payload(fetched)
+                stories = _coerce_story_payload(fetched_payload)
             except Exception as exc:
                 reason = _repo_handoff_read_failure_reason(
                     repo=repo,

--- a/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
+++ b/tests/unit/agents/test_moonspec_doc_reconcile_skill.py
@@ -70,7 +70,8 @@ def test_moonspec_breakdown_skill_classifies_input_documents() -> None:
 
     assert "## Input Classification" in text
     assert "canonical-declarative" in text
-    assert "imperative-override" in text
+    assert "imperative-input" in text
+    assert "instead of requiring explicit confirmation" in text
     assert "sourceDocumentClass" in text
     assert "docs/Workflows/MoonSpecDocumentModel.md" in text
 
@@ -83,7 +84,8 @@ def test_moonspec_breakdown_skill_requires_stable_canonical_claim_ids() -> None:
     assert "stable canonical claim IDs" in text
     assert "sourceReference.claimIds" in text
     assert "path-anchored IDs" in text
-    assert "do not fabricate canonical claim IDs" in text
+    assert "do not fabricate canonical" in text
+    assert "claim IDs" in text
     assert (
         "coverage matrix from every selected canonical claim ID and every"
         in text

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -2137,13 +2137,16 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "Inline workflow source." in expanded_with_null_optional_sources[
                 "steps"
             ][0]["instructions"]
-            assert "inline workflow-instruction override" in (
+            assert "sourceDocumentClass as imperative-input" in (
                 expanded_with_null_optional_sources["steps"][0]["instructions"]
             )
-            assert "imperative-override" in (
+            assert "underlying actionable desired system behavior" in (
                 expanded_with_null_optional_sources["steps"][0]["instructions"]
             )
             assert "fail fast with the moonspec-breakdown imperative-input error" not in (
+                expanded_with_null_optional_sources["steps"][0]["instructions"]
+            )
+            assert "imperative-override" not in (
                 expanded_with_null_optional_sources["steps"][0]["instructions"]
             )
 
@@ -2167,10 +2170,10 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
             assert "docs/Designs/RuntimeTypes.md" in expanded_with_path_and_issue[
                 "steps"
             ][0]["instructions"]
-            assert "inline workflow-instruction override" not in (
+            assert "sourceDocumentClass as imperative-input" in (
                 expanded_with_path_and_issue["steps"][0]["instructions"]
             )
-            assert "fail fast with the moonspec-breakdown imperative-input error" in (
+            assert "fail fast with the moonspec-breakdown imperative-input error" not in (
                 expanded_with_path_and_issue["steps"][0]["instructions"]
             )
 
@@ -2190,7 +2193,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(
         {
             "path": "preset.inputs",
             "message": (
-                "Provide a Declarative Document Path, Source Jira Issue Key, "
+                "Provide a Source Document Path, Source Jira Issue Key, "
                 "or Workflow Instructions."
             ),
             "code": "required",
@@ -2261,11 +2264,11 @@ async def test_jira_breakdown_presets_allow_inline_instruction_roadmaps(
             )
 
     breakdown_instructions = expanded["steps"][0]["instructions"]
-    assert "inline workflow-instruction override" in breakdown_instructions
-    assert "decompose the actionable desired system behavior" in (
+    assert "sourceDocumentClass as imperative-input" in breakdown_instructions
+    assert "decompose the underlying actionable desired system behavior" in (
         breakdown_instructions
     )
-    assert "imperative-override" in breakdown_instructions
+    assert "imperative-override" not in breakdown_instructions
     assert "fail fast with the moonspec-breakdown imperative-input error" not in (
         breakdown_instructions
     )

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1207,6 +1207,85 @@ async def test_create_jira_issues_accepts_imperative_file_backed_story_without_c
     assert "Canonical Claim IDs:" not in service.requests[0].description
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_blocks_misclassified_canonical_story_without_claim_ids():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+            "storyBreakdown": {
+                "source": {
+                    "referencePath": "docs/Designs/RuntimeTypes.md",
+                    "sourceDocumentClass": "imperative-input",
+                },
+                "stories": [
+                    {
+                        "id": "STORY-001",
+                        "summary": "Misclassified canonical source",
+                    },
+                ],
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert service.requests == []
+    assert result.outputs["storyOutput"]["status"] == "fallback"
+    assert "requires sourceReference.claimIds" in result.outputs["storyOutput"]["reason"]
+    assert "STORY-001" in result.outputs["storyOutput"]["reason"]
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_preserves_source_metadata_from_story_breakdown_json():
+    service = _FakeJiraService()
+    breakdown = {
+        "source": {
+            "referencePath": "docs/tmp/Roadmap.md",
+            "sourceDocumentClass": "imperative-input",
+        },
+        "stories": [
+            {
+                "id": "STORY-001",
+                "summary": "JSON payload story",
+                "sourceReference": {
+                    "coverageIds": ["DESIGN-REQ-001"],
+                },
+            },
+        ],
+    }
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+            "storyBreakdownJson": json.dumps(breakdown),
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert result.outputs["jira"]["issueMappings"][0]["sourceDesignPath"] == (
+        "docs/tmp/Roadmap.md"
+    )
+    assert len(service.requests) == 1
+    assert service.requests[0].description.startswith(
+        "Source Reference\nSource Document: docs/tmp/Roadmap.md"
+    )
+    assert "Coverage IDs:" in service.requests[0].description
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_accepts_optional_file_backed_story_without_claim_ids():
     service = _FakeJiraService()
 
@@ -1260,6 +1339,21 @@ def test_requires_story_source_reference_accepts_falsy_policy_values(policy):
         )
         is False
     )
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (".specify/memory/constitution.md", True),
+        ("./.specify/memory/constitution.md", True),
+        ("/.specify/memory/constitution.md", True),
+        ("docs/Designs/RuntimeTypes.md", True),
+        ("./docs/Designs/RuntimeTypes.md", True),
+        ("docs/tmp/Roadmap.md", False),
+        ("artifacts/story-breakdowns/demo/stories.json", False),
+    ],
+)
+def test_is_canonical_source_path_handles_prefixes(path, expected):
+    assert story_tools._is_canonical_source_path(path) is expected
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_accepts_claim_backed_source_reference_from_breakdown():

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -781,11 +781,8 @@ async def test_create_jira_issues_fails_for_failed_empty_story_artifact():
     service = _FakeJiraService()
     breakdown = {
         "error": {
-            "code": "moonspec-breakdown.imperative-input",
-            "message": (
-                "Imperative input: provide the underlying declarative design or "
-                "explicitly confirm imperative input"
-            ),
+            "code": "moonspec-breakdown.no-technical-design",
+            "message": "No technical design provided",
         },
         "stories": [],
     }
@@ -796,7 +793,7 @@ async def test_create_jira_issues_fails_for_failed_empty_story_artifact():
 
     with pytest.raises(
         ValueError,
-        match="moonspec-breakdown\\.imperative-input",
+        match="moonspec-breakdown\\.no-technical-design",
     ):
         await create_jira_issues_from_stories(
             {
@@ -1168,6 +1165,46 @@ async def test_create_jira_issues_blocks_file_backed_story_without_claim_ids():
     assert result.outputs["storyOutput"]["status"] == "fallback"
     assert "requires sourceReference.claimIds" in result.outputs["storyOutput"]["reason"]
     assert "STORY-001" in result.outputs["storyOutput"]["reason"]
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_accepts_imperative_file_backed_story_without_claim_ids():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+            "storyBreakdown": {
+                "source": {
+                    "referencePath": "docs/tmp/Roadmap.md",
+                    "sourceDocumentClass": "imperative-input",
+                },
+                "stories": [
+                    {
+                        "id": "STORY-001",
+                        "summary": "Imperative fallback story",
+                        "sourceReference": {
+                            "path": "docs/tmp/Roadmap.md",
+                            "claimIds": [],
+                            "coverageIds": ["DESIGN-REQ-001"],
+                        },
+                    },
+                ],
+            },
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    assert len(service.requests) == 1
+    assert "Coverage IDs:" in service.requests[0].description
+    assert "Canonical Claim IDs:" not in service.requests[0].description
 
 @pytest.mark.asyncio
 async def test_create_jira_issues_accepts_optional_file_backed_story_without_claim_ids():


### PR DESCRIPTION
## Summary

- Update `moonspec-breakdown` so imperative input no longer requires explicit confirmation; when no declarative source is selected, it records `sourceDocumentClass: imperative-input` and extracts the underlying desired behavior.
- Align Jira breakdown presets, MoonSpec document/tool contracts, and Jira export handling so canonical docs still require stable `claimIds`, while non-canonical or imperative sources use preserved source paths/titles plus run-local `coverageIds`.
- Amend the constitution to v2.2.0 with resilience as a core pillar: workflows should use explicit, evidence-backed fallbacks or workarounds when intent and safety boundaries remain clear.

## Root Cause

The breakdown guidance treated imperative framing as a hard error unless the user supplied magic-word confirmation. That made source selection brittle and contradicted MoonMind's goal of resilient agentic workflows.

## Validation

- `python3 -m py_compile moonmind/workflows/temporal/story_output_tools.py api_service/services/presets/catalog.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/agents/test_moonspec_doc_reconcile_skill.py tests/unit/api/test_presets_service.py tests/unit/workflows/temporal/test_story_output_tools.py`
- `python3 /Users/nsticco/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/moonspec-breakdown`
- `python3 /Users/nsticco/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/jira-issue-creator`
- `git diff --check`