### PR TITLE
MM-967 Simplify Jira Breakdown fields

### DIFF
--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -35,11 +35,6 @@ inputs:
     type: text
     required: true
     default: Story
-  - name: jira_board_id
-    label: Jira Board
-    type: jira_board
-    required: false
-    default: ""
   - name: jira_dependency_mode
     label: Jira Dependency Mode
     type: enum
@@ -135,7 +130,6 @@ steps:
       For stories where jiraCreation.action is create_remaining_work_issue, create the Jira issue from the story's remainingWork while preserving the original story traceability.
       {% if inputs.source_issue_key %}Source Jira issue key: {{ inputs.source_issue_key }}.{% endif %}
       {% if inputs.source_issue_key and inputs.jira_issue_type | lower in ["sub-task", "subtask", "sub task"] %}Create each generated Jira issue as a sub-task of {{ inputs.source_issue_key }}.{% endif %}
-      {% if inputs.jira_board_id %}Selected Jira board ID: {{ inputs.jira_board_id }}.{% endif %}
       Dependency mode: {{ inputs.jira_dependency_mode }}.
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
@@ -146,7 +140,6 @@ steps:
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"
-        boardId: "{{ inputs.jira_board_id }}"
         sourceIssueKey: "{{ inputs.source_issue_key }}"
         dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -398,6 +398,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         implement_composite_template = result.scalar_one_or_none()
         assert implement_composite_template is not None
+        assert "jira_board_id" not in {
+            item["name"] for item in implement_composite_template.inputs_schema
+        }
         assert [
             (step.get("skill") or step.get("tool"))["id"]
             for step in implement_composite_template.steps
@@ -411,6 +414,9 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         implement_downstream_step = (
             implement_composite_template.steps[4]
         )
+        implement_jira_step = implement_composite_template.steps[3]
+        assert "Selected Jira board ID" not in implement_jira_step["instructions"]
+        assert "boardId" not in implement_jira_step["storyOutput"]["jira"]
         assert (
             "Create one Jira Implement task"
             in implement_downstream_step["instructions"]

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3130,7 +3130,6 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "MM",
                     "jira_issue_type": "Story",
-                    "jira_board_id": "84",
                     "jira_dependency_mode": "linear_blocker_chain",
                     "publish_mode": "pr_with_merge_automation",
                     "source_issue_key": "MM-404",
@@ -3141,12 +3140,26 @@ async def test_seed_catalog_includes_jira_breakdown_implement_preset(tmp_path):
                 },
             )
 
+            template = await service.get_template(
+                slug="jira-breakdown-implement",
+                scope="global",
+                scope_ref=None,
+            )
+
+    assert "jira_board_id" not in {item["name"] for item in template["inputs"]}
     assert len(expanded["steps"]) == 5
     assert expanded["steps"][0]["tool"]["id"] == "jira.load_preset_brief"
     assert expanded["steps"][0]["tool"]["inputs"] == {"issueKey": "MM-404"}
     assert expanded["steps"][1]["skill"]["id"] == "moonspec-breakdown"
     assert expanded["steps"][2]["skill"]["id"] == "story-reconcile-implementation"
     assert expanded["steps"][3]["skill"]["id"] == "story.create_jira_issues"
+    assert "Selected Jira board ID" not in expanded["steps"][3]["instructions"]
+    assert expanded["steps"][3]["storyOutput"]["jira"] == {
+        "projectKey": "MM",
+        "issueTypeName": "Story",
+        "sourceIssueKey": "MM-404",
+        "dependencyMode": "linear_blocker_chain",
+    }
     downstream = expanded["steps"][4]
     assert downstream["skill"]["id"] == "story.create_jira_implement_tasks"
     assert downstream["jiraOrchestration"]["task"] == {


### PR DESCRIPTION
Issue: MM-967

Summary:
- Removed the Jira Board input from the Jira Breakdown and Implement preset.
- Removed the selected-board instruction and boardId payload field from the Jira issue creation step.
- Added preset expansion and startup seeding coverage to keep the board field absent.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_presets_service.py (Python pytest portion passed: 73 passed; script later failed in unrelated frontend workflow-list timeout)
- ./tools/test_integration.sh tests/integration/test_startup_preset_seeding.py (runner selected full integration_ci suite: 371 passed, 1 skipped, 87 deselected)

Remaining risks:
- Unit runner frontend segment has an unrelated timeout in frontend/src/entrypoints/workflow-list.test.tsx; this branch does not touch frontend code.
