### PR TITLE
MM-954 Label workflow-list sorting as current-page-only

### DIFF
--- a/docs/UI/WorkflowsListPage.md
+++ b/docs/UI/WorkflowsListPage.md
@@ -163,16 +163,14 @@ Current URL parameters:
 | `repo` | Repository filter. |
 | `limit` | Page size. |
 | `nextPageToken` | Current opaque pagination cursor. |
-| `sort` | Selected table sort field when non-default. |
-| `sortDir` | `asc` or `desc` when non-default. |
 
 Rules:
 
 1. Query-string state is synchronized with `history.replaceState`.
 2. Filter changes reset pagination to the first page.
 3. Page-size changes reset pagination to the first page.
-4. Sort state is persisted in the URL.
-5. The current list request does not send sort parameters to the API; rows are sorted in the browser after the current page is fetched.
+4. Sort state is **not** persisted in the URL. Sorting is current-page-only client state (MM-954): the table reorders only the rows on the currently loaded page, so the sort field/direction live in component state and are intentionally neither seeded from nor written to the URL. This avoids implying a global server-side sort across the full filtered result set in shared links.
+5. The current list request does not send sort parameters to the API; rows are sorted in the browser after the current page is fetched. The UI labels this scope explicitly through a footer notice, header tooltip, and screen-reader hints.
 
 ### 5.4 Current API request
 

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -118,12 +118,12 @@ describe('Workflows Entrypoint', () => {
     );
 
     const scheduledHeaderButton = await screen.findByRole('button', {
-      name: /Updated\. Sorted descending\. Activate to sort ascending\./i,
+      name: /Updated\. Sorted descending, current page only\. Activate to sort ascending\./i,
     });
     expect(scheduledHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('descending');
 
     const runtimeHeaderButton = screen.getByRole('button', {
-      name: /Runtime\. Not sorted\. Activate to sort ascending\./i,
+      name: /Runtime\. Not sorted\. Activate to sort the current page ascending\./i,
     });
     expect(runtimeHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('none');
 
@@ -132,9 +132,62 @@ describe('Workflows Entrypoint', () => {
     await waitFor(() => {
       expect(runtimeHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
       expect(runtimeHeaderButton.getAttribute('aria-label')).toBe(
-        'Runtime. Sorted ascending. Activate to sort descending.',
+        'Runtime. Sorted ascending, current page only. Activate to sort descending.',
       );
     });
+  });
+
+  it('labels sorting as current-page-only and keeps it out of the URL and API request (MM-954)', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    // Visible explanatory text near pagination.
+    expect(screen.getByText('Sorting applies to the current page only.')).toBeTruthy();
+
+    const runtimeHeaderButton = screen.getByRole('button', {
+      name: /Runtime\. Not sorted\. Activate to sort the current page ascending\./i,
+    });
+    // Tooltip text reinforces the current-page-only scope.
+    expect(runtimeHeaderButton.getAttribute('title')).toBe('Sorting applies to the current page only.');
+
+    fireEvent.click(runtimeHeaderButton);
+
+    await waitFor(() => {
+      expect(runtimeHeaderButton.closest('th')?.getAttribute('aria-sort')).toBe('ascending');
+    });
+
+    // URL state must not imply a global server-side sort.
+    expect(window.location.search).not.toContain('sort=');
+    expect(window.location.search).not.toContain('sortDir=');
+
+    // The API request must not send sort/sortDir; sorting is purely client-side
+    // over the currently loaded page.
+    const requestedUrls = executionListCalls().map(([url]) => String(url));
+    expect(requestedUrls.length).toBeGreaterThan(0);
+    for (const url of requestedUrls) {
+      expect(url).not.toContain('sort=');
+      expect(url).not.toContain('sortDir=');
+    }
+  });
+
+  it('ignores sort/sortDir present in the initial URL so deep links never imply a global sort (MM-954)', async () => {
+    window.history.pushState({}, 'Seeded sort', '/workflows?sort=status&sortDir=asc');
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    // The default current-page sort (Updated, descending) is used regardless of
+    // the URL, and the misleading sort params are dropped from the URL.
+    expect(
+      screen.getByRole('button', {
+        name: /Updated\. Sorted descending, current page only\. Activate to sort ascending\./i,
+      }),
+    ).toBeTruthy();
+    expect(window.location.search).not.toContain('sort=');
+    expect(window.location.search).not.toContain('sortDir=');
+    expect(String(lastExecutionListUrl())).not.toContain('sort=');
   });
 
   it('exposes the exact updated timestamp with a two-digit year on hover', async () => {
@@ -276,7 +329,7 @@ describe('Workflows Entrypoint', () => {
     await screen.findAllByText('Example task');
 
     const updatedHeaderButton = await screen.findByRole('button', {
-      name: /Updated\. Sorted descending\. Activate to sort ascending\./i,
+      name: /Updated\. Sorted descending, current page only\. Activate to sort ascending\./i,
     });
     const repositoryFilterButton = screen.getByRole('button', {
       name: /Filter Repository\. No filter applied\./i,

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -10,6 +10,11 @@ import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
 
 const POLL_MS_DEFAULT = 5000;
 
+// MM-954: the workflow list uses cursor pagination and sorts only the rows on the
+// currently loaded page (client-side). This notice keeps the UI honest about that
+// scope instead of implying a global server-side sort across the full result set.
+const CURRENT_PAGE_SORT_NOTICE = 'Sorting applies to the current page only.';
+
 type ListDashboardConfig = {
   pollIntervalsMs?: { list?: number };
   features?: {
@@ -101,7 +106,6 @@ const FILTER_FIELDS = [
   ['closedAt', 'Finished'],
 ] as const;
 type FilterColumn = (typeof FILTER_FIELDS)[number];
-const VALID_TABLE_SORT_FIELDS = new Set<string>([...FILTER_FIELDS.map((column) => column[0]), 'integration', 'updatedAt']);
 const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
   'workflowId',
   'status',
@@ -192,11 +196,6 @@ type ExecutionFacetResponse = z.infer<typeof ExecutionFacetResponseSchema>;
 function readListDashboardConfig(payload: BootPayload): ListDashboardConfig | undefined {
   const raw = payload.initialData as { dashboardConfig?: ListDashboardConfig } | undefined;
   return raw?.dashboardConfig;
-}
-
-function normalizeTableSortField(raw: string | null): string {
-  const candidate = (raw || '').trim();
-  return VALID_TABLE_SORT_FIELDS.has(candidate) ? candidate : 'updatedAt';
 }
 
 function formatWhen(iso: string | null | undefined): string {
@@ -699,12 +698,12 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     ignoredWorkflowScopeState ? null : initial.get('nextPageToken')?.trim() || null,
   );
   const [cursorStack, setCursorStack] = useState<string[]>([]);
-  const [sortField, setSortField] = useState<string>(() => normalizeTableSortField(initial.get('sort')));
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>(() => {
-    const initialSortDir = initial.get('sortDir');
-    if (initialSortDir === 'asc' || initialSortDir === 'desc') return initialSortDir;
-    return 'desc';
-  });
+  // MM-954: sorting is current-page-only. The sort field/direction live in
+  // component state only — they are intentionally neither seeded from nor written
+  // to the URL, so a shared link never implies a global server-side sort across
+  // the full filtered result set.
+  const [sortField, setSortField] = useState<string>('updatedAt');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const filterValidationErrors = useMemo(() => {
     if (!hasEditedFilters) return initialFilterValidationErrors;
     const params = new URLSearchParams();
@@ -718,18 +717,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     appendFilterParams(params, filters);
     params.set('limit', String(pageSize));
     if (listCursor) params.set('nextPageToken', listCursor);
-    if (sortField !== 'updatedAt' || sortDir !== 'desc') {
-      params.set('sort', sortField);
-      params.set('sortDir', sortDir);
-    }
+    // MM-954: do not persist sort/sortDir to the URL. Sorting only reorders the
+    // currently loaded page, so writing it to the URL would falsely imply a
+    // global server-side sort across the full filtered result set.
     replaceUrlQuery(params);
   }, [
     filters,
     filterValidationErrors.length,
     pageSize,
     listCursor,
-    sortField,
-    sortDir,
   ]);
 
   useEffect(() => {
@@ -873,10 +869,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
         ? 'ascending'
         : 'descending';
     const sortHint = !isSorted
-      ? 'Not sorted. Activate to sort ascending.'
+      ? 'Not sorted. Activate to sort the current page ascending.'
       : sortDir === 'asc'
-        ? 'Sorted ascending. Activate to sort descending.'
-        : 'Sorted descending. Activate to sort ascending.';
+        ? 'Sorted ascending, current page only. Activate to sort descending.'
+        : 'Sorted descending, current page only. Activate to sort ascending.';
     return {
       ariaSort,
       ariaLabel: `${label}. ${sortHint}`,
@@ -909,6 +905,9 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             ? `Live updates enabled. Polling every ${Math.round(listPollMs / 1000)}s`
             : 'Live updates unavailable while the list is disabled.'}
         </span>
+        {sortedItems.length > 0 ? (
+          <span className="small workflow-list-sort-scope-note">{CURRENT_PAGE_SORT_NOTICE}</span>
+        ) : null}
       </div>
       <div className="queue-pagination workflow-list-footer-pagination">
         <PageSizeSelector
@@ -1563,6 +1562,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                                   className="table-sort-button"
                                   onClick={() => onHeaderClick(field)}
                                   aria-label={ariaLabel}
+                                  title={CURRENT_PAGE_SORT_NOTICE}
                                 >
                                   {label}
                                   {sortIndicator(field)}

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,1 +1,2 @@
 - [Pre-existing test_executions failures](pre-existing-test-executions-failures.md) — describe_execution IllegalStateChangeError reproduces on main; not a regression
+- [MM-954 workflow-list current-page sort](mm954-workflow-list-current-page-sort.md) — why list sorting is intentionally page-only, not global server-side

--- a/memory/mm954-workflow-list-current-page-sort.md
+++ b/memory/mm954-workflow-list-current-page-sort.md
@@ -1,0 +1,12 @@
+---
+name: mm954-workflow-list-current-page-sort
+description: Why the workflow-list (frontend/src/entrypoints/workflow-list.tsx) sorting is intentionally current-page-only, not global server-side
+metadata:
+  type: project
+---
+
+MM-954 was implemented with the issue's **fallback** (current-page-only) path, not the preferred server-side path, even though `/api/executions` already accepts/validates `sort`/`sortDir` and applies `ORDER BY` (see `api_service/api/routers/executions.py`, `_EXECUTION_SORT_FIELDS`).
+
+**Why:** The workflow-list's primary sortable column is the workflow **title**, but titles are indexed only as a Temporal `KeywordList` (`mm_title`) for word-membership filtering. Temporal SQL `ORDER BY` does not support `KeywordList`, the custom single-Keyword budget (10) is full (comment in `moonmind/workflows/temporal/workflows/run.py` ~line 13880), and adding a sortable title attribute is "New search indexing" — explicitly **out of scope** in MM-954. A mix of some columns sorted globally and title sorted page-only would be the misleading contract the issue set out to remove.
+
+**How to apply:** The frontend deliberately does NOT send `sort`/`sortDir` to the API, does NOT persist them in the URL, and labels sorting as current-page-only (footer note `CURRENT_PAGE_SORT_NOTICE`, header tooltip, and screen-reader hints). The backend `sort`/`sortDir` capability remains a valid API surface for other consumers — left intact, not removed. If global sorting is ever needed, it requires adding a sortable single-Keyword title search attribute first.


### PR DESCRIPTION
## Issue

[MM-954](https://moonladder.atlassian.net/browse/MM-954): Make workflow-list sorting global or explicitly current-page-only

## Summary

The workflow list synced `sort`/`sortDir` into the URL but never sent them to the backend, and only reordered the currently loaded page client-side. Under cursor pagination this misled users into thinking the entire workflow set was sorted.

This change implements the issue's **fallback** solution — explicit current-page-only sorting — rather than the preferred server-side path. The `/api/executions` endpoint already accepts, validates, and applies `sort`/`sortDir` server-side, but the workflow list's primary sortable column (workflow **title**) is indexed only as a Temporal `KeywordList` (`mm_title`), which SQL `ORDER BY` cannot sort. Adding a sortable title search attribute is "New search indexing", which is explicitly out of scope for MM-954. A mix of globally-sorted columns and a page-only title sort would reproduce exactly the misleading contract this issue set out to remove, so the honest fallback was chosen.

Changes in `frontend/src/entrypoints/workflow-list.tsx`:
- Sort field/direction now live in component state only — they are no longer seeded from or written to the URL, so a shared link never implies a global server-side sort.
- The API request no longer sends `sort`/`sortDir`; sorting purely reorders the currently loaded page.
- Added a visible footer notice near pagination: "Sorting applies to the current page only."
- Added a header-button `title` tooltip with the same notice.
- Screen-reader hints now say "current page only" (e.g. "Sorted descending, current page only. Activate to sort ascending." and "Not sorted. Activate to sort the current page ascending.").
- Removed the now-unused `VALID_TABLE_SORT_FIELDS` set and `normalizeTableSortField` helper.

The backend `sort`/`sortDir` capability is intentionally left intact as a valid API surface for other consumers.

## Tests

- `frontend/src/entrypoints/workflow-list.test.tsx`: updated existing aria-label expectations to the current-page wording, and added two new tests:
  - labels sorting as current-page-only, exposes the tooltip, and asserts sort/sortDir never appear in the URL or the API request;
  - ignores `sort`/`sortDir` present in the initial URL (deep links) so they never imply a global sort and are dropped from the URL.
- Frontend unit suite for the workflow-list entrypoint was run locally and passes.

## Remaining risks

- This is the fallback (current-page-only) outcome; the preferred global server-side sort is not delivered. Delivering it later requires first adding a sortable single-Keyword title search attribute (out of scope here).
- The backend `sort`/`sortDir` parameters remain available but are no longer exercised by the workflow list UI; other consumers relying on them are unaffected.


[MM-954]: https://moonladder.atlassian.net/browse/MM-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