### PR TITLE
MM-990 Validate Omnigent requests and targets

### DIFF
--- a/moonmind/omnigent/__init__.py
+++ b/moonmind/omnigent/__init__.py
@@ -1,0 +1,5 @@
+"""Omnigent integration settings and request helpers."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/moonmind/omnigent/settings.py
+++ b/moonmind/omnigent/settings.py
@@ -1,0 +1,90 @@
+"""Runtime gate for the Omnigent external-agent integration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+OMNIGENT_DISABLED_MESSAGE = (
+    "targetRuntime=omnigent requires OMNIGENT_ENABLED=true with "
+    "OMNIGENT_SERVER_URL configured"
+)
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+@dataclass(frozen=True, slots=True)
+class OmnigentRuntimeGate:
+    """Whether Omnigent is enabled and required endpoint config is present."""
+
+    enabled: bool
+    missing: tuple[str, ...]
+    error_message: str
+
+
+def _clean(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _enabled_from_env(*, env: Mapping[str, Any]) -> bool:
+    raw = _clean(env.get("OMNIGENT_ENABLED"))
+    if not raw:
+        return False
+    lowered = raw.lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    return False
+
+
+def build_omnigent_gate(
+    *,
+    env: Mapping[str, Any] | None = None,
+    error_message: str = OMNIGENT_DISABLED_MESSAGE,
+) -> OmnigentRuntimeGate:
+    """Return env-driven gate state for Omnigent."""
+
+    source = env if env is not None else os.environ
+    missing: list[str] = []
+    if not _enabled_from_env(env=source):
+        missing.append("OMNIGENT_ENABLED")
+    if not _clean(source.get("OMNIGENT_SERVER_URL")):
+        missing.append("OMNIGENT_SERVER_URL")
+    return OmnigentRuntimeGate(
+        enabled=not missing,
+        missing=tuple(missing),
+        error_message=error_message,
+    )
+
+
+def is_omnigent_enabled(*, env: Mapping[str, Any] | None = None) -> bool:
+    return build_omnigent_gate(env=env).enabled
+
+
+def resolved_server_url(*, env: Mapping[str, Any] | None = None) -> str:
+    source = env if env is not None else os.environ
+    return _clean(source.get("OMNIGENT_SERVER_URL"))
+
+
+def resolved_api_token(*, env: Mapping[str, Any] | None = None) -> str:
+    source = env if env is not None else os.environ
+    return _clean(source.get("OMNIGENT_API_TOKEN"))
+
+
+def resolved_default_agent_name(*, env: Mapping[str, Any] | None = None) -> str:
+    source = env if env is not None else os.environ
+    return _clean(source.get("OMNIGENT_DEFAULT_AGENT_NAME"))
+
+
+__all__ = [
+    "OMNIGENT_DISABLED_MESSAGE",
+    "OmnigentRuntimeGate",
+    "build_omnigent_gate",
+    "is_omnigent_enabled",
+    "resolved_api_token",
+    "resolved_default_agent_name",
+    "resolved_server_url",
+]

--- a/moonmind/workflows/adapters/external_adapter_registry.py
+++ b/moonmind/workflows/adapters/external_adapter_registry.py
@@ -129,20 +129,6 @@ def build_default_registry(
         registry.register("openclaw", _openclaw_factory)
         logger.info("Registered OpenClaw external adapter")
 
-    # --- Omnigent (streaming gateway) ---
-    from moonmind.omnigent.settings import is_omnigent_enabled
-
-    if is_omnigent_enabled(env=env):
-        from moonmind.workflows.adapters.omnigent_agent_adapter import (
-            OmnigentExternalAdapter,
-        )
-
-        def _omnigent_factory() -> AgentAdapter:
-            return OmnigentExternalAdapter()
-
-        registry.register("omnigent", _omnigent_factory)
-        logger.info("Registered Omnigent external adapter")
-
     return registry
 
 __all__ = [

--- a/moonmind/workflows/adapters/external_adapter_registry.py
+++ b/moonmind/workflows/adapters/external_adapter_registry.py
@@ -64,7 +64,7 @@ def build_default_registry(
     *,
     env: dict[str, Any] | None = None,
 ) -> ExternalAdapterRegistry:
-    """Build the default registry with Jules and Codex Cloud adapters.
+    """Build the default registry with configured external adapters.
 
     Each adapter is only registered if its runtime gate is satisfied
     (i.e. the provider is enabled and configured).
@@ -128,6 +128,20 @@ def build_default_registry(
 
         registry.register("openclaw", _openclaw_factory)
         logger.info("Registered OpenClaw external adapter")
+
+    # --- Omnigent (streaming gateway) ---
+    from moonmind.omnigent.settings import is_omnigent_enabled
+
+    if is_omnigent_enabled(env=env):
+        from moonmind.workflows.adapters.omnigent_agent_adapter import (
+            OmnigentExternalAdapter,
+        )
+
+        def _omnigent_factory() -> AgentAdapter:
+            return OmnigentExternalAdapter()
+
+        registry.register("omnigent", _omnigent_factory)
+        logger.info("Registered Omnigent external adapter")
 
     return registry
 

--- a/moonmind/workflows/adapters/omnigent_agent_adapter.py
+++ b/moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -1,0 +1,492 @@
+"""Omnigent external-agent request validation and target resolution.
+
+MM-990 implements the bounded adapter contract slice from
+``docs/Omnigent/OmnigentAdapter.md``: Omnigent-specific selection stays under
+``parameters.omnigent``, workspace rules are host-type specific, repository
+tasks normalize repository URLs into the managed session workspace, and target
+resolution is deterministic.
+
+Source issue traceability: MM-981 -> MM-990.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+    FailureClass,
+    ProviderCapabilityDescriptor,
+)
+from moonmind.workflows.adapters.base_external_agent_adapter import (
+    BaseExternalAgentAdapter,
+)
+
+HostType = Literal["managed", "external"]
+
+_OMNIGENT_CAPABILITY = ProviderCapabilityDescriptor(
+    providerName="omnigent",
+    supportsCallbacks=False,
+    supportsCancel=False,
+    supportsResultFetch=False,
+    defaultPollHintSeconds=15,
+    execution_style="streaming_gateway",
+)
+
+_ROOT_SELECTION_KEYS = {
+    "endpointRef",
+    "endpoint_ref",
+    "agent",
+    "agentId",
+    "agentName",
+    "bundleRef",
+    "harnessOverride",
+    "session",
+    "hostType",
+    "hostId",
+    "modelOverride",
+    "reasoningEffort",
+    "terminalLaunchArgs",
+}
+
+
+class OmnigentAdapterError(ValueError):
+    """Adapter validation error carrying the canonical MoonMind failure class."""
+
+    def __init__(self, message: str, *, failure_class: FailureClass) -> None:
+        super().__init__(message)
+        self.failure_class = failure_class
+
+
+@dataclass(frozen=True, slots=True)
+class OmnigentAgentSelection:
+    agent_id: str | None = None
+    agent_name: str | None = None
+    bundle_ref: str | None = None
+    harness_override: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OmnigentSessionSelection:
+    host_type: HostType = "managed"
+    host_id: str | None = None
+    workspace: str | None = None
+    title: str | None = None
+    labels: dict[str, Any] = field(default_factory=dict)
+    model_override: str | None = None
+    reasoning_effort: str | None = None
+    terminal_launch_args: list[str] = field(default_factory=list)
+    collaboration_mode: str | None = None
+    allow_empty_workspace: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class OmnigentExecutionSelection:
+    endpoint_ref: str = "default"
+    agent: OmnigentAgentSelection = field(default_factory=OmnigentAgentSelection)
+    session: OmnigentSessionSelection = field(default_factory=OmnigentSessionSelection)
+    prompt: dict[str, Any] = field(default_factory=dict)
+    capture: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class OmnigentResolvedTarget:
+    agent_id: str
+    source: Literal["agent_id", "agent_name", "bundle_ref", "default_agent_name"]
+    agent_name: str | None = None
+
+
+def build_omnigent_selection(
+    request: AgentExecutionRequest,
+) -> OmnigentExecutionSelection:
+    """Validate and normalize the Omnigent-specific selection block."""
+
+    if request.agent_kind != "external":
+        raise OmnigentAdapterError(
+            "Omnigent only supports external agent_kind",
+            failure_class="user_error",
+        )
+    if request.agent_id.strip().lower() != "omnigent":
+        raise OmnigentAdapterError(
+            "Omnigent target selection must not alter top-level agentId; "
+            "use agentId='omnigent'",
+            failure_class="user_error",
+        )
+
+    parameters = dict(request.parameters or {})
+    leaked = sorted(key for key in _ROOT_SELECTION_KEYS if key in parameters)
+    if leaked:
+        raise OmnigentAdapterError(
+            "Omnigent selection fields must be nested under parameters.omnigent: "
+            + ", ".join(leaked),
+            failure_class="user_error",
+        )
+
+    raw = parameters.get("omnigent")
+    if raw is None:
+        raw_payload: Mapping[str, Any] = {}
+    elif isinstance(raw, Mapping):
+        raw_payload = raw
+    else:
+        raise OmnigentAdapterError(
+            "parameters.omnigent must be an object",
+            failure_class="user_error",
+        )
+
+    agent = _parse_agent(raw_payload.get("agent"))
+    session = _parse_session(raw_payload.get("session"))
+    session = _normalize_session_workspace(
+        request=request,
+        parameters=parameters,
+        session=session,
+    )
+    _validate_session(session)
+
+    return OmnigentExecutionSelection(
+        endpoint_ref=_clean(raw_payload.get("endpointRef")) or "default",
+        agent=agent,
+        session=session,
+        prompt=_mapping(
+            raw_payload.get("prompt"),
+            field_name="parameters.omnigent.prompt",
+        ),
+        capture=_mapping(
+            raw_payload.get("capture"),
+            field_name="parameters.omnigent.capture",
+        ),
+    )
+
+
+async def resolve_omnigent_target(
+    selection: OmnigentExecutionSelection,
+    *,
+    list_agents: Callable[[], Awaitable[list[Mapping[str, Any]]]],
+    upload_agent_bundle: Callable[[str], Awaitable[Mapping[str, Any]]],
+    default_agent_name: str | None,
+) -> OmnigentResolvedTarget:
+    """Resolve target agent in the MM-990 canonical order."""
+
+    agent = selection.agent
+    if agent.agent_id:
+        return OmnigentResolvedTarget(agent_id=agent.agent_id, source="agent_id")
+
+    if agent.agent_name:
+        resolved = await _resolve_agent_name(agent.agent_name, list_agents=list_agents)
+        return OmnigentResolvedTarget(
+            agent_id=resolved,
+            source="agent_name",
+            agent_name=agent.agent_name,
+        )
+
+    if agent.bundle_ref:
+        created = await upload_agent_bundle(agent.bundle_ref)
+        created_id = _extract_agent_id(created)
+        if created_id:
+            return OmnigentResolvedTarget(
+                agent_id=created_id,
+                source="bundle_ref",
+            )
+        raise OmnigentAdapterError(
+            "Omnigent bundle upload did not return an agent id",
+            failure_class="integration_error",
+        )
+
+    default_name = _clean(default_agent_name)
+    if default_name:
+        resolved = await _resolve_agent_name(default_name, list_agents=list_agents)
+        return OmnigentResolvedTarget(
+            agent_id=resolved,
+            source="default_agent_name",
+            agent_name=default_name,
+        )
+
+    raise OmnigentAdapterError(
+        "Unable to resolve Omnigent target agent",
+        failure_class="integration_error",
+    )
+
+
+def build_omnigent_session_create_payload(
+    *,
+    request: AgentExecutionRequest,
+    selection: OmnigentExecutionSelection,
+    target: OmnigentResolvedTarget,
+) -> dict[str, Any]:
+    """Build the JSON session-create payload sent to Omnigent."""
+
+    session = selection.session
+    title = (
+        session.title
+        or _clean((request.parameters or {}).get("title"))
+        or "MoonMind Agent Task"
+    )
+    payload: dict[str, Any] = {
+        "agent_id": target.agent_id,
+        "title": title,
+        "labels": {
+            "moonmind.correlation_id": request.correlation_id,
+            "moonmind.idempotency_key": request.idempotency_key,
+            **session.labels,
+        },
+        "host_type": session.host_type,
+        "workspace": session.workspace,
+        "model_override": session.model_override,
+        "reasoning_effort": session.reasoning_effort,
+        "terminal_launch_args": session.terminal_launch_args,
+    }
+    if session.host_type == "external":
+        payload["host_id"] = session.host_id
+    if session.collaboration_mode:
+        payload["collaboration_mode"] = session.collaboration_mode
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+class OmnigentExternalAdapter(BaseExternalAgentAdapter):
+    """Registry entry for Omnigent; execution uses integration.omnigent.execute."""
+
+    def __init__(self) -> None:
+        super().__init__(accepted_agent_ids=frozenset({"omnigent"}))
+
+    @property
+    def provider_capability(self) -> ProviderCapabilityDescriptor:
+        return _OMNIGENT_CAPABILITY
+
+    async def do_start(
+        self,
+        request: AgentExecutionRequest,
+        title: str,
+        description: str,
+        metadata: dict[str, Any],
+    ) -> AgentRunHandle:
+        raise RuntimeError(
+            "Omnigent executes via integration.omnigent.execute only; "
+            "start activity is not registered for this provider."
+        )
+
+    async def do_status(self, run_id: str) -> AgentRunStatus:
+        raise RuntimeError(
+            "Omnigent uses streaming execution; status polling is unused."
+        )
+
+    async def do_fetch_result(self, run_id: str) -> AgentRunResult:
+        raise RuntimeError("Omnigent uses streaming execution; fetch_result is unused.")
+
+    async def do_cancel(self, run_id: str) -> AgentRunStatus:
+        raise RuntimeError("Omnigent cancels via activity cancellation on execute.")
+
+
+def _parse_agent(raw: object) -> OmnigentAgentSelection:
+    payload = _mapping(raw, field_name="parameters.omnigent.agent")
+    return OmnigentAgentSelection(
+        agent_id=_clean(payload.get("agentId")),
+        agent_name=_clean(payload.get("agentName")),
+        bundle_ref=_clean(payload.get("bundleRef")),
+        harness_override=_clean(payload.get("harnessOverride")),
+    )
+
+
+def _parse_session(raw: object) -> OmnigentSessionSelection:
+    payload = _mapping(raw, field_name="parameters.omnigent.session")
+    host_type = _clean(payload.get("hostType")) or "managed"
+    if host_type not in {"managed", "external"}:
+        raise OmnigentAdapterError(
+            "parameters.omnigent.session.hostType must be 'managed' or 'external'",
+            failure_class="user_error",
+        )
+    labels = _mapping(
+        payload.get("labels"),
+        field_name="parameters.omnigent.session.labels",
+    )
+    launch_args = payload.get("terminalLaunchArgs") or []
+    if not isinstance(launch_args, list) or not all(
+        isinstance(item, str) for item in launch_args
+    ):
+        raise OmnigentAdapterError(
+            "parameters.omnigent.session.terminalLaunchArgs must be a string array",
+            failure_class="user_error",
+        )
+    return OmnigentSessionSelection(
+        host_type=host_type,
+        host_id=_clean(payload.get("hostId")),
+        workspace=_clean(payload.get("workspace")),
+        title=_clean(payload.get("title")),
+        labels=dict(labels),
+        model_override=_clean(payload.get("modelOverride")),
+        reasoning_effort=_clean(payload.get("reasoningEffort")),
+        terminal_launch_args=list(launch_args),
+        collaboration_mode=_clean(payload.get("collaborationMode")),
+        allow_empty_workspace=bool(payload.get("allowEmptyWorkspace", False)),
+    )
+
+
+def _normalize_session_workspace(
+    *,
+    request: AgentExecutionRequest,
+    parameters: Mapping[str, Any],
+    session: OmnigentSessionSelection,
+) -> OmnigentSessionSelection:
+    if session.host_type != "managed" or session.workspace:
+        return session
+
+    repository = _find_repository_url(request.workspace_spec)
+    workspace_context = parameters.get("workspaceContext")
+    if repository is None and isinstance(workspace_context, Mapping):
+        repository = _find_repository_url(workspace_context)
+    omnigent = parameters.get("omnigent")
+    if repository is None and isinstance(omnigent, Mapping):
+        nested_context = omnigent.get("workspaceContext")
+        if isinstance(nested_context, Mapping):
+            repository = _find_repository_url(nested_context)
+
+    if repository is None:
+        return session
+
+    workspace = _repository_workspace_value(repository, request.workspace_spec)
+    return OmnigentSessionSelection(
+        host_type=session.host_type,
+        host_id=session.host_id,
+        workspace=workspace,
+        title=session.title,
+        labels=session.labels,
+        model_override=session.model_override,
+        reasoning_effort=session.reasoning_effort,
+        terminal_launch_args=session.terminal_launch_args,
+        collaboration_mode=session.collaboration_mode,
+        allow_empty_workspace=session.allow_empty_workspace,
+    )
+
+
+def _validate_session(session: OmnigentSessionSelection) -> None:
+    if session.host_type == "managed":
+        if session.host_id:
+            raise OmnigentAdapterError(
+                "Managed Omnigent sessions reject caller-provided hostId",
+                failure_class="user_error",
+            )
+        if session.workspace and not _is_git_url_with_optional_branch(
+            session.workspace
+        ):
+            raise OmnigentAdapterError(
+                "Managed Omnigent session.workspace must be a git repository "
+                "URL or absent",
+                failure_class="user_error",
+            )
+        return
+
+    if not session.host_id:
+        raise OmnigentAdapterError(
+            "External Omnigent sessions require hostId",
+            failure_class="user_error",
+        )
+    if not session.workspace:
+        raise OmnigentAdapterError(
+            "External Omnigent sessions require an absolute host workspace path",
+            failure_class="user_error",
+        )
+    if _is_git_url_with_optional_branch(session.workspace):
+        raise OmnigentAdapterError(
+            "External Omnigent session.workspace must be a host path, "
+            "not a repository URL",
+            failure_class="user_error",
+        )
+    if not session.workspace.startswith("/"):
+        raise OmnigentAdapterError(
+            "External Omnigent session.workspace must be an absolute host path",
+            failure_class="user_error",
+        )
+
+
+async def _resolve_agent_name(
+    agent_name: str,
+    *,
+    list_agents: Callable[[], Awaitable[list[Mapping[str, Any]]]],
+) -> str:
+    for agent in await list_agents():
+        if _clean(agent.get("name")) == agent_name:
+            agent_id = _extract_agent_id(agent)
+            if agent_id:
+                return agent_id
+    raise OmnigentAdapterError(
+        f"Unknown Omnigent agent name: {agent_name}",
+        failure_class="user_error",
+    )
+
+
+def _extract_agent_id(payload: Mapping[str, Any]) -> str | None:
+    return (
+        _clean(payload.get("id"))
+        or _clean(payload.get("agentId"))
+        or _clean(payload.get("agent_id"))
+        or None
+    )
+
+
+def _find_repository_url(payload: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(payload, Mapping):
+        return None
+    for key in ("repository", "repositoryUrl", "repoUrl", "gitUrl"):
+        value = payload.get(key)
+        if isinstance(value, str) and _is_git_url_with_optional_branch(value):
+            return value
+        if isinstance(value, Mapping):
+            nested = _find_repository_url(value)
+            if nested:
+                return nested
+    return None
+
+
+def _repository_workspace_value(
+    repository: str,
+    workspace_spec: Mapping[str, Any],
+) -> str:
+    branch = _clean(workspace_spec.get("branch")) or _clean(
+        workspace_spec.get("targetBranch")
+    )
+    if branch and "#" not in repository:
+        return f"{repository}#{branch}"
+    return repository
+
+
+def _is_git_url_with_optional_branch(value: str) -> bool:
+    candidate = value.split("#", 1)[0]
+    parsed = urlparse(candidate)
+    if parsed.scheme in {"http", "https", "ssh", "git"} and parsed.netloc:
+        return True
+    if candidate.startswith("git@") and ":" in candidate:
+        return True
+    return False
+
+
+def _mapping(raw: object, *, field_name: str) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise OmnigentAdapterError(
+            f"{field_name} must be an object",
+            failure_class="user_error",
+        )
+    return dict(raw)
+
+
+def _clean(value: object | None) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+__all__ = [
+    "OmnigentAdapterError",
+    "OmnigentAgentSelection",
+    "OmnigentExecutionSelection",
+    "OmnigentExternalAdapter",
+    "OmnigentResolvedTarget",
+    "OmnigentSessionSelection",
+    "build_omnigent_selection",
+    "build_omnigent_session_create_payload",
+    "resolve_omnigent_target",
+]

--- a/moonmind/workflows/adapters/omnigent_agent_adapter.py
+++ b/moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -12,7 +12,7 @@ Source issue traceability: MM-981 -> MM-990.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 from urllib.parse import urlparse
 
@@ -348,18 +348,7 @@ def _normalize_session_workspace(
         return session
 
     workspace = _repository_workspace_value(repository, request.workspace_spec)
-    return OmnigentSessionSelection(
-        host_type=session.host_type,
-        host_id=session.host_id,
-        workspace=workspace,
-        title=session.title,
-        labels=session.labels,
-        model_override=session.model_override,
-        reasoning_effort=session.reasoning_effort,
-        terminal_launch_args=session.terminal_launch_args,
-        collaboration_mode=session.collaboration_mode,
-        allow_empty_workspace=session.allow_empty_workspace,
-    )
+    return replace(session, workspace=workspace)
 
 
 def _validate_session(session: OmnigentSessionSelection) -> None:
@@ -446,7 +435,7 @@ def _repository_workspace_value(
     workspace_spec: Mapping[str, Any],
 ) -> str:
     branch = _clean(workspace_spec.get("branch")) or _clean(
-        workspace_spec.get("targetBranch")
+        workspace_spec.get("startingBranch")
     )
     if branch and "#" not in repository:
         return f"{repository}#{branch}"

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -1,0 +1,312 @@
+"""Thin HTTP/SSE client for Omnigent confirmed API operations."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Mapping
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from moonmind.utils.logging import (
+    SecretRedactor,
+    redact_sensitive_payload,
+    redact_sensitive_text,
+)
+
+
+class OmnigentClientError(RuntimeError):
+    """Structured client error for non-2xx Omnigent responses or transport failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        response_body: Any | None = None,
+        failure_class: str = "integration_error",
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+        self.failure_class = failure_class
+
+    def diagnostics(self) -> dict[str, Any]:
+        return {
+            "statusCode": self.status_code,
+            "failureClass": self.failure_class,
+            "message": redact_sensitive_text(str(self)),
+            "responseBody": redact_sensitive_payload(self.response_body),
+        }
+
+
+class OmnigentHttpClient:
+    """Async client for Omnigent HTTP/SSE transport.
+
+    The client is intentionally transport-only; Temporal workflow/activity
+    concerns live at the adapter boundary.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_token: str = "",
+        timeout_seconds: float = 60.0,
+        stream_timeout_seconds: float | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._base = str(base_url).rstrip("/")
+        self._api_token = api_token
+        self._timeout = httpx.Timeout(timeout_seconds)
+        self._stream_timeout = httpx.Timeout(
+            timeout_seconds,
+            read=stream_timeout_seconds,
+        )
+        self._transport = transport
+        self._redactor = SecretRedactor(
+            secrets=[api_token],
+            placeholder="[REDACTED]",
+        )
+
+    def _headers(self, *, accept: str = "application/json") -> dict[str, str]:
+        headers = {"Accept": accept}
+        if self._api_token:
+            headers["Authorization"] = f"Bearer {self._api_token}"
+        return headers
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        data = await self._request("GET", "/api/agents")
+        if isinstance(data, list):
+            return [dict(item) for item in data if isinstance(item, Mapping)]
+        if isinstance(data, Mapping) and isinstance(data.get("agents"), list):
+            return [dict(item) for item in data["agents"] if isinstance(item, Mapping)]
+        return []
+
+    async def get_agent(self, agent_id: str) -> dict[str, Any]:
+        return await self._request("GET", f"/api/agents/{quote(agent_id, safe='')}")
+
+    async def create_agent_bundle(
+        self,
+        *,
+        filename: str,
+        content: bytes,
+        content_type: str = "application/octet-stream",
+    ) -> dict[str, Any]:
+        files = {"bundle": (filename, content, content_type)}
+        return await self._request("POST", "/api/agents", files=files)
+
+    async def create_session(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        return await self._request("POST", "/v1/sessions", json=dict(payload))
+
+    async def get_session(self, session_id: str) -> dict[str, Any]:
+        return await self._request("GET", f"/v1/sessions/{quote(session_id, safe='')}")
+
+    async def post_event(
+        self,
+        session_id: str,
+        event: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            f"/v1/sessions/{quote(session_id, safe='')}/events",
+            json=dict(event),
+        )
+
+    async def stream_events(self, session_id: str) -> AsyncIterator[dict[str, Any]]:
+        path = f"/v1/sessions/{quote(session_id, safe='')}/stream"
+        async with httpx.AsyncClient(
+            timeout=self._stream_timeout,
+            transport=self._transport,
+        ) as client:
+            try:
+                async with client.stream(
+                    "GET",
+                    f"{self._base}{path}",
+                    headers=self._headers(accept="text/event-stream"),
+                ) as response:
+                    if response.status_code < 200 or response.status_code >= 300:
+                        body = (await response.aread()).decode(
+                            "utf-8",
+                            errors="replace",
+                        )
+                        raise self._error_from_response(response.status_code, body)
+                    async for line in response.aiter_lines():
+                        event = parse_sse_line(line)
+                        if event is not None:
+                            yield event
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    failure_class="integration_error",
+                ) from exc
+
+    async def resolve_elicitation(
+        self,
+        session_id: str,
+        elicitation_id: str,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        return await self._request(
+            "POST",
+            "/v1/sessions/"
+            f"{quote(session_id, safe='')}/elicitations/"
+            f"{quote(elicitation_id, safe='')}/resolve",
+            json=dict(payload),
+        )
+
+    async def list_changed_files(self, session_id: str) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}"
+            "/resources/environments/default/changes",
+        )
+
+    async def get_workspace_file(self, session_id: str, path: str) -> bytes:
+        return await self._request_bytes(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}"
+            "/resources/environments/default/filesystem/"
+            f"{quote(path, safe='')}",
+        )
+
+    async def list_session_files(self, session_id: str) -> dict[str, Any]:
+        return await self._request(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}/resources/files",
+        )
+
+    async def get_session_file_content(self, session_id: str, file_id: str) -> bytes:
+        return await self._request_bytes(
+            "GET",
+            f"/v1/sessions/{quote(session_id, safe='')}/resources/files/"
+            f"{quote(file_id, safe='')}/content",
+        )
+
+    async def interrupt(self, session_id: str) -> dict[str, Any]:
+        return await self.post_event(session_id, {"type": "interrupt"})
+
+    async def stop_session(self, session_id: str) -> dict[str, Any]:
+        return await self.post_event(session_id, {"type": "stop_session"})
+
+    async def delete_session(self, session_id: str) -> dict[str, Any]:
+        return await self._request(
+            "DELETE",
+            f"/v1/sessions/{quote(session_id, safe='')}",
+        )
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        async with httpx.AsyncClient(
+            timeout=self._timeout,
+            transport=self._transport,
+        ) as client:
+            try:
+                response = await client.request(
+                    method,
+                    f"{self._base}{path}",
+                    headers=self._headers(),
+                    **kwargs,
+                )
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    failure_class="integration_error",
+                ) from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise self._error_from_response(response.status_code, response.text)
+        if not response.content:
+            return {}
+        try:
+            parsed = response.json()
+        except json.JSONDecodeError:
+            return {"body": self._redact(response.text)}
+        if isinstance(parsed, Mapping):
+            return dict(redact_sensitive_payload(parsed))
+        return {"body": redact_sensitive_payload(parsed)}
+
+    async def _request_bytes(self, method: str, path: str) -> bytes:
+        async with httpx.AsyncClient(
+            timeout=self._timeout,
+            transport=self._transport,
+        ) as client:
+            try:
+                response = await client.request(
+                    method,
+                    f"{self._base}{path}",
+                    headers=self._headers(),
+                )
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    failure_class="integration_error",
+                ) from exc
+        if response.status_code < 200 or response.status_code >= 300:
+            raise self._error_from_response(response.status_code, response.text)
+        return response.content
+
+    def _error_from_response(self, status_code: int, body: str) -> OmnigentClientError:
+        response_body: Any
+        try:
+            response_body = json.loads(body)
+        except json.JSONDecodeError:
+            response_body = body[:4096]
+        response_body = _scrub_payload_with_redactor(
+            redact_sensitive_payload(response_body),
+            redactor=self._redactor,
+        )
+        return OmnigentClientError(
+            self._redact(f"Omnigent HTTP {status_code}"),
+            status_code=status_code,
+            response_body=response_body,
+            failure_class="integration_error",
+        )
+
+    def _redact(self, value: str) -> str:
+        return redact_sensitive_text(self._redactor.scrub(value))
+
+
+def parse_sse_line(line: str) -> dict[str, Any] | None:
+    """Parse one Omnigent SSE data line for tests and stream consumption."""
+
+    if not line or line.startswith(":") or not line.startswith("data:"):
+        return None
+    data = line[5:].strip()
+    if not data or data == "[DONE]":
+        return None
+    try:
+        parsed = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise OmnigentClientError(
+            "Malformed Omnigent SSE frame",
+            failure_class="integration_error",
+        ) from exc
+    if not isinstance(parsed, Mapping):
+        raise OmnigentClientError(
+            "Malformed Omnigent SSE frame",
+            failure_class="integration_error",
+        )
+    return dict(redact_sensitive_payload(parsed))
+
+
+def _scrub_payload_with_redactor(payload: Any, *, redactor: SecretRedactor) -> Any:
+    if isinstance(payload, str):
+        return redactor.scrub(payload)
+    if isinstance(payload, Mapping):
+        return {
+            str(key): _scrub_payload_with_redactor(value, redactor=redactor)
+            for key, value in payload.items()
+        }
+    if isinstance(payload, list):
+        return [
+            _scrub_payload_with_redactor(item, redactor=redactor)
+            for item in payload
+        ]
+    return payload
+
+
+__all__ = [
+    "OmnigentClientError",
+    "OmnigentHttpClient",
+    "parse_sse_line",
+]

