### PR TITLE
MM-987: Generalize managed-session controls around explicit capabilities

### DIFF
--- a/api_service/api/routers/agent_runs.py
+++ b/api_service/api/routers/agent_runs.py
@@ -48,6 +48,7 @@ _HISTORICAL_EVENT_CHUNK_SIZE = 65536
 _OBSERVABILITY_TERMINAL_STATUSES = frozenset(
     {"completed", "failed", "canceled", "cancelled", "timed_out"}
 )
+_MANAGED_SESSION_TERMINAL_STATUSES = frozenset({"terminated", "degraded", "failed"})
 
 # Live Session legacy endpoints removed in Phase 6. Use /observability-summary and /logs/stream.
 
@@ -356,6 +357,28 @@ def _build_session_snapshot(
         "latestResetBoundaryRef": record.latest_reset_boundary_ref,
     }
 
+def _build_intervention_capabilities(
+    record: CodexManagedSessionRecord | None,
+) -> dict[str, bool]:
+    """Return compact operator controls supported by the current session record."""
+
+    if record is None or record.runtime_id != "codex_cli":
+        return {
+            "sendFollowUp": False,
+            "clearSession": False,
+            "interruptTurn": False,
+            "cancelSession": False,
+        }
+
+    active = record.status not in _MANAGED_SESSION_TERMINAL_STATUSES
+    has_active_turn = bool(record.active_turn_id)
+    return {
+        "sendFollowUp": active and record.status == "ready",
+        "clearSession": active and record.status in {"ready", "busy"},
+        "interruptTurn": active and record.status == "busy" and has_active_turn,
+        "cancelSession": active and record.status == "busy" and has_active_turn,
+    }
+
 def _build_record_session_snapshot(record: object) -> dict[str, object] | None:
     session_id = str(getattr(record, "session_id", "") or "").strip()
     if not session_id:
@@ -367,6 +390,29 @@ def _build_record_session_snapshot(record: object) -> dict[str, object] | None:
         "threadId": getattr(record, "thread_id", None),
         "activeTurnId": getattr(record, "active_turn_id", None),
     }
+
+def _require_session_control_capability(
+    *,
+    action: str,
+    capabilities: dict[str, bool],
+) -> None:
+    capability_by_action = {
+        "send_follow_up": "sendFollowUp",
+        "clear_session": "clearSession",
+        "interrupt_turn": "interruptTurn",
+        "cancel_session": "cancelSession",
+    }
+    capability = capability_by_action.get(action)
+    if capability is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported session control action: {action}",
+        )
+    if not capabilities.get(capability, False):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Session control action {action} is not currently supported by this managed session.",
+        )
 
 def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]]:
     if not workspace_path:
