### PR TITLE
MM-961: Extend reduced-motion and performance fallbacks across the dashboard

### DIFF
--- a/docs/UI/DashboardDesignSystem.md
+++ b/docs/UI/DashboardDesignSystem.md
@@ -1,7 +1,7 @@
 # Dashboard Design System
 Status: Active  
 Owners: MoonMind Engineering  
-Last updated: 2026-04-20
+Last updated: 2026-06-28
 
 ## 1. Purpose
 
@@ -348,6 +348,36 @@ These effects must remain low-amplitude.
 ### 9.4 Reduced motion
 
 A reduced-motion path is required. Pulses, shimmer, scanner effects, and highlight drift should be removed or significantly softened when the user requests reduced motion.
+
+The reduced-motion path covers every non-essential dashboard effect, not only the segmented-control shimmer:
+
+- panel enter animation (the slide/fade-in is suppressed)
+- step type / settings control shimmer and scan border
+- executing sweep effects and status-pill shimmer/glint
+- the masked conic border beam
+- submit ripple / arrow animation
+- LiquidGL hero surface transition and animation durations
+- hover scan / glint effects
+- general button transform/glow motion
+
+No readable text may depend on blur or refraction to be legible. LiquidGL is a decorative surface only; when it is disabled or unsupported it must fall back to the CSS glass/matte surface, and text remains readable on the fallback.
+
+### 9.5 Performance fallbacks
+
+Effects that are cheap on desktop can be expensive on mobile and touch/low-power devices:
+
+- `background-attachment: fixed` on the page atmosphere falls back to `scroll` on narrow viewports and on coarse-pointer / no-hover devices, where fixed attachment commonly causes scroll-repaint jank. The atmosphere stays visually intact.
+- LiquidGL is opt-in and must never be applied to dense default surfaces (panels, cards, tables, data slabs); it degrades to the CSS glass/matte fallback when backdrop filtering is unavailable.
+
+### 9.6 Manual QA checklist (motion and performance fallbacks)
+
+Run this checklist when changing dashboard motion, glass/LiquidGL surfaces, or atmosphere. Verify each combination on a representative route (e.g. the workflows home and a workflow details page):
+
+- **Normal motion (default):** panel enter animation plays once; executing sweeps, shimmer/glint, border beam, submit ripple, hover scans, and LiquidGL hero motion are present and low-amplitude.
+- **Reduced motion (`prefers-reduced-motion: reduce`):** no panel enter animation; sweeps, shimmer/glint, border beam, segmented-control shimmer/scan, submit ripple/arrow, and LiquidGL hero motion are stopped or softened; nothing pulses or drifts.
+- **Dark mode:** atmosphere, glass surfaces, and text contrast read correctly; no readable text relies on blur/refraction.
+- **Light mode:** same verification as dark mode through the light token swap.
+- **Narrow viewport (mobile width) and touch/low-power devices:** background atmosphere uses scroll attachment (no fixed-attachment scroll jank); layout and motion remain comfortable; LiquidGL falls back cleanly where unsupported.
 
 ---
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -517,6 +517,38 @@ describe('Dashboard shared entry', () => {
     expect(premiumEffectBlock).toContain('animation-duration: 0s !important');
   });
 
