### PR TITLE
The workflows table does not need a header with the title "Workflows" since the first column is already labeled similarly. Remove it. The Filters can…

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -583,6 +583,49 @@ def _datetime_range_parts(
     return parts
 
 
+def _datetime_range_clause_from_values(
+    attr: str,
+    start_value: str | None,
+    end_value: str | None,
+) -> str:
+    parts: list[str] = []
+    if start_value:
+        parts.append(f'{attr}>="{_escape_temporal_value(start_value)}"')
+    if end_value:
+        parts.append(f'{attr}<="{_escape_temporal_value(end_value)}"')
+    return " AND ".join(parts)
+
+
+def _append_updated_temporal_filter(
+    query_parts: list[str],
+    start_raw: str | None,
+    end_raw: str | None,
+) -> None:
+    start_value = _normalize_date_bound(start_raw, alias="updatedFrom")
+    end_value = _normalize_date_bound(end_raw, alias="updatedTo", end_of_day=True)
+    if start_value and end_value:
+        start_dt = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
+        end_dt = datetime.fromisoformat(end_value.replace("Z", "+00:00"))
+        if start_dt > end_dt:
+            raise TemporalExecutionValidationError(
+                "updatedFrom must be before or equal to updatedTo."
+            )
+    if not start_value and not end_value:
+        return
+    close_clause = _datetime_range_clause_from_values("CloseTime", start_value, end_value)
+    scheduled_clause = _datetime_range_clause_from_values("mm_scheduled_for", start_value, end_value)
+    start_clause = _datetime_range_clause_from_values("StartTime", start_value, end_value)
+    query_parts.append(
+        "("
+        f"(CloseTime IS NOT NULL AND {close_clause})"
+        " OR "
+        f"(CloseTime IS NULL AND mm_scheduled_for IS NOT NULL AND {scheduled_clause})"
+        " OR "
+        f"(CloseTime IS NULL AND mm_scheduled_for IS NULL AND {start_clause})"
+        ")"
+    )
+
+
 def _any_temporal_query(attr: str, values: list[str]) -> str | None:
     if not values:
         return None
@@ -794,6 +837,8 @@ def _build_temporal_execution_query(
     scheduled_from: str | None,
     scheduled_to: str | None,
     scheduled_blank: str | None,
+    updated_from: str | None,
+    updated_to: str | None,
     created_from: str | None,
     created_to: str | None,
     finished_from: str | None,
@@ -923,6 +968,8 @@ def _build_temporal_execution_query(
         end_alias="scheduledTo",
         blank_mode=None if excluded("scheduledBlank") else scheduled_blank,
     )
+    if not excluded("updatedFrom") and not excluded("updatedTo"):
+        _append_updated_temporal_filter(query_parts, updated_from, updated_to)
     _append_datetime_temporal_filter(
         query_parts,
         "StartTime",
@@ -8247,6 +8294,8 @@ async def list_executions(
     scheduled_from: Optional[str] = Query(None, alias="scheduledFrom"),
     scheduled_to: Optional[str] = Query(None, alias="scheduledTo"),
     scheduled_blank: Optional[str] = Query(None, alias="scheduledBlank"),
+    updated_from: Optional[str] = Query(None, alias="updatedFrom"),
+    updated_to: Optional[str] = Query(None, alias="updatedTo"),
     created_from: Optional[str] = Query(None, alias="createdFrom"),
     created_to: Optional[str] = Query(None, alias="createdTo"),
     finished_from: Optional[str] = Query(None, alias="finishedFrom"),
@@ -8297,6 +8346,8 @@ async def list_executions(
                 scheduled_from=scheduled_from,
                 scheduled_to=scheduled_to,
                 scheduled_blank=scheduled_blank,
+                updated_from=updated_from,
+                updated_to=updated_to,
                 created_from=created_from,
                 created_to=created_to,
                 finished_from=finished_from,
@@ -8577,6 +8628,8 @@ async def get_execution_metrics(
     scheduled_from: Optional[str] = Query(None, alias="scheduledFrom"),
     scheduled_to: Optional[str] = Query(None, alias="scheduledTo"),
     scheduled_blank: Optional[str] = Query(None, alias="scheduledBlank"),
+    updated_from: Optional[str] = Query(None, alias="updatedFrom"),
+    updated_to: Optional[str] = Query(None, alias="updatedTo"),
     created_from: Optional[str] = Query(None, alias="createdFrom"),
     created_to: Optional[str] = Query(None, alias="createdTo"),
     finished_from: Optional[str] = Query(None, alias="finishedFrom"),
@@ -8659,6 +8712,8 @@ async def get_execution_metrics(
             scheduled_from=scheduled_from,
             scheduled_to=scheduled_to,
             scheduled_blank=scheduled_blank,
+            updated_from=updated_from,
+            updated_to=updated_to,
             created_from=created_from,
             created_to=created_to,
             finished_from=finished_from,
@@ -8796,6 +8851,8 @@ async def list_execution_facets(
     scheduled_from: Optional[str] = Query(None, alias="scheduledFrom"),
     scheduled_to: Optional[str] = Query(None, alias="scheduledTo"),
     scheduled_blank: Optional[str] = Query(None, alias="scheduledBlank"),
+    updated_from: Optional[str] = Query(None, alias="updatedFrom"),
+    updated_to: Optional[str] = Query(None, alias="updatedTo"),
     created_from: Optional[str] = Query(None, alias="createdFrom"),
     created_to: Optional[str] = Query(None, alias="createdTo"),
     finished_from: Optional[str] = Query(None, alias="finishedFrom"),
@@ -8868,6 +8925,8 @@ async def list_execution_facets(
             scheduled_from=scheduled_from,
             scheduled_to=scheduled_to,
             scheduled_blank=scheduled_blank,
+            updated_from=updated_from,
+            updated_to=updated_to,
             created_from=created_from,
             created_to=created_to,
             finished_from=finished_from,

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -41,8 +41,8 @@ describe('Workflows Entrypoint', () => {
 
   const lastExecutionListUrl = () => executionListCalls().at(-1)?.[0];
 
-  // The advanced filter drawer is the single surface that exposes the full
-  // filter UI. These helpers open it and apply the staged draft.
+  // The mobile filter drawer exposes the full filter UI. These helpers open it
+  // and apply the staged draft.
   const openFilterDrawer = () => fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
   const applyFilterDrawer = () => fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }));
 
@@ -72,15 +72,18 @@ describe('Workflows Entrypoint', () => {
     expect(screen.queryByLabelText('Live updates')).toBeNull();
   });
 
-  it('moves advanced filters out of every desktop table header', async () => {
+  it('renders desktop column filters and keeps the mobile filter drawer available', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
 
-    // No per-column filter icon button remains in the table headers.
-    expect(document.querySelectorAll('.workflow-list-column-filter-button')).toHaveLength(0);
-    expect(screen.queryByRole('button', { name: /No filter applied\./i })).toBeNull();
-    // A single visible Filters control opens the full filter UI instead.
+    expect(document.querySelectorAll('.workflow-list-column-filter-button')).toHaveLength(5);
+    const workflowFilter = screen.getByRole('button', {
+      name: 'Workflow filter. No filter applied.',
+    });
+    fireEvent.click(workflowFilter);
+    expect(screen.getByRole('dialog', { name: 'Workflow filter' })).toBeTruthy();
+
     const filtersTrigger = screen.getByRole('button', { name: 'Filters' });
     expect(filtersTrigger).toBeTruthy();
     expect(screen.queryByRole('dialog', { name: 'Advanced filters' })).toBeNull();
@@ -1343,7 +1346,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByText('21 total entries')).toBeTruthy();
   });
 
-  it('places filters in the Workflows header and uses the data slab composition', async () => {
+  it('uses the data slab composition without a duplicate Workflows header title', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Example task');
@@ -1358,7 +1361,9 @@ describe('Workflows Entrypoint', () => {
 
     expect(noticesDeck).toBeNull();
     expect(resultsHeader?.querySelector('.workflow-list-filter-trigger')).toBeTruthy();
-    expect(resultsHeader?.textContent).toContain('Workflows');
+    expect(resultsHeader?.querySelector('.page-title')).toBeNull();
+    expect(resultsHeader?.textContent).not.toContain('Workflows');
+    expect(tableHead?.textContent).toContain('Workflow');
     expect(screen.queryByRole('button', { name: /^Kind\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Workflow Type\./i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Entry\./i })).toBeNull();

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -174,6 +174,7 @@ describe('Workflows Entrypoint', () => {
 
     expect(await screen.findByText('No workflows found for the current filters.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
     expect(screen.queryByLabelText('Live updates')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
   }, 10000);
@@ -423,6 +424,7 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByLabelText('ID filter value')).toBeTruthy();
     expect(screen.getByLabelText('Skill filter value')).toBeTruthy();
     expect(screen.getByLabelText('Title filter value')).toBeTruthy();
+    expect(screen.getByLabelText('Updated from')).toBeTruthy();
     expect(screen.getByLabelText('Scheduled from')).toBeTruthy();
     expect(screen.getByLabelText('Created from')).toBeTruthy();
     expect(screen.getByLabelText('Finished blank values')).toBeTruthy();
@@ -449,6 +451,32 @@ describe('Workflows Entrypoint', () => {
         '/api/executions?source=temporal&pageSize=50&workflowIdContains=task-123&stateIn=completed&repoContains=owner%2Frepo&targetRuntimeIn=codex_cloud&titleContains=Example',
       );
     });
+  });
+
+  it('filters the Updated column by the displayed updated timestamp', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const updatedFilter = screen.getByRole('button', {
+      name: 'Updated filter. No filter applied.',
+    });
+    fireEvent.click(updatedFilter);
+
+    fireEvent.change(screen.getByLabelText('Updated from'), {
+      target: { value: '2026-04-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Updated to'), {
+      target: { value: '2026-04-30' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Updated filter' }));
+
+    await waitFor(() => {
+      expect(lastExecutionListUrl()).toBe(
+        '/api/executions?source=temporal&pageSize=50&updatedFrom=2026-04-01&updatedTo=2026-04-30',
+      );
+    });
+    expect(screen.getByRole('button', { name: 'Updated filter: from 2026-04-01, to 2026-04-30' })).toBeTruthy();
+    expect(window.location.search).toBe('?updatedFrom=2026-04-01&updatedTo=2026-04-30&limit=50');
   });
 
   it('applies runtime and skill exclude modes from the drawer', async () => {

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -68,6 +68,7 @@ type FilterField =
   | 'targetSkill'
   | 'title'
   | 'scheduledFor'
+  | 'updatedAt'
   | 'createdAt'
   | 'closedAt';
 
@@ -94,7 +95,7 @@ const TABLE_COLUMN_FILTER_FIELDS: Partial<Record<string, FilterField>> = {
   status: 'status',
   repository: 'repository',
   targetRuntime: 'targetRuntime',
-  updatedAt: 'createdAt',
+  updatedAt: 'updatedAt',
 };
 
 // All filterable columns. This is the durable filter data model and feeds the
@@ -106,6 +107,7 @@ const FILTER_FIELDS = [
   ['repository', 'Repository'],
   ['targetRuntime', 'Runtime'],
   ['targetSkill', 'Skill'],
+  ['updatedAt', 'Updated'],
   ['scheduledFor', 'Scheduled'],
   ['createdAt', 'Created'],
   ['closedAt', 'Finished'],
@@ -118,6 +120,7 @@ const ACTIVE_FILTER_FIELDS = new Set<FilterField>([
   'targetRuntime',
   'targetSkill',
   'title',
+  'updatedAt',
   'scheduledFor',
   'createdAt',
   'closedAt',
@@ -133,6 +136,7 @@ const DRAWER_FILTER_FIELDS: Array<[FilterField, string]> = [
   ['repository', 'Repository'],
   ['targetRuntime', 'Runtime'],
   ['targetSkill', 'Skill'],
+  ['updatedAt', 'Updated'],
   ['scheduledFor', 'Scheduled'],
   ['createdAt', 'Created'],
   ['closedAt', 'Finished'],
@@ -151,6 +155,7 @@ type ColumnFilters = {
   targetRuntime: ValueFilter;
   targetSkill: ValueFilter;
   title: TextFilter;
+  updatedAt: DateFilter;
   scheduledFor: DateFilter;
   createdAt: DateFilter;
   closedAt: DateFilter;
@@ -408,6 +413,7 @@ function emptyFilters(): ColumnFilters {
     targetRuntime: emptyValueFilter(),
     targetSkill: emptyValueFilter(),
     title: {},
+    updatedAt: {},
     scheduledFor: {},
     createdAt: {},
     closedAt: {},
@@ -509,6 +515,10 @@ function parseInitialFilters(params: URLSearchParams): ColumnFilters {
     to: params.get('scheduledTo') || '',
     blank: (params.get('scheduledBlank') as DateFilter['blank']) || '',
   };
+  filters.updatedAt = {
+    from: params.get('updatedFrom') || '',
+    to: params.get('updatedTo') || '',
+  };
   filters.createdAt = {
     from: params.get('createdFrom') || '',
     to: params.get('createdTo') || '',
@@ -559,6 +569,7 @@ function appendFilterParams(params: URLSearchParams, filters: ColumnFilters) {
   appendValueParams(params, filters.targetSkill, 'targetSkillIn', 'targetSkillNotIn', 'targetSkillBlank');
   if (filters.title.contains?.trim()) params.set('titleContains', filters.title.contains.trim());
   appendDateParams(params, filters.scheduledFor, 'scheduledFrom', 'scheduledTo', 'scheduledBlank');
+  appendDateParams(params, filters.updatedAt, 'updatedFrom', 'updatedTo');
   appendDateParams(params, filters.createdAt, 'createdFrom', 'createdTo');
   appendDateParams(params, filters.closedAt, 'finishedFrom', 'finishedTo', 'finishedBlank');
 }
@@ -682,7 +693,14 @@ function filterSummary(field: FilterField, filters: ColumnFilters): string {
     return summarizeValues(filters.repository);
   }
   if (field === 'title') return filters.title.contains?.trim() || '';
-  const dateFilter = field === 'scheduledFor' ? filters.scheduledFor : field === 'createdAt' ? filters.createdAt : filters.closedAt;
+  const dateFilter =
+    field === 'scheduledFor'
+      ? filters.scheduledFor
+      : field === 'updatedAt'
+        ? filters.updatedAt
+        : field === 'createdAt'
+          ? filters.createdAt
+          : filters.closedAt;
   if (dateFilter.blank === 'include' && !dateFilter.from && !dateFilter.to) return 'blank';
   if (dateFilter.blank === 'exclude' && !dateFilter.from && !dateFilter.to) return 'not blank';
   const parts = [];
@@ -697,7 +715,7 @@ function clearFilterField(filters: ColumnFilters, field: FilterField): ColumnFil
   const next = { ...filters };
   if (field === 'workflowId' || field === 'title') next[field] = {};
   else if (field === 'repository') next.repository = { ...emptyValueFilter(), exactText: '' };
-  else if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') next[field] = {};
+  else if (field === 'scheduledFor' || field === 'updatedAt' || field === 'createdAt' || field === 'closedAt') next[field] = {};
   else next[field] = emptyValueFilter();
   return next;
 }
@@ -1111,7 +1129,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     }));
   };
 
-  const updateDraftDate = (field: 'scheduledFor' | 'createdAt' | 'closedAt', patch: DateFilter) => {
+  const updateDraftDate = (field: 'scheduledFor' | 'updatedAt' | 'createdAt' | 'closedAt', patch: DateFilter) => {
     setDraftFilters((current) => ({ ...current, [field]: { ...current[field], ...patch } }));
   };
 
@@ -1337,8 +1355,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       );
     }
 
-    if (field === 'scheduledFor' || field === 'createdAt' || field === 'closedAt') {
-      const label = field === 'scheduledFor' ? 'Scheduled' : field === 'createdAt' ? 'Created' : 'Finished';
+    if (field === 'scheduledFor' || field === 'updatedAt' || field === 'createdAt' || field === 'closedAt') {
+      const label =
+        field === 'scheduledFor'
+          ? 'Scheduled'
+          : field === 'updatedAt'
+            ? 'Updated'
+            : field === 'createdAt'
+              ? 'Created'
+              : 'Finished';
       const draft = draftFilters[field];
       return (
         <div className="queue-inline-filter workflow-list-filter-control">
@@ -1360,7 +1385,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               onChange={(event) => updateDraftDate(field, { to: event.target.value })}
             />
           </label>
-          {field !== 'createdAt' ? (
+          {field !== 'createdAt' && field !== 'updatedAt' ? (
             <label>
               {label} blank values
               <select
@@ -1638,7 +1663,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                                     className={`workflow-list-column-filter-button${filterValue ? ' is-active' : ''}`}
                                     aria-label={
                                       filterValue
-                                        ? `${label} filter: ${filterValue}`
+                                        ? `${label} column filter: ${filterValue}`
                                         : `${label} filter. No filter applied.`
                                     }
                                     aria-haspopup="dialog"

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -73,9 +73,8 @@ type FilterField =
 
 // Scan-first desktop columns, ordered left-to-right. `field` is the sort/identity
 // key and `sortable` controls whether the header renders a sort button or a static
-// label. Filtering no longer lives in the headers; it is driven entirely by the
-// advanced filter drawer. Workflow title leads as the primary anchor; raw/debug
-// identifiers move out of the default table.
+// label. Workflow title leads as the primary anchor; raw/debug identifiers move
+// out of the default table.
 type TableColumnDef = {
   field: string;
   label: string;
@@ -90,6 +89,13 @@ const TABLE_COLUMNS: TableColumnDef[] = [
   { field: 'targetRuntime', label: 'Runtime', sortable: true, colClassName: 'queue-table-column-runtime' },
   { field: 'updatedAt', label: 'Updated', sortable: true, colClassName: 'queue-table-column-date' },
 ];
+const TABLE_COLUMN_FILTER_FIELDS: Partial<Record<string, FilterField>> = {
+  title: 'title',
+  status: 'status',
+  repository: 'repository',
+  targetRuntime: 'targetRuntime',
+  updatedAt: 'createdAt',
+};
 
 // All filterable columns. This is the durable filter data model and feeds the
 // advanced filter drawer sections and the active filter chips.
@@ -716,11 +722,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const [filters, setFilters] = useState(() => parseInitialFilters(initial));
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
   const [hasEditedFilters, setHasEditedFilters] = useState(false);
-  // The advanced filter drawer is the single surface that exposes the full
-  // filter UI. `drawerOpen` controls visibility.
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [desktopFilterField, setDesktopFilterField] = useState<FilterField | null>(null);
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const drawerToggleRef = useRef<HTMLButtonElement | null>(null);
+  const desktopFilterRef = useRef<HTMLDivElement | null>(null);
   // The element that opened the drawer (the Filters trigger or a chip). Focus is
   // returned here when the drawer closes so keyboard users keep their place.
   const filterTriggerRef = useRef<HTMLElement | null>(null);
@@ -788,16 +794,18 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       }
       return ExecutionListResponseSchema.parse(await response.json());
     },
-    refetchInterval: listEnabled && !drawerOpen ? listPollMs : false,
+    refetchInterval: listEnabled && !drawerOpen && desktopFilterField === null ? listPollMs : false,
   });
 
-  // Facets enrich the include/exclude dropdowns. The drawer shows every value
-  // field at once, so we fetch each field's facet values while the drawer is
-  // open. This reuses the existing single-facet backend contract (one request
-  // per facet) without any API changes.
+  // Facets enrich the include/exclude dropdowns. The mobile drawer can show
+  // every value field at once; desktop column popovers request the active field.
+  // This reuses the existing single-facet backend contract without API changes.
   const getFacetQueryOptions = (facet: ExecutionFacetResponse['facet']) => ({
     queryKey: ['workflow-list-facet', facet, filters] as const,
-    enabled: listEnabled && filterValidationErrors.length === 0 && drawerOpen,
+    enabled:
+      listEnabled &&
+      filterValidationErrors.length === 0 &&
+      (drawerOpen || facetForFilterField(desktopFilterField) === facet),
     queryFn: async () => {
       const params = new URLSearchParams();
       params.set('source', 'temporal');
@@ -837,6 +845,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     });
   }, []);
 
+  const closeDesktopFilter = useCallback(() => {
+    setDesktopFilterField(null);
+    setDraftFilters(filters);
+  }, [filters]);
+
   const openDrawer = useCallback(
     (field: FilterField | null, trigger: HTMLElement | null) => {
       filterTriggerRef.current = trigger;
@@ -863,6 +876,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     setFilters(draftFilters);
     resetToFirstPage();
     setDrawerOpen(false);
+    setDesktopFilterField(null);
     restoreTriggerFocus();
   }, [draftFilters, resetToFirstPage, restoreTriggerFocus]);
 
@@ -872,6 +886,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     setDraftFilters(cleared);
     setFilters(cleared);
     resetToFirstPage();
+    setDesktopFilterField(null);
   }, [resetToFirstPage]);
 
   const removeActiveFilter = useCallback(
@@ -881,9 +896,32 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       setFilters(next);
       setDraftFilters(next);
       resetToFirstPage();
+      setDesktopFilterField(null);
     },
     [filters, resetToFirstPage],
   );
+
+  useEffect(() => {
+    if (desktopFilterField === null) return;
+    const onMouseDown = (event: MouseEvent) => {
+      const root = desktopFilterRef.current;
+      if (root && !root.contains(event.target as Node)) {
+        closeDesktopFilter();
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [closeDesktopFilter, desktopFilterField]);
+
+  useEffect(() => {
+    if (desktopFilterField === null) return;
+    const frame = window.requestAnimationFrame(() => {
+      desktopFilterRef.current
+        ?.querySelector<HTMLElement>('input:not([disabled]), select:not([disabled]), button:not([disabled])')
+        ?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [desktopFilterField]);
 
   // When the drawer opens, move focus to the first control of the requested
   // field (or the first control overall). This drives the keyboard "open the
@@ -1130,9 +1168,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     return null;
   };
 
-  // Renders one filter's controls bound to the draft filter state. The drawer is
-  // the only surface that renders these now; edits stage into `draftFilters`
-  // until the user applies them.
+  // Renders one filter's controls bound to the draft filter state. Edits stage
+  // into `draftFilters` until the user applies them.
   const renderFilterControl = (field: FilterField) => {
     if (field === 'workflowId' || field === 'title') {
       const label = field === 'workflowId' ? 'ID' : 'Title';
@@ -1481,10 +1518,9 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
       <section
         className="queue-layouts panel--data workflow-list-data-slab"
-        aria-labelledby="workflow-list-title"
+        aria-label="Workflow list"
       >
         <header className="workflow-list-results-header">
-          <h2 className="page-title" id="workflow-list-title">Workflows</h2>
           <div className="workflow-list-filter-bar">
             <button
               type="button"
@@ -1567,27 +1603,114 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                     <tr>
                       {TABLE_COLUMNS.map(({ field, label, sortable }) => {
                         const { ariaSort, ariaLabel, sortHint } = sortAccessibilityProps(field, label);
+                        const filterField = TABLE_COLUMN_FILTER_FIELDS[field];
+                        const filterValue = filterField ? filterSummary(filterField, filters) : '';
+                        const isFilterOpen = filterField === desktopFilterField;
                         return (
                           <th
                             key={field}
                             aria-sort={sortable ? ariaSort : undefined}
                             className="workflow-list-header-cell"
                           >
-                            {sortable ? (
-                              <button
-                                type="button"
-                                className="table-sort-button"
-                                onClick={() => onHeaderClick(field)}
-                                aria-label={ariaLabel}
-                                title={CURRENT_PAGE_SORT_NOTICE}
-                              >
-                                {label}
-                                {sortIndicator(field)}
-                                <span className="sr-only">{sortHint}</span>
-                              </button>
-                            ) : (
-                              <span className="workflow-list-static-header">{label}</span>
-                            )}
+                            <div className="workflow-list-column-header">
+                              {sortable ? (
+                                <button
+                                  type="button"
+                                  className="table-sort-button"
+                                  onClick={() => onHeaderClick(field)}
+                                  aria-label={ariaLabel}
+                                  title={CURRENT_PAGE_SORT_NOTICE}
+                                >
+                                  {label}
+                                  {sortIndicator(field)}
+                                  <span className="sr-only">{sortHint}</span>
+                                </button>
+                              ) : (
+                                <span className="workflow-list-static-header">{label}</span>
+                              )}
+                              {filterField ? (
+                                <div
+                                  className="workflow-list-column-filter"
+                                  ref={isFilterOpen ? desktopFilterRef : null}
+                                >
+                                  <button
+                                    type="button"
+                                    className={`workflow-list-column-filter-button${filterValue ? ' is-active' : ''}`}
+                                    aria-label={
+                                      filterValue
+                                        ? `${label} filter: ${filterValue}`
+                                        : `${label} filter. No filter applied.`
+                                    }
+                                    aria-haspopup="dialog"
+                                    aria-expanded={isFilterOpen}
+                                    onClick={() => {
+                                      setDraftFilters(filters);
+                                      setDesktopFilterField((current) => (current === filterField ? null : filterField));
+                                    }}
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      className="workflow-list-column-filter-icon"
+                                      viewBox="0 0 16 16"
+                                      focusable="false"
+                                    >
+                                      <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
+                                    </svg>
+                                  </button>
+                                  {isFilterOpen ? (
+                                    <div
+                                      className="workflow-list-column-filter-popover"
+                                      role="dialog"
+                                      aria-label={`${label} filter`}
+                                      onKeyDown={(event) => {
+                                        if (event.key === 'Escape') {
+                                          event.stopPropagation();
+                                          closeDesktopFilter();
+                                        }
+                                        if (
+                                          event.key === 'Enter' &&
+                                          event.target instanceof HTMLInputElement &&
+                                          !event.defaultPrevented
+                                        ) {
+                                          event.preventDefault();
+                                          applyDraftFilters();
+                                        }
+                                      }}
+                                    >
+                                      <div className="workflow-list-column-filter-title">{label} filter</div>
+                                      {renderFilterControl(filterField)}
+                                      <div className="workflow-list-filter-actions">
+                                        <button
+                                          type="button"
+                                          className="secondary"
+                                          onClick={() => removeActiveFilter(filterField)}
+                                          disabled={!listEnabled || !filterValue}
+                                          aria-label={`Reset ${label} filter`}
+                                        >
+                                          Reset
+                                        </button>
+                                        <button
+                                          type="button"
+                                          className="secondary"
+                                          onClick={closeDesktopFilter}
+                                          aria-label={`Cancel ${label} filter`}
+                                        >
+                                          Cancel
+                                        </button>
+                                        <button
+                                          type="button"
+                                          onClick={applyDraftFilters}
+                                          disabled={!listEnabled}
+                                          aria-label={`Apply ${label} filter`}
+                                        >
+                                          Apply
+                                        </button>
+                                      </div>
+                                    </div>
+                                  ) : null}
+                                </div>
+                              ) : null}
+                            </div>
                           </th>
                         );
                       })}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11971,6 +11971,8 @@ export interface operations {
                 scheduledFrom?: string | null;
                 scheduledTo?: string | null;
                 scheduledBlank?: string | null;
+                updatedFrom?: string | null;
+                updatedTo?: string | null;
                 createdFrom?: string | null;
                 createdTo?: string | null;
                 finishedFrom?: string | null;
@@ -12071,6 +12073,8 @@ export interface operations {
                 scheduledFrom?: string | null;
                 scheduledTo?: string | null;
                 scheduledBlank?: string | null;
+                updatedFrom?: string | null;
+                updatedTo?: string | null;
                 createdFrom?: string | null;
                 createdTo?: string | null;
                 finishedFrom?: string | null;
@@ -12130,6 +12134,8 @@ export interface operations {
                 scheduledFrom?: string | null;
                 scheduledTo?: string | null;
                 scheduledBlank?: string | null;
+                updatedFrom?: string | null;
+                updatedTo?: string | null;
                 createdFrom?: string | null;
                 createdTo?: string | null;
                 finishedFrom?: string | null;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1824,7 +1824,7 @@ tbody tr:hover {
 }
 
 .workflow-list-results-header {
-  display: none;
+  display: flex;
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
@@ -1921,7 +1921,12 @@ tbody tr:hover {
  * table never needs horizontal scrolling.
  */
 .workflow-list-data-slab .queue-table-wrapper:has(
-  .td-workflow-actions-popover,
+  .td-workflow-actions-popover
+) {
+  overflow: visible;
+}
+
+.workflow-list-data-slab .queue-table-wrapper:has(
   .workflow-list-column-filter-popover
 ) {
   overflow: visible;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -237,14 +237,14 @@ samp {
   display: block;
   flex: 0 0 auto;
   width: auto;
-  height: 2.45rem;
-  max-width: 3.2rem;
+  height: 2.05rem;
+  max-width: 2.7rem;
   object-fit: contain;
 }
 
 .masthead-brand h1 {
   margin: 0;
-  font-size: clamp(1.48rem, 2.42vw, 2.08rem);
+  font-size: clamp(1.28rem, 2vw, 1.72rem);
 }
 
 .masthead-title-meta {
@@ -760,6 +760,91 @@ h1 {
   margin-top: 0.85rem;
   padding-top: 0.75rem;
   border-top: 1px solid rgb(var(--mm-border) / 0.7);
+}
+
+.workflow-list-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.workflow-list-column-filter {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.workflow-list-column-filter-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.65rem;
+  height: 1.65rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.workflow-list-column-filter-button:hover,
+.workflow-list-column-filter-button:focus-visible,
+.workflow-list-column-filter-button[aria-expanded="true"],
+.workflow-list-column-filter-button.is-active {
+  border-color: rgb(var(--mm-accent) / 0.55);
+  background: rgb(var(--mm-accent) / 0.1);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-column-filter-icon {
+  display: block;
+  width: 0.82rem;
+  height: 0.82rem;
+  fill: currentColor;
+}
+
+.workflow-list-column-filter-popover {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  display: grid;
+  gap: 0.7rem;
+  width: min(20rem, calc(100vw - 2rem));
+  padding: 0.85rem;
+  border: 1px solid rgb(var(--mm-border) / 0.82);
+  border-radius: 0.75rem;
+  background: rgb(var(--mm-panel) / 0.99);
+  color: rgb(var(--mm-ink));
+  box-shadow: var(--mm-elevation-panel);
+}
+
+.workflow-list-header-cell:nth-last-child(-n + 2) .workflow-list-column-filter-popover {
+  left: auto;
+  right: 0;
+}
+
+.workflow-list-column-filter-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.workflow-list-column-filter-popover .workflow-list-filter-control {
+  display: grid;
+  gap: 0.65rem;
+  align-items: stretch;
+}
+
+.workflow-list-column-filter-popover .workflow-list-filter-control label {
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
 }
 
 .workflow-list-pill-multiselect {
@@ -1739,7 +1824,7 @@ tbody tr:hover {
 }
 
 .workflow-list-results-header {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
@@ -1836,7 +1921,8 @@ tbody tr:hover {
  * table never needs horizontal scrolling.
  */
 .workflow-list-data-slab .queue-table-wrapper:has(
-  .td-workflow-actions-popover
+  .td-workflow-actions-popover,
+  .workflow-list-column-filter-popover
 ) {
   overflow: visible;
 }
@@ -2332,6 +2418,7 @@ tr[data-proposal-id].proposal-consuming td {
   }
 
   .workflow-list-results-header {
+    display: flex;
     padding: 0 0 0.75rem;
     border-bottom: 0;
     background: transparent;
@@ -3203,7 +3290,29 @@ button.secondary:hover {
 }
 
 button.workflow-list-filter-chip-open,
-button.workflow-list-filter-chip-remove {
+button.workflow-list-filter-chip-remove,
+button.workflow-list-column-filter-button {
+  background-image: none;
+  transform: none;
+  filter: none;
+}
+
+button.workflow-list-column-filter-button {
+  width: 1.65rem;
+  border-color: transparent;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+}
+
+button.workflow-list-column-filter-button:hover,
+button.workflow-list-column-filter-button:focus-visible,
+button.workflow-list-column-filter-button[aria-expanded="true"],
+button.workflow-list-column-filter-button.is-active {
+  border-color: rgb(var(--mm-accent) / 0.55);
+  background: rgb(var(--mm-accent) / 0.1);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
   transform: none;
   filter: none;
 }

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1318,6 +1318,8 @@ def test_list_executions_temporal_query_includes_canonical_date_bounds() -> None
                 "source": "temporal",
                 "scheduledFrom": "2026-05-01",
                 "scheduledTo": "2026-05-05",
+                "updatedFrom": "2026-05-04",
+                "updatedTo": "2026-05-08",
                 "createdFrom": "2026-05-02",
                 "createdTo": "2026-05-06",
                 "finishedFrom": "2026-05-03",
@@ -1332,6 +1334,20 @@ def test_list_executions_temporal_query_includes_canonical_date_bounds() -> None
     assert "mm_scheduled_for IS NOT NULL" in query
     assert 'mm_scheduled_for>="2026-05-01T00:00:00Z"' in query
     assert 'mm_scheduled_for<="2026-05-05T23:59:59.999999Z"' in query
+    assert (
+        '(CloseTime IS NOT NULL AND CloseTime>="2026-05-04T00:00:00Z" '
+        'AND CloseTime<="2026-05-08T23:59:59.999999Z")'
+    ) in query
+    assert (
+        '(CloseTime IS NULL AND mm_scheduled_for IS NOT NULL '
+        'AND mm_scheduled_for>="2026-05-04T00:00:00Z" '
+        'AND mm_scheduled_for<="2026-05-08T23:59:59.999999Z")'
+    ) in query
+    assert (
+        '(CloseTime IS NULL AND mm_scheduled_for IS NULL '
+        'AND StartTime>="2026-05-04T00:00:00Z" '
+        'AND StartTime<="2026-05-08T23:59:59.999999Z")'
+    ) in query
     assert 'StartTime>="2026-05-02T00:00:00Z"' in query
     assert 'StartTime<="2026-05-06T23:59:59.999999Z"' in query
     assert "CloseTime IS NOT NULL" in query
@@ -1542,6 +1558,14 @@ def test_list_executions_temporal_query_rejects_invalid_filter_bounds() -> None:
                 "createdTo": "2026-05-01",
             },
         )
+        invalid_updated_range = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "updatedFrom": "2026-05-06",
+                "updatedTo": "2026-05-01",
+            },
+        )
         invalid_sort = test_client.get(
             "/api/executions",
             params={"source": "temporal", "sort": "workflowType"},
@@ -1552,6 +1576,8 @@ def test_list_executions_temporal_query_rejects_invalid_filter_bounds() -> None:
     assert "include, exclude" in invalid_blank.json()["detail"]["message"]
     assert invalid_range.status_code == 422
     assert "createdFrom must be before or equal to createdTo" in invalid_range.json()["detail"]["message"]
+    assert invalid_updated_range.status_code == 422
+    assert "updatedFrom must be before or equal to updatedTo" in invalid_updated_range.json()["detail"]["message"]
     assert invalid_sort.status_code == 422
     assert "sort must be one of" in invalid_sort.json()["detail"]["message"]
     temporal_client.count_workflows.assert_not_called()


### PR DESCRIPTION
The workflows table does not need a header with the title "Workflows" since the first column is already labeled similarly. Remove it. The Filters can remain a button on mobile above the table, but on desktop I'd like the filters to go back to column specific filter dropdowns. The MoonMind text in the upper left should be made a bit smaller as well as the logo.