### PR TITLE
[codex] Allow pr-resolver to target authored PR branches

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -6284,8 +6284,60 @@ _PR_RESOLVER_SELECTOR_ERROR = (
     "pr-resolver workflow requires a structured PR selector: "
     "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
     "payload.workflow.tool.inputs.pr/branch, or "
-    "payload.workflow.git.startingBranch."
+    "payload.workflow.git.startingBranch, or a non-default "
+    "payload.workflow.git.branch."
 )
+_PR_RESOLVER_DEFAULT_BRANCH_NAMES = frozenset(
+    {"main", "master", "develop", "development", "trunk"}
+)
+
+
+def _pr_resolver_default_branch_names(
+    *payloads: Mapping[str, Any],
+) -> set[str]:
+    names = set(_PR_RESOLVER_DEFAULT_BRANCH_NAMES)
+    for payload in payloads:
+        if not isinstance(payload, Mapping):
+            continue
+        for key in (
+            "defaultBranch",
+            "default_branch",
+            "repositoryDefaultBranch",
+            "repository_default_branch",
+        ):
+            value = str(payload.get(key) or "").strip().lower()
+            if value:
+                names.add(value)
+    return names
+
+
+def _pr_resolver_authored_branch_selector(
+    *,
+    task_payload: Mapping[str, Any],
+    normalized_task: Mapping[str, Any],
+    task_inputs: Mapping[str, Any],
+    normalized_inputs: Mapping[str, Any],
+    task_git: Mapping[str, Any],
+    normalized_git: Mapping[str, Any],
+) -> str:
+    default_names = _pr_resolver_default_branch_names(
+        task_payload,
+        normalized_task,
+        task_inputs,
+        normalized_inputs,
+        task_git,
+        normalized_git,
+    )
+    for value in (
+        task_git.get("branch"),
+        normalized_git.get("branch"),
+        task_payload.get("branch"),
+        normalized_task.get("branch"),
+    ):
+        text = str(value or "").strip()
+        if text and text.lower() not in default_names:
+            return text
+    return ""
 
 
 def _pr_resolver_structured_selector(
@@ -6328,6 +6380,14 @@ def _pr_resolver_structured_selector(
         normalized_inputs.get("branch"),
         tool_inputs.get("branch"),
         skill_inputs.get("branch"),
+        _pr_resolver_authored_branch_selector(
+            task_payload=task_payload,
+            normalized_task=normalized_task,
+            task_inputs=task_inputs,
+            normalized_inputs=normalized_inputs,
+            task_git=task_git,
+            normalized_git=normalized_git,
+        ),
     ):
         text = str(value or "").strip()
         if text:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -14,6 +14,15 @@ Workflow publishing controls how agent-produced changes reach the repository aft
 
 The agent runs in its workspace but no git operations occur after completion. Useful for read-only Workflow Executions (analysis, diagnostics, research) or for Workflow Executions with side effects other than a final publish action.
 
+Some self-managed skills own their own repository side effects while requiring
+MoonMind publish mode `none`. Standalone `pr-resolver` is the canonical case:
+it resolves and merges an existing pull request from inside the managed runtime.
+For these runs, an explicit PR selector in `inputs.pr` or `inputs.branch` is
+preferred. When the create-form single `git.branch` field names a non-default
+branch, MoonMind may use that branch as the resolver's PR selector; common
+default/base branch names such as `main` and `master` remain invalid as implicit
+resolver selectors.
+
 ### `branch`
 
 After the agent completes, the infrastructure pushes the current work branch to the remote. The agent is instructed to commit but **not** to push or create a PR — that is handled deterministically by the runtime.

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -753,8 +753,52 @@ def _derive_pr_branch_prefix(
 
 _PR_RESOLVER_SELECTOR_ERROR = (
     "pr-resolver workflow requires workflow.tool.inputs.pr, "
-    "workflow.tool.inputs.branch, or workflow.git.startingBranch"
+    "workflow.tool.inputs.branch, workflow.git.startingBranch, "
+    "or a non-default workflow.git.branch"
 )
+_PR_RESOLVER_DEFAULT_BRANCH_NAMES = frozenset(
+    {"main", "master", "develop", "development", "trunk"}
+)
+
+
+def _pr_resolver_default_branch_names(
+    *payloads: Mapping[str, Any],
+) -> set[str]:
+    names = set(_PR_RESOLVER_DEFAULT_BRANCH_NAMES)
+    for payload in payloads:
+        if not isinstance(payload, Mapping):
+            continue
+        for key in (
+            "defaultBranch",
+            "default_branch",
+            "repositoryDefaultBranch",
+            "repository_default_branch",
+        ):
+            value = str(payload.get(key) or "").strip().lower()
+            if value:
+                names.add(value)
+    return names
+
+
+def _pr_resolver_authored_branch_selector(
+    *,
+    task_payload: Mapping[str, Any],
+    selected_skill_inputs: Mapping[str, Any],
+    git_payload: Mapping[str, Any],
+) -> str:
+    default_names = _pr_resolver_default_branch_names(
+        task_payload,
+        selected_skill_inputs,
+        git_payload,
+    )
+    for value in (
+        git_payload.get("branch"),
+        task_payload.get("branch"),
+    ):
+        text = str(value or "").strip()
+        if text and text.lower() not in default_names:
+            return text
+    return ""
 
 
 def _pr_resolver_structured_selector(
@@ -783,6 +827,11 @@ def _pr_resolver_structured_selector(
         str(selected_skill_inputs.get("branch") or "").strip(),
         str(tool_inputs.get("branch") or "").strip(),
         str(skill_inputs.get("branch") or "").strip(),
+        _pr_resolver_authored_branch_selector(
+            task_payload=task_payload,
+            selected_skill_inputs=selected_skill_inputs,
+            git_payload=git_payload,
+        ),
     )
 
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -1372,19 +1372,23 @@ def _build_runtime_planner():
             # may come from git_payload rather than selected_skill_inputs, so
             # the generic " with inputs:" block above can miss it.
             effective_selector = pr_selector or pr_resolver_selector
-            if (
-                not has_explicit_instructions
-                and effective_selector
-                and not pr_selector
-            ):
+            if effective_selector and not pr_selector:
                 merged_inputs = (
                     dict(selected_skill_inputs) if selected_skill_inputs else {}
                 )
                 merged_inputs["pr"] = effective_selector
-                instructions = (
-                    f"Execute skill '{selected_skill_name}' with inputs:\n"
-                    + json.dumps(merged_inputs, indent=2, sort_keys=True)
-                )
+                selected_skill_inputs = merged_inputs
+                if has_explicit_instructions:
+                    instructions = (
+                        f"{str(instructions).strip()}\n\n"
+                        f"Selected skill inputs:\n"
+                        + json.dumps(merged_inputs, indent=2, sort_keys=True)
+                    )
+                else:
+                    instructions = (
+                        f"Execute skill '{selected_skill_name}' with inputs:\n"
+                        + json.dumps(merged_inputs, indent=2, sort_keys=True)
+                    )
 
         # --- Resolve runtime mode ---
         runtime_payload = _coerce_mapping(task_payload.get("runtime"))

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4822,7 +4822,8 @@ def test_create_task_shaped_execution_rejects_pr_resolver_without_structured_sel
         == "pr-resolver workflow requires a structured PR selector: "
         "payload.workflow.inputs.pr, payload.workflow.inputs.branch, "
         "payload.workflow.tool.inputs.pr/branch, or "
-        "payload.workflow.git.startingBranch."
+        "payload.workflow.git.startingBranch, or a non-default "
+        "payload.workflow.git.branch."
     )
     service.create_execution.assert_not_awaited()
 
@@ -4858,6 +4859,39 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
     assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
     assert initial_parameters["workflow"]["git"] == {
         "startingBranch": "feature/resolve-pr"
+    }
+
+
+def test_create_task_shaped_execution_allows_pr_resolver_with_non_default_git_branch(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "workflow": {
+                    "runtime": {"mode": "gemini_cli"},
+                    "tool": {
+                        "type": "skill",
+                        "name": "pr-resolver",
+                    },
+                    "git": {"branch": "feature/resolve-pr"},
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    assert called_kwargs["title"] == "feature/resolve-pr"
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert initial_parameters["workflow"]["title"] == "feature/resolve-pr"
+    assert initial_parameters["workflow"]["git"] == {
+        "branch": "feature/resolve-pr"
     }
 
 

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2550,6 +2550,34 @@ def test_runtime_planner_pr_resolver_injects_branch_selector_into_instruction():
     assert '"pr": "fix/my-feature-branch"' in node_inputs["instructions"]
     assert plan["metadata"]["title"] == "fix/my-feature-branch"
 
+
+def test_runtime_planner_pr_resolver_uses_non_default_git_branch_as_selector():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "tool": {
+                    "type": "skill",
+                    "name": "pr-resolver",
+                },
+                "git": {"branch": "feature/current-pr"},
+                "runtime": {"mode": "gemini_cli"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert '"pr": "feature/current-pr"' in node_inputs["instructions"]
+    assert plan["metadata"]["title"] == "feature/current-pr"
+
+
 def test_runtime_planner_pr_resolver_title_uses_case_insensitive_tool_inputs():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
@@ -2619,7 +2647,8 @@ def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions(
         RuntimeError,
         match=(
             "pr-resolver workflow requires workflow.tool.inputs.pr, "
-            "workflow.tool.inputs.branch, or workflow.git.startingBranch"
+            "workflow.tool.inputs.branch, workflow.git.startingBranch, "
+            "or a non-default workflow.git.branch"
         ),
     ):
         planner(
@@ -3283,7 +3312,8 @@ def test_runtime_planner_rejects_pr_resolver_with_only_jira_instructions_and_bas
         RuntimeError,
         match=(
             "pr-resolver workflow requires workflow.tool.inputs.pr, "
-            "workflow.tool.inputs.branch, or workflow.git.startingBranch"
+            "workflow.tool.inputs.branch, workflow.git.startingBranch, "
+            "or a non-default workflow.git.branch"
         ),
     ):
         planner(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -2578,6 +2578,36 @@ def test_runtime_planner_pr_resolver_uses_non_default_git_branch_as_selector():
     assert plan["metadata"]["title"] == "feature/current-pr"
 
 
+def test_runtime_planner_pr_resolver_includes_git_branch_selector_with_explicit_instructions():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Resolve the selected PR.",
+                "tool": {
+                    "type": "skill",
+                    "name": "pr-resolver",
+                },
+                "git": {"branch": "feature/current-pr"},
+                "runtime": {"mode": "gemini_cli"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][0]["inputs"]
+    assert node_inputs["instructions"].startswith("Resolve the selected PR.")
+    assert "Selected skill inputs:" in node_inputs["instructions"]
+    assert '"pr": "feature/current-pr"' in node_inputs["instructions"]
+    assert plan["metadata"]["title"] == "feature/current-pr"
+
+
 def test_runtime_planner_pr_resolver_title_uses_case_insensitive_tool_inputs():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary
- allow standalone pr-resolver submissions to use a non-default `git.branch` as the PR selector
- keep default/base branches such as `main` rejected unless an explicit `inputs.pr` or `inputs.branch` selector is provided
- update the runtime planner, API validation, regression tests, and publishing docs to match

## Validation
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/api/routers/test_executions.py -k 'pr_resolver'`
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/test_temporal_worker_runtime.py -k 'pr_resolver'`

Note: `./tools/test_unit.sh ...` could not reach pytest locally because the preflight capability scan hit a root-owned unreadable `deploy/state/desired-state.json` in this checkout.