### PR TITLE
MM-953: Replace per-column workflow filters with an advanced filter drawer

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -76,14 +76,13 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
 });
 
 describe('Workflow list table dropdown overflow', () => {
-  it('lets table filter and action popovers overflow the table edges instead of clipping them', () => {
+  it('lets row action popovers overflow the table edges instead of clipping them', () => {
     // `overflow-x: auto` on the wrapper is coerced to `overflow-y: auto` by the
     // browser, so the wrapper clips popovers. A highly restrictive filter leaves
-    // a short table that cut the filter popover off. While a popover is open the
-    // wrapper must switch to `overflow: visible` so the popover can escape.
+    // a short table that cut the row actions popover off. While a popover is open
+    // the wrapper must switch to `overflow: visible` so the popover can escape.
     const wrapperBlock = cssRuleBlock(
       `.workflow-list-data-slab .queue-table-wrapper:has(
-        .workflow-list-header-filter-popover,
         .td-workflow-actions-popover
       )`,
     );

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -874,19 +874,19 @@ describe('Dashboard shared entry', () => {
     const filterChipBlock = cssRuleBlock(dashboardCss, '.workflow-list-filter-chip {');
     expect(filterChipBlock).toContain('background: var(--mm-control-shell)');
     expect(filterChipBlock).toContain('border: 1px solid var(--mm-control-border)');
-    const popoverFilterBlock = cssRuleBlock(
+    const drawerFilterBlock = cssRuleBlock(
       dashboardCss,
-      '.workflow-list-header-filter-popover .workflow-list-header-filter-control',
+      '.workflow-list-filter-section .workflow-list-filter-control',
     );
-    expect(popoverFilterBlock).toContain('display: grid');
-    expect(popoverFilterBlock).toContain('gap: 0.75rem');
-    expect(popoverFilterBlock).toContain('border: 0');
-    expect(popoverFilterBlock).toContain('background: transparent');
-    expect(popoverFilterBlock).toContain('box-shadow: none');
+    expect(drawerFilterBlock).toContain('display: grid');
+    expect(drawerFilterBlock).toContain('gap: 0.75rem');
+    expect(drawerFilterBlock).toContain('border: 0');
+    expect(drawerFilterBlock).toContain('background: transparent');
+    expect(drawerFilterBlock).toContain('box-shadow: none');
     expect(
       cssRuleBlock(
         dashboardCss,
-        '.workflow-list-header-filter-popover .workflow-list-header-filter-control label',
+        '.workflow-list-filter-section .workflow-list-filter-control label',
       ),
     ).toContain('gap: 0.55rem');
     expect(cssRuleBlock(dashboardCss, '.workflow-list-filter-actions')).toContain(

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -111,6 +111,28 @@ describe('Workflows Entrypoint', () => {
     });
   });
 
+  it('traps Tab focus inside the open advanced filter drawer', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+
+    const drawer = screen.getByRole('dialog', { name: 'Advanced filters' });
+    const closeButton = screen.getByRole('button', { name: 'Close filters' });
+    const applyButton = screen.getByRole('button', { name: 'Apply filters' });
+
+    // Shift+Tab from the first focusable control wraps to the last one instead
+    // of escaping into the inert background.
+    closeButton.focus();
+    fireEvent.keyDown(drawer, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(applyButton);
+
+    // Tab from the last focusable control wraps back to the first.
+    applyButton.focus();
+    fireEvent.keyDown(drawer, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+  });
+
   it('keeps active filter chips visible on an empty first page with active filters', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -41,6 +41,11 @@ describe('Workflows Entrypoint', () => {
 
   const lastExecutionListUrl = () => executionListCalls().at(-1)?.[0];
 
+  // The advanced filter drawer is the single surface that exposes the full
+  // filter UI. These helpers open it and apply the staged draft.
+  const openFilterDrawer = () => fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+  const applyFilterDrawer = () => fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }));
+
   it('shows the loading state while the workflow list request is pending', () => {
     fetchSpy.mockReturnValue(new Promise(() => {}) as Promise<Response>);
 
@@ -65,6 +70,45 @@ describe('Workflows Entrypoint', () => {
 
     expect(await screen.findByText('Cannot combine stateIn and stateNotIn.')).toBeTruthy();
     expect(screen.queryByLabelText('Live updates')).toBeNull();
+  });
+
+  it('moves advanced filters out of every desktop table header', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    // No per-column filter icon button remains in the table headers.
+    expect(document.querySelectorAll('.workflow-list-column-filter-button')).toHaveLength(0);
+    expect(screen.queryByRole('button', { name: /No filter applied\./i })).toBeNull();
+    // A single visible Filters control opens the full filter UI instead.
+    const filtersTrigger = screen.getByRole('button', { name: 'Filters' });
+    expect(filtersTrigger).toBeTruthy();
+    expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
+
+    fireEvent.click(filtersTrigger);
+    expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
+  });
+
+  it('opens and closes the advanced filter drawer and returns focus to the trigger', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const filtersTrigger = screen.getByRole('button', { name: 'Filters' });
+    fireEvent.click(filtersTrigger);
+
+    const drawer = screen.getByRole('dialog', { name: 'Advanced filters' });
+    expect(drawer).toBeTruthy();
+    // Opening moves focus into the drawer for keyboard users.
+    await waitFor(() => {
+      expect(drawer.contains(document.activeElement)).toBe(true);
+    });
+
+    fireEvent.keyDown(drawer, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(filtersTrigger);
+    });
   });
 
   it('keeps active filter chips visible on an empty first page with active filters', async () => {
@@ -97,11 +141,11 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter value'), {
       target: { value: 'completed' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     expect(await screen.findByText('No workflows found for the current filters.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
@@ -238,14 +282,14 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Needs operator input');
     expect(screen.getAllByText('Intervention requested').length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     const statusFilter = screen.getByLabelText('Status filter value') as HTMLSelectElement;
     expect(
       Array.from(statusFilter.options).some((option) => option.value === 'intervention_requested'),
     ).toBe(true);
   });
 
-  it('separates desktop header sorting from filter popovers', async () => {
+  it('keeps header sorting independent from the advanced filter drawer', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -253,14 +297,9 @@ describe('Workflows Entrypoint', () => {
     const scheduledHeaderButton = await screen.findByRole('button', {
       name: /Scheduled\. Sorted descending\. Activate to sort ascending\./i,
     });
-    const repositoryFilterButton = screen.getByRole('button', {
-      name: /Filter Repository\. No filter applied\./i,
-    });
 
-    fireEvent.click(repositoryFilterButton);
-
-    expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
-    expect(repositoryFilterButton.closest('th')?.classList.contains('is-filter-open')).toBe(true);
+    openFilterDrawer();
+    expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
     expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
 
     fireEvent.click(scheduledHeaderButton);
@@ -268,45 +307,48 @@ describe('Workflows Entrypoint', () => {
     await waitFor(() => {
       expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
     });
-    expect(screen.queryByRole('dialog', { name: 'Scheduled filter' })).toBeNull();
+    // Sorting does not disturb the open drawer.
+    expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
   });
 
-  it('keeps workflow filters available outside the desktop-only table layout', async () => {
+  it('exposes every advanced filter field in one drawer and applies them together', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
 
-    expect(screen.getByLabelText('Mobile ID filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Skill filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Title filter value')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Scheduled from')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Created from')).toBeTruthy();
-    expect(screen.getByLabelText('Mobile Finished blank values')).toBeTruthy();
+    openFilterDrawer();
+    expect(screen.getByLabelText('ID filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Skill filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Title filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Scheduled from')).toBeTruthy();
+    expect(screen.getByLabelText('Created from')).toBeTruthy();
+    expect(screen.getByLabelText('Finished blank values')).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText('Mobile ID filter value'), {
+    fireEvent.change(screen.getByLabelText('ID filter value'), {
       target: { value: 'task-123' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Status filter value'), {
+    fireEvent.change(screen.getByLabelText('Status filter value'), {
       target: { value: 'completed' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Repository filter value'), {
+    fireEvent.change(screen.getByLabelText('Repository filter value'), {
       target: { value: 'owner/repo' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Runtime filter value'), {
+    fireEvent.change(screen.getByLabelText('Runtime filter value'), {
       target: { value: 'codex_cloud' },
     });
-    fireEvent.change(screen.getByLabelText('Mobile Title filter value'), {
+    fireEvent.change(screen.getByLabelText('Title filter value'), {
       target: { value: 'Example' },
     });
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&workflowIdContains=task-123&stateIn=completed&repoContains=owner%2Frepo&targetRuntimeIn=codex_cloud&titleContains=Example',
       );
     });
   });
 
-  it('applies runtime and skill exclude modes from value-list popovers', async () => {
+  it('applies runtime and skill exclude modes from the drawer', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -329,24 +371,24 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Runtime filter mode'), { target: { value: 'exclude' } });
     fireEvent.change(screen.getByLabelText('Runtime filter value'), { target: { value: 'codex_cli' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Runtime filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('targetRuntimeNotIn=codex_cli');
+      expect(lastExecutionListUrl()).toContain('targetRuntimeNotIn=codex_cli');
     });
     expect(screen.getByRole('button', { name: 'Runtime filter: not Codex CLI' })).toBeTruthy();
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Skill\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Skill filter mode'), { target: { value: 'exclude' } });
     fireEvent.change(screen.getByLabelText('Skill filter value'), { target: { value: 'pr-resolver' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Skill filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      const url = fetchSpy.mock.calls.at(-1)?.[0];
+      const url = lastExecutionListUrl();
       expect(url).toContain('targetRuntimeNotIn=codex_cli');
       expect(url).toContain('targetSkillNotIn=pr-resolver');
     });
@@ -357,7 +399,7 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
+    openFilterDrawer();
 
     const runtimeFilter = screen.getByLabelText('Runtime filter value') as HTMLSelectElement;
     expect(runtimeFilter.multiple).toBe(false);
@@ -674,13 +716,13 @@ describe('Workflows Entrypoint', () => {
     expect((await screen.findAllByText('—')).length).toBeGreaterThan(0);
   });
 
-  it('reuses the trimmed repository column filter for both the request and the query key', async () => {
+  it('reuses the trimmed repository filter for both the request and the query key', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
     const baselineCalls = executionListCalls().length;
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+    openFilterDrawer();
     expect(screen.getAllByPlaceholderText('repo starts with…')).not.toHaveLength(0);
     expect(screen.getByLabelText('Repository filter value').getAttribute('title')).toBe(
       'Prefix match: finds repository names that start with this text.',
@@ -690,7 +732,7 @@ describe('Workflows Entrypoint', () => {
     });
 
     expect(executionListCalls().length).toBe(baselineCalls);
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Repository filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
       expect(executionListCalls().length).toBe(baselineCalls + 1);
@@ -712,12 +754,12 @@ describe('Workflows Entrypoint', () => {
     expect(executionListCalls().length).toBe(baselineCalls + 1);
   }, 10_000);
 
-  it('labels the lifecycle column filter as status and exposes canonical status options', async () => {
+  it('labels the lifecycle filter as status and exposes canonical status options', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
     // Skip the leading placeholder option that prompts the user to add a value.
     const options = Array.from(statusFilter.options)
@@ -764,7 +806,7 @@ describe('Workflows Entrypoint', () => {
     const baselineCalls = executionListCalls().length;
     fireEvent.change(statusFilter, { target: { value: 'completed' } });
     expect(executionListCalls().length).toBe(baselineCalls);
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
       expect(executionListCalls().length).toBe(baselineCalls + 1);
@@ -779,7 +821,7 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
 
     fireEvent.change(statusFilter, { target: { value: 'completed' } });
@@ -793,10 +835,10 @@ describe('Workflows Entrypoint', () => {
     expect(pillList.textContent).not.toContain('completed');
     expect(pillList.textContent).toContain('failed');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&stateIn=failed',
       );
     });
@@ -808,88 +850,68 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
     const baselineCalls = executionListCalls().length;
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'completed' } });
     expect(executionListCalls().length).toBe(baselineCalls);
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel Status filter' }));
-    expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel filters' }));
+    expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
     expect(executionListCalls().length).toBe(baselineCalls);
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'failed' } });
-    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Status filter' }), { key: 'Escape' });
-    expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Advanced filters' }), { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
     expect(executionListCalls().length).toBe(baselineCalls);
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'planning' } });
-    fireEvent.mouseDown(document.body);
-    expect(screen.queryByRole('dialog', { name: 'Status filter' })).toBeNull();
+    fireEvent.mouseDown(document.querySelector('.workflow-list-filter-drawer-overlay') as Element);
+    expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
     expect(executionListCalls().length).toBe(baselineCalls);
   }, 10000);
 
-  it('moves focus into column filter dialogs and applies staged text filters with Enter', async () => {
+  it('moves focus into the drawer and applies staged text filters with Enter', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    const titleFilterButton = screen.getByRole('button', {
-      name: /Filter Title\. No filter applied\./i,
-    });
 
-    fireEvent.click(titleFilterButton);
+    openFilterDrawer();
+
+    // The drawer focuses its first control so keyboard users land inside it.
+    const idInput = (await screen.findByLabelText('ID filter value')) as HTMLInputElement;
+    await waitFor(() => {
+      expect(document.activeElement).toBe(idInput);
+    });
 
     const titleInput = (await screen.findByLabelText('Title filter value')) as HTMLInputElement;
-    await waitFor(() => {
-      expect(document.activeElement).toBe(titleInput);
-    });
-
     fireEvent.change(titleInput, { target: { value: 'Example' } });
-    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Title filter' }), { key: 'Enter' });
+    fireEvent.keyDown(titleInput, { key: 'Enter' });
 
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&titleContains=Example',
       );
-      expect(screen.queryByRole('dialog', { name: 'Title filter' })).toBeNull();
-      expect(
-        screen.getByRole('button', { name: /Filter Title\. Filter active: Example\./i }),
-      ).toBeTruthy();
+      expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Title filter: Example' })).toBeTruthy();
     });
   });
 
-  it('does not apply staged filters when Enter is pressed on popover action buttons', async () => {
+  it('does not apply staged filters when Enter is pressed on drawer action buttons', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
     const baselineCalls = executionListCalls().length;
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Title\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Title filter value'), { target: { value: 'Example' } });
-    const clearButton = screen.getByRole('button', { name: 'Clear' });
-    clearButton.focus();
+    const cancelButton = screen.getByRole('button', { name: 'Cancel filters' });
+    cancelButton.focus();
 
-    fireEvent.keyDown(clearButton, { key: 'Enter' });
+    fireEvent.keyDown(cancelButton, { key: 'Enter' });
 
     expect(executionListCalls().length).toBe(baselineCalls);
     expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50');
-    expect(screen.getByRole('dialog', { name: 'Title filter' })).toBeTruthy();
-  });
-
-  it('keeps mobile filter focus from jumping to a stale desktop trigger', async () => {
-    renderWithClient(<WorkflowListPage payload={mockPayload} />);
-
-    await screen.findAllByText('Example task');
-    const desktopStatusFilter = screen.getByRole('button', {
-      name: /Filter Status\. No filter applied\./i,
-    });
-    fireEvent.click(desktopStatusFilter);
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel Status filter' }));
-
-    const mobileStatusFilter = screen.getByLabelText('Mobile Status filter value') as HTMLSelectElement;
-    mobileStatusFilter.focus();
-    fireEvent.change(mobileStatusFilter, { target: { value: 'completed' } });
-
-    expect(document.activeElement).toBe(mobileStatusFilter);
+    expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
   });
 
   it('applies status exclude semantics and removes only the selected chip', async () => {
@@ -897,13 +919,13 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Status filter mode'), { target: { value: 'exclude' } });
     fireEvent.change(screen.getByLabelText('Status filter value'), { target: { value: 'canceled' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&stateNotIn=canceled',
       );
     });
@@ -913,7 +935,7 @@ describe('Workflows Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Remove Status filter' }));
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50',
       );
     });
@@ -923,15 +945,15 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
 
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
     fireEvent.change(statusFilter, { target: { value: 'completed' } });
     fireEvent.change(statusFilter, { target: { value: 'failed' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&stateIn=completed%2Cfailed',
       );
     });
@@ -949,7 +971,7 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter mode'), { target: { value: 'exclude' } });
 
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
@@ -957,14 +979,35 @@ describe('Workflows Entrypoint', () => {
     fireEvent.change(statusFilter, { target: { value: 'failed' } });
     fireEvent.change(statusFilter, { target: { value: 'planning' } });
     fireEvent.change(statusFilter, { target: { value: 'canceled' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe(
+      expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&stateNotIn=completed%2Cfailed%2Cplanning%2Ccanceled',
       );
     });
     expect(screen.getByRole('button', { name: 'Status filter: not (completed, failed, planning +1)' })).toBeTruthy();
+  });
+
+  it('resets every active filter from the drawer', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    openFilterDrawer();
+    fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'completed' } });
+    applyFilterDrawer();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Status filter: completed' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Status filter: completed' })).toBeNull();
+      expect(lastExecutionListUrl()).toBe('/api/executions?source=temporal&pageSize=50');
+    });
   });
 
   it('clears stale cursor state when the page size changes', async () => {
@@ -1012,24 +1055,24 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Skill\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Skill filter value'), {
       target: { value: 'moonspec-implement' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Skill filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('targetSkillIn=moonspec-implement');
+      expect(lastExecutionListUrl()).toContain('targetSkillIn=moonspec-implement');
     });
     expect(screen.getByRole('button', { name: 'Skill filter: moonspec-implement' })).toBeTruthy();
     await screen.findAllByText('Example task');
 
-    fireEvent.click(screen.getByRole('button', { name: /Filter Finished\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Finished blank values'), { target: { value: 'include' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Finished filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
-      expect(fetchSpy.mock.calls.at(-1)?.[0]).toContain('finishedBlank=include');
+      expect(lastExecutionListUrl()).toContain('finishedBlank=include');
     });
     expect(screen.getByRole('button', { name: 'Finished filter: blank' })).toBeTruthy();
   });
@@ -1066,7 +1109,7 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+    openFilterDrawer();
 
     expect(
       (await screen.findAllByText('Facet values unavailable. Showing current page values only.')).length,
@@ -1168,6 +1211,8 @@ describe('Workflows Entrypoint', () => {
 
     expect(controlDeck).toBeTruthy();
     expect(controlDeck?.querySelector('form.workflow-list-control-grid')).toBeNull();
+    // The advanced filter trigger lives in the control deck, not the headers.
+    expect(controlDeck?.querySelector('.workflow-list-filter-trigger')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /^Kind\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Workflow Type\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();
@@ -1185,7 +1230,7 @@ describe('Workflows Entrypoint', () => {
     expect(pageSizeLabel?.classList.contains('queue-page-size-selector')).toBe(true);
     expect(pageSizeLabel?.classList.contains('queue-inline-filter')).toBe(false);
     expect(tableWrapper).toBeTruthy();
-    // The slab intentionally allows overflow so the column filter popover
+    // The slab intentionally allows overflow so the row actions popover
     // can extend below the table without being clipped.
     expect(getComputedStyle(dataSlab as HTMLElement).overflow).toBe('visible');
     expect(getComputedStyle(tableWrapper as HTMLElement).overflowX).toBe('auto');
@@ -1233,7 +1278,7 @@ describe('Workflows Entrypoint', () => {
 
     const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
-    // The slab intentionally allows overflow so the column filter popover
+    // The slab intentionally allows overflow so the row actions popover
     // can extend below the table without being clipped by the data slab.
     expect(dataSlabStyles.overflow).toBe('visible');
     expect(dataSlabStyles.paddingTop).toBe('0px');
@@ -1246,21 +1291,21 @@ describe('Workflows Entrypoint', () => {
     expect(tableWrapperStyles.overflowY).toBe('visible');
   });
 
-  it('shows clickable active column filter chips and removes individual filters from the chip row', async () => {
+  it('shows clickable active filter chips and removes individual filters from the chip row', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(await screen.findByLabelText('Status filter value'), { target: { value: 'completed' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Status filter' }));
+    applyFilterDrawer();
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Repository\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Repository filter value'), { target: { value: 'owner/repo' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Repository filter' }));
+    applyFilterDrawer();
     await screen.findAllByText('Example task');
-    fireEvent.click(screen.getByRole('button', { name: /Filter Runtime\. No filter applied\./i }));
+    openFilterDrawer();
     fireEvent.change(screen.getByLabelText('Runtime filter value'), { target: { value: 'codex_cli' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Apply Runtime filter' }));
+    applyFilterDrawer();
 
     await waitFor(() => {
       const activeFilterText = document.querySelector('.workflow-list-filter-chips')?.textContent || '';
@@ -1270,17 +1315,21 @@ describe('Workflows Entrypoint', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Repository filter: owner/repo' }));
-    expect(screen.getByRole('dialog', { name: 'Repository filter' })).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Advanced filters' })).toBeTruthy();
     await waitFor(() => {
       expect(lastExecutionListUrl()).toBe(
         '/api/executions?source=temporal&pageSize=50&stateIn=completed&repoContains=owner%2Frepo&targetRuntimeIn=codex_cli',
       );
     });
+    // The drawer opens focused on the chip's field.
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText('Repository filter value'));
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove Status filter' }));
 
     await waitFor(() => {
-      fireEvent.click(screen.getByRole('button', { name: /Filter Status\. No filter applied\./i }));
+      openFilterDrawer();
       expect((screen.getByLabelText('Status filter value') as HTMLSelectElement).value).toBe('');
     });
   }, 10000);

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -89,6 +89,21 @@ const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
   'createdAt',
   'closedAt',
 ]);
+// Advanced filter drawer field order. The drawer groups the precise
+// include/exclude/date/blank filters that previously lived in every desktop
+// table header. Labels match the column labels so chips, sections, and the
+// underlying filter state share one vocabulary.
+const DRAWER_FILTER_FIELDS: Array<[FilterField, string]> = [
+  ['workflowId', 'ID'],
+  ['title', 'Title'],
+  ['status', 'Status'],
+  ['repository', 'Repository'],
+  ['targetRuntime', 'Runtime'],
+  ['targetSkill', 'Skill'],
+  ['scheduledFor', 'Scheduled'],
+  ['createdAt', 'Created'],
+  ['closedAt', 'Finished'],
+];
 function isFilterField(field: string): field is FilterField {
   return ACTIVE_FILTER_FIELDS.has(field as FilterField);
 }
@@ -477,7 +492,12 @@ function appendFilterParams(params: URLSearchParams, filters: ColumnFilters) {
   appendDateParams(params, filters.closedAt, 'finishedFrom', 'finishedTo', 'finishedBlank');
 }
 
-function facetForFilterField(field: FilterField | null): ExecutionFacetResponse['facet'] | null {
+// The four value fields that resolve to a server-side facet. `integration` is a
+// valid response facet but is not a workflow-list filter field, so it is not
+// part of this map.
+type FacetField = 'status' | 'targetRuntime' | 'targetSkill' | 'repository';
+
+function facetForFilterField(field: FilterField | null): FacetField | null {
   if (field === 'status') return 'status';
   if (field === 'targetRuntime') return 'targetRuntime';
   if (field === 'targetSkill') return 'targetSkill';
@@ -602,6 +622,15 @@ function filterSummary(field: FilterField, filters: ColumnFilters): string {
   return parts.join(', ');
 }
 
+function clearFilterField(filters: ColumnFilters, field: FilterField): ColumnFilters {
+  const next = { ...filters };
+  if (field === 'workflowId' || field === 'title') next[field] = {};
+  else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
+  else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
+  else next[field] = emptyValueFilter();
+  return next;
+}
+
 export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const dashboardCfg = useMemo(() => readListDashboardConfig(payload), [payload.initialData]);
   const listPollMs = useMemo(() => {
@@ -622,11 +651,16 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const [filters, setFilters] = useState(() => parseInitialFilters(initial));
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
   const [hasEditedFilters, setHasEditedFilters] = useState(false);
-  const [openFilter, setOpenFilter] = useState<FilterField | null>(null);
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
-  const [pendingFocusField, setPendingFocusField] = useState<FilterField | null>(null);
-  const popoverRef = useRef<HTMLDivElement | null>(null);
-  const filterTriggerRef = useRef<HTMLButtonElement | null>(null);
+  // The advanced filter drawer is the single surface that exposes the full
+  // filter UI. `drawerOpen` controls visibility.
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const drawerToggleRef = useRef<HTMLButtonElement | null>(null);
+  // The element that opened the drawer (the Filters trigger or a chip). Focus is
+  // returned here when the drawer closes so keyboard users keep their place.
+  const filterTriggerRef = useRef<HTMLElement | null>(null);
+  // Field whose first control should receive focus when the drawer opens.
+  const pendingDrawerFocusRef = useRef<FilterField | null>(null);
   const [pageSize, setPageSize] = useState(() => parsePageSize(initial.get('limit')));
   const [listCursor, setListCursor] = useState<string | null>(() =>
     ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
@@ -692,83 +726,127 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       }
       return ExecutionListResponseSchema.parse(await response.json());
     },
-    refetchInterval: listEnabled && !openFilter ? listPollMs : false,
+    refetchInterval: listEnabled && !drawerOpen ? listPollMs : false,
   });
 
-  const openFacet = facetForFilterField(openFilter);
-  const {
-    data: facetData,
-    isError: isFacetError,
-    isFetching: isFacetFetching,
-  } = useQuery({
-    queryKey: ['workflow-list-facet', openFacet, filters] as const,
-    enabled: listEnabled && filterValidationErrors.length === 0 && Boolean(openFacet),
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      params.set('source', 'temporal');
-      params.set('facet', openFacet as string);
-      params.set('pageSize', '50');
-      appendFilterParams(params, filters);
-      const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch facets: ${response.statusText}`);
-      }
-      return ExecutionFacetResponseSchema.parse(await response.json());
-    },
-    staleTime: listPollMs,
-    retry: false,
-  });
+  // Facets enrich the include/exclude dropdowns. The drawer shows every value
+  // field at once, so we fetch each field's facet values while the drawer is
+  // open. This reuses the existing single-facet backend contract (one request
+  // per facet) without any API changes.
+  const useExecutionFacet = (facet: ExecutionFacetResponse['facet']) =>
+    useQuery({
+      queryKey: ['workflow-list-facet', facet, filters] as const,
+      enabled: listEnabled && filterValidationErrors.length === 0 && drawerOpen,
+      queryFn: async () => {
+        const params = new URLSearchParams();
+        params.set('source', 'temporal');
+        params.set('facet', facet);
+        params.set('pageSize', '50');
+        appendFilterParams(params, filters);
+        const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch facets: ${response.statusText}`);
+        }
+        return ExecutionFacetResponseSchema.parse(await response.json());
+      },
+      staleTime: listPollMs,
+      retry: false,
+    });
 
-  useEffect(() => {
-    if (!openFilter) return;
-    setDraftFilters(filters);
-  }, [openFilter, filters]);
+  const facetByField = {
+    status: useExecutionFacet('status'),
+    targetRuntime: useExecutionFacet('targetRuntime'),
+    targetSkill: useExecutionFacet('targetSkill'),
+    repository: useExecutionFacet('repository'),
+  } as const;
 
-  const closeFilter = useCallback((nextDraftFilters = filters, fieldToFocus = openFilter) => {
-    const fallback = fieldToFocus
-      ? document.querySelector<HTMLButtonElement>(
-          `.workflow-list-column-filter-button[data-filter-field="${fieldToFocus}"]`,
-        )
-      : null;
-    if (fieldToFocus) {
-      (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
-    }
-    setOpenFilter(null);
-    setDraftFilters(nextDraftFilters);
-    setPendingFocusField(fieldToFocus);
-  }, [filters, openFilter]);
+  const resetToFirstPage = useCallback(() => {
+    setListCursor(null);
+    setCursorStack([]);
+  }, []);
 
-  useEffect(() => {
-    if (openFilter || !pendingFocusField) return;
-    const fallback = document.querySelector<HTMLButtonElement>(
-      `.workflow-list-column-filter-button[data-filter-field="${pendingFocusField}"]`,
-    );
-    (filterTriggerRef.current?.isConnected ? filterTriggerRef.current : fallback)?.focus();
-    setPendingFocusField(null);
-  }, [openFilter, pendingFocusField]);
-
-  useEffect(() => {
-    if (!openFilter) return;
+  const restoreTriggerFocus = useCallback(() => {
+    const trigger = filterTriggerRef.current;
     window.requestAnimationFrame(() => {
-      const firstControl = popoverRef.current?.querySelector<HTMLElement>(
+      if (trigger?.isConnected) {
+        trigger.focus();
+      } else {
+        drawerToggleRef.current?.focus();
+      }
+    });
+  }, []);
+
+  const openDrawer = useCallback(
+    (field: FilterField | null, trigger: HTMLElement | null) => {
+      filterTriggerRef.current = trigger;
+      pendingDrawerFocusRef.current = field;
+      setDraftFilters(filters);
+      setDrawerOpen(true);
+    },
+    [filters],
+  );
+
+  const closeDrawer = useCallback(
+    (options: { restoreFocus?: boolean } = {}) => {
+      setDrawerOpen(false);
+      setDraftFilters(filters);
+      if (options.restoreFocus !== false) {
+        restoreTriggerFocus();
+      }
+    },
+    [filters, restoreTriggerFocus],
+  );
+
+  const applyDraftFilters = useCallback(() => {
+    setHasEditedFilters(true);
+    setFilters(draftFilters);
+    resetToFirstPage();
+    setDrawerOpen(false);
+    restoreTriggerFocus();
+  }, [draftFilters, resetToFirstPage, restoreTriggerFocus]);
+
+  const resetDraftFilters = useCallback(() => {
+    const cleared = emptyFilters();
+    setHasEditedFilters(true);
+    setDraftFilters(cleared);
+    setFilters(cleared);
+    resetToFirstPage();
+  }, [resetToFirstPage]);
+
+  const removeActiveFilter = useCallback(
+    (field: FilterField) => {
+      setHasEditedFilters(true);
+      const next = clearFilterField(filters, field);
+      setFilters(next);
+      setDraftFilters(next);
+      resetToFirstPage();
+    },
+    [filters, resetToFirstPage],
+  );
+
+  // When the drawer opens, move focus to the first control of the requested
+  // field (or the first control overall). This drives the keyboard "open the
+  // drawer" and "navigate fields" behaviors.
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const frame = window.requestAnimationFrame(() => {
+      const field = pendingDrawerFocusRef.current;
+      pendingDrawerFocusRef.current = null;
+      const root = drawerRef.current;
+      if (!root) return;
+      // Focus the requested field's first control, or fall back to the first
+      // control in the filter body (not the header close button).
+      const scope =
+        (field && root.querySelector<HTMLElement>(`[data-filter-section="${field}"]`)) ||
+        root.querySelector<HTMLElement>('.workflow-list-filter-drawer-body') ||
+        root;
+      const focusTarget = scope.querySelector<HTMLElement>(
         'input:not([disabled]), select:not([disabled]), button:not([disabled])',
       );
-      firstControl?.focus();
+      focusTarget?.focus();
     });
-  }, [openFilter]);
-
-  useEffect(() => {
-    if (!openFilter) return;
-    const onPointerDown = (event: MouseEvent) => {
-      const target = event.target as Node | null;
-      const targetElement = event.target as Element | null;
-      if (target && popoverRef.current?.contains(target)) return;
-      if (targetElement?.closest('.workflow-list-column-filter-button, .workflow-list-filter-chip-open')) return;
-      closeFilter(filters, openFilter);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    return () => document.removeEventListener('mousedown', onPointerDown);
-  }, [closeFilter, openFilter, filters]);
+    return () => window.cancelAnimationFrame(frame);
+  }, [drawerOpen]);
 
   const sortedItems = useMemo(() => {
     const items = data?.items || [];
@@ -780,11 +858,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const pageEnd = pageIndex * pageSize + sortedItems.length;
   const countSummary = displayTemporalCount(data?.count, data?.countMode);
   const hasPaginationContext = cursorStack.length > 0 || Boolean(listCursor);
-
-  const resetToFirstPage = useCallback(() => {
-    setListCursor(null);
-    setCursorStack([]);
-  }, []);
 
   const onHeaderClick = (field: string) => {
     if (sortField === field) {
@@ -879,13 +952,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       </div>
     </div>
   );
-  const filterValueForField = useCallback(
-    (field: string): string => {
-      if (!isFilterField(field)) return '';
-      return filterSummary(field, filters);
-    },
-    [filters],
-  );
   const activeFilters = useMemo(
     () =>
       TABLE_COLUMNS.map(([field, label]) => {
@@ -898,20 +964,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     [filters],
   );
   const hasActiveFilters = activeFilters.length > 0;
-  const toggleFilter = useCallback((field: FilterField) => {
-    setOpenFilter((current) => (current === field ? null : field));
-  }, []);
-
-  const applyFilters = useCallback(
-    (nextFilters: ColumnFilters, focusField: FilterField | null = openFilter) => {
-      setHasEditedFilters(true);
-      setFilters(nextFilters);
-      setDraftFilters(nextFilters);
-      closeFilter(nextFilters, focusField);
-      resetToFirstPage();
-    },
-    [closeFilter, openFilter, resetToFirstPage],
-  );
 
   const updateDraftText = (field: 'workflowId' | 'title', value: string) => {
     setDraftFilters((current) => ({
@@ -957,47 +1009,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     setDraftFilters((current) => ({ ...current, [field]: { ...current[field], ...patch } }));
   };
 
-  const applyMobileValues = (
-    field: 'status' | 'targetRuntime' | 'targetSkill',
-    values: string[],
-  ) => {
-    const dedupedValues = field === 'targetRuntime' ? uniqueRuntimeValues(values) : uniqueValues(values);
-    const currentField = filters[field];
-    applyFilters({
-      ...filters,
-      [field]:
-        dedupedValues.length === 0
-          ? { ...emptyValueFilter(), mode: currentField.mode }
-          : { ...currentField, values: dedupedValues, blank: '' },
-    });
-  };
-
-  const applyMobileRepository = (value: string) => {
-    applyFilters({
-      ...filters,
-      repository: { ...filters.repository, mode: 'include', values: [], exactText: value },
-    });
-  };
-
-  const applyMobileDate = (field: 'scheduledFor' | 'createdAt' | 'closedAt', patch: DateFilter) => {
-    applyFilters({
-      ...filters,
-      [field]: { ...filters[field], ...patch },
-    });
-  };
-
-  const filterAccessibilityLabel = (field: string, label: string): string => {
-    const value = filterValueForField(field);
-    if (!isFilterField(field)) return `Filter ${label}. No filter available.`;
-    if (!value) return `Filter ${label}. No filter applied.`;
-    return `Filter ${label}. Filter active: ${value}.`;
-  };
-
   const valueOptionsForField = (field: FilterField): string[] => {
+    const facetKey = facetForFilterField(field);
+    const facetData = facetKey ? facetByField[facetKey].data : undefined;
     const facetValues =
-      facetData && facetForFilterField(field) === facetData.facet
-        ? facetData.items.map((item) => item.value)
-        : [];
+      facetData && facetData.facet === facetKey ? facetData.items.map((item) => item.value) : [];
     if (field === 'status') return uniqueValues([...facetValues, ...TEMPORAL_STATUSES]);
     if (field === 'targetRuntime') {
       return uniqueRuntimeValues([
@@ -1027,32 +1043,36 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   };
 
   const renderFacetNotice = (field: FilterField) => {
-    if (facetForFilterField(field) !== openFacet) return null;
-    if (isFacetError) {
+    const facetKey = facetForFilterField(field);
+    if (!facetKey) return null;
+    const facetQuery = facetByField[facetKey];
+    if (facetQuery.isError) {
       return (
         <p className="small workflow-list-facet-notice" role="status">
           Facet values unavailable. Showing current page values only.
         </p>
       );
     }
-    if (isFacetFetching) {
+    if (facetQuery.isFetching) {
       return <p className="small workflow-list-facet-notice">Loading facet values...</p>;
     }
-    if (facetData?.truncated) {
+    if (facetQuery.data?.truncated) {
       return <p className="small workflow-list-facet-notice">Facet values truncated by the server.</p>;
     }
     return null;
   };
 
-  const renderFilterControl = (field: FilterField, labelPrefix = '') => {
-    const isMobile = Boolean(labelPrefix);
+  // Renders one filter's controls bound to the draft filter state. The drawer is
+  // the only surface that renders these now; edits stage into `draftFilters`
+  // until the user applies them.
+  const renderFilterControl = (field: FilterField) => {
     if (field === 'workflowId' || field === 'title') {
       const label = field === 'workflowId' ? 'ID' : 'Title';
-      const draft = isMobile ? filters[field] : draftFilters[field];
+      const draft = draftFilters[field];
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}{label} filter value
+            {label} filter value
             <input
               type="text"
               value={draft.contains || ''}
@@ -1063,10 +1083,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   ? 'Prefix match: finds workflow IDs that start with this text.'
                   : 'Word match: finds titles containing this whole word.'
               }
-              onChange={(event) => {
-              if (isMobile) applyFilters({ ...filters, [field]: { contains: event.target.value } }, null);
-                else updateDraftText(field, event.target.value);
-              }}
+              onChange={(event) => updateDraftText(field, event.target.value)}
             />
           </label>
         </div>
@@ -1074,22 +1091,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     }
 
     if (field === 'status') {
-      const draft = isMobile ? filters.status : draftFilters.status;
+      const draft = draftFilters.status;
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}Status filter mode
+            Status filter mode
             <select
               value={draft.mode}
               disabled={!listEnabled}
-              onChange={(event) => {
-                const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) {
-                  applyFilters({ ...filters, status: { ...filters.status, mode } });
-                } else {
-                  updateDraftValueMode('status', mode);
-                }
-              }}
+              onChange={(event) => updateDraftValueMode('status', event.target.value as ValueFilter['mode'])}
             >
               <option value="include">Include selected</option>
               <option value="exclude">Exclude selected</option>
@@ -1100,15 +1110,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             options={[...TEMPORAL_STATUSES]}
             formatValue={formatStatusLabel}
             disabled={!listEnabled}
-            ariaLabelAdd={`${labelPrefix}Status filter value`}
-            ariaLabelSelected={`${labelPrefix}Selected status filters`}
+            ariaLabelAdd="Status filter value"
+            ariaLabelSelected="Selected status filters"
             addPlaceholder="Add status"
             emptyMessage="No status filters selected"
-            onChange={(next) => {
-              const normalized = next.map((value) => value.toLowerCase());
-              if (isMobile) applyMobileValues('status', normalized);
-              else updateDraftValues('status', normalized);
-            }}
+            onChange={(next) => updateDraftValues('status', next.map((value) => value.toLowerCase()))}
           />
           {renderFacetNotice('status')}
         </div>
@@ -1116,23 +1122,21 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     }
 
     if (field === 'repository') {
+      const repositoryOptions = valueOptionsForField('repository');
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}Repository filter value
+            Repository filter value
             <input
               type="text"
-              value={isMobile ? filters.repository.exactText || '' : draftFilters.repository.exactText || ''}
+              value={draftFilters.repository.exactText || ''}
               disabled={!listEnabled}
               placeholder="repo starts with…"
               title="Prefix match: finds repository names that start with this text."
-              onChange={(event) => {
-                if (isMobile) applyMobileRepository(event.target.value);
-                else updateDraftRepository(event.target.value);
-              }}
+              onChange={(event) => updateDraftRepository(event.target.value)}
             />
           </label>
-          {!isMobile && valueOptionsForField('repository').length > 0 ? (
+          {repositoryOptions.length > 0 ? (
             <label>
               Repository values
               <select
@@ -1152,7 +1156,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                 }}
               >
                 <option value="">Repository values</option>
-                {valueOptionsForField('repository').map((repo) => (
+                {repositoryOptions.map((repo) => (
                   <option key={repo} value={repo}>
                     {repo}
                   </option>
@@ -1167,19 +1171,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'targetRuntime') {
       const runtimeOptions = valueOptionsForField('targetRuntime');
-      const draft = isMobile ? filters.targetRuntime : draftFilters.targetRuntime;
+      const draft = draftFilters.targetRuntime;
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}Runtime filter mode
+            Runtime filter mode
             <select
               value={draft.mode}
               disabled={!listEnabled}
-              onChange={(event) => {
-                const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetRuntime: { ...filters.targetRuntime, mode } }, null);
-                else updateDraftValueMode('targetRuntime', mode);
-              }}
+              onChange={(event) => updateDraftValueMode('targetRuntime', event.target.value as ValueFilter['mode'])}
             >
               <option value="include">Include selected</option>
               <option value="exclude">Exclude selected</option>
@@ -1190,14 +1190,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             options={runtimeOptions}
             formatValue={formatRuntimeLabel}
             disabled={!listEnabled}
-            ariaLabelAdd={`${labelPrefix}Runtime filter value`}
-            ariaLabelSelected={`${labelPrefix}Selected runtime filters`}
+            ariaLabelAdd="Runtime filter value"
+            ariaLabelSelected="Selected runtime filters"
             addPlaceholder="Add runtime"
             emptyMessage="No runtime filters selected"
-            onChange={(next) => {
-              if (isMobile) applyMobileValues('targetRuntime', next);
-              else updateDraftValues('targetRuntime', next);
-            }}
+            onChange={(next) => updateDraftValues('targetRuntime', next)}
           />
           {renderFacetNotice('targetRuntime')}
         </div>
@@ -1206,19 +1203,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'targetSkill') {
       const skillOptions = valueOptionsForField('targetSkill');
-      const draft = isMobile ? filters.targetSkill : draftFilters.targetSkill;
+      const draft = draftFilters.targetSkill;
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}Skill filter mode
+            Skill filter mode
             <select
               value={draft.mode}
               disabled={!listEnabled}
-              onChange={(event) => {
-                const mode = event.target.value as ValueFilter['mode'];
-                if (isMobile) applyFilters({ ...filters, targetSkill: { ...filters.targetSkill, mode } }, null);
-                else updateDraftValueMode('targetSkill', mode);
-              }}
+              onChange={(event) => updateDraftValueMode('targetSkill', event.target.value as ValueFilter['mode'])}
             >
               <option value="include">Include selected</option>
               <option value="exclude">Exclude selected</option>
@@ -1228,14 +1221,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             values={draft.values}
             options={skillOptions}
             disabled={!listEnabled}
-            ariaLabelAdd={`${labelPrefix}Skill filter value`}
-            ariaLabelSelected={`${labelPrefix}Selected skill filters`}
+            ariaLabelAdd="Skill filter value"
+            ariaLabelSelected="Selected skill filters"
             addPlaceholder="Add skill"
             emptyMessage="No skill filters selected"
-            onChange={(next) => {
-              if (isMobile) applyMobileValues('targetSkill', next);
-              else updateDraftValues('targetSkill', next);
-            }}
+            onChange={(next) => updateDraftValues('targetSkill', next)}
           />
           {renderFacetNotice('targetSkill')}
         </div>
@@ -1244,44 +1234,36 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
     if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') {
       const label = field === 'scheduledFor' ? 'Scheduled' : field === 'createdAt' ? 'Created' : 'Finished';
-      const draft = isMobile ? filters[field] : draftFilters[field];
+      const draft = draftFilters[field];
       return (
-        <div className="queue-inline-filter workflow-list-header-filter-control">
+        <div className="queue-inline-filter workflow-list-filter-control">
           <label>
-            {labelPrefix}{label} from
+            {label} from
             <input
               type="date"
               value={draft.from || ''}
               disabled={!listEnabled}
-              onChange={(event) => {
-                if (isMobile) applyMobileDate(field, { from: event.target.value });
-                else updateDraftDate(field, { from: event.target.value });
-              }}
+              onChange={(event) => updateDraftDate(field, { from: event.target.value })}
             />
           </label>
           <label>
-            {labelPrefix}{label} to
+            {label} to
             <input
               type="date"
               value={draft.to || ''}
               disabled={!listEnabled}
-              onChange={(event) => {
-                if (isMobile) applyMobileDate(field, { to: event.target.value });
-                else updateDraftDate(field, { to: event.target.value });
-              }}
+              onChange={(event) => updateDraftDate(field, { to: event.target.value })}
             />
           </label>
           {field !== 'createdAt' ? (
             <label>
-              {labelPrefix}{label} blank values
+              {label} blank values
               <select
                 value={draft.blank || ''}
                 disabled={!listEnabled}
-                onChange={(event) => {
-                  const blank = event.target.value as NonNullable<DateFilter['blank']>;
-                  if (isMobile) applyMobileDate(field, { blank });
-                  else updateDraftDate(field, { blank });
-                }}
+                onChange={(event) =>
+                  updateDraftDate(field, { blank: event.target.value as NonNullable<DateFilter['blank']> })
+                }
               >
                 <option value="">Ignore blanks</option>
                 <option value="include">Include blanks</option>
@@ -1294,74 +1276,6 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     }
 
     return null;
-  };
-
-  const renderFilterPopover = (field: FilterField, label: string) => {
-    if (openFilter !== field) return null;
-
-    const control = renderFilterControl(field) || (
-      <p className="small">No filter is available for {label} yet.</p>
-    );
-
-    return (
-      <div
-        className="workflow-list-header-filter-popover"
-        role="dialog"
-        aria-label={`${label} filter`}
-        ref={popoverRef}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape') {
-            closeFilter(filters, field);
-          }
-          if (event.key === 'Enter' && event.target instanceof HTMLElement) {
-            const tagName = event.target.tagName.toLowerCase();
-            if (tagName !== 'textarea' && tagName !== 'button' && !event.defaultPrevented) {
-              event.preventDefault();
-              applyFilters(draftFilters, field);
-            }
-          }
-        }}
-      >
-        {control}
-        {isFilterField(field) ? (
-          <div className="workflow-list-filter-actions">
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => {
-                const next = { ...draftFilters };
-                if (field === 'workflowId' || field === 'title') next[field] = {};
-                else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
-                else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
-                else next[field] = emptyValueFilter();
-                applyFilters(next, field);
-              }}
-              disabled={!listEnabled}
-            >
-              Clear
-            </button>
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => {
-                closeFilter(filters, field);
-              }}
-              aria-label={`Cancel ${label} filter`}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => applyFilters(draftFilters, field)}
-              disabled={!listEnabled}
-              aria-label={`Apply ${label} filter`}
-            >
-              Apply
-            </button>
-          </div>
-        ) : null}
-      </div>
-    );
   };
 
   return (
@@ -1383,21 +1297,39 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
           </div>
         ) : null}
 
-        {hasActiveFilters ? (
-          <div className="workflow-list-filter-row" aria-live="polite">
-            <div className="workflow-list-filter-chips" aria-label="Active filters">
+        <div className="workflow-list-filter-bar">
+          <button
+            type="button"
+            className={`workflow-list-filter-trigger${hasActiveFilters ? ' is-active' : ''}`}
+            ref={drawerToggleRef}
+            aria-haspopup="dialog"
+            aria-expanded={drawerOpen}
+            onClick={(event) => openDrawer(null, event.currentTarget)}
+          >
+            <svg
+              aria-hidden="true"
+              className="workflow-list-filter-trigger-icon"
+              viewBox="0 0 16 16"
+              focusable="false"
+            >
+              <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
+            </svg>
+            <span>Filters</span>
+            {hasActiveFilters ? (
+              <span className="workflow-list-filter-trigger-count" aria-hidden="true">
+                {activeFilters.length}
+              </span>
+            ) : null}
+          </button>
+          {hasActiveFilters ? (
+            <div className="workflow-list-filter-chips" aria-label="Active filters" aria-live="polite">
               {activeFilters.map(({ field, label, value }) => (
                 <span className="workflow-list-filter-chip" key={`${label}:${value}`}>
                   <button
                     type="button"
                     className="workflow-list-filter-chip-open"
                     data-filter-field={field}
-                    onMouseDown={(event) => event.stopPropagation()}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      filterTriggerRef.current = event.currentTarget;
-                      setOpenFilter(field);
-                    }}
+                    onClick={(event) => openDrawer(field, event.currentTarget)}
                     aria-label={`${label} filter: ${value}`}
                   >
                     <span>{label}</span>
@@ -1406,14 +1338,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   <button
                     type="button"
                     className="workflow-list-filter-chip-remove"
-                    onClick={() => {
-                      const next = { ...filters };
-                      if (field === 'workflowId' || field === 'title') next[field] = {};
-                      else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
-                      else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
-                      else next[field] = emptyValueFilter();
-                      applyFilters(next);
-                    }}
+                    onClick={() => removeActiveFilter(field)}
                     aria-label={`Remove ${label} filter`}
                   >
                     ×
@@ -1421,30 +1346,94 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                 </span>
               ))}
             </div>
-          </div>
-        ) : null}
-        <div className="workflow-list-mobile-filter-disclosure">
-          <button
-            type="button"
-            className="workflow-list-mobile-filter-toggle"
-            aria-expanded={mobileFiltersOpen}
-            aria-controls="workflow-list-mobile-filter-panel"
-            onClick={() => setMobileFiltersOpen((open) => !open)}
-          >
-            {mobileFiltersOpen ? 'Hide filters' : 'Show filters'}
-            {hasActiveFilters ? ` (${activeFilters.length})` : ''}
-          </button>
-          <div
-            id="workflow-list-mobile-filter-panel"
-            className={`workflow-list-mobile-filter-controls${mobileFiltersOpen ? ' is-open' : ''}`}
-            aria-label="Mobile workflow filters"
-          >
-            {TABLE_COLUMNS.map(([field]) =>
-              isFilterField(field) ? <div key={field}>{renderFilterControl(field, 'Mobile ')}</div> : null,
-            )}
-          </div>
+          ) : (
+            <span className="workflow-list-filter-empty small">No filters applied.</span>
+          )}
         </div>
       </section>
+
+      {drawerOpen ? (
+        <div
+          className="workflow-list-filter-drawer-overlay"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) closeDrawer();
+          }}
+        >
+          <div
+            className="workflow-list-filter-drawer"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Advanced filters"
+            ref={drawerRef}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.stopPropagation();
+                closeDrawer();
+                return;
+              }
+              if (
+                event.key === 'Enter' &&
+                event.target instanceof HTMLInputElement &&
+                !event.defaultPrevented
+              ) {
+                event.preventDefault();
+                applyDraftFilters();
+              }
+            }}
+          >
+            <header className="workflow-list-filter-drawer-header">
+              <h2 className="workflow-list-filter-drawer-title">Advanced filters</h2>
+              <button
+                type="button"
+                className="secondary workflow-list-filter-drawer-close"
+                onClick={() => closeDrawer()}
+                aria-label="Close filters"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </header>
+            <div className="workflow-list-filter-drawer-body">
+              {DRAWER_FILTER_FIELDS.map(([field, label]) => (
+                <section
+                  key={field}
+                  className="workflow-list-filter-section"
+                  data-filter-section={field}
+                  aria-label={`${label} filter`}
+                >
+                  {renderFilterControl(field)}
+                </section>
+              ))}
+            </div>
+            <footer className="workflow-list-filter-drawer-actions workflow-list-filter-actions">
+              <button
+                type="button"
+                className="secondary"
+                onClick={resetDraftFilters}
+                disabled={!listEnabled || !hasActiveFilters}
+                aria-label="Reset filters"
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => closeDrawer()}
+                aria-label="Cancel filters"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={applyDraftFilters}
+                disabled={!listEnabled}
+                aria-label="Apply filters"
+              >
+                Apply
+              </button>
+            </footer>
+          </div>
+        </div>
+      ) : null}
 
       <section
         className="queue-layouts panel--data workflow-list-data-slab"
@@ -1489,57 +1478,22 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                     <tr>
                       {TABLE_COLUMNS.map(([field, label]) => {
                         const { ariaSort, ariaLabel, sortHint } = sortAccessibilityProps(field, label);
-                        const filterField = isFilterField(field) ? field : null;
                         return (
                           <th
                             key={field}
                             aria-sort={ariaSort}
-                            className={`workflow-list-compound-header-cell${filterField && openFilter === filterField ? " is-filter-open" : ""}`}
+                            className="workflow-list-header-cell"
                           >
-                            <div className="workflow-list-compound-header">
-                              <button
-                                type="button"
-                                className="table-sort-button"
-                                onClick={() => onHeaderClick(field)}
-                                aria-label={ariaLabel}
-                              >
-                                {label}
-                                {sortIndicator(field)}
-                                <span className="sr-only">{sortHint}</span>
-                              </button>
-                              <button
-                                type="button"
-                                className={`workflow-list-column-filter-button${
-                                  filterValueForField(field) ? ' is-active' : ''
-                                }`}
-                                data-filter-field={field}
-                                ref={
-                                  filterField && pendingFocusField === filterField
-                                    ? (node) => node?.focus()
-                                    : undefined
-                                }
-                                onMouseDown={(event) => event.stopPropagation()}
-                                onClick={(event) => {
-                                  event.stopPropagation();
-                                  if (filterField) {
-                                    filterTriggerRef.current = event.currentTarget;
-                                    toggleFilter(filterField);
-                                  }
-                                }}
-                                aria-label={filterAccessibilityLabel(field, label)}
-                                aria-expanded={filterField ? openFilter === filterField : false}
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  className="workflow-list-column-filter-icon"
-                                  viewBox="0 0 16 16"
-                                  focusable="false"
-                                >
-                                  <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
-                                </svg>
-                              </button>
-                            </div>
-                            {filterField ? renderFilterPopover(filterField, label) : null}
+                            <button
+                              type="button"
+                              className="table-sort-button"
+                              onClick={() => onHeaderClick(field)}
+                              aria-label={ariaLabel}
+                            >
+                              {label}
+                              {sortIndicator(field)}
+                              <span className="sr-only">{sortHint}</span>
+                            </button>
                           </th>
                         );
                       })}

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -733,31 +733,30 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   // field at once, so we fetch each field's facet values while the drawer is
   // open. This reuses the existing single-facet backend contract (one request
   // per facet) without any API changes.
-  const useExecutionFacet = (facet: ExecutionFacetResponse['facet']) =>
-    useQuery({
-      queryKey: ['workflow-list-facet', facet, filters] as const,
-      enabled: listEnabled && filterValidationErrors.length === 0 && drawerOpen,
-      queryFn: async () => {
-        const params = new URLSearchParams();
-        params.set('source', 'temporal');
-        params.set('facet', facet);
-        params.set('pageSize', '50');
-        appendFilterParams(params, filters);
-        const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch facets: ${response.statusText}`);
-        }
-        return ExecutionFacetResponseSchema.parse(await response.json());
-      },
-      staleTime: listPollMs,
-      retry: false,
-    });
+  const getFacetQueryOptions = (facet: ExecutionFacetResponse['facet']) => ({
+    queryKey: ['workflow-list-facet', facet, filters] as const,
+    enabled: listEnabled && filterValidationErrors.length === 0 && drawerOpen,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set('source', 'temporal');
+      params.set('facet', facet);
+      params.set('pageSize', '50');
+      appendFilterParams(params, filters);
+      const response = await fetch(`${payload.apiBase}/executions/facets?${params}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch facets: ${response.statusText}`);
+      }
+      return ExecutionFacetResponseSchema.parse(await response.json());
+    },
+    staleTime: listPollMs,
+    retry: false,
+  });
 
   const facetByField = {
-    status: useExecutionFacet('status'),
-    targetRuntime: useExecutionFacet('targetRuntime'),
-    targetSkill: useExecutionFacet('targetSkill'),
-    repository: useExecutionFacet('repository'),
+    status: useQuery(getFacetQueryOptions('status')),
+    targetRuntime: useQuery(getFacetQueryOptions('targetRuntime')),
+    targetSkill: useQuery(getFacetQueryOptions('targetSkill')),
+    repository: useQuery(getFacetQueryOptions('repository')),
   } as const;
 
   const resetToFirstPage = useCallback(() => {
@@ -1369,6 +1368,34 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               if (event.key === 'Escape') {
                 event.stopPropagation();
                 closeDrawer();
+                return;
+              }
+              if (event.key === 'Tab') {
+                // Trap focus inside the modal drawer so keyboard users cannot
+                // Tab/Shift+Tab into the inert background while it is open.
+                const root = drawerRef.current;
+                if (!root) return;
+                const focusable = Array.from(
+                  root.querySelectorAll<HTMLElement>(
+                    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+                  ),
+                );
+                if (focusable.length === 0) {
+                  event.preventDefault();
+                  return;
+                }
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                const active = document.activeElement as HTMLElement | null;
+                if (event.shiftKey) {
+                  if (active === first || !root.contains(active)) {
+                    event.preventDefault();
+                    last.focus();
+                  }
+                } else if (active === last || !root.contains(active)) {
+                  event.preventDefault();
+                  first.focus();
+                }
                 return;
               }
               if (

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -615,72 +615,85 @@ h1 {
   box-shadow: var(--mm-control-focus-ring);
 }
 
-.workflow-list-compound-header-cell {
+.workflow-list-header-cell {
   position: relative;
 }
 
-.workflow-list-compound-header {
+/*
+ * The advanced filter drawer is the single surface that exposes the full filter
+ * UI. The control deck only carries the trigger and active chips, so the table
+ * headers stay calm (sort buttons only).
+ */
+.workflow-list-filter-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  justify-content: flex-end;
+  background: rgb(var(--mm-ink) / 0.42);
+}
+
+.workflow-list-filter-drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(28rem, 100vw);
+  max-width: 100%;
+  height: 100%;
+  background: rgb(var(--mm-panel) / 0.99);
+  border-left: 1px solid rgb(var(--mm-border) / 0.84);
+  box-shadow: -24px 0 56px -32px rgb(var(--mm-ink) / 0.7);
+}
+
+.workflow-list-filter-drawer-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.35rem;
-  min-width: 0;
+  gap: 0.6rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.5);
 }
 
-.workflow-list-column-filter-button {
-  flex: 0 0 auto;
+.workflow-list-filter-drawer-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.workflow-list-filter-drawer-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  min-height: 1.65rem;
-  padding: 0.12rem 0.32rem;
-  border: 1px solid transparent;
-  border-radius: 0.35rem;
-  background: transparent;
-  color: rgb(var(--mm-muted));
-  font-size: 0.68rem;
-  font-weight: 600;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  font-size: 1.1rem;
   line-height: 1;
-  box-shadow: none;
 }
 
-.workflow-list-column-filter-button:hover,
-.workflow-list-column-filter-button:focus-visible,
-.workflow-list-column-filter-button.is-active {
-  border-color: var(--mm-control-border);
-  background: var(--mm-control-shell);
-  color: rgb(var(--mm-accent));
-  box-shadow: var(--mm-control-focus-ring);
-  transform: none;
-  filter: none;
+.workflow-list-filter-drawer-body {
+  flex: 1 1 auto;
+  display: grid;
+  gap: 0.85rem;
+  overflow-y: auto;
+  padding: 1rem;
 }
 
-.workflow-list-column-filter-icon {
-  display: block;
-  width: 0.85rem;
-  height: 0.85rem;
-  fill: currentColor;
+.workflow-list-filter-section {
+  display: grid;
+  gap: 0.5rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.3);
 }
 
-.workflow-list-header-filter-popover {
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  left: 0;
-  z-index: 80;
-  width: min(22rem, calc(100vw - 2rem));
-  padding: 0.85rem;
-  border: 1px solid rgb(var(--mm-border) / 0.84);
-  border-radius: 0.5rem;
-  background: rgb(var(--mm-panel) / 0.98);
-  box-shadow: 0 18px 42px -28px rgb(var(--mm-ink) / 0.7);
+.workflow-list-filter-section:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
 }
 
-.workflow-list-header-filter-control {
+.workflow-list-filter-control {
   width: 100%;
 }
 
-.workflow-list-header-filter-popover .workflow-list-header-filter-control {
+.workflow-list-filter-section .workflow-list-filter-control {
   display: grid;
   gap: 0.75rem;
   align-items: stretch;
@@ -692,23 +705,38 @@ h1 {
   transform: none;
 }
 
-.workflow-list-header-filter-popover .workflow-list-header-filter-control:hover,
-.workflow-list-header-filter-popover .workflow-list-header-filter-control:focus-within {
+.workflow-list-filter-section .workflow-list-filter-control:hover,
+.workflow-list-filter-section .workflow-list-filter-control:focus-within {
   border: 0;
   background: transparent;
   box-shadow: none;
   transform: none;
 }
 
-.workflow-list-header-filter-popover .workflow-list-header-filter-control label {
+.workflow-list-filter-section .workflow-list-filter-control label {
   gap: 0.55rem;
   font-size: 0.82rem;
   line-height: 1.35;
 }
 
-.workflow-list-header-filter-control select,
-.workflow-list-header-filter-control input {
+.workflow-list-filter-control select,
+.workflow-list-filter-control input {
   width: 100%;
+}
+
+/* The drawer footer reuses .workflow-list-filter-actions for flex layout and the
+ * divider; it only needs horizontal padding to align with the drawer body. */
+.workflow-list-filter-drawer-actions {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 0.85rem;
+}
+
+@media (max-width: 767px) {
+  .workflow-list-filter-drawer {
+    width: 100vw;
+    border-left: 0;
+  }
 }
 
 .workflow-list-filter-checkbox {
@@ -927,14 +955,6 @@ h1 {
   display: grid;
   gap: 0.85rem;
   padding: 0;
-}
-
-.workflow-list-control-grid {
-  display: grid;
-  width: 100%;
-  max-width: none;
-  grid-template-columns: repeat(4, minmax(12rem, 1fr));
-  gap: 0.8rem;
 }
 
 .manifests-page > .panel {
@@ -1494,16 +1514,66 @@ h1 {
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 }
 
-.workflow-list-utility-cluster {
-  justify-content: flex-end;
-}
-
-.workflow-list-filter-row {
+.workflow-list-filter-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
+  min-width: 0;
+}
+
+.workflow-list-filter-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+  padding: 0.45rem 0.85rem;
+  border: 1px solid var(--mm-control-border);
+  border-radius: 0.85rem;
+  background: var(--mm-control-shell);
+  color: rgb(var(--mm-ink));
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
+}
+
+.workflow-list-filter-trigger:hover,
+.workflow-list-filter-trigger:focus-visible,
+.workflow-list-filter-trigger[aria-expanded="true"],
+.workflow-list-filter-trigger.is-active {
+  background: var(--mm-control-shell-hover);
+  background-image: none;
+  border-color: rgb(var(--mm-accent) / 0.7);
+  color: rgb(var(--mm-ink));
+  box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-filter-trigger-icon {
+  display: block;
+  width: 0.85rem;
+  height: 0.85rem;
+  fill: currentColor;
+}
+
+.workflow-list-filter-trigger-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: rgb(var(--mm-accent) / 0.22);
+  color: rgb(var(--mm-accent));
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.workflow-list-filter-empty {
+  color: rgb(var(--mm-muted));
 }
 
 .workflow-list-filter-chips {
@@ -1573,57 +1643,6 @@ h1 {
   min-width: 0;
   overflow-wrap: anywhere;
   font-weight: 600;
-}
-
-.workflow-list-clear-filters {
-  flex: 0 0 auto;
-}
-
-.workflow-list-mobile-filter-disclosure {
-  display: none;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-
-.workflow-list-mobile-filter-toggle {
-  align-self: stretch;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.55rem 0.9rem;
-  border: 1px solid var(--mm-control-border);
-  border-radius: 0.85rem;
-  background: var(--mm-control-shell);
-  color: rgb(var(--mm-ink));
-  font: inherit;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: inset 0 1px 0 var(--mm-glass-edge);
-}
-
-.workflow-list-mobile-filter-toggle:hover,
-.workflow-list-mobile-filter-toggle:focus-visible,
-.workflow-list-mobile-filter-toggle:active,
-.workflow-list-mobile-filter-toggle[aria-expanded="true"] {
-  background: var(--mm-control-shell-hover);
-  background-image: none;
-  border-color: rgb(var(--mm-accent) / 0.7);
-  color: rgb(var(--mm-ink));
-  box-shadow: var(--mm-control-focus-ring);
-  transform: none;
-  filter: none;
-}
-
-.workflow-list-mobile-filter-controls {
-  display: none;
-  gap: 0.7rem;
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.workflow-list-mobile-filter-controls .queue-inline-filter {
-  border-radius: 0.6rem;
-  padding: 0.28rem 0.6rem;
 }
 
 table {
@@ -1793,17 +1812,16 @@ tbody tr:hover {
 }
 
 /*
- * While a column filter or row actions popover is open, let the table wrapper
- * overflow visibly so the popover can extend past the table edges. The wrapper
- * is normally `overflow-x: auto`, which browsers coerce to `overflow-y: auto`
- * as well — that turns the wrapper into a clipping box. When a highly
- * restrictive filter leaves only a few rows, the short table clipped the
- * popover and made it unreadable. Dropping to `overflow: visible` only while a
- * popover is present lets it escape into the page (which scrolls) instead of
- * being cut off, and the fixed-layout table never needs horizontal scrolling.
+ * While a row actions popover is open, let the table wrapper overflow visibly so
+ * the popover can extend past the table edges. The wrapper is normally
+ * `overflow-x: auto`, which browsers coerce to `overflow-y: auto` as well — that
+ * turns the wrapper into a clipping box. When a highly restrictive filter leaves
+ * only a few rows, the short table clipped the popover and made it unreadable.
+ * Dropping to `overflow: visible` only while a popover is present lets it escape
+ * into the page (which scrolls) instead of being cut off, and the fixed-layout
+ * table never needs horizontal scrolling.
  */
 .workflow-list-data-slab .queue-table-wrapper:has(
-  .workflow-list-header-filter-popover,
   .td-workflow-actions-popover
 ) {
   overflow: visible;
@@ -1833,10 +1851,6 @@ tbody tr:hover {
   background: rgb(var(--mm-panel) / 0.98);
   border-bottom: 0;
   box-shadow: 0 1px 0 rgb(var(--mm-border) / 0.72);
-}
-
-.queue-table-wrapper .workflow-list-compound-header-cell.is-filter-open {
-  z-index: 12;
 }
 
 .queue-table-wrapper th,
@@ -2213,33 +2227,15 @@ tr[data-proposal-id].proposal-consuming td {
   }
 }
 
-@media (min-width: 768px) and (max-width: 1080px) {
-  .workflow-list-control-grid {
-    grid-template-columns: repeat(2, minmax(14rem, 1fr));
-  }
-}
-
 @media (max-width: 767px) {
-  .workflow-list-control-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .workflow-list-utility-cluster,
-  .workflow-list-filter-row {
+  .workflow-list-filter-bar {
     align-items: stretch;
     width: 100%;
   }
 
-  .workflow-list-clear-filters {
+  .workflow-list-filter-trigger {
+    justify-content: center;
     width: 100%;
-  }
-
-  .workflow-list-mobile-filter-disclosure {
-    display: flex;
-  }
-
-  .workflow-list-mobile-filter-controls.is-open {
-    display: grid;
   }
 
   .queue-results-toolbar,
@@ -3149,27 +3145,10 @@ button.secondary:hover {
   transform: scale(var(--mm-control-hover-scale));
 }
 
-button.workflow-list-column-filter-button,
 button.workflow-list-filter-chip-open,
 button.workflow-list-filter-chip-remove {
   transform: none;
   filter: none;
-}
-
-button.workflow-list-column-filter-button {
-  border-color: transparent;
-  background: transparent;
-  color: rgb(var(--mm-muted));
-  box-shadow: none;
-}
-
-button.workflow-list-column-filter-button:hover,
-button.workflow-list-column-filter-button:focus-visible,
-button.workflow-list-column-filter-button.is-active {
-  border-color: var(--mm-control-border);
-  background: var(--mm-control-shell);
-  color: rgb(var(--mm-accent));
-  box-shadow: var(--mm-control-focus-ring);
 }
 
 .button {


### PR DESCRIPTION
## Issue
[MM-953](https://moonladder.atlassian.net/browse/MM-953) — Replace per-column workflow filters with a compact control deck and advanced filter drawer

## Summary
Moves advanced workflow-list filtering out of every desktop table header and into a single advanced filter drawer opened from a compact **Filters** control in the control deck.

- Removes the per-column filter icon button and header popover; table headers now carry sort controls only.
- Adds a Filters trigger and an advanced filter drawer (`role="dialog"`) that renders every filter field — workflow id/title contains, status/repository/runtime/skill include–exclude, scheduled/created/finished date ranges + blank handling — bound to the existing draft/active/validation/facet state model.
- Active filters stay visible as removable chips above the data slab; clicking a chip opens the drawer focused on that field.
- Keyboard support: open the drawer, navigate fields, apply/reset, Escape to close, and focus returns to the trigger.
- The same drawer serves desktop and mobile (responsive full-width panel), replacing the separate mobile disclosure.
- Preserves existing URL serialization/deserialization and validation-error behavior.
- Fetches each value field's facet while the drawer is open — no backend/facet API changes.

Reuses the pre-existing `filters` / `draftFilters` / `activeFilters` / validation / facet-loading / focus-restoration state model as called out in the issue's implementation notes; only the presentation changed.

## Tests run
Frontend unit tests via `./tools/test_unit.sh --dashboard-only --ui-args` (colon-safe mirror):
- `src/entrypoints/workflow-list.test.tsx` + `src/entrypoints/dashboard.test.tsx` — 89 passed
- `src/components/WorkflowRowActionsMenu.responsive.test.tsx` — 4 passed

Coverage includes drawer open/close, active chip removal, URL sync preservation, and invalid filter error rendering.

## Remaining risks
- Change is frontend-only (workflow-list component, dashboard CSS contract, row-actions overflow). No backend, facet API, or Temporal/contract surfaces touched.
- Out of scope per the issue and untouched here: server-side sorting, column customization, backend facet API changes.
- Visual/responsive polish of the drawer across very narrow viewports is exercised by unit tests but not a full cross-browser visual pass.


[MM-953]: https://moonladder.atlassian.net/browse/MM-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