### PR TITLE
MM-959: Extract shared dashboard primitives (DataTable, LogPanel, Notice/ErrorDetails, surfaces)

### DIFF
--- a/frontend/src/components/dashboard/DashboardErrorDetails.test.tsx
+++ b/frontend/src/components/dashboard/DashboardErrorDetails.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { DashboardErrorDetails } from './DashboardErrorDetails';
+
+describe('DashboardErrorDetails (MM-959)', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces the friendly message in the foreground', () => {
+    render(<DashboardErrorDetails message="Couldn't reach the service." endpoint="https://api/start" />);
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain("Couldn't reach the service.");
+  });
+
+  it('keeps endpoint/status/request id behind a technical disclosure', () => {
+    render(
+      <DashboardErrorDetails
+        message="Couldn't reach the service."
+        endpoint="https://api/start"
+        status={503}
+        requestId="req-42"
+        rawError="TypeError: Failed to fetch"
+      />,
+    );
+    const summary = screen.getByText('Technical details');
+    expect(summary).toBeTruthy();
+    // The endpoint is not part of the main message text.
+    const message = screen.getByText("Couldn't reach the service.");
+    expect(message.textContent).not.toContain('https://api/start');
+    // Disclosure body exposes the technical fields.
+    expect(screen.getByText('https://api/start')).toBeTruthy();
+    expect(screen.getByText('req-42')).toBeTruthy();
+    expect(screen.getByText('503')).toBeTruthy();
+  });
+
+  it('copies aggregated diagnostics on demand', async () => {
+    render(
+      <DashboardErrorDetails
+        message="Couldn't reach the service."
+        endpoint="https://api/start"
+        rawError="TypeError: Failed to fetch"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0]![0] as string;
+    expect(copied).toContain('Endpoint: https://api/start');
+    expect(copied).toContain('Raw error: TypeError: Failed to fetch');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy());
+  });
+
+  it('omits the disclosure when there is no technical detail', () => {
+    render(<DashboardErrorDetails message="Something went wrong." />);
+    expect(screen.queryByText('Technical details')).toBeNull();
+  });
+});

