### PR TITLE
MM-973: Stop rerun from auto-navigating

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -40,6 +40,15 @@ describe('WorkflowRowActionsMenu', () => {
         taskEditingEnabled={false}
       />,
     );
+  const renderTaskEditingMenu = () =>
+    renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
 
   it('renders an icon trigger labeled "Actions" and does not fetch until opened', () => {
     renderMenu();
@@ -94,6 +103,47 @@ describe('WorkflowRowActionsMenu', () => {
         signalName: 'Pause',
       });
     });
+  });
+
+  it('requests rerun from a row action without navigating to the workflow detail page', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...detailResponse,
+            actions: { canRerun: true },
+          }),
+        } as Response);
+      }
+      if (url === '/api/executions/wf-123/update') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            accepted: true,
+            applied: 'continue_as_new',
+            execution: { workflowId: 'wf-rerun-created' },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderTaskEditingMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
+
+    await waitFor(() => {
+      const updateCall = fetchSpy.mock.calls.find(
+        ([url]) => String(url) === '/api/executions/wf-123/update',
+      );
+      expect(updateCall).toBeTruthy();
+      expect(JSON.parse(String((updateCall?.[1] as RequestInit).body))).toEqual({
+        updateName: 'RequestRerun',
+      });
+    });
+    expect(window.location.pathname).not.toBe('/workflows/wf-rerun-created');
   });
 
   it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -144,6 +144,11 @@ describe('WorkflowRowActionsMenu', () => {
       });
     });
     expect(window.location.pathname).not.toBe('/workflows/wf-rerun-created');
