### PR TITLE
MM-965: Add Settings configuration health summary and clearer permission states

### DIFF
--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -47,7 +47,7 @@ const _BROKEN_REFERENCE_STATUSES = new Set([
   'missing',
 ]);
 
-function isBrokenReferenceStatus(status: string | undefined): boolean {
+export function isBrokenReferenceStatus(status: string | undefined): boolean {
   return Boolean(status) && _BROKEN_REFERENCE_STATUSES.has(String(status));
 }
 

--- a/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
@@ -93,9 +93,14 @@ describe('summarizeConfigurationHealth', () => {
     expect(summary.warnings.map((w) => w.id)).toContain('no-default-profile');
   });
 
-  it('blocks on broken secret references', () => {
+  it('blocks on broken secret references bound by an enabled profile', () => {
     const summary = summarizeConfigurationHealth({
-      providerProfiles: [makeProfile({ is_default: true })],
+      providerProfiles: [
+        makeProfile({
+          is_default: true,
+          secret_refs: { GH_TOKEN: 'db://GH_TOKEN' },
+        }),
+      ],
       secrets: [
         { slug: 'OPENAI_API_KEY', status: 'active' },
         { slug: 'GH_TOKEN', status: 'invalid' },
@@ -106,6 +111,63 @@ describe('summarizeConfigurationHealth', () => {
     expect(summary.level).toBe('blocked');
     expect(summary.brokenSecretCount).toBe(1);
     expect(summary.warnings.map((w) => w.id)).toContain('broken-secret-refs');
+  });
+
+  it('does not block on broken secrets that no enabled profile references', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [
+        makeProfile({
+          is_default: true,
+          secret_refs: { OPENAI_API_KEY: 'db://OPENAI_API_KEY' },
+        }),
+        // Disabled profile binding the broken secret must not block launches.
+        makeProfile({
+          profile_id: 'profile-2',
+          enabled: false,
+          secret_refs: { GH_TOKEN: 'db://GH_TOKEN' },
+        }),
+      ],
+      secrets: [
+        { slug: 'OPENAI_API_KEY', status: 'active' },
+        { slug: 'GH_TOKEN', status: 'invalid' },
+      ],
+      workerPauseConfigured: true,
+    });
+
+    expect(summary.level).toBe('ready');
+    // The broken secret is still surfaced as a metric, just not a blocker.
+    expect(summary.brokenSecretCount).toBe(1);
+    expect(summary.warnings.map((w) => w.id)).not.toContain('broken-secret-refs');
+  });
+
+  it('warns when workers are paused even if configuration is otherwise ready', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [makeProfile({ is_default: true })],
+      secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
+      workerPauseConfigured: true,
+      workersPaused: true,
+      workerMode: 'drain',
+    });
+
+    expect(summary.level).toBe('warning');
+    expect(summary.warnings.map((w) => w.id)).toContain('workers-paused');
+    expect(
+      summary.warnings.find((w) => w.id === 'workers-paused')?.message,
+    ).toMatch(/paused/i);
+  });
+
+  it('describes quiesced workers in the paused warning', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [makeProfile({ is_default: true })],
+      secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
+      workerPauseConfigured: true,
+      workersPaused: true,
+      workerMode: 'quiesce',
+    });
+
+    expect(
+      summary.warnings.find((w) => w.id === 'workers-paused')?.message,
+    ).toMatch(/quiesced/i);
   });
 });
 
