### PR TITLE
MM-1001 Protect mobile workflow standalone behavior

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -637,6 +637,41 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
   });
 
+  it('MM-1001 keeps mobile direct detail links standalone with no sidebar control leakage', async () => {
+    window.history.pushState({}, 'Workspace Mobile Direct Detail Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(false);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            dashboardConfig: {
+              ...stepsPayload.initialData?.dashboardConfig,
+              features: {
+                temporalDashboard: {
+                  workspaceShellEnabled: true,
+                  listEnabled: true,
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Back to workflows' }).getAttribute('href')).toBe('/workflows');
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(document.querySelector('.workflow-workspace-shell')).toBeNull();
+    expect(document.querySelector('.workflow-workspace-sidebar')).toBeNull();
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBeUndefined();
+  });
+
   it('MM-801 renders Overview as a concise summary with route preview cards', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-123?source=temporal');
     mockWorkflowDetailSubrouteFetch();

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -648,7 +648,7 @@ describe('Workflow Detail Entrypoint', () => {
           ...stepsPayload,
           initialData: {
             dashboardConfig: {
-              ...stepsPayload.initialData?.dashboardConfig,
+              ...((stepsPayload.initialData as { dashboardConfig: unknown }).dashboardConfig as Record<string, unknown>),
               features: {
                 temporalDashboard: {
                   workspaceShellEnabled: true,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -117,7 +117,12 @@ function formatWorkflowWorkspaceRelativeTime(iso: string | null | undefined): st
 }
 
 function useWorkflowWorkspaceDesktop(): boolean {
-  const [isDesktop, setIsDesktop] = useState(true);
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return true;
+    }
+    return window.matchMedia(WORKFLOW_WORKSPACE_DESKTOP_MEDIA_QUERY).matches;
+  });
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -5892,6 +5897,14 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     <div className="stack workflow-detail-page">
       <div className="toolbar">
         <div>
+          <a
+            className="breadcrumb-link"
+            href="/workflows"
+            data-jira-issue="MM-1001"
+            data-source-issue="MM-975"
+          >
+            Back to workflows
+          </a>
           <h2 className="page-title">Workflow Detail</h2>
           <div className="toolbar-identity-row">
             <p className="page-meta">Workflow {taskId || '—'}</p>

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1527,6 +1527,47 @@ describe('Workflows Entrypoint', () => {
     expect(detailsLink.closest('.queue-card-actions')).toBeTruthy();
   });
 
+  it('MM-1001 keeps mobile workflow cards, filters, and detail navigation available', async () => {
+    renderWithClient(
+      <WorkflowListPage
+        payload={{
+          ...mockPayload,
+          initialData: {
+            dashboardConfig: {
+              features: {
+                temporalDashboard: {
+                  workspaceShellEnabled: true,
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    await screen.findAllByText('Example task');
+
+    const cardList = document.querySelector('.queue-card-list') as HTMLElement;
+    expect(cardList).toBeTruthy();
+
+    const cardTitle = await within(cardList).findByRole('link', { name: 'Example task' });
+    const detailsLink = within(cardList).getByRole('button', { name: 'View details' });
+
+    expect(cardTitle.getAttribute('href')).toBe('/workflows/task-123?source=temporal');
+    expect(detailsLink.getAttribute('href')).toBe('/workflows/task-123?source=temporal');
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
+
+    openFilterDrawer();
+    fireEvent.change(await screen.findByLabelText('Status filter value'), {
+      target: { value: 'completed' },
+    });
+    applyFilterDrawer();
+
+    expect(await screen.findByRole('button', { name: 'Status filter: completed' })).toBeTruthy();
+    expect(await within(cardList).findByRole('link', { name: 'Example task' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
+  }, 10000);
+
   it('keeps mobile task cards constrained to the viewport width', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 


### PR DESCRIPTION
Issue: MM-1001

Summary:
- Added a visible Back to workflows affordance on the standalone workflow detail page.
- Initialized desktop workspace presentation from matchMedia so mobile direct detail links do not briefly instantiate desktop sidebar state.
- Added mobile regression coverage for workflow list cards, filters, title/View details links, standalone detail rendering, and no sidebar/control accessibility leakage.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx` (blocked: container is missing pytest before the UI target runs).
- `npm ci --no-fund --no-audit`
- `npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx` (blocked before dependency install because vitest was missing from node_modules).
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx` (blocked: Vitest resolved test modules as /frontend/... in this workspace).
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts` (blocked for the same /frontend/... module-resolution issue).

Remaining risks:
- Focused UI tests could not complete in this managed workspace because Vitest resolves frontend test files to /frontend/... paths here. The code diff is limited to the workflow detail/list UI and matching regression tests.
