### PR TITLE
[codex] fix codex permanent runtime retries

### DIFF
--- a/docs/Observability/LiveLogs.md
+++ b/docs/Observability/LiveLogs.md
@@ -369,6 +369,7 @@ type RunObservabilityEvent = {
     | "session_terminated"
     | "turn_started"
     | "turn_completed"
+    | "empty_assistant_turn_detected"
     | "turn_interrupted"
     | "approval_requested"
     | "approval_resolved"
@@ -416,6 +417,7 @@ MoonMind should normalize at least these event classes:
 ### Turn lifecycle events
 - `turn_started`
 - `turn_completed`
+- `empty_assistant_turn_detected`
 - `turn_interrupted`
 
 ### Control-boundary and continuity events
@@ -498,6 +500,7 @@ The normalized event stream should represent at least these MoonMind-side semant
 - `send_turn` → `turn_started`
 - `interrupt_turn` → `turn_interrupted`
 - successful turn completion → `turn_completed`
+- completed turn with no assistant output → `empty_assistant_turn_detected`
 - `clear_session` → `session_cleared` plus `reset_boundary_published`
 - continuity artifact publication → `summary_published` or `checkpoint_published`
 - approval-required workflow pauses → `approval_requested`

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1732,6 +1732,7 @@ ObservabilityEventKind = Literal[
     "session_resumed",
     "turn_started",
     "turn_completed",
+    "empty_assistant_turn_detected",
     "turn_interrupted",
     "session_cleared",
     "session_terminated",

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -78,9 +78,11 @@ _AUTH_FAILURE_MARKERS = (
     "invalid api key",
     "invalid token",
     "expired token",
+    "access token could not be refreshed",
     "authentication failed",
     "not logged in",
     "please run /login",
+    "refresh token was revoked",
 )
 
 # Credential-scope markers are deliberately scoped to HTTP 403 wording or

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -519,6 +519,9 @@ RUN_RESILIENCE_POLICY_PATCH = "run-resilience-policy-v1"
 # profile, so that step's manifest references the cooldown/rate-limit values that
 # actually governed its child runtime instead of the run-level policy.
 RUN_STEP_RESILIENCE_POLICY_PATCH = "run-step-resilience-policy-v1"
+RUN_AGENT_RUNTIME_RETRY_CLASSIFICATION_PATCH = (
+    "run-agent-runtime-retry-classification-v1"
+)
 # MM-884: stamp a stable correlation (trace) ref onto step-execution manifests
 # and emit a single incident reconstruction manifest before terminal failure so
 # policy, provider/profile/credential source, failed step, progress, workspace
@@ -6754,11 +6757,17 @@ class MoonMindRunWorkflow:
                             failure_message=failure_message,
                         )
 
-                        retryable = self._activity_result_retryable(
-                            execution_result,
-                            failure_message=failure_message,
-                            tool_type=tool_type,
-                        )
+                        if workflow.patched(RUN_AGENT_RUNTIME_RETRY_CLASSIFICATION_PATCH):
+                            retryable = self._activity_result_retryable(
+                                execution_result,
+                                failure_message=failure_message,
+                                tool_type=tool_type,
+                            )
+                        else:
+                            retryable = failure_message == "system_error" or (
+                                failure_message == "execution_error"
+                                and tool_type == "agent_runtime"
+                            )
                         if retryable and system_retries < 3:
                             self._mark_step_terminal(
                                 node_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -6754,9 +6754,10 @@ class MoonMindRunWorkflow:
                             failure_message=failure_message,
                         )
 
-                        retryable = failure_message == "system_error" or (
-                            failure_message == "execution_error"
-                            and tool_type == "agent_runtime"
+                        retryable = self._activity_result_retryable(
+                            execution_result,
+                            failure_message=failure_message,
+                            tool_type=tool_type,
                         )
                         if retryable and system_retries < 3:
                             self._mark_step_terminal(
@@ -7657,6 +7658,74 @@ class MoonMindRunWorkflow:
         if isinstance(summary, str) and summary.strip():
             return summary.strip()
         return None
+
+    def _activity_result_retryable(
+        self,
+        result: Any,
+        *,
+        failure_message: str,
+        tool_type: str,
+    ) -> bool:
+        if failure_message == "system_error":
+            return True
+        if failure_message != "execution_error" or tool_type != "agent_runtime":
+            return False
+
+        outputs = self._get_from_result(result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return True
+
+        provider_failure = outputs.get("providerFailure")
+        if not isinstance(provider_failure, Mapping):
+            provider_failure = {}
+        turn_metadata = outputs.get("turnMetadata")
+        if not isinstance(turn_metadata, Mapping):
+            turn_metadata = {}
+
+        def _first_text(*values: Any) -> str | None:
+            for value in values:
+                if isinstance(value, str) and value.strip():
+                    return value.strip().lower()
+            return None
+
+        provider_error_code = _first_text(
+            outputs.get("providerErrorCode"),
+            outputs.get("provider_error_code"),
+            provider_failure.get("providerErrorCode"),
+            provider_failure.get("provider_error_code"),
+        )
+        provider_error_class = _first_text(
+            provider_failure.get("providerErrorClass"),
+            provider_failure.get("provider_error_class"),
+        )
+        retry_recommendation = _first_text(
+            outputs.get("retryRecommendation"),
+            outputs.get("retry_recommendation"),
+            provider_failure.get("retryRecommendation"),
+            provider_failure.get("retry_recommendation"),
+        )
+        failure_class = _first_text(
+            outputs.get("failureClass"),
+            outputs.get("failure_class"),
+            provider_failure.get("failureClass"),
+            provider_failure.get("failure_class"),
+        )
+        turn_failure_class = _first_text(
+            turn_metadata.get("failureClass"),
+            turn_metadata.get("failure_class"),
+        )
+
+        if provider_error_code in {"401", "403"}:
+            return False
+        if provider_error_class in {"auth", "credential_scope"}:
+            return False
+        if retry_recommendation in {"reauthenticate", "expand_credential_scope"}:
+            return False
+        if failure_class in {"user_error", "permanent"}:
+            return False
+        if turn_failure_class == "permanent":
+            return False
+        return True
 
     def _activity_result_provider_failure_summary(self, result: Any) -> str | None:
         outputs = self._get_from_result(result, "outputs")

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -368,6 +368,32 @@ def test_emit_observability_event_publishes_session_metadata(streamer):
     assert persisted_events[0]["sessionEpoch"] == 2
     assert "session_id" not in persisted_events[0]
 
+
+def test_empty_assistant_turn_event_kind_is_schema_valid(streamer):
+    log_streamer, _storage = streamer
+
+    log_streamer.emit_observability_event(
+        run_id="run-empty-turn",
+        workspace_path=None,
+        stream="session",
+        text="Codex app-server completed a turn without assistant output.",
+        kind="empty_assistant_turn_detected",
+        session_id="sess-1",
+        session_epoch=1,
+        container_id="ctr-1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+        active_turn_id=None,
+        metadata={
+            "failureCause": "app_server_protocol_empty_turn",
+            "retryRecommendedAction": "clear_session",
+        },
+    )
+
+    persisted_events = log_streamer.consume_observability_events("run-empty-turn")
+    assert persisted_events[0]["kind"] == "empty_assistant_turn_detected"
+
+
 def test_persist_observability_events_promotes_spool_to_artifact(
     streamer,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 from datetime import datetime, timezone
 from itertools import count
@@ -3344,6 +3345,13 @@ def test_activity_result_retryable_allows_empty_assistant_turn_recovery() -> Non
     )
 
     assert retryable is True
+
+
+def test_agent_runtime_retry_classification_is_patch_gated() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow._run_execution_stage)
+
+    assert "workflow.patched(RUN_AGENT_RUNTIME_RETRY_CLASSIFICATION_PATCH)" in source
+    assert "self._activity_result_retryable(" in source
 
 
 def test_activity_result_provider_failure_summary_ignores_generic_activity_failure() -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -3297,6 +3297,54 @@ def test_activity_result_provider_failure_summary_includes_agent_runtime_reason(
         "diagnosticsRef: art_empty_turn)"
     )
 
+def test_activity_result_retryable_blocks_permanent_agent_runtime_failure() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    retryable = workflow._activity_result_retryable(
+        {
+            "status": "FAILED",
+            "outputs": {
+                "error": "execution_error",
+                "summary": (
+                    "Your access token could not be refreshed because your "
+                    "refresh token was revoked."
+                ),
+                "profileId": "codex_default",
+                "turnStatus": "failed",
+                "turnMetadata": {"failureClass": "permanent"},
+            },
+        },
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+
+    assert retryable is False
+
+
+def test_activity_result_retryable_allows_empty_assistant_turn_recovery() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    retryable = workflow._activity_result_retryable(
+        {
+            "status": "FAILED",
+            "outputs": {
+                "error": "execution_error",
+                "summary": "codex app-server turn/completed produced no assistant output",
+                "profileId": "codex_default",
+                "turnStatus": "failed",
+                "turnMetadata": {
+                    "failureClass": "transient",
+                    "failureCause": "app_server_protocol_empty_turn",
+                    "retryRecommendedAction": "clear_session",
+                },
+            },
+        },
+        failure_message="execution_error",
+        tool_type="agent_runtime",
+    )
+
+    assert retryable is True
+
 
 def test_activity_result_provider_failure_summary_ignores_generic_activity_failure() -> None:
     workflow = MoonMindRunWorkflow()
@@ -3731,6 +3779,164 @@ async def test_run_execution_stage_fail_fast_raises_agent_runtime_failure_summar
         )
 
     assert child_attempts == 4
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_does_not_retry_permanent_agent_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.schemas.agent_runtime_models import AgentRunResult
+
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    step_execution_artifact_ids = count(1)
+    child_attempts = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        if activity_type == "artifact.create":
+            artifact_create_result = _step_execution_artifact_create_result(
+                payload,
+                step_execution_artifact_ids,
+            )
+            if artifact_create_result is not None:
+                return artifact_create_result
+        if activity_type == "step_checkpoint.create":
+            return _checkpoint_create_result(payload)
+        assert activity_type == "artifact.read"
+        return json.dumps(
+            {
+                "plan_version": "1.0",
+                "metadata": {
+                    "title": "Test Plan",
+                    "created_at": "2026-03-12T00:00:00Z",
+                    "registry_snapshot": {
+                        "digest": "reg:sha256:" + ("a" * 64),
+                        "artifact_ref": "artifact://registry/1",
+                    },
+                },
+                "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                "nodes": [
+                    {
+                        "id": "node-1",
+                        "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                        "inputs": {
+                            "instructions": "Resolve PR",
+                            "repository": "MoonLadderStudios/MoonMind",
+                            "runtime": {
+                                "mode": "codex_cli",
+                                "executionProfileRef": "codex_default",
+                            },
+                        },
+                        "options": {},
+                    }
+                ],
+                "edges": [],
+            }
+        ).encode("utf-8")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **kwargs: Any,
+    ) -> object:
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return await fake_execute_activity(activity_type, payload, **kwargs)
+
+    async def fake_execute_child_workflow(
+        *_args: object,
+        **_kwargs: object,
+    ) -> AgentRunResult:
+        nonlocal child_attempts
+        child_attempts += 1
+        return AgentRunResult(
+            summary=(
+                "Your access token could not be refreshed because your refresh "
+                "token was revoked."
+            ),
+            failureClass="execution_error",
+            metadata={
+                "profileId": "codex_default",
+                "turnStatus": "failed",
+                "turnMetadata": {"failureClass": "permanent"},
+            },
+        )
+
+    async def fake_resolve_skillset_ref(_self: object, **_kwargs: object) -> str:
+        return "art_skillset_1"
+
+    async def fake_bind_workflow_scoped_session(_self: object, request: object) -> object:
+        return request
+
+    async def fake_fetch_profile_snapshots(_self: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_resolve_agent_node_skillset_ref",
+        fake_resolve_skillset_ref,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_workflow_scoped_session",
+        fake_bind_workflow_scoped_session,
+    )
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_fetch_profile_snapshots",
+        fake_fetch_profile_snapshots,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Agent runtime failed with execution_error for profile codex_default: "
+            "Your access token could not be refreshed"
+        ),
+    ):
+        await workflow._run_execution_stage(
+            parameters={"repo": "MoonLadderStudios/MoonMind"},
+            plan_ref="art_plan_1",
+        )
+
+    assert child_attempts == 1
 
 def test_blocked_outcome_message_detects_structured_agent_report() -> None:
     workflow = MoonMindRunWorkflow()

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -115,6 +115,19 @@ def test_classifies_claude_not_logged_in_as_auth_user_error() -> None:
     assert result.provider_error_code == "401"
     assert result.retry_recommendation == "reauthenticate"
 
+
+def test_classifies_codex_revoked_refresh_token_as_auth_user_error() -> None:
+    result = classify_provider_failure(
+        "Your access token could not be refreshed because your refresh token "
+        "was revoked. Please log out and sign in again."
+    )
+
+    assert result is not None
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
+
+
 def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> None:
     assert provider_error_requires_cooldown(
         provider_error_code="provider_capacity",


### PR DESCRIPTION
## Summary
- Classify Codex revoked refresh-token failures as provider auth user errors.
- Stop retrying agent runtime `execution_error` results when the failure envelope says auth, credential scope, user error, or permanent turn failure.
- Add `empty_assistant_turn_detected` as a valid live-log event kind and cover it in docs/tests.

## Root Cause
Workflow `mm:aa050218-08c1-42d7-b08e-39ec7d80dada` reached a permanent Codex provider/auth failure, but the parent workflow retried every agent-runtime `execution_error` as recoverable. Later empty-turn retries masked the actionable reauthentication message.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/test_provider_failures.py tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/services/temporal/runtime/test_log_streamer.py`
- `git diff --check`