### PR TITLE
MM-970 add Omnigent server using shared Postgres

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,6 +1,27 @@
 # Deployment Settings
 MOONMIND_IMAGE="ghcr.io/moonladderstudios/moonmind:latest"
 MOONMIND_API_HOST_PORT=7000
+
+# Omnigent local server (MM-970, sourced from MM-968)
+OMNIGENT_IMAGE="ghcr.io/moonladderstudios/omnigent"
+OMNIGENT_IMAGE_TAG="latest"
+OMNIGENT_PORT=8000
+OMNIGENT_POSTGRES_USER="omnigent"
+OMNIGENT_POSTGRES_PASSWORD="omnigent"
+OMNIGENT_POSTGRES_DB="omnigent"
+OMNIGENT_BUILTIN_ADMIN_EMAIL="admin@example.local"
+OMNIGENT_BUILTIN_ADMIN_PASSWORD="admin"
+OMNIGENT_BUILTIN_USER_EMAIL="user@example.local"
+OMNIGENT_BUILTIN_USER_PASSWORD="user"
+OMNIGENT_OIDC_ENABLED="false"
+OMNIGENT_OIDC_ISSUER_URL=""
+OMNIGENT_OIDC_CLIENT_ID=""
+OMNIGENT_OIDC_CLIENT_SECRET=""
+OMNIGENT_OIDC_SCOPES="openid profile email"
+OMNIGENT_CONFIG=""
+OMNIGENT_HOST_IMAGE="ghcr.io/moonladderstudios/omnigent-host"
+OMNIGENT_HOST_IMAGE_TAG="latest"
+
 # Deployment update operations run Docker Compose from the trusted agent-runtime
 # worker. The worker auto-detects the host path of this checkout by inspecting
 # its own bind mounts via the Docker proxy, so leaving this blank is correct on

--- a/deploy/omnigent/server-config.example.yaml
+++ b/deploy/omnigent/server-config.example.yaml
@@ -1,0 +1,32 @@
+# Non-secret Omnigent server configuration example for local Docker Compose.
+# Set OMNIGENT_CONFIG to a mounted config path only when overriding defaults.
+
+server:
+  host: 0.0.0.0
+  port: 8000
+  data_dir: /data
+
+database:
+  url_env: DATABASE_URL
+
+accounts:
+  built_in:
+    enabled: true
+    admin_email_env: OMNIGENT_BUILTIN_ADMIN_EMAIL
+    admin_password_env: OMNIGENT_BUILTIN_ADMIN_PASSWORD
+    user_email_env: OMNIGENT_BUILTIN_USER_EMAIL
+    user_password_env: OMNIGENT_BUILTIN_USER_PASSWORD
+
+oidc:
+  enabled_env: OMNIGENT_OIDC_ENABLED
+  issuer_url_env: OMNIGENT_OIDC_ISSUER_URL
+  client_id_env: OMNIGENT_OIDC_CLIENT_ID
+  client_secret_env: OMNIGENT_OIDC_CLIENT_SECRET
+  scopes_env: OMNIGENT_OIDC_SCOPES
+
+sandbox:
+  enabled: false
+  host_image_env: OMNIGENT_HOST_IMAGE
+  host_image_tag_env: OMNIGENT_HOST_IMAGE_TAG
+  network: local-network
+  workspace_root: /data/workspaces

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -897,6 +897,7 @@ services:
         if [ "$$role_exists" != "1" ]; then
           psql -v ON_ERROR_STOP=1 -c "CREATE ROLE $$role_sql LOGIN PASSWORD $$password_sql"
         fi
+        psql -v ON_ERROR_STOP=1 -c "ALTER ROLE $$role_sql PASSWORD $$password_sql"
 
         db_exists="$$(psql -v ON_ERROR_STOP=1 -tAc "SELECT 1 FROM pg_database WHERE datname = $$db_literal")"
         if [ "$$db_exists" != "1" ]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -868,6 +868,82 @@ services:
       qdrant:
         condition: service_started
 