+  it('enforces MM-961 reduced-motion suppression for the panel entry animation', async () => {
+    const panelReducedMotionBlock = cssRuleBlockMatching(
+      dashboardCss,
+      (rule) =>
+        normalizeCssSelector(rule.selector) === '.panel' &&
+        rule.parent?.type === 'atrule' &&
+        rule.parent.name === 'media' &&
+        rule.parent.params.includes('prefers-reduced-motion: reduce'),
+    );
+    expect(panelReducedMotionBlock).toContain('animation: none !important');
+  });
+
+  it('disables MM-961 fixed background attachment on mobile and touch/low-power devices', async () => {
+    const mobileBackgroundBlock = cssRuleBlockMatching(
+      dashboardCss,
+      (rule) =>
+        rule.selector
+          .split(',')
+          .map(normalizeCssSelector)
+          .includes('body') &&
+        rule.parent?.type === 'atrule' &&
+        rule.parent.name === 'media' &&
+        rule.parent.params.includes('max-width: 767px') &&
+        rule.parent.params.includes('(hover: none) and (pointer: coarse)'),
+    );
+    expect(mobileBackgroundBlock).toContain('background-attachment: scroll');
+
+    // The default desktop atmosphere should still pin the background.
+    expect(cssRuleBlock(dashboardCss, 'body')).toContain('background-attachment: fixed');
+    expect(cssRuleBlock(dashboardCss, '.dark body')).toContain('background-attachment: fixed');
+  });
+
   it('enforces MM-429 fallback shells and premium-effect limits', async () => {
     expect(dashboardCss).toMatch(
       /@supports not \(\(backdrop-filter:\s*blur\(2px\)\) or \(-webkit-backdrop-filter:\s*blur\(2px\)\)\)\s*\{[^}]*\.surface--glass-control,[^}]*\.panel--controls,[^}]*\.panel--floating,[^}]*\.panel--utility,[^}]*\.surface--liquidgl-hero,[^}]*\.queue-floating-bar\s*\{[^}]*background:\s*rgb\(var\(--mm-panel\) \/ 0\.94\);[^}]*border-color:\s*rgb\(var\(--mm-border\) \/ 0\.84\);/s,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -164,6 +164,16 @@ samp {
   background-repeat: no-repeat;
 }
 
+/* MM-961: background-attachment: fixed is expensive to repaint on mobile and
+   touch/low-power devices, where it commonly causes scroll jank. Fall back to
+   the default scroll attachment there; the atmosphere stays visually intact. */
+@media (max-width: 767px), (hover: none) and (pointer: coarse) {
+  body,
+  .dark body {
+    background-attachment: scroll;
+  }
+}
+
 .dashboard-root {
   --dashboard-pt: 0;
 
@@ -531,6 +541,14 @@ h1 {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* MM-961: the panel enter slide/fade is non-essential motion; show panels
+   immediately for reduced-motion users instead of animating them in. */
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    animation: none !important;
   }
 }
 


### PR DESCRIPTION
## Issue
[MM-961](https://moonladder.atlassian.net/browse/MM-961) — Extend reduced-motion and performance fallbacks across the dashboard

## Summary
Closes the remaining MM-961 gaps on top of the existing reduced-motion coverage already carried by MM-429 and related work in `frontend/src/styles/dashboard.css` (executing sweeps, status-pill shimmer/glint, conic border beam, segmented-control shimmer/scan, submit ripple/arrow, LiquidGL hero surface, general button transforms; plus the LiquidGL CSS-fallback renderer in `useLiquidGL.ts`):

- **`.panel` entry animation** — the `panel-enter` slide/fade (220ms) is now suppressed under `prefers-reduced-motion: reduce`, the one in-scope motion effect that was not previously covered.
- **`background-attachment: fixed` performance fallback** — falls back to `scroll` on narrow viewports and on coarse-pointer / no-hover (touch / low-power) devices, where fixed attachment causes scroll-repaint jank. The atmospheric background is preserved; only the attachment mode changes.
- **Manual QA checklist + documentation** — `docs/UI/DashboardDesignSystem.md` now documents the full reduced-motion coverage, the performance fallbacks, and a manual QA checklist covering normal motion, reduced motion, dark mode, light mode, and narrow viewport.

No readable text depends on blur/refraction effects: LiquidGL remains a decorative surface only, and readable text continues to use solid ink colors.

## Tests run
- `./tools/test_unit.sh --dashboard-only --ui-args src/entrypoints/dashboard.test.tsx` — **41 passed**.
  - New assertions cover the `.panel` reduced-motion suppression and the mobile/coarse-pointer `background-attachment` fallback, while verifying the desktop default keeps `fixed` attachment.

## Remaining risks
- CSS media-query behavior (`prefers-reduced-motion`, `pointer: coarse`, `hover: none`, narrow-viewport breakpoints) is asserted via the jsdom CSS-text checks in `dashboard.test.tsx`; true rendered behavior across real browsers/devices still relies on the added manual QA checklist.
- Live-log auto-scroll has no CSS animation/transition and is handled by the virtual scroller; it was assessed as already conforming and is unchanged here.
- Scope intentionally limited to MM-961 items; existing MM-429 reduced-motion blocks and the broader theme system were left untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MM-961]: https://moonladder.atlassian.net/browse/MM-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