+    expect(
+      await screen.findByText('Rerun was requested and the latest execution view is ready.'),
+    ).toBeTruthy();
+    expect(screen.getByRole('status').className).toContain('notice');
+    expect(screen.getByRole('status').className).toContain('ok');
   });
 
   it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -101,6 +101,7 @@ export function WorkflowRowActionsMenu({
   const queryClient = useQueryClient();
   const [hasOpened, setHasOpened] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
   const [activeDialog, setActiveDialog] = useState<RowActionDialogKind | null>(null);
 
   const detailQuery = useQuery({
@@ -315,8 +316,16 @@ export function WorkflowRowActionsMenu({
         onCompareRun: () => {},
         onRerun: () => {
           setActionError(null);
+          setActionNotice(null);
           if (busy || !workflowId) return;
-          updateMutation.mutate({ updateName: 'RequestRerun' });
+          updateMutation.mutate(
+            { updateName: 'RequestRerun' },
+            {
+              onSuccess: () => {
+                setActionNotice('Rerun was requested and the latest execution view is ready.');
+              },
+            },
+          );
         },
         onResumeFromFailedStep: () => {
           setActionError(null);
@@ -576,6 +585,11 @@ export function WorkflowRowActionsMenu({
       {actionError ? (
         <p className="workflow-row-actions-error" role="alert">
           {actionError}
+        </p>
+      ) : null}
+      {actionNotice ? (
+        <p className="notice ok" role="status">
+          {actionNotice}
         </p>
       ) : null}
     </div>

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { DashboardActionDialog } from './DashboardActionDialog';
 import { formatStatusLabel } from '../utils/formatters';
-import { navigateTo } from '../lib/navigation';
 import {
   taskCompareHref,
   taskEditForRerunHref,
@@ -317,25 +316,7 @@ export function WorkflowRowActionsMenu({
         onRerun: () => {
           setActionError(null);
           if (busy || !workflowId) return;
-          updateMutation.mutate(
-            { updateName: 'RequestRerun' },
-            {
-              onSuccess: (result: unknown) => {
-                const payloadResult =
-                  result && typeof result === 'object'
-                    ? (result as {
-                        execution?: { workflowId?: string | null };
-                        workflow_id?: string | null;
-                      })
-                    : {};
-                const redirectWorkflowId =
-                  String(payloadResult.execution?.workflowId || '').trim() ||
-                  String(payloadResult.workflow_id || '').trim() ||
-                  workflowId;
-                navigateTo(`/workflows/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
-              },
-            },
-          );
+          updateMutation.mutate({ updateName: 'RequestRerun' });
         },
         onResumeFromFailedStep: () => {
           setActionError(null);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2530,6 +2530,10 @@ describe('Workflow Detail Entrypoint', () => {
       );
     });
     expect(navigateTo).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('Rerun was requested and the latest execution view is ready.'),
+    ).toBeTruthy();
+    expect(screen.getByRole('status')).toBeTruthy();
     expect(telemetryEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2529,6 +2529,7 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
+    expect(navigateTo).not.toHaveBeenCalled();
     expect(telemetryEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,7 +20,6 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
-import { navigateTo } from '../lib/navigation';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -5411,24 +5410,15 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     updateMutation.mutate(
       { updateName: 'RequestRerun' },
       {
-        onSuccess: (result: unknown) => {
-          const payloadResult = result as {
-            execution?: { workflowId?: string | null };
-            workflow_id?: string | null;
-          };
-          const redirectWorkflowId =
-            String(payloadResult.execution?.workflowId || '').trim() ||
-            String(payloadResult.workflow_id || '').trim() ||
-            workflowId;
+        onSuccess: () => {
           try {
             window.sessionStorage.setItem(
               'moonmind.temporalTaskEditing.notice',
               'Rerun was requested and the latest execution view is ready.',
             );
           } catch {
-            // Navigation should not depend on session storage availability.
+            // Success handling should not depend on session storage availability.
           }
-          navigateTo(`/workflows/${encodeURIComponent(redirectWorkflowId)}?source=temporal`);
         },
       },
     );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5411,6 +5411,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       { updateName: 'RequestRerun' },
       {
         onSuccess: () => {
+          setActionNotice('Rerun was requested and the latest execution view is ready.');
           try {
             window.sessionStorage.setItem(
               'moonmind.temporalTaskEditing.notice',

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -3971,6 +3971,11 @@ describe.skip("Task Create Entrypoint", () => {
     ).toBe(false);
     expect(navigateTo).not.toHaveBeenCalled();
     expect(
+      await screen.findByText("Rerun was requested and the latest execution view is ready."),
+    ).toBeTruthy();
+    expect(screen.getByRole("status").className).toContain("notice");
+    expect(screen.getByRole("status").className).toContain("ok");
+    expect(
       window.sessionStorage.getItem("moonmind.temporalTaskEditing.notice"),
     ).toBe("Rerun was requested and the latest execution view is ready.");
   });

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -3969,11 +3969,7 @@ describe.skip("Task Create Entrypoint", () => {
         ([url, init]) => String(url) === "/api/executions" && init?.method === "POST",
       ),
     ).toBe(false);
-    await waitFor(() => {
-      expect(navigateTo).toHaveBeenCalledWith(
-        "/workflows/mm%3Arerun-created?source=temporal",
-      );
-    });
+    expect(navigateTo).not.toHaveBeenCalled();
     expect(
       window.sessionStorage.getItem("moonmind.temporalTaskEditing.notice"),
     ).toBe("Rerun was requested and the latest execution view is ready.");

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5363,7 +5363,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     Record<string, string>
   >({});
   const [submitMessageState, setSubmitMessageState] = useState<
-    { text: string; tone: "error" | "pending" } | null
+    { text: string; tone: "error" | "pending" | "ok" } | null
   >(null);
   const submitMessage = submitMessageState?.text ?? null;
   const submitMessageTone = submitMessageState?.tone ?? "error";
@@ -5378,7 +5378,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
     rawError?: string | null;
   } | null>(null);
   const setSubmitMessage = useCallback(
-    (text: string | null, tone: "error" | "pending" = "error") => {
+    (text: string | null, tone: "error" | "pending" | "ok" = "error") => {
       setSubmitErrorDetail(null);
       setSubmitMessageState(text === null ? null : { text, tone });
     },
@@ -8507,6 +8507,7 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
         // Success handling should not depend on session storage availability.
       }
       if (isRerun) {
+        setSubmitMessage(statusText, "ok");
         return;
       }
       const redirectWorkflowId =
@@ -12090,7 +12091,9 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
             className={
               submitMessageTone === "pending"
                 ? "queue-submit-message notice pending"
-                : "queue-submit-message notice error"
+                : submitMessageTone === "ok"
+                  ? "queue-submit-message notice ok"
+                  : "queue-submit-message notice error"
             }
           >
             {submitMessage}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8504,7 +8504,10 @@ export function WorkflowStartPage({ payload }: { payload: BootPayload }) {
           statusText,
         );
       } catch {
-        // Navigation should not depend on session storage availability.
+        // Success handling should not depend on session storage availability.
+      }
+      if (isRerun) {
+        return;
       }
       const redirectWorkflowId =
         String(result.execution?.workflowId || "").trim() || workflowId;


### PR DESCRIPTION
Issue reference: MM-973

Summary:
- Removed automatic workflow-detail navigation after RequestRerun succeeds from the workflow detail page, workflow row action menu, and rerun submit flow.
- Kept the existing rerun success notice behavior and added/updated frontend tests for the no-navigation behavior.

Tests run:
- npm ci --no-fund --no-audit
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-start.test.tsx (failed in the managed workspace because Vite resolved the colon-containing workspace path incorrectly)
- In /tmp/mm973-worktree: npm ci --no-fund --no-audit && ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-start.test.tsx (passed: 3 files, 209 passed, 236 skipped)

Remaining risks:
- Full frontend suite was not run; verification was limited to the changed rerun/navigation areas.
- The managed workspace has root-owned Git metadata from the implementation step, so publication used a clean temporary clone with the same amended branch diff.