+  omnigent-db-init:
+    image: postgres:${POSTGRES_VERSION:-17}
+    environment:
+      - PGHOST=postgres
+      - PGPORT=5432
+      - PGUSER=${POSTGRES_USER:-postgres}
+      - PGPASSWORD=${POSTGRES_PASSWORD:-password}
+      - PGDATABASE=${POSTGRES_DB:-moonmind}
+      - OMNIGENT_POSTGRES_USER=${OMNIGENT_POSTGRES_USER:-omnigent}
+      - OMNIGENT_POSTGRES_PASSWORD=${OMNIGENT_POSTGRES_PASSWORD:-omnigent}
+      - OMNIGENT_POSTGRES_DB=${OMNIGENT_POSTGRES_DB:-omnigent}
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        set -eu
+        quote_ident() { printf '%s' "$$1" | sed 's/"/""/g'; }
+        quote_literal() { printf '%s' "$$1" | sed "s/'/''/g"; }
+
+        role_sql="\"$$(quote_ident "$$OMNIGENT_POSTGRES_USER")\""
+        db_sql="\"$$(quote_ident "$$OMNIGENT_POSTGRES_DB")\""
+        password_sql="'$$(quote_literal "$$OMNIGENT_POSTGRES_PASSWORD")'"
+        role_literal="'$$(quote_literal "$$OMNIGENT_POSTGRES_USER")'"
+        db_literal="'$$(quote_literal "$$OMNIGENT_POSTGRES_DB")'"
+
+        role_exists="$$(psql -v ON_ERROR_STOP=1 -tAc "SELECT 1 FROM pg_roles WHERE rolname = $$role_literal")"
+        if [ "$$role_exists" != "1" ]; then
+          psql -v ON_ERROR_STOP=1 -c "CREATE ROLE $$role_sql LOGIN PASSWORD $$password_sql"
+        fi
+
+        db_exists="$$(psql -v ON_ERROR_STOP=1 -tAc "SELECT 1 FROM pg_database WHERE datname = $$db_literal")"
+        if [ "$$db_exists" != "1" ]; then
+          psql -v ON_ERROR_STOP=1 -c "CREATE DATABASE $$db_sql OWNER $$role_sql"
+        fi
+
+        psql -v ON_ERROR_STOP=1 -c "GRANT ALL PRIVILEGES ON DATABASE $$db_sql TO $$role_sql"
+        psql -v ON_ERROR_STOP=1 --dbname="$$OMNIGENT_POSTGRES_DB" -c "GRANT ALL ON SCHEMA public TO $$role_sql"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - local-network
+    restart: "no"
+
+  omnigent:
+    image: ${OMNIGENT_IMAGE:-ghcr.io/moonladderstudios/omnigent}:${OMNIGENT_IMAGE_TAG:-latest}
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - DATABASE_URL=postgresql://${OMNIGENT_POSTGRES_USER:-omnigent}:${OMNIGENT_POSTGRES_PASSWORD:-omnigent}@postgres:5432/${OMNIGENT_POSTGRES_DB:-omnigent}
+      - OMNIGENT_CONFIG=${OMNIGENT_CONFIG:-}
+      - OMNIGENT_BUILTIN_ADMIN_EMAIL=${OMNIGENT_BUILTIN_ADMIN_EMAIL:-admin@example.local}
+      - OMNIGENT_BUILTIN_ADMIN_PASSWORD=${OMNIGENT_BUILTIN_ADMIN_PASSWORD:-admin}
+      - OMNIGENT_BUILTIN_USER_EMAIL=${OMNIGENT_BUILTIN_USER_EMAIL:-user@example.local}
+      - OMNIGENT_BUILTIN_USER_PASSWORD=${OMNIGENT_BUILTIN_USER_PASSWORD:-user}
+      - OMNIGENT_OIDC_ENABLED=${OMNIGENT_OIDC_ENABLED:-false}
+      - OMNIGENT_OIDC_ISSUER_URL=${OMNIGENT_OIDC_ISSUER_URL:-}
+      - OMNIGENT_OIDC_CLIENT_ID=${OMNIGENT_OIDC_CLIENT_ID:-}
+      - OMNIGENT_OIDC_CLIENT_SECRET=${OMNIGENT_OIDC_CLIENT_SECRET:-}
+      - OMNIGENT_OIDC_SCOPES=${OMNIGENT_OIDC_SCOPES:-openid profile email}
+      - OMNIGENT_HOST_IMAGE=${OMNIGENT_HOST_IMAGE:-ghcr.io/moonladderstudios/omnigent-host}
+      - OMNIGENT_HOST_IMAGE_TAG=${OMNIGENT_HOST_IMAGE_TAG:-latest}
+    ports:
+      - "${OMNIGENT_PORT:-8000}:8000"
+    volumes:
+      - omnigent-data:/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      omnigent-db-init:
+        condition: service_completed_successfully
+    networks:
+      - local-network
+    restart: unless-stopped
+
   agent-workspaces-init:
     image: alpine:3.20
     command: >-
