### PR TITLE
MM-986 add chat-like timeline row treatments

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7417,6 +7417,186 @@ describe('LiveLogsPanel', () => {
     expect(publicationRow?.getAttribute('data-row-type')).toBe('publication');
   });
 
+  it('renders standardized chat timeline event families with distinct treatments', async () => {
+    const events = [
+      {
+        sequence: 1,
+        timestamp: '2026-04-08T00:00:01Z',
+        stream: 'session',
+        kind: 'user_message_submitted',
+        text: 'User asked for implementation.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 2,
+        timestamp: '2026-04-08T00:00:02Z',
+        stream: 'session',
+        kind: 'assistant_message_delta',
+        text: 'Assistant draft output.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 3,
+        timestamp: '2026-04-08T00:00:03Z',
+        stream: 'session',
+        kind: 'assistant_message_completed',
+        text: 'Assistant completed output.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 4,
+        timestamp: '2026-04-08T00:00:04Z',
+        stream: 'session',
+        kind: 'assistant_message',
+        text: 'Assistant full message.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 5,
+        timestamp: '2026-04-08T00:00:05Z',
+        stream: 'session',
+        kind: 'tool_call_started',
+        text: 'Tool call started.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 6,
+        timestamp: '2026-04-08T00:00:06Z',
+        stream: 'session',
+        kind: 'tool_call_output',
+        text: 'Tool call output.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 7,
+        timestamp: '2026-04-08T00:00:07Z',
+        stream: 'session',
+        kind: 'tool_call_completed',
+        text: 'Tool call completed.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 8,
+        timestamp: '2026-04-08T00:00:08Z',
+        stream: 'session',
+        kind: 'tool_call_failed',
+        text: 'Tool call failed.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 9,
+        timestamp: '2026-04-08T00:00:09Z',
+        stream: 'session',
+        kind: 'intervention_requested',
+        text: 'Operator intervention requested.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 10,
+        timestamp: '2026-04-08T00:00:10Z',
+        stream: 'session',
+        kind: 'turn_started',
+        text: 'Turn started.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 11,
+        timestamp: '2026-04-08T00:00:11Z',
+        stream: 'session',
+        kind: 'turn_completed',
+        text: 'Turn completed.',
+        turn_id: 'turn-1',
+      },
+      {
+        sequence: 12,
+        timestamp: '2026-04-08T00:00:12Z',
+        stream: 'session',
+        kind: 'turn_failed',
+        text: 'Turn failed.',
+        turn_id: 'turn-2',
+      },
+      {
+        sequence: 13,
+        timestamp: '2026-04-08T00:00:13Z',
+        stream: 'session',
+        kind: 'turn_interrupted',
+        text: 'Turn interrupted.',
+        turn_id: 'turn-3',
+      },
+    ];
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events, truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText('User asked for implementation.')).toBeTruthy();
+      expect(screen.getByText('Assistant full message.')).toBeTruthy();
+      expect(screen.getByText('Tool call failed.')).toBeTruthy();
+      expect(screen.getByText('Operator intervention requested.')).toBeTruthy();
+      expect(screen.getByText('Turn interrupted.')).toBeTruthy();
+    });
+
+    const expectedRowTypes = new Map([
+      ['user_message_submitted', 'user'],
+      ['assistant_message_delta', 'assistant'],
+      ['assistant_message_completed', 'assistant'],
+      ['assistant_message', 'assistant'],
+      ['tool_call_started', 'tool'],
+      ['tool_call_output', 'tool'],
+      ['tool_call_completed', 'tool'],
+      ['tool_call_failed', 'tool'],
+      ['intervention_requested', 'approval'],
+      ['turn_started', 'turn'],
+      ['turn_completed', 'turn'],
+      ['turn_failed', 'turn-failure'],
+      ['turn_interrupted', 'turn-failure'],
+    ]);
+
+    for (const [kind, rowType] of expectedRowTypes) {
+      expect(document.querySelector(`[data-kind="${kind}"]`)?.getAttribute('data-row-type')).toBe(rowType);
+    }
+    expect(screen.getByText('User turn')).toBeTruthy();
+    expect(screen.getAllByText('Assistant output')).toHaveLength(3);
+    expect(screen.getByText('Tool call')).toBeTruthy();
+    expect(screen.getByText('Tool output')).toBeTruthy();
+    expect(screen.getByText('Tool completed')).toBeTruthy();
+    expect(screen.getByText('Tool failed')).toBeTruthy();
+    expect(screen.getByText('Operator intervention')).toBeTruthy();
+    expect(screen.getByText('Turn started')).toBeTruthy();
+    expect(screen.getByText('Turn completed')).toBeTruthy();
+    expect(screen.getByText('Turn failed')).toBeTruthy();
+    expect(screen.getByText('Turn interrupted')).toBeTruthy();
+  });
+
   it('renders inline artifact links for publication and clear-reset timeline rows', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1896,7 +1896,19 @@ type TimelineRow = {
   turnId: string | null;
   activeTurnId: string | null;
   metadata: Record<string, unknown>;
-  rowType: 'output' | 'system' | 'session' | 'approval' | 'publication' | 'boundary' | 'fallback';
+  rowType:
+    | 'output'
+    | 'system'
+    | 'session'
+    | 'approval'
+    | 'publication'
+    | 'boundary'
+    | 'user'
+    | 'assistant'
+    | 'tool'
+    | 'turn'
+    | 'turn-failure'
+    | 'fallback';
 };
 
 function splitLogText(content: string): string[] {
@@ -1952,18 +1964,59 @@ function parseArtifactToRows(content: string): TimelineRow[] {
   });
 }
 
