### PR TITLE
MM-998 Preserve workflow list context across detail navigation

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -446,6 +446,40 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('reconstructs the full workflow list from allowlisted detail-route context (MM-998, MM-975)', async () => {
+    window.history.pushState(
+      {},
+      'Detail Context Test',
+      '/workflows/test-123?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&sort=status&selectedWorkflowId=test-123&unsafe=1',
+    );
+    mockWorkflowDetailSubrouteFetch();
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await screen.findByText('Focused route summary');
+    const expandLink = screen.getByRole('link', { name: 'Expand to full list' });
+    expect(expandLink.getAttribute('href')).toBe(
+      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&returnFromWorkflowDetail=1',
+    );
+    expect(expandLink.getAttribute('href')).not.toContain('source=');
+    expect(expandLink.getAttribute('href')).not.toContain('sort=');
+    expect(expandLink.getAttribute('href')).not.toContain('selectedWorkflowId=');
+    expect(expandLink.getAttribute('href')).not.toContain('unsafe=');
+    expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('href')).toBe(
+      '/workflows/test-123/steps?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2',
+    );
+  });
+
+  it('expands to plain workflow list when no preserved list context exists (MM-998, MM-975)', async () => {
+    window.history.pushState({}, 'Plain Detail Test', '/workflows/test-123?source=temporal');
+    mockWorkflowDetailSubrouteFetch();
+
+    renderWithClient(<WorkflowDetailPage payload={stepsPayload} />);
+
+    await screen.findByText('Focused route summary');
+    expect(screen.getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe('/workflows');
+  });
+
   it('renders recovery evidence from the failed step execution detail payload', async () => {
     window.history.pushState({}, 'Recovery Evidence Test', '/workflows/test-123/steps?source=temporal');
     const failedStepsSnapshot = {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -459,14 +459,15 @@ describe('Workflow Detail Entrypoint', () => {
     await screen.findByText('Focused route summary');
     const expandLink = screen.getByRole('link', { name: 'Expand to full list' });
     expect(expandLink.getAttribute('href')).toBe(
-      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&returnFromWorkflowDetail=1',
+      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=25&returnFromWorkflowDetail=1',
     );
     expect(expandLink.getAttribute('href')).not.toContain('source=');
     expect(expandLink.getAttribute('href')).not.toContain('sort=');
+    expect(expandLink.getAttribute('href')).not.toContain('nextPageToken=');
     expect(expandLink.getAttribute('href')).not.toContain('selectedWorkflowId=');
     expect(expandLink.getAttribute('href')).not.toContain('unsafe=');
     expect(screen.getByRole('link', { name: 'Steps' }).getAttribute('href')).toBe(
-      '/workflows/test-123/steps?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2',
+      '/workflows/test-123/steps?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=25&nextPageToken=cursor-2&sort=status&selectedWorkflowId=test-123&unsafe=1',
     );
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,10 +20,7 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
-import {
-  workflowListContextParams,
-  workflowListHrefFromContext,
-} from '../lib/workflowListContext';
+import { workflowListHrefFromContext } from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -4845,10 +4842,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   );
   const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
-  const search = useMemo(
-    () => workflowListContextParams(new URLSearchParams(window.location.search)),
-    [],
-  );
+  const search = useMemo(() => new URLSearchParams(window.location.search), []);
   const expandToFullListHref = useMemo(
     () => workflowListHrefFromContext(search, { markDetailReturn: true }),
     [search],

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,6 +20,10 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
+import {
+  workflowListContextParams,
+  workflowListHrefFromContext,
+} from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -4841,7 +4845,14 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   );
   const taskId = decodeTaskPathSegment(workflowIdMatch ? workflowIdMatch[1] : null);
   const encodedTaskId = taskId ? encodeURIComponent(taskId) : null;
-  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  const search = useMemo(
+    () => workflowListContextParams(new URLSearchParams(window.location.search)),
+    [],
+  );
+  const expandToFullListHref = useMemo(
+    () => workflowListHrefFromContext(search, { markDetailReturn: true }),
+    [search],
+  );
   const detailSubroute = workflowDetailSubrouteFromPath(window.location.pathname);
   const sourceTemporal = search.get('source') === 'temporal';
 
@@ -5595,6 +5606,9 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           </div>
         </div>
         <div className="toolbar-controls">
+          <a className="button secondary" href={expandToFullListHref}>
+            Expand to full list
+          </a>
           <span className="small">
             Live updates enabled. Polling every {Math.round(detailPoll / 1000)}s
           </span>

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1286,6 +1286,11 @@ describe('Workflows Entrypoint', () => {
       );
     });
     expect(window.location.search).toBe('?stateIn=completed&limit=50');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(
+      screen.queryByText('Saved pagination was no longer available. Showing the first page.'),
+    ).toBeNull();
   });
 
   it('supports skill and date filter chips with blank semantics', async () => {

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -242,6 +242,35 @@ describe('Workflows Entrypoint', () => {
     }
   });
 
+  it('preserves allowlisted list context on workflow detail links and keeps browser back target intact (MM-998, MM-975)', async () => {
+    window.history.pushState(
+      {},
+      'Context list',
+      '/workflows?stateIn=completed&repoContains=moon%2Frepo&targetRuntimeIn=codex_cli&limit=25&nextPageToken=cursor-2&sort=status&sortDir=asc&selectedWorkflowId=task-123&unsafe=1',
+    );
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const previousListUrl = window.location.href;
+    const detailHref = screen.getAllByRole('link', { name: 'Example task' })[0]?.getAttribute('href');
+
+    expect(detailHref).toBe(
+      '/workflows/task-123?stateIn=completed&repoContains=moon%2Frepo&targetRuntimeIn=codex_cli&limit=25&nextPageToken=cursor-2&source=temporal',
+    );
+    expect(detailHref).not.toContain('sort=');
+    expect(detailHref).not.toContain('sortDir=');
+    expect(detailHref).not.toContain('selectedWorkflowId=');
+    expect(detailHref).not.toContain('unsafe=');
+
+    window.history.pushState({}, 'Detail', detailHref || '/workflows/task-123');
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(previousListUrl);
+    });
+  });
+
   it('ignores sort/sortDir present in the initial URL so deep links never imply a global sort (MM-954)', async () => {
     window.history.pushState({}, 'Seeded sort', '/workflows?sort=status&sortDir=asc');
 
@@ -1207,6 +1236,56 @@ describe('Workflows Entrypoint', () => {
       );
     });
     expect(window.location.search).toBe('?limit=100');
+  });
+
+  it('recovers stale cursor context when returning from workflow detail (MM-998, MM-975)', async () => {
+    window.history.pushState(
+      {},
+      'Workspace return',
+      '/workflows?stateIn=completed&limit=50&nextPageToken=stale-token&returnFromWorkflowDetail=1',
+    );
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('nextPageToken=stale-token')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [], count: 1 }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              taskId: 'task-123',
+              source: 'temporal',
+              title: 'Example task',
+              status: 'completed',
+              state: 'completed',
+              rawState: 'completed',
+              createdAt: '2026-03-28T00:00:00Z',
+            },
+          ],
+          count: 1,
+        }),
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(executionListCalls().map(([url]) => String(url))).toContain(
+        '/api/executions?source=temporal&pageSize=50&nextPageToken=stale-token&stateIn=completed',
+      );
+    });
+    expect(await screen.findByText('Saved pagination was no longer available. Showing the first page.')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(lastExecutionListUrl()).toBe(
+        '/api/executions?source=temporal&pageSize=50&stateIn=completed',
+      );
+    });
+    expect(window.location.search).toBe('?stateIn=completed&limit=50');
   });
 
   it('supports skill and date filter chips with blank semantics', async () => {

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1933,7 +1933,7 @@ describe('Workflows Entrypoint', () => {
     const titleLink = workflowCell.querySelector('a.workflow-list-row-title');
     expect(titleLink?.textContent).toBe('Scan first task');
     expect(titleLink?.getAttribute('href')).toBe(
-      '/workflows/mm%3Arun%3Ascan-first-001?source=temporal',
+      '/workflows/mm%3Arun%3Ascan-first-001?limit=50&source=temporal',
     );
     // The compact workflow id stays present but secondary.
     const compactId = workflowCell.querySelector('code.workflow-list-row-id');

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -8,6 +8,10 @@ import { ExecutionStatusPill } from '../components/ExecutionStatusPill';
 import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector';
 import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
 import {
+  WORKFLOW_LIST_CONTEXT_RETURN_PARAM,
+  workflowDetailHref,
+} from '../lib/workflowListContext';
+import {
   TOGGLEABLE_WORKFLOW_LIST_COLUMNS,
   readDashboardPreferences,
   resetDashboardPreferences,
@@ -784,6 +788,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const initial = useMemo(() => new URLSearchParams(window.location.search), []);
 
   const initialFilterValidationErrors = useMemo(() => validateInitialFilterParams(initial), [initial]);
+  const [workspaceCursorResetNotice, setWorkspaceCursorResetNotice] = useState(false);
+  const [workspaceReturnFromDetail, setWorkspaceReturnFromDetail] = useState(() =>
+    initial.get(WORKFLOW_LIST_CONTEXT_RETURN_PARAM) === '1',
+  );
   const [ignoredWorkflowScopeState] = useState(() => hasUnsupportedWorkflowScopeState(initial));
   const [filters, setFilters] = useState(() => parseInitialFilters(initial));
   const [draftFilters, setDraftFilters] = useState(() => parseInitialFilters(initial));
@@ -848,6 +856,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     appendFilterParams(params, filters);
     params.set('limit', String(pageSize));
     if (listCursor) params.set('nextPageToken', listCursor);
+    params.delete(WORKFLOW_LIST_CONTEXT_RETURN_PARAM);
     // MM-954: do not persist sort/sortDir to the URL. Sorting only reorders the
     // currently loaded page, so writing it to the URL would falsely imply a
     // global server-side sort across the full filtered result set.
@@ -932,6 +941,24 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     setListCursor(null);
     setCursorStack([]);
   }, []);
+
+  useEffect(() => {
+    if (!workspaceReturnFromDetail || !listCursor || isLoading || isError || !data) return;
+    if (data.items.length > 0 || data.nextPageToken) {
+      setWorkspaceReturnFromDetail(false);
+      return;
+    }
+    setWorkspaceReturnFromDetail(false);
+    setWorkspaceCursorResetNotice(true);
+    resetToFirstPage();
+  }, [
+    data,
+    isError,
+    isLoading,
+    listCursor,
+    resetToFirstPage,
+    workspaceReturnFromDetail,
+  ]);
 
   // MM-964: column visibility. The workflow title column is the primary anchor
   // and is always shown; every other column honors the stored preference.
@@ -1126,6 +1153,13 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     const items = data?.items || [];
     return sortRows(items, sortField, sortDir);
   }, [data?.items, sortField, sortDir]);
+  const detailListContext = useMemo(() => {
+    const params = new URLSearchParams();
+    appendFilterParams(params, filters);
+    params.set('limit', String(pageSize));
+    if (listCursor) params.set('nextPageToken', listCursor);
+    return params;
+  }, [filters, listCursor, pageSize]);
 
   const pageIndex = cursorStack.length;
   const pageStart = sortedItems.length > 0 ? pageIndex * pageSize + 1 : 0;
@@ -1243,7 +1277,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const hasWorkflowListNotices =
     !listEnabled ||
     Boolean(ignoredWorkflowScopeState) ||
-    filterValidationErrors.length > 0;
+    filterValidationErrors.length > 0 ||
+    workspaceCursorResetNotice;
 
   const updateDraftText = (field: 'workflowId' | 'title', value: string) => {
     setDraftFilters((current) => ({
@@ -1751,6 +1786,11 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
               ))}
             </div>
           ) : null}