@@ -957,6 +1033,7 @@ volumes:
     name: ${GEMINI_VOLUME_NAME:-gemini_auth_volume}
   claude_auth_volume:
     name: ${CLAUDE_VOLUME_NAME:-claude_auth_volume}
+  omnigent-data:
 
 networks:
   local-network:

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -317,6 +317,7 @@ def test_omnigent_shared_postgres_compose_topology_for_mm_970():
     command_text = "\n".join(str(part) for part in init_service["command"])
     assert "SELECT 1 FROM pg_roles" in command_text
     assert "CREATE ROLE" in command_text
+    assert "ALTER ROLE $$role_sql PASSWORD $$password_sql" in command_text
     assert "SELECT 1 FROM pg_database" in command_text
     assert "CREATE DATABASE" in command_text
     assert "GRANT ALL PRIVILEGES ON DATABASE" in command_text

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -288,3 +288,94 @@ def test_runtime_image_includes_agent_skill_sources():
     )
 
     assert "COPY .agents /app/.agents/" in dockerfile
+
+
+def test_omnigent_shared_postgres_compose_topology_for_mm_970():
+    compose = _load_compose()
+    services = compose["services"]
+
+    assert "postgres" in services
+    assert not any(
+        service_name != "postgres" and "postgres" in service_name
+        for service_name in services
+    )
+
+    init_service = services["omnigent-db-init"]
+    assert init_service["restart"] == "no"
+    assert init_service["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert _network_names(init_service) == {"local-network"}
+
+    init_env = _env_map(init_service["environment"])
+    assert init_env["OMNIGENT_POSTGRES_USER"] == (
+        "${OMNIGENT_POSTGRES_USER:-omnigent}"
+    )
+    assert init_env["OMNIGENT_POSTGRES_PASSWORD"] == (
+        "${OMNIGENT_POSTGRES_PASSWORD:-omnigent}"
+    )
+    assert init_env["OMNIGENT_POSTGRES_DB"] == "${OMNIGENT_POSTGRES_DB:-omnigent}"
+
+    command_text = "\n".join(str(part) for part in init_service["command"])
+    assert "SELECT 1 FROM pg_roles" in command_text
+    assert "CREATE ROLE" in command_text
+    assert "SELECT 1 FROM pg_database" in command_text
+    assert "CREATE DATABASE" in command_text
+    assert "GRANT ALL PRIVILEGES ON DATABASE" in command_text
+    assert "DROP DATABASE" not in command_text
+    assert "DROP ROLE" not in command_text
+
+    omnigent_service = services["omnigent"]
+    assert omnigent_service["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert (
+        omnigent_service["depends_on"]["omnigent-db-init"]["condition"]
+        == "service_completed_successfully"
+    )
+    assert omnigent_service["ports"] == ["${OMNIGENT_PORT:-8000}:8000"]
+    assert _network_names(omnigent_service) == {"local-network"}
+    assert "omnigent-data:/data" in omnigent_service["volumes"]
+    assert "omnigent-data" in compose["volumes"]
+
+    omnigent_env = _env_map(omnigent_service["environment"])
+    assert omnigent_env["DATABASE_URL"] == (
+        "postgresql://${OMNIGENT_POSTGRES_USER:-omnigent}:"
+        "${OMNIGENT_POSTGRES_PASSWORD:-omnigent}@postgres:5432/"
+        "${OMNIGENT_POSTGRES_DB:-omnigent}"
+    )
+    assert "POSTGRES_USER" not in omnigent_env
+    assert "POSTGRES_PASSWORD" not in omnigent_env
+    assert "POSTGRES_DB" not in omnigent_env
+
+
+def test_omnigent_env_template_and_example_config_for_mm_970():
+    env_template = (REPO_ROOT / ".env-template").read_text(encoding="utf-8")
+    for expected_name in (
+        "OMNIGENT_IMAGE",
+        "OMNIGENT_IMAGE_TAG",
+        "OMNIGENT_PORT",
+        "OMNIGENT_POSTGRES_USER",
+        "OMNIGENT_POSTGRES_PASSWORD",
+        "OMNIGENT_POSTGRES_DB",
+        "OMNIGENT_BUILTIN_ADMIN_EMAIL",
+        "OMNIGENT_BUILTIN_ADMIN_PASSWORD",
+        "OMNIGENT_BUILTIN_USER_EMAIL",
+        "OMNIGENT_BUILTIN_USER_PASSWORD",
+        "OMNIGENT_OIDC_ENABLED",
+        "OMNIGENT_OIDC_ISSUER_URL",
+        "OMNIGENT_OIDC_CLIENT_ID",
+        "OMNIGENT_OIDC_CLIENT_SECRET",
+        "OMNIGENT_OIDC_SCOPES",
+        "OMNIGENT_CONFIG",
+        "OMNIGENT_HOST_IMAGE",
+        "OMNIGENT_HOST_IMAGE_TAG",
+    ):
+        assert f"{expected_name}=" in env_template
+
+    config = yaml.safe_load(
+        (REPO_ROOT / "deploy" / "omnigent" / "server-config.example.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert config["database"]["url_env"] == "DATABASE_URL"
+    assert config["accounts"]["built_in"]["admin_email_env"] == (
+        "OMNIGENT_BUILTIN_ADMIN_EMAIL"
+    )
+    assert config["sandbox"]["host_image_env"] == "OMNIGENT_HOST_IMAGE"

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -349,3 +349,107 @@ def test_agent_workspaces_init_avoids_recursive_permission_repair():
         "/work/agent_jobs/workspaces",
     ):
         assert expected_dir in command
+
+
+def test_omnigent_compose_uses_shared_postgres_for_mm_970():
+    """MM-970: Omnigent runs beside MoonMind using the shared Postgres service."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    services = compose_data.get("services", {})
+
+    assert "postgres" in services
+    assert not any(
+        service_name != "postgres" and "postgres" in service_name
+        for service_name in services
+    ), "Omnigent must reuse the existing postgres service, not add another one"
+
+    init_service = services.get("omnigent-db-init")
+    assert isinstance(
+        init_service, dict
+    ), "omnigent-db-init service is missing from docker-compose.yaml"
+    assert init_service.get("restart") == "no"
+    assert init_service["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert _network_names(init_service) == {"local-network"}
+
+    init_env = _env_map(init_service.get("environment"))
+    assert init_env["OMNIGENT_POSTGRES_USER"] == (
+        "${OMNIGENT_POSTGRES_USER:-omnigent}"
+    )
+    assert init_env["OMNIGENT_POSTGRES_PASSWORD"] == (
+        "${OMNIGENT_POSTGRES_PASSWORD:-omnigent}"
+    )
+    assert init_env["OMNIGENT_POSTGRES_DB"] == "${OMNIGENT_POSTGRES_DB:-omnigent}"
+    assert "POSTGRES_USER" not in {
+        key for key in init_env if key.startswith("OMNIGENT_")
+    }
+
+    command_text = "\n".join(str(part) for part in init_service.get("command", []))
+    assert "SELECT 1 FROM pg_roles" in command_text
+    assert "CREATE ROLE" in command_text
+    assert "SELECT 1 FROM pg_database" in command_text
+    assert "CREATE DATABASE" in command_text
+    assert "DROP DATABASE" not in command_text
+    assert "DROP ROLE" not in command_text
+    assert "GRANT ALL PRIVILEGES ON DATABASE" in command_text
+
+    omnigent_service = services.get("omnigent")
+    assert isinstance(
+        omnigent_service, dict
+    ), "omnigent service is missing from docker-compose.yaml"
+    assert omnigent_service["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert (
+        omnigent_service["depends_on"]["omnigent-db-init"]["condition"]
+        == "service_completed_successfully"
+    )
+    assert _network_names(omnigent_service) == {"local-network"}
+    assert omnigent_service["ports"] == ["${OMNIGENT_PORT:-8000}:8000"]
+    assert _has_volume_mount(omnigent_service, "omnigent-data", "/data")
+    assert "omnigent-data" in compose_data.get("volumes", {})
+
+    omnigent_env = _env_map(omnigent_service.get("environment"))
+    assert omnigent_env["DATABASE_URL"] == (
+        "postgresql://${OMNIGENT_POSTGRES_USER:-omnigent}:"
+        "${OMNIGENT_POSTGRES_PASSWORD:-omnigent}@postgres:5432/"
+        "${OMNIGENT_POSTGRES_DB:-omnigent}"
+    )
+    assert omnigent_env["OMNIGENT_CONFIG"] == "${OMNIGENT_CONFIG:-}"
+    assert "POSTGRES_USER" not in omnigent_env
+    assert "POSTGRES_PASSWORD" not in omnigent_env
+    assert "POSTGRES_DB" not in omnigent_env
+
+
+def test_omnigent_env_template_and_optional_config_for_mm_970():
+    env_template = Path(".env-template").read_text(encoding="utf-8")
+    for expected_name in (
+        "OMNIGENT_IMAGE",
+        "OMNIGENT_IMAGE_TAG",
+        "OMNIGENT_PORT",
+        "OMNIGENT_POSTGRES_USER",
+        "OMNIGENT_POSTGRES_PASSWORD",
+        "OMNIGENT_POSTGRES_DB",
+        "OMNIGENT_BUILTIN_ADMIN_EMAIL",
+        "OMNIGENT_BUILTIN_ADMIN_PASSWORD",
+        "OMNIGENT_BUILTIN_USER_EMAIL",
+        "OMNIGENT_BUILTIN_USER_PASSWORD",
+        "OMNIGENT_OIDC_ENABLED",
+        "OMNIGENT_OIDC_ISSUER_URL",
+        "OMNIGENT_OIDC_CLIENT_ID",
+        "OMNIGENT_OIDC_CLIENT_SECRET",
+        "OMNIGENT_OIDC_SCOPES",
+        "OMNIGENT_CONFIG",
+        "OMNIGENT_HOST_IMAGE",
+        "OMNIGENT_HOST_IMAGE_TAG",
+    ):
+        assert f"{expected_name}=" in env_template
+
+    config_path = Path("deploy/omnigent/server-config.example.yaml")
+    assert config_path.exists(), "Omnigent example server config is missing"
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["database"]["url_env"] == "DATABASE_URL"
+    assert config["server"]["data_dir"] == "/data"
+    assert config["sandbox"]["enabled"] is False


### PR DESCRIPTION
Issue reference: MM-970 (https://moonladder.atlassian.net/browse/MM-970)

Summary:
- Adds an Omnigent server service to docker-compose.yaml using the shared postgres service and local-network.
- Adds an idempotent omnigent-db-init one-shot service for the dedicated Omnigent role and database.
- Adds OMNIGENT_* defaults to .env-template, a non-secret sample server config, and topology tests for compose/env contracts.

Tests run:
- python -m pytest tests/test_local_dev.py -q
- python -m pytest tests/integration/temporal/test_compose_foundation.py -q
- ./tools/test_integration.sh

Remaining risks:
- Omnigent image startup was not live-smoke-tested in this environment.
- Built-in account and OIDC variables are exposed for configuration only; SSO/OIDC behavior is intentionally out of scope for MM-970.
- ./tools/test_unit.sh tests/test_local_dev.py previously passed the Python target, then failed in an unrelated frontend workflow-detail test outside this change.