### PR TITLE
[codex] Fix provider cooldown retry profile stickiness

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -153,6 +153,9 @@ SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
 PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID = (
     "agent-run-pin-provider-profile-before-slot-request-v1"
 )
+STICKY_PINNED_PROFILE_COOLDOWN_RETRY_PATCH_ID = (
+    "agent-run-sticky-pinned-profile-cooldown-retry-v1"
+)
 RUNTIME_SELECTION_PROFILE_CLEAR_PATCH_ID = (
     "agent-run-runtime-selection-profile-clear-v1"
 )
@@ -2689,6 +2692,9 @@ class MoonMindAgentRun:
         try:
             while True:
                 skip_poll_and_fetch = False
+                sticky_pinned_profile_on_cooldown_retry = workflow.patched(
+                    STICKY_PINNED_PROFILE_COOLDOWN_RETRY_PATCH_ID
+                )
                 uses_codex_session_adapter = self._uses_codex_session_adapter(request)
                 parent_info = workflow.info().parent
                 elapsed = (workflow.now() - overall_start).total_seconds()
@@ -2723,7 +2729,8 @@ class MoonMindAgentRun:
                         exclude_none=True,
                     )
                     if (
-                        self._skip_default_profile_pin_once
+                        not sticky_pinned_profile_on_cooldown_retry
+                        and self._skip_default_profile_pin_once
                         and not request.execution_profile_ref
                         and not self._profile_selector_has_constraints(
                             request.profile_selector
@@ -2742,12 +2749,20 @@ class MoonMindAgentRun:
                         )
                         if workflow.patched(
                             PIN_PROVIDER_PROFILE_BEFORE_SLOT_REQUEST_PATCH_ID
-                        ) and not self._skip_default_profile_pin_once:
+                        ) and (
+                            sticky_pinned_profile_on_cooldown_retry
+                            or not self._skip_default_profile_pin_once
+                        ):
                             pinned_profile_id = self._default_execution_profile_ref(
                                 request
                             )
                             if pinned_profile_id:
                                 request.execution_profile_ref = pinned_profile_id
+                                if (
+                                    sticky_pinned_profile_on_cooldown_retry
+                                    and requested_execution_profile_ref is None
+                                ):
+                                    requested_execution_profile_ref = pinned_profile_id
                         self._skip_default_profile_pin_once = False
                         manager_handle = await self._ensure_manager_and_signal(
                             manager_id,
@@ -3827,9 +3842,21 @@ class MoonMindAgentRun:
                         self.completion_event.clear()
                         self.final_result = None
                         self._assigned_profile_id = None
-                        request.execution_profile_ref = requested_execution_profile_ref
+                        retry_execution_profile_ref = requested_execution_profile_ref
+                        if (
+                            sticky_pinned_profile_on_cooldown_retry
+                            and retry_execution_profile_ref is None
+                        ):
+                            retry_execution_profile_ref = profile_id
+                        if (
+                            sticky_pinned_profile_on_cooldown_retry
+                            and retry_execution_profile_ref is not None
+                        ):
+                            requested_execution_profile_ref = retry_execution_profile_ref
+                        request.execution_profile_ref = retry_execution_profile_ref
                         self._skip_default_profile_pin_once = (
-                            requested_execution_profile_ref is None
+                            not sticky_pinned_profile_on_cooldown_retry
+                            and requested_execution_profile_ref is None
                         )
                         self.run_status = RunStatus.awaiting_slot
                         continue  # Retries loop
@@ -3848,12 +3875,32 @@ class MoonMindAgentRun:
                                 request=request,
                             ),
                         )
+                        active_profile_id = (
+                            str(
+                                request.execution_profile_ref
+                                or self._assigned_profile_id
+                                or ""
+                            ).strip()
+                            or None
+                        )
                         self.completion_event.clear()
                         self.final_result = None
                         self._assigned_profile_id = None
