### PR TITLE
I do not want this top row above the column headers for the Workflows table on desktop. On desktop, the Filters button in the top left should be hidde

### DIFF
--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1705,6 +1705,56 @@ describe('Workflows Entrypoint', () => {
     expect(detailCallsBefore).toHaveLength(0);
   });
 
+  it('promotes "View options" into the Actions header and drops the Filters row on desktop', async () => {
+    const actionsPayload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard: { listEnabled: true, actionsEnabled: true } },
+        },
+      },
+    };
+
+    // Force the desktop breakpoint (jsdom has no matchMedia, so the component
+    // otherwise defaults to the mobile layout).
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    );
+
+    try {
+      renderWithClient(<WorkflowListPage payload={actionsPayload} />);
+      await screen.findAllByText('Example task');
+
+      // The results header row is dropped on desktop, so the Filters trigger is
+      // gone in favor of the per-column filter buttons.
+      expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
+
+      // The single "View options" control is now the icon button hosted to the
+      // right of the Actions column header.
+      const viewOptions = screen.getByRole('button', { name: 'View options' });
+      expect(viewOptions.closest('th')?.classList.contains('queue-table-actions-header')).toBe(
+        true,
+      );
+
+      // It still opens the preferences popover from its new location.
+      fireEvent.click(viewOptions);
+      expect(screen.getByRole('radio', { name: 'Compact' })).toBeTruthy();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   // MM-952: scan-first desktop table information architecture.
   it('leads the desktop table with a title-first Workflow column and secondary compact id', async () => {
     fetchSpy.mockResolvedValue({

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1755,6 +1755,58 @@ describe('Workflows Entrypoint', () => {
     }
   });
 
+  it('keeps a desktop entry point to the advanced filters drawer after dropping the Filters row', async () => {
+    const actionsPayload: BootPayload = {
+      page: 'workflow-list',
+      apiBase: '/api',
+      initialData: {
+        dashboardConfig: {
+          features: { temporalDashboard: { listEnabled: true, actionsEnabled: true } },
+        },
+      },
+    };
+
+    // Force the desktop breakpoint (jsdom has no matchMedia, so the component
+    // otherwise defaults to the mobile layout).
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    );
+
+    try {
+      renderWithClient(<WorkflowListPage payload={actionsPayload} />);
+      await screen.findAllByText('Example task');
+
+      // The top-row Filters trigger is gone, but the full filter surface must
+      // stay reachable on desktop: the per-column buttons only cover
+      // TABLE_COLUMN_FILTER_FIELDS, so drawer-only fields (ID, Skill, Scheduled,
+      // Created, Finished) would otherwise be unreachable. The entry point moves
+      // to a compact icon in the Actions header.
+      expect(screen.queryByRole('button', { name: 'Filters' })).toBeNull();
+      const advancedFilters = screen.getByRole('button', { name: 'Advanced filters' });
+      expect(
+        advancedFilters.closest('th')?.classList.contains('queue-table-actions-header'),
+      ).toBe(true);
+
+      // Opening it surfaces the advanced filters drawer, including a drawer-only
+      // field (Skill) that has no per-column filter button.
+      fireEvent.click(advancedFilters);
+      const drawer = screen.getByRole('dialog', { name: 'Advanced filters' });
+      expect(within(drawer).getByRole('region', { name: 'Skill filter' })).toBeTruthy();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   // MM-952: scan-first desktop table information architecture.
   it('leads the desktop table with a title-first Workflow column and secondary compact id', async () => {
     fetchSpy.mockResolvedValue({

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1650,6 +1650,43 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     </div>
   );
 
+  // Desktop entry point to the full advanced-filters drawer. When the results
+  // header row is dropped on desktop, the per-column buttons only cover
+  // TABLE_COLUMN_FILTER_FIELDS, so this keeps every drawer-only field (ID, Skill,
+  // Scheduled, Created, Finished, and any column hidden via View options)
+  // reachable and surfaces the active-filter count so those filters can still be
+  // reviewed and cleared without hand-editing the URL.
+  const renderAdvancedFiltersTrigger = () => (
+    <button
+      type="button"
+      className={`workflow-list-advanced-filters-trigger${hasActiveFilters ? ' is-active' : ''}`}
+      ref={drawerToggleRef}
+      aria-haspopup="dialog"
+      aria-expanded={drawerOpen}
+      aria-label={
+        hasActiveFilters
+          ? `Advanced filters. ${activeFilters.length} active.`
+          : 'Advanced filters'
+      }
+      title="Advanced filters"
+      onClick={(event) => openDrawer(null, event.currentTarget)}
+    >
+      <svg
+        aria-hidden="true"
+        className="workflow-list-advanced-filters-icon"
+        viewBox="0 0 16 16"
+        focusable="false"
+      >
+        <path d="M2 3h12l-4.8 5.4v3.4l-2.4 1.2V8.4L2 3Z" />
+      </svg>
+      {hasActiveFilters ? (
+        <span className="workflow-list-advanced-filters-count" aria-hidden="true">
+          {activeFilters.length}
+        </span>
+      ) : null}
+    </button>
+  );
+
   // Desktop promotes the per-column filter buttons and an Actions-header "View
   // options" icon, dropping the results header row. The icon lives inside the
   // rendered table header, so it can only host "View options" when the table is
@@ -1999,6 +2036,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <th scope="col" className="queue-table-actions-header">
                           <div className="queue-table-actions-header-inner">
                             <span>Actions</span>
+                            {showViewOptionsIcon ? renderAdvancedFiltersTrigger() : null}
                             {showViewOptionsIcon ? renderViewOptions('icon') : null}
                           </div>
                         </th>

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -80,6 +80,12 @@ type FilterField =
   | 'createdAt'
   | 'closedAt';
 
+// Matches the 768px breakpoint that switches dashboard.css between the mobile
+// card list and the desktop table. Above it, the table headers carry the
+// per-column filters and the "View options" control, so the results header row
+// (Filters trigger + chips) is not rendered.
+const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
+
 // Scan-first desktop columns, ordered left-to-right. `field` is the sort/identity
 // key and `sortable` controls whether the header renders a sort button or a static
 // label. Workflow title leads as the primary anchor; raw/debug identifiers move
@@ -770,6 +776,17 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const [liveUpdatesPref, setLiveUpdatesPref] = useState(initialPrefs.liveUpdatesEnabled);
   const [prefsMenuOpen, setPrefsMenuOpen] = useState(false);
   const prefsMenuRef = useRef<HTMLDivElement | null>(null);
+  // The desktop table and the mobile card list are separate surfaces. On desktop
+  // the per-column filter buttons replace the Filters trigger and the "View
+  // options" control moves into the Actions header, so the results header row
+  // above the table is dropped entirely. matchMedia is unavailable under jsdom;
+  // fall back to the mobile layout there so the test surface keeps the Filters
+  // trigger and text "View options" button.
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(DESKTOP_MEDIA_QUERY).matches
+      : false,
+  );
   const [pageSize, setPageSize] = useState(() => {
     const limitParam = initial.get('limit');
     return limitParam !== null ? parsePageSize(limitParam) : initialPrefs.workflowListPageSize;
@@ -1011,6 +1028,18 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     document.addEventListener('mousedown', onMouseDown);
     return () => document.removeEventListener('mousedown', onMouseDown);
   }, [closeDesktopFilter, desktopFilterField]);
+
+  // Track the desktop breakpoint so the toolbar layout (Filters trigger vs.
+  // per-column filters, results header vs. Actions-header "View options") stays
+  // in sync with the active responsive surface.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const onChange = (event: MediaQueryListEvent) => setIsDesktop(event.matches);
+    setIsDesktop(query.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
 
   // MM-964: close the dashboard preferences popover on an outside click.
   useEffect(() => {
@@ -1501,6 +1530,137 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     return null;
   };
 
+  // The "View options" control is a single instance whose placement follows the
+  // active surface: an icon button in the Actions header on desktop, the labelled
+  // button in the results header otherwise.
+  const renderViewOptions = (variant: 'text' | 'icon') => (
+    <div
+      className={`workflow-list-view-options${variant === 'icon' ? ' workflow-list-view-options--icon' : ''}`}
+      ref={prefsMenuRef}
+    >
+      <button
+        type="button"
+        className={
+          variant === 'icon'
+            ? 'workflow-list-view-options-trigger workflow-list-view-options-trigger--icon'
+            : 'secondary workflow-list-view-options-trigger'
+        }
+        aria-haspopup="dialog"
+        aria-expanded={prefsMenuOpen}
+        aria-label="View options"
+        title={variant === 'icon' ? 'View options' : undefined}
+        onClick={() => setPrefsMenuOpen((open) => !open)}
+      >
+        {variant === 'icon' ? (
+          <svg
+            aria-hidden="true"
+            className="workflow-list-view-options-icon"
+            viewBox="0 0 16 16"
+            focusable="false"
+          >
+            <g fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round">
+              <line x1="2.5" y1="4.5" x2="13.5" y2="4.5" />
+              <line x1="2.5" y1="8" x2="13.5" y2="8" />
+              <line x1="2.5" y1="11.5" x2="13.5" y2="11.5" />
+              <circle cx="6" cy="4.5" r="1.7" fill="currentColor" stroke="none" />
+              <circle cx="10.5" cy="8" r="1.7" fill="currentColor" stroke="none" />
+              <circle cx="5" cy="11.5" r="1.7" fill="currentColor" stroke="none" />
+            </g>
+          </svg>
+        ) : (
+          'View options'
+        )}
+      </button>
+      {prefsMenuOpen ? (
+        <div
+          className="workflow-list-view-options-popover"
+          role="dialog"
+          aria-label="Workflow list view options"
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.stopPropagation();
+              setPrefsMenuOpen(false);
+            }
+          }}
+        >
+          <fieldset className="workflow-list-view-options-group">
+            <legend>Density</legend>
+            <label className="checkbox">
+              <input
+                type="radio"
+                name="workflow-list-density"
+                checked={density === 'comfortable'}
+                onChange={() => handleDensityChange('comfortable')}
+              />
+              Comfortable
+            </label>
+            <label className="checkbox">
+              <input
+                type="radio"
+                name="workflow-list-density"
+                checked={density === 'compact'}
+                onChange={() => handleDensityChange('compact')}
+              />
+              Compact
+            </label>
+          </fieldset>
+          <fieldset className="workflow-list-view-options-group">
+            <legend>Columns</legend>
+            {TABLE_COLUMNS.filter((column) =>
+              (TOGGLEABLE_WORKFLOW_LIST_COLUMNS as readonly string[]).includes(column.field),
+            ).map((column) => (
+              <label className="checkbox" key={column.field}>
+                <input
+                  type="checkbox"
+                  checked={isColumnVisible(column.field)}
+                  onChange={(event) =>
+                    handleToggleColumn(
+                      column.field as ToggleableWorkflowListColumn,
+                      event.target.checked,
+                    )
+                  }
+                />
+                {column.label}
+              </label>
+            ))}
+          </fieldset>
+          <fieldset className="workflow-list-view-options-group">
+            <legend>Live updates</legend>
+            <label className="checkbox">
+              <input
+                type="checkbox"
+                checked={liveUpdatesPref}
+                onChange={(event) => handleLiveUpdatesChange(event.target.checked)}
+              />
+              Poll for live updates
+            </label>
+          </fieldset>
+          <div className="workflow-list-view-options-actions">
+            <button
+              type="button"
+              className="secondary"
+              onClick={handleResetPreferences}
+              aria-label="Reset dashboard preferences to defaults"
+            >
+              Reset to defaults
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  // Desktop promotes the per-column filter buttons and an Actions-header "View
+  // options" icon, dropping the results header row. The icon lives inside the
+  // rendered table header, so it can only host "View options" when the table is
+  // actually on screen. The labelled control falls back to the results header
+  // otherwise — on mobile, when there is no Actions column, and on the
+  // loading/error/empty states where the table (and its column filters) are
+  // replaced by a message and the Filters trigger is the only filter affordance.
+  const tableHasRows = !isLoading && !isError && sortedItems.length > 0;
+  const showViewOptionsIcon = isDesktop && actionsEnabled && tableHasRows;
+  const showResultsHeader = !showViewOptionsIcon;
+
   return (
     <div className="stack">
       {hasWorkflowListNotices ? (
@@ -1638,6 +1798,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
         className="queue-layouts panel--data workflow-list-data-slab"
         aria-label="Workflow list"
       >
+        {showResultsHeader ? (
         <header className="workflow-list-results-header">
           <div className="workflow-list-filter-bar">
             <button
@@ -1690,94 +1851,9 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               </div>
             ) : null}
           </div>
-          <div className="workflow-list-view-options" ref={prefsMenuRef}>
-            <button
-              type="button"
-              className="secondary workflow-list-view-options-trigger"
-              aria-haspopup="dialog"
-              aria-expanded={prefsMenuOpen}
-              onClick={() => setPrefsMenuOpen((open) => !open)}
-            >
-              View options
-            </button>
-            {prefsMenuOpen ? (
-              <div
-                className="workflow-list-view-options-popover"
-                role="dialog"
-                aria-label="Workflow list view options"
-                onKeyDown={(event) => {
-                  if (event.key === 'Escape') {
-                    event.stopPropagation();
-                    setPrefsMenuOpen(false);
-                  }
-                }}
-              >
-                <fieldset className="workflow-list-view-options-group">
-                  <legend>Density</legend>
-                  <label className="checkbox">
-                    <input
-                      type="radio"
-                      name="workflow-list-density"
-                      checked={density === 'comfortable'}
-                      onChange={() => handleDensityChange('comfortable')}
-                    />
-                    Comfortable
-                  </label>
-                  <label className="checkbox">
-                    <input
-                      type="radio"
-                      name="workflow-list-density"
-                      checked={density === 'compact'}
-                      onChange={() => handleDensityChange('compact')}
-                    />
-                    Compact
-                  </label>
-                </fieldset>
-                <fieldset className="workflow-list-view-options-group">
-                  <legend>Columns</legend>
-                  {TABLE_COLUMNS.filter((column) =>
-                    (TOGGLEABLE_WORKFLOW_LIST_COLUMNS as readonly string[]).includes(column.field),
-                  ).map((column) => (
-                    <label className="checkbox" key={column.field}>
-                      <input
-                        type="checkbox"
-                        checked={isColumnVisible(column.field)}
-                        onChange={(event) =>
-                          handleToggleColumn(
-                            column.field as ToggleableWorkflowListColumn,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      {column.label}
-                    </label>
-                  ))}
-                </fieldset>
-                <fieldset className="workflow-list-view-options-group">
-                  <legend>Live updates</legend>
-                  <label className="checkbox">
-                    <input
-                      type="checkbox"
-                      checked={liveUpdatesPref}
-                      onChange={(event) => handleLiveUpdatesChange(event.target.checked)}
-                    />
-                    Poll for live updates
-                  </label>
-                </fieldset>
-                <div className="workflow-list-view-options-actions">
-                  <button
-                    type="button"
-                    className="secondary"
-                    onClick={handleResetPreferences}
-                    aria-label="Reset dashboard preferences to defaults"
-                  >
-                    Reset to defaults
-                  </button>
-                </div>
-              </div>
-            ) : null}
-          </div>
+          {renderViewOptions('text')}
         </header>
+        ) : null}
         {isLoading ? (
           <p className="loading workflow-list-empty-message">Loading workflows...</p>
         ) : isError ? (
@@ -1921,7 +1997,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                       })}
                       {actionsEnabled ? (
                         <th scope="col" className="queue-table-actions-header">
-                          Actions
+                          <div className="queue-table-actions-header-inner">
+                            <span>Actions</span>
+                            {showViewOptionsIcon ? renderViewOptions('icon') : null}
+                          </div>
                         </th>
                       ) : null}
                     </tr>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -852,10 +852,25 @@ h1 {
   font-weight: 700;
 }
 
-.workflow-list-column-filter-popover .workflow-list-filter-control {
+/*
+ * `renderFilterControl` wraps each control in `.queue-inline-filter`, whose
+ * toolbar styling includes `border-radius: 999px`. Inside the stacked popover
+ * that pill border collapses into awkward semi-circular ends overlapping the
+ * dropdown edges, so reset it to a flat container — matching the drawer's
+ * `.workflow-list-filter-section .workflow-list-filter-control` treatment.
+ */
+.workflow-list-column-filter-popover .workflow-list-filter-control,
+.workflow-list-column-filter-popover .workflow-list-filter-control:hover,
+.workflow-list-column-filter-popover .workflow-list-filter-control:focus-within {
   display: grid;
   gap: 0.65rem;
   align-items: stretch;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
 }
 
 .workflow-list-column-filter-popover .workflow-list-filter-control label {
@@ -1949,6 +1964,14 @@ tbody tr:hover {
   overflow: visible;
 }
 
+/* The Actions-header "View options" popover (desktop) escapes the table edge the
+ * same way the per-column filter popovers do. */
+.workflow-list-data-slab .queue-table-wrapper:has(
+  .workflow-list-view-options-popover
+) {
+  overflow: visible;
+}
+
 .queue-table-wrapper table {
   border: 0;
   border-collapse: separate;
@@ -2044,6 +2067,50 @@ tbody tr:hover {
 .workflow-list-view-options {
   position: relative;
   margin-left: auto;
+}
+
+/* Icon variant: lives inline in the Actions header on desktop rather than the
+ * (dropped) results header, so it neither pushes itself right nor needs the
+ * relative wrapper's auto margin. */
+.workflow-list-view-options--icon {
+  margin-left: 0;
+  flex: 0 0 auto;
+}
+
+.workflow-list-view-options-trigger--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.workflow-list-view-options-trigger--icon:hover,
+.workflow-list-view-options-trigger--icon:focus-visible,
+.workflow-list-view-options-trigger--icon[aria-expanded="true"] {
+  border-color: rgb(var(--mm-accent) / 0.55);
+  background: rgb(var(--mm-accent) / 0.1);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-view-options-icon {
+  display: block;
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.workflow-list-view-options--icon .workflow-list-view-options-popover {
+  z-index: 30;
 }
 
 .workflow-list-view-options-popover {
@@ -3490,7 +3557,8 @@ button.secondary:hover {
 
 button.workflow-list-filter-chip-open,
 button.workflow-list-filter-chip-remove,
-button.workflow-list-column-filter-button {
+button.workflow-list-column-filter-button,
+button.workflow-list-view-options-trigger--icon {
   background-image: none;
   transform: none;
   filter: none;
@@ -6499,11 +6567,21 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-table-column-actions {
-  width: 4.5rem;
+  width: 6.5rem;
 }
 
 .queue-table-actions-header {
   text-align: right;
+}
+
+/* Keeps the "Actions" label and the small desktop "View options" icon button on
+ * one right-aligned row. */
+.queue-table-actions-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  white-space: nowrap;
 }
 
 .queue-table-cell-actions {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2113,6 +2113,59 @@ tbody tr:hover {
   z-index: 30;
 }
 
+/* Desktop advanced-filters entry point: a compact funnel icon in the Actions
+ * header that opens the full filter drawer once the results header row (and its
+ * Filters trigger) is dropped. Mirrors the per-column filter buttons so the two
+ * filter affordances read as one family. */
+.workflow-list-advanced-filters-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  height: 1.6rem;
+  min-width: 1.6rem;
+  padding: 0 0.3rem;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: rgb(var(--mm-muted));
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.workflow-list-advanced-filters-trigger:hover,
+.workflow-list-advanced-filters-trigger:focus-visible,
+.workflow-list-advanced-filters-trigger[aria-expanded="true"],
+.workflow-list-advanced-filters-trigger.is-active {
+  border-color: rgb(var(--mm-accent) / 0.55);
+  background: rgb(var(--mm-accent) / 0.1);
+  color: rgb(var(--mm-accent));
+  box-shadow: var(--mm-control-focus-ring);
+  transform: none;
+  filter: none;
+}
+
+.workflow-list-advanced-filters-icon {
+  display: block;
+  width: 0.95rem;
+  height: 0.95rem;
+  fill: currentColor;
+}
+
+.workflow-list-advanced-filters-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.05rem;
+  height: 1.05rem;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: rgb(var(--mm-accent) / 0.22);
+  color: rgb(var(--mm-accent));
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 .workflow-list-view-options-popover {
   position: absolute;
   right: 0;
@@ -3558,7 +3611,8 @@ button.secondary:hover {
 button.workflow-list-filter-chip-open,
 button.workflow-list-filter-chip-remove,
 button.workflow-list-column-filter-button,
-button.workflow-list-view-options-trigger--icon {
+button.workflow-list-view-options-trigger--icon,
+button.workflow-list-advanced-filters-trigger {
   background-image: none;
   transform: none;
   filter: none;
@@ -6567,15 +6621,15 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-table-column-actions {
-  width: 6.5rem;
+  width: 8.5rem;
 }
 
 .queue-table-actions-header {
   text-align: right;
 }
 
-/* Keeps the "Actions" label and the small desktop "View options" icon button on
- * one right-aligned row. */
+/* Keeps the "Actions" label and the small desktop "Advanced filters" + "View
+ * options" icon buttons on one right-aligned row. */
 .queue-table-actions-header-inner {
   display: flex;
   align-items: center;


### PR DESCRIPTION
I do not want this top row above the column headers for the Workflows table on desktop. On desktop, the Filters button in the top left should be hidden in favor of the filter buttons in each column. I want the View Options button converted to some kind of icon button instead of using text. That icon button should be small and to the right of the Actions column header.

Additionally, the column filter buttons now show dropdowns with an awkward semi-circular border overlapping the edges strangely. This should not be here.