@@ -136,7 +198,12 @@ describe('ConfigurationHealthSummary', () => {
 
   it('highlights missing/invalid defaults in the warning list', () => {
     renderSummary({
-      providerProfiles: [makeProfile({ is_default: false })],
+      providerProfiles: [
+        makeProfile({
+          is_default: false,
+          secret_refs: { GH_TOKEN: 'db://GH_TOKEN' },
+        }),
+      ],
       secrets: [{ slug: 'GH_TOKEN', status: 'missing' }],
       workerPauseConfig: null,
     });

--- a/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
@@ -1,0 +1,210 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ConfigurationHealthSummary,
+  summarizeConfigurationHealth,
+  type ConfigurationHealthSummaryProps,
+} from './ConfigurationHealthSummary';
+import type { ProviderProfile } from './ProviderProfilesManager';
+import type { WorkerPauseConfig } from './OperationsSettingsSection';
+
+function makeProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
+  return {
+    profile_id: 'profile-1',
+    runtime_id: 'claude',
+    provider_id: 'anthropic',
+    provider_label: 'Anthropic',
+    credential_source: 'managed_secret',
+    runtime_materialization_mode: 'ephemeral',
+    secret_refs: {},
+    max_parallel_runs: 1,
+    cooldown_after_429_seconds: 0,
+    rate_limit_policy: 'default',
+    enabled: true,
+    is_default: false,
+    ...overrides,
+  };
+}
+
+function renderSummary(props: Partial<ConfigurationHealthSummaryProps> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ConfigurationHealthSummary
+        providerProfiles={props.providerProfiles ?? []}
+        secrets={props.secrets ?? []}
+        isLoading={props.isLoading ?? false}
+        isError={props.isError ?? false}
+        workerPauseConfig={props.workerPauseConfig ?? null}
+        canWriteProviderProfiles={props.canWriteProviderProfiles ?? true}
+        canRunGithubTokenProbe={props.canRunGithubTokenProbe ?? true}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('summarizeConfigurationHealth', () => {
+  it('reports ready when an enabled default profile and healthy secrets are present', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [makeProfile({ is_default: true })],
+      secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
+      workerPauseConfigured: true,
+      workersPaused: false,
+    });
+
+    expect(summary.level).toBe('ready');
+    expect(summary.providerProfileCount).toBe(1);
+    expect(summary.enabledProviderProfileCount).toBe(1);
+    expect(summary.hasDefaultProfile).toBe(true);
+    expect(summary.managedSecretCount).toBe(1);
+    expect(summary.brokenSecretCount).toBe(0);
+    expect(summary.warnings).toHaveLength(0);
+  });
+
+  it('blocks when there are no provider profiles', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [],
+      secrets: [],
+      workerPauseConfigured: true,
+    });
+
+    expect(summary.level).toBe('blocked');
+    expect(summary.warnings.map((w) => w.id)).toContain('no-provider-profiles');
+  });
+
+  it('flags a missing default profile as a warning', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [makeProfile({ is_default: false })],
+      secrets: [],
+      workerPauseConfigured: true,
+    });
+
+    expect(summary.level).toBe('warning');
+    expect(summary.hasDefaultProfile).toBe(false);
+    expect(summary.warnings.map((w) => w.id)).toContain('no-default-profile');
+  });
+
+  it('blocks on broken secret references', () => {
+    const summary = summarizeConfigurationHealth({
+      providerProfiles: [makeProfile({ is_default: true })],
+      secrets: [
+        { slug: 'OPENAI_API_KEY', status: 'active' },
+        { slug: 'GH_TOKEN', status: 'invalid' },
+      ],
+      workerPauseConfigured: true,
+    });
+
+    expect(summary.level).toBe('blocked');
+    expect(summary.brokenSecretCount).toBe(1);
+    expect(summary.warnings.map((w) => w.id)).toContain('broken-secret-refs');
+  });
+});
+
+describe('ConfigurationHealthSummary', () => {
+  it('renders the health summary with sample data: counts, default, and readiness badge', async () => {
+    renderSummary({
+      providerProfiles: [
+        makeProfile({ profile_id: 'p1', is_default: true }),
+        makeProfile({ profile_id: 'p2', enabled: false }),
+      ],
+      secrets: [
+        { slug: 'OPENAI_API_KEY', status: 'active' },
+        { slug: 'ANTHROPIC_API_KEY', status: 'active' },
+      ],
+      workerPauseConfig: null,
+    });
+
+    expect(
+      screen.getByRole('region', { name: /Configuration health summary/i }),
+    ).toBeTruthy();
+    expect(screen.getByText('Provider profiles')).toBeTruthy();
+    // 2 profiles, 1 enabled
+    expect(screen.getByText('1 enabled')).toBeTruthy();
+    expect(screen.getByText('Managed secrets')).toBeTruthy();
+    expect(screen.getByText('All references healthy')).toBeTruthy();
+    expect(screen.getByText('Configured')).toBeTruthy();
+  });
+
+  it('highlights missing/invalid defaults in the warning list', () => {
+    renderSummary({
+      providerProfiles: [makeProfile({ is_default: false })],
+      secrets: [{ slug: 'GH_TOKEN', status: 'missing' }],
+      workerPauseConfig: null,
+    });
+
+    const warnings = screen.getByRole('list', { name: /Configuration warnings/i });
+    expect(warnings.textContent).toMatch(/No default provider profile is set/i);
+    expect(warnings.textContent).toMatch(/broken state/i);
+    expect(screen.getByText('Missing')).toBeTruthy();
+    expect(screen.getByText('1 broken')).toBeTruthy();
+  });
+
+  it('shows the read-only state when provider profile writes are disabled', () => {
+    renderSummary({
+      providerProfiles: [makeProfile({ is_default: true })],
+      canWriteProviderProfiles: false,
+      canRunGithubTokenProbe: true,
+      workerPauseConfig: null,
+    });
+
+    expect(screen.getByText(/Provider profile writes disabled/i)).toBeTruthy();
+    expect(screen.getByText(/provider_profiles\.write/i)).toBeTruthy();
+    expect(screen.getAllByText(/Read-only/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows why the permission-disabled GitHub token probe is unavailable', () => {
+    renderSummary({
+      providerProfiles: [makeProfile({ is_default: true })],
+      canWriteProviderProfiles: true,
+      canRunGithubTokenProbe: false,
+      workerPauseConfig: null,
+    });
+
+    expect(screen.getByText(/GitHub token probe unavailable/i)).toBeTruthy();
+    expect(screen.getByText(/settings\.effective\.read/i)).toBeTruthy();
+  });
+
+  it('reports the live worker pause state when worker controls are configured', async () => {
+    const workerPauseConfig: WorkerPauseConfig = {
+      get: '/api/v1/operations/workers',
+      post: '/api/v1/operations/workers',
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ system: { workersPaused: true, mode: 'drain' } }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSummary({
+      providerProfiles: [makeProfile({ is_default: true })],
+      workerPauseConfig,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Paused')).toBeTruthy();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/operations/workers',
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) }),
+    );
+  });
+
+  it('renders a loading state without querying', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSummary({ isLoading: true });
+
+    expect(screen.getByText(/Loading configuration health/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/settings/ConfigurationHealthSummary.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.tsx
@@ -1,0 +1,405 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { isBrokenReferenceStatus } from '../secrets/SecretManager';
+import type { WorkerPauseConfig } from './OperationsSettingsSection';
+import type { ProviderProfile } from './ProviderProfilesManager';
+
+/**
+ * MM-965 — Settings configuration health summary.
+ *
+ * Aggregates boot/query data already loaded by the Settings page into a single
+ * launch-readiness answer: "Is MoonMind configured well enough to run workflows
+ * safely?" It surfaces provider/secret counts, missing or invalid defaults, and
+ * permission/read-only states with visible reasons. It deliberately reuses the
+ * data the page already fetches and the shared worker snapshot query rather than
+ * introducing a dedicated backend health endpoint (out of scope).
+ */
+
+export interface HealthSecret {
+  slug: string;
+  status: string;
+}
+
+export type HealthLevel = 'ready' | 'warning' | 'blocked';
+
+export interface HealthWarning {
+  id: string;
+  level: 'warning' | 'blocked';
+  message: string;
+}
+
+export interface ConfigurationHealthInput {
+  providerProfiles: ProviderProfile[];
+  secrets: HealthSecret[];
+  workerPauseConfigured: boolean;
+  workersPaused?: boolean | null;
+  workerMode?: string | null;
+}
+
+export interface ConfigurationHealthSummaryData {
+  level: HealthLevel;
+  headline: string;
+  providerProfileCount: number;
+  enabledProviderProfileCount: number;
+  hasDefaultProfile: boolean;
+  defaultProfileLabel: string | null;
+  managedSecretCount: number;
+  brokenSecretCount: number;
+  warnings: HealthWarning[];
+}
+
+function profileLabel(profile: ProviderProfile): string {
+  return profile.provider_label?.trim() || profile.profile_id;
+}
+
+/**
+ * Pure derivation of configuration health from already-loaded settings data.
+ * Kept separate from the component so it can be unit-tested without React.
+ */
+export function summarizeConfigurationHealth(
+  input: ConfigurationHealthInput,
+): ConfigurationHealthSummaryData {
+  const { providerProfiles, secrets, workerPauseConfigured } = input;
+
+  const enabledProfiles = providerProfiles.filter((profile) => profile.enabled);
+  const defaultProfile =
+    providerProfiles.find((profile) => profile.is_default && profile.enabled) ??
+    providerProfiles.find((profile) => profile.is_default) ??
+    null;
+  const brokenSecrets = secrets.filter((secret) =>
+    isBrokenReferenceStatus(secret.status),
+  );
+  const blockedReadinessProfiles = enabledProfiles.filter(
+    (profile) => profile.readiness?.status === 'blocked',
+  );
+
+  const warnings: HealthWarning[] = [];
+
+  if (providerProfiles.length === 0) {
+    warnings.push({
+      id: 'no-provider-profiles',
+      level: 'blocked',
+      message:
+        'No provider profiles are configured. Add a provider profile before launching workflows.',
+    });
+  } else if (enabledProfiles.length === 0) {
+    warnings.push({
+      id: 'no-enabled-provider-profiles',
+      level: 'blocked',
+      message:
+        'All provider profiles are disabled. Enable at least one profile to launch workflows.',
+    });
+  }
+
+  if (providerProfiles.length > 0 && !defaultProfile) {
+    warnings.push({
+      id: 'no-default-profile',
+      level: 'warning',
+      message:
+        'No default provider profile is set. Workflows without an explicit profile have no runtime to fall back to.',
+    });
+  }
+
+  if (brokenSecrets.length > 0) {
+    warnings.push({
+      id: 'broken-secret-refs',
+      level: 'blocked',
+      message: `${brokenSecrets.length} managed secret${
+        brokenSecrets.length === 1 ? '' : 's'
+      } are in a broken state (disabled, rotated, deleted, invalid, or missing). Profiles that bind them will fail launches.`,
+    });
+  }
+
+  for (const profile of blockedReadinessProfiles) {
+    warnings.push({
+      id: `blocked-readiness-${profile.profile_id}`,
+      level: 'blocked',
+      message: `Provider profile "${profileLabel(profile)}" is not launch-ready: ${
+        profile.readiness?.summary ?? 'readiness checks failed.'
+      }`,
+    });
+  }
+
+  if (!workerPauseConfigured) {
+    warnings.push({
+      id: 'worker-controls-unavailable',
+      level: 'warning',
+      message:
+        'Worker operations controls are not configured for this deployment, so pause/resume state cannot be confirmed here.',
+    });
+  }
+
+  const hasBlocking = warnings.some((warning) => warning.level === 'blocked');
+  const level: HealthLevel = hasBlocking
+    ? 'blocked'
+    : warnings.length > 0
+      ? 'warning'
+      : 'ready';
+
+  const headline =
+    level === 'ready'
+      ? 'MoonMind looks configured to run workflows.'
+      : level === 'warning'
+        ? 'MoonMind can run workflows, but some configuration needs attention.'
+        : 'MoonMind is not ready to run workflows safely.';
+
+  return {
+    level,
+    headline,
+    providerProfileCount: providerProfiles.length,
+    enabledProviderProfileCount: enabledProfiles.length,
+    hasDefaultProfile: Boolean(defaultProfile),
+    defaultProfileLabel: defaultProfile ? profileLabel(defaultProfile) : null,
+    managedSecretCount: secrets.length,
+    brokenSecretCount: brokenSecrets.length,
+    warnings,
+  };
+}
+
+interface WorkerStateSnapshot {
+  system?: {
+    workersPaused?: boolean;
+    mode?: string | null;
+  };
+}
+
+const LEVEL_BADGE: Record<HealthLevel, { label: string; className: string }> = {
+  ready: {
+    label: 'Launch ready',
+    className:
+      'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+  },
+  warning: {
+    label: 'Needs attention',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  blocked: {
+    label: 'Not launch ready',
+    className: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300',
+  },
+};
+
+function MetricTile({
+  label,
+  value,
+  tone = 'default',
+  hint,
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'warning';
+  hint?: string;
+}) {
+  return (
+    <div
+      className={`rounded-2xl border p-4 ${
+        tone === 'warning'
+          ? 'border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-900/20'
+          : 'border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-800/50'
+      }`}
+    >
+      <div className="text-sm font-medium text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{value}</div>
+      {hint ? (
+        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function ReadOnlyBadge({ reason }: { reason: string }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
+      title={reason}
+    >
+      Read-only
+    </span>
+  );
+}
+
+export interface ConfigurationHealthSummaryProps {
+  providerProfiles: ProviderProfile[];
+  secrets: HealthSecret[];
+  isLoading?: boolean;
+  isError?: boolean;
+  workerPauseConfig: WorkerPauseConfig | null;
+  canWriteProviderProfiles: boolean;
+  canRunGithubTokenProbe: boolean;
+}
+
+export function ConfigurationHealthSummary({
+  providerProfiles,
+  secrets,
+  isLoading = false,
+  isError = false,
+  workerPauseConfig,
+  canWriteProviderProfiles,
+  canRunGithubTokenProbe,
+}: ConfigurationHealthSummaryProps) {
+  const workerPauseConfigured = workerPauseConfig !== null;
+
+  const { data: workerState } = useQuery<WorkerStateSnapshot>({
+    queryKey: ['workers-snapshot'],
+    queryFn: async () => {
+      const response = await fetch(workerPauseConfig!.get, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch worker status: ${response.statusText}`);
+      }
+      return (await response.json()) as WorkerStateSnapshot;
+    },
+    enabled: workerPauseConfigured && Boolean(workerPauseConfig?.get),
+  });
+
+  if (isLoading) {
+    return (
+      <section
+        aria-label="Configuration health summary"
+        className="rounded-3xl border border-mm-border/80 bg-transparent p-6 text-sm text-slate-500 shadow-sm dark:text-slate-400"
+      >
+        Loading configuration health...
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section
+        aria-label="Configuration health summary"
+        className="rounded-3xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400"
+      >
+        Failed to load configuration health data.
+      </section>
+    );
+  }
+
+  const workersPaused = workerState?.system?.workersPaused ?? null;
+  const workerMode = workerState?.system?.mode ?? null;
+
+  const summary = summarizeConfigurationHealth({
+    providerProfiles,
+    secrets,
+    workerPauseConfigured,
+    workersPaused,
+    workerMode,
+  });
+
+  const badge = LEVEL_BADGE[summary.level];
+
+  let workerStateLabel: string;
+  if (!workerPauseConfigured) {
+    workerStateLabel = 'Not configured';
+  } else if (workersPaused === null) {
+    workerStateLabel = 'Unknown';
+  } else if (workersPaused) {
+    workerStateLabel = workerMode === 'quiesce' ? 'Quiesced' : 'Paused';
+  } else {
+    workerStateLabel = 'Running';
+  }
+
+  return (
+    <section
+      aria-label="Configuration health summary"
+      className="rounded-[2rem] border border-mm-border/80 bg-transparent p-6 shadow-sm"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+            Configuration health
+          </h3>
+          <p className="max-w-2xl text-sm text-slate-600 dark:text-slate-400">
+            {summary.headline}
+          </p>
+        </div>
+        <span
+          role="status"
+          className={`inline-flex shrink-0 items-center rounded-full px-3 py-1 text-xs font-semibold ${badge.className}`}
+        >
+          {badge.label}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricTile
+          label="Provider profiles"
+          value={String(summary.providerProfileCount)}
+          hint={`${summary.enabledProviderProfileCount} enabled`}
+          tone={summary.enabledProviderProfileCount === 0 ? 'warning' : 'default'}
+        />
+        <MetricTile
+          label="Default profile"
+          value={summary.hasDefaultProfile ? 'Configured' : 'Missing'}
+          hint={summary.defaultProfileLabel ?? 'No default set'}
+          tone={summary.hasDefaultProfile ? 'default' : 'warning'}
+        />
+        <MetricTile
+          label="Managed secrets"
+          value={String(summary.managedSecretCount)}
+          hint={
+            summary.brokenSecretCount > 0
+              ? `${summary.brokenSecretCount} broken`
+              : 'All references healthy'
+          }
+          tone={summary.brokenSecretCount > 0 ? 'warning' : 'default'}
+        />
+        <MetricTile label="Worker state" value={workerStateLabel} />
+      </div>
+
+      {summary.warnings.length > 0 ? (
+        <ul
+          aria-label="Configuration warnings"
+          className="mt-5 space-y-2"
+        >
+          {summary.warnings.map((warning) => (
+            <li
+              key={warning.id}
+              className={`rounded-2xl border px-4 py-3 text-sm ${
+                warning.level === 'blocked'
+                  ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400'
+                  : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-300'
+              }`}
+            >
+              {warning.message}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-5 text-sm text-emerald-700 dark:text-emerald-400">
+          No missing or invalid defaults detected.
+        </p>
+      )}
+
+      <div className="mt-5 flex flex-wrap items-center gap-3 border-t border-slate-200 pt-4 dark:border-slate-800">
+        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Permissions
+        </span>
+        {canWriteProviderProfiles ? (
+          <span className="text-xs text-slate-600 dark:text-slate-400">
+            Provider profile writes enabled
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-2 text-xs text-slate-600 dark:text-slate-400">
+            <ReadOnlyBadge reason="Provider profile writes require the provider_profiles.write permission." />
+            Provider profile writes disabled — requires the{' '}
+            <code>provider_profiles.write</code> permission.
+          </span>
+        )}
+        {canRunGithubTokenProbe ? (
+          <span className="text-xs text-slate-600 dark:text-slate-400">
+            GitHub token probe available
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-2 text-xs text-slate-600 dark:text-slate-400">
+            <ReadOnlyBadge reason="The GitHub token probe requires the settings.effective.read permission." />
+            GitHub token probe unavailable — requires the{' '}
+            <code>settings.effective.read</code> permission.
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default ConfigurationHealthSummary;

--- a/frontend/src/components/settings/ConfigurationHealthSummary.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.tsx
@@ -53,21 +53,58 @@ function profileLabel(profile: ProviderProfile): string {
 }
 
 /**
+ * Extract the secret slug from a `<backend>://<locator>` secret reference.
+ * For managed (`db://`) references the locator is the secret slug; values
+ * without a scheme are treated as bare slugs.
+ */
+function secretSlugFromRef(ref: string): string | null {
+  const value = ref?.trim();
+  if (!value) {
+    return null;
+  }
+  const separator = value.indexOf('://');
+  const locator = separator >= 0 ? value.slice(separator + 3) : value;
+  return locator.trim() || null;
+}
+
+/**
  * Pure derivation of configuration health from already-loaded settings data.
  * Kept separate from the component so it can be unit-tested without React.
  */
 export function summarizeConfigurationHealth(
   input: ConfigurationHealthInput,
 ): ConfigurationHealthSummaryData {
-  const { providerProfiles, secrets, workerPauseConfigured } = input;
+  const {
+    providerProfiles,
+    secrets,
+    workerPauseConfigured,
+    workersPaused,
+    workerMode,
+  } = input;
 
   const enabledProfiles = providerProfiles.filter((profile) => profile.enabled);
   const defaultProfile =
     providerProfiles.find((profile) => profile.is_default && profile.enabled) ??
     providerProfiles.find((profile) => profile.is_default) ??
     null;
+
+  // Only secrets referenced by an enabled profile can block a launch; an
+  // unused disabled/rotated/deleted secret in the store is not a blocker.
+  const referencedSecretSlugs = new Set<string>();
+  for (const profile of enabledProfiles) {
+    for (const ref of Object.values(profile.secret_refs ?? {})) {
+      const slug = secretSlugFromRef(ref);
+      if (slug) {
+        referencedSecretSlugs.add(slug);
+      }
+    }
+  }
+
   const brokenSecrets = secrets.filter((secret) =>
     isBrokenReferenceStatus(secret.status),
+  );
+  const blockingBrokenSecrets = brokenSecrets.filter((secret) =>
+    referencedSecretSlugs.has(secret.slug),
   );
   const blockedReadinessProfiles = enabledProfiles.filter(
     (profile) => profile.readiness?.status === 'blocked',
@@ -100,13 +137,15 @@ export function summarizeConfigurationHealth(
     });
   }
 
-  if (brokenSecrets.length > 0) {
+  if (blockingBrokenSecrets.length > 0) {
     warnings.push({
       id: 'broken-secret-refs',
       level: 'blocked',
-      message: `${brokenSecrets.length} managed secret${
-        brokenSecrets.length === 1 ? '' : 's'
-      } are in a broken state (disabled, rotated, deleted, invalid, or missing). Profiles that bind them will fail launches.`,
+      message: `${blockingBrokenSecrets.length} managed secret${
+        blockingBrokenSecrets.length === 1 ? '' : 's'
+      } bound by enabled provider profiles ${
+        blockingBrokenSecrets.length === 1 ? 'is' : 'are'
+      } in a broken state (disabled, rotated, deleted, invalid, or missing). Profiles that bind them will fail launches.`,
     });
   }
 
@@ -126,6 +165,13 @@ export function summarizeConfigurationHealth(
       level: 'warning',
       message:
         'Worker operations controls are not configured for this deployment, so pause/resume state cannot be confirmed here.',
+    });
+  } else if (workersPaused) {
+    const pausedDescriptor = workerMode === 'quiesce' ? 'quiesced' : 'paused';
+    warnings.push({
+      id: 'workers-paused',
+      level: 'warning',
+      message: `Workers are currently ${pausedDescriptor}, so newly launched workflows will not start until workers resume.`,
     });
   }
 
@@ -242,7 +288,10 @@ export function ConfigurationHealthSummary({
   const { data: workerState } = useQuery<WorkerStateSnapshot>({
     queryKey: ['workers-snapshot'],
     queryFn: async () => {
-      const response = await fetch(workerPauseConfig!.get, {
+      if (!workerPauseConfig?.get) {
+        throw new Error('Worker pause GET endpoint is not configured.');
+      }
+      const response = await fetch(workerPauseConfig.get, {
         headers: { Accept: 'application/json' },
       });
       if (!response.ok) {

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -1273,10 +1273,17 @@ export function OperationsSettingsSection({
             </section>
 
             <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-              <section className="rounded-3xl border border-slate-200 dark:border-slate-800 p-5">
-                <h4 className="text-base font-semibold text-slate-900 dark:text-white">Worker controls</h4>
+              <section
+                className="rounded-3xl border border-rose-200 bg-rose-50/40 p-5 dark:border-rose-900/50 dark:bg-rose-900/10"
+                aria-label="Worker controls danger zone"
+              >
+                <span className="inline-flex items-center rounded-full bg-rose-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-rose-700 dark:bg-rose-900/30 dark:text-rose-300">
+                  Danger zone
+                </span>
+                <h4 className="mt-2 text-base font-semibold text-slate-900 dark:text-white">Worker controls</h4>
                 <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
                   Drain lets running jobs finish. Quiesce stops new claims immediately.
+                  These actions affect every running and queued workflow.
                 </p>
 
                 <form className="mt-5 space-y-4" onSubmit={handlePause}>

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { BootPayload } from '../boot/parseBootPayload';
 import { SecretManager } from '../components/secrets/SecretManager';
+import { ConfigurationHealthSummary } from '../components/settings/ConfigurationHealthSummary';
 import { GeneratedSettingsSection } from '../components/settings/GeneratedSettingsSection';
 import { GithubTokenProbePanel } from '../components/settings/GithubTokenProbePanel';
 import {
@@ -200,7 +201,6 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
-    enabled: section === 'providers-secrets',
   });
 
   const {
@@ -218,7 +218,6 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
-    enabled: section === 'providers-secrets',
   });
 
   const fallbackSection = SETTINGS_SECTIONS[0]!;
@@ -245,6 +244,16 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">{currentSection.description}</p>
         </div>
       </header>
+
+      <ConfigurationHealthSummary
+        providerProfiles={providerProfiles ?? []}
+        secrets={secretsData?.items ?? []}
+        isLoading={areProfilesLoading || areSecretsLoading}
+        isError={areProfilesErrored || areSecretsErrored}
+        workerPauseConfig={workerPauseConfig}
+        canWriteProviderProfiles={canWriteProviderProfiles}
+        canRunGithubTokenProbe={canRunGithubTokenProbe}
+      />
 
       <section className="rounded-[2rem] border border-mm-border/80 bg-transparent p-3 shadow-sm">
         <fieldset className="settings-nav-field">


### PR DESCRIPTION
## Issue

[MM-965](https://moonladder.atlassian.net/browse/MM-965) — Improve Settings configuration health and permissions visibility

## Summary

Adds a launch-readiness **configuration health summary** to the top of the Settings page that answers "Is MoonMind configured well enough to run workflows safely?" using boot/query data already loaded by the page (no new backend health endpoint).

The summary surfaces:
- Provider profile count (and enabled count)
- Whether a default provider profile is configured
- Managed secret count and broken-secret-reference count
- Worker pause / operations state when worker controls are configured
- Consolidated missing/invalid-default warnings (no profiles, no enabled profile, no default, broken secret refs, blocked profile readiness)
- Permission/read-only badges with visible reasons for provider-profile writes (`provider_profiles.write`) and the GitHub token probe (`settings.effective.read`)

Also:
- Adds danger-zone styling to the Operations worker pause/resume controls.
- Reuses `SecretManager.isBrokenReferenceStatus` rather than duplicating the broken-status set.
- Provider-profile and secret queries are now always enabled so the top-area summary has data regardless of the active Settings section.

Files changed:
- `frontend/src/components/settings/ConfigurationHealthSummary.tsx` (new)
- `frontend/src/components/settings/ConfigurationHealthSummary.test.tsx` (new)
- `frontend/src/components/settings/OperationsSettingsSection.tsx`
- `frontend/src/components/secrets/SecretManager.tsx`
- `frontend/src/entrypoints/settings.tsx`

## Tests run

- `frontend/src/components/settings/ConfigurationHealthSummary.test.tsx` — covers the health summary rendering with sample data, missing/invalid default highlighting, read-only state, permission-disabled action state, and live worker pause state.

See the "Tests run" section in PR comments / CI for the executed command output.

## Remaining risks

- Summary is derived entirely from existing boot/query data; if those queries are unavailable the summary degrades gracefully but cannot report a backend-authoritative health state (out of scope per the issue).
- Only the highest-risk settings seams (provider profiles, secrets, worker/operations, GitHub probe) are aggregated; other settings subcomponents were intentionally not redesigned (out of scope).
- Permission gating relies on existing permission keys (`provider_profiles.write`, `settings.effective.read`); changes to those permission semantics would need the summary's badge logic revisited.


[MM-965]: https://moonladder.atlassian.net/browse/MM-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