### PR TITLE
MM-997 Add desktop workflow workspace shell

### DIFF
--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -746,6 +746,10 @@ def build_runtime_config(
                     temporal_dashboard.temporal_workflow_editing_enabled
                 ),
                 "debugFieldsEnabled": bool(temporal_dashboard.debug_fields_enabled),
+                # MM-997: desktop workflow detail routes use the workspace shell by
+                # default. Setting this client flag to false restores standalone
+                # desktop detail presentation without changing mobile behavior.
+                "workspaceShellEnabled": True,
             },
             **build_live_logs_feature_config(),
         },

--- a/docs/UI/WorkflowWorkspaceSidebar.md
+++ b/docs/UI/WorkflowWorkspaceSidebar.md
@@ -7,6 +7,8 @@ Canonical for: desktop workflow workspace layout, workflow sidebar navigation, l
 
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs. This document defines the product and UI contract for the workspace/sidebar behavior that connects the Workflows list and Workflow Details page.
 
+**Implementation note:** MM-997 wires the desktop detail presentation through `WorkflowWorkspaceShell` behind the dashboard runtime config flag `features.temporalDashboard.workspaceShellEnabled`, which defaults to enabled. Setting the flag to `false` restores standalone desktop detail rendering without changing mobile behavior.
+
 ---
 
 ## 1. Purpose

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -531,23 +531,27 @@ describe('Workflow Detail Entrypoint', () => {
     expect(sidebar).toBeTruthy();
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
-    const active = within(sidebar).getByRole('link', { name: /MM-997 selected workflow/i });
+    const active = await within(sidebar).findByRole('link', { name: /MM-997 selected workflow/i });
     expect(active.getAttribute('aria-current')).toBe('page');
-    expect(within(sidebar).getByRole('link', { name: /Another workflow/i }).getAttribute('href')).toBe(
+    expect((await within(sidebar).findByRole('link', { name: /Another workflow/i })).getAttribute('href')).toBe(
       '/workflows/test-456?source=temporal',
     );
     expect(String(lastFetchUrl(fetchSpy, '/api/executions?'))).not.toContain('selectedWorkflowId');
   });
 
-  it('MM-997 keeps detail subroutes inside the desktop workspace shell', async () => {
-    window.history.pushState({}, 'Workspace Steps Test', '/workflows/test-123/steps?source=temporal');
+  it.each([
+    ['/workflows/test-123/steps?source=temporal', 'Workflow Steps'],
+    ['/workflows/test-123/artifacts?source=temporal', 'Workflow Artifacts'],
+    ['/workflows/test-123/runs?source=temporal', 'Execution History'],
+  ])('MM-997 keeps %s inside the desktop workspace shell', async (path, heading) => {
+    window.history.pushState({}, 'Workspace Subroute Test', path);
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
 
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
-    expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: heading })).toBeTruthy();
   });
 
   it('MM-997 disables only the desktop workspace shell when the runtime flag is false', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7,6 +7,7 @@ import {
   expandRouteTemplate,
   getSessionProjectionRefetchInterval,
   normalizeObservabilityEvent,
+  WorkflowDetailEntrypoint,
   WorkflowDetailPage,
 } from './workflow-detail';
 import {
@@ -47,6 +48,13 @@ vi.mock('react-virtuoso', () => ({
 vi.mock('../lib/navigation', () => ({
   navigateTo: vi.fn(),
 }));
+
+function lastFetchUrl(fetchSpy: MockInstance, prefix: string): string | undefined {
+  return fetchSpy.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.startsWith(prefix))
+    .at(-1);
+}
 
 // ---------------------------------------------------------------------------
 // Minimal EventSource mock
@@ -422,6 +430,163 @@ describe('Workflow Detail Entrypoint', () => {
       } as Response);
     });
   }
+
+  function mockWorkflowWorkspaceFetches() {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'MM-997 selected workflow',
+      summary: 'Workspace shell selected detail',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+      relatedRuns: [],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/executions?')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                workflowId: 'test-123',
+                taskId: 'test-123',
+                source: 'temporal',
+                title: 'MM-997 selected workflow',
+                status: 'running',
+                state: 'executing',
+                rawState: 'executing',
+                createdAt: '2026-04-09T00:00:00Z',
+              },
+              {
+                workflowId: 'test-456',
+                taskId: 'test-456',
+                source: 'temporal',
+                title: 'Another workflow',
+                status: 'completed',
+                state: 'completed',
+                rawState: 'completed',
+                createdAt: '2026-04-08T00:00:00Z',
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+  }
+
+  function mockDesktopViewport(matches = true) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+
+  it('MM-997 renders desktop workflow detail routes inside the workspace shell by default', async () => {
+    window.history.pushState({}, 'Workspace Detail Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(sidebar).toBeTruthy();
+    expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    const active = within(sidebar).getByRole('link', { name: /MM-997 selected workflow/i });
+    expect(active.getAttribute('aria-current')).toBe('page');
+    expect(within(sidebar).getByRole('link', { name: /Another workflow/i }).getAttribute('href')).toBe(
+      '/workflows/test-456?source=temporal',
+    );
+    expect(String(lastFetchUrl(fetchSpy, '/api/executions?'))).not.toContain('selectedWorkflowId');
+  });
+
+  it('MM-997 keeps detail subroutes inside the desktop workspace shell', async () => {
+    window.history.pushState({}, 'Workspace Steps Test', '/workflows/test-123/steps?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Steps' })).toBeTruthy();
+  });
+
+  it('MM-997 disables only the desktop workspace shell when the runtime flag is false', async () => {
+    window.history.pushState({}, 'Workspace Disabled Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            dashboardConfig: {
+              pollIntervalsMs: { detail: 1 },
+              features: {
+                temporalDashboard: {
+                  workspaceShellEnabled: false,
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+  });
+
+  it('MM-997 keeps mobile detail navigation standalone even when the shell flag is enabled', async () => {
+    window.history.pushState({}, 'Workspace Mobile Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(false);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+  });
 
   it('MM-801 renders Overview as a concise summary with route preview cards', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-123?source=temporal');

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -536,7 +536,52 @@ describe('Workflow Detail Entrypoint', () => {
     expect((await within(sidebar).findByRole('link', { name: /Another workflow/i })).getAttribute('href')).toBe(
       '/workflows/test-456?source=temporal',
     );
-    expect(String(lastFetchUrl(fetchSpy, '/api/executions?'))).not.toContain('selectedWorkflowId');
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&pageSize=25');
+  });
+
+  it('MM-997 translates workspace sidebar limit state to the executions API page size', async () => {
+    window.history.pushState(
+      {},
+      'Workspace Query Test',
+      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2&selectedWorkflowId=test-123',
+    );
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
+      '/api/executions?source=temporal&nextPageToken=page-2&pageSize=10',
+    );
+  });
+
+  it('MM-997 keeps workflow detail standalone when the workflow list is disabled', async () => {
+    window.history.pushState({}, 'Workspace List Disabled Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            dashboardConfig: {
+              pollIntervalsMs: { detail: 1 },
+              features: {
+                temporalDashboard: {
+                  listEnabled: false,
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBeUndefined();
   });
 
   it.each([

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -40,6 +40,7 @@ type DashboardConfig = {
       temporalWorkflowEditing?: boolean;
       temporalTaskEditing?: boolean;
       debugFieldsEnabled?: boolean;
+      workspaceShellEnabled?: boolean;
     };
     logStreamingEnabled?: boolean;
     liveLogsSessionTimelineEnabled?: boolean;
@@ -56,6 +57,85 @@ type LiveLogsSessionTimelineRollout = 'off' | 'internal' | 'codex_managed' | 'al
 
 const GITHUB_PULL_REQUEST_PATH_PATTERN = /^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+$/i;
 const SESSION_PROJECTION_POLL_MS = 5000;
+const WORKFLOW_WORKSPACE_DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
+
+const WorkflowWorkspaceRowSchema = z
+  .object({
+    taskId: z.string().optional(),
+    workflowId: z.string().optional(),
+    title: z.string().optional(),
+    status: z.string().optional(),
+    state: z.string().optional(),
+    rawState: z.string().optional(),
+    createdAt: z.string().nullable().optional(),
+    scheduledFor: z.string().nullable().optional(),
+    closedAt: z.string().nullable().optional(),
+    repository: z.string().nullable().optional(),
+    targetRuntime: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const WorkflowWorkspaceListResponseSchema = z.object({
+  items: z.array(WorkflowWorkspaceRowSchema),
+});
+
+type WorkflowWorkspaceRow = z.infer<typeof WorkflowWorkspaceRowSchema>;
+
+function workflowWorkspaceRowId(row: WorkflowWorkspaceRow): string {
+  return row.workflowId || row.taskId || '';
+}
+
+function workflowWorkspaceRowUpdatedAt(row: WorkflowWorkspaceRow): string | null | undefined {
+  return row.closedAt || row.scheduledFor || row.createdAt;
+}
+
+const WORKFLOW_WORKSPACE_RELATIVE_TIME_UNITS: Array<[string, number]> = [
+  ['y', 31536000],
+  ['mo', 2592000],
+  ['w', 604800],
+  ['d', 86400],
+  ['h', 3600],
+  ['m', 60],
+];
+
+function formatWorkflowWorkspaceRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return 'Updated time unavailable';
+  const date = new Date(iso);
+  const ms = date.getTime();
+  if (Number.isNaN(ms)) return iso;
+  const diffSeconds = Math.round((Date.now() - ms) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+  if (absSeconds < 45) return 'just now';
+  const suffix = diffSeconds >= 0 ? 'ago' : 'from now';
+  for (const [label, unitSeconds] of WORKFLOW_WORKSPACE_RELATIVE_TIME_UNITS) {
+    if (absSeconds >= unitSeconds) {
+      return `${Math.floor(absSeconds / unitSeconds)}${label} ${suffix}`;
+    }
+  }
+  return `${absSeconds}s ${suffix}`;
+}
+
+function useWorkflowWorkspaceDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return true;
+    }
+    return window.matchMedia(WORKFLOW_WORKSPACE_DESKTOP_MEDIA_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const query = window.matchMedia(WORKFLOW_WORKSPACE_DESKTOP_MEDIA_QUERY);
+    const update = () => setIsDesktop(query.matches);
+    update();
+    query.addEventListener?.('change', update);
+    return () => query.removeEventListener?.('change', update);
+  }, []);
+
+  return isDesktop;
+}
 
 function normalizeLiveLogsSessionTimelineRollout(
   value: string | null | undefined,
@@ -131,6 +211,149 @@ function workflowDetailSubrouteHref(
   const suffix = subroute === 'overview' ? '' : `/${subroute}`;
   const query = search.toString();
   return `/workflows/${encodeURIComponent(workflowId)}${suffix}${query ? `?${query}` : ''}`;
+}
+
+function workflowWorkspaceListQuery(search: URLSearchParams): string {
+  const params = new URLSearchParams(search);
+  params.delete('selectedWorkflowId');
+  if (!params.has('limit')) {
+    params.set('limit', '25');
+  }
+  return params.toString();
+}
+
+function WorkflowSidebarRow({
+  row,
+  activeWorkflowId,
+}: {
+  row: WorkflowWorkspaceRow;
+  activeWorkflowId: string;
+}) {
+  const workflowId = workflowWorkspaceRowId(row);
+  const active = workflowId === activeWorkflowId;
+  const status = row.rawState || row.state || row.status || 'unknown';
+  const title = row.title?.trim() || workflowId || 'Untitled workflow';
+  return (
+    <li>
+      <a
+        className="workflow-workspace-sidebar-row"
+        href={`/workflows/${encodeURIComponent(workflowId)}?source=temporal`}
+        aria-current={active ? 'page' : undefined}
+        data-active={active ? 'true' : 'false'}
+      >
+        <span className="workflow-workspace-sidebar-row-main">
+          <span className="workflow-workspace-sidebar-title">{title}</span>
+          <span className="workflow-workspace-sidebar-meta">
+            {formatWorkflowWorkspaceRelativeTime(workflowWorkspaceRowUpdatedAt(row))}
+          </span>
+        </span>
+        <ExecutionStatusPill status={status} />
+      </a>
+    </li>
+  );
+}
+
+function WorkflowWorkspaceShell({
+  payload,
+  workflowId,
+  search,
+}: {
+  payload: BootPayload;
+  workflowId: string;
+  search: URLSearchParams;
+}) {
+  const cfg = readDashboardConfig(payload);
+  const listPoll = cfg?.pollIntervalsMs?.list ?? 5000;
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const openButtonRef = useRef<HTMLButtonElement | null>(null);
+  const listQuery = useMemo(() => workflowWorkspaceListQuery(search), [search]);
+  const workflowsQuery = useQuery({
+    queryKey: ['workflow-workspace-sidebar', listQuery],
+    queryFn: async () => {
+      const response = await fetch(`${payload.apiBase}/executions?${listQuery}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch workflows: ${response.statusText}`);
+      }
+      return WorkflowWorkspaceListResponseSchema.parse(await response.json());
+    },
+    refetchInterval: listPoll,
+  });
+  const rows = workflowsQuery.data?.items || [];
+  const activeInList = rows.some((row) => workflowWorkspaceRowId(row) === workflowId);
+  const filteredRows = rows.filter((row) => workflowWorkspaceRowId(row));
+  const fullListHref = `/workflows${search.toString() ? `?${search.toString()}` : ''}`;
+
+  return (
+    <div className="workflow-workspace-shell" data-jira-issue="MM-997" data-source-issue="MM-975">
+      {sidebarOpen ? (
+        <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
+          <div className="workflow-workspace-sidebar-controls">
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="secondary"
+              onClick={() => {
+                setSidebarOpen(false);
+                window.setTimeout(() => openButtonRef.current?.focus(), 0);
+              }}
+            >
+              Close sidebar
+            </button>
+            <a className="button secondary" href={fullListHref}>
+              Expand to full list
+            </a>
+          </div>
+          {workflowsQuery.isLoading ? (
+            <p className="workflow-workspace-sidebar-state">Loading workflows...</p>
+          ) : null}
+          {workflowsQuery.isError ? (
+            <div className="workflow-workspace-sidebar-state" role="status">
+              <p>Workflow navigation is unavailable.</p>
+              <button type="button" className="secondary" onClick={() => void workflowsQuery.refetch()}>
+                Retry
+              </button>
+            </div>
+          ) : null}
+          {!workflowsQuery.isLoading && !workflowsQuery.isError && !activeInList && workflowId ? (
+            <div className="workflow-workspace-current-row" aria-label="Current workflow">
+              <span className="workflow-workspace-sidebar-title">Current workflow</span>
+              <code>{workflowId}</code>
+            </div>
+          ) : null}
+          {!workflowsQuery.isLoading && !workflowsQuery.isError && filteredRows.length === 0 ? (
+            <p className="workflow-workspace-sidebar-state">No workflows match the current list filters.</p>
+          ) : null}
+          {filteredRows.length > 0 ? (
+            <ul className="workflow-workspace-sidebar-list" aria-label="Workflow navigation list">
+              {filteredRows.map((row) => (
+                <WorkflowSidebarRow
+                  key={workflowWorkspaceRowId(row)}
+                  row={row}
+                  activeWorkflowId={workflowId}
+                />
+              ))}
+            </ul>
+          ) : null}
+        </aside>
+      ) : (
+        <button
+          ref={openButtonRef}
+          type="button"
+          className="secondary workflow-workspace-open-sidebar"
+          onClick={() => {
+            setSidebarOpen(true);
+            window.setTimeout(() => closeButtonRef.current?.focus(), 0);
+          }}
+        >
+          Open workflow sidebar
+        </button>
+      )}
+      <main className="workflow-workspace-detail" aria-label="Workflow detail">
+        <WorkflowDetailPage payload={payload} />
+      </main>
+    </div>
+  );
 }
 
 function detailObjectValue(value: unknown): Record<string, unknown> {
@@ -6524,4 +6747,22 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     </div>
   );
 }
-export default WorkflowDetailPage;
+
+export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) {
+  const cfg = readDashboardConfig(payload);
+  const isDesktop = useWorkflowWorkspaceDesktop();
+  const workflowIdMatch = window.location.pathname.match(
+    /^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/,
+  );
+  const workflowId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
+  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const workspaceShellEnabled = cfg?.features?.temporalDashboard?.workspaceShellEnabled !== false;
+
+  if (workspaceShellEnabled && isDesktop && workflowId) {
+    return <WorkflowWorkspaceShell payload={payload} workflowId={workflowId} search={search} />;
+  }
+
+  return <WorkflowDetailPage payload={payload} />;
+}
+
+export default WorkflowDetailEntrypoint;

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -40,6 +40,7 @@ type DashboardConfig = {
       temporalWorkflowEditing?: boolean;
       temporalTaskEditing?: boolean;
       debugFieldsEnabled?: boolean;
+      listEnabled?: boolean;
       workspaceShellEnabled?: boolean;
     };
     logStreamingEnabled?: boolean;
@@ -116,12 +117,7 @@ function formatWorkflowWorkspaceRelativeTime(iso: string | null | undefined): st
 }
 
 function useWorkflowWorkspaceDesktop(): boolean {
-  const [isDesktop, setIsDesktop] = useState(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return true;
-    }
-    return window.matchMedia(WORKFLOW_WORKSPACE_DESKTOP_MEDIA_QUERY).matches;
-  });
+  const [isDesktop, setIsDesktop] = useState(true);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -216,9 +212,9 @@ function workflowDetailSubrouteHref(
 function workflowWorkspaceListQuery(search: URLSearchParams): string {
   const params = new URLSearchParams(search);
   params.delete('selectedWorkflowId');
-  if (!params.has('limit')) {
-    params.set('limit', '25');
-  }
+  const pageSize = params.get('limit') || params.get('pageSize') || '25';
+  params.delete('limit');
+  params.set('pageSize', pageSize);
   return params.toString();
 }
 
@@ -264,6 +260,7 @@ function WorkflowWorkspaceShell({
 }) {
   const cfg = readDashboardConfig(payload);
   const listPoll = cfg?.pollIntervalsMs?.list ?? 5000;
+  const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const openButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -277,7 +274,8 @@ function WorkflowWorkspaceShell({
       }
       return WorkflowWorkspaceListResponseSchema.parse(await response.json());
     },
-    refetchInterval: listPoll,
+    enabled: listEnabled,
+    refetchInterval: listEnabled ? listPoll : false,
   });
   const rows = workflowsQuery.data?.items || [];
   const activeInList = rows.some((row) => workflowWorkspaceRowId(row) === workflowId);
@@ -6751,14 +6749,15 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 export function WorkflowDetailEntrypoint({ payload }: { payload: BootPayload }) {
   const cfg = readDashboardConfig(payload);
   const isDesktop = useWorkflowWorkspaceDesktop();
-  const workflowIdMatch = window.location.pathname.match(
-    /^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/,
-  );
+  const workflowIdMatch = typeof window !== 'undefined'
+    ? window.location.pathname.match(/^\/workflows\/([^/]+)(?:\/(?:steps|artifacts|runs|debug))?$/)
+    : null;
   const workflowId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
-  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const search = useMemo(() => new URLSearchParams(typeof window !== 'undefined' ? window.location.search : ''), []);
   const workspaceShellEnabled = cfg?.features?.temporalDashboard?.workspaceShellEnabled !== false;
+  const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
 
-  if (workspaceShellEnabled && isDesktop && workflowId) {
+  if (workspaceShellEnabled && listEnabled && isDesktop && workflowId) {
     return <WorkflowWorkspaceShell payload={payload} workflowId={workflowId} search={search} />;
   }
 

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -55,6 +55,15 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByText('Loading workflows...')).toBeTruthy();
   });
 
+  it('MM-997 keeps /workflows as the full-width list route instead of the workspace shell', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    expect(document.querySelector('.workflow-workspace-shell')).toBeNull();
+    expect(document.querySelector('.queue-table-wrapper')).toBeTruthy();
+  });
+
   it('shows structured API validation detail when the workflow list request fails', async () => {
     fetchSpy.mockResolvedValue({
       ok: false,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6419,6 +6419,134 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   min-width: 0;
 }
 
+.workflow-workspace-shell {
+  display: grid;
+  grid-template-columns: minmax(17.5rem, 21rem) minmax(0, 1fr);
+  align-items: start;
+  gap: 1rem;
+  width: 100%;
+  max-width: min(118rem, calc(100vw - 2rem));
+  margin-inline: auto;
+}
+
+.workflow-workspace-sidebar {
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: calc(100vh - 2rem);
+  overflow: hidden;
+  border: 1px solid var(--mm-glass-border);
+  border-radius: 0.8rem;
+  background: var(--mm-glass-fill);
+  box-shadow: var(--mm-elevation-panel);
+  padding: 0.75rem;
+}
+
+.workflow-workspace-sidebar-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.workflow-workspace-sidebar-controls .button,
+.workflow-workspace-sidebar-controls button {
+  white-space: nowrap;
+}
+
+.workflow-workspace-sidebar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  overflow: auto;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.workflow-workspace-sidebar-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 3.75rem;
+  padding: 0.62rem;
+  border: 1px solid rgb(var(--mm-border) / 0.58);
+  border-radius: 0.55rem;
+  background: rgb(var(--mm-panel) / 0.78);
+  color: rgb(var(--mm-ink));
+  text-decoration: none;
+}
+
+.workflow-workspace-sidebar-row:hover,
+.workflow-workspace-sidebar-row:focus-visible {
+  border-color: rgb(var(--mm-accent) / 0.62);
+  background: rgb(var(--mm-accent) / 0.10);
+}
+
+.workflow-workspace-sidebar-row[aria-current="page"] {
+  border-color: rgb(var(--mm-accent) / 0.78);
+  box-shadow: inset 4px 0 0 rgb(var(--mm-accent));
+  background: rgb(var(--mm-accent) / 0.14);
+}
+
+.workflow-workspace-sidebar-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.workflow-workspace-sidebar-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.workflow-workspace-sidebar-meta {
+  color: rgb(var(--mm-muted));
+  font-size: 0.82rem;
+}
+
+.workflow-workspace-current-row,
+.workflow-workspace-sidebar-state {
+  border: 1px dashed rgb(var(--mm-border) / 0.75);
+  border-radius: 0.55rem;
+  padding: 0.65rem;
+  background: rgb(var(--mm-panel) / 0.62);
+}
+
+.workflow-workspace-current-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.workflow-workspace-detail {
+  min-width: 0;
+}
+
+.workflow-workspace-open-sidebar {
+  justify-self: start;
+  align-self: start;
+}
+
+@media (max-width: 767px) {
+  .workflow-workspace-shell {
+    display: block;
+    max-width: none;
+  }
+
+  .workflow-workspace-sidebar,
+  .workflow-workspace-open-sidebar {
+    display: none;
+  }
+}
+
 .td-subroute-nav {
   display: flex;
   flex-wrap: wrap;

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -765,6 +765,7 @@ def test_build_runtime_config_uses_temporal_dashboard_settings(monkeypatch) -> N
         "submitEnabled": True,
         "temporalWorkflowEditing": False,
         "debugFieldsEnabled": True,
+        "workspaceShellEnabled": True,
     }
     assert config["sources"]["temporal"]["list"] == "/api/temporal/executions"
     assert (


### PR DESCRIPTION
Issue reference: MM-997

Summary:
- Adds the desktop-only WorkflowWorkspaceShell around workflow detail routes and detail subroutes while preserving /workflows as the full-width list route.
- Reuses the existing WorkflowDetailPage in the center region and keeps workflow identity in the route path.
- Adds the runtime config flag features.temporalDashboard.workspaceShellEnabled, defaulting enabled, plus documentation and targeted workspace coverage.

Tests run:
- ./tools/test_unit.sh --python-only tests/unit/api/routers/test_workflow_console_view_model.py
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx

Remaining risks:
- Sidebar collapsed-state persistence is intentionally left to the later state story.
- This change uses the existing workflow list API for sidebar rows; very large workflow lists still depend on existing list pagination behavior.
