### PR TITLE
MM-1005 Preserve workflow list context through desktop navigation

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -724,7 +724,7 @@ describe('Workflow Detail Entrypoint', () => {
     window.history.pushState(
       {},
       'Workspace Query Test',
-      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2&selectedWorkflowId=test-123',
+      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2&selectedWorkflowId=test-123&sort=status&unsafe=1',
     );
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -737,6 +737,23 @@ describe('Workflow Detail Entrypoint', () => {
     );
   });
 
+  it('preserves API-style pageSize state when fetching the workspace sidebar', async () => {
+    window.history.pushState(
+      {},
+      'Workspace Page Size Test',
+      '/workflows/test-123?source=temporal&pageSize=100&nextPageToken=page-2&selectedWorkflowId=test-123&sort=status&unsafe=1',
+    );
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    expect(await screen.findByRole('complementary', { name: 'Workflow navigation' })).toBeTruthy();
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
+      '/api/executions?source=temporal&nextPageToken=page-2&pageSize=100',
+    );
+  });
+
   it('MM-1000 persists collapsed sidebar state across desktop detail reloads without changing the route', async () => {
     window.history.pushState({}, 'Workspace Collapse Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -828,7 +828,7 @@ describe('Workflow Detail Entrypoint', () => {
     window.history.pushState(
       {},
       'Workspace Expand Test',
-      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2',
+      '/workflows/test-123?source=temporal&stateIn=completed&repoContains=moon%2Frepo&limit=10&nextPageToken=page-2&sort=status&selectedWorkflowId=test-123&unsafe=1',
     );
     mockDesktopViewport(true);
     mockWorkflowWorkspaceFetches();
@@ -837,8 +837,28 @@ describe('Workflow Detail Entrypoint', () => {
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     const expand = within(sidebar).getByRole('link', { name: 'Expand to full list' });
-    expect(expand.getAttribute('href')).toBe('/workflows?source=temporal&limit=10&nextPageToken=page-2');
+    expect(expand.getAttribute('href')).toBe(
+      '/workflows?stateIn=completed&repoContains=moon%2Frepo&limit=10&returnFromWorkflowDetail=1',
+    );
+    expect(expand.getAttribute('href')).not.toContain('source=');
+    expect(expand.getAttribute('href')).not.toContain('nextPageToken=');
+    expect(expand.getAttribute('href')).not.toContain('sort=');
+    expect(expand.getAttribute('href')).not.toContain('selectedWorkflowId=');
+    expect(expand.getAttribute('href')).not.toContain('unsafe=');
     expect(expand.getAttribute('class') || '').toContain('button');
+  });
+
+  it('MM-1005 expands to the plain workflow list from the desktop workspace when no list context exists', async () => {
+    window.history.pushState({}, 'Workspace Plain Expand Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe(
+      '/workflows',
+    );
   });
 
   it('MM-1000 uses a single-column collapsed workspace layout and reduced-motion guard', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -436,13 +436,13 @@ function WorkflowWorkspaceShell({
   const pinnedCurrentRow = selectedWorkflowQuery.data && !activeInList
     ? workflowWorkspaceRowFromDetail(selectedWorkflowQuery.data)
     : null;
-  const fullListHref = `/workflows${search.toString() ? `?${search.toString()}` : ''}`;
+  const fullListHref = workflowListHrefFromContext(search, { markDetailReturn: true });
 
   return (
     <div
       className="workflow-workspace-shell"
       data-sidebar-collapsed={sidebarOpen ? 'false' : 'true'}
-      data-jira-issue="MM-997 MM-999 MM-1000"
+      data-jira-issue="MM-997 MM-999 MM-1000 MM-1005"
       data-source-issue="MM-975"
     >
       {sidebarOpen ? (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,7 +20,7 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
-import { workflowListHrefFromContext } from '../lib/workflowListContext';
+import { workflowListContextParams, workflowListHrefFromContext } from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -229,8 +229,7 @@ function workflowDetailSubrouteHref(
 }
 
 function workflowWorkspaceListQuery(search: URLSearchParams): string {
-  const params = new URLSearchParams(search);
-  params.delete('selectedWorkflowId');
+  const params = workflowListContextParams(search);
   const pageSize = params.get('limit') || params.get('pageSize') || '25';
   params.delete('limit');
   params.set('pageSize', pageSize);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -229,8 +229,8 @@ function workflowDetailSubrouteHref(
 }
 
 function workflowWorkspaceListQuery(search: URLSearchParams): string {
+  const pageSize = search.get('limit') || search.get('pageSize') || '25';
   const params = workflowListContextParams(search);
-  const pageSize = params.get('limit') || params.get('pageSize') || '25';
   params.delete('limit');
   params.set('pageSize', pageSize);
   return params.toString();


### PR DESCRIPTION
Issue reference: MM-1005

Summary:
- Reuses the existing workflow list context allowlist when constructing the desktop workspace Expand to full list href.
- Drops unsupported detail query state such as source, selectedWorkflowId, unsafe params, unsupported sort, and stale nextPageToken from the full-list return link.
- Adds coverage for preserving supported context and returning to plain /workflows when no list context exists.

Tests run:
- git diff --check origin/main...HEAD
- ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx (blocked: local Python environment is missing pytest before UI tests run)
- npm ci --no-fund --no-audit
- npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx (blocked: npm script cannot find vitest on PATH in this environment)
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx (blocked: Vitest resolves the test module as /frontend/src/entrypoints/workflow-detail.test.tsx in this container)

Remaining risks:
- Focused frontend tests could not complete in this managed container due local test environment/module-resolution issues above; CI should provide the authoritative frontend run.