### PR TITLE
MM-957 Move raw Temporal/runtime debug details into a workflow detail Debug tab

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -65,7 +65,7 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 _SAFE_DETAIL_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _SAFE_WORKFLOW_ID_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:{}-]{0,254}$")
-_WORKFLOW_DETAIL_TABS = {"steps", "artifacts", "runs"}
+_WORKFLOW_DETAIL_TABS = {"steps", "artifacts", "runs", "debug"}
 _RESERVED_WORKFLOW_ROUTE_SEGMENTS = {
     "manifests",
     "new",
@@ -90,7 +90,8 @@ _DASHBOARD_ROUTE_NOT_FOUND_DETAIL = {
     "message": (
         "Workflow console route was not found. Use /workflows, /workflows/new, "
         "/workflows/{workflowId}, /workflows/{workflowId}/steps, "
-        "/workflows/{workflowId}/artifacts, or /workflows/{workflowId}/runs."
+        "/workflows/{workflowId}/artifacts, /workflows/{workflowId}/runs, "
+        "or /workflows/{workflowId}/debug."
     ),
 }
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1005,6 +1005,68 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('MM-957 keeps raw Temporal facts out of the default overview while preserving summary and evidence sections', async () => {
+    window.history.pushState({}, 'Overview Debug IA Test', '/workflows/test-123?source=temporal');
+    mockWorkflowDetailSubrouteFetch();
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      // Summary and evidence preview sections still render on the default overview.
+      expect(screen.getByRole('heading', { name: 'Summary' })).toBeTruthy();
+      expect(screen.getByText('Focused route summary')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Workflow Preview' })).toBeTruthy();
+      expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('aria-current')).toBe('page');
+    });
+
+    // The raw Temporal FactGroup no longer competes with outcome/evidence content.
+    expect(screen.queryByRole('heading', { name: 'Temporal' })).toBeNull();
+    for (const label of ['Temporal Status', 'Workflow State', 'Workflow Type', 'Entry', 'Source']) {
+      expect(screen.queryByText(new RegExp(`^${label}:?$`))).toBeNull();
+    }
+    // The hero no longer leads with Temporal metadata, but the compact workflow ID stays accessible.
+    expect(screen.queryByText('MoonMind.UserWorkflow')).toBeNull();
+    expect(screen.getAllByText('test-123').length).toBeGreaterThan(0);
+  });
+
+  it('MM-957 exposes the moved Temporal fields on the keyboard-accessible Debug subroute', async () => {
+    window.history.pushState({}, 'Debug Route Test', '/workflows/test-123/debug?source=temporal');
+    mockWorkflowDetailSubrouteFetch();
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Debug' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Temporal' })).toBeTruthy();
+    });
+
+    // All moved Temporal/runtime identifiers are exposed in the Debug view.
+    for (const label of [
+      'Temporal Status',
+      'Workflow State',
+      'Source',
+      'Workflow Type',
+      'Entry',
+      'Current Run ID',
+      'Workflow ID',
+    ]) {
+      expect(screen.getByText(new RegExp(`^${label}:?$`))).toBeTruthy();
+    }
+    expect(screen.getAllByText('MoonMind.UserWorkflow').length).toBeGreaterThan(0);
+
+    // Deep-linking to the subroute selects the Debug tab, and tab navigation uses
+    // focusable anchor links (keyboard accessible by default).
+    const debugLink = screen.getByRole('link', { name: 'Debug' });
+    expect(debugLink.getAttribute('aria-current')).toBe('page');
+    expect(debugLink.tagName).toBe('A');
+    expect(debugLink.getAttribute('href')).toBe('/workflows/test-123/debug?source=temporal');
+    // Overview is reachable from the Debug subroute (deep links round-trip).
+    expect(screen.getByRole('link', { name: 'Overview' }).getAttribute('href')).toBe('/workflows/test-123?source=temporal');
+
+    // Raw Temporal facts are scoped to Debug only — not the Overview preview cards.
+    expect(screen.queryByRole('heading', { name: 'Workflow Preview' })).toBeNull();
+  });
+
   it('returns null for route templates with missing parameters', () => {
     expect(
       expandRouteTemplate('/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}', {
@@ -1149,16 +1211,20 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
 
     await waitFor(() => {
+      // MM-957: raw Temporal fact labels are no longer surfaced on the default overview.
       for (const label of [
         'Workflow ID',
         'Current Run ID',
         'Workflow Type',
         'Workflow State',
       ]) {
-        expect(screen.getByText(new RegExp(`^${label}:?$`))).toBeTruthy();
+        expect(screen.queryByText(new RegExp(`^${label}:?$`))).toBeNull();
       }
+      // The compact workflow ID stays accessible in the hero as secondary metadata.
+      expect(screen.getAllByText('test-123').length).toBeGreaterThan(0);
       expect(screen.getByRole('button', { name: 'Show Workflow Inputs' })).toBeTruthy();
       expect(screen.getByRole('heading', { name: 'Workflow Preview' })).toBeTruthy();
+      expect(screen.getByRole('link', { name: 'Debug' })).toBeTruthy();
       expect(screen.queryByRole('heading', { name: 'Workflow Steps' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Workflow Artifacts' })).toBeNull();
       expect(screen.queryByText(/^Task ID:?$/)).toBeNull();

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -103,11 +103,16 @@ function shouldUseStructuredHistory(config: DashboardConfig | undefined): boolea
   return config?.features?.liveLogsStructuredHistoryEnabled !== false;
 }
 
-type WorkflowDetailSubroute = 'overview' | 'steps' | 'artifacts' | 'runs';
+type WorkflowDetailSubroute = 'overview' | 'steps' | 'artifacts' | 'runs' | 'debug';
 
 function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
-  const match = pathname.match(/^\/workflows\/[^/]+(?:\/(steps|artifacts|runs))?$/);
-  if (match?.[1] === 'steps' || match?.[1] === 'artifacts' || match?.[1] === 'runs') {
+  const match = pathname.match(/^\/workflows\/[^/]+(?:\/(steps|artifacts|runs|debug))?$/);
+  if (
+    match?.[1] === 'steps'
+    || match?.[1] === 'artifacts'
+    || match?.[1] === 'runs'
+    || match?.[1] === 'debug'
+  ) {
     return match[1];
   }
   return 'overview';
@@ -4736,6 +4741,7 @@ function WorkflowDetailSubrouteNav({
     { route: 'steps', label: 'Steps' },
     { route: 'artifacts', label: 'Artifacts' },
     { route: 'runs', label: 'Runs' },
+    { route: 'debug', label: 'Debug' },
   ];
   return (
     <nav className="td-subroute-nav" aria-label="Workflow detail sections">
@@ -4885,7 +4891,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const structuredHistoryEnabled = shouldUseStructuredHistory(cfg);
 
   const workflowIdMatch = window.location.pathname.match(
-    /^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs))?$/,
+    /^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/,
   );
   const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
@@ -5675,21 +5681,11 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             <div className="td-hero-body">
               <div className="td-hero-headline">
                 <h3 className="td-title-text">{execution.title}</h3>
-                <span className="meta-inline">
-                  Temporal
-                  {execution.workflowType ? (
-                    <>
-                      <span className="dot">·</span>
-                      {execution.workflowType}
-                    </>
-                  ) : null}
-                  {execution.entry ? (
-                    <>
-                      <span className="dot">·</span>
-                      {execution.entry}
-                    </>
-                  ) : null}
-                </span>
+                {workflowId ? (
+                  <span className="meta-inline td-hero-workflow-id">
+                    <code className="text-xs break-all">{workflowId}</code>
+                  </span>
+                ) : null}
               </div>
               <button
                 type="button"
@@ -5851,27 +5847,47 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
                 {execution.scheduledFor ? <Fact label="Scheduled For">{formatWhen(execution.scheduledFor)}</Fact> : null}
                 {execution.waitingReason ? <Fact label="Waiting Reason">{execution.waitingReason}</Fact> : null}
               </FactGroup>
-
-              <FactGroup title="Temporal">
-                <Fact label="Temporal Status">{formatStatusLabel(execution.temporalStatus)}</Fact>
-                <Fact label="Workflow State">{formatStatusLabel(execution.rawState || execution.state)}</Fact>
-                {execution.closeStatus ? <Fact label="Close Status">{formatStatusLabel(execution.closeStatus)}</Fact> : null}
-                <Fact label="Source">Temporal</Fact>
-                <Fact label="Workflow Type">{execution.workflowType || '—'}</Fact>
-                <Fact label="Entry">{execution.entry || '—'}</Fact>
-                <Fact label="Current Run ID">
-                  <code className="text-xs break-all">{latestRunId || '—'}</code>
-                </Fact>
-                {resolvedAgentRunId ? (
-                  <Fact label="Workflow Run">
-                    <code className="text-xs break-all">{resolvedAgentRunId}</code>
-                  </Fact>
-                ) : null}
-                <Fact label="Workflow ID">
-                  <code className="text-xs break-all">{workflowId}</code>
-                </Fact>
-              </FactGroup>
             </div>
+          ) : null}
+
+          {detailSubroute === 'debug' ? (
+            <section className="stack td-debug-region" aria-label="Workflow debug details">
+              <div>
+                <h3>Debug</h3>
+                <p className="small">
+                  Raw Temporal and runtime identifiers for this workflow. These details are
+                  diagnostic only and do not affect the default overview.
+                </p>
+              </div>
+              <div className="td-facts-region">
+                <FactGroup title="Temporal">
+                  <Fact label="Temporal Status">{formatStatusLabel(execution.temporalStatus)}</Fact>
+                  <Fact label="Workflow State">{formatStatusLabel(execution.rawState || execution.state)}</Fact>
+                  {execution.closeStatus ? <Fact label="Close Status">{formatStatusLabel(execution.closeStatus)}</Fact> : null}
+                  <Fact label="Source">Temporal</Fact>
+                  <Fact label="Workflow Type">{execution.workflowType || '—'}</Fact>
+                  <Fact label="Entry">{execution.entry || '—'}</Fact>
+                  <Fact label="Current Run ID">
+                    <code className="text-xs break-all">{latestRunId || '—'}</code>
+                  </Fact>
+                  {resolvedAgentRunId ? (
+                    <Fact label="Workflow Run">
+                      <code className="text-xs break-all">{resolvedAgentRunId}</code>
+                    </Fact>
+                  ) : null}
+                  <Fact label="Workflow ID">
+                    <code className="text-xs break-all">{workflowId}</code>
+                  </Fact>
+                </FactGroup>
+                {actions ? (
+                  <FactGroup title="Action Capability Map">
+                    <Fact label="Raw Actions">
+                      <pre className="text-xs break-all">{JSON.stringify(actions, null, 2)}</pre>
+                    </Fact>
+                  </FactGroup>
+                ) : null}
+              </div>
+            </section>
           ) : null}
 
           {detailSubroute === 'overview' && runSummary ? (
@@ -6381,7 +6397,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             </section>
           ) : null}
 
-          {detailSubroute === 'overview' && debugOn && execution.debugFields ? (
+          {detailSubroute === 'debug' && debugOn && execution.debugFields ? (
             <section className="stack">
               <h3>Debug Metadata</h3>
               <div className="grid-2">

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -107,15 +107,7 @@ type WorkflowDetailSubroute = 'overview' | 'steps' | 'artifacts' | 'runs' | 'deb
 
 function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
   const match = pathname.match(/^\/workflows\/[^/]+(?:\/(steps|artifacts|runs|debug))?$/);
-  if (
-    match?.[1] === 'steps'
-    || match?.[1] === 'artifacts'
-    || match?.[1] === 'runs'
-    || match?.[1] === 'debug'
-  ) {
-    return match[1];
-  }
-  return 'overview';
+  return (match?.[1] as WorkflowDetailSubroute) || 'overview';
 }
 
 function workflowDetailSubrouteHref(

--- a/tests/integration/api/test_workflow_console_routes.py
+++ b/tests/integration/api/test_workflow_console_routes.py
@@ -117,6 +117,7 @@ async def async_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Async
         ("/workflows/mm:workflow-123/steps", "workflow-detail"),
         ("/workflows/mm:workflow-123/artifacts", "workflow-detail"),
         ("/workflows/mm:workflow-123/runs", "workflow-detail"),
+        ("/workflows/mm:workflow-123/debug", "workflow-detail"),
     ),
 )
 async def test_supported_workflow_routes_render_console_shell(

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -549,7 +549,8 @@ def test_invalid_dashboard_route_returns_404(client: TestClient) -> None:
     assert detail["message"] == (
         "Workflow console route was not found. Use /workflows, /workflows/new, "
         "/workflows/{workflowId}, /workflows/{workflowId}/steps, "
-        "/workflows/{workflowId}/artifacts, or /workflows/{workflowId}/runs."
+        "/workflows/{workflowId}/artifacts, /workflows/{workflowId}/runs, "
+        "or /workflows/{workflowId}/debug."
     )
 
 def test_skills_api_returns_available_skill_ids(


### PR DESCRIPTION
## Issue
MM-957 — Move raw Temporal/runtime debug details into a workflow detail Debug tab
https://moonladder.atlassian.net/browse/MM-957

## Summary
Makes the workflow detail view evidence-first by default and debug-rich on demand.

- Adds a **Debug** subroute/tab (`/workflows/:id/debug`) to the workflow detail subroute set (`overview | steps | artifacts | runs | debug`), wired into routing, the subroute matcher, and the subroute nav.
- **Moves** the `FactGroup title="Temporal"` (Temporal status, raw workflow state, close status, source, workflow type, entry, current run ID, agent/workflow run, workflow ID) out of the default overview and into the Debug view. Adds an **Action Capability Map** fact group (raw actions) to Debug when available.
- Relocates the existing config-gated **Debug Metadata** section (`debugFieldsEnabled` / `execution.debugFields`) from the overview to the Debug subroute, reusing the existing feature flag rather than adding a new one.
- **Removes** the `Temporal · workflowType · entry` lead-in from the hero. The compact workflow ID remains accessible in the hero as secondary metadata.
- The Debug tab is keyboard accessible (anchor-link nav) and deep-linkable: selected tab state is derived from the path and the `?source=` query is preserved across tab links.

No backend contract changes; raw fields are relocated, not removed (in line with the issue's out-of-scope notes).

## Tests run
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` → **124 passed**.

New/updated coverage in `workflow-detail.test.tsx`:
- raw Temporal facts hidden on the default overview while Summary / Workflow Preview (evidence) sections still render;
- Debug subroute exposes the moved Temporal fields, is keyboard-accessible, and deep-links round-trip with Overview;
- existing default-overview assertions updated to confirm Temporal fact labels are no longer surfaced there and the Debug nav link is present.

## Remaining risks
- Frontend-only change; raw debug data is now one click away rather than inline, so any operator workflow that relied on Temporal facts appearing directly on the overview now needs the Debug tab.
- The Action Capability Map renders raw JSON; it is gated on `actions` being present and confined to the Debug view.
- No backend/API changes, so no in-flight workflow payload compatibility impact.
