### PR TITLE
MM-978 fix pause control paths

### DIFF
--- a/api_service/api/routers/system_operations.py
+++ b/api_service/api/routers/system_operations.py
@@ -70,10 +70,13 @@ def _validation_error(exc: SystemOperationValidationError) -> HTTPException:
 @router.get("/worker-pause", response_model=WorkerPauseSnapshotResponse)
 async def get_worker_pause_snapshot(
     session: AsyncSession = Depends(get_async_session),
+    temporal_service: TemporalExecutionService = Depends(_get_temporal_execution_service),
     user: User = Depends(get_current_user()),
 ) -> WorkerPauseSnapshotResponse:
     _require_operation_permission(user, "operations.read")
-    return await SystemOperationsService(session).snapshot()
+    return await SystemOperationsService(
+        session, temporal_service=temporal_service
+    ).snapshot()
 
 
 @router.post("/worker-pause", response_model=WorkerPauseSnapshotResponse)

--- a/api_service/services/system_operations.py
+++ b/api_service/services/system_operations.py
@@ -99,16 +99,11 @@ class SystemOperationsService:
         failure_reason: str | None = None,
     ) -> WorkerPauseSnapshotResponse:
         state = await self._load_state()
+        metrics = await self._load_metrics()
         audit = await self._latest_audit()
         return WorkerPauseSnapshotResponse(
             system=QueueSystemMetadataModel.from_service_metadata(state),
-            metrics=WorkerPauseMetricsModel(
-                queued=0,
-                running=0,
-                staleRunning=0,
-                isDrained=True,
-                metricsSource="temporal",
-            ),
+            metrics=metrics,
             commands=self._command_descriptors(state),
             audit=WorkerPauseAuditListModel(latest=audit),
             signalStatus=failure_reason or signal_status,
@@ -358,6 +353,28 @@ class SystemOperationsService:
                 updated_at=now,
             )
         return self._metadata_from_payload(row.value_json)
