### PR TITLE
MM-999 Build compact workflow sidebar navigation

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -520,7 +520,7 @@ describe('Workflow Detail Entrypoint', () => {
       rawState: 'executing',
       temporalStatus: 'running',
       createdAt: '2026-04-09T00:00:00Z',
-      updatedAt: '2026-04-09T00:00:04Z',
+      updatedAt: 'detail-updated-marker',
       actions: {},
       relatedRuns: [],
     };
@@ -665,6 +665,8 @@ describe('Workflow Detail Entrypoint', () => {
     const pinned = within(pinnedGroup).getByRole('link', { name: /MM-999 selected workflow outside filters/i });
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
+    expect(within(pinned).getByLabelText('executing')).toBeTruthy();
+    expect(within(pinned).getByText('detail-updated-marker')).toBeTruthy();
     expect(within(sidebar).getByRole('link', { name: /Filtered workflow/i }).getAttribute('aria-current')).toBeNull();
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -521,6 +521,7 @@ describe('Workflow Detail Entrypoint', () => {
       temporalStatus: 'running',
       createdAt: '2026-04-09T00:00:00Z',
       updatedAt: 'detail-updated-marker',
+      scheduledFor: 'scheduled-marker',
       actions: {},
       relatedRuns: [],
     };
@@ -666,7 +667,8 @@ describe('Workflow Detail Entrypoint', () => {
     expect(pinned.getAttribute('aria-current')).toBe('page');
     expect(pinned.getAttribute('data-pinned')).toBe('true');
     expect(within(pinned).getByLabelText('executing')).toBeTruthy();
-    expect(within(pinned).getByText('detail-updated-marker')).toBeTruthy();
+    expect(within(pinned).getByText('scheduled-marker')).toBeTruthy();
+    expect(within(pinned).queryByText('detail-updated-marker')).toBeNull();
     expect(within(sidebar).getByRole('link', { name: /Filtered workflow/i }).getAttribute('aria-current')).toBeNull();
     expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -503,6 +503,120 @@ describe('Workflow Detail Entrypoint', () => {
     });
   }
 
+  function mockWorkflowWorkspaceFetchesWithSelectedOutsideList() {
+    const selectedExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'MM-999 selected workflow outside filters',
+      summary: 'Workspace shell selected detail',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+      relatedRuns: [],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/executions?')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                workflowId: 'test-456',
+                taskId: 'test-456',
+                source: 'temporal',
+                title: 'Filtered workflow',
+                status: 'completed',
+                state: 'completed',
+                rawState: 'completed',
+                createdAt: '2026-04-08T00:00:00Z',
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => selectedExecution,
+      } as Response);
+    });
+  }
+
+  function mockWorkflowWorkspaceSidebarFailure() {
+    const selectedExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      title: 'MM-999 detail survives sidebar error',
+      summary: 'Workspace shell selected detail',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+      relatedRuns: [],
+    };
+
+    let sidebarAttempts = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/executions?')) {
+        sidebarAttempts += 1;
+        return Promise.resolve({
+          ok: false,
+          statusText: sidebarAttempts === 1 ? 'Service Unavailable' : 'Gateway Timeout',
+          json: async () => ({}),
+        } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => selectedExecution,
+      } as Response);
+    });
+  }
+
   function mockDesktopViewport(matches = true) {
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
@@ -537,6 +651,57 @@ describe('Workflow Detail Entrypoint', () => {
       '/workflows/test-456?source=temporal',
     );
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&pageSize=25');
+  });
+
+  it('MM-999 pins the selected workflow above sidebar rows when it is outside the filtered result', async () => {
+    window.history.pushState({}, 'Workspace Pinned Current Test', '/workflows/test-123?source=temporal&stateIn=completed');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetchesWithSelectedOutsideList();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    const pinnedGroup = await within(sidebar).findByRole('list', { name: 'Current workflow' });
+    const pinned = within(pinnedGroup).getByRole('link', { name: /MM-999 selected workflow outside filters/i });
+    expect(pinned.getAttribute('aria-current')).toBe('page');
+    expect(pinned.getAttribute('data-pinned')).toBe('true');
+    expect(within(sidebar).getByRole('link', { name: /Filtered workflow/i }).getAttribute('aria-current')).toBeNull();
+    expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+  });
+
+  it('MM-999 does not show a pinned current row when the selected workflow is in the normal sidebar list', async () => {
+    window.history.pushState({}, 'Workspace No Pinned Current Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(within(sidebar).queryByRole('list', { name: 'Current workflow' })).toBeNull();
+    expect((await within(sidebar).findByRole('link', { name: /MM-997 selected workflow/i })).getAttribute('aria-current')).toBe(
+      'page',
+    );
+  });
+
+  it('MM-999 keeps detail visible and retries only sidebar data after a recoverable sidebar error', async () => {
+    window.history.pushState({}, 'Workspace Sidebar Error Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceSidebarFailure();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(await within(sidebar).findByText('Workflow navigation is unavailable.')).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+
+    fireEvent.click(within(sidebar).getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      const sidebarFetches = fetchSpy.mock.calls.filter(([url]) => String(url).startsWith('/api/executions?'));
+      expect(sidebarFetches.length).toBeGreaterThanOrEqual(2);
+    });
+    expect(screen.getByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
   });
 
   it('MM-997 translates workspace sidebar limit state to the executions API page size', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import Anser from 'anser';
 import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
@@ -69,6 +69,7 @@ const WorkflowWorkspaceRowSchema = z
     state: z.string().optional(),
     rawState: z.string().optional(),
     createdAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
     scheduledFor: z.string().nullable().optional(),
     closedAt: z.string().nullable().optional(),
     repository: z.string().nullable().optional(),
@@ -87,7 +88,7 @@ function workflowWorkspaceRowId(row: WorkflowWorkspaceRow): string {
 }
 
 function workflowWorkspaceRowUpdatedAt(row: WorkflowWorkspaceRow): string | null | undefined {
-  return row.closedAt || row.scheduledFor || row.createdAt;
+  return row.closedAt || row.updatedAt || row.scheduledFor || row.createdAt;
 }
 
 function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorkspaceRow {
@@ -99,6 +100,7 @@ function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorksp
     state: detail.state,
     rawState: detail.rawState,
     createdAt: detail.createdAt,
+    updatedAt: detail.updatedAt,
     scheduledFor: detail.scheduledFor,
     closedAt: detail.closedAt,
     repository: detail.repository,
@@ -269,6 +271,115 @@ function WorkflowSidebarRow({
   );
 }
 
+function WorkflowSidebarControls({
+  fullListHref,
+  closeButtonRef,
+  onClose,
+}: {
+  fullListHref: string;
+  closeButtonRef: RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
+}) {
+  return (
+    <div className="workflow-workspace-sidebar-controls">
+      <button
+        ref={closeButtonRef}
+        type="button"
+        className="secondary"
+        onClick={onClose}
+      >
+        Close sidebar
+      </button>
+      <a className="button secondary" href={fullListHref}>
+        Expand to full list
+      </a>
+    </div>
+  );
+}
+
+function WorkflowSidebarList({
+  rows,
+  activeWorkflowId,
+  ariaLabel = 'Workflow navigation list',
+  pinned = false,
+}: {
+  rows: WorkflowWorkspaceRow[];
+  activeWorkflowId: string;
+  ariaLabel?: string;
+  pinned?: boolean;
+}) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul
+      className={`workflow-workspace-sidebar-list${pinned ? ' workflow-workspace-sidebar-pinned-list' : ''}`}
+      aria-label={ariaLabel}
+    >
+      {rows.map((row) => (
+        <WorkflowSidebarRow
+          key={workflowWorkspaceRowId(row)}
+          row={row}
+          activeWorkflowId={activeWorkflowId}
+          pinned={pinned}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function WorkflowSidebar({
+  workflowId,
+  workflowsQuery,
+  filteredRows,
+  pinnedCurrentRow,
+  fullListHref,
+  closeButtonRef,
+  onClose,
+}: {
+  workflowId: string;
+  workflowsQuery: UseQueryResult<z.infer<typeof WorkflowWorkspaceListResponseSchema>, Error>;
+  filteredRows: WorkflowWorkspaceRow[];
+  pinnedCurrentRow: WorkflowWorkspaceRow | null;
+  fullListHref: string;
+  closeButtonRef: RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
+}) {
+  return (
+    <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
+      <WorkflowSidebarControls
+        fullListHref={fullListHref}
+        closeButtonRef={closeButtonRef}
+        onClose={onClose}
+      />
+      {workflowsQuery.isLoading ? (
+        <p className="workflow-workspace-sidebar-state">Loading workflows...</p>
+      ) : null}
+      {workflowsQuery.isError ? (
+        <div className="workflow-workspace-sidebar-state" role="status">
+          <p>Workflow navigation is unavailable.</p>
+          <button type="button" className="secondary" onClick={() => void workflowsQuery.refetch()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {!workflowsQuery.isLoading && !workflowsQuery.isError && pinnedCurrentRow ? (
+        <WorkflowSidebarList
+          rows={[pinnedCurrentRow]}
+          activeWorkflowId={workflowId}
+          ariaLabel="Current workflow"
+          pinned
+        />
+      ) : null}
+      {!workflowsQuery.isLoading && !workflowsQuery.isError && filteredRows.length === 0 ? (
+        <p className="workflow-workspace-sidebar-state">No workflows match the current list filters.</p>
+      ) : null}
+      <WorkflowSidebarList rows={filteredRows} activeWorkflowId={workflowId} />
+    </aside>
+  );
+}
+
 function WorkflowWorkspaceShell({
   payload,
   workflowId,
@@ -327,54 +438,18 @@ function WorkflowWorkspaceShell({
   return (
     <div className="workflow-workspace-shell" data-jira-issue="MM-999" data-source-issue="MM-975">
       {sidebarOpen ? (
-        <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
-          <div className="workflow-workspace-sidebar-controls">
-            <button
-              ref={closeButtonRef}
-              type="button"
-              className="secondary"
-              onClick={() => {
-                setSidebarOpen(false);
-                window.setTimeout(() => openButtonRef.current?.focus(), 0);
-              }}
-            >
-              Close sidebar
-            </button>
-            <a className="button secondary" href={fullListHref}>
-              Expand to full list
-            </a>
-          </div>
-          {workflowsQuery.isLoading ? (
-            <p className="workflow-workspace-sidebar-state">Loading workflows...</p>
-          ) : null}
-          {workflowsQuery.isError ? (
-            <div className="workflow-workspace-sidebar-state" role="status">
-              <p>Workflow navigation is unavailable.</p>
-              <button type="button" className="secondary" onClick={() => void workflowsQuery.refetch()}>
-                Retry
-              </button>
-            </div>
-          ) : null}
-          {!workflowsQuery.isLoading && !workflowsQuery.isError && pinnedCurrentRow ? (
-            <ul className="workflow-workspace-sidebar-list workflow-workspace-sidebar-pinned-list" aria-label="Current workflow">
-              <WorkflowSidebarRow row={pinnedCurrentRow} activeWorkflowId={workflowId} pinned />
-            </ul>
-          ) : null}
-          {!workflowsQuery.isLoading && !workflowsQuery.isError && filteredRows.length === 0 ? (
-            <p className="workflow-workspace-sidebar-state">No workflows match the current list filters.</p>
-          ) : null}
-          {filteredRows.length > 0 ? (
-            <ul className="workflow-workspace-sidebar-list" aria-label="Workflow navigation list">
-              {filteredRows.map((row) => (
-                <WorkflowSidebarRow
-                  key={workflowWorkspaceRowId(row)}
-                  row={row}
-                  activeWorkflowId={workflowId}
-                />
-              ))}
-            </ul>
-          ) : null}
-        </aside>
+        <WorkflowSidebar
+          workflowId={workflowId}
+          workflowsQuery={workflowsQuery}
+          filteredRows={filteredRows}
+          pinnedCurrentRow={pinnedCurrentRow}
+          fullListHref={fullListHref}
+          closeButtonRef={closeButtonRef}
+          onClose={() => {
+            setSidebarOpen(false);
+            window.setTimeout(() => openButtonRef.current?.focus(), 0);
+          }}
+        />
       ) : (
         <button
           ref={openButtonRef}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -88,7 +88,7 @@ function workflowWorkspaceRowId(row: WorkflowWorkspaceRow): string {
 }
 
 function workflowWorkspaceRowUpdatedAt(row: WorkflowWorkspaceRow): string | null | undefined {
-  return row.closedAt || row.updatedAt || row.scheduledFor || row.createdAt;
+  return row.closedAt || row.scheduledFor || row.updatedAt || row.createdAt;
 }
 
 function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorkspaceRow {
@@ -423,7 +423,7 @@ function WorkflowWorkspaceShell({
     enabled: Boolean(workflowId),
     refetchInterval: (query) => (
       !isExecutionTerminal(query.state.data)
-        ? listPoll
+        ? (cfg?.pollIntervalsMs?.detail ?? 2000)
         : false
     ),
   });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -90,6 +90,22 @@ function workflowWorkspaceRowUpdatedAt(row: WorkflowWorkspaceRow): string | null
   return row.closedAt || row.scheduledFor || row.createdAt;
 }
 
+function workflowWorkspaceRowFromDetail(detail: ExecutionDetail): WorkflowWorkspaceRow {
+  return {
+    taskId: detail.taskId,
+    workflowId: detail.workflowId,
+    title: detail.title,
+    status: detail.status,
+    state: detail.state,
+    rawState: detail.rawState,
+    createdAt: detail.createdAt,
+    scheduledFor: detail.scheduledFor,
+    closedAt: detail.closedAt,
+    repository: detail.repository,
+    targetRuntime: detail.targetRuntime,
+  };
+}
+
 const WORKFLOW_WORKSPACE_RELATIVE_TIME_UNITS: Array<[string, number]> = [
   ['y', 31536000],
   ['mo', 2592000],
@@ -221,9 +237,11 @@ function workflowWorkspaceListQuery(search: URLSearchParams): string {
 function WorkflowSidebarRow({
   row,
   activeWorkflowId,
+  pinned = false,
 }: {
   row: WorkflowWorkspaceRow;
   activeWorkflowId: string;
+  pinned?: boolean;
 }) {
   const workflowId = workflowWorkspaceRowId(row);
   const active = workflowId === activeWorkflowId;
@@ -232,12 +250,14 @@ function WorkflowSidebarRow({
   return (
     <li>
       <a
-        className="workflow-workspace-sidebar-row"
+        className={`workflow-workspace-sidebar-row${pinned ? ' workflow-workspace-sidebar-row-pinned' : ''}`}
         href={`/workflows/${encodeURIComponent(workflowId)}?source=temporal`}
         aria-current={active ? 'page' : undefined}
         data-active={active ? 'true' : 'false'}
+        data-pinned={pinned ? 'true' : 'false'}
       >
         <span className="workflow-workspace-sidebar-row-main">
+          {pinned ? <span className="workflow-workspace-sidebar-kicker">Current workflow</span> : null}
           <span className="workflow-workspace-sidebar-title">{title}</span>
           <span className="workflow-workspace-sidebar-meta">
             {formatWorkflowWorkspaceRelativeTime(workflowWorkspaceRowUpdatedAt(row))}
@@ -265,6 +285,8 @@ function WorkflowWorkspaceShell({
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const openButtonRef = useRef<HTMLButtonElement | null>(null);
   const listQuery = useMemo(() => workflowWorkspaceListQuery(search), [search]);
+  const sourceTemporal = search.get('source') === 'temporal';
+  const encodedWorkflowId = encodeURIComponent(workflowId);
   const workflowsQuery = useQuery({
     queryKey: ['workflow-workspace-sidebar', listQuery],
     queryFn: async () => {
@@ -277,13 +299,33 @@ function WorkflowWorkspaceShell({
     enabled: listEnabled,
     refetchInterval: listEnabled ? listPoll : false,
   });
+  const selectedWorkflowQuery = useQuery({
+    queryKey: ['workflow-detail', encodedWorkflowId, sourceTemporal],
+    queryFn: async () => {
+      const suffix = sourceTemporal ? '?source=temporal' : '';
+      const response = await fetch(`${payload.apiBase}/executions/${encodedWorkflowId}${suffix}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch workflow: ${response.statusText}`);
+      }
+      return ExecutionDetailSchema.parse(await response.json());
+    },
+    enabled: Boolean(workflowId),
+    refetchInterval: (query) => (
+      !isExecutionTerminal(query.state.data)
+        ? listPoll
+        : false
+    ),
+  });
   const rows = workflowsQuery.data?.items || [];
   const activeInList = rows.some((row) => workflowWorkspaceRowId(row) === workflowId);
   const filteredRows = rows.filter((row) => workflowWorkspaceRowId(row));
+  const pinnedCurrentRow = selectedWorkflowQuery.data && !activeInList
+    ? workflowWorkspaceRowFromDetail(selectedWorkflowQuery.data)
+    : null;
   const fullListHref = `/workflows${search.toString() ? `?${search.toString()}` : ''}`;
 
   return (
-    <div className="workflow-workspace-shell" data-jira-issue="MM-997" data-source-issue="MM-975">
+    <div className="workflow-workspace-shell" data-jira-issue="MM-999" data-source-issue="MM-975">
       {sidebarOpen ? (
         <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
           <div className="workflow-workspace-sidebar-controls">
@@ -313,11 +355,10 @@ function WorkflowWorkspaceShell({
               </button>
             </div>
           ) : null}
-          {!workflowsQuery.isLoading && !workflowsQuery.isError && !activeInList && workflowId ? (
-            <div className="workflow-workspace-current-row" aria-label="Current workflow">
-              <span className="workflow-workspace-sidebar-title">Current workflow</span>
-              <code>{workflowId}</code>
-            </div>
+          {!workflowsQuery.isLoading && !workflowsQuery.isError && pinnedCurrentRow ? (
+            <ul className="workflow-workspace-sidebar-list workflow-workspace-sidebar-pinned-list" aria-label="Current workflow">
+              <WorkflowSidebarRow row={pinnedCurrentRow} activeWorkflowId={workflowId} pinned />
+            </ul>
           ) : null}
           {!workflowsQuery.isLoading && !workflowsQuery.isError && filteredRows.length === 0 ? (
             <p className="workflow-workspace-sidebar-state">No workflows match the current list filters.</p>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6466,6 +6466,11 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin: 0;
 }
 
+.workflow-workspace-sidebar-pinned-list {
+  flex: 0 0 auto;
+  overflow: visible;
+}
+
 .workflow-workspace-sidebar-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -6478,6 +6483,11 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   background: rgb(var(--mm-panel) / 0.78);
   color: rgb(var(--mm-ink));
   text-decoration: none;
+}
+
+.workflow-workspace-sidebar-row-pinned {
+  border-style: dashed;
+  background: rgb(var(--mm-accent) / 0.08);
 }
 
 .workflow-workspace-sidebar-row:hover,
@@ -6499,6 +6509,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   gap: 0.18rem;
 }
 
+.workflow-workspace-sidebar-kicker {
+  color: rgb(var(--mm-accent));
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
 .workflow-workspace-sidebar-title {
   min-width: 0;
   overflow: hidden;
@@ -6512,18 +6529,11 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-size: 0.82rem;
 }
 
-.workflow-workspace-current-row,
 .workflow-workspace-sidebar-state {
   border: 1px dashed rgb(var(--mm-border) / 0.75);
   border-radius: 0.55rem;
   padding: 0.65rem;
   background: rgb(var(--mm-panel) / 0.62);
-}
-
-.workflow-workspace-current-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
 }
 
 .workflow-workspace-detail {


### PR DESCRIPTION
Issue reference: MM-999

Summary:
- Adds explicit workflow sidebar components for desktop workflow detail mode.
- Renders compact sidebar rows with workflow title, status, recency/action context, active row highlighting, and detail-route navigation.
- Adds a pinned Current workflow row when the selected workflow is absent from sidebar results but detail data exists, while keeping sidebar data/loading/error state independent from the selected detail page.
- Covers sidebar loading, empty, error, retry, active-row, navigation, and pinned-current behavior in workflow detail frontend tests.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: local Python environment is missing `pytest` before the UI target runs)
- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: shell cannot resolve `vitest` from npm script in this environment)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx` (blocked: Vitest resolves the filtered path as `/frontend/src/entrypoints/workflow-detail.test.tsx`)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts` (blocked: same `/frontend/...` module resolution failure across discovered frontend tests)

Remaining risks:
- Local verification could not complete because of this managed runtime's Python and Vitest path-resolution environment issues; CI should run the canonical frontend checks.
