### PR TITLE
[codex] Fix duplicate Omnigent compose service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -838,21 +838,9 @@ services:
     networks:
       - local-network
 
-  omnigent:
-    profiles: ["omnigent-host"]
-    image: ${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:${OMNIGENT_IMAGE_TAG:-latest}
-    command: ["omnigent", "server", "--host", "0.0.0.0", "--port", "8000", "--no-open"]
-    expose:
-      - "8000"
-    volumes:
-      - omnigent-server-state:/data
-    networks:
-      - local-network
-    restart: unless-stopped
-
   omnigent-host:
     profiles: ["omnigent-host"]
-    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/omnigent-ai/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
+    image: ${OMNIGENT_HOST_IMAGE:-ghcr.io/moonladderstudios/omnigent-host}:${OMNIGENT_HOST_IMAGE_TAG:-latest}
     command: ["omnigent", "host", "--server", "http://omnigent:8000", "--non-interactive"]
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -860,7 +848,8 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
     env_file:
-      - .env
+      - path: .env
+        required: false
     volumes:
       - omnigent-host-state:/root/.omnigent
       - ./omnigent_workspaces:/workspaces
@@ -1050,7 +1039,6 @@ services:
 
 volumes:
   qdrant-storage:
-  omnigent-server-state:
   omnigent-host-state:
   postgres-data:
   minio-data:

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -9,9 +9,38 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
+
+class UniqueKeySafeLoader(yaml.SafeLoader):
+    """PyYAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_mapping_with_unique_keys(loader, node, deep=False):
+    seen_keys = set()
+    for key_node, _value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen_keys:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key ({key!r})",
+                key_node.start_mark,
+            )
+        seen_keys.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep=deep)
+
+
+UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_with_unique_keys,
+)
+
+
 def _load_compose() -> dict:
     compose_path = REPO_ROOT / "docker-compose.yaml"
-    return yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    return yaml.load(
+        compose_path.read_text(encoding="utf-8"),
+        Loader=UniqueKeySafeLoader,
+    )
 
 def _env_map(environment: object) -> dict[str, str]:
     if isinstance(environment, dict):
@@ -260,20 +289,20 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert "omnigent-host" in services
 
     server_service = services["omnigent"]
-    assert server_service["profiles"] == ["omnigent-host"]
-    assert server_service["command"] == [
-        "omnigent",
-        "server",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "8000",
-        "--no-open",
-    ]
+    assert "profiles" not in server_service
+    assert server_service["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert (
+        server_service["depends_on"]["omnigent-db-init"]["condition"]
+        == "service_completed_successfully"
+    )
     assert _network_names(server_service) == {"local-network"}
 
     host_service = services["omnigent-host"]
     assert host_service["profiles"] == ["omnigent-host"]
+    assert host_service["image"] == (
+        "${OMNIGENT_HOST_IMAGE:-ghcr.io/moonladderstudios/omnigent-host}:"
+        "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
+    )
     assert host_service["command"] == [
         "omnigent",
         "host",
@@ -294,6 +323,7 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     assert "omnigent-host-state:/root/.omnigent" in host_volumes
     assert "./omnigent_workspaces:/workspaces" in host_volumes
     assert "omnigent-host-state" in volumes
+    assert "omnigent-server-state" not in volumes
 
 def test_visibility_schema_rehearsal_service_is_wired():
     compose = _load_compose()

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -8,6 +8,43 @@ from pathlib import Path
 import yaml
 
 
+class UniqueKeySafeLoader(yaml.SafeLoader):
+    """PyYAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_mapping_with_unique_keys(loader, node, deep=False):
+    seen_keys = set()
+    for key_node, _value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen_keys:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key ({key!r})",
+                key_node.start_mark,
+            )
+        seen_keys.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep=deep)
+
+
+UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_with_unique_keys,
+)
+
+
+def _load_compose() -> dict:
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    return yaml.load(
+        compose_path.read_text(encoding="utf-8"),
+        Loader=UniqueKeySafeLoader,
+    )
+
+
 def _has_volume_mount(service_config: dict, source: str, target: str) -> bool:
     volumes = service_config.get("volumes", [])
     assert isinstance(volumes, list), "service volumes must be a list"
@@ -353,12 +390,7 @@ def test_agent_workspaces_init_avoids_recursive_permission_repair():
 
 def test_omnigent_compose_uses_shared_postgres_for_mm_970():
     """MM-970: Omnigent runs beside MoonMind using the shared Postgres service."""
-    compose_path = Path("docker-compose.yaml")
-    assert (
-        compose_path.exists()
-    ), "docker-compose.yaml must exist at the repository root"
-
-    compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    compose_data = _load_compose()
     services = compose_data.get("services", {})
 
     assert "postgres" in services


### PR DESCRIPTION
## Summary

Fixes the Docker Compose YAML unmarshal error caused by two `services.omnigent` entries.

The MM-970 shared-Postgres Omnigent server remains the single canonical `omnigent` service. The optional MM-971 `omnigent-host` profile now depends on that service instead of redefining it. The host image default is aligned with `.env-template`, and its `.env` file reference is optional like the rest of local compose startup.

## Validation

- `docker compose -f docker-compose.yaml config --quiet`
- `docker compose -f docker-compose.yaml --profile omnigent-host config --quiet`
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/test_local_dev.py -q` -> 11 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/temporal/test_compose_foundation.py -q` -> 13 passed

Additional notes:
- `./tools/test_unit.sh tests/test_local_dev.py` did not reach pytest because local ignored file `deploy/state/desired-state.json` is root-owned and unreadable.
- `./tools/test_integration.sh` was started and later interrupted at the user's request. `tests/integration/temporal/test_compose_foundation.py` passed inside that run before interruption; two failures had already appeared in `tests/integration/services/temporal/test_codex_session_task_creation.py`, outside this compose change.