+
+    async def _load_metrics(self) -> WorkerPauseMetricsModel:
+        reader = getattr(self._temporal_service, "get_drain_metrics", None)
+        if not callable(reader):
+            return WorkerPauseMetricsModel(
+                queued=0,
+                running=0,
+                staleRunning=0,
+                isDrained=False,
+                metricsSource="unavailable",
+            )
+        raw = await reader()
+        queued = max(0, int(raw.get("queued") or 0))
+        running = max(0, int(raw.get("running") or 0))
+        stale_running = max(0, int(raw.get("stale_running") or 0))
+        return WorkerPauseMetricsModel(
+            queued=queued,
+            running=running,
+            staleRunning=stale_running,
+            isDrained=(queued + running + stale_running) == 0,
+            metricsSource="temporal",
+        )
 
     async def _state_row(self) -> SettingsOverride | None:
         result = await self._session.execute(

--- a/api_service/services/system_operations.py
+++ b/api_service/services/system_operations.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Mapping
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -24,6 +25,7 @@ from api_service.db.models import SettingsAuditEvent, SettingsOverride
 _DEFAULT_SUBJECT_ID = UUID("00000000-0000-0000-0000-000000000000")
 _WORKER_STATE_KEY = "operations.workers.pause_state"
 _WORKER_AUDIT_KEY = "operations.workers"
+_LOG = logging.getLogger(__name__)
 
 
 class SystemOperationValidationError(ValueError):
@@ -355,8 +357,7 @@ class SystemOperationsService:
         return self._metadata_from_payload(row.value_json)
 
     async def _load_metrics(self) -> WorkerPauseMetricsModel:
-        reader = getattr(self._temporal_service, "get_drain_metrics", None)
-        if not callable(reader):
+        def unavailable() -> WorkerPauseMetricsModel:
             return WorkerPauseMetricsModel(
                 queued=0,
                 running=0,
@@ -364,10 +365,20 @@ class SystemOperationsService:
                 isDrained=False,
                 metricsSource="unavailable",
             )
-        raw = await reader()
-        queued = max(0, int(raw.get("queued") or 0))
-        running = max(0, int(raw.get("running") or 0))
-        stale_running = max(0, int(raw.get("stale_running") or 0))
+
+        reader = getattr(self._temporal_service, "get_drain_metrics", None)
+        if not callable(reader):
+            return unavailable()
+        try:
+            raw = await reader()
+            if not isinstance(raw, Mapping):
+                return unavailable()
+            queued = max(0, int(raw.get("queued") or 0))
+            running = max(0, int(raw.get("running") or 0))
+            stale_running = max(0, int(raw.get("stale_running") or 0))
+        except Exception:
+            _LOG.warning("Failed to load worker pause drain metrics", exc_info=True)
+            return unavailable()
         return WorkerPauseMetricsModel(
             queued=queued,
             running=running,

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Protocol
 
-from temporalio.client import Client, WorkflowExecutionDescription
+from temporalio.client import Client, WorkflowExecutionDescription, WorkflowUpdateStage
 from temporalio.common import (
     SearchAttributeKey,
     SearchAttributePair,
@@ -59,6 +59,7 @@ MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE = (
     "mm-operational:managed-runtime-workspace-cleanup"
 )
 ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
+_WORKFLOW_UPDATE_ACCEPTED_TIMEOUT = timedelta(seconds=10)
 
 def _is_rpc_status(exc: BaseException, status_name: str) -> bool:
     """Check whether *exc* is a Temporal ``RPCError`` with the given gRPC status.
@@ -484,7 +485,7 @@ class TemporalClientAdapter:
 
     # --- Worker Pause/Resume: Batch Updates for Quiesce mode (DOC-REQ-003) ---
 
-    async def send_batch_pause_signal(
+    async def send_batch_pause_update(
         self,
         *,
         task_queues: Sequence[str] | None = None,
@@ -498,7 +499,7 @@ class TemporalClientAdapter:
             task_queues=task_queues,
         )
 
-    async def send_batch_resume_signal(
+    async def send_batch_resume_update(
         self,
         *,
         task_queues: Sequence[str] | None = None,
@@ -534,7 +535,6 @@ class TemporalClientAdapter:
             quoted = ", ".join(f'"{tq}"' for tq in task_queues)
             visibility_filter += f" AND TaskQueue IN ({quoted})"
 
-        signaled = 0
         _log = logging.getLogger(__name__)
         _sem = asyncio.Semaphore(50)
 
@@ -542,7 +542,11 @@ class TemporalClientAdapter:
             async with _sem:
                 try:
                     handle = client.get_workflow_handle(wf_id)
-                    await handle.execute_update(update_name)
+                    await handle.start_update(
+                        update_name,
+                        wait_for_stage=WorkflowUpdateStage.ACCEPTED,
+                        rpc_timeout=_WORKFLOW_UPDATE_ACCEPTED_TIMEOUT,
+                    )
                     return True
                 except Exception:
                     _log.warning(
@@ -558,8 +562,7 @@ class TemporalClientAdapter:
             tasks.append(asyncio.create_task(_update_one(execution.id)))
 
         results = await asyncio.gather(*tasks)
-        signaled = sum(1 for ok in results if ok)
-        return signaled
+        return sum(1 for ok in results if ok)
 
     # --- Temporal Schedule CRUD ---
 

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -482,19 +482,19 @@ class TemporalClientAdapter:
             "stale_running": 0,
         }
 
-    # --- Worker Pause/Resume: Batch Signals for Quiesce mode (DOC-REQ-003) ---
+    # --- Worker Pause/Resume: Batch Updates for Quiesce mode (DOC-REQ-003) ---
 
     async def send_batch_pause_signal(
         self,
         *,
         task_queues: Sequence[str] | None = None,
     ) -> int:
-        """Send a ``pause`` signal to all running workflows (Quiesce mode).
+        """Send the canonical ``Pause`` update to all running workflows.
 
-        Returns the number of workflows signaled.
+        Returns the number of workflows updated.
         """
-        return await self._send_signal_to_running_workflows(
-            signal_name="pause",
+        return await self._send_update_to_running_workflows(
+            update_name="Pause",
             task_queues=task_queues,
         )
 
@@ -503,22 +503,22 @@ class TemporalClientAdapter:
         *,
         task_queues: Sequence[str] | None = None,
     ) -> int:
-        """Send a ``resume`` signal to all running workflows.
+        """Send the canonical ``Resume`` update to all running workflows.
 
-        Returns the number of workflows signaled.
+        Returns the number of workflows updated.
         """
-        return await self._send_signal_to_running_workflows(
-            signal_name="resume",
+        return await self._send_update_to_running_workflows(
+            update_name="Resume",
             task_queues=task_queues,
         )
 
-    async def _send_signal_to_running_workflows(
+    async def _send_update_to_running_workflows(
         self,
         *,
-        signal_name: str,
+        update_name: str,
         task_queues: Sequence[str] | None = None,
     ) -> int:
-        """Iterate running workflows via Visibility and signal each one.
+        """Iterate running workflows via Visibility and update each one.
 
         This approach works with all Temporal server versions.  When the
         Temporal Batch Operations API becomes available in the Python SDK,
@@ -538,24 +538,24 @@ class TemporalClientAdapter:
         _log = logging.getLogger(__name__)
         _sem = asyncio.Semaphore(50)
 
-        async def _signal_one(wf_id: str) -> bool:
+        async def _update_one(wf_id: str) -> bool:
             async with _sem:
                 try:
                     handle = client.get_workflow_handle(wf_id)
-                    await handle.signal(signal_name)
+                    await handle.execute_update(update_name)
                     return True
                 except Exception:
                     _log.warning(
-                        "Failed to signal workflow %s with %s",
+                        "Failed to update workflow %s with %s",
                         wf_id,
-                        signal_name,
+                        update_name,
                         exc_info=True,
                     )
                     return False
 
         tasks: list[asyncio.Task[bool]] = []
         async for execution in client.list_workflows(query=visibility_filter):
-            tasks.append(asyncio.create_task(_signal_one(execution.id)))
+            tasks.append(asyncio.create_task(_update_one(execution.id)))
 
         results = await asyncio.gather(*tasks)
         signaled = sum(1 for ok in results if ok)

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import (
     MoonMindWorkflowState,
+    SettingsOverride,
     TemporalArtifact,
     TemporalArtifactStatus,
     TemporalExecutionCanonicalRecord,
@@ -230,9 +231,17 @@ NON_TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.FINALIZING,
 }
 
-OPERATOR_SIGNAL_ALLOWED_STATES: set[MoonMindWorkflowState] = (
-    NON_TERMINAL_STATES | {MoonMindWorkflowState.AWAITING_SLOT}
-)
+OPERATOR_SIGNAL_ALLOWED_STATES: set[MoonMindWorkflowState] = {
+    MoonMindWorkflowState.SCHEDULED,
+    MoonMindWorkflowState.INITIALIZING,
+    MoonMindWorkflowState.WAITING_ON_DEPENDENCIES,
+    MoonMindWorkflowState.PLANNING,
+    MoonMindWorkflowState.AWAITING_SLOT,
+    MoonMindWorkflowState.EXECUTING,
+    MoonMindWorkflowState.PROPOSALS,
+    MoonMindWorkflowState.AWAITING_EXTERNAL,
+    MoonMindWorkflowState.FINALIZING,
+}
 
 _RUNNING_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.PLANNING,
@@ -383,9 +392,18 @@ class TemporalExecutionService:
         Used by API guard to prevent new workflow submissions (DOC-REQ-001/004/005).
         """
 
-        # TODO(phase-4): Implement Temporal-native system pause check.
-        # AgentQueueRepository was removed in Phase 3.5 queue backend removal.
-        return False
+        result = await self._session.execute(
+            select(SettingsOverride.value_json).where(
+                SettingsOverride.scope == "workspace",
+                SettingsOverride.workspace_id
+                == UUID("00000000-0000-0000-0000-000000000000"),
+                SettingsOverride.user_id
+                == UUID("00000000-0000-0000-0000-000000000000"),
+                SettingsOverride.key == "operations.workers.pause_state",
+            )
+        )
+        payload = result.scalar_one_or_none()
+        return bool(isinstance(payload, Mapping) and payload.get("workersPaused"))
 
     async def send_quiesce_pause_signal(self) -> int:
         """Send a Quiesce pause signal to all running workflows (DOC-REQ-003, FR-007)."""
@@ -394,6 +412,10 @@ class TemporalExecutionService:
     async def send_quiesce_resume_signal(self) -> int:
         """Send a Quiesce resume signal to all paused workflows (DOC-REQ-003, FR-010)."""
         return await self._client_adapter.send_batch_resume_signal()
+
+    async def get_drain_metrics(self) -> dict[str, int]:
+        """Return Temporal Visibility counts for worker-pause drain status."""
+        return await self._client_adapter.get_drain_metrics()
 
     async def _validate_dependencies(
         self,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -392,13 +392,12 @@ class TemporalExecutionService:
         Used by API guard to prevent new workflow submissions (DOC-REQ-001/004/005).
         """
 
+        system_id = UUID("00000000-0000-0000-0000-000000000000")
         result = await self._session.execute(
             select(SettingsOverride.value_json).where(
                 SettingsOverride.scope == "workspace",
-                SettingsOverride.workspace_id
-                == UUID("00000000-0000-0000-0000-000000000000"),
-                SettingsOverride.user_id
-                == UUID("00000000-0000-0000-0000-000000000000"),
+                SettingsOverride.workspace_id == system_id,
+                SettingsOverride.user_id == system_id,
                 SettingsOverride.key == "operations.workers.pause_state",
             )
         )
@@ -407,11 +406,11 @@ class TemporalExecutionService:
 
     async def send_quiesce_pause_signal(self) -> int:
         """Send a Quiesce pause signal to all running workflows (DOC-REQ-003, FR-007)."""
-        return await self._client_adapter.send_batch_pause_signal()
+        return await self._client_adapter.send_batch_pause_update()
 
     async def send_quiesce_resume_signal(self) -> int:
         """Send a Quiesce resume signal to all paused workflows (DOC-REQ-003, FR-010)."""
-        return await self._client_adapter.send_batch_resume_signal()
+        return await self._client_adapter.send_batch_resume_update()
 
     async def get_drain_metrics(self) -> dict[str, int]:
         """Return Temporal Visibility counts for worker-pause drain status."""

--- a/tests/integration/temporal/test_system_operations_api.py
+++ b/tests/integration/temporal/test_system_operations_api.py
@@ -25,6 +25,9 @@ class FakeTemporalService:
     async def send_resume_signal(self) -> int:
         return 0
 
+    async def get_drain_metrics(self) -> dict[str, int]:
+        return {"queued": 0, "running": 0, "stale_running": 0}
+
 
 def _override_user() -> object:
     return SimpleNamespace(

--- a/tests/unit/api/routers/test_system_operations.py
+++ b/tests/unit/api/routers/test_system_operations.py
@@ -23,6 +23,7 @@ class FakeTemporalService:
     def __init__(self) -> None:
         self.pause_calls = 0
         self.resume_calls = 0
+        self.metrics = {"queued": 0, "running": 0, "stale_running": 0}
 
     async def send_quiesce_pause_signal(self) -> int:
         self.pause_calls += 1
@@ -31,6 +32,9 @@ class FakeTemporalService:
     async def send_resume_signal(self) -> int:
         self.resume_calls += 1
         return 1
+
+    async def get_drain_metrics(self) -> dict[str, int]:
+        return dict(self.metrics)
 
 
 @pytest.fixture

--- a/tests/unit/api/test_temporal_service_pause_guard.py
+++ b/tests/unit/api/test_temporal_service_pause_guard.py
@@ -1,4 +1,4 @@
-"""Unit tests for API guard: workflow submission blocked when system paused (DOC-REQ-001/004/005)."""
+"""Unit tests for API guard: workflow submission blocked when system paused."""
 
 from __future__ import annotations
 
@@ -13,12 +13,6 @@ from moonmind.workflows.temporal.service import (
 
 pytestmark = [pytest.mark.asyncio]
 
-def _make_pause_state(paused: bool):
-    """Create a minimal mock pause state object."""
-    state = MagicMock()
-    state.paused = paused
-    return state
-
 @pytest.fixture
 def mock_session():
     session = MagicMock()
@@ -31,30 +25,36 @@ def mock_session():
 def mock_client_adapter():
     return AsyncMock()
 
-# ---- check_system_paused ----
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
 
-async def test_check_system_paused_returns_false_after_queue_removal(mock_session, mock_client_adapter):
-    """check_system_paused always returns False after Phase 3.5 queue removal (stub)."""
+    def scalar_one_or_none(self):
+        return self._value
+
+
+async def test_check_system_paused_returns_false_when_pause_state_missing(
+    mock_session, mock_client_adapter
+):
     svc = TemporalExecutionService(mock_session, client_adapter=mock_client_adapter)
+    mock_session.execute = AsyncMock(return_value=_ScalarResult(None))
 
     result = await svc.check_system_paused()
+
     assert result is False
 
-async def test_check_system_paused_returns_false(mock_session, mock_client_adapter):
-    """check_system_paused should return False when pause state is inactive."""
+
+async def test_check_system_paused_reads_persisted_pause_state(
+    mock_session, mock_client_adapter
+):
     svc = TemporalExecutionService(mock_session, client_adapter=mock_client_adapter)
+    mock_session.execute = AsyncMock(
+        return_value=_ScalarResult({"workersPaused": True, "mode": "drain"})
+    )
 
-    with patch(
-        "unittest.mock.MagicMock",
-    ) as MockRepo:
-        repo_instance = AsyncMock()
-        repo_instance.get_pause_state = AsyncMock(
-            return_value=_make_pause_state(paused=False)
-        )
-        MockRepo.return_value = repo_instance
+    result = await svc.check_system_paused()
 
-        result = await svc.check_system_paused()
-        assert result is False
+    assert result is True
 
 # ---- API Guard on create_execution ----
 

--- a/tests/unit/services/test_system_operations.py
+++ b/tests/unit/services/test_system_operations.py
@@ -38,6 +38,7 @@ class FakeTemporalService:
     def __init__(self) -> None:
         self.pause_calls = 0
         self.resume_calls = 0
+        self.metrics = {"queued": 0, "running": 0, "stale_running": 0}
 
     async def send_quiesce_pause_signal(self) -> int:
         self.pause_calls += 1
@@ -46,6 +47,9 @@ class FakeTemporalService:
     async def send_resume_signal(self) -> int:
         self.resume_calls += 1
         return 2
+
+    async def get_drain_metrics(self) -> dict[str, int]:
+        return dict(self.metrics)
 
 
 @pytest.mark.asyncio
@@ -71,11 +75,14 @@ async def test_worker_snapshot_defaults_and_projects_sanitized_audit(
         )
         await session.commit()
 
-        snapshot = await SystemOperationsService(session).snapshot()
+        snapshot = await SystemOperationsService(
+            session, temporal_service=FakeTemporalService()
+        ).snapshot()
 
     assert snapshot.system.workers_paused is False
     assert snapshot.metrics.queued == 0
     assert snapshot.metrics.is_drained is True
+    assert snapshot.metrics.metrics_source == "temporal"
     assert snapshot.audit.latest[0].action == "pause"
     assert snapshot.audit.latest[0].actor_user_id == actor_id
     assert "should-not-render" not in snapshot.model_dump_json()
@@ -180,6 +187,23 @@ async def test_submit_returns_actual_subsystem_signal_status(
 
 
 @pytest.mark.asyncio
+async def test_snapshot_derives_drained_status_from_temporal_metrics(
+    system_operations_session_maker,
+) -> None:
+    """MM-978: worker-pause metrics must not hardcode drained status."""
+    temporal = FakeTemporalService()
+    temporal.metrics = {"queued": 0, "running": 2, "stale_running": 0}
+    async with system_operations_session_maker() as session:
+        snapshot = await SystemOperationsService(
+            session, temporal_service=temporal
+        ).snapshot()
+
+    assert snapshot.metrics.running == 2
+    assert snapshot.metrics.is_drained is False
+    assert snapshot.metrics.metrics_source == "temporal"
+
+
+@pytest.mark.asyncio
 async def test_quiesce_and_resume_fail_fast_when_signal_handler_is_missing(
     system_operations_session_maker,
 ) -> None:
@@ -269,7 +293,9 @@ async def test_snapshot_includes_operations_command_catalog(
     system_operations_session_maker,
 ) -> None:
     async with system_operations_session_maker() as session:
-        snapshot = await SystemOperationsService(session).snapshot()
+        snapshot = await SystemOperationsService(
+            session, temporal_service=FakeTemporalService()
+        ).snapshot()
 
     command_ids = {command.id for command in snapshot.commands}
     assert {

--- a/tests/unit/services/test_system_operations.py
+++ b/tests/unit/services/test_system_operations.py
@@ -52,6 +52,16 @@ class FakeTemporalService:
         return dict(self.metrics)
 
 
+class FailingMetricsTemporalService(FakeTemporalService):
+    async def get_drain_metrics(self) -> dict[str, int]:
+        raise RuntimeError("visibility unavailable")
+
+
+class MalformedMetricsTemporalService(FakeTemporalService):
+    async def get_drain_metrics(self) -> list[int]:
+        return [1, 2, 3]
+
+
 @pytest.mark.asyncio
 async def test_worker_snapshot_defaults_and_projects_sanitized_audit(
     system_operations_session_maker,
@@ -201,6 +211,31 @@ async def test_snapshot_derives_drained_status_from_temporal_metrics(
     assert snapshot.metrics.running == 2
     assert snapshot.metrics.is_drained is False
     assert snapshot.metrics.metrics_source == "temporal"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "temporal_service",
+    [
+        FailingMetricsTemporalService(),
+        MalformedMetricsTemporalService(),
+        object(),
+    ],
+)
+async def test_snapshot_degrades_when_temporal_metrics_are_unavailable(
+    system_operations_session_maker,
+    temporal_service,
+) -> None:
+    async with system_operations_session_maker() as session:
+        snapshot = await SystemOperationsService(
+            session, temporal_service=temporal_service
+        ).snapshot()
+
+    assert snapshot.metrics.queued == 0
+    assert snapshot.metrics.running == 0
+    assert snapshot.metrics.stale_running == 0
+    assert snapshot.metrics.is_drained is False
+    assert snapshot.metrics.metrics_source == "unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_client.py
+++ b/tests/unit/workflows/temporal/test_temporal_client.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from moonmind.workflows.temporal.client import TemporalClientAdapter
+from temporalio.client import WorkflowUpdateStage
 from moonmind.workflows.temporal import client as temporal_client_module
 from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
 from moonmind.workflows.temporal.hard_switch_cutover import (
@@ -126,9 +127,9 @@ async def test_get_drain_metrics_empty_namespace(adapter):
 
     assert result == {"running": 0, "queued": 0, "stale_running": 0}
 
-# ---- send_batch_pause_signal / send_batch_resume_signal ----
+# ---- send_batch_pause_update / send_batch_resume_update ----
 
-async def test_send_batch_pause_signal_updates_all_with_canonical_pause(adapter):
+async def test_send_batch_pause_update_starts_all_with_canonical_pause(adapter):
     """Batch pause should update each running workflow with 'Pause'."""
 
     executions = [_FakeWorkflowExecution(f"wf-{i}") for i in range(3)]
@@ -144,13 +145,18 @@ async def test_send_batch_pause_signal_updates_all_with_canonical_pause(adapter)
     adapter._client.list_workflows = _fake_list
     adapter._client.get_workflow_handle = lambda wid: mock_handles[wid]
 
-    signaled = await adapter.send_batch_pause_signal()
+    signaled = await adapter.send_batch_pause_update()
 
     assert signaled == 3
     for handle in mock_handles.values():
-        handle.execute_update.assert_awaited_once_with("Pause")
+        handle.start_update.assert_awaited_once()
+        assert handle.start_update.await_args.args == ("Pause",)
+        assert handle.start_update.await_args.kwargs["wait_for_stage"] is (
+            WorkflowUpdateStage.ACCEPTED
+        )
+        handle.execute_update.assert_not_awaited()
 
-async def test_send_batch_resume_signal_updates_all_with_canonical_resume(adapter):
+async def test_send_batch_resume_update_starts_all_with_canonical_resume(adapter):
     """Batch resume should update each running workflow with 'Resume'."""
 
     executions = [_FakeWorkflowExecution("wf-1")]
@@ -163,10 +169,15 @@ async def test_send_batch_resume_signal_updates_all_with_canonical_resume(adapte
     adapter._client.list_workflows = _fake_list
     adapter._client.get_workflow_handle = lambda wid: mock_handle
 
-    signaled = await adapter.send_batch_resume_signal()
+    signaled = await adapter.send_batch_resume_update()
 
     assert signaled == 1
-    mock_handle.execute_update.assert_awaited_once_with("Resume")
+    mock_handle.start_update.assert_awaited_once()
+    assert mock_handle.start_update.await_args.args == ("Resume",)
+    assert mock_handle.start_update.await_args.kwargs["wait_for_stage"] is (
+        WorkflowUpdateStage.ACCEPTED
+    )
+    mock_handle.execute_update.assert_not_awaited()
 
 async def test_send_batch_update_skips_failed_workflows(adapter):
     """Update dispatch should continue when individual workflows fail."""
@@ -178,7 +189,7 @@ async def test_send_batch_update_skips_failed_workflows(adapter):
     ]
     ok_handle = AsyncMock()
     fail_handle = AsyncMock()
-    fail_handle.execute_update = AsyncMock(side_effect=RuntimeError("gone"))
+    fail_handle.start_update = AsyncMock(side_effect=RuntimeError("gone"))
     ok2_handle = AsyncMock()
 
     handles = {"wf-ok": ok_handle, "wf-fail": fail_handle, "wf-ok2": ok2_handle}
@@ -190,9 +201,11 @@ async def test_send_batch_update_skips_failed_workflows(adapter):
     adapter._client.list_workflows = _fake_list
     adapter._client.get_workflow_handle = lambda wid: handles[wid]
 
-    signaled = await adapter.send_batch_pause_signal()
+    signaled = await adapter.send_batch_pause_update()
 
     # 2 succeeded, 1 failed
     assert signaled == 2
-    ok_handle.execute_update.assert_awaited_once_with("Pause")
-    ok2_handle.execute_update.assert_awaited_once_with("Pause")
+    ok_handle.start_update.assert_awaited_once()
+    assert ok_handle.start_update.await_args.args == ("Pause",)
+    ok2_handle.start_update.assert_awaited_once()
+    assert ok2_handle.start_update.await_args.args == ("Pause",)

--- a/tests/unit/workflows/temporal/test_temporal_client.py
+++ b/tests/unit/workflows/temporal/test_temporal_client.py
@@ -128,8 +128,8 @@ async def test_get_drain_metrics_empty_namespace(adapter):
 
 # ---- send_batch_pause_signal / send_batch_resume_signal ----
 
-async def test_send_batch_pause_signal_sends_to_all(adapter):
-    """Batch pause signal should signal each running workflow with 'pause'."""
+async def test_send_batch_pause_signal_updates_all_with_canonical_pause(adapter):
+    """Batch pause should update each running workflow with 'Pause'."""
 
     executions = [_FakeWorkflowExecution(f"wf-{i}") for i in range(3)]
     mock_handles = {}
@@ -148,10 +148,10 @@ async def test_send_batch_pause_signal_sends_to_all(adapter):
 
     assert signaled == 3
     for handle in mock_handles.values():
-        handle.signal.assert_awaited_once_with("pause")
+        handle.execute_update.assert_awaited_once_with("Pause")
 
-async def test_send_batch_resume_signal_sends_to_all(adapter):
-    """Batch resume signal should signal each running workflow with 'resume'."""
+async def test_send_batch_resume_signal_updates_all_with_canonical_resume(adapter):
+    """Batch resume should update each running workflow with 'Resume'."""
 
     executions = [_FakeWorkflowExecution("wf-1")]
     mock_handle = AsyncMock()
@@ -166,10 +166,10 @@ async def test_send_batch_resume_signal_sends_to_all(adapter):
     signaled = await adapter.send_batch_resume_signal()
 
     assert signaled == 1
-    mock_handle.signal.assert_awaited_once_with("resume")
+    mock_handle.execute_update.assert_awaited_once_with("Resume")
 
-async def test_send_batch_signal_skips_failed_workflows(adapter):
-    """Signal dispatch should continue when individual workflows fail."""
+async def test_send_batch_update_skips_failed_workflows(adapter):
+    """Update dispatch should continue when individual workflows fail."""
 
     executions = [
         _FakeWorkflowExecution("wf-ok"),
@@ -178,7 +178,7 @@ async def test_send_batch_signal_skips_failed_workflows(adapter):
     ]
     ok_handle = AsyncMock()
     fail_handle = AsyncMock()
-    fail_handle.signal = AsyncMock(side_effect=RuntimeError("gone"))
+    fail_handle.execute_update = AsyncMock(side_effect=RuntimeError("gone"))
     ok2_handle = AsyncMock()
 
     handles = {"wf-ok": ok_handle, "wf-fail": fail_handle, "wf-ok2": ok2_handle}
@@ -194,5 +194,5 @@ async def test_send_batch_signal_skips_failed_workflows(adapter):
 
     # 2 succeeded, 1 failed
     assert signaled == 2
-    ok_handle.signal.assert_awaited_once_with("pause")
-    ok2_handle.signal.assert_awaited_once_with("pause")
+    ok_handle.execute_update.assert_awaited_once_with("Pause")
+    ok2_handle.execute_update.assert_awaited_once_with("Pause")

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -18,6 +18,7 @@ from temporalio.client import WorkflowExecutionDescription, WorkflowExecutionSta
 from api_service.db.models import (
     Base,
     MoonMindWorkflowState,
+    SettingsOverride,
     TemporalArtifact,
     TemporalArtifactEncryption,
     TemporalArtifactRedactionLevel,
@@ -3942,6 +3943,77 @@ async def test_signal_pause_allows_awaiting_slot(tmp_path, mock_client_adapter):
         assert paused.state is MoonMindWorkflowState.AWAITING_SLOT
         assert paused.paused is True
         assert paused.memo["waiting_reason"] == "operator_paused"
+
+
+@pytest.mark.asyncio
+async def test_signal_pause_allows_waiting_on_dependencies(
+    tmp_path, mock_client_adapter
+):
+    """MM-978: AWAITING dependency waits accept lifecycle Pause."""
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        source = await service._require_source_execution(created.workflow_id)
+        service._set_state(source, MoonMindWorkflowState.WAITING_ON_DEPENDENCIES)
+        await session.commit()
+
+        await service.signal_execution(
+            workflow_id=created.workflow_id,
+            signal_name="Pause",
+            payload={},
+            payload_artifact_ref=None,
+        )
+
+        mock_client_adapter.update_workflow.assert_awaited_once_with(
+            created.workflow_id,
+            "Pause",
+        )
+        paused = await service.describe_execution(created.workflow_id)
+        assert paused.state is MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
+        assert paused.paused is True
+        assert paused.memo["waiting_reason"] == "operator_paused"
+
+
+@pytest.mark.asyncio
+async def test_check_system_paused_reads_persisted_worker_pause_state(tmp_path):
+    """MM-978: new execution creation uses persisted system pause state."""
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+
+        assert await service.check_system_paused() is False
+
+        subject_id = UUID("00000000-0000-0000-0000-000000000000")
+        session.add(
+            SettingsOverride(
+                scope="workspace",
+                workspace_id=subject_id,
+                user_id=subject_id,
+                key="operations.workers.pause_state",
+                value_json={
+                    "workersPaused": True,
+                    "mode": "drain",
+                    "reason": "MM-978 maintenance",
+                    "version": 1,
+                },
+                schema_version=1,
+                value_version=1,
+            )
+        )
+        await session.commit()
+
+        assert await service.check_system_paused() is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue reference: MM-978 (https://moonladder.atlassian.net/browse/MM-978)

Summary:
- Allows operator Pause/Resume for workflows in waiting_on_dependencies and keeps backend validation aligned with non-terminal pauseable states.
- Wires system pause checks to the persisted worker pause state so drain pause can block new execution creation.
- Sends canonical Temporal Pause/Resume updates for system quiesce instead of lowercase pause/resume signals.
- Derives worker-pause drained status from Temporal metrics instead of hardcoded drained values.
- Adds targeted service, API, and Temporal client tests for the MM-978 pause paths.

Tests run:
- PASS: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_client.py tests/unit/services/test_system_operations.py tests/unit/api/test_temporal_service_pause_guard.py tests/unit/api/routers/test_system_operations.py (164 passed, 16 warnings)
- NON-BLOCKING FAILURE OBSERVED: MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/test_temporal_client.py tests/unit/services/test_system_operations.py tests/unit/api/test_temporal_service_pause_guard.py tests/unit/api/routers/test_system_operations.py passed the same Python tests, then failed in the dashboard phase due two unrelated frontend/src/entrypoints/workflow-list.test.tsx timeouts.

Remaining risks:
- Temporal visibility reports running workflows but does not expose a distinct queued count, so queued remains zero in these metrics.
- The broader dashboard timeout should be handled separately from this backend pause fix.
