### PR TITLE
The finalize provider profile page should change the button from reading "Finalize Provider Profile" to just "Finalize". The context of the page shoul

### DIFF
--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1757,7 +1757,7 @@ export function ProviderProfilesManager({
                   }}
                   disabled={finalizeOAuthMutation.isPending}
                 >
-                  Finalize Provider Profile
+                  Finalize
                 </button>
               ) : null}
             </div>

--- a/frontend/src/entrypoints/oauth-terminal.test.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.test.tsx
@@ -240,7 +240,7 @@ describe('OAuthTerminalPage clipboard behavior', () => {
     renderPage();
     await waitForSocket();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Finalize Provider Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Finalize' }));
 
     expect((await screen.findAllByText('Succeeded')).length).toBeGreaterThan(0);
     expect(await screen.findByText('Provider profile registered successfully.')).toBeTruthy();
@@ -317,7 +317,7 @@ describe('OAuthTerminalPage clipboard behavior', () => {
     expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Finalize Provider Profile' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Finalize' })).toBeNull();
   });
 
   it('navigates to the replacement session returned by reconnect', async () => {

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -647,7 +647,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
                 onClick={() => runSessionAction('finalize', 'Failed to finalize OAuth session.')}
                 disabled={actionPending !== null}
               >
-                Finalize Provider Profile
+                Finalize
               </button>
             ) : null}
             {['pending', 'starting', 'bridge_ready', 'awaiting_user', 'verifying'].includes(


### PR DESCRIPTION
The finalize provider profile page should change the button from reading "Finalize Provider Profile" to just "Finalize". The context of the page should be enough for it to be understood.