@@ -1167,6 +1213,7 @@ async def get_observability_summary(
         base["supportsLiveStreaming"] = supports_live
         base["liveStreamStatus"] = live_stream_status
         base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
+        base["interventionCapabilities"] = _build_intervention_capabilities(session_record)
         return {"summary": base}
     finally:
         _emit_livelogs_metric_observe(
@@ -1223,7 +1270,12 @@ async def control_agent_run_artifact_session(
         record = None
     if record is None or record.agent_run_id != agent_run_id:
         _session_projection_not_found()
-    if record.status in {"terminated", "degraded", "failed"}:
+    capabilities = _build_intervention_capabilities(record)
+    _require_session_control_capability(
+        action=payload.action,
+        capabilities=capabilities,
+    )
+    if record.status in _MANAGED_SESSION_TERMINAL_STATUSES:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="This managed session is not available for control actions.",
@@ -1247,6 +1299,23 @@ async def control_agent_run_artifact_session(
         await client.update_workflow(
             workflow_id,
             "ClearSession",
+            {
+                **({"reason": payload.reason} if payload.reason else {}),
+            },
+        )
+    elif payload.action == "interrupt_turn":
+        await client.update_workflow(
+            workflow_id,
+            "InterruptTurn",
+            {
+                "sessionEpoch": record.session_epoch,
+                **({"reason": payload.reason} if payload.reason else {}),
+            },
+        )
+    elif payload.action == "cancel_session":
+        await client.update_workflow(
+            workflow_id,
+            "CancelSession",
             {
                 **({"reason": payload.reason} if payload.reason else {}),
             },

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6366,6 +6366,91 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  it('does not derive Session Continuity controls from Codex runtime names without a session snapshot', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex one-shot task',
+      summary: 'One-shot managed run',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      targetRuntime: 'codex_cli',
+      agentRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+              sessionSnapshot: null,
+              interventionCapabilities: {
+                sendFollowUp: true,
+                clearSession: true,
+                interruptTurn: true,
+                cancelSession: true,
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events: [], truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => '' } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/observability-summary'),
+        expect.anything(),
+      );
+    });
+    expect(screen.queryByRole('heading', { name: 'Session Continuity' })).toBeNull();
+    expect(
+      fetchSpy.mock.calls.some(([input]) => String(input).includes('/artifact-sessions/')),
+    ).toBe(false);
+  });
+
   it('explains Live Logs as timeline history and Session Continuity as durable drill-down evidence', async () => {
     const codexPayload: BootPayload = {
       ...mockPayload,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6445,7 +6445,9 @@ describe('Workflow Detail Entrypoint', () => {
         expect.anything(),
       );
     });
-    expect(screen.queryByRole('heading', { name: 'Session Continuity' })).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Session Continuity' })).toBeNull();
+    });
     expect(
       fetchSpy.mock.calls.some(([input]) => String(input).includes('/artifact-sessions/')),
     ).toBe(false);
@@ -6675,6 +6677,9 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.change(await screen.findByLabelText('Follow-up message'), {
       target: { value: 'Continue with the existing session.' },
     });
+    const summaryCallsBeforeControl = fetchSpy.mock.calls.filter(([input]) =>
+      String(input).includes('/observability-summary'),
+    ).length;
     fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
 
     await waitFor(() => {
@@ -6693,6 +6698,11 @@ describe('Workflow Detail Entrypoint', () => {
       expect(
         fetchSpy.mock.calls.filter(([input]) => String(input) === executionDetailUrl).length,
       ).toBeGreaterThan(1);
+    });
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(([input]) => String(input).includes('/observability-summary')).length,
+      ).toBeGreaterThan(summaryCallsBeforeControl);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear / Reset' }));

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6459,6 +6459,7 @@ describe('Workflow Detail Entrypoint', () => {
       initialData: {
         dashboardConfig: {
           features: {
+            temporalDashboard: { actionsEnabled: true },
             logStreamingEnabled: true,
             liveLogsSessionTimelineEnabled: true,
           },
@@ -7336,7 +7337,7 @@ describe('LiveLogsPanel', () => {
     const summaryCallsBeforeExpand = fetchSpy.mock.calls.filter(([input]) =>
       String(input).includes('/observability-summary'),
     ).length;
-    expect(summaryCallsBeforeExpand).toBeGreaterThanOrEqual(1);
+    expect(summaryCallsBeforeExpand).toBe(0);
 
     fireEvent.click(await screen.findByText('Live Logs'));
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6271,6 +6271,40 @@ describe('Workflow Detail Entrypoint', () => {
 
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 2,
+                containerId: 'ctr-1',
+                threadId: 'thread-2',
+                activeTurnId: null,
+              },
+              interventionCapabilities: {
+                sendFollowUp: true,
+                clearSession: true,
+                interruptTurn: false,
+                cancelSession: false,
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events: [], truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => '' } as Response);
+      }
       if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
         return Promise.resolve({
           ok: true,
@@ -6375,6 +6409,19 @@ describe('Workflow Detail Entrypoint', () => {
               status: 'completed',
               supportsLiveStreaming: false,
               liveStreamStatus: 'ended',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 2,
+                containerId: 'ctr-1',
+                threadId: 'thread-2',
+                activeTurnId: null,
+              },
+              interventionCapabilities: {
+                sendFollowUp: false,
+                clearSession: false,
+                interruptTurn: false,
+                cancelSession: false,
+              },
             },
           }),
         } as Response);
@@ -6462,6 +6509,31 @@ describe('Workflow Detail Entrypoint', () => {
 
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 1,
+                containerId: 'ctr-1',
+                threadId: 'thread-1',
+                activeTurnId: null,
+              },
+              interventionCapabilities: {
+                sendFollowUp: true,
+                clearSession: true,
+                interruptTurn: false,
+                cancelSession: false,
+              },
+            },
+          }),
+        } as Response);
+      }
       if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
         return Promise.resolve({
           ok: true,
@@ -6553,7 +6625,7 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
-  it('reuses the existing execution cancel route from the Session Continuity panel', async () => {
+  it('routes active-turn interrupt and cancel controls through the agent-run session control API', async () => {
     const codexPayload: BootPayload = {
       ...mockPayload,
       initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
@@ -6579,15 +6651,48 @@ describe('Workflow Detail Entrypoint', () => {
       },
     };
 
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.endsWith('/cancel')) {
+      if (url.includes('/observability-summary')) {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            ...mockExecution,
-            state: 'canceled',
-            rawState: 'canceled',
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 1,
+                containerId: 'ctr-1',
+                threadId: 'thread-1',
+                activeTurnId: 'turn-1',
+              },
+              interventionCapabilities: {
+                sendFollowUp: false,
+                clearSession: true,
+                interruptTurn: true,
+                cancelSession: true,
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            action: JSON.parse(String(init?.body || '{}')).action,
+            projection: {
+              agent_run_id: 'wf-task-1',
+              session_id: 'sess:wf-task-1:codex_cli',
+              session_epoch: 1,
+              grouped_artifacts: [],
+              latest_summary_ref: null,
+              latest_checkpoint_ref: null,
+              latest_control_event_ref: { artifact_id: 'art-control' },
+              latest_reset_boundary_ref: null,
+            },
           }),
         } as Response);
       }
@@ -6623,17 +6728,29 @@ describe('Workflow Detail Entrypoint', () => {
 
     renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Execution' }));
-    confirmWorkflowDialog('Cancel workflow');
+    fireEvent.click(await screen.findByRole('button', { name: 'Interrupt turn' }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/executions/test-123/cancel',
+        '/api/agent-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({
-            action: 'cancel',
-            graceful: true,
+            action: 'interrupt_turn',
+          }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel session' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/agent-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'cancel_session',
           }),
         }),
       );
@@ -7121,14 +7238,18 @@ describe('LiveLogsPanel', () => {
     // Wait until the initial execute fetch finishes so task is loaded
     await waitFor(() => expect(screen.getByText('Active task')).toBeTruthy());
 
-    // Before click, it shouldn't have fetched the summary
-    expect(fetchSpy).not.toHaveBeenCalledWith(expect.stringContaining('/observability-summary'), expect.anything());
+    const summaryCallsBeforeExpand = fetchSpy.mock.calls.filter(([input]) =>
+      String(input).includes('/observability-summary'),
+    ).length;
+    expect(summaryCallsBeforeExpand).toBeGreaterThanOrEqual(1);
 
     fireEvent.click(await screen.findByText('Live Logs'));
 
-    // Now it should fetch
+    // Now the Live Logs panel should perform its own summary fetch.
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/observability-summary'), expect.anything());
+      expect(
+        fetchSpy.mock.calls.filter(([input]) => String(input).includes('/observability-summary')).length,
+      ).toBeGreaterThan(summaryCallsBeforeExpand);
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -3291,6 +3291,7 @@ function LiveLogsPanel({
     enabled: !!agentRunId && expanded,
     // The summary indicates stream availability; refetch occasionally if not terminal
     staleTime: 1000 * 10,
+    refetchOnMount: 'always',
   });
 
   const historyQuery = useQuery({
@@ -6534,7 +6535,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             </>
           ) : null}
 
-          {detailSubroute === 'steps' && resolvedAgentRunId ? (
+          {detailSubroute === 'steps' && actionsOn && resolvedAgentRunId ? (
             <SessionContinuityPanel
               apiBase={payload.apiBase}
               agentRunId={resolvedAgentRunId}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -899,9 +899,23 @@ const ArtifactSessionProjectionSchema = z.object({
 });
 
 const ArtifactSessionControlResponseSchema = z.object({
-  action: z.enum(['send_follow_up', 'clear_session']),
+  action: z.enum(['send_follow_up', 'clear_session', 'interrupt_turn', 'cancel_session']),
   projection: ArtifactSessionProjectionSchema,
 });
+
+const InterventionCapabilitiesSchema = z
+  .object({
+    sendFollowUp: z.boolean().default(false),
+    clearSession: z.boolean().default(false),
+    interruptTurn: z.boolean().default(false),
+    cancelSession: z.boolean().default(false),
+  })
+  .default({
+    sendFollowUp: false,
+    clearSession: false,
+    interruptTurn: false,
+    cancelSession: false,
+  });
 
 const SessionSnapshotSchema = z
   .object({
@@ -923,6 +937,7 @@ const ObservabilitySummarySchema = z.object({
   liveStreamStatus: z.string().default('unavailable'),
   status: z.string().default(''),
   sessionSnapshot: SessionSnapshotSchema.nullable().optional(),
+  interventionCapabilities: InterventionCapabilitiesSchema,
 });
 
 const RawObservabilityEventSchema = z
@@ -1725,17 +1740,6 @@ async function fetchRunSummaryArtifact(
   return RunSummaryArtifactSchema.parse(JSON.parse(text));
 }
 
-function deriveCodexSessionId(
-  agentRunId: string | null | undefined,
-  runtimeId: string | null | undefined,
-): string | null {
-  const normalizedRuntime = String(runtimeId || '').trim().toLowerCase();
-  if (!agentRunId || (normalizedRuntime !== 'codex' && normalizedRuntime !== 'codex_cli')) {
-    return null;
-  }
-  return `sess:${agentRunId}:codex_cli`;
-}
-
 async function fetchArtifactSessionProjection(
   apiBase: string,
   agentRunId: string,
@@ -1762,7 +1766,7 @@ async function controlArtifactSession(
   apiBase: string,
   agentRunId: string,
   sessionId: string,
-  body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string },
+  body: { action: 'send_follow_up' | 'clear_session' | 'interrupt_turn' | 'cancel_session'; message?: string; reason?: string },
   routeTemplate?: string | null,
 ): Promise<z.infer<typeof ArtifactSessionControlResponseSchema>> {
   const resp = await fetch(
@@ -1780,7 +1784,16 @@ async function controlArtifactSession(
     },
   );
   if (!resp.ok) {
-    throw new Error(`Session control: ${resp.status}`);
+    let detail = `Session control: ${resp.status}`;
+    try {
+      const payload = await resp.json();
+      if (typeof payload?.detail === 'string' && payload.detail.trim()) {
+        detail = payload.detail;
+      }
+    } catch {
+      // Keep the status fallback when the response is not JSON.
+    }
+    throw new Error(detail);
   }
   return ArtifactSessionControlResponseSchema.parse(await resp.json());
 }
@@ -3939,24 +3952,28 @@ function RecoveryEvidencePanel({
 function SessionContinuityPanel({
   apiBase,
   agentRunId,
-  targetRuntime,
   isTerminal,
-  onCancel,
   invalidateWorkflowDetail,
-  cancelBusy,
   routes,
 }: {
   apiBase: string;
   agentRunId: string;
-  targetRuntime: string | null | undefined;
   isTerminal: boolean;
-  onCancel: () => void;
   invalidateWorkflowDetail: () => void;
-  cancelBusy: boolean;
   routes: AgentRunRouteTemplates;
 }) {
   const queryClient = useQueryClient();
-  const sessionId = deriveCodexSessionId(agentRunId, targetRuntime);
+  const summaryQuery = useQuery({
+    queryKey: ['observability-summary', agentRunId, 'session-controls'],
+    queryFn: () => fetchObservabilitySummary(apiBase, agentRunId, routes.observabilitySummary),
+    enabled: !!agentRunId,
+    staleTime: 1000 * 10,
+    retry: false,
+  });
+  const summary = summaryQuery.data;
+  const sessionSnapshot = summary?.sessionSnapshot ?? null;
+  const interventionCapabilities = summary?.interventionCapabilities ?? InterventionCapabilitiesSchema.parse({});
+  const sessionId = sessionSnapshot?.sessionId ?? null;
   const [followUpMessage, setFollowUpMessage] = useState('');
   const [panelError, setPanelError] = useState<string | null>(null);
 
@@ -3966,7 +3983,7 @@ function SessionContinuityPanel({
       if (!sessionId) return Promise.resolve(null);
       return fetchArtifactSessionProjection(apiBase, agentRunId, sessionId, routes.artifactSession);
     },
-    enabled: Boolean(agentRunId && sessionId),
+    enabled: Boolean(agentRunId && sessionId && summaryQuery.isSuccess),
     refetchInterval: (query) => {
       return getSessionProjectionRefetchInterval(
         isTerminal,
@@ -3978,7 +3995,7 @@ function SessionContinuityPanel({
   });
 
   const controlMutation = useMutation({
-    mutationFn: async (body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string }) => {
+    mutationFn: async (body: { action: 'send_follow_up' | 'clear_session' | 'interrupt_turn' | 'cancel_session'; message?: string; reason?: string }) => {
       if (!sessionId) throw new Error('Managed session is unavailable.');
       return controlArtifactSession(apiBase, agentRunId, sessionId, body, routes.artifactSessionControl);
     },
@@ -3996,6 +4013,17 @@ function SessionContinuityPanel({
     onError: (error: Error) => setPanelError(error.message),
   });
 
+  if (summaryQuery.isLoading) {
+    return (
+      <section className="stack">
+        <h3>Session Continuity</h3>
+        <p className="small">Loading session capabilities...</p>
+      </section>
+    );
+  }
+  if (summaryQuery.isError) {
+    return null;
+  }
   if (!sessionId) {
     return null;
   }
@@ -4034,7 +4062,11 @@ function SessionContinuityPanel({
     ['Latest Control', projection.latest_control_event_ref?.artifact_id ?? null],
     ['Latest Reset', projection.latest_reset_boundary_ref?.artifact_id ?? null],
   ].filter(([, artifactId]) => artifactId !== null) as Array<[string, string]>;
-  const busy = controlMutation.isPending || cancelBusy;
+  const busy = controlMutation.isPending;
+  const canSendFollowUp = Boolean(sessionId && interventionCapabilities.sendFollowUp && !isTerminal);
+  const canClearSession = Boolean(sessionId && interventionCapabilities.clearSession && !isTerminal);
+  const canInterruptTurn = Boolean(sessionId && interventionCapabilities.interruptTurn && !isTerminal);
+  const canCancelSession = Boolean(sessionId && interventionCapabilities.cancelSession && !isTerminal);
 
   const submitFollowUp = () => {
     const message = followUpMessage.trim();
@@ -4050,6 +4082,20 @@ function SessionContinuityPanel({
     setPanelError(null);
     controlMutation.mutate({
       action: 'clear_session',
+    });
+  };
+
+  const interruptTurn = () => {
+    setPanelError(null);
+    controlMutation.mutate({
+      action: 'interrupt_turn',
+    });
+  };
+
+  const cancelSession = () => {
+    setPanelError(null);
+    controlMutation.mutate({
+      action: 'cancel_session',
     });
   };
 
@@ -4111,33 +4157,49 @@ function SessionContinuityPanel({
           onChange={(event) => setFollowUpMessage(event.target.value)}
           rows={3}
           placeholder="Send a follow-up turn to the managed Codex session."
-          disabled={busy || isTerminal}
+          disabled={busy || !canSendFollowUp}
         />
         <div className="actions">
-          <button
-            type="button"
-            className="secondary"
-            disabled={busy || isTerminal || !followUpMessage.trim()}
-            onClick={submitFollowUp}
-          >
-            Send follow-up
-          </button>
-          <button
-            type="button"
-            className="secondary"
-            disabled={busy || isTerminal}
-            onClick={clearSession}
-          >
-            Clear / Reset
-          </button>
-          <button
-            type="button"
-            className="queue-action queue-action-danger"
-            disabled={busy || isTerminal}
-            onClick={onCancel}
-          >
-            Cancel Execution
-          </button>
+          {canSendFollowUp ? (
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy || !followUpMessage.trim()}
+              onClick={submitFollowUp}
+            >
+              Send follow-up
+            </button>
+          ) : null}
+          {canClearSession ? (
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={clearSession}
+            >
+              Clear / Reset
+            </button>
+          ) : null}
+          {canInterruptTurn ? (
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={interruptTurn}
+            >
+              Interrupt turn
+            </button>
+          ) : null}
+          {canCancelSession ? (
+            <button
+              type="button"
+              className="queue-action queue-action-danger"
+              disabled={busy}
+              onClick={cancelSession}
+            >
+              Cancel session
+            </button>
+          ) : null}
         </div>
       </div>
     </section>
@@ -6469,11 +6531,8 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
             <SessionContinuityPanel
               apiBase={payload.apiBase}
               agentRunId={resolvedAgentRunId}
-              targetRuntime={execution.targetRuntime}
               isTerminal={isTerminalExecution}
-              onCancel={onCancel}
               invalidateWorkflowDetail={invalidate}
-              cancelBusy={cancelMutation.isPending}
               routes={agentRunRoutes}
             />
           ) : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -3964,10 +3964,16 @@ function SessionContinuityPanel({
 }) {
   const queryClient = useQueryClient();
   const summaryQuery = useQuery({
-    queryKey: ['observability-summary', agentRunId, 'session-controls'],
+    queryKey: ['observability-summary', agentRunId],
     queryFn: () => fetchObservabilitySummary(apiBase, agentRunId, routes.observabilitySummary),
     enabled: !!agentRunId,
     staleTime: 1000 * 10,
+    refetchInterval: (query) => {
+      if (isTerminal || !query.state.data?.sessionSnapshot) {
+        return false;
+      }
+      return SESSION_PROJECTION_POLL_MS;
+    },
     retry: false,
   });
   const summary = summaryQuery.data;
@@ -4005,6 +4011,7 @@ function SessionContinuityPanel({
         ['agent-run-session-projection', agentRunId, sessionId],
         result.projection,
       );
+      void queryClient.invalidateQueries({ queryKey: ['observability-summary', agentRunId] });
       invalidateWorkflowDetail();
       if (result.action === 'send_follow_up') {
         setFollowUpMessage('');

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3137,7 +3137,7 @@ export interface components {
              * Action
              * @enum {string}
              */
-            action: "send_follow_up" | "clear_session";
+            action: "send_follow_up" | "clear_session" | "interrupt_turn" | "cancel_session";
             /** Message */
             message?: string | null;
             /** Reason */
@@ -3152,7 +3152,7 @@ export interface components {
              * Action
              * @enum {string}
              */
-            action: "send_follow_up" | "clear_session";
+            action: "send_follow_up" | "clear_session" | "interrupt_turn" | "cancel_session";
             projection: components["schemas"]["ArtifactSessionProjectionModel"];
         };
         /**

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -225,7 +225,12 @@ class ArtifactSessionControlRequest(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    action: Literal["send_follow_up", "clear_session"]
+    action: Literal[
+        "send_follow_up",
+        "clear_session",
+        "interrupt_turn",
+        "cancel_session",
+    ]
     message: str | None = None
     reason: str | None = None
 
@@ -242,7 +247,12 @@ class ArtifactSessionControlResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    action: Literal["send_follow_up", "clear_session"]
+    action: Literal[
+        "send_follow_up",
+        "clear_session",
+        "interrupt_turn",
+        "cancel_session",
+    ]
     projection: ArtifactSessionProjectionModel
 
 class PresignDownloadResponse(BaseModel):

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -315,6 +315,34 @@ def test_get_observability_summary_includes_active_turn_capabilities(
         "cancelSession": True,
     }
 
+def test_get_observability_summary_reports_false_capabilities_for_one_shot_run(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.session_id = ""
+
+    with patch("api_service.api.routers.agent_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.agent_runs._load_agent_run_session_record",
+            return_value=None,
+        ):
+            response = test_client.get(f"/api/agent-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    body = response.json()["summary"]
+    assert body["sessionSnapshot"] is None
+    assert body["interventionCapabilities"] == {
+        "sendFollowUp": False,
+        "clearSession": False,
+        "interruptTurn": False,
+        "cancelSession": False,
+    }
+
 def test_get_observability_summary_emits_latency_metric(
     client: tuple[TestClient, AsyncMock],
 ) -> None:

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -280,6 +280,40 @@ def test_get_observability_summary_includes_session_snapshot(
     assert snapshot["sessionId"] == "sess:wf-task-1:codex_cli"
     assert snapshot["sessionEpoch"] == 2
     assert snapshot["threadId"] == "thread-2"
+    assert response.json()["summary"]["interventionCapabilities"] == {
+        "sendFollowUp": True,
+        "clearSession": True,
+        "interruptTurn": False,
+        "cancelSession": False,
+    }
+
+def test_get_observability_summary_includes_active_turn_capabilities(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    session_record = _build_session_record().model_copy(
+        update={"status": "busy", "active_turn_id": "turn-1"}
+    )
+
+    with patch("api_service.api.routers.agent_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.agent_runs._load_agent_run_session_record",
+            return_value=session_record,
+        ):
+            response = test_client.get(f"/api/agent-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["interventionCapabilities"] == {
+        "sendFollowUp": False,
+        "clearSession": True,
+        "interruptTurn": True,
+        "cancelSession": True,
+    }
 
 def test_get_observability_summary_emits_latency_metric(
     client: tuple[TestClient, AsyncMock],
@@ -2965,6 +2999,95 @@ def test_post_agent_run_artifact_session_control_routes_clear_session_and_return
     assert body["projection"]["session_epoch"] == 3
     assert body["projection"]["latest_control_event_ref"]["artifact_id"] == "art_control"
     assert body["projection"]["latest_reset_boundary_ref"]["artifact_id"] == "art_reset"
+
+def test_post_agent_run_artifact_session_control_routes_interrupt_turn(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record().model_copy(
+        update={"status": "busy", "active_turn_id": "turn-9"}
+    )
+    artifact_service.get_metadata.side_effect = lambda **kwargs: _build_artifact(
+        kwargs["artifact_id"],
+        "session.summary",
+        label="summary",
+    )
+    client_adapter = AsyncMock()
+    client_adapter.update_workflow.return_value = {"accepted": True}
+
+    with patch("api_service.api.routers.agent_runs.ManagedSessionStore.load", return_value=record):
+        with patch("api_service.api.routers.agent_runs.get_temporal_client_adapter", return_value=client_adapter):
+            response = test_client.post(
+                "/api/agent-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+                json={
+                    "action": "interrupt_turn",
+                    "reason": "Stop this turn",
+                },
+            )
+
+    assert response.status_code == 200
+    client_adapter.update_workflow.assert_awaited_once_with(
+        "wf-task-1:session:codex_cli",
+        "InterruptTurn",
+        {
+            "sessionEpoch": 2,
+            "reason": "Stop this turn",
+        },
+    )
+    assert response.json()["action"] == "interrupt_turn"
+
+def test_post_agent_run_artifact_session_control_routes_cancel_session(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record().model_copy(
+        update={"status": "busy", "active_turn_id": "turn-9"}
+    )
+    artifact_service.get_metadata.side_effect = lambda **kwargs: _build_artifact(
+        kwargs["artifact_id"],
+        "session.summary",
+        label="summary",
+    )
+    client_adapter = AsyncMock()
+    client_adapter.update_workflow.return_value = {"accepted": True}
+
+    with patch("api_service.api.routers.agent_runs.ManagedSessionStore.load", return_value=record):
+        with patch("api_service.api.routers.agent_runs.get_temporal_client_adapter", return_value=client_adapter):
+            response = test_client.post(
+                "/api/agent-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+                json={
+                    "action": "cancel_session",
+                    "reason": "Operator cancel",
+                },
+            )
+
+    assert response.status_code == 200
+    client_adapter.update_workflow.assert_awaited_once_with(
+        "wf-task-1:session:codex_cli",
+        "CancelSession",
+        {
+            "reason": "Operator cancel",
+        },
+    )
+    assert response.json()["action"] == "cancel_session"
+
+def test_post_agent_run_artifact_session_control_rejects_false_capability(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _artifact_service = client
+    record = _build_session_record()
+    client_adapter = AsyncMock()
+
+    with patch("api_service.api.routers.agent_runs.ManagedSessionStore.load", return_value=record):
+        with patch("api_service.api.routers.agent_runs.get_temporal_client_adapter", return_value=client_adapter):
+            response = test_client.post(
+                "/api/agent-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+                json={"action": "interrupt_turn"},
+            )
+
+    assert response.status_code == 409
+    assert "interrupt_turn" in response.json()["detail"]
+    client_adapter.update_workflow.assert_not_awaited()
 
 def test_post_agent_run_artifact_session_control_rejects_blank_follow_up_message(
     client: tuple[TestClient, AsyncMock],


### PR DESCRIPTION
Issue reference: MM-987 (https://moonladder.atlassian.net/browse/MM-987)

Summary:
- Adds explicit interventionCapabilities to managed-session observability summaries and artifact session projections.
- Generalizes artifact session controls for send_follow_up, clear_session, interrupt_turn, and cancel_session with server-side capability/state validation and operator-readable errors.
- Updates workflow detail UI controls to rely on bounded sessionSnapshot and explicit capabilities instead of Codex runtime-name/session guesses.
- Adds backend and frontend coverage for session-capable, one-shot, terminal, unsupported, and active-turn control states.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_agent_runs.py --ui-args frontend/src/entrypoints/workflow-detail.test.tsx

Remaining risks:
- Integration coverage was not run because this change targets API/router and frontend unit behavior; Temporal adapter behavior is covered through existing unit surfaces.
- The managed workspace has root-owned .git internals, so an additional local marker commit could not be created in this step; the implementation branch was already committed and pushed before PR creation.