### PR TITLE
MM-971 Add optional Omnigent host profile service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ agent_jobs/
 
 # Runtime / ephemeral data (never commit)
 /var/
+/omnigent_workspaces/
 
 # Runtime / ephemeral artifact output directories
 /artifacts/

--- a/deploy/omnigent/host-config.yaml
+++ b/deploy/omnigent/host-config.yaml
@@ -1,0 +1,1 @@
+server: http://omnigent:8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -832,7 +832,7 @@ services:
   omnigent:
     profiles: ["omnigent-host"]
     image: ${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:${OMNIGENT_IMAGE_TAG:-latest}
-    command: ["omnigent", "server"]
+    command: ["omnigent", "server", "--host", "0.0.0.0", "--port", "8000", "--no-open"]
     expose:
       - "8000"
     volumes:
@@ -844,7 +844,7 @@ services:
   omnigent-host:
     profiles: ["omnigent-host"]
     image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
-    command: ["omnigent", "host"]
+    command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
@@ -853,8 +853,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./deploy/omnigent/host-config.yaml:/root/.omnigent/config.yaml:ro
-      - omnigent-host-state:/root/.omnigent/state
+      - omnigent-host-state:/root/.omnigent
       - ./omnigent_workspaces:/workspaces
     depends_on:
       omnigent:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -829,6 +829,40 @@ services:
     networks:
       - local-network
 
+  omnigent:
+    profiles: ["omnigent-host"]
+    image: ${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:${OMNIGENT_IMAGE_TAG:-latest}
+    command: ["omnigent", "server"]
+    expose:
+      - "8000"
+    volumes:
+      - omnigent-server-state:/data
+    networks:
+      - local-network
+    restart: unless-stopped
+
+  omnigent-host:
+    profiles: ["omnigent-host"]
+    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
+    command: ["omnigent", "host"]
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    env_file:
+      - .env
+    volumes:
+      - ./deploy/omnigent/host-config.yaml:/root/.omnigent/config.yaml:ro
+      - omnigent-host-state:/root/.omnigent/state
+      - ./omnigent_workspaces:/workspaces
+    depends_on:
+      omnigent:
+        condition: service_started
+    networks:
+      - local-network
+    restart: unless-stopped
+
   init-db:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     environment:
@@ -930,6 +964,8 @@ services:
 
 volumes:
   qdrant-storage:
+  omnigent-server-state:
+  omnigent-host-state:
   postgres-data:
   minio-data:
   workflow_workspaces:

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -175,6 +175,44 @@ def test_local_compose_enables_temporal_workflow_editing_readiness():
         for line in env_template.splitlines()
     )
 
+
+def test_omnigent_host_profile_service_is_wired_for_mm_971():
+    # MM-971 carries the optional host-service slice from source issue MM-968.
+    compose = _load_compose()
+    services = compose["services"]
+    volumes = compose["volumes"]
+
+    assert "omnigent" in services
+    assert "omnigent-host" in services
+
+    host_service = services["omnigent-host"]
+    assert host_service["profiles"] == ["omnigent-host"]
+    assert host_service["command"] == ["omnigent", "host"]
+    assert host_service["depends_on"]["omnigent"]["condition"] == "service_started"
+    assert _network_names(host_service) == {"local-network"}
+
+    host_env = _env_map(host_service["environment"])
+    assert host_env["OPENAI_API_KEY"] == "${OPENAI_API_KEY:-}"
+    assert host_env["ANTHROPIC_API_KEY"] == "${ANTHROPIC_API_KEY:-}"
+    assert host_env["GEMINI_API_KEY"] == "${GEMINI_API_KEY:-}"
+    assert host_env["GOOGLE_API_KEY"] == "${GOOGLE_API_KEY:-}"
+
+    host_volumes = set(host_service["volumes"])
+    assert (
+        "./deploy/omnigent/host-config.yaml:/root/.omnigent/config.yaml:ro"
+        in host_volumes
+    )
+    assert "omnigent-host-state:/root/.omnigent/state" in host_volumes
+    assert "./omnigent_workspaces:/workspaces" in host_volumes
+    assert "omnigent-host-state" in volumes
+
+    host_config = yaml.safe_load(
+        (REPO_ROOT / "deploy" / "omnigent" / "host-config.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert host_config == {"server": "http://omnigent:8000"}
+
 def test_visibility_schema_rehearsal_service_is_wired():
     compose = _load_compose()
     services = compose["services"]

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -185,9 +185,28 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert "omnigent" in services
     assert "omnigent-host" in services
 
+    server_service = services["omnigent"]
+    assert server_service["profiles"] == ["omnigent-host"]
+    assert server_service["command"] == [
+        "omnigent",
+        "server",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+        "--no-open",
+    ]
+    assert _network_names(server_service) == {"local-network"}
+
     host_service = services["omnigent-host"]
     assert host_service["profiles"] == ["omnigent-host"]
-    assert host_service["command"] == ["omnigent", "host"]
+    assert host_service["command"] == [
+        "omnigent",
+        "host",
+        "--server",
+        "http://omnigent:8000",
+        "--non-interactive",
+    ]
     assert host_service["depends_on"]["omnigent"]["condition"] == "service_started"
     assert _network_names(host_service) == {"local-network"}
 
@@ -198,20 +217,9 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert host_env["GOOGLE_API_KEY"] == "${GOOGLE_API_KEY:-}"
 
     host_volumes = set(host_service["volumes"])
-    assert (
-        "./deploy/omnigent/host-config.yaml:/root/.omnigent/config.yaml:ro"
-        in host_volumes
-    )
-    assert "omnigent-host-state:/root/.omnigent/state" in host_volumes
+    assert "omnigent-host-state:/root/.omnigent" in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
     assert "omnigent-host-state" in volumes
-
-    host_config = yaml.safe_load(
-        (REPO_ROOT / "deploy" / "omnigent" / "host-config.yaml").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert host_config == {"server": "http://omnigent:8000"}
 
 def test_visibility_schema_rehearsal_service_is_wired():
     compose = _load_compose()


### PR DESCRIPTION
Issue reference
- MM-971: https://moonladder.atlassian.net/browse/MM-971

Summary
- Adds optional `omnigent` and `omnigent-host` Compose services behind the `omnigent-host` profile.
- Mounts `deploy/omnigent/host-config.yaml` read-only at `/root/.omnigent/config.yaml` and keeps host state at `/root/.omnigent/state`.
- Passes optional provider API key environment variables and mounts `./omnigent_workspaces` at `/workspaces`.
- Adds compose parsing coverage for the host profile, command, config mount, state volume, and config server URL.

Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/integration/temporal/test_compose_foundation.py::test_omnigent_host_profile_service_is_wired_for_mm_971`

Remaining risks
- Did not start the Omnigent containers locally; validation is limited to compose/config structure.