### PR TITLE
MM-1000 implement workflow sidebar collapsed state

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen, waitFor, act, fireEvent, within } from '@testing-library/react';
+import { screen, waitFor, act, fireEvent, within, cleanup } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
 import { EXECUTING_STATUS_PILL_TRACEABILITY } from '../utils/executionStatusPillClasses';
 import {
@@ -18,6 +18,10 @@ import {
 import { navigateTo } from '../lib/navigation';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
+import {
+  readDashboardPreferences,
+  updateDashboardPreferences,
+} from '../utils/dashboardPreferences';
 
 type MockVirtuosoRow = { id: string };
 type MockVirtuosoProps<Row = MockVirtuosoRow> = {
@@ -553,6 +557,136 @@ describe('Workflow Detail Entrypoint', () => {
     expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
       '/api/executions?source=temporal&nextPageToken=page-2&pageSize=10',
+    );
+  });
+
+  it('MM-1000 persists collapsed sidebar state across desktop detail reloads without changing the route', async () => {
+    window.history.pushState({}, 'Workspace Collapse Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const closeSidebar = await screen.findByRole('button', { name: 'Close sidebar' });
+    fireEvent.click(closeSidebar);
+
+    const openSidebar = await screen.findByRole('button', { name: 'Open workflow sidebar' });
+    expect(openSidebar).toBeTruthy();
+    expect(document.activeElement).toBe(openSidebar);
+    expect(window.location.pathname).toBe('/workflows/test-123');
+    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(true);
+    expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
+  });
+
+  it('MM-1000 opens desktop detail routes by default unless the sidebar collapse preference is persisted', async () => {
+    window.history.pushState({}, 'Workspace Reload Default Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+
+    cleanup();
+    window.localStorage.clear();
+    updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('button', { name: 'Open workflow sidebar' })).toBeTruthy();
+  });
+
+  it('MM-1000 restores the sidebar from persisted collapse without refetching selected detail data', async () => {
+    window.history.pushState({}, 'Workspace Reopen Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+    updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
+
+    renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            dashboardConfig: {
+              ...((stepsPayload.initialData as { dashboardConfig: Record<string, unknown> }).dashboardConfig),
+              pollIntervalsMs: { detail: 60000, list: 60000 },
+            },
+          },
+        }}
+      />,
+    );
+
+    await screen.findByRole('button', { name: 'Open workflow sidebar' });
+    await screen.findByRole('heading', { name: 'Workflow Detail' });
+    const detailCallsBeforeOpen = fetchSpy.mock.calls.filter(
+      ([input]) => String(input) === '/api/executions/test-123?source=temporal',
+    ).length;
+    fireEvent.click(screen.getByRole('button', { name: 'Open workflow sidebar' }));
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close sidebar' }));
+    expect(sidebar).toBeTruthy();
+    expect(readDashboardPreferences().workflowWorkspaceSidebarCollapsed).toBe(false);
+    expect(
+      fetchSpy.mock.calls.filter(
+        ([input]) => String(input) === '/api/executions/test-123?source=temporal',
+      ).length,
+    ).toBe(detailCallsBeforeOpen);
+  });
+
+  it('MM-1000 keeps persisted collapsed state out of mobile standalone detail routing', async () => {
+    window.history.pushState({}, 'Workspace Mobile Collapse Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(false);
+    mockWorkflowWorkspaceFetches();
+    updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+  });
+
+  it('MM-1000 expands to the full list with preserved context and focusable list target', async () => {
+    window.history.pushState(
+      {},
+      'Workspace Expand Test',
+      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2',
+    );
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    const expand = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expand.getAttribute('href')).toBe('/workflows?source=temporal&limit=10&nextPageToken=page-2');
+    expect(expand.getAttribute('class') || '').toContain('button');
+  });
+
+  it('MM-1000 uses a single-column collapsed workspace layout and reduced-motion guard', async () => {
+    window.history.pushState({}, 'Workspace Motion Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+    updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
+
+    const { container } = renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('button', { name: 'Open workflow sidebar' })).toBeTruthy();
+    expect(container.querySelector('.workflow-workspace-shell')?.getAttribute('data-sidebar-collapsed')).toBe(
+      'true',
+    );
+
+    const { readFileSync } = await import('node:fs');
+    const dashboardCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/dashboard.css`,
+      'utf8',
+    );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\);/,
+    );
+    expect(dashboardCss).toMatch(
+      /@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.workflow-workspace-shell,[\s\S]*\.workflow-workspace-detail[\s\S]*transition:\s*none !important;[\s\S]*animation:\s*none !important;[\s\S]*transform:\s*none !important;/,
     );
   });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -23,6 +23,8 @@ import {
   updateDashboardPreferences,
 } from '../utils/dashboardPreferences';
 
+declare const __dirname: string;
+
 type MockVirtuosoRow = { id: string };
 type MockVirtuosoProps<Row = MockVirtuosoRow> = {
   data?: Row[];

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -60,6 +60,12 @@ function lastFetchUrl(fetchSpy: MockInstance, prefix: string): string | undefine
     .at(-1);
 }
 
+async function readDashboardCss(): Promise<string> {
+  const { readFileSync } = await import('node:fs');
+  const { resolve } = await import('node:path');
+  return readFileSync(resolve(__dirname, '../styles/dashboard.css'), 'utf8');
+}
+
 // ---------------------------------------------------------------------------
 // Minimal EventSource mock
 // ---------------------------------------------------------------------------
@@ -677,11 +683,7 @@ describe('Workflow Detail Entrypoint', () => {
       'true',
     );
 
-    const { readFileSync } = await import('node:fs');
-    const dashboardCss = readFileSync(
-      `${process.cwd()}/frontend/src/styles/dashboard.css`,
-      'utf8',
-    );
+    const dashboardCss = await readDashboardCss();
     expect(dashboardCss).toMatch(
       /\.workflow-workspace-shell\[data-sidebar-collapsed="true"\]\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\);/,
     );
@@ -4908,11 +4910,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
   it('keeps remediation panels accessible and contained in dashboard CSS', async () => {
-    const { readFileSync } = await import('node:fs');
-    const dashboardCss = readFileSync(
-      `${process.cwd()}/frontend/src/styles/dashboard.css`,
-      'utf8',
-    );
+    const dashboardCss = await readDashboardCss();
 
     expect(dashboardCss).toMatch(/\.td-remediation-region:focus-within\s*\{[^}]*outline:\s*2px solid/s);
     expect(dashboardCss).toMatch(/\.td-remediation-list\s+\.card\s*\{[^}]*min-width:\s*0;[^}]*max-width:\s*100%;/s);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -261,7 +261,9 @@ function WorkflowWorkspaceShell({
   const cfg = readDashboardConfig(payload);
   const listPoll = cfg?.pollIntervalsMs?.list ?? 5000;
   const listEnabled = cfg?.features?.temporalDashboard?.listEnabled !== false;
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(
+    () => !readDashboardPreferences().workflowWorkspaceSidebarCollapsed,
+  );
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const openButtonRef = useRef<HTMLButtonElement | null>(null);
   const listQuery = useMemo(() => workflowWorkspaceListQuery(search), [search]);
@@ -283,7 +285,12 @@ function WorkflowWorkspaceShell({
   const fullListHref = `/workflows${search.toString() ? `?${search.toString()}` : ''}`;
 
   return (
-    <div className="workflow-workspace-shell" data-jira-issue="MM-997" data-source-issue="MM-975">
+    <div
+      className="workflow-workspace-shell"
+      data-sidebar-collapsed={sidebarOpen ? 'false' : 'true'}
+      data-jira-issue="MM-997 MM-1000"
+      data-source-issue="MM-975"
+    >
       {sidebarOpen ? (
         <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
           <div className="workflow-workspace-sidebar-controls">
@@ -292,6 +299,7 @@ function WorkflowWorkspaceShell({
               type="button"
               className="secondary"
               onClick={() => {
+                updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: true });
                 setSidebarOpen(false);
                 window.setTimeout(() => openButtonRef.current?.focus(), 0);
               }}
@@ -340,6 +348,7 @@ function WorkflowWorkspaceShell({
           type="button"
           className="secondary workflow-workspace-open-sidebar"
           onClick={() => {
+            updateDashboardPreferences({ workflowWorkspaceSidebarCollapsed: false });
             setSidebarOpen(true);
             window.setTimeout(() => closeButtonRef.current?.focus(), 0);
           }}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6482,6 +6482,10 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   margin-inline: auto;
 }
 
+.workflow-workspace-shell[data-sidebar-collapsed="true"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .workflow-workspace-sidebar {
   position: sticky;
   top: 1rem;
@@ -6586,6 +6590,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-open-sidebar {
   justify-self: start;
   align-self: start;
+  margin-bottom: 0.75rem;
 }
 
 @media (max-width: 767px) {
@@ -6597,6 +6602,17 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   .workflow-workspace-sidebar,
   .workflow-workspace-open-sidebar {
     display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-workspace-shell,
+  .workflow-workspace-sidebar,
+  .workflow-workspace-open-sidebar,
+  .workflow-workspace-detail {
+    transition: none !important;
+    animation: none !important;
+    transform: none !important;
   }
 }
 

--- a/frontend/src/utils/dashboardPreferences.test.ts
+++ b/frontend/src/utils/dashboardPreferences.test.ts
@@ -44,6 +44,7 @@ describe('dashboardPreferences', () => {
         liveUpdatesEnabled: false,
         createExpertMode: true,
         debugFieldsVisible: false,
+        workflowWorkspaceSidebarCollapsed: true,
         preferredDetailTab: 'steps',
         defaultRuntime: 'codex_cli',
       });
@@ -55,6 +56,7 @@ describe('dashboardPreferences', () => {
       expect(reloaded.workflowListColumnVisibility.progress).toBe(false);
       expect(reloaded.createExpertMode).toBe(true);
       expect(reloaded.debugFieldsVisible).toBe(false);
+      expect(reloaded.workflowWorkspaceSidebarCollapsed).toBe(true);
       expect(reloaded.preferredDetailTab).toBe('steps');
     });
 
@@ -107,6 +109,7 @@ describe('dashboardPreferences', () => {
             workflowListPageSize: 7, // unsupported page size
             preferredDetailTab: 'nope', // invalid enum
             liveUpdatesEnabled: 'yes', // wrong type
+            workflowWorkspaceSidebarCollapsed: 'yes', // wrong type
             createExpertMode: true, // valid
             workflowListColumnVisibility: { repository: false, bogus: true },
             workflowListDefaultStatuses: ['executing', 42, '  failed  ', ''],
@@ -119,6 +122,7 @@ describe('dashboardPreferences', () => {
       expect(prefs.workflowListPageSize).toBe(DEFAULT_DASHBOARD_PREFERENCES.workflowListPageSize);
       expect(prefs.preferredDetailTab).toBe('overview'); // reset
       expect(prefs.liveUpdatesEnabled).toBe(true); // reset to default
+      expect(prefs.workflowWorkspaceSidebarCollapsed).toBe(false); // reset to default
       expect(prefs.createExpertMode).toBe(true); // kept
       expect(prefs.workflowListColumnVisibility.repository).toBe(false); // kept
       expect(prefs.workflowListColumnVisibility).not.toHaveProperty('bogus'); // dropped
@@ -177,6 +181,14 @@ describe('dashboardPreferences', () => {
       const parsed = JSON.parse(storedRaw() ?? '{}');
       expect(parsed.preferences.workflowListColumnVisibility.progress).toBe(false);
       expect(parsed.preferences.workflowListColumnVisibility).not.toHaveProperty('nextAction');
+    });
+
+    it('MM-1000 keeps a valid persisted workflow workspace sidebar collapse preference', () => {
+      const prefs = sanitizeDashboardPreferences({
+        workflowWorkspaceSidebarCollapsed: true,
+      });
+
+      expect(prefs.workflowWorkspaceSidebarCollapsed).toBe(true);
     });
   });
 

--- a/frontend/src/utils/dashboardPreferences.ts
+++ b/frontend/src/utils/dashboardPreferences.ts
@@ -2,7 +2,7 @@
 //
 // This utility is the single source of truth for operator-tunable dashboard
 // preferences (workflow list columns/density, create-page expert mode default,
-// workflow detail debug visibility, and related defaults). Preferences are
+// workflow detail debug visibility/sidebar layout, and related defaults). Preferences are
 // stored locally in `localStorage` under one versioned key and are always read
 // back through a validation/sanitization pass so a corrupt, partial, or
 // hand-edited blob can never crash the dashboard — invalid values silently fall
@@ -68,6 +68,8 @@ export type DashboardPreferences = {
   createExpertMode: boolean;
   /** Whether diagnostic debug fields are surfaced on the workflow detail page. */
   debugFieldsVisible: boolean;
+  /** Whether the desktop workflow detail sidebar is collapsed on reload. */
+  workflowWorkspaceSidebarCollapsed: boolean;
   /** Preferred default workflow detail tab. */
   preferredDetailTab: WorkflowDetailTab;
   /** Preferred runtime default for the create page, where safe. */
@@ -92,6 +94,7 @@ export const DEFAULT_DASHBOARD_PREFERENCES: DashboardPreferences = {
   liveUpdatesEnabled: true,
   createExpertMode: false,
   debugFieldsVisible: true,
+  workflowWorkspaceSidebarCollapsed: false,
   preferredDetailTab: 'overview',
   defaultRuntime: '',
   defaultProviderProfile: '',
@@ -180,6 +183,10 @@ export function sanitizeDashboardPreferences(value: unknown): DashboardPreferenc
     debugFieldsVisible: sanitizeBoolean(
       value.debugFieldsVisible,
       DEFAULT_DASHBOARD_PREFERENCES.debugFieldsVisible,
+    ),
+    workflowWorkspaceSidebarCollapsed: sanitizeBoolean(
+      value.workflowWorkspaceSidebarCollapsed,
+      DEFAULT_DASHBOARD_PREFERENCES.workflowWorkspaceSidebarCollapsed,
     ),
     preferredDetailTab: sanitizeDetailTab(value.preferredDetailTab),
     defaultRuntime: sanitizeString(value.defaultRuntime),


### PR DESCRIPTION
Issue reference
- MM-1000: Implement sidebar controls and collapsed layout state

Summary
- Persists the desktop workflow workspace sidebar collapsed state through the existing dashboard preferences layer.
- Restores collapsed/open state on desktop detail routes without changing the selected workflow route or refetching selected detail data on reopen.
- Expands the detail layout to a single column while collapsed, keeps mobile detail routing independent of the desktop collapsed preference, and adds reduced-motion guards for workspace sidebar transitions.
- Adds MM-1000 coverage for persistence, reload defaults, reopen focus/refetch behavior, mobile behavior, full-list expansion context, collapsed layout, and reduced-motion CSS.

Tests run
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/utils/dashboardPreferences.test.ts` (blocked: container is missing pytest before Vitest starts)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/utils/dashboardPreferences.test.ts` (blocked in managed job path: Vitest resolves modules to `/frontend/...`)
- `/tmp/moonmind-mm1000-worktree`: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/utils/dashboardPreferences.test.ts` (pass: 155 tests)

Remaining risks
- Full unit wrapper was not runnable in this container because pytest is not installed.
- Targeted Vitest had to run from a colon-free temporary worktree because the managed job path caused Vitest module resolution failures.
