### PR TITLE
MM-1002 Style and secure workflow sidebar contract

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -431,7 +431,9 @@ describe('Workflow Detail Entrypoint', () => {
     });
   }
 
-  function mockWorkflowWorkspaceFetches() {
+  function mockWorkflowWorkspaceFetches(
+    options: { rows?: Array<Record<string, unknown>> } = {},
+  ) {
     const mockExecution = {
       taskId: 'test-123',
       workflowId: 'test-123',
@@ -459,7 +461,7 @@ describe('Workflow Detail Entrypoint', () => {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            items: [
+            items: options.rows ?? [
               {
                 workflowId: 'test-123',
                 taskId: 'test-123',
@@ -468,6 +470,8 @@ describe('Workflow Detail Entrypoint', () => {
                 status: 'running',
                 state: 'executing',
                 rawState: 'executing',
+                repository: 'MoonLadderStudios/MoonMind',
+                targetRuntime: 'codex_cli',
                 createdAt: '2026-04-09T00:00:00Z',
               },
               {
@@ -478,6 +482,8 @@ describe('Workflow Detail Entrypoint', () => {
                 status: 'completed',
                 state: 'completed',
                 rawState: 'completed',
+                repository: 'octo/widgets',
+                targetRuntime: 'claude_code',
                 createdAt: '2026-04-08T00:00:00Z',
               },
             ],
@@ -554,6 +560,65 @@ describe('Workflow Detail Entrypoint', () => {
     expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
       '/api/executions?source=temporal&nextPageToken=page-2&pageSize=10',
     );
+  });
+
+  it('MM-1002 keeps sidebar API and full-list navigation within allowlisted workflow context', async () => {
+    window.history.pushState(
+      {},
+      'Workspace Sidebar Security Test',
+      '/workflows/test-123?source=temporal&limit=10&nextPageToken=page-2&repoContains=moon%2Frepo&selectedWorkflowId=test-123&sort=status&token=secret&unsafe=1',
+    );
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe(
+      '/api/executions?source=temporal&nextPageToken=page-2&repoContains=moon%2Frepo&pageSize=10',
+    );
+    const anotherWorkflow = await within(sidebar).findByRole('link', { name: /Another workflow/i });
+    expect(anotherWorkflow.getAttribute('href')).toBe(
+      '/workflows/test-456?source=temporal&limit=10&nextPageToken=page-2&repoContains=moon%2Frepo',
+    );
+    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expandLink.getAttribute('href')).toBe(
+      '/workflows?limit=10&repoContains=moon%2Frepo&returnFromWorkflowDetail=1',
+    );
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('selectedWorkflowId=');
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('sort=');
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).not.toContain('token=');
+    expect(expandLink.getAttribute('href')).not.toContain('token=');
+  });
+
+  it('MM-1002 renders sidebar titles, repositories, runtimes, and statuses as React text', async () => {
+    window.history.pushState({}, 'Workspace Sidebar Text Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches({
+      rows: [
+        {
+          workflowId: 'test-123',
+          taskId: 'test-123',
+          title: '<img src=x onerror=alert(1)>',
+          status: '<script>alert(1)</script>',
+          state: '<script>alert(1)</script>',
+          rawState: '<script>alert(1)</script>',
+          repository: '<b>owner/repo</b>',
+          targetRuntime: 'codex_cli',
+          createdAt: '2026-04-09T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(within(sidebar).getByText('<img src=x onerror=alert(1)>')).toBeTruthy();
+    expect(within(sidebar).getByText('<b>owner/repo</b>')).toBeTruthy();
+    expect(within(sidebar).getByText('Codex CLI')).toBeTruthy();
+    expect(within(sidebar).getAllByText('<script>alert(1)</script>').length).toBeGreaterThan(0);
+    expect(within(sidebar).queryByRole('img')).toBeNull();
+    expect(sidebar.querySelector('script')).toBeNull();
   });
 
   it('MM-997 keeps workflow detail standalone when the workflow list is disabled', async () => {
@@ -4819,6 +4884,28 @@ describe('Workflow Detail Entrypoint', () => {
     expect(dashboardCss).toMatch(/\.td-remediation-list\s+\.card\s*\{[^}]*min-width:\s*0;[^}]*max-width:\s*100%;/s);
     expect(dashboardCss).toMatch(/@media\s*\(max-width:\s*720px\)\s*\{[^}]*\.td-remediation-region/s);
     expect(dashboardCss).toMatch(/\.td-remediation-list\s+code\s*\{[^}]*overflow-wrap:\s*anywhere;/s);
+  });
+
+  it('MM-1002 keeps workflow sidebar rows matte, bounded, and reduced-motion aware in CSS', async () => {
+    const { readFileSync } = await import('node:fs');
+    const dashboardCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/dashboard.css`,
+      'utf8',
+    );
+
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-shell\s*\{[^}]*grid-template-columns:\s*minmax\(17\.5rem,\s*21rem\)\s+minmax\(0,\s*1fr\);/s,
+    );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-sidebar\s*\{[^}]*border-right-color:\s*rgb\(var\(--mm-border\) \/ 0\.92\);/s,
+    );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-sidebar-row\s*\{[^}]*background:\s*rgb\(var\(--mm-panel\) \/ 0\.92\);/s,
+    );
+    expect(dashboardCss).toMatch(
+      /\.workflow-workspace-sidebar-row\[aria-current="page"\]\s*\{[^}]*box-shadow:\s*inset 4px 0 0 rgb\(var\(--mm-accent\)\);/s,
+    );
+    expect(dashboardCss).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^}]*\.workflow-workspace-sidebar-row/s);
   });
 
   it('renders workflow detail as separated matte evidence and action regions', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -613,7 +613,7 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(within(sidebar).getByText('<img src=x onerror=alert(1)>')).toBeTruthy();
+    expect(await within(sidebar).findByText('<img src=x onerror=alert(1)>')).toBeTruthy();
     expect(within(sidebar).getByText('<b>owner/repo</b>')).toBeTruthy();
     expect(within(sidebar).getByText('Codex CLI')).toBeTruthy();
     expect(within(sidebar).getAllByText('<script>alert(1)</script>').length).toBeGreaterThan(0);

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -20,7 +20,11 @@ import {
   taskEditForRerunHref,
   taskEditHref,
 } from '../lib/temporalTaskEditing';
-import { workflowListHrefFromContext } from '../lib/workflowListContext';
+import {
+  workflowDetailHref,
+  workflowListContextParams,
+  workflowListHrefFromContext,
+} from '../lib/workflowListContext';
 import { WorkflowActionsMenu } from '../components/WorkflowActionsMenu';
 import {
   buildRemediationRuntimeRequestFields,
@@ -211,9 +215,8 @@ function workflowDetailSubrouteHref(
 }
 
 function workflowWorkspaceListQuery(search: URLSearchParams): string {
-  const params = new URLSearchParams(search);
-  params.delete('selectedWorkflowId');
-  const pageSize = params.get('limit') || params.get('pageSize') || '25';
+  const params = workflowListContextParams(search);
+  const pageSize = params.get('limit') || '25';
   params.delete('limit');
   params.set('pageSize', pageSize);
   return params.toString();
@@ -222,19 +225,23 @@ function workflowWorkspaceListQuery(search: URLSearchParams): string {
 function WorkflowSidebarRow({
   row,
   activeWorkflowId,
+  search,
 }: {
   row: WorkflowWorkspaceRow;
   activeWorkflowId: string;
+  search: URLSearchParams;
 }) {
   const workflowId = workflowWorkspaceRowId(row);
   const active = workflowId === activeWorkflowId;
   const status = row.rawState || row.state || row.status || 'unknown';
   const title = row.title?.trim() || workflowId || 'Untitled workflow';
+  const repository = row.repository?.trim();
+  const runtime = formatRuntimeLabel(row.targetRuntime);
   return (
     <li>
       <a
         className="workflow-workspace-sidebar-row"
-        href={`/workflows/${encodeURIComponent(workflowId)}?source=temporal`}
+        href={workflowDetailHref(workflowId, search)}
         aria-current={active ? 'page' : undefined}
         data-active={active ? 'true' : 'false'}
       >
@@ -242,6 +249,11 @@ function WorkflowSidebarRow({
           <span className="workflow-workspace-sidebar-title">{title}</span>
           <span className="workflow-workspace-sidebar-meta">
             {formatWorkflowWorkspaceRelativeTime(workflowWorkspaceRowUpdatedAt(row))}
+          </span>
+          <span className="workflow-workspace-sidebar-labels" aria-label="Workflow metadata">
+            {repository ? <span>{repository}</span> : null}
+            {runtime !== '—' ? <span>{runtime}</span> : null}
+            <span>{formatStatusLabel(status)}</span>
           </span>
         </span>
         <ExecutionStatusPill status={status} />
@@ -281,10 +293,10 @@ function WorkflowWorkspaceShell({
   const rows = workflowsQuery.data?.items || [];
   const activeInList = rows.some((row) => workflowWorkspaceRowId(row) === workflowId);
   const filteredRows = rows.filter((row) => workflowWorkspaceRowId(row));
-  const fullListHref = `/workflows${search.toString() ? `?${search.toString()}` : ''}`;
+  const fullListHref = workflowListHrefFromContext(search, { markDetailReturn: true });
 
   return (
-    <div className="workflow-workspace-shell" data-jira-issue="MM-997" data-source-issue="MM-975">
+    <div className="workflow-workspace-shell" data-jira-issue="MM-1002" data-source-issue="MM-975">
       {sidebarOpen ? (
         <aside className="workflow-workspace-sidebar" aria-label="Workflow navigation">
           <div className="workflow-workspace-sidebar-controls">
@@ -330,6 +342,7 @@ function WorkflowWorkspaceShell({
                   key={workflowWorkspaceRowId(row)}
                   row={row}
                   activeWorkflowId={workflowId}
+                  search={search}
                 />
               ))}
             </ul>

--- a/frontend/src/lib/workflowListContext.test.ts
+++ b/frontend/src/lib/workflowListContext.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { workflowListContextParams } from "./workflowListContext";
+
+describe("workflowListContextParams", () => {
+  it("preserves supported workflow list filters for detail sidebar queries", () => {
+    const params = workflowListContextParams(
+      new URLSearchParams(
+        "source=temporal&integration=jira&repo=MoonMind&state=executing&limit=10",
+      ),
+    );
+
+    expect(params.toString()).toBe(
+      "source=temporal&integration=jira&repo=MoonMind&state=executing&limit=10",
+    );
+  });
+
+  it("drops parameters that are not part of the workflow list context", () => {
+    const params = workflowListContextParams(
+      new URLSearchParams("integration=jira&unknown=value"),
+    );
+
+    expect(params.toString()).toBe("integration=jira");
+  });
+});

--- a/frontend/src/lib/workflowListContext.ts
+++ b/frontend/src/lib/workflowListContext.ts
@@ -15,6 +15,7 @@ const WORKFLOW_LIST_CONTEXT_ALLOWLIST = new Set([
   'repoContains',
   'repoExact',
   'repo',
+  'integration',
   'targetRuntimeIn',
   'targetRuntimeNotIn',
   'targetRuntimeBlank',

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6494,6 +6494,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   border-radius: 0.8rem;
   background: var(--mm-glass-fill);
   box-shadow: var(--mm-elevation-panel);
+  border-right-color: rgb(var(--mm-border) / 0.92);
   padding: 0.75rem;
 }
 
@@ -6517,20 +6518,25 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   list-style: none;
   padding: 0;
   margin: 0;
+  scrollbar-gutter: stable;
 }
 
 .workflow-workspace-sidebar-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
+  align-items: start;
   gap: 0.55rem;
   min-height: 3.75rem;
   padding: 0.62rem;
-  border: 1px solid rgb(var(--mm-border) / 0.58);
+  border: 1px solid rgb(var(--mm-border) / 0.68);
   border-radius: 0.55rem;
-  background: rgb(var(--mm-panel) / 0.78);
+  background: rgb(var(--mm-panel) / 0.92);
   color: rgb(var(--mm-ink));
   text-decoration: none;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
 }
 
 .workflow-workspace-sidebar-row:hover,
@@ -6565,12 +6571,34 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-size: 0.82rem;
 }
 
+.workflow-workspace-sidebar-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  color: rgb(var(--mm-muted));
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.workflow-workspace-sidebar-labels span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-workspace-sidebar-labels span:not(:last-child)::after {
+  content: "|";
+  margin-left: 0.25rem;
+  color: rgb(var(--mm-muted) / 0.72);
+}
+
 .workflow-workspace-current-row,
 .workflow-workspace-sidebar-state {
   border: 1px dashed rgb(var(--mm-border) / 0.75);
   border-radius: 0.55rem;
   padding: 0.65rem;
-  background: rgb(var(--mm-panel) / 0.62);
+  background: rgb(var(--mm-panel) / 0.88);
 }
 
 .workflow-workspace-current-row {
@@ -6586,6 +6614,13 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 .workflow-workspace-open-sidebar {
   justify-self: start;
   align-self: start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-workspace-sidebar-row,
+  .workflow-workspace-sidebar {
+    transition-duration: 1ms;
+  }
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Issue reference: MM-1002

Summary:
- Hardened workflow sidebar list/detail URL construction to use the allowlisted workflow list context helper.
- Added repository, runtime, and status labels to sidebar rows while preserving React text rendering.
- Refined sidebar styling for matte readable rows, stronger visual boundary, active state, stable scrolling, and reduced-motion behavior.

Tests run:
- npm ci --no-fund --no-audit
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx (failed in managed workspace path because Vitest resolved the colon-containing path incorrectly)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx (blocked: Python pytest is not installed in this container)
- /tmp/mmrepo-mm-1002-copy/node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx (passed: 139 tests)

Remaining risks:
- Focused frontend coverage passed from a temporary clean-path copy because the managed workspace path contains a colon that breaks Vitest test-file resolution.
- Full unit suite was not run because pytest is not installed in this container.