-function classifyTimelineRow(event: ObservabilityEvent): TimelineRow['rowType'] {
+const USER_MESSAGE_EVENT_KINDS = new Set(['user_message_submitted']);
+const ASSISTANT_MESSAGE_EVENT_KINDS = new Set([
+  'assistant_message_delta',
+  'assistant_message_completed',
+  'assistant_message',
+]);
+const TOOL_CALL_EVENT_KINDS = new Set([
+  'tool_call_started',
+  'tool_call_output',
+  'tool_call_completed',
+  'tool_call_failed',
+]);
+const TURN_BOUNDARY_EVENT_KINDS = new Set(['turn_started', 'turn_completed']);
+const TURN_FAILURE_EVENT_KINDS = new Set(['turn_failed', 'turn_interrupted']);
+const OPERATOR_ATTENTION_EVENT_KINDS = new Set([
+  'approval_requested',
+  'approval_granted',
+  'approval_denied',
+  'intervention_requested',
+  'intervention_resolved',
+]);
+
+export function classifyTimelineRow(event: ObservabilityEvent): TimelineRow['rowType'] {
+  const kind = event.kind ?? '';
   if (event.kind === 'session_reset_boundary') {
     return 'boundary';
+  }
+  if (USER_MESSAGE_EVENT_KINDS.has(kind)) {
+    return 'user';
+  }
+  if (ASSISTANT_MESSAGE_EVENT_KINDS.has(kind)) {
+    return 'assistant';
+  }
+  if (TOOL_CALL_EVENT_KINDS.has(kind)) {
+    return 'tool';
+  }
+  if (TURN_FAILURE_EVENT_KINDS.has(kind)) {
+    return 'turn-failure';
+  }
+  if (TURN_BOUNDARY_EVENT_KINDS.has(kind)) {
+    return 'turn';
+  }
+  if (OPERATOR_ATTENTION_EVENT_KINDS.has(kind)) {
+    return 'approval';
   }
   if (event.stream === 'system') {
     return 'system';
   }
   if (event.stream === 'session') {
-    if ((event.kind ?? '').startsWith('approval_')) {
+    if (kind.startsWith('approval_') || kind.startsWith('intervention_')) {
       return 'approval';
     }
-    if ((event.kind ?? '').endsWith('_published')) {
+    if (kind.endsWith('_published')) {
       return 'publication';
     }
     return 'session';
@@ -2068,6 +2121,31 @@ function renderTimelineRowText(row: TimelineRow, timelineViewerEnabled: boolean)
     return renderAnsiFragments(row.text);
   }
   return row.text;
+}
+
+function getTimelineRowTreatmentLabel(row: TimelineRow): string | null {
+  if (row.rowType === 'user') {
+    return 'User turn';
+  }
+  if (row.rowType === 'assistant') {
+    return 'Assistant output';
+  }
+  if (row.rowType === 'tool') {
+    if (row.kind === 'tool_call_failed') return 'Tool failed';
+    if (row.kind === 'tool_call_completed') return 'Tool completed';
+    if (row.kind === 'tool_call_output') return 'Tool output';
+    return 'Tool call';
+  }
+  if (row.rowType === 'approval') {
+    return row.kind?.startsWith('intervention_') ? 'Operator intervention' : 'Operator approval';
+  }
+  if (row.rowType === 'turn-failure') {
+    return row.kind === 'turn_interrupted' ? 'Turn interrupted' : 'Turn failed';
+  }
+  if (row.rowType === 'turn') {
+    return row.kind === 'turn_completed' ? 'Turn completed' : 'Turn started';
+  }
+  return null;
 }
 
 function getCopyableRowText(row: TimelineRow): string {
@@ -2505,8 +2583,15 @@ function renderTimelineRow(
       key={row.id}
       className={rowClasses}
     >
-      {timelineViewerEnabled && row.kind ? (
-        <span className="live-logs-kind-chip">{row.kind.replaceAll('_', ' ')}</span>
+      {timelineViewerEnabled && (row.kind || getTimelineRowTreatmentLabel(row)) ? (
+        <div className="live-logs-row-heading">
+          {getTimelineRowTreatmentLabel(row) ? (
+            <span className="live-logs-treatment-label">{getTimelineRowTreatmentLabel(row)}</span>
+          ) : null}
+          {row.kind ? (
+            <span className="live-logs-kind-chip">{row.kind.replaceAll('_', ' ')}</span>
+          ) : null}
+        </div>
       ) : null}
       <div
         className="live-logs-row-text"

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1988,7 +1988,7 @@ const OPERATOR_ATTENTION_EVENT_KINDS = new Set([
 
 export function classifyTimelineRow(event: ObservabilityEvent): TimelineRow['rowType'] {
   const kind = event.kind ?? '';
-  if (event.kind === 'session_reset_boundary') {
+  if (kind === 'session_reset_boundary') {
     return 'boundary';
   }
   if (USER_MESSAGE_EVENT_KINDS.has(kind)) {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4353,6 +4353,38 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   background: rgb(14 165 233 / 0.08);
 }
 
+.live-logs-row-user {
+  margin: 0.35rem 0.75rem;
+  border-left-color: rgb(59 130 246);
+  border-radius: 0.45rem;
+  background: rgb(59 130 246 / 0.12);
+}
+
+.live-logs-row-assistant {
+  margin: 0.25rem 0.75rem;
+  border-left-color: rgb(20 184 166);
+  border-radius: 0.45rem;
+  background: rgb(20 184 166 / 0.09);
+}
+
+.live-logs-row-tool {
+  margin: 0.25rem 0.75rem;
+  border: 1px solid rgb(148 163 184 / 0.24);
+  border-left: 4px solid rgb(148 163 184 / 0.82);
+  border-radius: 0.45rem;
+  background: rgb(148 163 184 / 0.08);
+}
+
+.live-logs-row-turn {
+  border-left-color: rgb(168 85 247);
+  background: rgb(168 85 247 / 0.08);
+}
+
+.live-logs-row-turn-failure {
+  border-left-color: rgb(239 68 68);
+  background: rgb(239 68 68 / 0.11);
+}
+
 .live-logs-row-boundary {
   margin: 0.5rem 0.6rem;
   border: 1px solid rgb(var(--mm-warn) / 0.8);
@@ -4367,6 +4399,27 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.live-logs-row-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.live-logs-treatment-label {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.14rem 0.5rem;
+  background: rgb(255 255 255 / 0.12);
+  color: rgb(255 255 255 / 0.9);
+  font-size: 0.62rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .live-logs-kind-chip {


### PR DESCRIPTION
Issue reference: MM-986

Summary:
- Adds explicit Live Logs timeline row classification for standardized user, assistant, tool, operator-attention, turn, and turn-failure event kinds.
- Adds row treatment labels and CSS treatments so chat-like event families are visually distinct while preserving the existing projection/fallback path.
- Extends workflow detail renderer coverage for every standardized event family in the issue acceptance criteria.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: `/usr/local/bin/python: No module named pytest` before UI tests ran)
- `npm ci --no-fund --no-audit`
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: Vitest resolves the suite as `/frontend/src/entrypoints/workflow-detail.test.tsx` and fails with `ERR_MODULE_NOT_FOUND`)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts` (blocked globally for the same `/frontend/...` module-resolution issue across configured frontend suites)

Remaining risks:
- Local frontend verification is blocked by this managed workspace Vitest path-resolution issue, so CI should confirm the renderer test behavior in a normal checkout.
