### PR TITLE
The bypass dependencies button launches a pop-up now and I'd rather not get the pop-up. The X buttons on the screenshots which are added to Start Work

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -97,6 +97,39 @@ describe('WorkflowRowActionsMenu', () => {
     });
   });
 
+  it('bypasses dependencies directly without opening a confirmation dialog', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...detailResponse,
+            actions: { canBypassDependencies: true },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Bypass Dependencies' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Bypass dependencies' })).toBeNull();
+    await waitFor(() => {
+      const signalCall = fetchSpy.mock.calls.find(([url, init]) => {
+        if (String(url) !== '/api/executions/wf-123/signal') return false;
+        return JSON.parse(String((init as RequestInit).body)).signalName === 'BypassDependencies';
+      });
+      expect(signalCall).toBeTruthy();
+      expect(JSON.parse(String((signalCall?.[1] as RequestInit).body))).toMatchObject({
+        signalName: 'BypassDependencies',
+        payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
+      });
+    });
+  });
+
   it('requests a rerun from the row menu without navigating away from the workflow list', async () => {
     renderWithClient(
       <WorkflowRowActionsMenu

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -120,10 +120,17 @@ describe('WorkflowRowActionsMenu', () => {
     await waitFor(() => {
       const signalCall = fetchSpy.mock.calls.find(([url, init]) => {
         if (String(url) !== '/api/executions/wf-123/signal') return false;
-        return JSON.parse(String((init as RequestInit).body)).signalName === 'BypassDependencies';
+        const body = (init as RequestInit | undefined)?.body;
+        if (!body) return false;
+        try {
+          return JSON.parse(String(body)).signalName === 'BypassDependencies';
+        } catch {
+          return false;
+        }
       });
       expect(signalCall).toBeTruthy();
-      expect(JSON.parse(String((signalCall?.[1] as RequestInit).body))).toMatchObject({
+      const signalInit = signalCall?.[1] as RequestInit | undefined;
+      expect(signalInit?.body ? JSON.parse(String(signalInit.body)) : null).toMatchObject({
         signalName: 'BypassDependencies',
         payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
       });

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -361,10 +361,18 @@ export function WorkflowRowActionsMenu({
         },
         onBypassDependencies: () => {
           setActionError(null);
-          signalMutation.mutate({
-            signalName: 'BypassDependencies',
-            payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
-          });
+          setActionNotice(null);
+          signalMutation.mutate(
+            {
+              signalName: 'BypassDependencies',
+              payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
+            },
+            {
+              onSuccess: () => {
+                setActionNotice('Dependency wait bypass was requested.');
+              },
+            },
+          );
         },
         onCreateRemediation: () => {
           setActionError(null);

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -60,7 +60,6 @@ type RowActionsExecution = z.infer<typeof RowActionsExecutionSchema>;
 type RowActionDialogKind =
   | 'rename'
   | 'resume-from-failed-step'
-  | 'bypass-dependencies'
   | 'cancel'
   | 'force-cancel'
   | 'reject'
@@ -362,7 +361,10 @@ export function WorkflowRowActionsMenu({
         },
         onBypassDependencies: () => {
           setActionError(null);
-          setActiveDialog('bypass-dependencies');
+          signalMutation.mutate({
+            signalName: 'BypassDependencies',
+            payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
+          });
         },
         onCreateRemediation: () => {
           setActionError(null);
@@ -409,15 +411,6 @@ export function WorkflowRowActionsMenu({
         break;
       case 'resume-from-failed-step':
         failedStepResumeMutation.mutate(undefined, closeOnSuccess);
-        break;
-      case 'bypass-dependencies':
-        signalMutation.mutate(
-          {
-            signalName: 'BypassDependencies',
-            payload: { reason: value || 'Dependency wait bypassed by operator from the dashboard.' },
-          },
-          closeOnSuccess,
-        );
         break;
       case 'cancel':
         cancelMutation.mutate(
@@ -491,23 +484,6 @@ export function WorkflowRowActionsMenu({
         confirmPending={failedStepResumeMutation.isPending}
         disabledReason={disabledReason('canResumeFromFailedStep')}
         error={activeDialog === 'resume-from-failed-step' ? actionError : null}
-        onCancel={closeDialog}
-        onConfirm={confirmDialog}
-      />
-      <DashboardActionDialog
-        open={activeDialog === 'bypass-dependencies'}
-        title="Bypass dependencies"
-        subject={subject}
-        compactId={workflowId}
-        consequence="Bypass dependency waiting for this workflow. Downstream work may proceed before prerequisites finish."
-        valueLabel="Reason"
-        valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
-        valueMultiline
-        confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
-        confirmPending={signalMutation.isPending}
-        danger
-        disabledReason={disabledReason('canBypassDependencies')}
-        error={activeDialog === 'bypass-dependencies' ? actionError : null}
         onCancel={closeDialog}
         onConfirm={confirmDialog}
       />

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -5217,7 +5217,6 @@ describe('Workflow Detail Entrypoint', () => {
 
     const menu = await openWorkflowActionsMenu();
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Bypass Dependencies' }));
-    confirmWorkflowDialog('Bypass dependencies');
 
     await waitFor(() => {
       expect(signalBodies).toEqual([

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -5364,10 +5364,18 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onBypassDependencies = () => {
     setActionError(null);
-    signalMutation.mutate({
-      signalName: 'BypassDependencies',
-      payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
-    });
+    setActionNotice(null);
+    signalMutation.mutate(
+      {
+        signalName: 'BypassDependencies',
+        payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
+      },
+      {
+        onSuccess: () => {
+          setActionNotice('Dependency wait bypass was requested.');
+        },
+      },
+    );
   };
 
   const onCancel = () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -113,7 +113,6 @@ type WorkflowDialogKind =
   | 'rename'
   | 'resume-from-failed-step'
   | 'recover-from-selected-step'
-  | 'bypass-dependencies'
   | 'cancel'
   | 'force-cancel'
   | 'reject'
@@ -5365,7 +5364,10 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onBypassDependencies = () => {
     setActionError(null);
-    setActiveWorkflowDialog('bypass-dependencies');
+    signalMutation.mutate({
+      signalName: 'BypassDependencies',
+      payload: { reason: 'Dependency wait bypassed by operator from the dashboard.' },
+    });
   };
 
   const onCancel = () => {
@@ -5538,15 +5540,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       case 'recover-from-selected-step':
         selectedStepRecoveryMutation.mutate(undefined, closeOnSuccess);
         break;
-      case 'bypass-dependencies':
-        signalMutation.mutate(
-          {
-            signalName: 'BypassDependencies',
-            payload: { reason: value || 'Dependency wait bypassed by operator from the dashboard.' },
-          },
-          closeOnSuccess,
-        );
-        break;
       case 'cancel':
         cancelMutation.mutate(
           { action: 'cancel', graceful: true, ...(value ? { reason: value } : {}) },
@@ -5689,23 +5682,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
               : 'selected step is not eligible'
         }
         error={activeWorkflowDialog === 'recover-from-selected-step' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'bypass-dependencies'}
-        title="Bypass dependencies"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence="Bypass dependency waiting for this workflow. Downstream work may proceed before prerequisites finish."
-        valueLabel="Reason"
-        valuePlaceholder="Dependency wait bypassed by operator from the dashboard."
-        valueMultiline
-        confirmLabel={signalMutation.isPending ? 'Bypassing' : 'Bypass dependencies'}
-        confirmPending={signalMutation.isPending}
-        danger
-        disabledReason={actionDisabledReason('canBypassDependencies')}
-        error={activeWorkflowDialog === 'bypass-dependencies' ? actionError : null}
         onCancel={closeWorkflowDialog}
         onConfirm={confirmWorkflowDialog}
       />

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16495,6 +16495,7 @@ describe("Task Create governed Tool authoring", () => {
     const addToStep = within(step).getByRole("button", {
       name: "Add to Step 1",
     });
+    expect(addToStep.getAttribute("title")).toBe("Add files or capabilities");
 
     fireEvent.click(addToStep);
     const menu = within(step).getByRole("menu", { name: "Add to step" });

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4835,6 +4835,7 @@ function StepAddMenu({
   }, [closeMenu, focusMenuItem, open]);
 
   const menuLabel = `Add to Step ${stepNumber}`;
+  const menuTitle = "Add files or capabilities";
   const menuTitleId = `queue-step-add-menu-title-${stepNumber}`;
   const imageItemLabel = isImageOnlyPolicy(attachmentPolicy)
     ? "Image…"
@@ -4854,7 +4855,7 @@ function StepAddMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={menuLabel}
-        title={menuLabel}
+        title={menuTitle}
         ref={triggerRef}
         onClick={() => setOpen((value) => !value)}
       >

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4645,17 +4645,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   line-height: 1.35;
 }
 
-.queue-step-capability-chip-remove {
-  width: 0.95rem;
-  height: 0.95rem;
-  border-radius: 999px;
-}
-
-.queue-step-capability-chip-remove svg {
-  width: 0.58rem;
-  height: 0.58rem;
-}
-
 .queue-step-attachment-add-button {
   display: inline-grid;
   place-items: center;
@@ -4772,6 +4761,17 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 :is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-icon-button svg {
   width: 1rem;
   height: 1rem;
+}
+
+:is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-capability-chip-remove {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+}
+
+:is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-capability-chip-remove svg {
+  width: 0.58rem;
+  height: 0.58rem;
 }
 
 .queue-attachment-preview {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4501,6 +4501,12 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-weight: 750;
 }
 
+.queue-step-attachment-add-button.queue-step-context-menu-button > span {
+  display: block;
+  line-height: 1;
+  transform: translateY(-0.04em);
+}
+
 .queue-step-context-menu-popover {
   position: absolute;
   top: calc(100% + 0.35rem);
@@ -4640,14 +4646,14 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-step-capability-chip-remove {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 0.95rem;
+  height: 0.95rem;
   border-radius: 999px;
 }
 
 .queue-step-capability-chip-remove svg {
-  width: 0.68rem;
-  height: 0.68rem;
+  width: 0.58rem;
+  height: 0.58rem;
 }
 
 .queue-step-attachment-add-button {
@@ -4733,15 +4739,15 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-step-attachment-chip-remove {
-  width: 1.1rem;
-  height: 1.1rem;
+  width: 0.95rem;
+  height: 0.95rem;
   border-radius: 999px;
   flex: 0 0 auto;
 }
 
 .queue-step-attachment-chip-remove svg {
-  width: 0.68rem;
-  height: 0.68rem;
+  width: 0.58rem;
+  height: 0.58rem;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) li {


### PR DESCRIPTION
The bypass dependencies button launches a pop-up now and I'd rather not get the pop-up. The X buttons on the screenshots which are added to Start Workflow steps are too big. The + symbol within the button for adding images and capabilities appears slightly off center vertically and seems closer to the bottom border than the top border. When hovered, the tooltip says "Add to Step 1", but I'd prefer for the tooltip to say "Add files or capabilities". Fix these issues.