--- a/tests/unit/workflows/adapters/test_external_adapter_registry.py
+++ b/tests/unit/workflows/adapters/test_external_adapter_registry.py
@@ -113,3 +113,11 @@ class TestBuildDefaultRegistry:
         }
         registry = build_default_registry(env=env)
         assert "jules" not in registry
+
+    def test_omnigent_registered_when_enabled(self):
+        env = {
+            "OMNIGENT_ENABLED": "true",
+            "OMNIGENT_SERVER_URL": "https://omnigent.test",
+        }
+        registry = build_default_registry(env=env)
+        assert registry.registered_ids == ["omnigent"]

--- a/tests/unit/workflows/adapters/test_external_adapter_registry.py
+++ b/tests/unit/workflows/adapters/test_external_adapter_registry.py
@@ -114,10 +114,10 @@ class TestBuildDefaultRegistry:
         registry = build_default_registry(env=env)
         assert "jules" not in registry
 
-    def test_omnigent_registered_when_enabled(self):
+    def test_omnigent_not_registered_without_execute_activity(self):
         env = {
             "OMNIGENT_ENABLED": "true",
             "OMNIGENT_SERVER_URL": "https://omnigent.test",
         }
         registry = build_default_registry(env=env)
-        assert registry.registered_ids == ["omnigent"]
+        assert "omnigent" not in registry

