### PR TITLE
MM-973 Stop rerun navigation

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -15,10 +15,12 @@ describe('WorkflowRowActionsMenu', () => {
     actions: {
       canPause: true,
       canCancel: true,
+      canRerun: true,
     },
   };
 
   beforeEach(() => {
+    window.history.pushState({}, 'Workflows', '/workflows?source=temporal');
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/executions/wf-123?source=temporal') {
@@ -94,6 +96,31 @@ describe('WorkflowRowActionsMenu', () => {
         signalName: 'Pause',
       });
     });
+  });
+
+  it('requests a rerun from the row menu without navigating away from the workflow list', async () => {
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    await waitFor(() => {
+      const rerunCall = fetchSpy.mock.calls.find(
+        ([url]) => String(url) === '/api/executions/wf-123/update',
+      );
+      expect(rerunCall).toBeTruthy();
+      expect(JSON.parse(String((rerunCall?.[1] as RequestInit).body))).toMatchObject({
+        updateName: 'RequestRerun',
+      });
+    });
+    expect(window.location.pathname).toBe('/workflows');
+    expect(window.location.search).toBe('?source=temporal');
   });
 
   it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -115,7 +115,9 @@ describe('WorkflowRowActionsMenu', () => {
         ([url]) => String(url) === '/api/executions/wf-123/update',
       );
       expect(rerunCall).toBeTruthy();
-      expect(JSON.parse(String((rerunCall?.[1] as RequestInit).body))).toMatchObject({
+      const requestBody = (rerunCall?.[1] as RequestInit | undefined)?.body;
+      expect(requestBody).toBeDefined();
+      expect(JSON.parse(requestBody as string)).toMatchObject({
         updateName: 'RequestRerun',
       });
     });

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { DashboardActionDialog } from './DashboardActionDialog';
 import { formatStatusLabel } from '../utils/formatters';
-import { navigateTo } from '../lib/navigation';
 import {
   taskCompareHref,
   taskEditForRerunHref,
@@ -317,25 +316,7 @@ export function WorkflowRowActionsMenu({
         onRerun: () => {
           setActionError(null);
           if (busy || !workflowId) return;
-          updateMutation.mutate(
-            { updateName: 'RequestRerun' },
-            {
-              onSuccess: (result: unknown) => {
-                const payloadResult =
-                  result && typeof result === 'object'
-                    ? (result as {
-                        execution?: { workflowId?: string | null };
-                        workflow_id?: string | null;
-                      })
-                    : {};
-                const redirectWorkflowId =
-                  String(payloadResult.execution?.workflowId || '').trim() ||
-                  String(payloadResult.workflow_id || '').trim() ||
-                  workflowId;
-                navigateTo(`/workflows/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
-              },
-            },
-          );
+          updateMutation.mutate({ updateName: 'RequestRerun' });
         },
         onResumeFromFailedStep: () => {
           setActionError(null);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2529,6 +2529,12 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
+    expect(navigateTo).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/workflows/test-123/steps');
+    expect(window.location.search).toBe('?source=temporal');
+    expect(
+      window.sessionStorage.getItem('moonmind.temporalTaskEditing.notice'),
+    ).toBeNull();
     expect(telemetryEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,7 +20,6 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
-import { navigateTo } from '../lib/navigation';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -5408,30 +5407,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       mode: 'detail',
       workflowId,
     });
-    updateMutation.mutate(
-      { updateName: 'RequestRerun' },
-      {
-        onSuccess: (result: unknown) => {
-          const payloadResult = result as {
-            execution?: { workflowId?: string | null };
-            workflow_id?: string | null;
-          };
-          const redirectWorkflowId =
-            String(payloadResult.execution?.workflowId || '').trim() ||
-            String(payloadResult.workflow_id || '').trim() ||
-            workflowId;
-          try {
-            window.sessionStorage.setItem(
-              'moonmind.temporalTaskEditing.notice',
-              'Rerun was requested and the latest execution view is ready.',
-            );
-          } catch {
-            // Navigation should not depend on session storage availability.
-          }
-          navigateTo(`/workflows/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
-        },
-      },
-    );
+    updateMutation.mutate({ updateName: 'RequestRerun' });
   };
   const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
   // The remediation mode/authority/action-policy controls only render on the Artifacts


### PR DESCRIPTION
Issue reference: MM-973 (https://moonladder.atlassian.net/browse/MM-973)

Summary:
- Removed automatic navigation after RequestRerun succeeds from the workflow list row action.
- Removed automatic navigation and session-storage notice writes after RequestRerun succeeds from the workflow detail action.
- Added UI tests asserting rerun requests leave the operator on the current page.

Tests run:
- `git diff --check origin/main...HEAD`
- Secret-pattern scan over `git diff origin/main...HEAD`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked before UI tests: `/usr/local/bin/python: No module named pytest`)
- `npm ci --no-fund --no-audit`
- `npm run ui:test -- frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: npm script could not resolve `vitest`)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked during Vitest module resolution: `Cannot find module /frontend/src/...`)

Remaining risks:
- Focused UI tests could not execute in this managed workspace because local Python test dependencies and Vitest path resolution were unavailable/misconfigured. The code change is narrowly scoped to removing rerun navigation side effects and adding assertions for that behavior.