+          {workspaceCursorResetNotice ? (
+            <div className="notice" role="status">
+              Saved pagination was no longer available. Showing the first page.
+            </div>
+          ) : null}
         </section>
       ) : null}
 
@@ -2086,7 +2126,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         <tr key={rowWorkflowId(row)}>
                           <td className="queue-table-cell-workflow">
                             <a
-                              href={`/workflows/${encodeURIComponent(rowWorkflowId(row))}?source=temporal`}
+                              href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                               className="workflow-list-row-title"
                             >
                               {row.title}
@@ -2147,7 +2187,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                     <div className="queue-card-header">
                       <div>
                         <a
-                          href={`/workflows/${encodeURIComponent(rowWorkflowId(row))}?source=temporal`}
+                          href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                           className="queue-card-title"
                         >
                           {row.title}
@@ -2190,7 +2230,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                     </dl>
                     <div className="queue-card-actions">
                       <a
-                        href={`/workflows/${encodeURIComponent(rowWorkflowId(row))}?source=temporal`}
+                        href={workflowDetailHref(rowWorkflowId(row), detailListContext)}
                         className="button secondary queue-card-details-action"
                         role="button"
                       >

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1789,6 +1789,13 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
           {workspaceCursorResetNotice ? (
             <div className="notice" role="status">
               Saved pagination was no longer available. Showing the first page.
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setWorkspaceCursorResetNotice(false)}
+              >
+                Dismiss
+              </button>
             </div>
           ) : null}
         </section>