--- a/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
@@ -102,6 +102,27 @@ def test_managed_repository_task_normalizes_repo_url_and_branch() -> None:
     )
 
 
+def test_managed_repository_task_uses_starting_branch_not_target_branch() -> None:
+    req = _request(
+        workspaceSpec={
+            "repository": "https://github.com/MoonLadderStudios/MoonMind.git",
+            "startingBranch": "main",
+            "targetBranch": "feature/mm-990",
+        },
+        parameters={
+            "title": "Edit repo",
+            "omnigent": {"session": {"hostType": "managed"}},
+        },
+    )
+
+    selection = build_omnigent_selection(req)
+
+    assert (
+        selection.session.workspace
+        == "https://github.com/MoonLadderStudios/MoonMind.git#main"
+    )
+
+
 def test_external_session_requires_host_id_absolute_path_and_rejects_repo_url() -> None:
     missing = _request(
         parameters={

--- a/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
@@ -1,0 +1,249 @@
+"""MM-990 tests for Omnigent request validation and target resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.adapters.omnigent_agent_adapter import (
+    OmnigentAdapterError,
+    OmnigentExternalAdapter,
+    OmnigentResolvedTarget,
+    build_omnigent_selection,
+    build_omnigent_session_create_payload,
+    resolve_omnigent_target,
+)
+
+
+def _request(**overrides: object) -> AgentExecutionRequest:
+    payload = {
+        "agentKind": "external",
+        "agentId": "omnigent",
+        "executionProfileRef": "profile:test",
+        "correlationId": "corr-1",
+        "idempotencyKey": "idem-1",
+        "parameters": {"title": "MM-990 task", "omnigent": {}},
+    }
+    payload.update(overrides)
+    return AgentExecutionRequest(**payload)
+
+
+def test_omnigent_selection_fields_must_be_nested_under_parameters_omnigent() -> None:
+    req = _request(parameters={"agent": {"agentId": "ag_top"}, "omnigent": {}})
+
+    with pytest.raises(OmnigentAdapterError) as exc:
+        build_omnigent_selection(req)
+
+    assert exc.value.failure_class == "user_error"
+    assert "parameters.omnigent" in str(exc.value)
+
+
+def test_omnigent_selection_does_not_change_top_level_agent_identity() -> None:
+    req = _request(
+        agentId="omnigent_codex",
+        parameters={"omnigent": {"agent": {"agentId": "ag_1"}}},
+    )
+
+    with pytest.raises(OmnigentAdapterError) as exc:
+        build_omnigent_selection(req)
+
+    assert exc.value.failure_class == "user_error"
+    assert "agentId='omnigent'" in str(exc.value)
+
+
+def test_managed_session_rejects_host_id_and_local_workspace() -> None:
+    req = _request(
+        parameters={
+            "omnigent": {
+                "session": {
+                    "hostType": "managed",
+                    "hostId": "host_1",
+                    "workspace": "/work/repo",
+                }
+            }
+        }
+    )
+
+    with pytest.raises(OmnigentAdapterError, match="hostId"):
+        build_omnigent_selection(req)
+
+    req = _request(
+        parameters={
+            "omnigent": {
+                "session": {
+                    "hostType": "managed",
+                    "workspace": "/work/repo",
+                }
+            }
+        }
+    )
+
+    with pytest.raises(OmnigentAdapterError, match="git repository URL"):
+        build_omnigent_selection(req)
+
+
+def test_managed_repository_task_normalizes_repo_url_and_branch() -> None:
+    req = _request(
+        workspaceSpec={
+            "repository": "https://github.com/MoonLadderStudios/MoonMind.git",
+            "branch": "feature/mm-990",
+        },
+        parameters={
+            "title": "Edit repo",
+            "omnigent": {"session": {"hostType": "managed"}},
+        },
+    )
+
+    selection = build_omnigent_selection(req)
+
+    assert (
+        selection.session.workspace
+        == "https://github.com/MoonLadderStudios/MoonMind.git#feature/mm-990"
+    )
+
+
+def test_external_session_requires_host_id_absolute_path_and_rejects_repo_url() -> None:
+    missing = _request(
+        parameters={
+            "omnigent": {
+                "session": {"hostType": "external", "workspace": "/workspace/repo"}
+            }
+        }
+    )
+    with pytest.raises(OmnigentAdapterError, match="hostId"):
+        build_omnigent_selection(missing)
+
+    relative = _request(
+        parameters={
+            "omnigent": {
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host_1",
+                    "workspace": "workspace/repo",
+                }
+            }
+        }
+    )
+    with pytest.raises(OmnigentAdapterError, match="absolute host path"):
+        build_omnigent_selection(relative)
+
+    repo_url = _request(
+        parameters={
+            "omnigent": {
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host_1",
+                    "workspace": "https://github.com/org/repo.git",
+                }
+            }
+        }
+    )
+    with pytest.raises(OmnigentAdapterError, match="not a repository URL"):
+        build_omnigent_selection(repo_url)
+
+
+@pytest.mark.asyncio
+async def test_target_resolution_order() -> None:
+    agents = [{"id": "ag_named", "name": "codex-native-ui"}]
+    calls: list[str] = []
+
+    async def list_agents() -> list[dict[str, str]]:
+        calls.append("list")
+        return agents
+
+    async def upload(bundle_ref: str) -> dict[str, str]:
+        calls.append(f"upload:{bundle_ref}")
+        return {"id": "ag_bundle"}
+
+    direct = build_omnigent_selection(
+        _request(parameters={"omnigent": {"agent": {"agentId": "ag_direct"}}})
+    )
+    assert (await resolve_omnigent_target(
+        direct,
+        list_agents=list_agents,
+        upload_agent_bundle=upload,
+        default_agent_name=None,
+    )).source == "agent_id"
+    assert calls == []
+
+    named = build_omnigent_selection(
+        _request(parameters={"omnigent": {"agent": {"agentName": "codex-native-ui"}}})
+    )
+    assert (await resolve_omnigent_target(
+        named,
+        list_agents=list_agents,
+        upload_agent_bundle=upload,
+        default_agent_name=None,
+    )).agent_id == "ag_named"
+
+    bundle = build_omnigent_selection(
+        _request(parameters={"omnigent": {"agent": {"bundleRef": "artifact://bundle"}}})
+    )
+    assert (await resolve_omnigent_target(
+        bundle,
+        list_agents=list_agents,
+        upload_agent_bundle=upload,
+        default_agent_name=None,
+    )).source == "bundle_ref"
+
+    default = build_omnigent_selection(_request())
+    assert (await resolve_omnigent_target(
+        default,
+        list_agents=list_agents,
+        upload_agent_bundle=upload,
+        default_agent_name="codex-native-ui",
+    )).source == "default_agent_name"
+
+    with pytest.raises(OmnigentAdapterError) as exc:
+        await resolve_omnigent_target(
+            default,
+            list_agents=list_agents,
+            upload_agent_bundle=upload,
+            default_agent_name=None,
+        )
+    assert exc.value.failure_class == "integration_error"
+
+
+def test_session_create_payload_host_id_rules() -> None:
+    managed_req = _request(
+        workspaceSpec={
+            "repository": "https://github.com/org/repo.git",
+            "branch": "main",
+        }
+    )
+    managed_selection = build_omnigent_selection(managed_req)
+    payload = build_omnigent_session_create_payload(
+        request=managed_req,
+        selection=managed_selection,
+        target=OmnigentResolvedTarget(agent_id="ag_1", source="agent_id"),
+    )
+
+    assert payload["workspace"] == "https://github.com/org/repo.git#main"
+    assert payload["host_type"] == "managed"
+    assert "host_id" not in payload
+
+    external_req = _request(
+        parameters={
+            "omnigent": {
+                "session": {
+                    "hostType": "external",
+                    "hostId": "host_1",
+                    "workspace": "/workspace/repo",
+                }
+            }
+        }
+    )
+    external_selection = build_omnigent_selection(external_req)
+    payload = build_omnigent_session_create_payload(
+        request=external_req,
+        selection=external_selection,
+        target=OmnigentResolvedTarget(agent_id="ag_1", source="agent_id"),
+    )
+    assert payload["host_id"] == "host_1"
+
+
+def test_omnigent_external_adapter_capability_is_streaming_gateway() -> None:
+    cap = OmnigentExternalAdapter().provider_capability
+    assert cap.provider_name == "omnigent"
+    assert cap.execution_style == "streaming_gateway"
+    assert cap.supports_result_fetch is False

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -1,0 +1,90 @@
+"""MM-990 tests for the thin Omnigent HTTP client."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from moonmind.workflows.adapters.omnigent_client import (
+    OmnigentClientError,
+    OmnigentHttpClient,
+    parse_sse_line,
+)
+
+
+@pytest.mark.asyncio
+async def test_omnigent_client_exposes_confirmed_operations() -> None:
+    assert not hasattr(OmnigentHttpClient, "get_workspace_diff")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/api/agents":
+            return httpx.Response(
+                200,
+                json={"agents": [{"id": "ag_1", "name": "codex"}]},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.test",
+        api_token="secret-token",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert await client.list_agents() == [{"id": "ag_1", "name": "codex"}]
+    assert await client.get_agent("ag_1") == {"ok": True}
+    assert await client.create_agent_bundle(
+        filename="bundle.tgz",
+        content=b"x",
+    ) == {"ok": True}
+    assert await client.create_session({"agent_id": "ag_1"}) == {"ok": True}
+    assert await client.get_session("sess_1") == {"ok": True}
+    assert await client.post_event("sess_1", {"type": "message"}) == {"ok": True}
+    assert await client.resolve_elicitation(
+        "sess_1",
+        "el_1",
+        {"answer": "yes"},
+    ) == {"ok": True}
+    assert await client.list_changed_files("sess_1") == {"ok": True}
+    assert await client.list_session_files("sess_1") == {"ok": True}
+    assert await client.interrupt("sess_1") == {"ok": True}
+    assert await client.stop_session("sess_1") == {"ok": True}
+    assert await client.delete_session("sess_1") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_omnigent_client_structures_and_redacts_non_2xx_diagnostics() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer secret-token"
+        return httpx.Response(
+            503,
+            json={
+                "error": "bad",
+                "apiKey": "secret-token",
+                "authorization": "Bearer secret-token",
+            },
+        )
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.test",
+        api_token="secret-token",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(OmnigentClientError) as exc:
+        await client.get_session("sess_1")
+
+    diagnostics = exc.value.diagnostics()
+    assert diagnostics["statusCode"] == 503
+    assert diagnostics["failureClass"] == "integration_error"
+    assert "secret-token" not in str(diagnostics)
+    assert diagnostics["responseBody"]["apiKey"] == "[REDACTED]"
+
+
+def test_parse_sse_line_redacts_payload_and_rejects_malformed_frames() -> None:
+    parsed = parse_sse_line(
+        'data: {"type":"message","token":"sensitive-value"}'
+    )
+    assert parsed == {"type": "message", "token": "[REDACTED]"}
+
+    with pytest.raises(OmnigentClientError, match="Malformed Omnigent SSE frame"):
+        parse_sse_line("data: not-json")


### PR DESCRIPTION
Issue: MM-990

Summary:
- Adds Omnigent request validation and target resolution behind the external adapter registry.
- Validates managed versus external workspace rules and normalizes repository workspace context for managed sessions.
- Adds a thin Omnigent HTTP client with structured non-2xx diagnostics and redaction coverage.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_omnigent_client.py tests/unit/workflows/adapters/test_omnigent_agent_adapter.py tests/unit/workflows/adapters/test_external_adapter_registry.py

Remaining risks:
- Omnigent provider behavior is covered with unit-level mock transport tests; live provider verification was not run in this environment.