--- a/frontend/src/components/dashboard/DashboardErrorDetails.tsx
+++ b/frontend/src/components/dashboard/DashboardErrorDetails.tsx
@@ -1,0 +1,163 @@
+import { useId, useState, type ReactNode } from 'react';
+import { copyTextToClipboard } from '../../utils/clipboard';
+
+/**
+ * Friendly error surface with collapsible technical disclosure (MM-959).
+ *
+ * Surfaces a human-readable message in the foreground and tucks raw API /
+ * network diagnostics (endpoint, status, request id, raw error) behind a
+ * disclosure with a copy-diagnostics affordance. Pages should use this instead
+ * of dumping endpoint URLs and stack traces directly into the main error text.
+ */
+export interface DashboardErrorDetailsProps {
+  /** Human-readable, non-technical summary of what went wrong. */
+  message: ReactNode;
+  endpoint?: string | null | undefined;
+  status?: number | string | null | undefined;
+  requestId?: string | null | undefined;
+  /** Raw error / diagnostics text shown inside the disclosure. */
+  rawError?: string | null | undefined;
+  detailsLabel?: string;
+  copyLabel?: string;
+  className?: string;
+  actions?: ReactNode;
+}
+
+function buildDiagnosticsText({
+  message,
+  endpoint,
+  status,
+  requestId,
+  rawError,
+}: {
+  message: ReactNode;
+  endpoint?: string | null | undefined;
+  status?: number | string | null | undefined;
+  requestId?: string | null | undefined;
+  rawError?: string | null | undefined;
+}): string {
+  const lines: string[] = [];
+  if (typeof message === 'string') {
+    lines.push(`Message: ${message}`);
+  }
+  if (endpoint) {
+    lines.push(`Endpoint: ${endpoint}`);
+  }
+  if (status !== null && status !== undefined && status !== '') {
+    lines.push(`Status: ${status}`);
+  }
+  if (requestId) {
+    lines.push(`Request ID: ${requestId}`);
+  }
+  if (rawError) {
+    lines.push(`Raw error: ${rawError}`);
+  }
+  return lines.join('\n');
+}
+
+export function DashboardErrorDetails({
+  message,
+  endpoint,
+  status,
+  requestId,
+  rawError,
+  detailsLabel = 'Technical details',
+  copyLabel = 'Copy diagnostics',
+  className,
+  actions,
+}: DashboardErrorDetailsProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const detailsId = useId();
+
+  const hasTechnicalDetail = Boolean(
+    endpoint ||
+      (status !== null && status !== undefined && status !== '') ||
+      requestId ||
+      rawError,
+  );
+
+  const diagnosticsText = buildDiagnosticsText({
+    message,
+    endpoint,
+    status,
+    requestId,
+    rawError,
+  });
+
+  const handleCopy = async () => {
+    const ok = await copyTextToClipboard(diagnosticsText);
+    if (ok) {
+      setCopied(true);
+    }
+  };
+
+  const classes = ['dashboard-error-details'];
+  if (className) {
+    classes.push(className);
+  }
+
+  return (
+    <div className={classes.join(' ')} role="alert" aria-live="assertive">
+      <p className="dashboard-error-details__message">{message}</p>
+      {hasTechnicalDetail ? (
+        <details
+          className="dashboard-error-details__disclosure"
+          open={open}
+          onToggle={(event) =>
+            setOpen((event.target as HTMLDetailsElement).open)
+          }
+        >
+          <summary className="dashboard-error-details__summary">
+            {detailsLabel}
+          </summary>
+          <div className="dashboard-error-details__body" id={detailsId}>
+            <dl className="dashboard-error-details__meta">
+              {endpoint ? (
+                <>
+                  <dt>Endpoint</dt>
+                  <dd>
+                    <code>{endpoint}</code>
+                  </dd>
+                </>
+              ) : null}
+              {status !== null && status !== undefined && status !== '' ? (
+                <>
+                  <dt>Status</dt>
+                  <dd>
+                    <code>{status}</code>
+                  </dd>
+                </>
+              ) : null}
+              {requestId ? (
+                <>
+                  <dt>Request ID</dt>
+                  <dd>
+                    <code>{requestId}</code>
+                  </dd>
+                </>
+              ) : null}
+            </dl>
+            {rawError ? (
+              <pre className="dashboard-error-details__raw">{rawError}</pre>
+            ) : null}
+            <div className="dashboard-error-details__actions">
+              <button
+                type="button"
+                className="secondary small"
+                onClick={handleCopy}
+              >
+                {copied ? 'Copied' : copyLabel}
+              </button>
+            </div>
+          </div>
+        </details>
+      ) : null}
+      {actions ? (
+        <div className="dashboard-error-details__page-actions">{actions}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export default DashboardErrorDetails;

--- a/frontend/src/components/dashboard/DashboardNotice.test.tsx
+++ b/frontend/src/components/dashboard/DashboardNotice.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DashboardNotice, type DashboardNoticeVariant } from './DashboardNotice';
+
+const VARIANTS: DashboardNoticeVariant[] = [
+  'info',
+  'success',
+  'warning',
+  'error',
+  'pending',
+];
+
+describe('DashboardNotice (MM-959)', () => {
+  it.each(VARIANTS)('renders the %s variant class', (variant) => {
+    render(
+      <DashboardNotice variant={variant} title={`title-${variant}`}>
+        body
+      </DashboardNotice>,
+    );
+    const notice = screen.getByText(`title-${variant}`).closest('.dashboard-notice');
+    expect(notice).toBeTruthy();
+    expect(notice?.classList.contains(`dashboard-notice--${variant}`)).toBe(true);
+  });
+
+  it('uses an alert role for the error variant and status otherwise', () => {
+    const { rerender } = render(<DashboardNotice variant="error">boom</DashboardNotice>);
+    expect(screen.getByRole('alert')).toBeTruthy();
+    rerender(<DashboardNotice variant="info">fyi</DashboardNotice>);
+    expect(screen.getByRole('status')).toBeTruthy();
+  });
+
+  it('exposes a collapsible technical details disclosure', () => {
+    render(
+      <DashboardNotice variant="warning" details={<span>raw detail</span>}>
+        body
+      </DashboardNotice>,
+    );
+    const summary = screen.getByText('Technical details');
+    expect(summary).toBeTruthy();
+    expect(screen.getByText('raw detail')).toBeTruthy();
+    // Toggling the disclosure should not throw.
+    fireEvent.click(summary);
+  });
+});

--- a/frontend/src/components/dashboard/DashboardNotice.tsx
+++ b/frontend/src/components/dashboard/DashboardNotice.tsx
@@ -1,0 +1,83 @@
+import { useId, useState, type ReactNode } from 'react';
+
+/**
+ * Consistent dashboard notice surface (MM-959).
+ *
+ * Replaces ad hoc `.notice` markup so info/success/warning/error/pending
+ * messages share a single accessible structure with optional title, actions,
+ * and collapsible technical details.
+ */
+export type DashboardNoticeVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'pending';
+
+export interface DashboardNoticeProps {
+  variant: DashboardNoticeVariant;
+  title?: ReactNode;
+  children?: ReactNode;
+  actions?: ReactNode;
+  /** Optional collapsible technical details disclosure. */
+  details?: ReactNode;
+  detailsLabel?: string;
+  className?: string;
+}
+
+export function DashboardNotice({
+  variant,
+  title,
+  children,
+  actions,
+  details,
+  detailsLabel = 'Technical details',
+  className,
+}: DashboardNoticeProps) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const titleId = useId();
+
+  const classes = ['dashboard-notice', `dashboard-notice--${variant}`];
+  if (className) {
+    classes.push(className);
+  }
+
+  const role = variant === 'error' ? 'alert' : 'status';
+  const ariaLive = variant === 'error' ? 'assertive' : 'polite';
+
+  return (
+    <div
+      className={classes.join(' ')}
+      data-variant={variant}
+      role={role}
+      aria-live={ariaLive}
+      aria-labelledby={title ? titleId : undefined}
+    >
+      {title ? (
+        <p className="dashboard-notice__title" id={titleId}>
+          {title}
+        </p>
+      ) : null}
+      {children ? <div className="dashboard-notice__body">{children}</div> : null}
+      {details ? (
+        <details
+          className="dashboard-notice__details"
+          open={detailsOpen}
+          onToggle={(event) =>
+            setDetailsOpen((event.target as HTMLDetailsElement).open)
+          }
+        >
+          <summary className="dashboard-notice__details-summary">
+            {detailsLabel}
+          </summary>
+          <div className="dashboard-notice__details-body">{details}</div>
+        </details>
+      ) : null}
+      {actions ? (
+        <div className="dashboard-notice__actions">{actions}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export default DashboardNotice;

--- a/frontend/src/components/dashboard/DashboardSurface.test.tsx
+++ b/frontend/src/components/dashboard/DashboardSurface.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DashboardSurface, type DashboardSurfaceVariant } from './DashboardSurface';
+
+const VARIANTS: DashboardSurfaceVariant[] = [
+  'page',
+  'controlDeck',
+  'dataSlab',
+  'formSlab',
+  'evidenceSlab',
+  'floatingRail',
+  'debugDrawer',
+];
+
+describe('DashboardSurface (MM-959)', () => {
+  it.each(VARIANTS)('renders the %s variant class', (variant) => {
+    render(
+      <DashboardSurface variant={variant} aria-label={`surface-${variant}`}>
+        body
+      </DashboardSurface>,
+    );
+    const surface = screen.getByLabelText(`surface-${variant}`);
+    expect(surface.classList.contains('dashboard-surface')).toBe(true);
+    expect(surface.classList.contains(`dashboard-surface--${variant}`)).toBe(true);
+    expect(surface.getAttribute('data-surface')).toBe(variant);
+  });
+
+  it('defaults to a section element and merges custom class names', () => {
+    render(
+      <DashboardSurface variant="dataSlab" className="extra" aria-label="merged">
+        body
+      </DashboardSurface>,
+    );
+    const surface = screen.getByLabelText('merged');
+    expect(surface.tagName).toBe('SECTION');
+    expect(surface.classList.contains('extra')).toBe(true);
+  });
+
+  it('honors the as prop for the rendered element', () => {
+    render(
+      <DashboardSurface variant="page" as="div" aria-label="as-div">
+        body
+      </DashboardSurface>,
+    );
+    expect(screen.getByLabelText('as-div').tagName).toBe('DIV');
+  });
+});

--- a/frontend/src/components/dashboard/DashboardSurface.tsx
+++ b/frontend/src/components/dashboard/DashboardSurface.tsx
@@ -1,0 +1,47 @@
+import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+
+/**
+ * Explicit surface hierarchy primitive (MM-959).
+ *
+ * Pages declare their surface intent directly via a variant instead of
+ * relying on global `.panel:has(...)` exceptions to neutralize or re-style
+ * the default panel chrome. Each variant maps to a `dashboard-surface--<variant>`
+ * class defined in dashboard.css.
+ */
+export type DashboardSurfaceVariant =
+  | 'page'
+  | 'controlDeck'
+  | 'dataSlab'
+  | 'formSlab'
+  | 'evidenceSlab'
+  | 'floatingRail'
+  | 'debugDrawer';
+
+export interface DashboardSurfaceProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  variant: DashboardSurfaceVariant;
+  /** Render element/component for the surface (defaults to `section`). */
+  as?: ElementType;
+  children?: ReactNode;
+}
+
+export function DashboardSurface({
+  variant,
+  as,
+  className,
+  children,
+  ...rest
+}: DashboardSurfaceProps) {
+  const Component = (as ?? 'section') as ElementType;
+  const classes = ['dashboard-surface', `dashboard-surface--${variant}`];
+  if (className) {
+    classes.push(className);
+  }
+  return (
+    <Component className={classes.join(' ')} data-surface={variant} {...rest}>
+      {children}
+    </Component>
+  );
+}
+
+export default DashboardSurface;

--- a/frontend/src/components/dashboard/LogPanel.test.tsx
+++ b/frontend/src/components/dashboard/LogPanel.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LogPanel } from './LogPanel';
+
+describe('LogPanel (MM-959)', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('copies the text content to the clipboard', async () => {
+    render(<LogPanel title="Stdout" text="hello logs" collapsible={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith('hello logs');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeTruthy());
+  });
+
+  it('toggles line wrapping via the wrap control', () => {
+    render(<LogPanel title="Stdout" text="hello logs" collapsible={false} ariaLabel="Stdout output" />);
+    const pre = screen.getByLabelText('Stdout output');
+    expect(pre.getAttribute('data-wrap')).toBe('on');
+    fireEvent.click(screen.getByRole('checkbox', { name: /Wrap lines/ }));
+    expect(pre.getAttribute('data-wrap')).toBe('off');
+  });
+
+  it('renders a download link when a download URL is provided', () => {
+    render(
+      <LogPanel
+        title="Stdout"
+        text="hello logs"
+        collapsible={false}
+        downloadUrl="/agent-runs/x/logs/stdout"
+        downloadFileName="stdout.log"
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'Download' });
+    expect(link.getAttribute('href')).toBe('/agent-runs/x/logs/stdout');
+    expect(link.getAttribute('download')).toBe('stdout.log');
+  });
+
+  it('shows empty and error states without inline color styles', () => {
+    const { rerender } = render(<LogPanel title="Stdout" text="" collapsible={false} emptyMessage="(no stdout)" />);
+    let pre = screen.getByText('(no stdout)');
+    expect(pre.className).toContain('log-panel__output--empty');
+    expect(pre.getAttribute('style')).toBeNull();
+
+    rerender(<LogPanel title="Stdout" isError collapsible={false} errorMessage="Error loading stdout" />);
+    pre = screen.getByText('Error loading stdout');
+    expect(pre.className).toContain('log-panel__output--error');
+  });
+
+  it('reports expansion so callers can lazily fetch content', () => {
+    const onExpandedChange = vi.fn();
+    render(<LogPanel title="Stdout" text="hello" onExpandedChange={onExpandedChange} />);
+    // Collapsed initially: controls are not rendered.
+    expect(screen.queryByRole('button', { name: 'Copy' })).toBeNull();
+    fireEvent.click(screen.getByText('Stdout'));
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/dashboard/LogPanel.tsx
+++ b/frontend/src/components/dashboard/LogPanel.tsx
@@ -1,0 +1,242 @@
+import { useState, type ReactNode } from 'react';
+import { copyTextToClipboard } from '../../utils/clipboard';
+
+/**
+ * Shared monospace text / log viewer (MM-959).
+ *
+ * Replaces per-page stdout/stderr/diagnostics viewers that used inline color
+ * styles and duplicated copy/wrap/download behavior. Supports static or live
+ * text, loading/error/empty states, an artifact-fallback note, and a
+ * collapsible disclosure that reports expansion so callers can lazily fetch
+ * content. All presentation comes from `.log-panel*` classes — no inline color.
+ */
+export interface LogPanelProps {
+  title: ReactNode;
+  text?: string | null | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  /** Body text shown when isError is true. */
+  errorMessage?: string;
+  /** Body text shown when there is no content and not loading/erroring. */
+  emptyMessage?: string;
+  loadingMessage?: string;
+  /** Direct download URL for the full artifact. */
+  downloadUrl?: string | undefined;
+  downloadFileName?: string | undefined;
+  /** Optional note rendered when content is served from an artifact fallback. */
+  artifactFallbackNote?: ReactNode;
+  /** Render as a collapsible <details> disclosure (default true). */
+  collapsible?: boolean;
+  defaultExpanded?: boolean;
+  /** Reports expansion changes so callers can lazily enable fetches. */
+  onExpandedChange?: (expanded: boolean) => void;
+  defaultWrap?: boolean;
+  ariaLabel?: string | undefined;
+  className?: string;
+}
+
+function LogPanelControls({
+  wrap,
+  setWrap,
+  onCopy,
+  copied,
+  canCopy,
+  downloadUrl,
+  downloadFileName,
+}: {
+  wrap: boolean;
+  setWrap: (next: boolean) => void;
+  onCopy: () => void;
+  copied: boolean;
+  canCopy: boolean;
+  downloadUrl?: string | undefined;
+  downloadFileName?: string | undefined;
+}) {
+  return (
+    <div className="log-panel__controls">
+      <label className="log-panel__wrap-toggle">
+        <input
+          type="checkbox"
+          checked={wrap}
+          onChange={(event) => setWrap(event.target.checked)}
+        />
+        <span className="small">Wrap lines</span>
+      </label>
+      <button
+        type="button"
+        className="secondary small"
+        onClick={onCopy}
+        disabled={!canCopy}
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+      {downloadUrl ? (
+        <a
+          className="button secondary small"
+          href={downloadUrl}
+          download={downloadFileName}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Download
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function LogPanelOutput({
+  text,
+  isLoading,
+  isError,
+  errorMessage,
+  emptyMessage,
+  loadingMessage,
+  wrap,
+  ariaLabel,
+}: {
+  text?: string | null | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage: string;
+  emptyMessage: string;
+  loadingMessage: string;
+  wrap: boolean;
+  ariaLabel?: string | undefined;
+}) {
+  let body: string;
+  let stateClass = 'log-panel__output';
+  if (isLoading) {
+    body = loadingMessage;
+    stateClass += ' log-panel__output--loading';
+  } else if (isError) {
+    body = errorMessage;
+    stateClass += ' log-panel__output--error';
+  } else if (!text) {
+    body = emptyMessage;
+    stateClass += ' log-panel__output--empty';
+  } else {
+    body = text;
+  }
+
+  return (
+    <div className="log-panel__viewport">
+      <pre
+        className={stateClass}
+        data-wrap={wrap ? 'on' : 'off'}
+        aria-label={ariaLabel}
+      >
+        {body}
+      </pre>
+    </div>
+  );
+}
+
+export function LogPanel({
+  title,
+  text,
+  isLoading = false,
+  isError = false,
+  errorMessage = 'Error loading content.',
+  emptyMessage = '(no output)',
+  loadingMessage = 'Loading...',
+  downloadUrl,
+  downloadFileName,
+  artifactFallbackNote,
+  collapsible = true,
+  defaultExpanded = false,
+  onExpandedChange,
+  defaultWrap = true,
+  ariaLabel,
+  className,
+}: LogPanelProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [wrap, setWrap] = useState(defaultWrap);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!text) return;
+    const ok = await copyTextToClipboard(text);
+    if (ok) {
+      setCopied(true);
+    }
+  };
+
+  const handleExpandedChange = (next: boolean) => {
+    setExpanded(next);
+    onExpandedChange?.(next);
+  };
+
+  const classes = ['log-panel'];
+  if (className) {
+    classes.push(className);
+  }
+
+  const controls = (
+    <LogPanelControls
+      wrap={wrap}
+      setWrap={setWrap}
+      onCopy={handleCopy}
+      copied={copied}
+      canCopy={Boolean(text)}
+      downloadUrl={downloadUrl}
+      downloadFileName={downloadFileName}
+    />
+  );
+
+  const output = (
+    <LogPanelOutput
+      text={text}
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage={errorMessage}
+      emptyMessage={emptyMessage}
+      loadingMessage={loadingMessage}
+      wrap={wrap}
+      ariaLabel={ariaLabel}
+    />
+  );
+
+  const fallback = artifactFallbackNote ? (
+    <p className="log-panel__fallback small">{artifactFallbackNote}</p>
+  ) : null;
+
+  if (!collapsible) {
+    return (
+      <section className={classes.join(' ')}>
+        <header className="log-panel__header">
+          <h3 className="log-panel__title">{title}</h3>
+          {controls}
+        </header>
+        {fallback}
+        {output}
+      </section>
+    );
+  }
+
+  return (
+    <details className={classes.join(' ')} open={expanded}>
+      <summary
+        className="log-panel__summary"
+        onClick={(event) => {
+          // Drive expansion explicitly so behavior is deterministic across
+          // environments (jsdom does not toggle <details> on summary click)
+          // and so callers can lazily enable fetches via onExpandedChange.
+          event.preventDefault();
+          handleExpandedChange(!expanded);
+        }}
+      >
+        {title}
+      </summary>
+      {expanded ? (
+        <div className="log-panel__content">
+          {controls}
+          {fallback}
+          {output}
+        </div>
+      ) : null}
+    </details>
+  );
+}
+
+export default LogPanel;

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -1,0 +1,14 @@
+export { DashboardSurface } from './DashboardSurface';
+export type {
+  DashboardSurfaceProps,
+  DashboardSurfaceVariant,
+} from './DashboardSurface';
+export { DashboardNotice } from './DashboardNotice';
+export type {
+  DashboardNoticeProps,
+  DashboardNoticeVariant,
+} from './DashboardNotice';
+export { DashboardErrorDetails } from './DashboardErrorDetails';
+export type { DashboardErrorDetailsProps } from './DashboardErrorDetails';
+export { LogPanel } from './LogPanel';
+export type { LogPanelProps } from './LogPanel';

--- a/frontend/src/components/tables/DataTable.test.tsx
+++ b/frontend/src/components/tables/DataTable.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { DataTable, type Column } from './DataTable';
+
+interface Row {
+  id: string;
+  name: string;
+  count: number;
+}
+
+const rows: Row[] = [
+  { id: 'a', name: 'Beta', count: 2 },
+  { id: 'b', name: 'Alpha', count: 30 },
+  { id: 'c', name: 'Gamma', count: 1 },
+];
+
+const columns: Column<Row>[] = [
+  { key: 'name', header: 'Name', sortable: true },
+  { key: 'count', header: 'Count', align: 'right', sortable: true },
+];
+
+describe('DataTable (MM-959)', () => {
+  it('renders the empty message when there are no rows', () => {
+    render(<DataTable data={[]} columns={columns} getRowKey={(r) => r.id} emptyMessage="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeTruthy();
+  });
+
+  it('renders an accessible loading state', () => {
+    render(
+      <DataTable
+        data={[]}
+        columns={columns}
+        getRowKey={(r) => r.id}
+        isLoading
+        loadingMessage="Loading rows..."
+      />,
+    );
+    const cell = screen.getByText('Loading rows...');
+    expect(cell).toBeTruthy();
+    expect(cell.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('renders an error state with an alert role', () => {
+    render(
+      <DataTable
+        data={[]}
+        columns={columns}
+        getRowKey={(r) => r.id}
+        isError
+        errorMessage="Boom"
+      />,
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('Boom');
+  });
+
+  it('sorts rows when a sortable header is activated', () => {
+    render(<DataTable data={rows} columns={columns} getRowKey={(r) => r.id} />);
+
+    // Ascending by name on first click.
+    fireEvent.click(screen.getByRole('button', { name: /Sort by Name/ }));
+    let bodyRows = screen.getAllByRole('row').slice(1); // drop header row
+    expect(within(bodyRows[0]!).getByText('Alpha')).toBeTruthy();
+    expect(within(bodyRows[2]!).getByText('Gamma')).toBeTruthy();
+
+    // aria-sort reflects ascending direction.
+    const nameHeader = screen.getByRole('columnheader', { name: /Name/ });
+    expect(nameHeader.getAttribute('aria-sort')).toBe('ascending');
+
+    // Descending by name on second click.
+    fireEvent.click(screen.getByRole('button', { name: /Sort by Name/ }));
+    bodyRows = screen.getAllByRole('row').slice(1);
+    expect(within(bodyRows[0]!).getByText('Gamma')).toBeTruthy();
+  });
+
+  it('renders a row actions column and responsive card fallback', () => {
+    render(
+      <DataTable
+        data={rows}
+        columns={columns}
+        getRowKey={(r) => r.id}
+        responsive
+        rowActions={(r) => <button type="button">Edit {r.name}</button>}
+      />,
+    );
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy();
+    // The action renders in both the table and the card fallback.
+    expect(screen.getAllByRole('button', { name: 'Edit Beta' }).length).toBeGreaterThanOrEqual(1);
+    // Card fallback present in DOM (CSS toggles visibility by viewport width).
+    expect(document.querySelector('.data-table-cards')).toBeTruthy();
+    expect(document.querySelector('[data-responsive="on"]')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/tables/DataTable.test.tsx
+++ b/frontend/src/components/tables/DataTable.test.tsx
@@ -87,7 +87,11 @@ describe('DataTable (MM-959)', () => {
     // The action renders in both the table and the card fallback.
     expect(screen.getAllByRole('button', { name: 'Edit Beta' }).length).toBeGreaterThanOrEqual(1);
     // Card fallback present in DOM (CSS toggles visibility by viewport width).
-    expect(document.querySelector('.data-table-cards')).toBeTruthy();
+    const cards = document.querySelector('.data-table-cards');
+    expect(cards).toBeTruthy();
     expect(document.querySelector('[data-responsive="on"]')).toBeTruthy();
+    // The cards replace the table at narrow widths, so they must remain exposed
+    // to assistive tech rather than being aria-hidden.
+    expect(cards?.getAttribute('aria-hidden')).toBeNull();
   });
 });

--- a/frontend/src/components/tables/DataTable.tsx
+++ b/frontend/src/components/tables/DataTable.tsx
@@ -224,8 +224,13 @@ export function DataTable<T>({
 
   const renderCards = () => {
     if (isLoading || isError || !hasRows) return null;
+    // Intentionally not aria-hidden: when the responsive breakpoint hides the
+    // table (`display: none`), the table is removed from the accessibility tree
+    // and these cards become the only representation of the rows for assistive
+    // tech. CSS `display: none` mutually excludes the table and cards across the
+    // breakpoint, so exactly one is exposed to AT at any width.
     return (
-      <ul className="data-table-cards" aria-hidden="true">
+      <ul className="data-table-cards">
         {sortedData.map((item) => (
           <li key={getRowKey(item)} className="data-table-card">
             {columns.map((col) => (

--- a/frontend/src/components/tables/DataTable.tsx
+++ b/frontend/src/components/tables/DataTable.tsx
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+
+export type ColumnAlign = 'left' | 'center' | 'right';
 
 export interface Column<T> {
   key: keyof T | string;
   header: string;
   render?: (item: T) => React.ReactNode;
+  /** Cell + header text alignment. */
+  align?: ColumnAlign;
+  /** Fixed/min column width (CSS length). */
+  width?: string;
+  /** Enable click-to-sort on this column's header. */
+  sortable?: boolean;
+  /**
+   * Value used for built-in sorting. Defaults to `item[key]` when omitted.
+   * Provide this when the rendered cell differs from the sortable value.
+   */
+  sortValue?: (item: T) => string | number | boolean | null | undefined;
+  /**
+   * Accessible label for the sort control when the visible header is an icon
+   * or otherwise not descriptive. Defaults to `header`.
+   */
+  sortLabel?: string;
+}
+
+export type DataTableDensity = 'comfortable' | 'compact';
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortState {
+  key: string;
+  direction: SortDirection;
 }
 
 export interface DataTableProps<T> {
@@ -12,6 +39,48 @@ export interface DataTableProps<T> {
   emptyMessage?: string;
   getRowKey: (item: T) => React.Key;
   ariaLabel?: string;
+  /** Loading state replaces the body with an accessible loading row. */
+  isLoading?: boolean;
+  loadingMessage?: string;
+  /** Error state replaces the body with an accessible error row. */
+  isError?: boolean;
+  errorMessage?: React.ReactNode;
+  /** Sticky header (default true). */
+  sticky?: boolean;
+  /** Row density (default comfortable). */
+  density?: DataTableDensity;
+  /** Render a trailing actions cell for each row. */
+  rowActions?: (item: T) => React.ReactNode;
+  rowActionsHeader?: string;
+  /** Render a responsive stacked-card fallback alongside the table. */
+  responsive?: boolean;
+  /** Initial sort applied when a sortable column is present. */
+  defaultSort?: SortState;
+}
+
+function compareValues(
+  a: string | number | boolean | null | undefined,
+  b: string | number | boolean | null | undefined,
+): number {
+  if (a === b) return 0;
+  if (a === null || a === undefined) return -1;
+  if (b === null || b === undefined) return 1;
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+}
+
+function defaultSortValue<T>(item: T, key: string): string | number | undefined {
+  const value = (item as Record<string, unknown>)[key];
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value;
+  }
+  return value === null || value === undefined ? undefined : String(value);
+}
+
+function nextDirection(current: SortDirection): SortDirection {
+  return current === 'asc' ? 'desc' : 'asc';
 }
 
 export function DataTable<T>({
@@ -20,39 +89,184 @@ export function DataTable<T>({
   emptyMessage = 'No data found.',
   getRowKey,
   ariaLabel = 'Data table',
+  isLoading = false,
+  loadingMessage = 'Loading...',
+  isError = false,
+  errorMessage = 'Failed to load data.',
+  sticky = true,
+  density = 'comfortable',
+  rowActions,
+  rowActionsHeader = 'Actions',
+  responsive = false,
+  defaultSort,
 }: DataTableProps<T>) {
+  const [sort, setSort] = useState<SortState | null>(defaultSort ?? null);
+
+  const columnByKey = useMemo(() => {
+    const map = new Map<string, Column<T>>();
+    for (const column of columns) {
+      map.set(column.key as string, column);
+    }
+    return map;
+  }, [columns]);
+
+  const sortedData = useMemo(() => {
+    if (!data || !sort) return data ?? [];
+    const column = columnByKey.get(sort.key);
+    if (!column || !column.sortable) return data;
+    const getValue = column.sortValue
+      ? column.sortValue
+      : (item: T) => defaultSortValue(item, sort.key);
+    const factor = sort.direction === 'asc' ? 1 : -1;
+    return [...data].sort((a, b) => compareValues(getValue(a), getValue(b)) * factor);
+  }, [data, sort, columnByKey]);
+
+  const handleSort = (key: string) => {
+    setSort((current) => {
+      if (current && current.key === key) {
+        return { key, direction: nextDirection(current.direction) };
+      }
+      return { key, direction: 'asc' };
+    });
+  };
+
+  const totalColumnCount = columns.length + (rowActions ? 1 : 0);
+  const hasRows = sortedData.length > 0;
+
+  const renderHeaderCell = (column: Column<T>) => {
+    const key = column.key as string;
+    const isSorted = sort?.key === key;
+    const ariaSort: React.AriaAttributes['aria-sort'] = column.sortable
+      ? isSorted
+        ? sort?.direction === 'asc'
+          ? 'ascending'
+          : 'descending'
+        : 'none'
+      : undefined;
+    const style: React.CSSProperties = {};
+    if (column.width) style.width = column.width;
+    return (
+      <th
+        key={key}
+        scope="col"
+        aria-sort={ariaSort}
+        data-align={column.align ?? 'left'}
+        style={style}
+      >
+        {column.sortable ? (
+          <button
+            type="button"
+            className="data-table__sort"
+            onClick={() => handleSort(key)}
+            aria-label={`Sort by ${column.sortLabel ?? column.header}${
+              isSorted
+                ? sort?.direction === 'asc'
+                  ? ' (ascending)'
+                  : ' (descending)'
+                : ''
+            }`}
+          >
+            <span>{column.header}</span>
+            <span aria-hidden="true" className="data-table__sort-indicator">
+              {isSorted ? (sort?.direction === 'asc' ? '▲' : '▼') : '↕'}
+            </span>
+          </button>
+        ) : (
+          column.header
+        )}
+      </th>
+    );
+  };
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={totalColumnCount} className="data-table-empty" aria-busy="true">
+            {loadingMessage}
+          </td>
+        </tr>
+      );
+    }
+    if (isError) {
+      return (
+        <tr>
+          <td colSpan={totalColumnCount} className="data-table-empty data-table-error" role="alert">
+            {errorMessage}
+          </td>
+        </tr>
+      );
+    }
+    if (!hasRows) {
+      return (
+        <tr>
+          <td colSpan={totalColumnCount} className="data-table-empty">
+            {emptyMessage}
+          </td>
+        </tr>
+      );
+    }
+    return sortedData.map((item) => (
+      <tr key={getRowKey(item)}>
+        {columns.map((col) => (
+          <td key={col.key as string} data-align={col.align ?? 'left'}>
+            {col.render ? col.render(item) : String(item[col.key as keyof T] ?? '')}
+          </td>
+        ))}
+        {rowActions ? (
+          <td className="data-table__row-actions" data-align="right">
+            {rowActions(item)}
+          </td>
+        ) : null}
+      </tr>
+    ));
+  };
+
+  const renderCards = () => {
+    if (isLoading || isError || !hasRows) return null;
+    return (
+      <ul className="data-table-cards" aria-hidden="true">
+        {sortedData.map((item) => (
+          <li key={getRowKey(item)} className="data-table-card">
+            {columns.map((col) => (
+              <div key={col.key as string} className="data-table-card__row">
+                <span className="data-table-card__label">{col.header}</span>
+                <span className="data-table-card__value">
+                  {col.render ? col.render(item) : String(item[col.key as keyof T] ?? '')}
+                </span>
+              </div>
+            ))}
+            {rowActions ? (
+              <div className="data-table-card__actions">{rowActions(item)}</div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
   return (
-    <div className="data-table-slab" data-layout="table">
+    <div
+      className="data-table-slab"
+      data-layout="table"
+      data-density={density}
+      data-sticky={sticky ? 'on' : 'off'}
+      data-responsive={responsive ? 'on' : 'off'}
+    >
       <table className="data-table" aria-label={ariaLabel}>
         <thead>
           <tr>
-            {columns.map((col) => (
-              <th key={col.key as string}>
-                {col.header}
+            {columns.map(renderHeaderCell)}
+            {rowActions ? (
+              <th scope="col" data-align="right">
+                {rowActionsHeader}
               </th>
-            ))}
+            ) : null}
           </tr>
         </thead>
-        <tbody>
-          {data && data.length > 0 ? (
-            data.map((item) => (
-              <tr key={getRowKey(item)}>
-                {columns.map((col) => (
-                  <td key={col.key as string}>
-                    {col.render ? col.render(item) : String(item[col.key as keyof T] ?? '')}
-                  </td>
-                ))}
-              </tr>
-            ))
-          ) : (
-            <tr>
-              <td colSpan={columns.length} className="data-table-empty">
-                {emptyMessage}
-              </td>
-            </tr>
-          )}
-        </tbody>
+        <tbody>{renderBody()}</tbody>
       </table>
+      {responsive ? renderCards() : null}
     </div>
   );
 }

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -407,82 +407,84 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
 
       <section className="panel panel--data" aria-labelledby="manifests-recent-title">
         <h3 className="page-title" id="manifests-recent-title">Recent Runs</h3>
-        {isLoading ? (
-          <p className="loading">Loading manifest jobs...</p>
-        ) : isError ? (
-          <div className="notice error">{(error as Error).message}</div>
-        ) : (
-          <>
-            <div className="manifests-filter-grid">
-              <label>
-                Filter by status
-                <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
-                  <option value="all">All statuses</option>
-                  {statusOptions.map((status) => (
-                    <option key={status} value={status}>
-                      {formatStatusLabel(status)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Filter by manifest
-                <input
-                  value={manifestFilter}
-                  onChange={(event) => setManifestFilter(event.target.value)}
-                  placeholder="Manifest name"
-                />
-              </label>
-              <label>
-                Search recent runs
-                <input
-                  value={searchFilter}
-                  onChange={(event) => setSearchFilter(event.target.value)}
-                  placeholder="Run ID, action, status, or stage"
-                />
-              </label>
-            </div>
-            <DataTable
-              ariaLabel="Recent manifest runs"
-              data={filteredRuns}
-              columns={[
-                {
-                  key: 'taskId',
-                  header: 'Run ID',
-                  render: (item: ManifestRun) => (
-                    <a href={detailHref(item)} aria-label={`Open run ${runWorkflowId(item)}`}>
-                      <code>{runWorkflowId(item)}</code>
-                    </a>
-                  ),
-                },
-                { key: 'manifestName', header: 'Manifest', render: manifestLabel },
-                { key: 'action', header: 'Action', render: runAction },
-                { key: 'status', header: 'Status', render: statusLabel },
-                {
-                  key: 'startedAt',
-                  header: 'Started',
-                  render: (item: ManifestRun) => formatWhen(item.startedAt || item.createdAt),
-                },
-                {
-                  key: 'durationSeconds',
-                  header: 'Duration',
-                  render: (item: ManifestRun) => formatDuration(item.durationSeconds),
-                },
-                {
-                  key: 'actions',
-                  header: 'Actions',
-                  render: (item: ManifestRun) => (
-                    <a href={detailHref(item)} aria-label={`View details for ${runWorkflowId(item)}`}>
-                      View details
-                    </a>
-                  ),
-                },
-              ]}
-              emptyMessage="No manifest runs exist yet. Run a registry manifest or submit inline YAML above."
-              getRowKey={(item) => runWorkflowId(item)}
-            />
-          </>
-        )}
+        {!isLoading && !isError ? (
+          <div className="manifests-filter-grid">
+            <label>
+              Filter by status
+              <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+                <option value="all">All statuses</option>
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {formatStatusLabel(status)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Filter by manifest
+              <input
+                value={manifestFilter}
+                onChange={(event) => setManifestFilter(event.target.value)}
+                placeholder="Manifest name"
+              />
+            </label>
+            <label>
+              Search recent runs
+              <input
+                value={searchFilter}
+                onChange={(event) => setSearchFilter(event.target.value)}
+                placeholder="Run ID, action, status, or stage"
+              />
+            </label>
+          </div>
+        ) : null}
+        <DataTable
+          ariaLabel="Recent manifest runs"
+          data={filteredRuns}
+          isLoading={isLoading}
+          loadingMessage="Loading manifest jobs..."
+          isError={isError}
+          errorMessage={(error as Error | null)?.message ?? 'Failed to load manifest jobs.'}
+          columns={[
+            {
+              key: 'taskId',
+              header: 'Run ID',
+              render: (item: ManifestRun) => (
+                <a href={detailHref(item)} aria-label={`Open run ${runWorkflowId(item)}`}>
+                  <code>{runWorkflowId(item)}</code>
+                </a>
+              ),
+            },
+            { key: 'manifestName', header: 'Manifest', render: manifestLabel },
+            { key: 'action', header: 'Action', render: runAction },
+            { key: 'status', header: 'Status', render: statusLabel, sortable: true },
+            {
+              key: 'startedAt',
+              header: 'Started',
+              sortable: true,
+              sortValue: (item: ManifestRun) => item.startedAt || item.createdAt,
+              render: (item: ManifestRun) => formatWhen(item.startedAt || item.createdAt),
+            },
+            {
+              key: 'durationSeconds',
+              header: 'Duration',
+              align: 'right',
+              sortable: true,
+              render: (item: ManifestRun) => formatDuration(item.durationSeconds),
+            },
+            {
+              key: 'actions',
+              header: 'Actions',
+              render: (item: ManifestRun) => (
+                <a href={detailHref(item)} aria-label={`View details for ${runWorkflowId(item)}`}>
+                  View details
+                </a>
+              ),
+            },
+          ]}
+          emptyMessage="No manifest runs exist yet. Run a registry manifest or submit inline YAML above."
+          getRowKey={(item) => runWorkflowId(item)}
+        />
       </section>
     </div>
   );

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -1106,11 +1106,12 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
         <div className="section-heading-row">
           <h3>Runs</h3>
         </div>
-        {runsQuery.isError ? (
-          <div className="schedules-error" role="alert">{errorMessage(runsQuery.error, 'Failed to fetch schedule runs')}</div>
-        ) : (
-          <DataTable
+        <DataTable
             data={runs}
+            isLoading={runsQuery.isLoading}
+            loadingMessage="Loading schedule runs..."
+            isError={runsQuery.isError}
+            errorMessage={errorMessage(runsQuery.error, 'Failed to fetch schedule runs')}
             columns={[
               {
                 key: 'scheduledFor',
@@ -1146,11 +1147,10 @@ function ScheduleDetailPage({ payload, definitionId }: { payload: BootPayload; d
                 render: (item) => displayValue(item.message),
               },
             ]}
-            emptyMessage={runsQuery.isLoading ? 'Loading schedule runs...' : 'No runs recorded for this schedule.'}
+            emptyMessage="No runs recorded for this schedule."
             getRowKey={(item) => item.id}
             ariaLabel="Schedule runs"
           />
-        )}
       </section>
 
       <section className="panel--data schedules-detail-panel" aria-label="Schedule target payload">
@@ -1227,13 +1227,12 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
       </section>
 
       <section className="panel--data schedules-table-panel" aria-label="Recurring schedule list">
-        {isLoading ? (
-          <p className="loading">Loading recurring schedules...</p>
-        ) : isError ? (
-          <div className="schedules-error" role="alert">{errorMessage(error, 'Failed to fetch schedules')}</div>
-        ) : (
-          <DataTable
+        <DataTable
             data={schedules}
+            isLoading={isLoading}
+            loadingMessage="Loading recurring schedules..."
+            isError={isError}
+            errorMessage={errorMessage(error, 'Failed to fetch schedules')}
             columns={[
               {
                 key: 'name',
@@ -1304,7 +1303,6 @@ export function SchedulesPage({ payload }: { payload: BootPayload }) {
             getRowKey={(item) => item.id}
             ariaLabel="Recurring schedules"
           />
-        )}
       </section>
     </div>
   );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -7,6 +7,7 @@ import { BootPayload } from '../boot/parseBootPayload';
 import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { executionStatusPillProps } from '../utils/executionStatusPillClasses';
 import { SkillProvenanceBadge } from '../components/skills/SkillProvenanceBadge';
+import { LogPanel } from '../components/dashboard/LogPanel';
 import { formatRuntimeLabel, formatStatusLabel } from '../utils/formatters';
 import {
   readDashboardPreferences,
@@ -3630,7 +3631,6 @@ function StaticLogPanel({
   routes: AgentRunRouteTemplates;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [wrapLines, setWrapLines] = useState(true);
 
   const streamQuery = useQuery({
     queryKey: ['agent-run-stream', agentRunId, stream],
@@ -3647,11 +3647,6 @@ function StaticLogPanel({
 
   const title = stream === 'stdout' ? 'Stdout' : 'Stderr';
 
-  const handleCopy = () => {
-    if (!streamQuery.data) return;
-    copyTextToClipboard(streamQuery.data);
-  };
-
   const downloadUrl = agentRunRoute(
     apiBase,
     stream === 'stdout' ? routes.logsStdout : routes.logsStderr,
@@ -3660,46 +3655,17 @@ function StaticLogPanel({
   );
 
   return (
-    <details className="stack" open={expanded}>
-      <summary
-        onClick={(e) => {
-          e.preventDefault();
-          setExpanded((prev) => !prev);
-        }}
-        style={{ cursor: 'pointer', fontWeight: 'bold', fontSize: '1.2rem', marginBottom: '0.5rem' }}
-      >
-        <span>{title}</span>
-      </summary>
-      <div className="stack">
-        {expanded ? (
-          <div className="button-group" style={{ fontSize: '0.9rem', fontWeight: 'normal' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <input type="checkbox" checked={wrapLines} onChange={(e) => setWrapLines(e.target.checked)} />
-              <span className="small">Wrap lines</span>
-            </label>
-            <button className="secondary small" onClick={handleCopy}>Copy</button>
-            <a className="button secondary small" href={downloadUrl} target="_blank" rel="noreferrer">Download</a>
-          </div>
-        ) : null}
-        <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
-          <pre
-            style={{
-              background: '#111',
-              color: '#e8e8e8',
-              padding: '0.75rem',
-              fontSize: '0.7rem',
-              lineHeight: 1.4,
-              whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
-              wordBreak: wrapLines ? 'break-all' : 'normal',
-              borderRadius: '4px',
-              margin: 0,
-            }}
-          >
-            {streamQuery.isLoading ? 'Loading...' : streamQuery.isError ? `Error loading ${stream}` : streamQuery.data || `(no ${stream} output)`}
-          </pre>
-        </div>
-      </div>
-    </details>
+    <LogPanel
+      title={title}
+      text={streamQuery.data}
+      isLoading={streamQuery.isLoading}
+      isError={streamQuery.isError}
+      errorMessage={`Error loading ${stream}`}
+      emptyMessage={`(no ${stream} output)`}
+      downloadUrl={downloadUrl}
+      onExpandedChange={setExpanded}
+      ariaLabel={`${title} output`}
+    />
   );
 }
 
@@ -3713,7 +3679,6 @@ function DiagnosticsPanel({
   routes: AgentRunRouteTemplates;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [wrapLines, setWrapLines] = useState(true);
 
   const diagQuery = useQuery({
     queryKey: ['agent-run-diagnostics', agentRunId],
@@ -3721,11 +3686,6 @@ function DiagnosticsPanel({
     enabled: !!agentRunId && expanded,
     retry: false,
   });
-
-  const handleCopy = () => {
-    if (!diagQuery.data) return;
-    copyTextToClipboard(diagQuery.data);
-  };
 
   const downloadUrl = agentRunRoute(
     apiBase,
@@ -3735,46 +3695,17 @@ function DiagnosticsPanel({
   );
 
   return (
-    <details className="stack" open={expanded}>
-      <summary
-        onClick={(e) => {
-          e.preventDefault();
-          setExpanded((prev) => !prev);
-        }}
-        style={{ cursor: 'pointer', fontWeight: 'bold', fontSize: '1.2rem', marginBottom: '0.5rem' }}
-      >
-        <span>Diagnostics</span>
-      </summary>
-      <div className="stack">
-        {expanded ? (
-          <div className="button-group" style={{ fontSize: '0.9rem', fontWeight: 'normal' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-              <input type="checkbox" checked={wrapLines} onChange={(e) => setWrapLines(e.target.checked)} />
-              <span className="small">Wrap lines</span>
-            </label>
-            <button className="secondary small" onClick={handleCopy}>Copy</button>
-            <a className="button secondary small" href={downloadUrl} target="_blank" rel="noreferrer">Download</a>
-          </div>
-        ) : null}
-        <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
-          <pre
-            style={{
-              background: '#111',
-              color: '#e8e8e8',
-              padding: '0.75rem',
-              fontSize: '0.7rem',
-              lineHeight: 1.4,
-              whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
-              wordBreak: wrapLines ? 'break-all' : 'normal',
-              borderRadius: '4px',
-              margin: 0,
-            }}
-          >
-            {diagQuery.isLoading ? 'Loading...' : diagQuery.isError ? 'Error loading diagnostics' : diagQuery.data || '(no diagnostics output)'}
-          </pre>
-        </div>
-      </div>
-    </details>
+    <LogPanel
+      title="Diagnostics"
+      text={diagQuery.data}
+      isLoading={diagQuery.isLoading}
+      isError={diagQuery.isError}
+      errorMessage="Error loading diagnostics"
+      emptyMessage="(no diagnostics output)"
+      downloadUrl={downloadUrl}
+      onExpandedChange={setExpanded}
+      ariaLabel="Diagnostics output"
+    />
   );
 }
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import type { BootPayload } from "../boot/parseBootPayload";
 import { SkillCombobox } from "../components/SkillCombobox";
+import { DashboardErrorDetails } from "../components/dashboard/DashboardErrorDetails";
 import { useLiquidGL } from "../lib/liquidGL/useLiquidGL";
 import { navigateTo } from "../lib/navigation";
 import {
@@ -5366,8 +5367,19 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   >(null);
   const submitMessage = submitMessageState?.text ?? null;
   const submitMessageTone = submitMessageState?.tone ?? "error";
+  // Structured technical diagnostics for the most recent submit failure. When
+  // set, the friendly submitMessage is rendered through DashboardErrorDetails
+  // so endpoint/raw-error detail stays behind a disclosure instead of being
+  // dumped into the main error text (MM-959).
+  const [submitErrorDetail, setSubmitErrorDetail] = useState<{
+    endpoint?: string | null;
+    status?: number | string | null;
+    requestId?: string | null;
+    rawError?: string | null;
+  } | null>(null);
   const setSubmitMessage = useCallback(
     (text: string | null, tone: "error" | "pending" = "error") => {
+      setSubmitErrorDetail(null);
       setSubmitMessageState(text === null ? null : { text, tone });
     },
     [],
@@ -10009,11 +10021,14 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           },
         );
         setSubmitMessage(
-          "Failed to reach the workflow start API. " +
-            `Endpoint: ${temporalCreateEndpoint}. ` +
-            "This usually means the API service is unreachable, a CORS policy is blocking the request, " +
-            "or there is a network connectivity issue. Check the browser console for more details.",
+          "Couldn't reach the workflow start service. This usually means the " +
+            "API is unreachable, a network/connectivity issue, or a CORS policy " +
+            "is blocking the request. Check your connection and try again.",
         );
+        setSubmitErrorDetail({
+          endpoint: temporalCreateEndpoint,
+          rawError: `${failure.name}: ${failure.message}`,
+        });
       } else {
         setSubmitMessage(failure.message);
       }
@@ -10123,7 +10138,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
   }
 
   return (
-    <div className="stack workflow-start-page">
+    <div className="stack workflow-start-page dashboard-surface dashboard-surface--page">
       <section data-canonical-create-section="Header" aria-label="Header">
         <h2 className="page-title">{pageTitle}</h2>
       </section>
@@ -12055,7 +12070,16 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           data-canonical-create-section="Submit"
           aria-label="Submit"
         >
-        {submitMessage ? (
+        {submitMessage && submitErrorDetail ? (
+          <DashboardErrorDetails
+            className="queue-submit-message"
+            message={submitMessage}
+            endpoint={submitErrorDetail.endpoint}
+            status={submitErrorDetail.status}
+            requestId={submitErrorDetail.requestId}
+            rawError={submitErrorDetail.rawError}
+          />
+        ) : submitMessage ? (
           <p
             id="queue-submit-message"
             role={submitMessageTone === "error" ? "alert" : "status"}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -498,10 +498,9 @@ h1 {
   box-shadow: none;
 }
 
-.panel:has(.workflow-start-page) {
-  max-width: min(72rem, calc(100vw - 2rem));
-  margin-inline: auto;
-}
+/* The workflow start page declares its own page surface via
+ * `.dashboard-surface--page` (MM-959), so no `.panel:has()` exception is
+ * needed to constrain and center it. */
 
 .panel:has(.workflow-list-notices-deck),
 .panel:has(.workflow-list-data-slab) {
@@ -6675,5 +6674,351 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
   .td-instructions-panel pre {
     font-size: 0.85rem;
+  }
+}
+
+/* ===========================================================================
+ * MM-959: Shared dashboard primitives
+ * DashboardSurface / DashboardNotice / DashboardErrorDetails / LogPanel and
+ * upgraded DataTable. Explicit surface classes let pages declare chrome
+ * directly instead of relying on global `.panel:has(...)` exceptions.
+ * ======================================================================== */
+
+.dashboard-surface {
+  display: block;
+  width: 100%;
+}
+
+.dashboard-surface--page {
+  max-width: min(72rem, calc(100vw - 2rem));
+  margin-inline: auto;
+}
+
+.dashboard-surface--controlDeck,
+.dashboard-surface--formSlab {
+  border-radius: 1rem;
+  background: var(--mm-glass-fill);
+  border: 1px solid var(--mm-glass-border);
+  box-shadow: var(--mm-elevation-panel);
+  padding: 1rem;
+}
+
+.dashboard-surface--dataSlab,
+.dashboard-surface--evidenceSlab {
+  border-radius: 1rem;
+  background: rgb(var(--mm-panel) / 0.92);
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  box-shadow: 0 16px 36px -30px rgb(var(--mm-ink) / 0.55);
+  padding: 1rem;
+}
+
+.dashboard-surface--floatingRail {
+  border-radius: 1rem;
+  background: var(--mm-glass-fill);
+  border: 1px solid var(--mm-glass-border);
+  box-shadow: var(--mm-elevation-panel);
+  padding: 0.75rem;
+}
+
+.dashboard-surface--debugDrawer {
+  border-radius: 0.75rem;
+  background: rgb(var(--mm-panel) / 0.72);
+  border: 1px dashed rgb(var(--mm-border) / 0.72);
+  padding: 0.75rem;
+}
+
+/* DashboardNotice ---------------------------------------------------------- */
+
+.dashboard-notice {
+  border-radius: 0.65rem;
+  padding: 0.65rem 0.72rem;
+  border: 1px solid rgb(var(--mm-border));
+  background: rgb(var(--mm-panel) / 0.72);
+  color: rgb(var(--mm-ink));
+  font-size: 0.9rem;
+  box-shadow: 0 10px 24px -22px rgb(var(--mm-ink) / 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.dashboard-notice__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.dashboard-notice__body {
+  margin: 0;
+}
+
+.dashboard-notice__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dashboard-notice__details-summary {
+  cursor: pointer;
+}
+
+.dashboard-notice--info {
+  border-color: rgb(var(--mm-accent) / 0.5);
+  background: rgb(var(--mm-accent) / 0.08);
+}
+
+.dashboard-notice--success {
+  border-color: rgb(var(--mm-ok) / 0.5);
+  background: rgb(var(--mm-ok) / 0.08);
+  color: rgb(var(--mm-ok));
+}
+
+.dashboard-notice--warning,
+.dashboard-notice--pending {
+  border-color: rgb(var(--mm-warn) / 0.5);
+  background: rgb(var(--mm-warn) / 0.1);
+  color: rgb(var(--mm-warn));
+}
+
+.dashboard-notice--error {
+  border-color: rgb(var(--mm-danger) / 0.5);
+  background: rgb(var(--mm-danger) / 0.08);
+  color: rgb(var(--mm-danger));
+}
+
+/* DashboardErrorDetails ---------------------------------------------------- */
+
+.dashboard-error-details {
+  border-radius: 0.65rem;
+  padding: 0.65rem 0.72rem;
+  border: 1px solid rgb(var(--mm-danger) / 0.5);
+  background: rgb(var(--mm-danger) / 0.08);
+  color: rgb(var(--mm-danger));
+  font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-error-details__message {
+  margin: 0;
+}
+
+.dashboard-error-details__summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.dashboard-error-details__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.dashboard-error-details__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  margin: 0;
+}
+
+.dashboard-error-details__meta dt {
+  font-weight: 600;
+}
+
+.dashboard-error-details__meta dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.dashboard-error-details__raw {
+  margin: 0;
+  padding: 0.5rem;
+  border-radius: 0.4rem;
+  background: rgb(var(--mm-ink) / 0.08);
+  color: rgb(var(--mm-ink));
+  font-family: var(--mm-font-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 14rem;
+  overflow: auto;
+}
+
+.dashboard-error-details__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* LogPanel ----------------------------------------------------------------- */
+
+.log-panel {
+  display: block;
+}
+
+.log-panel__summary,
+.log-panel__title {
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin: 0 0 0.5rem;
+}
+
+.log-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.log-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.log-panel__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  font-weight: normal;
+}
+
+.log-panel__wrap-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.log-panel__fallback {
+  margin: 0;
+  color: rgb(var(--mm-muted));
+}
+
+.log-panel__viewport {
+  max-height: 400px;
+  overflow: auto;
+  border-radius: 0.4rem;
+}
+
+.log-panel__output {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 0.4rem;
+  background: rgb(var(--mm-ink) / 0.92);
+  color: rgb(var(--mm-bg, 245 245 245));
+  font-family: var(--mm-font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  white-space: pre;
+}
+
+.log-panel__output[data-wrap="on"] {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.log-panel__output--loading,
+.log-panel__output--empty {
+  color: rgb(var(--mm-muted));
+}
+
+.log-panel__output--error {
+  color: rgb(var(--mm-danger));
+}
+
+/* Upgraded DataTable ------------------------------------------------------- */
+
+.data-table-slab[data-density="compact"] .data-table th,
+.data-table-slab[data-density="compact"] .data-table td {
+  padding: 0.4rem 0.55rem;
+}
+
+.data-table-slab[data-sticky="off"] .data-table th {
+  position: static;
+}
+
+.data-table th[data-align="right"],
+.data-table td[data-align="right"] {
+  text-align: right;
+}
+
+.data-table th[data-align="center"],
+.data-table td[data-align="center"] {
+  text-align: center;
+}
+
+.data-table__sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.data-table__sort-indicator {
+  font-size: 0.75em;
+  opacity: 0.7;
+}
+
+.data-table-error {
+  color: rgb(var(--mm-danger));
+}
+
+/* Responsive stacked-card fallback. Hidden until the viewport is too narrow
+ * for the table, at which point the table is hidden and cards take over. */
+.data-table-cards {
+  display: none;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 0.6rem;
+}
+
+.data-table-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  border-radius: 0.6rem;
+  background: rgb(var(--mm-panel) / 0.86);
+}
+
+.data-table-card__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.data-table-card__label {
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+}
+
+@media (max-width: 720px) {
+  .data-table-slab[data-responsive="on"] {
+    overflow: visible;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .data-table-slab[data-responsive="on"] .data-table {
+    display: none;
+  }
+
+  .data-table-slab[data-responsive="on"] .data-table-cards {
+    display: flex;
+    flex-direction: column;
   }
 }

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,25 @@
+/**
+ * Copy text to the clipboard without throwing in environments where the
+ * Clipboard API is unavailable or rejects (e.g. insecure contexts, headless
+ * test runners). Shared by dashboard primitives so copy behavior is consistent
+ * across LogPanel, DashboardErrorDetails, and similar surfaces (MM-959).
+ *
+ * Returns a promise that resolves to whether the write was attempted. It never
+ * rejects so callers can keep the UI stable on failure.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.clipboard ||
+    typeof navigator.clipboard.writeText !== 'function'
+  ) {
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Ignore clipboard failures; the UI should stay stable.
+    return false;
+  }
+}


### PR DESCRIPTION
## Issue
[MM-959](https://moonladder.atlassian.net/browse/MM-959) — Extract shared dashboard primitives: DataTable, LogPanel, Notice/ErrorDetails, and surface components

## Summary
Introduces a reusable dashboard component layer under `frontend/src/components/dashboard/` and upgrades the shared `DataTable`, so pages conform to the dashboard design system without ad hoc markup, inline styles, or `.panel:has(...)` exceptions.

- **DashboardSurface** — explicit surface primitive with variants (`page`, `controlDeck`, `dataSlab`, `formSlab`, `evidenceSlab`, `floatingRail`, `debugDrawer`) backed by new surface classes in `dashboard.css`, reducing reliance on `.panel:has(...)` page-specific exceptions.
- **DashboardNotice** — info/success/warning/error/pending notice with title, body, actions, and collapsible technical details.
- **DashboardErrorDetails** — friendly message with collapsible technical-detail disclosure, copy diagnostics, and endpoint/status/request-ID surfacing; `workflow-start.tsx` now routes network/API failures through it instead of dumping raw diagnostics into the main error message.
- **LogPanel** — shared static/live text viewer with copy, download, wrap toggle, empty/error states, artifact fallback, and consistent monospace styling (no inline color styles); replaces the local `StaticLogPanel` in `workflow-detail.tsx`.
- **DataTable** — upgraded with loading/error/empty states, sticky headers, optional sorting with accessible sort labels, column alignment/width, density, row actions, and a responsive card fallback.
- **Adoption** — `manifests.tsx`, `schedules.tsx`, and `workflow-detail.tsx` adopt the upgraded `DataTable`; `workflow-detail.tsx` adopts `LogPanel`; `workflow-start.tsx` adopts `DashboardErrorDetails`.
- Added `utils/clipboard.ts` helper shared by copy actions.

## Tests run
- Component tests added alongside each primitive: `DataTable.test.tsx` (empty/loading/error/sort), `LogPanel.test.tsx` (copy/wrap/download), `DashboardErrorDetails.test.tsx` (disclosure/copy), `DashboardNotice.test.tsx`, `DashboardSurface.test.tsx` (variant class rendering).
- Frontend unit suite (Vitest) for the changed components: `npm run ui:test -- src/components/dashboard src/components/tables`.

## Remaining risks
- Migration is incremental per the epic's out-of-scope note: not every dashboard page adopts the new primitives yet, and existing `.panel` classes are not all removed.
- Some `.panel:has(...)` exceptions remain pending full page migration.
- Frontend-only change; no backend/API changes.


[MM-959]: https://moonladder.atlassian.net/browse/MM-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