### PR TITLE
MM-985 add chat observability API coverage

### DIFF
--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -79,7 +79,7 @@ def _standard_observability_event(kind: str, sequence: int) -> dict[str, object]
         "sequence": sequence,
         "stream": stream,
         "text": f"{kind} event\n",
-        "timestamp": f"2026-04-08T00:00:{sequence:02d}Z",
+        "timestamp": f"2026-04-08T00:{sequence // 60:02d}:{sequence % 60:02d}Z",
         "kind": kind,
         "metadata": {"sourceIssue": "MM-985", "sourceReference": "MM-976"},
     }

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import Iterator
+from typing import Iterator, get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import quote
 from uuid import uuid4
@@ -21,7 +21,10 @@ from api_service.auth_providers import get_current_user
 from api_service.api.routers.worker_auth import _require_worker_auth, _WorkerRequestAuth
 from api_service.db import models as db_models
 from api_service.db.models import User
-from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
+from moonmind.schemas.agent_runtime_models import (
+    ObservabilityEventKind,
+    RunObservabilityEvent,
+)
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 
 @pytest.fixture
@@ -60,6 +63,36 @@ def _encoded_agent_run_path_id(agent_run_id: str) -> str:
 
 def _agent_run_api_path(agent_run_id: str) -> str:
     return f"/api/agent-runs/{_encoded_agent_run_path_id(agent_run_id)}"
+
+def _standard_observability_event(kind: str, sequence: int) -> dict[str, object]:
+    if kind == "stdout_chunk":
+        stream = "stdout"
+    elif kind == "stderr_chunk":
+        stream = "stderr"
+    elif kind == "system_annotation":
+        stream = "system"
+    else:
+        stream = "session"
+
+    payload: dict[str, object] = {
+        "runId": "run-1",
+        "sequence": sequence,
+        "stream": stream,
+        "text": f"{kind} event\n",
+        "timestamp": f"2026-04-08T00:00:{sequence:02d}Z",
+        "kind": kind,
+        "metadata": {"sourceIssue": "MM-985", "sourceReference": "MM-976"},
+    }
+    if stream == "session":
+        payload.update(
+            {
+                "sessionId": "sess-1",
+                "sessionEpoch": 2,
+                "threadId": "thread-2",
+                "turnId": f"turn-{sequence}",
+            }
+        )
+    return payload
 
 @pytest.mark.parametrize(
     "suffix",
@@ -1627,12 +1660,17 @@ def test_get_agent_run_observability_events_prefers_persisted_event_artifact(
     mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
     mock_record.observability_events_ref = "run-1/observability.events.jsonl"
 
-    with patch("api_service.api.routers.agent_runs.ManagedRunStore.load", return_value=mock_record):
+    with patch(
+        "api_service.api.routers.agent_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ):
         with patch(
             "api_service.api.routers.agent_runs._get_agent_runtime_artifacts_root",
             return_value=str(artifacts_root),
         ):
-            response = test_client.get(f"/api/agent-runs/{uuid4()}/observability/events")
+            response = test_client.get(
+                f"/api/agent-runs/{uuid4()}/observability/events"
+            )
 
     assert response.status_code == 200
     body = response.json()
@@ -1642,6 +1680,56 @@ def test_get_agent_run_observability_events_prefers_persisted_event_artifact(
     assert body["events"][1]["sessionId"] == "sess-1"
     assert body["events"][1]["sessionEpoch"] == 2
     assert "run_id" not in body["events"][0]
+
+def test_get_agent_run_observability_events_reconstructs_complete_chat_vocabulary_from_history(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    event_kinds = list(get_args(ObservabilityEventKind))
+    events = [
+        _standard_observability_event(kind, sequence)
+        for sequence, kind in enumerate(event_kinds, start=1)
+    ]
+    (run_dir / "observability.events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in reversed(events)) + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.run_id = "run-1"
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.agent_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.agent_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(f"/api/agent-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["truncated"] is False
+    assert [event["sequence"] for event in body["events"]] == list(
+        range(1, len(event_kinds) + 1)
+    )
+    assert [event["kind"] for event in body["events"]] == event_kinds
+    session_events = [
+        event
+        for event in body["events"]
+        if event["kind"] not in {"stdout_chunk", "stderr_chunk", "system_annotation"}
+    ]
+    assert session_events
+    assert all(event["stream"] == "session" for event in session_events)
+    assert all(event["sessionId"] == "sess-1" for event in session_events)
+    assert all(
+        event["metadata"]["sourceIssue"] == "MM-985" for event in body["events"]
+    )
 
 def test_get_agent_run_observability_events_applies_since_stream_and_kind_filters(
     client: tuple[TestClient, AsyncMock],
@@ -2161,6 +2249,56 @@ def test_stream_agent_run_live_logs_serializes_canonical_event_aliases(
     assert '"sessionId":"sess-1"' in response.text
     assert '"activeTurnId":"turn-3"' in response.text
     assert '"session_id"' not in response.text
+
+def test_stream_agent_run_live_logs_emits_representative_chat_event_kinds(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    mock_record = MagicMock()
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.workspace_path = "/tmp/workspace"
+
+    representative_kinds = [
+        "user_message_submitted",
+        "assistant_message_delta",
+        "assistant_message_completed",
+        "assistant_message",
+        "tool_call_started",
+        "tool_call_output",
+        "tool_call_completed",
+        "tool_call_failed",
+        "approval_requested",
+        "approval_resolved",
+        "runtime_status",
+        "model_status",
+        "turn_failed",
+    ]
+
+    async def _follow(*args, **kwargs):
+        for sequence, kind in enumerate(representative_kinds, start=1):
+            yield RunObservabilityEvent.model_validate(
+                _standard_observability_event(kind, sequence)
+            )
+
+    with patch(
+        "api_service.api.routers.agent_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ):
+        with patch(
+            "api_service.api.routers.agent_runs.SpoolLogReader.follow",
+            new=_follow,
+        ):
+            response = test_client.get(
+                f"/api/agent-runs/{uuid4()}/logs/stream?since=0"
+            )
+
+    assert response.status_code == 200
+    for kind in representative_kinds:
+        assert f'"kind":"{kind}"' in response.text
+    assert '"sessionId":"sess-1"' in response.text
+    assert '"sourceIssue":"MM-985"' in response.text
 
 def test_stream_agent_run_live_logs_rejects_non_live_capable_active_run(
     client: tuple[TestClient, AsyncMock],


### PR DESCRIPTION
Issue reference: MM-985

Summary:
- Added API coverage proving persisted observability history reconstructs the complete standardized chat/session event vocabulary in run-global sequence order.
- Added SSE coverage for representative user, assistant, tool, approval, status, and failure event kinds over the existing /logs/stream path.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_agent_runs.py

Remaining risks:
- Coverage is focused on API validation and serialization; provider-specific live runtime emission remains covered by upstream runtime paths.