### PR TITLE
MM-979 Remove Next Action and add Progress column

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1753,12 +1753,12 @@ def _normalize_merge_automation_visibility_payload(
 def _bounded_execution_progress_from_sources(
     *,
     record: object,
-    memo: Mapping[str, object],
+    memo: Mapping[str, object] | None,
     finish_summary: Mapping[str, object] | None,
 ) -> ExecutionProgressModel | None:
     sources = (
         getattr(record, "progress", None),
-        memo.get("progress"),
+        memo.get("progress") if isinstance(memo, Mapping) else None,
         finish_summary.get("progress") if isinstance(finish_summary, Mapping) else None,
     )
     for source in sources:
@@ -8523,13 +8523,22 @@ async def list_executions(
                         record_obj.updated_at = (
                             getattr(record_obj, "started_at", None) or datetime.now(UTC)
                         )
-                    items.append(
-                        _serialize_execution(
-                            record_obj,
-                            include_artifact_refs=False,
-                            user=user,
-                        )
+                    execution = _serialize_execution(
+                        record_obj,
+                        include_artifact_refs=False,
+                        user=user,
                     )
+                    if _execution_uses_live_workflow_queries(execution):
+                        progress, queried_run_id = await _load_execution_progress(
+                            temporal_client=temporal_client,
+                            workflow_id=wf.id,
+                        )
+                        update: dict[str, object] = {"progress": progress}
+                        if queried_run_id:
+                            update["run_id"] = queried_run_id
+                            update["temporal_run_id"] = queried_run_id
+                        execution = execution.model_copy(update=update)
+                    items.append(execution)
 
                 items.sort(
                     key=lambda item: (

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1750,6 +1750,50 @@ def _normalize_merge_automation_visibility_payload(
         )
         return None
 
+def _bounded_execution_progress_from_sources(
+    *,
+    record: object,
+    memo: Mapping[str, object],
+    finish_summary: Mapping[str, object] | None,
+) -> ExecutionProgressModel | None:
+    sources = (
+        getattr(record, "progress", None),
+        memo.get("progress"),
+        finish_summary.get("progress") if isinstance(finish_summary, Mapping) else None,
+    )
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        payload = {
+            "total": source.get("total"),
+            "pending": source.get("pending"),
+            "ready": source.get("ready"),
+            "running": source.get("running"),
+            "awaitingExternal": source.get("awaitingExternal")
+            if source.get("awaitingExternal") is not None
+            else source.get("awaiting_external"),
+            "reviewing": source.get("reviewing"),
+            "succeeded": source.get("succeeded"),
+            "failed": source.get("failed"),
+            "skipped": source.get("skipped"),
+            "canceled": source.get("canceled"),
+            "currentStepTitle": source.get("currentStepTitle")
+            if source.get("currentStepTitle") is not None
+            else source.get("current_step_title"),
+            "updatedAt": source.get("updatedAt")
+            or source.get("updated_at")
+            or getattr(record, "updated_at", None),
+        }
+        try:
+            return ExecutionProgressModel.model_validate(payload)
+        except ValidationError:
+            logger.warning(
+                "Invalid bounded progress payload for execution %s",
+                getattr(record, "workflow_id", "<unknown>"),
+                exc_info=True,
+            )
+    return None
+
 def _serialize_execution(
     record, *, include_artifact_refs: bool = True, user: Optional["User"] = None
 ) -> ExecutionModel:
@@ -2121,6 +2165,11 @@ def _serialize_execution(
         proposal_summary=proposal_summary,
         pr_url=pr_url,
     )
+    progress = _bounded_execution_progress_from_sources(
+        record=record,
+        memo=memo,
+        finish_summary=finish_summary if isinstance(finish_summary, Mapping) else None,
+    )
 
     started_at = getattr(record, "started_at", None)
     created_at = getattr(record, "created_at", None) or started_at or record.updated_at
@@ -2129,7 +2178,7 @@ def _serialize_execution(
     return ExecutionModel(
         task_id=None,
         agent_run_id=agent_run_id,
-        progress=None,
+        progress=progress,
         namespace=record.namespace,
         source=_TEMPORAL_SOURCE,
         workflow_id=record.workflow_id,

--- a/docs/UI/WorkflowsListPage.md
+++ b/docs/UI/WorkflowsListPage.md
@@ -224,6 +224,8 @@ The current table row model includes these display fields:
 | `entry` | Entry kind, such as `run` or `manifest`. |
 | `dependsOn` | Dependency identifiers. |
 | `blockedOnDependencies` | Whether dependency blocking should be summarized. |
+| `attentionRequired` | Whether an intervention supplement should be shown under the status pill. |
+| `progress` | Optional bounded workflow-owned progress counters plus one `currentStepTitle`; never full step rows, logs, artifacts, stdout/stderr, or diagnostic payloads. |
 
 ### 5.6 Current desktop table
 
@@ -231,38 +233,37 @@ The current desktop table columns are:
 
 | Order | Column | Sort field |
 | --- | --- | --- |
-| 1 | ID | `taskId` |
-| 2 | Runtime | `targetRuntime` |
-| 3 | Skill | `targetSkill` |
+| 1 | Workflow | `title` |
+| 2 | Status | `status` |
+| 3 | Progress | none |
 | 4 | Repository | `repository` |
-| 5 | Status | `status` |
-| 6 | Title | `title` |
-| 7 | Scheduled | `scheduledFor` |
-| 8 | Created | `createdAt` |
-| 9 | Finished | `closedAt` |
+| 5 | Runtime | `targetRuntime` |
+| 6 | Updated | `updatedAt` |
+| 7 | Actions | none |
 
 Rules:
 
 1. Header buttons sort the current page.
-2. The default sort is `scheduledFor` descending.
-3. Timestamp columns sort by parsed timestamp. `scheduledFor` falls back to `createdAt` when no scheduled timestamp exists.
+2. The default sort is `updatedAt` descending.
+3. Timestamp columns sort by parsed timestamp. `updatedAt` falls back to the best available execution timestamp.
 4. Status sorting uses `rawState` or `state` when available.
 5. Non-timestamp columns sort as lowercase strings.
 6. Ties sort by `taskId` descending.
-7. Each status cell renders an `ExecutionStatusPill` using `rawState || state || status`.
-8. The `Started` timestamp is intentionally not shown in the list presentation.
-9. Rows blocked on dependencies show a compact dependency summary under the title.
+7. Each status cell renders an `ExecutionStatusPill` using `rawState || state || status`, followed by compact status supplement text when needed.
+8. Rows blocked on dependencies show dependency text under the status pill, for example `Blocked by 1 prerequisite`.
+9. Rows requiring intervention show `Intervention requested` under the status pill.
+10. Failed rows do not repeat `Failed - needs review`, and awaiting-external rows do not repeat `Waiting on external response` when the text merely restates the status.
+11. The Progress column renders compactly from `row.progress`: `{succeeded}/{total} · {currentStepTitle}`, `{succeeded}/{total} complete`, `{succeeded}/{total} · Failed at {currentStepTitle}`, or `—` when progress is missing or has no total.
+12. The list page must not fetch per-row step details to populate Progress.
+13. The `Started` timestamp is intentionally not shown in the list presentation.
 
 ### 5.7 Current mobile cards
 
 The current mobile layout renders a card list with:
 
 - title link;
-- Workflow ID;
-- runtime, skill, and workflow type metadata;
-- status pill;
-- field grid for ID, Runtime, Skill, Repository, Scheduled, Created, and Finished;
-- dependency summary when applicable;
+- status pill with the same dependency/intervention supplements used by the desktop status cell;
+- field grid for Progress, ID, Runtime, Repository, and Updated;
 - full-width `View details` card action.
 
 ### 5.8 Current empty, loading, error, and pagination states
@@ -316,15 +317,13 @@ The desired desktop table uses this default column model:
 
 | Default visibility | Column | Primary field | Sort | Filter |
 | --- | --- | --- | --- | --- |
-| Visible | ID | `taskId` | Yes | Text contains / exact IDs |
-| Visible | Runtime | `targetRuntime` | Yes | Value checklist, blanks |
-| Visible | Skill | `targetSkill` plus `taskSkills` | Yes | Value checklist, blanks |
+| Visible | Workflow | `title` plus compact workflow id | Yes | Text contains |
+| Visible | Status | `rawState || state || status` plus compact supplements | Yes | Canonical status checklist |
+| Visible | Progress | `progress` bounded counters and current step title | No | None |
 | Visible | Repository | `repository` | Yes | Value checklist, text search, blanks |
-| Visible | Status | `rawState || state || status` | Yes | Canonical status checklist |
-| Visible | Title | `title` | Yes | Text contains |
-| Visible | Scheduled | `scheduledFor` | Yes | Date range, relative dates, blanks |
-| Visible | Created | `createdAt` | Yes | Date range, relative dates |
-| Visible | Finished | `closedAt` | Yes | Date range, relative dates, blanks |
+| Visible | Runtime | `targetRuntime` | Yes | Value checklist, blanks |
+| Visible | Updated | `updatedAt` | Yes | Date range, relative dates |
+| Optional | Target skill | `targetSkill` plus `taskSkills` | Yes | Value checklist, blanks |
 | Optional | Integration | `integration` | Yes | Value checklist, blanks |
 
 Rules:

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1814,6 +1814,52 @@ describe('Workflows Entrypoint', () => {
             createdAt: '2026-03-28T00:00:00Z',
           },
           {
+            taskId: 'task-completed-skipped',
+            source: 'temporal',
+            title: 'Completed task with skipped step',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            progress: {
+              total: 4,
+              pending: 0,
+              ready: 0,
+              running: 0,
+              awaitingExternal: 0,
+              reviewing: 0,
+              succeeded: 3,
+              failed: 0,
+              skipped: 1,
+              canceled: 0,
+              currentStepTitle: 'Skipped cleanup',
+              updatedAt: '2026-03-28T00:00:00Z',
+            },
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+          {
+            taskId: 'task-failed-zero-counter',
+            source: 'temporal',
+            title: 'Failed task without failed counter',
+            status: 'failed',
+            state: 'failed',
+            rawState: 'failed',
+            progress: {
+              total: 2,
+              pending: 0,
+              ready: 0,
+              running: 0,
+              awaitingExternal: 0,
+              reviewing: 0,
+              succeeded: 1,
+              failed: 0,
+              skipped: 0,
+              canceled: 0,
+              currentStepTitle: 'Platform timeout',
+              updatedAt: '2026-03-28T00:00:00Z',
+            },
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+          {
             taskId: 'task-missing-progress',
             source: 'temporal',
             title: 'Missing progress task',
@@ -1838,6 +1884,8 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getAllByText('Blocked by 1 prerequisite').length).toBeGreaterThan(0);
     expect(screen.getAllByText('3/6 · Run test suite').length).toBeGreaterThan(0);
     expect(screen.getAllByText('1/2 · Failed at Publish result').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('3/4 complete').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1/2 · Failed at Platform timeout').length).toBeGreaterThan(0);
 
     // The signals are no longer buried under the workflow title cell.
     const workflowCell = document.querySelector('.queue-table-cell-workflow');

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1740,6 +1740,8 @@ describe('Workflows Entrypoint', () => {
     // The first desktop column is Workflow, not ID, and no standalone ID column remains.
     expect(headerLabels[0]).toBe('Workflow');
     expect(headerLabels).not.toContain('ID');
+    expect(headerLabels).not.toContain('Next action');
+    expect(headerLabels).toContain('Progress');
     // Status is visible before any timestamp column.
     expect(headerLabels.indexOf('Status')).toBeLessThan(headerLabels.indexOf('Updated'));
 
@@ -1757,7 +1759,7 @@ describe('Workflows Entrypoint', () => {
     expect(compactId?.textContent).toBe('mm:run:scan-first-001');
   });
 
-  it('surfaces dependency and intervention next-action signals in the status/next-action area', async () => {
+  it('renders status supplements and bounded progress without Next action surfaces', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -1772,6 +1774,53 @@ describe('Workflows Entrypoint', () => {
             attentionRequired: true,
             dependsOn: ['mm:dep-1'],
             blockedOnDependencies: true,
+            progress: {
+              total: 6,
+              pending: 2,
+              ready: 0,
+              running: 1,
+              awaitingExternal: 0,
+              reviewing: 0,
+              succeeded: 3,
+              failed: 0,
+              skipped: 0,
+              canceled: 0,
+              currentStepTitle: 'Run test suite',
+              updatedAt: '2026-03-28T00:00:00Z',
+            },
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+          {
+            taskId: 'task-failed',
+            source: 'temporal',
+            title: 'Failed task',
+            status: 'failed',
+            state: 'failed',
+            rawState: 'failed',
+            progress: {
+              total: 2,
+              pending: 0,
+              ready: 0,
+              running: 0,
+              awaitingExternal: 0,
+              reviewing: 0,
+              succeeded: 1,
+              failed: 1,
+              skipped: 0,
+              canceled: 0,
+              currentStepTitle: 'Publish result',
+              updatedAt: '2026-03-28T00:00:00Z',
+            },
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+          {
+            taskId: 'task-missing-progress',
+            source: 'temporal',
+            title: 'Missing progress task',
+            status: 'completed',
+            state: 'completed',
+            rawState: 'completed',
+            progress: null,
             createdAt: '2026-03-28T00:00:00Z',
           },
         ],
@@ -1781,19 +1830,25 @@ describe('Workflows Entrypoint', () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 
     await screen.findAllByText('Attention task');
-    const nextActionCell = document.querySelector('.queue-table-cell-next-action');
-    expect(nextActionCell?.textContent).toContain('Intervention requested');
-    expect(nextActionCell?.textContent).toContain('Blocked by 1 prerequisite');
+    expect(document.querySelector('.queue-table-cell-next-action')).toBeNull();
+    expect(document.querySelector('.queue-card-next-action')).toBeNull();
+    expect(screen.queryByText('Next action')).toBeNull();
+    expect(screen.queryByText('Failed — needs review')).toBeNull();
+    expect(screen.getAllByText('Intervention requested').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Blocked by 1 prerequisite').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('3/6 · Run test suite').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1/2 · Failed at Publish result').length).toBeGreaterThan(0);
 
     // The signals are no longer buried under the workflow title cell.
     const workflowCell = document.querySelector('.queue-table-cell-workflow');
     expect(workflowCell?.textContent).not.toContain('Intervention requested');
     expect(workflowCell?.textContent).not.toContain('Blocked by 1 prerequisite');
 
-    // Mobile cards mirror the scan-first hierarchy with a dedicated next-action block.
-    const cardNextAction = document.querySelector('.queue-card-next-action');
-    expect(cardNextAction?.textContent).toContain('Intervention requested');
-    expect(cardNextAction?.textContent).toContain('Blocked by 1 prerequisite');
+    const missingProgressRow = screen
+      .getAllByText('Missing progress task')
+      .map((element) => element.closest('tr'))
+      .find((candidate): candidate is HTMLTableRowElement => Boolean(candidate));
+    expect(missingProgressRow?.querySelector('.queue-table-cell-progress')?.textContent).toContain('—');
   });
 });
 

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -312,10 +312,10 @@ function formatProgress(row: ExecutionRow): { text: string; title?: string } {
   const isCompleted = state === 'completed' || state === 'succeeded';
   const isFailed = state === 'failed';
 
-  if (isCompleted && succeeded >= total) {
+  if (isCompleted) {
     return { text: `${succeeded}/${total} complete` };
   }
-  if (isFailed && failed > 0 && currentStepTitle) {
+  if (isFailed && currentStepTitle) {
     return {
       text: `${succeeded}/${total} · Failed at ${currentStepTitle}`,
       title: currentStepTitle,

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -306,7 +306,6 @@ function formatProgress(row: ExecutionRow): { text: string; title?: string } {
   const total = progress?.total ?? 0;
   if (!progress || total <= 0) return { text: '—' };
   const succeeded = progress.succeeded ?? 0;
-  const failed = progress.failed ?? 0;
   const currentStepTitle = (progress.currentStepTitle || '').trim();
   const state = String(row.rawState || row.state || row.status || '').toLowerCase();
   const isCompleted = state === 'completed' || state === 'succeeded';

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -93,7 +93,7 @@ type TableColumnDef = {
 const TABLE_COLUMNS: TableColumnDef[] = [
   { field: 'title', label: 'Workflow', sortable: true, colClassName: 'queue-table-column-workflow' },
   { field: 'status', label: 'Status', sortable: true, colClassName: 'queue-table-column-status' },
-  { field: 'nextAction', label: 'Next action', sortable: false, colClassName: 'queue-table-column-next-action' },
+  { field: 'progress', label: 'Progress', sortable: false, colClassName: 'queue-table-column-progress' },
   { field: 'repository', label: 'Repository', sortable: true, colClassName: 'queue-table-column-repository' },
   { field: 'targetRuntime', label: 'Runtime', sortable: true, colClassName: 'queue-table-column-runtime' },
   { field: 'updatedAt', label: 'Updated', sortable: true, colClassName: 'queue-table-column-date' },
@@ -192,6 +192,23 @@ const ExecutionRowSchema = z
     dependsOn: z.array(z.string()).optional(),
     blockedOnDependencies: z.boolean().optional(),
     attentionRequired: z.boolean().optional(),
+    progress: z
+      .object({
+        total: z.number().nullable().optional(),
+        pending: z.number().nullable().optional(),
+        ready: z.number().nullable().optional(),
+        running: z.number().nullable().optional(),
+        awaitingExternal: z.number().nullable().optional(),
+        reviewing: z.number().nullable().optional(),
+        succeeded: z.number().nullable().optional(),
+        failed: z.number().nullable().optional(),
+        skipped: z.number().nullable().optional(),
+        canceled: z.number().nullable().optional(),
+        currentStepTitle: z.string().nullable().optional(),
+        updatedAt: z.string().nullable().optional(),
+      })
+      .nullable()
+      .optional(),
   })
   .passthrough();
 
@@ -275,21 +292,39 @@ function interventionListSummary(row: ExecutionRow): string {
   return '';
 }
 
-// Next-action signals for the scan-first status area. Reuses the dependency and
-// intervention summaries and falls back to a terminal/waiting reason so operators
-// can see what needs attention without opening the workflow.
-function nextActionItems(row: ExecutionRow): string[] {
+function statusSupplementItems(row: ExecutionRow): string[] {
   const items: string[] = [];
   const intervention = interventionListSummary(row);
   if (intervention) items.push(intervention);
   const deps = dependencyListSummary(row);
   if (deps) items.push(deps);
-  if (items.length === 0) {
-    const state = String(row.rawState || row.state || row.status || '').toLowerCase();
-    if (state === 'failed') items.push('Failed — needs review');
-    else if (state === 'awaiting_external') items.push('Waiting on external response');
-  }
   return items;
+}
+
+function formatProgress(row: ExecutionRow): { text: string; title?: string } {
+  const progress = row.progress;
+  const total = progress?.total ?? 0;
+  if (!progress || total <= 0) return { text: '—' };
+  const succeeded = progress.succeeded ?? 0;
+  const failed = progress.failed ?? 0;
+  const currentStepTitle = (progress.currentStepTitle || '').trim();
+  const state = String(row.rawState || row.state || row.status || '').toLowerCase();
+  const isCompleted = state === 'completed' || state === 'succeeded';
+  const isFailed = state === 'failed';
+
+  if (isCompleted && succeeded >= total) {
+    return { text: `${succeeded}/${total} complete` };
+  }
+  if (isFailed && failed > 0 && currentStepTitle) {
+    return {
+      text: `${succeeded}/${total} · Failed at ${currentStepTitle}`,
+      title: currentStepTitle,
+    };
+  }
+  if (currentStepTitle) {
+    return { text: `${succeeded}/${total} · ${currentStepTitle}`, title: currentStepTitle };
+  }
+  return { text: `${succeeded}/${total}` };
 }
 
 function rowUpdatedAt(row: ExecutionRow): string | null | undefined {
@@ -1928,7 +1963,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                   </thead>
                   <tbody>
                     {sortedItems.map((row) => {
-                      const actionItems = nextActionItems(row);
+                      const statusSupplements = statusSupplementItems(row);
+                      const progress = formatProgress(row);
                       const updatedAt = rowUpdatedAt(row);
                       return (
                         <tr key={rowWorkflowId(row)}>
@@ -1944,19 +1980,18 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                           {isColumnVisible('status') ? (
                             <td className="queue-table-cell-status">
                               <ExecutionStatusPill status={row.rawState || row.state || row.status} />
+                              {statusSupplements.map((item) => (
+                                <div key={item} className="workflow-list-status-supplement small">
+                                  {item}
+                                </div>
+                              ))}
                             </td>
                           ) : null}
-                          {isColumnVisible('nextAction') ? (
-                            <td className="queue-table-cell-next-action">
-                              {actionItems.length > 0 ? (
-                                actionItems.map((item) => (
-                                  <div key={item} className="workflow-list-next-action-item small">
-                                    {item}
-                                  </div>
-                                ))
-                              ) : (
-                                <span className="workflow-list-next-action-empty">—</span>
-                              )}
+                          {isColumnVisible('progress') ? (
+                            <td className="queue-table-cell-progress">
+                              <span className="workflow-list-progress" title={progress.title}>
+                                {progress.text}
+                              </span>
                             </td>
                           ) : null}
                           {isColumnVisible('repository') ? (
@@ -1988,7 +2023,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               </div>
               <ul className="queue-card-list" data-layout="card" role="list">
                 {sortedItems.map((row) => {
-                      const actionItems = nextActionItems(row);
+                      const statusSupplements = statusSupplementItems(row);
+                      const progress = formatProgress(row);
                       const updatedAt = rowUpdatedAt(row);
                       return (
                   <li key={rowWorkflowId(row)} className="queue-card">
@@ -2003,19 +2039,20 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                       </div>
                       <div className="queue-card-status">
                         <ExecutionStatusPill status={row.rawState || row.state || row.status} />
-                      </div>
-                    </div>
-                    {actionItems.length > 0 ? (
-                      <div className="queue-card-next-action">
-                        <span className="queue-card-next-action-label small">Next action</span>
-                        {actionItems.map((item) => (
-                          <p key={item} className="queue-card-next-action-item">
+                        {statusSupplements.map((item) => (
+                          <div key={item} className="workflow-list-status-supplement small">
                             {item}
-                          </p>
+                          </div>
                         ))}
                       </div>
-                    ) : null}
+                    </div>
                     <dl className="queue-card-fields">
+                      <div>
+                        <dt>Progress</dt>
+                        <dd title={progress.title}>
+                          <span className="workflow-list-progress">{progress.text}</span>
+                        </dd>
+                      </div>
                       <div>
                         <dt>ID</dt>
                         <dd>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -1992,7 +1992,7 @@ tbody tr:hover {
   width: 30%;
 }
 
-.queue-table-column-next-action {
+.queue-table-column-progress {
   width: 18%;
 }
 
@@ -2014,7 +2014,7 @@ tbody tr:hover {
 
 .queue-table-cell-compact,
 .queue-table-cell-date,
-.queue-table-cell-next-action {
+.queue-table-cell-progress {
   font-size: 0.82rem;
 }
 
@@ -2036,7 +2036,7 @@ tbody tr:hover {
 
 .queue-table-wrapper[data-density='compact'] .queue-table-cell-compact,
 .queue-table-wrapper[data-density='compact'] .queue-table-cell-date,
-.queue-table-wrapper[data-density='compact'] .queue-table-cell-next-action {
+.queue-table-wrapper[data-density='compact'] .queue-table-cell-progress {
   font-size: 0.76rem;
 }
 
@@ -2107,12 +2107,29 @@ tbody tr:hover {
   word-break: break-word;
 }
 
-.workflow-list-next-action-empty {
+.workflow-list-status-supplement {
+  margin-top: 0.2rem;
+  color: rgb(var(--mm-muted));
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.workflow-list-progress {
+  display: -webkit-box;
+  max-width: 100%;
+  overflow: hidden;
+  color: rgb(var(--mm-ink));
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.workflow-list-progress:empty::before {
+  content: '—';
   color: rgb(var(--mm-muted));
 }
 
-.workflow-list-next-action-item + .workflow-list-next-action-item {
-  margin-top: 0.15rem;
+.queue-table-cell-progress .workflow-list-progress {
+  word-break: break-word;
 }
 
 .data-table-slab {
@@ -2348,23 +2365,6 @@ tr[data-proposal-id].proposal-consuming td {
 .queue-card-header > .queue-card-status {
   flex-shrink: 0;
   max-width: 100%;
-}
-
-.queue-card-next-action {
-  margin: 0.4rem 0 0;
-  display: grid;
-  gap: 0.15rem;
-}
-
-.queue-card-next-action-label {
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: rgb(var(--mm-muted));
-}
-
-.queue-card-next-action-item {
-  margin: 0;
-  font-weight: 500;
 }
 
 .queue-card-title {

--- a/frontend/src/utils/dashboardPreferences.test.ts
+++ b/frontend/src/utils/dashboardPreferences.test.ts
@@ -35,7 +35,7 @@ describe('dashboardPreferences', () => {
         workflowListDensity: 'compact',
         workflowListColumnVisibility: {
           status: true,
-          nextAction: false,
+          progress: false,
           repository: true,
           targetRuntime: false,
           updatedAt: true,
@@ -52,7 +52,7 @@ describe('dashboardPreferences', () => {
       const reloaded = readDashboardPreferences();
       expect(reloaded).toEqual(next);
       expect(reloaded.workflowListDensity).toBe('compact');
-      expect(reloaded.workflowListColumnVisibility.nextAction).toBe(false);
+      expect(reloaded.workflowListColumnVisibility.progress).toBe(false);
       expect(reloaded.createExpertMode).toBe(true);
       expect(reloaded.debugFieldsVisible).toBe(false);
       expect(reloaded.preferredDetailTab).toBe('steps');
@@ -142,6 +142,41 @@ describe('dashboardPreferences', () => {
       expect(written.workflowListDensity).toBe('comfortable');
       expect(written.workflowListPageSize).toBe(DEFAULT_DASHBOARD_PREFERENCES.workflowListPageSize);
       expect(readDashboardPreferences().workflowListDensity).toBe('comfortable');
+    });
+
+    it('defaults include progress and do not include removed nextAction column', () => {
+      expect(DEFAULT_DASHBOARD_PREFERENCES.workflowListColumnVisibility.progress).toBe(true);
+      expect(DEFAULT_DASHBOARD_PREFERENCES.workflowListColumnVisibility).not.toHaveProperty(
+        'nextAction',
+      );
+    });
+
+    it('ignores legacy nextAction visibility during sanitization', () => {
+      const prefs = sanitizeDashboardPreferences({
+        workflowListColumnVisibility: {
+          status: false,
+          nextAction: true,
+          progress: false,
+        },
+      });
+
+      expect(prefs.workflowListColumnVisibility.status).toBe(false);
+      expect(prefs.workflowListColumnVisibility.progress).toBe(false);
+      expect(prefs.workflowListColumnVisibility).not.toHaveProperty('nextAction');
+    });
+
+    it('round-trip preferences no longer include nextAction', () => {
+      writeDashboardPreferences({
+        ...DEFAULT_DASHBOARD_PREFERENCES,
+        workflowListColumnVisibility: {
+          ...DEFAULT_DASHBOARD_PREFERENCES.workflowListColumnVisibility,
+          progress: false,
+        },
+      });
+
+      const parsed = JSON.parse(storedRaw() ?? '{}');
+      expect(parsed.preferences.workflowListColumnVisibility.progress).toBe(false);
+      expect(parsed.preferences.workflowListColumnVisibility).not.toHaveProperty('nextAction');
     });
   });
 

--- a/frontend/src/utils/dashboardPreferences.ts
+++ b/frontend/src/utils/dashboardPreferences.ts
@@ -33,7 +33,7 @@ export type WorkflowDetailTab = 'overview' | 'steps' | 'artifacts' | 'runs' | 'd
 // from this set.
 export const TOGGLEABLE_WORKFLOW_LIST_COLUMNS = [
   'status',
-  'nextAction',
+  'progress',
   'repository',
   'targetRuntime',
   'updatedAt',
@@ -82,7 +82,7 @@ export const DEFAULT_DASHBOARD_PREFERENCES: DashboardPreferences = {
   workflowListDensity: 'comfortable',
   workflowListColumnVisibility: {
     status: true,
-    nextAction: true,
+    progress: true,
     repository: true,
     targetRuntime: true,
     updatedAt: true,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -861,10 +861,58 @@ def test_serialize_execution_includes_finish_summary_projection_fields():
         },
     }
 
-    payload = _serialize_execution(record).model_dump(by_alias=True)
+    payload = _serialize_execution(record).model_dump(by_alias=True, mode="json")
 
     assert payload["finishOutcomeCode"] == "NO_CHANGES"
     assert payload["finishSummary"] == record.finish_summary_json
+
+def test_serialize_execution_includes_bounded_progress_without_step_details() -> None:
+    record = _build_execution_record()
+    record.memo = {
+        **record.memo,
+        "progress": {
+            "total": 6,
+            "pending": 2,
+            "ready": 0,
+            "running": 1,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 3,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Run test suite",
+            "updatedAt": "2026-04-04T18:11:15Z",
+            "steps": [{"title": "too much detail"}],
+            "logs": "must not leak",
+            "artifacts": ["artifact-ref"],
+            "stdout": "raw stdout",
+            "stderr": "raw stderr",
+            "diagnostics": {"providerPayload": "raw"},
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True, mode="json")
+
+    assert payload["progress"] == {
+        "total": 6,
+        "pending": 2,
+        "ready": 0,
+        "running": 1,
+        "awaitingExternal": 0,
+        "reviewing": 0,
+        "succeeded": 3,
+        "failed": 0,
+        "skipped": 0,
+        "canceled": 0,
+        "currentStepTitle": "Run test suite",
+        "updatedAt": "2026-04-04T18:11:15Z",
+    }
+
+def test_serialize_execution_nulls_progress_for_legacy_rows() -> None:
+    payload = _serialize_execution(_build_execution_record()).model_dump(by_alias=True)
+
+    assert payload["progress"] is None
 
 def _override_temporal_client(app: FastAPI) -> AsyncMock:
     client = AsyncMock()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -909,6 +909,15 @@ def test_serialize_execution_includes_bounded_progress_without_step_details() ->
         "updatedAt": "2026-04-04T18:11:15Z",
     }
 
+def test_serialize_execution_ignores_non_mapping_memo_for_progress() -> None:
+    record = _build_execution_record()
+    record.memo = None
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["progress"] is None
+
+
 def test_serialize_execution_nulls_progress_for_legacy_rows() -> None:
     payload = _serialize_execution(_build_execution_record()).model_dump(by_alias=True)
 
@@ -1629,6 +1638,93 @@ def test_list_executions_temporal_query_rejects_invalid_filter_bounds() -> None:
     assert invalid_sort.status_code == 422
     assert "sort must be one of" in invalid_sort.json()["detail"]["message"]
     temporal_client.count_workflows.assert_not_called()
+
+def test_list_executions_source_temporal_hydrates_live_progress() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+
+    class _EmptyCanonicalResult:
+        def scalars(self) -> "_EmptyCanonicalResult":
+            return self
+
+        def all(self) -> list[TemporalExecutionCanonicalRecord]:
+            return []
+
+    class _Session:
+        async def execute(self, _stmt: object) -> _EmptyCanonicalResult:
+            return _EmptyCanonicalResult()
+
+    app.dependency_overrides[get_async_session] = lambda: _Session()
+    _override_user_dependencies(app, is_superuser=True)
+
+    async def _memo():
+        return {
+            "title": "Live workflow",
+            "summary": "Running tests.",
+        }
+
+    workflow = SimpleNamespace(
+        id="mm:wf-live",
+        run_id="run-temporal",
+        namespace="default",
+        workflow_type="MoonMind.UserWorkflow",
+        status="RUNNING",
+        start_time=datetime(2026, 4, 4, 18, 0, tzinfo=UTC),
+        close_time=None,
+        execution_time=None,
+        search_attributes={
+            "mm_state": "executing",
+            "mm_owner_id": "system",
+            "mm_owner_type": "system",
+            "mm_entry": "run",
+        },
+        memo=_memo,
+    )
+
+    class _WorkflowIterator:
+        current_page = [workflow]
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = _override_query_client(
+        app,
+        progress={
+            "total": 3,
+            "pending": 0,
+            "ready": 0,
+            "running": 1,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 2,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Run tests",
+            "updatedAt": "2026-04-04T18:11:15Z",
+            "runId": "run-live",
+        },
+    )
+    temporal_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=1))
+    temporal_client.list_workflows = Mock(return_value=_WorkflowIterator())
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "ownerType": "system"},
+        )
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["workflowId"] == "mm:wf-live"
+    assert item["runId"] == "run-live"
+    assert item["progress"]["succeeded"] == 2
+    assert item["progress"]["currentStepTitle"] == "Run tests"
+    temporal_client.get_workflow_handle.assert_called_once_with("mm:wf-live")
+
 
 def test_execution_facets_exclude_requested_facet_filter_and_keep_workflow_scope() -> None:
     app = FastAPI()


### PR DESCRIPTION
Issue reference: MM-979

Summary:
- Removes the Workflow list Next action column/card/preference surface and replaces it with a compact Progress column.
- Moves dependency and intervention status supplements directly under the status pill while avoiding redundant failed/awaiting-external list text.
- Serializes bounded execution progress from workflow-owned sources without leaking step rows, logs, artifacts, stdout/stderr, or diagnostics.
- Updates Workflow list documentation and frontend/backend tests for the new behavior.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py` — Python target passed: 318 passed; runner later also launched broad Vitest and failed on timeout-sensitive unrelated UI tests (`dashboard.test.tsx`, two existing `workflow-list.test.tsx` filter tests).
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-list.test.tsx frontend/src/utils/dashboardPreferences.test.ts` — passed: 76 tests.
- `git diff --check` — passed.

Remaining risks:
- The Progress column depends on execution rows carrying bounded `progress`; legacy rows continue to render the dash fallback.
- The broad unit runner still has unrelated timeout-sensitive Vitest coverage outside this change path.