### PR TITLE
[codex] Fix graceful cancel projection status

### DIFF
--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -65,6 +65,12 @@ PRE_WORK_STATES = frozenset(
     }
 )
 
+TERMINAL_DOMAIN_STATE_TO_CLOSE_STATUS = {
+    MoonMindWorkflowState.COMPLETED: TemporalExecutionCloseStatus.COMPLETED,
+    MoonMindWorkflowState.FAILED: TemporalExecutionCloseStatus.FAILED,
+    MoonMindWorkflowState.CANCELED: TemporalExecutionCloseStatus.CANCELED,
+}
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -109,6 +115,16 @@ def _coerce_temporal_scalar(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+def _coerce_mm_state(search_attributes: dict[str, Any]) -> MoonMindWorkflowState | None:
+    raw_state = _coerce_temporal_scalar(search_attributes.get("mm_state"))
+    if raw_state is None:
+        return None
+    try:
+        return MoonMindWorkflowState(raw_state)
+    except ValueError:
+        logger.warning("Invalid value for mm_state search attribute: '%s'", raw_state)
+        return None
 
 def _parse_temporal_datetime(value: Any) -> datetime | None:
     if isinstance(value, datetime):
@@ -265,17 +281,15 @@ async def map_temporal_state_to_projection(
     except ValueError:
         owner_type = TemporalExecutionOwnerType.USER
 
-    if desc.status == WorkflowExecutionStatus.RUNNING:
-        mm_state = search_attributes.get("mm_state")
-        if isinstance(mm_state, list) and mm_state:
-            mm_state = mm_state[0]
-        if mm_state:
-            try:
-                state_value = MoonMindWorkflowState(str(mm_state))
-            except ValueError:
-                logger.warning(
-                    "Invalid value for mm_state search attribute: '%s'", mm_state
-                )
+    mm_state = _coerce_mm_state(search_attributes)
+    if mm_state is not None:
+        if desc.status == WorkflowExecutionStatus.RUNNING:
+            state_value = mm_state
+        elif desc.status == WorkflowExecutionStatus.COMPLETED:
+            domain_close_status = TERMINAL_DOMAIN_STATE_TO_CLOSE_STATUS.get(mm_state)
+            if domain_close_status is not None:
+                state_value = mm_state
+                close_status = domain_close_status
 
     artifact_refs = memo.get("artifact_refs", [])
     if not isinstance(artifact_refs, list):

--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -616,12 +616,16 @@ Rules:
 
 - workflows own `mm_state` transitions
 - projections may mirror `mm_state`, but must not redefine it
-- terminal Temporal statuses must reconcile to terminal domain states:
+- native terminal Temporal statuses must reconcile to terminal domain states:
   - completed → `completed`
   - failed / timed out / terminated → `failed`
   - canceled → `canceled`
-- if Temporal status and projection state conflict, Temporal wins and projection repair must correct the row
-- if Temporal close status and `mm_state` conflict, the lifecycle contract must define the correction behavior and alert when it indicates a workflow bug
+- raw Temporal `Completed` with a workflow-owned terminal `mm_state` must preserve
+  the workflow-owned terminal state, so graceful cancellation that finalized and
+  returned normally projects as `canceled` rather than success
+- if a native failure/cancellation Temporal close status and `mm_state` conflict, Temporal
+  wins and projection repair must correct the row; the lifecycle contract must
+  define correction behavior and alert when the conflict indicates a workflow bug
 
 ---
 

--- a/docs/Temporal/VisibilityAndUiQueryModel.md
+++ b/docs/Temporal/VisibilityAndUiQueryModel.md
@@ -255,10 +255,14 @@ Allowed values for v1:
 Rules:
 
 - `mm_state` must be set immediately on workflow start
-- terminal mapping must remain consistent with Temporal close status:
+- terminal mapping must remain consistent with MoonMind `closeStatus`:
  - completed → `completed`
  - failed / terminated / timed out → `failed`
  - canceled → `canceled`
+- graceful workflow cancellation is represented by workflow-owned terminal
+  `mm_state=canceled` / `closeStatus=canceled` even when the raw Temporal
+  `ExecutionStatus` is `Completed` because the workflow finalized and returned
+  normally
 
 ### `mm_owner_type`
 

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -80,6 +80,41 @@ def test_map_temporal_state_to_projection_success():
     assert result["search_attributes"]["mm_custom"] == {"key": "value"}
     assert result["updated_at"] == updated_at
 
+def test_map_temporal_completed_with_canceled_mm_state_projects_canceled():
+    start_time = datetime.now(UTC)
+    updated_at = datetime(2026, 6, 27, 17, 0, tzinfo=UTC)
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = "mm:canceled-via-update"
+    desc.run_id = "run-canceled-via-update"
+    desc.namespace = "moonmind"
+    desc.workflow_type = "MoonMind.UserWorkflow"
+    desc.status = WorkflowExecutionStatus.COMPLETED
+    desc.start_time = start_time
+    desc.execution_time = start_time
+    desc.close_time = updated_at
+    desc.search_attributes = {
+        "mm_state": "canceled",
+        "mm_entry": "run",
+        "mm_updated_at": updated_at.isoformat(),
+    }
+
+    async def _memo() -> dict[str, object]:
+        return {
+            "entry": "run",
+            "owner_id": "owner-1",
+            "owner_type": "user",
+            "summary": "Execution canceled.",
+        }
+
+    desc.memo = _memo
+
+    result = asyncio.run(map_temporal_state_to_projection(desc))
+
+    assert result["state"] == MoonMindWorkflowState.CANCELED
+    assert result["close_status"] == TemporalExecutionCloseStatus.CANCELED
+    assert result["memo"]["summary"] == "Execution canceled."
+    assert result["updated_at"] == updated_at
+
 def test_map_temporal_state_to_projection_extracts_finish_summary():
     start_time = datetime.now(UTC)
     desc = Mock(spec=WorkflowExecutionDescription)
@@ -451,6 +486,109 @@ async def test_sync_execution_projection_refreshes_canonical_summary_and_started
             assert canonical.last_update_response == {"status": "accepted"}
             assert _as_utc(canonical.started_at) == started_at
             assert _as_utc(canonical.updated_at) == updated_at
+    finally:
+        await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_sync_execution_projection_repairs_completed_projection_for_graceful_cancel(
+    tmp_path,
+):
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from api_service.db.models import Base
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            created_at = datetime(2026, 6, 27, 16, 55, tzinfo=UTC)
+            canceled_at = datetime(2026, 6, 27, 17, 0, tzinfo=UTC)
+            canonical = TemporalExecutionCanonicalRecord(
+                workflow_id="mm:graceful-cancel-refresh",
+                run_id="run-1",
+                namespace="moonmind",
+                workflow_type=TemporalWorkflowType.USER_WORKFLOW,
+                owner_id="owner-1",
+                owner_type=TemporalExecutionOwnerType.USER,
+                state=MoonMindWorkflowState.CANCELED,
+                close_status=TemporalExecutionCloseStatus.CANCELED,
+                entry="run",
+                search_attributes={"mm_state": "canceled", "mm_entry": "run"},
+                memo={"title": "Task", "summary": "Execution canceled."},
+                artifact_refs=[],
+                parameters={"targetRuntime": "codex_cli"},
+                started_at=created_at,
+                updated_at=canceled_at,
+                closed_at=canceled_at,
+            )
+            projection = TemporalExecutionRecord(
+                workflow_id=canonical.workflow_id,
+                run_id="run-1",
+                namespace="moonmind",
+                workflow_type=TemporalWorkflowType.USER_WORKFLOW,
+                owner_id="owner-1",
+                owner_type=TemporalExecutionOwnerType.USER,
+                state=MoonMindWorkflowState.COMPLETED,
+                close_status=TemporalExecutionCloseStatus.COMPLETED,
+                entry="run",
+                search_attributes={"mm_state": "completed", "mm_entry": "run"},
+                memo={"title": "Task", "summary": "Execution canceled."},
+                artifact_refs=[],
+                parameters={"targetRuntime": "codex_cli"},
+                projection_version=1,
+                last_synced_at=created_at,
+                sync_state=TemporalExecutionProjectionSyncState.FRESH,
+                sync_error=None,
+                started_at=created_at,
+                updated_at=canceled_at,
+                closed_at=canceled_at,
+            )
+            session.add(canonical)
+            session.add(projection)
+            await session.commit()
+
+            desc = Mock(spec=WorkflowExecutionDescription)
+            desc.id = canonical.workflow_id
+            desc.run_id = "run-1"
+            desc.namespace = "moonmind"
+            desc.workflow_type = "MoonMind.UserWorkflow"
+            desc.status = WorkflowExecutionStatus.COMPLETED
+            desc.start_time = created_at
+            desc.execution_time = created_at
+            desc.close_time = canceled_at
+            desc.search_attributes = {
+                "mm_state": "canceled",
+                "mm_entry": "run",
+                "mm_updated_at": canceled_at.isoformat(),
+            }
+
+            async def _memo() -> dict[str, object]:
+                return {
+                    "entry": "run",
+                    "owner_id": "owner-1",
+                    "owner_type": "user",
+                    "title": "Task",
+                    "summary": "Execution canceled.",
+                }
+
+            desc.memo = _memo
+
+            refreshed = await sync_execution_projection(session, desc)
+            await session.commit()
+            await session.refresh(refreshed)
+            await session.refresh(canonical)
+
+            assert refreshed.state == MoonMindWorkflowState.CANCELED
+            assert refreshed.close_status == TemporalExecutionCloseStatus.CANCELED
+            assert refreshed.memo["summary"] == "Execution canceled."
+            assert canonical.state == MoonMindWorkflowState.CANCELED
+            assert canonical.close_status == TemporalExecutionCloseStatus.CANCELED
+            assert canonical.memo["summary"] == "Execution canceled."
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary
- Preserve workflow-owned terminal `mm_state` when a graceful cancellation finalizes and Temporal closes the run as `Completed`.
- Add regression coverage for the mapper and database projection repair path.
- Update Temporal visibility docs for the graceful-cancel projection rule.

## Root Cause
MoonMind graceful cancellation uses the workflow `Cancel` update, sets `mm_state=canceled`, records terminal state, and then returns normally. Temporal therefore reports raw `ExecutionStatus=Completed`. Projection sync trusted that raw completed status after close and overwrote the domain state/close status to completed while preserving the memo summary, producing a completed status with `Execution canceled.` text.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 uv run pytest tests/unit/test_sync.py -q`
- `uv run pytest tests/unit/api/routers/test_executions.py::test_serialize_execution_canceled_state_uses_correct_spelling -q`
- `git diff --check`
- `uv run python -B -c 'import py_compile; py_compile.compile("api_service/core/sync.py", cfile="/tmp/moonmind-sync.pyc", doraise=True); py_compile.compile("tests/unit/test_sync.py", cfile="/tmp/moonmind-test-sync.pyc", doraise=True)'`

Note: `./tools/test_unit.sh --python-only tests/unit/test_sync.py` is blocked in this workspace before pytest starts because `tools/check_removed_capability_semantics.py` cannot read root-owned `deploy/state/desired-state.json` (`PermissionError`).