--- a/frontend/src/lib/workflowListContext.ts
+++ b/frontend/src/lib/workflowListContext.ts
@@ -60,6 +60,9 @@ export function workflowListHrefFromContext(
 ): string {
   const params = workflowListContextParams(source);
   params.delete('source');
+  if (options.markDetailReturn) {
+    params.delete('nextPageToken');
+  }
   if (options.markDetailReturn && params.toString()) {
     params.set(WORKFLOW_LIST_CONTEXT_RETURN_PARAM, '1');
   }

--- a/frontend/src/lib/workflowListContext.ts
+++ b/frontend/src/lib/workflowListContext.ts
@@ -1,0 +1,68 @@
+export const WORKFLOW_LIST_CONTEXT_RETURN_PARAM = 'returnFromWorkflowDetail';
+
+const WORKFLOW_LIST_CONTEXT_ALLOWLIST = new Set([
+  'source',
+  'limit',
+  'nextPageToken',
+  'workflowIdContains',
+  'workflowId',
+  'stateIn',
+  'stateNotIn',
+  'state',
+  'repoIn',
+  'repoNotIn',
+  'repoBlank',
+  'repoContains',
+  'repoExact',
+  'repo',
+  'targetRuntimeIn',
+  'targetRuntimeNotIn',
+  'targetRuntimeBlank',
+  'targetRuntime',
+  'targetSkillIn',
+  'targetSkillNotIn',
+  'targetSkillBlank',
+  'titleContains',
+  'scheduledFrom',
+  'scheduledTo',
+  'scheduledBlank',
+  'updatedFrom',
+  'updatedTo',
+  'createdFrom',
+  'createdTo',
+  'finishedFrom',
+  'finishedTo',
+  'finishedBlank',
+]);
+
+export function workflowListContextParams(source: URLSearchParams): URLSearchParams {
+  const params = new URLSearchParams();
+  source.forEach((value, key) => {
+    if (WORKFLOW_LIST_CONTEXT_ALLOWLIST.has(key)) {
+      params.append(key, value);
+    }
+  });
+  return params;
+}
+
+export function workflowDetailHref(workflowId: string, source: URLSearchParams): string {
+  const params = workflowListContextParams(source);
+  if (!params.has('source')) {
+    params.set('source', 'temporal');
+  }
+  const query = params.toString();
+  return `/workflows/${encodeURIComponent(workflowId)}${query ? `?${query}` : ''}`;
+}
+
+export function workflowListHrefFromContext(
+  source: URLSearchParams,
+  options: { markDetailReturn?: boolean } = {},
+): string {
+  const params = workflowListContextParams(source);
+  params.delete('source');
+  if (options.markDetailReturn && params.toString()) {
+    params.set(WORKFLOW_LIST_CONTEXT_RETURN_PARAM, '1');
+  }
+  const query = params.toString();
+  return query ? `/workflows?${query}` : '/workflows';
+}


### PR DESCRIPTION
Issue reference: MM-998

Summary:
- Added a workflow list-context helper that allowlists safe query parameters for detail routes and Expand to full list links.
- Preserved list filters, page size, and usable cursor context when navigating from workflow list rows/cards to workflow detail.
- Added Expand to full list behavior on workflow detail pages, including plain /workflows fallback when no preserved context exists.
- Added workspace return stale-cursor recovery with a non-blocking notice.
- Added frontend coverage for detail-route allowlist behavior, browser back target preservation, Expand to full list reconstruction, and stale cursor recovery.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: container is missing pytest before the wrapper reaches Vitest)
- `npm ci --no-fund --no-audit`
- `npm run ui:test -- frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: npm script could not resolve vitest despite local install)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: Vite/Vitest resolved modules under unavailable /frontend path; creating /frontend symlink was denied)

Remaining risks:
- Focused frontend tests could not complete in this managed container because of local test environment resolution issues, so CI should be used as the final verification gate.