-                        request.execution_profile_ref = requested_execution_profile_ref
+                        retry_execution_profile_ref = requested_execution_profile_ref
+                        if (
+                            sticky_pinned_profile_on_cooldown_retry
+                            and retry_execution_profile_ref is None
+                        ):
+                            retry_execution_profile_ref = active_profile_id
+                        if (
+                            sticky_pinned_profile_on_cooldown_retry
+                            and retry_execution_profile_ref is not None
+                        ):
+                            requested_execution_profile_ref = retry_execution_profile_ref
+                        request.execution_profile_ref = retry_execution_profile_ref
                         self._skip_default_profile_pin_once = (
-                            requested_execution_profile_ref is None
+                            not sticky_pinned_profile_on_cooldown_retry
+                            and requested_execution_profile_ref is None
                         )
                         continue  # Retries loop
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -1149,9 +1149,16 @@ async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
     assert result.summary.endswith("...")
     assert result.summary.startswith("managed start failed: ")
 
-async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
+async def _run_default_profile_cooldown_retry_case(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    *,
+    sticky_patch_enabled: bool,
+) -> tuple[
+    AgentRunResult,
+    list[str | None],
+    list[dict[str, Any]],
+    list[tuple[str, dict[str, Any]]],
+]:
     run = MoonMindAgentRun()
     ensure_profile_refs: list[str | None] = []
     ensure_profile_selectors: list[dict[str, Any]] = []
@@ -1167,6 +1174,17 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
     ]
 
     _configure_workflow_runtime(monkeypatch)
+    if not sticky_patch_enabled:
+        sticky_patch_id = (
+            agent_run_module.STICKY_PINNED_PROFILE_COOLDOWN_RETRY_PATCH_ID
+        )
+
+        def patched(patch_id: str) -> bool:
+            if patch_id == sticky_patch_id:
+                return False
+            return _patch_all_enabled(patch_id)
+
+        monkeypatch.setattr(agent_run_module.workflow, "patched", patched)
 
     class _FakeManagedAgentAdapter:
         def __init__(self, **_kwargs: Any) -> None:
@@ -1262,6 +1280,59 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
 
     result = await run.run(request)
 
+    return result, ensure_profile_refs, ensure_profile_selectors, manager_signals
+
+
+async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (
+        result,
+        ensure_profile_refs,
+        ensure_profile_selectors,
+        manager_signals,
+    ) = await _run_default_profile_cooldown_retry_case(
+        monkeypatch,
+        sticky_patch_enabled=True,
+    )
+
+    assert result.summary == "Recovered on pinned profile."
+    assert ensure_profile_refs == ["codex-default", "codex-default"]
+    assert ensure_profile_selectors == [
+        {"tagsAny": [], "tagsAll": []},
+        {"tagsAny": [], "tagsAll": []},
+    ]
+    assert manager_signals[:2] == [
+        (
+            "report_cooldown",
+            {
+                "profile_id": "codex-default",
+                "cooldown_seconds": 0,
+            },
+        ),
+        (
+            "release_slot",
+            {
+                "requester_workflow_id": "wf-agent-run-1",
+                "profile_id": "codex-default",
+            },
+        ),
+    ]
+
+
+async def test_agent_run_replays_legacy_default_fallback_retry_when_patch_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (
+        result,
+        ensure_profile_refs,
+        ensure_profile_selectors,
+        manager_signals,
+    ) = await _run_default_profile_cooldown_retry_case(
+        monkeypatch,
+        sticky_patch_enabled=False,
+    )
+
     assert result.summary == "Recovered on pinned profile."
     assert ensure_profile_refs == ["codex-default", None]
     assert ensure_profile_selectors == [
@@ -1284,6 +1355,7 @@ async def test_agent_run_pins_default_profile_after_provider_cooldown_retry(
             },
         ),
     ]
+
 
 async def test_agent_run_preserves_operator_profile_selection_after_cooldown_retry(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Keep default-pinned provider profiles sticky across managed provider cooldown retries.
- Prevent new AgentRun executions from clearing the exact profile and emitting `allowDefaultFallback` after a 429/session-limit cooldown.
- Add workflow-boundary coverage for the new sticky behavior plus a patch-unset replay compatibility case.

## Root Cause

After a provider cooldown, AgentRun restored the originally requested profile ref. When the original request did not explicitly name a profile, the default-pinned profile was cleared and the next slot request allowed default fallback. That could switch a run from the default Anthropic Claude profile to another launch-ready Claude profile such as Minimax.

## Impact

Quota/cooldown retries now wait for and retry the same resolved provider profile instead of silently changing provider or credential policy.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py -q -p no:cacheprovider`