### PR TITLE
MM-958 Replace browser dialogs with dashboard modals

### DIFF
--- a/frontend/src/components/DashboardActionDialog.test.tsx
+++ b/frontend/src/components/DashboardActionDialog.test.tsx
@@ -80,4 +80,29 @@ describe('DashboardActionDialog', () => {
     fireEvent.click(confirmButton);
     expect(onConfirm).toHaveBeenCalledWith('');
   });
+
+  it('disables confirmation while the action is pending', () => {
+    const onConfirm = vi.fn();
+    render(
+      <DashboardActionDialog
+        open
+        title="Cancel workflow"
+        subject="Workflow title"
+        compactId="wf-1"
+        consequence="Cancel this workflow."
+        confirmLabel="Cancelling"
+        confirmPending
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirmButton = screen.getByRole('button', { name: 'Cancelling' }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+    expect(confirmButton.getAttribute('aria-busy')).toBe('true');
+
+    fireEvent.click(confirmButton);
+    fireEvent.submit(confirmButton.closest('form') as HTMLFormElement);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/DashboardActionDialog.test.tsx
+++ b/frontend/src/components/DashboardActionDialog.test.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DashboardActionDialog } from './DashboardActionDialog';
+
+describe('DashboardActionDialog', () => {
+  it('closes on Escape, restores focus, and does not confirm on cancel', async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Trigger action</button>
+          <DashboardActionDialog
+            open={open}
+            title="Rename workflow"
+            subject="Workflow title"
+            compactId="wf-1"
+            consequence="Rename this workflow."
+            valueLabel="Workflow title"
+            confirmLabel="Rename workflow"
+            onCancel={() => {
+              onCancel();
+              setOpen(false);
+            }}
+            onConfirm={onConfirm}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByRole('button', { name: 'Trigger action' });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'Rename workflow' }), { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('traps tab focus inside the dialog and requires typed destructive confirmation', () => {
+    const onConfirm = vi.fn();
+    render(
+      <DashboardActionDialog
+        open
+        title="Force cancel workflow"
+        subject="Workflow title"
+        compactId="wf-1"
+        consequence="Force cancel this workflow."
+        valueLabel="Reason"
+        confirmLabel="Force cancel workflow"
+        destructive
+        confirmationText="FORCE CANCEL"
+        onCancel={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Force cancel workflow' });
+    const closeButton = screen.getByRole('button', { name: 'Close Force cancel workflow' });
+    const confirmButton = screen.getByRole('button', { name: 'Force cancel workflow' }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+
+    closeButton.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
+
+    fireEvent.change(screen.getByLabelText('Type FORCE CANCEL to confirm'), {
+      target: { value: 'FORCE CANCEL' },
+    });
+    expect(confirmButton.disabled).toBe(false);
+    confirmButton.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledWith('');
+  });
+});

--- a/frontend/src/components/DashboardActionDialog.tsx
+++ b/frontend/src/components/DashboardActionDialog.tsx
@@ -1,0 +1,233 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+
+type DashboardActionDialogProps = {
+  open: boolean;
+  title: string;
+  subject: string;
+  compactId?: string | null;
+  consequence: ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  destructive?: boolean;
+  confirmationText?: string;
+  disabledReason?: string | null | undefined;
+  error?: string | null | undefined;
+  initialValue?: string;
+  valueLabel?: string;
+  valuePlaceholder?: string;
+  valueRequired?: boolean;
+  valueMultiline?: boolean;
+  nonDestructiveEscapeClose?: boolean;
+  onCancel: () => void;
+  onConfirm: (value: string) => void;
+};
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function DashboardActionDialog({
+  open,
+  title,
+  subject,
+  compactId,
+  consequence,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  danger = false,
+  destructive = false,
+  confirmationText,
+  disabledReason,
+  error,
+  initialValue = '',
+  valueLabel,
+  valuePlaceholder,
+  valueRequired = false,
+  valueMultiline = false,
+  nonDestructiveEscapeClose = true,
+  onCancel,
+  onConfirm,
+}: DashboardActionDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const [value, setValue] = useState(initialValue);
+  const [typedConfirmation, setTypedConfirmation] = useState('');
+  const [copyLabel, setCopyLabel] = useState('Copy diagnostics');
+
+  useEffect(() => {
+    if (!open) return undefined;
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    setValue(initialValue);
+    setTypedConfirmation('');
+    setCopyLabel('Copy diagnostics');
+    const focusTimer = window.setTimeout(() => {
+      const firstFocusable = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      firstFocusable?.focus();
+    }, 0);
+    return () => {
+      window.clearTimeout(focusTimer);
+      previousFocusRef.current?.focus();
+    };
+  }, [initialValue, open]);
+
+  if (!open) return null;
+
+  const expectedConfirmation = confirmationText?.trim() || '';
+  const valueMissing = valueRequired && !value.trim();
+  const confirmationMissing = destructive && expectedConfirmation
+    ? typedConfirmation.trim() !== expectedConfirmation
+    : false;
+  const confirmDisabled = Boolean(disabledReason || valueMissing || confirmationMissing);
+
+  const focusableElements = () => Array.from(
+    dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+  ).filter((element) => !element.hasAttribute('disabled'));
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && (!destructive || nonDestructiveEscapeClose)) {
+      event.preventDefault();
+      onCancel();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const elements = focusableElements();
+    if (elements.length === 0) return;
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    if (!first || !last) return;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (confirmDisabled) return;
+    onConfirm(value.trim());
+  };
+
+  const copyDiagnostics = async () => {
+    if (!error) return;
+    try {
+      await navigator.clipboard?.writeText(error);
+      setCopyLabel('Copied');
+    } catch {
+      setCopyLabel('Copy unavailable');
+    }
+  };
+
+  return (
+    <div className="dashboard-dialog-backdrop">
+      <div
+        ref={dialogRef}
+        className="dashboard-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onKeyDown={onKeyDown}
+      >
+        <form onSubmit={submit}>
+          <div className="dashboard-dialog-header">
+            <div>
+              <h3 id={titleId}>{title}</h3>
+              <p className="dashboard-dialog-subject">
+                <span>{subject}</span>
+                {compactId ? <code>{compactId}</code> : null}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="secondary dashboard-dialog-close"
+              aria-label={`Close ${title}`}
+              onClick={onCancel}
+            >
+              x
+            </button>
+          </div>
+          <div id={descriptionId} className="dashboard-dialog-consequence">
+            {consequence}
+          </div>
+          {disabledReason ? (
+            <div className="notice pending" role="note">
+              {disabledReason}
+            </div>
+          ) : null}
+          {valueLabel ? (
+            <label className="dashboard-dialog-field">
+              <span>{valueLabel}</span>
+              {valueMultiline ? (
+                <textarea
+                  value={value}
+                  placeholder={valuePlaceholder}
+                  onChange={(event) => setValue(event.currentTarget.value)}
+                  rows={4}
+                  required={valueRequired}
+                />
+              ) : (
+                <input
+                  value={value}
+                  placeholder={valuePlaceholder}
+                  onChange={(event) => setValue(event.currentTarget.value)}
+                  required={valueRequired}
+                />
+              )}
+            </label>
+          ) : null}
+          {destructive && expectedConfirmation ? (
+            <label className="dashboard-dialog-field">
+              <span>Type {expectedConfirmation} to confirm</span>
+              <input
+                value={typedConfirmation}
+                onChange={(event) => setTypedConfirmation(event.currentTarget.value)}
+                aria-label={`Type ${expectedConfirmation} to confirm`}
+              />
+            </label>
+          ) : null}
+          {error ? (
+            <div className="notice error dashboard-dialog-error" role="alert">
+              <span>{error}</span>
+              <button type="button" className="secondary" onClick={() => void copyDiagnostics()}>
+                {copyLabel}
+              </button>
+            </div>
+          ) : null}
+          <div className="dashboard-dialog-actions">
+            <button type="button" className="secondary" onClick={onCancel}>
+              {cancelLabel}
+            </button>
+            <button
+              type="submit"
+              className={danger ? 'button dashboard-dialog-danger' : 'button'}
+              disabled={confirmDisabled}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DashboardActionDialog.tsx
+++ b/frontend/src/components/DashboardActionDialog.tsx
@@ -15,6 +15,7 @@ type DashboardActionDialogProps = {
   compactId?: string | null;
   consequence: ReactNode;
   confirmLabel: string;
+  confirmPending?: boolean;
   cancelLabel?: string;
   danger?: boolean;
   destructive?: boolean;
@@ -47,6 +48,7 @@ export function DashboardActionDialog({
   compactId,
   consequence,
   confirmLabel,
+  confirmPending = false,
   cancelLabel = 'Cancel',
   danger = false,
   destructive = false,
@@ -95,7 +97,7 @@ export function DashboardActionDialog({
   const confirmationMissing = destructive && expectedConfirmation
     ? typedConfirmation.trim() !== expectedConfirmation
     : false;
-  const confirmDisabled = Boolean(disabledReason || valueMissing || confirmationMissing);
+  const confirmDisabled = Boolean(confirmPending || disabledReason || valueMissing || confirmationMissing);
 
   const focusableElements = () => Array.from(
     dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
@@ -222,6 +224,7 @@ export function DashboardActionDialog({
               type="submit"
               className={danger ? 'button dashboard-dialog-danger' : 'button'}
               disabled={confirmDisabled}
+              aria-busy={confirmPending}
             >
               {confirmLabel}
             </button>

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -96,11 +96,12 @@ describe('WorkflowRowActionsMenu', () => {
     });
   });
 
-  it('confirms before cancelling and posts to the cancel endpoint', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Cancel' }));
+    expect(screen.getByRole('dialog', { name: 'Cancel workflow' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel workflow' }));
 
     await waitFor(() => {
       const cancelCall = fetchSpy.mock.calls.find(
@@ -112,14 +113,19 @@ describe('WorkflowRowActionsMenu', () => {
         graceful: true,
       });
     });
-    confirmSpy.mockRestore();
   });
 
-  it('posts a forced cancel request when force cancel is selected', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('requires typed confirmation before posting a forced cancel request', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Force cancel' }));
+    const confirmButton = screen.getByRole('button', { name: 'Force cancel workflow' }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText('Type FORCE CANCEL to confirm'), {
+      target: { value: 'FORCE CANCEL' },
+    });
+    expect(confirmButton.disabled).toBe(false);
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       const cancelCall = fetchSpy.mock.calls.find(([url, init]) => {
@@ -134,6 +140,5 @@ describe('WorkflowRowActionsMenu', () => {
         reason: 'Force canceled by operator from the dashboard.',
       });
     });
-    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { DashboardActionDialog } from './DashboardActionDialog';
 import { formatStatusLabel } from '../utils/formatters';
 import { navigateTo } from '../lib/navigation';
 import {
@@ -57,6 +58,14 @@ const RowActionsExecutionSchema = z
   .passthrough();
 
 type RowActionsExecution = z.infer<typeof RowActionsExecutionSchema>;
+type RowActionDialogKind =
+  | 'rename'
+  | 'resume-from-failed-step'
+  | 'bypass-dependencies'
+  | 'cancel'
+  | 'force-cancel'
+  | 'reject'
+  | 'send-message';
 
 const KEBAB_ICON = (
   <svg
@@ -93,6 +102,7 @@ export function WorkflowRowActionsMenu({
   const queryClient = useQueryClient();
   const [hasOpened, setHasOpened] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [activeDialog, setActiveDialog] = useState<RowActionDialogKind | null>(null);
 
   const detailQuery = useQuery({
     queryKey: ['workflow-row-actions-detail', workflowId],
@@ -300,9 +310,7 @@ export function WorkflowRowActionsMenu({
       handlers: {
         onRename: () => {
           setActionError(null);
-          const title = window.prompt('New workflow title', execution?.title || '');
-          if (title === null || !title.trim()) return;
-          updateMutation.mutate({ updateName: 'SetTitle', title: title.trim() });
+          setActiveDialog('rename');
         },
         onEditTask: () => {},
         onCompareRun: () => {},
@@ -331,10 +339,7 @@ export function WorkflowRowActionsMenu({
         },
         onResumeFromFailedStep: () => {
           setActionError(null);
-          if (!window.confirm('Resume from the failed step using the original workflow input snapshot?')) {
-            return;
-          }
-          failedStepResumeMutation.mutate();
+          setActiveDialog('resume-from-failed-step');
         },
         onRecoverFromSelectedStep: () => {},
         onPause: () => {
@@ -351,37 +356,23 @@ export function WorkflowRowActionsMenu({
         },
         onReject: () => {
           setActionError(null);
-          if (!window.confirm('Reject this workflow?')) return;
-          cancelMutation.mutate({ action: 'reject', graceful: true, reason: 'Rejected by operator.' });
+          setActiveDialog('reject');
         },
         onCancel: () => {
           setActionError(null);
-          if (!window.confirm('Cancel this workflow?')) return;
-          cancelMutation.mutate({ action: 'cancel', graceful: true });
+          setActiveDialog('cancel');
         },
         onForceCancel: () => {
           setActionError(null);
-          if (!window.confirm('Force cancel this workflow? This terminates the Temporal workflow immediately.')) return;
-          cancelMutation.mutate({
-            action: 'cancel',
-            graceful: false,
-            reason: 'Force canceled by operator from the dashboard.',
-          });
+          setActiveDialog('force-cancel');
         },
         onSendMessage: () => {
           setActionError(null);
-          const message = window.prompt('Operator message', '');
-          if (message?.trim()) {
-            signalMutation.mutate({ signalName: 'SendMessage', payload: { message: message.trim() } });
-          }
+          setActiveDialog('send-message');
         },
         onBypassDependencies: () => {
           setActionError(null);
-          if (!window.confirm('Bypass dependency waiting for this workflow?')) return;
-          signalMutation.mutate({
-            signalName: 'BypassDependencies',
-            payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
-          });
+          setActiveDialog('bypass-dependencies');
         },
         onCreateRemediation: () => {
           setActionError(null);
@@ -415,6 +406,61 @@ export function WorkflowRowActionsMenu({
     : detailQuery.isError
       ? 'Unable to load workflow actions.'
       : 'No workflow actions are currently available.';
+  const subject = execution?.title?.trim() || workflowId;
+  const closeDialog = () => {
+    setActiveDialog(null);
+    setActionError(null);
+  };
+  const confirmDialog = (value: string) => {
+    const closeOnSuccess = { onSuccess: () => setActiveDialog(null) };
+    switch (activeDialog) {
+      case 'rename':
+        updateMutation.mutate({ updateName: 'SetTitle', title: value }, closeOnSuccess);
+        break;
+      case 'resume-from-failed-step':
+        failedStepResumeMutation.mutate(undefined, closeOnSuccess);
+        break;
+      case 'bypass-dependencies':
+        signalMutation.mutate(
+          {
+            signalName: 'BypassDependencies',
+            payload: { reason: value || 'Dependency wait bypassed by operator from the dashboard.' },
+          },
+          closeOnSuccess,
+        );
+        break;
+      case 'cancel':
+        cancelMutation.mutate(
+          { action: 'cancel', graceful: true, ...(value ? { reason: value } : {}) },
+          closeOnSuccess,
+        );
+        break;
+      case 'force-cancel':
+        cancelMutation.mutate(
+          {
+            action: 'cancel',
+            graceful: false,
+            reason: value || 'Force canceled by operator from the dashboard.',
+          },
+          closeOnSuccess,
+        );
+        break;
+      case 'reject':
+        cancelMutation.mutate(
+          { action: 'reject', graceful: true, reason: value || 'Rejected by operator.' },
+          closeOnSuccess,
+        );
+        break;
+      case 'send-message':
+        signalMutation.mutate(
+          { signalName: 'SendMessage', payload: { message: value } },
+          closeOnSuccess,
+        );
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <div className="workflow-row-actions">
@@ -428,6 +474,116 @@ export function WorkflowRowActionsMenu({
         onOpenChange={(open) => {
           if (open) setHasOpened(true);
         }}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'rename'}
+        title="Rename workflow"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Set a dashboard title for this workflow. Execution history, artifacts, and workflow identity stay unchanged."
+        valueLabel="Workflow title"
+        valueRequired
+        initialValue={execution?.title || ''}
+        confirmLabel={updateMutation.isPending ? 'Renaming' : 'Rename workflow'}
+        disabledReason={disabledReason('canSetTitle')}
+        error={activeDialog === 'rename' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'resume-from-failed-step'}
+        title="Resume from failed step"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Resume from the failed step using the original workflow input snapshot."
+        confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
+        disabledReason={disabledReason('canResumeFromFailedStep')}
+        error={activeDialog === 'resume-from-failed-step' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'bypass-dependencies'}
+        title="Bypass dependencies"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Bypass dependency waiting for this workflow. Downstream work may proceed before prerequisites finish."
+        valueLabel="Reason"
+        valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
+        valueMultiline
+        confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
+        danger
+        disabledReason={disabledReason('canBypassDependencies')}
+        error={activeDialog === 'bypass-dependencies' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'cancel'}
+        title="Cancel workflow"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Request a graceful workflow cancellation. Running work may stop at the next cancellation boundary."
+        valueLabel="Reason"
+        valuePlaceholder="Optional operator reason"
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
+        danger
+        disabledReason={disabledReason('canCancel')}
+        error={activeDialog === 'cancel' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'force-cancel'}
+        title="Force cancel workflow"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Terminate the Temporal workflow immediately. This is a high-risk operator action and may skip graceful cleanup."
+        valueLabel="Reason"
+        valuePlaceholder="Force canceled by operator from the dashboard."
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
+        danger
+        destructive
+        confirmationText="FORCE CANCEL"
+        disabledReason={disabledReason('canCancel')}
+        error={activeDialog === 'force-cancel' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'reject'}
+        title="Reject workflow"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Reject the workflow and record an operator rejection outcome."
+        valueLabel="Reason"
+        valuePlaceholder="Rejected by operator."
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
+        danger
+        destructive
+        confirmationText="REJECT"
+        disabledReason={disabledReason('canReject')}
+        error={activeDialog === 'reject' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
+      />
+      <DashboardActionDialog
+        open={activeDialog === 'send-message'}
+        title="Send operator message"
+        subject={subject}
+        compactId={workflowId}
+        consequence="Send a message into the workflow's operator intervention channel."
+        valueLabel="Message"
+        valueRequired
+        valueMultiline
+        confirmLabel={signalMutation.isPending ? 'Sending' : 'Send message'}
+        disabledReason={disabledReason('canSendMessage')}
+        error={activeDialog === 'send-message' ? actionError : null}
+        onCancel={closeDialog}
+        onConfirm={confirmDialog}
       />
       {actionError ? (
         <p className="workflow-row-actions-error" role="alert">

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -485,6 +485,7 @@ export function WorkflowRowActionsMenu({
         valueRequired
         initialValue={execution?.title || ''}
         confirmLabel={updateMutation.isPending ? 'Renaming' : 'Rename workflow'}
+        confirmPending={updateMutation.isPending}
         disabledReason={disabledReason('canSetTitle')}
         error={activeDialog === 'rename' ? actionError : null}
         onCancel={closeDialog}
@@ -497,6 +498,7 @@ export function WorkflowRowActionsMenu({
         compactId={workflowId}
         consequence="Resume from the failed step using the original workflow input snapshot."
         confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
+        confirmPending={failedStepResumeMutation.isPending}
         disabledReason={disabledReason('canResumeFromFailedStep')}
         error={activeDialog === 'resume-from-failed-step' ? actionError : null}
         onCancel={closeDialog}
@@ -512,6 +514,7 @@ export function WorkflowRowActionsMenu({
         valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
         valueMultiline
         confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
+        confirmPending={signalMutation.isPending}
         danger
         disabledReason={disabledReason('canBypassDependencies')}
         error={activeDialog === 'bypass-dependencies' ? actionError : null}
@@ -528,6 +531,7 @@ export function WorkflowRowActionsMenu({
         valuePlaceholder="Optional operator reason"
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         disabledReason={disabledReason('canCancel')}
         error={activeDialog === 'cancel' ? actionError : null}
@@ -544,6 +548,7 @@ export function WorkflowRowActionsMenu({
         valuePlaceholder="Force canceled by operator from the dashboard."
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         destructive
         confirmationText="FORCE CANCEL"
@@ -562,6 +567,7 @@ export function WorkflowRowActionsMenu({
         valuePlaceholder="Rejected by operator."
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         destructive
         confirmationText="REJECT"
@@ -580,6 +586,7 @@ export function WorkflowRowActionsMenu({
         valueRequired
         valueMultiline
         confirmLabel={signalMutation.isPending ? 'Sending' : 'Send message'}
+        confirmPending={signalMutation.isPending}
         disabledReason={disabledReason('canSendMessage')}
         error={activeDialog === 'send-message' ? actionError : null}
         onCancel={closeDialog}

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 
 import type { BootPayload } from "../boot/parseBootPayload";
 import { renderWithClient } from "../utils/test-utils";
@@ -427,7 +427,6 @@ describe("SchedulesPage", () => {
   });
 
   it("allows personal schedule owners to delete when the delete contract is available", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     mockScheduleDetailFetch(fetchSpy, {
       permissions: {
         canEdit: true,
@@ -451,6 +450,15 @@ describe("SchedulesPage", () => {
     const deleteButton = screen.getByRole("button", { name: "Delete schedule" }) as HTMLButtonElement;
     expect(deleteButton.disabled).toBe(false);
     fireEvent.click(deleteButton);
+    const dialog = screen.getByRole("dialog", { name: "Delete schedule" });
+    expect(dialog).not.toBeNull();
+    const confirmButton = within(dialog).getByRole("button", { name: "Delete schedule" }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText("Type DELETE to confirm"), {
+      target: { value: "DELETE" },
+    });
+    expect(confirmButton.disabled).toBe(false);
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(
@@ -460,8 +468,6 @@ describe("SchedulesPage", () => {
         )),
       ).toBe(true);
     });
-
-    confirmSpy.mockRestore();
   });
 
   it("explains missing delete permission when the delete contract is available", async () => {

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { DataTable } from '../components/tables/DataTable';
+import { DashboardActionDialog } from '../components/DashboardActionDialog';
 
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
@@ -593,6 +594,7 @@ function isDueSoon(schedule: Schedule, now: number): boolean {
 function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; definitionId: string }) {
   const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
   const [submitErrors, setSubmitErrors] = useState<ScheduleEditErrors>({});
   const isEditingRef = useRef(false);
@@ -819,11 +821,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
             <button
               type="button"
               className="secondary"
-              onClick={() => {
-                if (window.confirm('Delete this recurring schedule? Future runs will stop, but prior workflow executions and artifacts remain available.')) {
-                  deleteMutation.mutate();
-                }
-              }}
+              onClick={() => setDeleteDialogOpen(true)}
               disabled={deleteMutation.isPending}
             >
               {deleteMutation.isPending ? 'Deleting' : 'Delete schedule'}
@@ -842,6 +840,22 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
           </button>
         </div>
       </header>
+
+      <DashboardActionDialog
+        open={deleteDialogOpen}
+        title="Delete schedule"
+        subject={schedule.name}
+        compactId={definitionId}
+        consequence="Delete this recurring schedule. Future runs will stop, but prior workflow executions and artifacts remain available."
+        confirmLabel={deleteMutation.isPending ? 'Deleting' : 'Delete schedule'}
+        danger
+        destructive
+        confirmationText="DELETE"
+        disabledReason={actions?.canDelete ? null : actions?.deleteReason}
+        error={deleteMutation.isError ? errorMessage(deleteMutation.error, 'Failed to delete schedule') : null}
+        onCancel={() => setDeleteDialogOpen(false)}
+        onConfirm={() => deleteMutation.mutate()}
+      />
 
       {actions && (!actions.canEdit || !actions.canRun || (actions.deleteContractAvailable && !actions.canDelete)) ? (
         <div className="schedules-error" role="note">

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -848,6 +848,7 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         compactId={definitionId}
         consequence="Delete this recurring schedule. Future runs will stop, but prior workflow executions and artifacts remain available."
         confirmLabel={deleteMutation.isPending ? 'Deleting' : 'Delete schedule'}
+        confirmPending={deleteMutation.isPending}
         danger
         destructive
         confirmationText="DELETE"

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -325,6 +325,16 @@ describe('Workflow Detail Entrypoint', () => {
     return screen.getByRole('menu', { name: 'Workflow actions' });
   }
 
+  function confirmWorkflowDialog(name: string) {
+    fireEvent.click(screen.getByRole('button', { name }));
+  }
+
+  function typeWorkflowConfirmation(text: string) {
+    fireEvent.change(screen.getByLabelText(`Type ${text} to confirm`), {
+      target: { value: text },
+    });
+  }
+
   function mockWorkflowDetailSubrouteFetch() {
     const mockExecution = {
       taskId: 'test-123',
@@ -2721,8 +2731,6 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('routes menu selections through existing handlers and preserves destructive confirmations', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Updated title');
     const mockExecution = {
       taskId: 'test-123',
       workflowId: 'test-123',
@@ -2760,6 +2768,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Workflow actions' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    fireEvent.change(screen.getByLabelText('Workflow title'), {
+      target: { value: 'Updated title' },
+    });
+    confirmWorkflowDialog('Rename workflow');
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
         '/api/executions/test-123/update',
@@ -2784,12 +2796,10 @@ describe('Workflow Detail Entrypoint', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Workflow actions' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Cancel' }));
-    expect(confirmSpy).toHaveBeenCalledWith('Cancel this workflow?');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(
       fetchSpy.mock.calls.some(([url, init]) => String(url).includes('/cancel') && init?.method === 'POST'),
     ).toBe(false);
-    promptSpy.mockRestore();
-    confirmSpy.mockRestore();
   });
 
   it('dismisses the Workflow actions menu without side effects and supports keyboard selection', async () => {
@@ -3063,13 +3073,15 @@ describe('Workflow Detail Entrypoint', () => {
       }
       return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
     });
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Renamed task');
-
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
     let menu = await openWorkflowActionsMenu();
     expect(within(menu).getByRole('menuitem', { name: 'Rerun' })).toBeTruthy();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Rename' }));
+    fireEvent.change(screen.getByLabelText('Workflow title'), {
+      target: { value: 'Renamed task' },
+    });
+    confirmWorkflowDialog('Rename workflow');
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.some(([input]) => String(input).includes('/update'))).toBe(true);
@@ -3082,7 +3094,6 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.click(rerunItem);
     const updateCalls = fetchSpy.mock.calls.filter(([input]) => String(input).includes('/update'));
     expect(updateCalls).toHaveLength(1);
-    promptSpy.mockRestore();
   });
 
   it('shows failed workflow Edit task and Rerun entry points when capabilities allow them', async () => {
@@ -3254,7 +3265,6 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('renders failed-step Resume separately from lifecycle Resume and submits the resume command', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     const actionPayload: BootPayload = {
       ...mockPayload,
       initialData: {
@@ -3327,6 +3337,7 @@ describe('Workflow Detail Entrypoint', () => {
     const resumeButton = within(menu).getByRole('menuitem', { name: 'Resume from failed step' });
     expect(screen.queryByRole('button', { name: 'Resume' })).toBeNull();
     fireEvent.click(resumeButton);
+    confirmWorkflowDialog('Resume workflow');
 
     await waitFor(() => {
       expect(calls.some((call) => call.url.includes('/recover-from-failed-step'))).toBe(true);
@@ -3335,11 +3346,9 @@ describe('Workflow Detail Entrypoint', () => {
     expect(JSON.parse(String(resumeCall?.init?.body || '{}')).recoveryCheckpointRef).toBe(
       'artifact://checkpoint/source',
     );
-    confirmSpy.mockRestore();
   });
 
   it('submits selected-step recovery with pinned source identity', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     const actionPayload: BootPayload = {
       ...mockPayload,
       initialData: {
@@ -3465,6 +3474,7 @@ describe('Workflow Detail Entrypoint', () => {
     ).toBe(true);
     const menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Recover from selected step' }));
+    confirmWorkflowDialog('Recover workflow');
 
     await waitFor(() => {
       expect(calls.some((call) => call.url.includes('/recover-from-selected-step'))).toBe(true);
@@ -3477,7 +3487,6 @@ describe('Workflow Detail Entrypoint', () => {
       selectedStartStepId: 'plan',
       recoveryCheckpointRef: 'artifact://checkpoint/source',
     });
-    confirmSpy.mockRestore();
   });
 
   it('omits Temporal task editing entry points when the flag is off', async () => {
@@ -5131,7 +5140,6 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('signals a manual dependency wait bypass from the dependency panel', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     const signalBodies: unknown[] = [];
     const mockExecution = {
       taskId: 'mm:dependent-1',
@@ -5197,9 +5205,9 @@ describe('Workflow Detail Entrypoint', () => {
 
     const menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Bypass Dependencies' }));
+    confirmWorkflowDialog('Bypass dependencies');
 
     await waitFor(() => {
-      expect(confirmSpy).toHaveBeenCalledWith('Bypass dependency waiting for this workflow?');
       expect(signalBodies).toEqual([
         {
           signalName: 'BypassDependencies',
@@ -6105,8 +6113,6 @@ describe('Workflow Detail Entrypoint', () => {
       interventionAudit: [],
     };
 
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
@@ -6143,9 +6149,12 @@ describe('Workflow Detail Entrypoint', () => {
 
     renderWithClient(<WorkflowDetailPage payload={actionPayload} />);
 
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Please use Provider Profiles.');
     let menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Send Message' }));
+    fireEvent.change(screen.getByLabelText('Message'), {
+      target: { value: 'Please use Provider Profiles.' },
+    });
+    confirmWorkflowDialog('Send message');
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -6162,6 +6171,8 @@ describe('Workflow Detail Entrypoint', () => {
 
     menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Reject' }));
+    typeWorkflowConfirmation('REJECT');
+    confirmWorkflowDialog('Reject workflow');
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -6176,9 +6187,6 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
-    promptSpy.mockRestore();
-
-    confirmSpy.mockRestore();
   });
 
   it('does not show the obsolete dependency wait skip action in the Intervention panel', async () => {
@@ -6571,8 +6579,6 @@ describe('Workflow Detail Entrypoint', () => {
       },
     };
 
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/cancel')) {
@@ -6618,6 +6624,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel Execution' }));
+    confirmWorkflowDialog('Cancel workflow');
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -6631,8 +6638,6 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
-
-    confirmSpy.mockRestore();
   });
 
   it('keeps polling session continuity until a projection or terminal state exists', () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5,6 +5,7 @@ import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
+import { DashboardActionDialog } from '../components/DashboardActionDialog';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge';
 import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
@@ -108,6 +109,15 @@ function shouldUseStructuredHistory(config: DashboardConfig | undefined): boolea
 }
 
 type WorkflowDetailSubroute = 'overview' | 'steps' | 'artifacts' | 'runs' | 'debug';
+type WorkflowDialogKind =
+  | 'rename'
+  | 'resume-from-failed-step'
+  | 'recover-from-selected-step'
+  | 'bypass-dependencies'
+  | 'cancel'
+  | 'force-cancel'
+  | 'reject'
+  | 'send-message';
 
 function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
   const match = pathname.match(/^\/workflows\/[^/]+(?:\/(steps|artifacts|runs|debug))?$/);
@@ -4907,6 +4917,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   const sourceTemporal = search.get('source') === 'temporal';
 
   const [actionError, setActionError] = useState<string | null>(null);
+  const [activeWorkflowDialog, setActiveWorkflowDialog] = useState<WorkflowDialogKind | null>(null);
   const [actionNotice, setActionNotice] = useState<string | null>(() => {
     try {
       const message = window.sessionStorage.getItem(
@@ -5394,9 +5405,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onRename = () => {
     setActionError(null);
-    const title = window.prompt('New workflow title', execution?.title || '');
-    if (title === null || !title.trim()) return;
-    updateMutation.mutate({ updateName: 'SetTitle', title: title.trim() });
+    setActiveWorkflowDialog('rename');
   };
 
   const onPause = () => {
@@ -5411,15 +5420,12 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onResumeFromFailedStep = () => {
     setActionError(null);
-    if (!window.confirm('Resume from the failed step using the original workflow input snapshot?')) return;
-    failedStepResumeMutation.mutate();
+    setActiveWorkflowDialog('resume-from-failed-step');
   };
 
   const onRecoverFromSelectedStep = () => {
     setActionError(null);
-    const label = selectedRecoveryStep?.title || selectedRecoveryStep?.logicalStepId || 'the selected step';
-    if (!window.confirm(`Recover from ${label} using checkpoint evidence from the source run?`)) return;
-    selectedStepRecoveryMutation.mutate();
+    setActiveWorkflowDialog('recover-from-selected-step');
   };
 
   const onApprove = () => {
@@ -5434,37 +5440,22 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onBypassDependencies = () => {
     setActionError(null);
-    if (!window.confirm('Bypass dependency waiting for this workflow?')) return;
-    signalMutation.mutate({
-      signalName: 'BypassDependencies',
-      payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
-    });
+    setActiveWorkflowDialog('bypass-dependencies');
   };
 
   const onCancel = () => {
     setActionError(null);
-    if (!window.confirm('Cancel this workflow?')) return;
-    cancelMutation.mutate({ action: 'cancel', graceful: true });
+    setActiveWorkflowDialog('cancel');
   };
 
   const onForceCancel = () => {
     setActionError(null);
-    if (!window.confirm('Force cancel this workflow? This terminates the Temporal workflow immediately.')) return;
-    cancelMutation.mutate({
-      action: 'cancel',
-      graceful: false,
-      reason: 'Force canceled by operator from the dashboard.',
-    });
+    setActiveWorkflowDialog('force-cancel');
   };
 
   const onReject = () => {
     setActionError(null);
-    if (!window.confirm('Reject this workflow?')) return;
-    cancelMutation.mutate({
-      action: 'reject',
-      graceful: true,
-      reason: 'Rejected by operator.',
-    });
+    setActiveWorkflowDialog('reject');
   };
 
   const actions = execution?.actions;
@@ -5599,8 +5590,8 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       onCancel,
       onForceCancel,
       onSendMessage: () => {
-        const message = window.prompt('Operator message', '');
-        if (message?.trim()) onSendMessage(message.trim());
+        setActionError(null);
+        setActiveWorkflowDialog('send-message');
       },
       onBypassDependencies,
       onCreateRemediation: () => {
@@ -5614,6 +5605,68 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       ...prev,
       [logicalStepId]: !prev[logicalStepId],
     }));
+  };
+  const workflowDialogSubject = execution?.title?.trim() || taskId || 'Workflow';
+  const workflowDialogId = taskId || workflowId || '';
+  const selectedRecoveryStepLabel =
+    selectedRecoveryStep?.title || selectedRecoveryStep?.logicalStepId || 'the selected step';
+  const closeWorkflowDialog = () => {
+    setActiveWorkflowDialog(null);
+    setActionError(null);
+  };
+  const confirmWorkflowDialog = (value: string) => {
+    const closeOnSuccess = { onSuccess: () => setActiveWorkflowDialog(null) };
+    switch (activeWorkflowDialog) {
+      case 'rename':
+        updateMutation.mutate(
+          { updateName: 'SetTitle', title: value },
+          closeOnSuccess,
+        );
+        break;
+      case 'resume-from-failed-step':
+        failedStepResumeMutation.mutate(undefined, closeOnSuccess);
+        break;
+      case 'recover-from-selected-step':
+        selectedStepRecoveryMutation.mutate(undefined, closeOnSuccess);
+        break;
+      case 'bypass-dependencies':
+        signalMutation.mutate(
+          {
+            signalName: 'BypassDependencies',
+            payload: { reason: value || 'Dependency wait bypassed by operator from the dashboard.' },
+          },
+          closeOnSuccess,
+        );
+        break;
+      case 'cancel':
+        cancelMutation.mutate(
+          { action: 'cancel', graceful: true, ...(value ? { reason: value } : {}) },
+          closeOnSuccess,
+        );
+        break;
+      case 'force-cancel':
+        cancelMutation.mutate(
+          {
+            action: 'cancel',
+            graceful: false,
+            reason: value || 'Force canceled by operator from the dashboard.',
+          },
+          closeOnSuccess,
+        );
+        break;
+      case 'reject':
+        cancelMutation.mutate(
+          { action: 'reject', graceful: true, reason: value || 'Rejected by operator.' },
+          closeOnSuccess,
+        );
+        break;
+      case 'send-message':
+        onSendMessage(value);
+        setActiveWorkflowDialog(null);
+        break;
+      default:
+        break;
+    }
   };
   const primaryReport = latestReportQuery.data?.artifacts[0] ?? null;
   const relatedReports = relatedReportArtifacts(artifactsQuery.data?.artifacts || []);
@@ -5679,6 +5732,135 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           <WorkflowActionsMenu items={workflowActionMenuItems} />
         </section>
       ) : null}
+
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'rename'}
+        title="Rename workflow"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Set a dashboard title for this workflow. Execution history, artifacts, and workflow identity stay unchanged."
+        valueLabel="Workflow title"
+        valueRequired
+        initialValue={execution?.title || ''}
+        confirmLabel={updateMutation.isPending ? 'Renaming' : 'Rename workflow'}
+        disabledReason={actionDisabledReason('canSetTitle')}
+        error={activeWorkflowDialog === 'rename' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'resume-from-failed-step'}
+        title="Resume from failed step"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Resume from the failed step using the original workflow input snapshot."
+        confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
+        disabledReason={actionDisabledReason('canResumeFromFailedStep')}
+        error={activeWorkflowDialog === 'resume-from-failed-step' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'recover-from-selected-step'}
+        title="Recover from selected step"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence={`Recover from ${selectedRecoveryStepLabel} using checkpoint evidence from the source run.`}
+        confirmLabel={selectedStepRecoveryMutation.isPending ? 'Recovering' : 'Recover workflow'}
+        disabledReason={
+          selectedRecoveryStep?.eligible
+            ? null
+            : selectedRecoveryStep?.reason
+              ? formatStatusLabel(selectedRecoveryStep.reason)
+              : 'selected step is not eligible'
+        }
+        error={activeWorkflowDialog === 'recover-from-selected-step' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'bypass-dependencies'}
+        title="Bypass dependencies"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Bypass dependency waiting for this workflow. Downstream work may proceed before prerequisites finish."
+        valueLabel="Reason"
+        valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
+        valueMultiline
+        confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
+        danger
+        disabledReason={actionDisabledReason('canBypassDependencies')}
+        error={activeWorkflowDialog === 'bypass-dependencies' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'cancel'}
+        title="Cancel workflow"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Request a graceful workflow cancellation. Running work may stop at the next cancellation boundary."
+        valueLabel="Reason"
+        valuePlaceholder="Optional operator reason"
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
+        danger
+        disabledReason={actionDisabledReason('canCancel')}
+        error={activeWorkflowDialog === 'cancel' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'force-cancel'}
+        title="Force cancel workflow"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Terminate the Temporal workflow immediately. This is a high-risk operator action and may skip graceful cleanup."
+        valueLabel="Reason"
+        valuePlaceholder="Force canceled by operator from the dashboard."
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
+        danger
+        destructive
+        confirmationText="FORCE CANCEL"
+        disabledReason={actionDisabledReason('canCancel')}
+        error={activeWorkflowDialog === 'force-cancel' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'reject'}
+        title="Reject workflow"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Reject the workflow and record an operator rejection outcome."
+        valueLabel="Reason"
+        valuePlaceholder="Rejected by operator."
+        valueMultiline
+        confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
+        danger
+        destructive
+        confirmationText="REJECT"
+        disabledReason={actionDisabledReason('canReject')}
+        error={activeWorkflowDialog === 'reject' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
+      <DashboardActionDialog
+        open={activeWorkflowDialog === 'send-message'}
+        title="Send operator message"
+        subject={workflowDialogSubject}
+        compactId={workflowDialogId}
+        consequence="Send a message into the workflow's operator intervention channel."
+        valueLabel="Message"
+        valueRequired
+        valueMultiline
+        confirmLabel={signalMutation.isPending ? 'Sending' : 'Send message'}
+        disabledReason={actionDisabledReason('canSendMessage')}
+        error={activeWorkflowDialog === 'send-message' ? actionError : null}
+        onCancel={closeWorkflowDialog}
+        onConfirm={confirmWorkflowDialog}
+      />
 
       {actionError ? <div className="notice error">{actionError}</div> : null}
       {actionNotice ? (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5433,11 +5433,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     signalMutation.mutate({ signalName: 'Approve', payload: {} });
   };
 
-  const onSendMessage = (message: string) => {
-    setActionError(null);
-    signalMutation.mutate({ signalName: 'SendMessage', payload: { message } });
-  };
-
   const onBypassDependencies = () => {
     setActionError(null);
     setActiveWorkflowDialog('bypass-dependencies');
@@ -5661,8 +5656,10 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         );
         break;
       case 'send-message':
-        onSendMessage(value);
-        setActiveWorkflowDialog(null);
+        signalMutation.mutate(
+          { signalName: 'SendMessage', payload: { message: value } },
+          closeOnSuccess,
+        );
         break;
       default:
         break;
@@ -5743,6 +5740,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valueRequired
         initialValue={execution?.title || ''}
         confirmLabel={updateMutation.isPending ? 'Renaming' : 'Rename workflow'}
+        confirmPending={updateMutation.isPending}
         disabledReason={actionDisabledReason('canSetTitle')}
         error={activeWorkflowDialog === 'rename' ? actionError : null}
         onCancel={closeWorkflowDialog}
@@ -5755,6 +5753,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         compactId={workflowDialogId}
         consequence="Resume from the failed step using the original workflow input snapshot."
         confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
+        confirmPending={failedStepResumeMutation.isPending}
         disabledReason={actionDisabledReason('canResumeFromFailedStep')}
         error={activeWorkflowDialog === 'resume-from-failed-step' ? actionError : null}
         onCancel={closeWorkflowDialog}
@@ -5767,6 +5766,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         compactId={workflowDialogId}
         consequence={`Recover from ${selectedRecoveryStepLabel} using checkpoint evidence from the source run.`}
         confirmLabel={selectedStepRecoveryMutation.isPending ? 'Recovering' : 'Recover workflow'}
+        confirmPending={selectedStepRecoveryMutation.isPending}
         disabledReason={
           selectedRecoveryStep?.eligible
             ? null
@@ -5788,6 +5788,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
         valueMultiline
         confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
+        confirmPending={signalMutation.isPending}
         danger
         disabledReason={actionDisabledReason('canBypassDependencies')}
         error={activeWorkflowDialog === 'bypass-dependencies' ? actionError : null}
@@ -5804,6 +5805,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valuePlaceholder="Optional operator reason"
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         disabledReason={actionDisabledReason('canCancel')}
         error={activeWorkflowDialog === 'cancel' ? actionError : null}
@@ -5820,6 +5822,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valuePlaceholder="Force canceled by operator from the dashboard."
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         destructive
         confirmationText="FORCE CANCEL"
@@ -5838,6 +5841,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valuePlaceholder="Rejected by operator."
         valueMultiline
         confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
+        confirmPending={cancelMutation.isPending}
         danger
         destructive
         confirmationText="REJECT"
@@ -5856,6 +5860,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         valueRequired
         valueMultiline
         confirmLabel={signalMutation.isPending ? 'Sending' : 'Send message'}
+        confirmPending={signalMutation.isPending}
         disabledReason={actionDisabledReason('canSendMessage')}
         error={activeWorkflowDialog === 'send-message' ? actionError : null}
         onCancel={closeWorkflowDialog}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -3120,6 +3120,125 @@ tr[data-proposal-id].proposal-consuming td {
   color: rgb(var(--mm-warn));
 }
 
+.dashboard-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgb(15 23 42 / 0.52);
+}
+
+.dashboard-dialog {
+  width: min(34rem, 100%);
+  max-height: min(42rem, calc(100vh - 2rem));
+  overflow: auto;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  background: rgb(var(--mm-panel));
+  color: rgb(var(--mm-ink));
+  box-shadow: 0 24px 70px -34px rgb(0 0 0 / 0.72);
+}
+
+.dashboard-dialog form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+}
+
+.dashboard-dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dashboard-dialog-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+
+.dashboard-dialog-subject {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0.3rem 0 0;
+  color: rgb(var(--mm-muted));
+  font-size: 0.82rem;
+}
+
+.dashboard-dialog-subject code {
+  max-width: 16rem;
+  overflow-wrap: anywhere;
+  border-radius: 0.35rem;
+  padding: 0.1rem 0.28rem;
+  background: rgb(var(--mm-ink) / 0.06);
+  color: rgb(var(--mm-ink));
+  font-size: 0.76rem;
+}
+
+.dashboard-dialog-close {
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.45rem;
+}
+
+.dashboard-dialog-consequence {
+  color: rgb(var(--mm-ink));
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.dashboard-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.dashboard-dialog-field input,
+.dashboard-dialog-field textarea {
+  width: 100%;
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.45rem;
+  padding: 0.56rem 0.62rem;
+  background: rgb(var(--mm-bg));
+  color: rgb(var(--mm-ink));
+  font: inherit;
+  font-weight: 500;
+}
+
+.dashboard-dialog-field textarea {
+  resize: vertical;
+  min-height: 5.5rem;
+}
+
+.dashboard-dialog-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.dashboard-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+}
+
+.dashboard-dialog-danger {
+  background: rgb(var(--mm-danger));
+}
+
 .proposal-action-feedback {
   min-height: 3.2rem;
 }


### PR DESCRIPTION
Issue: MM-958

Summary:
- Added a reusable dashboard action dialog with focus management, inline error display, optional reason input, disabled-state messaging, diagnostics copy support, and typed confirmation for destructive actions.
- Replaced workflow detail, workflow row action, and schedule delete browser confirm/prompt flows with dashboard-native dialogs.
- Added and updated frontend tests for dialog open/close behavior, confirm and cancel mutation behavior, typed confirmation, and focus restoration.

Tests run:
- Passed: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/DashboardActionDialog.test.tsx frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/schedules.test.tsx` from `/tmp/mmrepo-mm958-worktree` with 4 files and 163 tests passing.
- Attempted: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args ...`; blocked before frontend tests because this container is missing the Python `pytest` module.

Remaining risks:
- Verification was limited to focused frontend tests because the unified unit runner could not start Python tests in this container.
- Backend action APIs and action availability logic were intentionally left unchanged per scope.
