### PR TITLE
MM-1014 Add chat session projection

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8458,6 +8458,136 @@ describe('LiveLogsPanel', () => {
     expect(screen.getByText('Turn interrupted')).toBeTruthy();
   });
 
+  it('MM-1014 renders chat session blocks, updates paired rows, streams live rows through the same projection, and exposes raw timeline', async () => {
+    const events = [
+      {
+        sequence: 1,
+        timestamp: '2026-04-08T00:00:01Z',
+        stream: 'session',
+        kind: 'user_message_submitted',
+        text: 'Please inspect the run.',
+        turn_id: 'turn-mm-1014',
+      },
+      {
+        sequence: 2,
+        timestamp: '2026-04-08T00:00:02Z',
+        stream: 'session',
+        kind: 'assistant_message',
+        text: 'I will inspect the run.',
+        turn_id: 'turn-mm-1014',
+      },
+      {
+        sequence: 3,
+        timestamp: '2026-04-08T00:00:03Z',
+        stream: 'session',
+        kind: 'tool_call_started',
+        text: 'exec_command: rg -n MM-1014',
+        turn_id: 'turn-mm-1014',
+        metadata: { toolCallId: 'tool-1', toolName: 'exec_command' },
+      },
+      {
+        sequence: 4,
+        timestamp: '2026-04-08T00:00:04Z',
+        stream: 'session',
+        kind: 'tool_call_output',
+        text: 'MM-1014 evidence line',
+        turn_id: 'turn-mm-1014',
+        metadata: { toolCallId: 'tool-1' },
+      },
+      {
+        sequence: 5,
+        timestamp: '2026-04-08T00:00:05Z',
+        stream: 'session',
+        kind: 'approval_requested',
+        text: 'Approval requested for command execution.',
+        turn_id: 'turn-mm-1014',
+        metadata: { requestId: 'approval-1' },
+      },
+      {
+        sequence: 6,
+        timestamp: '2026-04-08T00:00:06Z',
+        stream: 'session',
+        kind: 'approval_granted',
+        text: 'Approval granted by operator.',
+        turn_id: 'turn-mm-1014',
+        metadata: { requestId: 'approval-1' },
+      },
+      {
+        sequence: 7,
+        timestamp: '2026-04-08T00:00:07Z',
+        stream: 'session',
+        kind: 'session_cleared',
+        text: 'Session cleared before the next turn.',
+        metadata: { controlEventRef: 'art-control' },
+      },
+    ];
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: true,
+              liveStreamStatus: 'available',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events, truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => activeExecution } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-session-viewer')).toBeTruthy();
+      expect(screen.getByText('Please inspect the run.')).toBeTruthy();
+      expect(screen.getByText('I will inspect the run.')).toBeTruthy();
+      expect(screen.getByText('exec_command')).toBeTruthy();
+      expect(screen.getByText('MM-1014 evidence line')).toBeTruthy();
+      expect(screen.getByText('Approval requested for command execution.')).toBeTruthy();
+      expect(screen.getByText('Approval granted by operator.')).toBeTruthy();
+      expect(screen.getByText('Session cleared before the next turn.')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Raw Timeline')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+    fireEvent.click(screen.getByText('Raw Timeline'));
+    await waitFor(() => expect(screen.getByTestId('live-logs-timeline-viewer')).toBeTruthy());
+
+    await waitForEventSourceInstance();
+    const es = MockEventSource.instances.at(-1)!;
+    act(() => es.triggerOpen());
+    act(() =>
+      es.triggerLogChunk({
+        sequence: 8,
+        stream: 'session',
+        kind: 'assistant_message',
+        text: 'Live assistant update.',
+        turn_id: 'turn-mm-1014-live',
+      }),
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Live assistant update.').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('[data-chat-block-type="approval"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-chat-block-type="tool"]')).toHaveLength(1);
+  });
+
   it('renders inline artifact links for publication and clear-reset timeline rows', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8507,8 +8507,8 @@ describe('LiveLogsPanel', () => {
         sequence: 6,
         timestamp: '2026-04-08T00:00:06Z',
         stream: 'session',
-        kind: 'approval_granted',
-        text: 'Approval granted by operator.',
+        kind: 'approval_resolved',
+        text: 'Approval resolved by operator.',
         turn_id: 'turn-mm-1014',
         metadata: { requestId: 'approval-1' },
       },
@@ -8561,7 +8561,7 @@ describe('LiveLogsPanel', () => {
       expect(screen.getByText('exec_command')).toBeTruthy();
       expect(screen.getByText('MM-1014 evidence line')).toBeTruthy();
       expect(screen.getByText('Approval requested for command execution.')).toBeTruthy();
-      expect(screen.getByText('Approval granted by operator.')).toBeTruthy();
+      expect(screen.getByText('Approval resolved by operator.')).toBeTruthy();
       expect(screen.getByText('Session cleared before the next turn.')).toBeTruthy();
     });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2362,7 +2362,7 @@ const OPERATOR_ATTENTION_EVENT_KINDS = new Set([
 
 export function classifyTimelineRow(event: ObservabilityEvent): TimelineRow['rowType'] {
   const kind = event.kind ?? '';
-  if (kind === 'session_reset_boundary') {
+  if (kind === 'session_reset_boundary' || kind === 'session_cleared') {
     return 'boundary';
   }
   if (USER_MESSAGE_EVENT_KINDS.has(kind)) {
@@ -2426,6 +2426,201 @@ function mapEventsToTimelineRows(
 ): TimelineRow[] {
   if (!payload) return [];
   return payload.events.flatMap((event) => eventToTimelineRows(event));
+}
+
+type ChatBlockBase = {
+  id: string;
+  rows: TimelineRow[];
+  timestamp: string | null;
+  turnId: string | null;
+};
+
+type ChatToolOutput = {
+  id: string;
+  text: string;
+  kind: string | null;
+};
+
+type ChatBlock =
+  | (ChatBlockBase & { type: 'user' | 'assistant' | 'boundary' | 'status'; text: string })
+  | (ChatBlockBase & {
+      type: 'tool';
+      title: string;
+      status: 'running' | 'completed' | 'failed';
+      outputs: ChatToolOutput[];
+    })
+  | (ChatBlockBase & {
+      type: 'approval';
+      text: string;
+      status: 'pending' | 'granted' | 'denied' | 'resolved';
+    });
+
+type ChatSessionReducerState = {
+  blocks: ChatBlock[];
+  latestToolBlockIdByKey: Map<string, string>;
+  latestToolBlockIdByTurn: Map<string, string>;
+  latestApprovalBlockIdByKey: Map<string, string>;
+  latestApprovalBlockId: string | null;
+};
+
+function emptyChatSessionReducerState(): ChatSessionReducerState {
+  return {
+    blocks: [],
+    latestToolBlockIdByKey: new Map(),
+    latestToolBlockIdByTurn: new Map(),
+    latestApprovalBlockIdByKey: new Map(),
+    latestApprovalBlockId: null,
+  };
+}
+
+function chatMetadataString(row: TimelineRow, ...keys: string[]): string {
+  return metadataString(row.metadata, ...keys);
+}
+
+function toolCorrelationKey(row: TimelineRow): string | null {
+  const explicit = chatMetadataString(row, 'toolCallId', 'tool_call_id', 'callId', 'call_id', 'requestId', 'request_id');
+  if (explicit) return explicit;
+  const name = chatMetadataString(row, 'toolName', 'tool_name', 'name');
+  if (name && row.turnId) return `${row.turnId}:${name}`;
+  return row.turnId;
+}
+
+function approvalCorrelationKey(row: TimelineRow): string | null {
+  const explicit = chatMetadataString(row, 'approvalRequestId', 'approval_request_id', 'requestId', 'request_id', 'interventionId', 'intervention_id');
+  if (explicit) return explicit;
+  return row.turnId;
+}
+
+function replaceChatBlock(blocks: ChatBlock[], id: string, updater: (block: ChatBlock) => ChatBlock): ChatBlock[] {
+  return blocks.map((block) => (block.id === id ? updater(block) : block));
+}
+
+function appendChatBlock(state: ChatSessionReducerState, block: ChatBlock): ChatSessionReducerState {
+  return {
+    ...state,
+    blocks: [...state.blocks, block],
+  };
+}
+
+function chatSessionReducer(state: ChatSessionReducerState, row: TimelineRow): ChatSessionReducerState {
+  if (row.rowType === 'fallback' || row.rowType === 'output' || row.rowType === 'system') {
+    return state;
+  }
+
+  if (row.rowType === 'tool') {
+    const key = toolCorrelationKey(row);
+    const turnKey = row.turnId ?? row.activeTurnId;
+    const previousBlockId =
+      (key ? state.latestToolBlockIdByKey.get(key) : null)
+      ?? (turnKey && row.kind !== 'tool_call_started' ? state.latestToolBlockIdByTurn.get(turnKey) : null);
+
+    if (row.kind === 'tool_call_output' && previousBlockId) {
+      return {
+        ...state,
+        blocks: replaceChatBlock(state.blocks, previousBlockId, (block) => {
+          if (block.type !== 'tool') return block;
+          return {
+            ...block,
+            rows: [...block.rows, row],
+            outputs: [...block.outputs, { id: row.id, text: row.text, kind: row.kind }],
+          };
+        }),
+      };
+    }
+
+    if ((row.kind === 'tool_call_completed' || row.kind === 'tool_call_failed') && previousBlockId) {
+      return {
+        ...state,
+        blocks: replaceChatBlock(state.blocks, previousBlockId, (block) => {
+          if (block.type !== 'tool') return block;
+          return {
+            ...block,
+            rows: [...block.rows, row],
+            status: row.kind === 'tool_call_failed' ? 'failed' : 'completed',
+          };
+        }),
+      };
+    }
+
+    const block: ChatBlock = {
+      id: `chat-tool-${row.id}`,
+      type: 'tool',
+      rows: [row],
+      timestamp: row.timestamp,
+      turnId: row.turnId,
+      title: chatMetadataString(row, 'toolName', 'tool_name', 'name') || row.text || 'Tool call',
+      status: row.kind === 'tool_call_failed' ? 'failed' : row.kind === 'tool_call_completed' ? 'completed' : 'running',
+      outputs: row.kind === 'tool_call_output' ? [{ id: row.id, text: row.text, kind: row.kind }] : [],
+    };
+    const nextState = appendChatBlock(state, block);
+    if (key) nextState.latestToolBlockIdByKey = new Map(nextState.latestToolBlockIdByKey).set(key, block.id);
+    if (turnKey) nextState.latestToolBlockIdByTurn = new Map(nextState.latestToolBlockIdByTurn).set(turnKey, block.id);
+    return nextState;
+  }
+
+  if (row.rowType === 'approval') {
+    const key = approvalCorrelationKey(row);
+    const previousBlockId = key ? state.latestApprovalBlockIdByKey.get(key) : state.latestApprovalBlockId;
+    const resolvedStatus =
+      row.kind === 'approval_granted'
+        ? 'granted'
+        : row.kind === 'approval_denied'
+          ? 'denied'
+          : row.kind === 'intervention_resolved'
+            ? 'resolved'
+            : null;
+
+    if (resolvedStatus && previousBlockId) {
+      return {
+        ...state,
+        blocks: replaceChatBlock(state.blocks, previousBlockId, (block) => {
+          if (block.type !== 'approval') return block;
+          return {
+            ...block,
+            rows: [...block.rows, row],
+            text: block.text || row.text,
+            status: resolvedStatus,
+          };
+        }),
+      };
+    }
+
+    const block: ChatBlock = {
+      id: `chat-approval-${row.id}`,
+      type: 'approval',
+      rows: [row],
+      timestamp: row.timestamp,
+      turnId: row.turnId,
+      text: row.text,
+      status: resolvedStatus ?? 'pending',
+    };
+    const nextState = appendChatBlock(state, block);
+    if (key) nextState.latestApprovalBlockIdByKey = new Map(nextState.latestApprovalBlockIdByKey).set(key, block.id);
+    nextState.latestApprovalBlockId = block.id;
+    return nextState;
+  }
+
+  const blockType =
+    row.rowType === 'user'
+      ? 'user'
+      : row.rowType === 'assistant'
+        ? 'assistant'
+        : row.rowType === 'boundary'
+          ? 'boundary'
+          : 'status';
+
+  return appendChatBlock(state, {
+    id: `chat-${blockType}-${row.id}`,
+    type: blockType,
+    rows: [row],
+    timestamp: row.timestamp,
+    turnId: row.turnId,
+    text: row.text,
+  });
+}
+
+export function reduceTimelineRowsToChatBlocks(rows: TimelineRow[]): ChatBlock[] {
+  return rows.reduce(chatSessionReducer, emptyChatSessionReducerState()).blocks;
 }
 
 function deriveSessionSnapshotFromEvent(
@@ -2976,6 +3171,173 @@ function renderTimelineRow(
         {renderTimelineRowText(row, timelineViewerEnabled)}
       </div>
       <TimelineArtifactLinks links={artifactLinks} />
+    </div>
+  );
+}
+
+function chatBlockLabel(block: ChatBlock): string {
+  const firstRow = block.rows[0];
+  const treatmentLabel = firstRow ? getTimelineRowTreatmentLabel(firstRow) : null;
+  if (treatmentLabel) return treatmentLabel;
+  if (block.type === 'user') return 'User';
+  if (block.type === 'assistant') return 'Assistant';
+  if (block.type === 'tool') return 'Tool';
+  if (block.type === 'approval') return 'Approval';
+  if (block.type === 'boundary') return 'Session boundary';
+  return 'Status';
+}
+
+function chatBlockKindLabel(block: ChatBlock): string | null {
+  const kind = block.rows.at(-1)?.kind;
+  return kind ? kind.replaceAll('_', ' ') : null;
+}
+
+function chatBlockArtifactLinks(block: ChatBlock, apiBase: string): TimelineArtifactLink[] {
+  const links = block.rows.flatMap((row) => buildTimelineArtifactLinks(row, apiBase));
+  const seen = new Set<string>();
+  return links.filter((link) => {
+    if (seen.has(link.key)) return false;
+    seen.add(link.key);
+    return true;
+  });
+}
+
+function renderChatBlock(block: ChatBlock, wrapLines: boolean, apiBase: string): ReactNode {
+  const className = [
+    'chat-session-block',
+    `chat-session-block-${block.type}`,
+    wrapLines ? 'is-wrapped' : 'is-unwrapped',
+  ].join(' ');
+  const roleLabel = chatBlockLabel(block);
+  const kindLabel = chatBlockKindLabel(block);
+  const displayKindLabel = kindLabel && kindLabel.toLowerCase() !== roleLabel.toLowerCase() ? kindLabel : null;
+  const artifactLinks = chatBlockArtifactLinks(block, apiBase);
+
+  if (block.type === 'tool') {
+    return (
+      <div key={block.id} className={className} data-chat-block-type="tool">
+        <div className="chat-session-block-heading">
+          <span className="chat-session-role-label">{roleLabel}</span>
+          <span className={`chat-session-status-chip chat-session-status-${block.status}`}>{block.status}</span>
+          {displayKindLabel ? <span className="chat-session-kind-chip">{displayKindLabel}</span> : null}
+        </div>
+        <div
+          className="chat-session-block-text"
+          data-kind={block.rows[0]?.kind ?? undefined}
+          data-row-type="tool"
+        >
+          {block.title}
+        </div>
+        {block.rows.length > 1 ? (
+          <div className="chat-session-tool-events">
+            {block.rows
+              .filter((row) => row.kind !== 'tool_call_output' && row.id !== block.rows[0]?.id)
+              .map((row) => (
+                <div
+                  key={row.id}
+                  className="chat-session-tool-event"
+                  data-kind={row.kind ?? undefined}
+                  data-row-type="tool"
+                >
+                  {getTimelineRowTreatmentLabel(row) ? (
+                    <span className="chat-session-kind-chip">{getTimelineRowTreatmentLabel(row)}</span>
+                  ) : null}
+                  <span>{row.text}</span>
+                </div>
+              ))}
+          </div>
+        ) : null}
+        {block.outputs.length > 0 ? (
+          <details className="chat-session-tool-output" open={block.status !== 'running'}>
+            <summary>
+              <span>Tool output</span> <span>({block.outputs.length})</span>
+            </summary>
+            <div className="chat-session-tool-output-body">
+              {block.outputs.map((output) => (
+                <pre key={output.id} data-kind={output.kind ?? undefined} data-row-type="tool">{output.text}</pre>
+              ))}
+            </div>
+          </details>
+        ) : null}
+        <TimelineArtifactLinks links={artifactLinks} />
+      </div>
+    );
+  }
+
+  if (block.type === 'approval') {
+    return (
+      <div key={block.id} className={className} data-chat-block-type="approval">
+        <div className="chat-session-block-heading">
+          <span className="chat-session-role-label">{roleLabel}</span>
+          <span className={`chat-session-status-chip chat-session-status-${block.status}`}>{block.status}</span>
+          {displayKindLabel ? <span className="chat-session-kind-chip">{displayKindLabel}</span> : null}
+        </div>
+        <div
+          className="chat-session-block-text"
+          data-kind={block.rows[0]?.kind ?? undefined}
+          data-row-type="approval"
+        >
+          {block.text}
+        </div>
+        {block.rows.length > 1 ? (
+          <div className="chat-session-resolution-text">{block.rows.at(-1)?.text}</div>
+        ) : null}
+        <TimelineArtifactLinks links={artifactLinks} />
+      </div>
+    );
+  }
+
+  return (
+    <div key={block.id} className={className} data-chat-block-type={block.type}>
+      <div className="chat-session-block-heading">
+        <span className="chat-session-role-label">{roleLabel}</span>
+        {displayKindLabel ? <span className="chat-session-kind-chip">{displayKindLabel}</span> : null}
+      </div>
+      <div
+        className="chat-session-block-text"
+        data-kind={block.rows[0]?.kind ?? undefined}
+        data-row-type={block.rows[0]?.rowType}
+      >
+        {block.text}
+      </div>
+      <TimelineArtifactLinks links={artifactLinks} />
+    </div>
+  );
+}
+
+function ChatSessionView({
+  apiBase,
+  chatBlocks,
+  rows,
+  wrapLines,
+}: {
+  apiBase: string;
+  chatBlocks: ChatBlock[];
+  rows: TimelineRow[];
+  wrapLines: boolean;
+}) {
+  const hasFallbackRows = rows.some((row) => row.rowType === 'fallback' || row.rowType === 'output');
+
+  return (
+    <div className="chat-session-view" aria-label="Chat session projection">
+      <div className="chat-session-header">
+        <div>
+          <h3>Chat Session</h3>
+          <p className="small">Messages, tools, approvals, status, and session boundaries.</p>
+        </div>
+        {hasFallbackRows ? (
+          <span className="chat-session-fallback-chip">Raw history fallback active</span>
+        ) : null}
+      </div>
+      {chatBlocks.length === 0 ? (
+        <div className="chat-session-empty">
+          Structured chat projection is unavailable for these rows. Use Raw Timeline for durable history.
+        </div>
+      ) : (
+        <div className="chat-session-blocks">
+          {chatBlocks.map((block) => renderChatBlock(block, wrapLines, apiBase))}
+        </div>
+      )}
     </div>
   );
 }
@@ -3711,6 +4073,8 @@ function LiveLogsPanel({
   const esRef = useRef<EventSource | null>(null);
   const isTerminalRef = useRef(isTerminal);
   const [sessionSnapshot, setSessionSnapshot] = useState<SessionSnapshot | null>(null);
+  const [rawTimelineExpanded, setRawTimelineExpanded] = useState(false);
+  const chatBlocks = useMemo(() => reduceTimelineRowsToChatBlocks(logContent), [logContent]);
 
   // Keep isTerminalRef current so the onerror handler always sees the latest value.
   useEffect(() => {
@@ -3722,6 +4086,7 @@ function LiveLogsPanel({
     setLogContent([]);
     lastSeqRef.current = null;
     setViewerState('starting');
+    setRawTimelineExpanded(false);
   }, [agentRunId]);
 
   useEffect(() => {
@@ -3971,6 +4336,7 @@ function LiveLogsPanel({
         ['Live', liveStatusValue],
       ].filter(([, value]) => value) as Array<[string, string]>
     : [];
+  const showRawTimeline = rawTimelineExpanded || (sessionTimelineEnabled && logContent.length > 0 && chatBlocks.length === 0);
 
   const panelBody = (
     <div className="stack live-logs-panel">
@@ -4006,13 +4372,25 @@ function LiveLogsPanel({
         {logContent.length === 0 ? (
           <div className="live-logs-empty">{emptyLabel}</div>
         ) : sessionTimelineEnabled ? (
-          <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
-            <Virtuoso
-              style={{ height: 400 }}
-              data={logContent}
-              computeItemKey={(_, row) => row.id}
-              itemContent={(_, row) => renderTimelineRow(row, wrapLines, true, apiBase)}
-            />
+          <div data-testid="chat-session-viewer" className="chat-session-viewer">
+            <ChatSessionView apiBase={apiBase} chatBlocks={chatBlocks} rows={logContent} wrapLines={wrapLines} />
+            <details
+              className="raw-timeline-escape-hatch"
+              open={showRawTimeline}
+              onToggle={(event) => setRawTimelineExpanded(event.currentTarget.open)}
+            >
+              <summary>Raw Timeline</summary>
+              {showRawTimeline ? (
+                <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
+                  <Virtuoso
+                    style={{ height: 400 }}
+                    data={logContent}
+                    computeItemKey={(_, row) => row.id}
+                    itemContent={(_, row) => renderTimelineRow(row, wrapLines, true, apiBase)}
+                  />
+                </div>
+              ) : null}
+            </details>
           </div>
         ) : (
           <div data-testid="live-logs-legacy-viewer" className="live-logs-legacy-viewer">

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2354,6 +2354,7 @@ const TURN_BOUNDARY_EVENT_KINDS = new Set(['turn_started', 'turn_completed']);
 const TURN_FAILURE_EVENT_KINDS = new Set(['turn_failed', 'turn_interrupted']);
 const OPERATOR_ATTENTION_EVENT_KINDS = new Set([
   'approval_requested',
+  'approval_resolved',
   'approval_granted',
   'approval_denied',
   'intervention_requested',
@@ -2566,7 +2567,7 @@ function chatSessionReducer(state: ChatSessionReducerState, row: TimelineRow): C
         ? 'granted'
         : row.kind === 'approval_denied'
           ? 'denied'
-          : row.kind === 'intervention_resolved'
+          : row.kind === 'approval_resolved' || row.kind === 'intervention_resolved'
             ? 'resolved'
             : null;
 

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4294,6 +4294,236 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   color: rgb(232 234 240 / 0.8);
 }
 
+.chat-session-viewer {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.chat-session-view {
+  display: grid;
+  gap: 0.75rem;
+  font-family: var(--mm-font-sans);
+}
+
+.chat-session-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.chat-session-header h3 {
+  margin: 0;
+  color: rgb(255 255 255 / 0.94);
+  font-size: 0.95rem;
+}
+
+.chat-session-header p {
+  margin: 0.2rem 0 0;
+  color: rgb(232 234 240 / 0.72);
+}
+
+.chat-session-fallback-chip,
+.chat-session-kind-chip,
+.chat-session-status-chip,
+.chat-session-role-label {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.14rem 0.5rem;
+  font-size: 0.62rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.chat-session-fallback-chip {
+  flex-shrink: 0;
+  background: rgb(var(--mm-warn) / 0.18);
+  color: rgb(255 240 194);
+}
+
+.chat-session-empty {
+  border: 1px dashed rgb(255 255 255 / 0.2);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  color: rgb(232 234 240 / 0.8);
+}
+
+.chat-session-blocks {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.chat-session-block {
+  display: grid;
+  max-width: min(100%, 54rem);
+  gap: 0.45rem;
+  border: 1px solid rgb(255 255 255 / 0.13);
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  color: rgb(245 247 250);
+}
+
+.chat-session-block-user {
+  justify-self: end;
+  width: fit-content;
+  max-width: min(82%, 42rem);
+  border-color: rgb(59 130 246 / 0.34);
+  background: rgb(59 130 246 / 0.15);
+}
+
+.chat-session-block-assistant {
+  justify-self: start;
+  border-color: rgb(20 184 166 / 0.32);
+  background: rgb(20 184 166 / 0.11);
+}
+
+.chat-session-block-tool {
+  border-left: 4px solid rgb(148 163 184 / 0.82);
+  background: rgb(148 163 184 / 0.1);
+}
+
+.chat-session-block-approval {
+  border-left: 4px solid rgb(99 102 241);
+  background: rgb(99 102 241 / 0.12);
+}
+
+.chat-session-block-boundary {
+  justify-self: stretch;
+  border-color: rgb(var(--mm-warn) / 0.8);
+  background: rgb(var(--mm-warn) / 0.13);
+  color: rgb(255 240 194);
+  text-align: center;
+}
+
+.chat-session-block-status {
+  border-color: rgb(168 85 247 / 0.32);
+  background: rgb(168 85 247 / 0.1);
+}
+
+.chat-session-block-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.chat-session-role-label {
+  background: rgb(255 255 255 / 0.13);
+  color: rgb(255 255 255 / 0.92);
+}
+
+.chat-session-kind-chip {
+  background: rgb(255 255 255 / 0.08);
+  color: rgb(255 255 255 / 0.76);
+}
+
+.chat-session-status-chip {
+  background: rgb(255 255 255 / 0.1);
+  color: rgb(255 255 255 / 0.86);
+}
+
+.chat-session-status-completed,
+.chat-session-status-granted,
+.chat-session-status-resolved {
+  background: rgb(34 197 94 / 0.18);
+  color: rgb(187 247 208);
+}
+
+.chat-session-status-failed,
+.chat-session-status-denied {
+  background: rgb(239 68 68 / 0.2);
+  color: rgb(254 202 202);
+}
+
+.chat-session-block-text,
+.chat-session-resolution-text {
+  min-width: 0;
+  font-family: var(--mm-font-mono);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.chat-session-block.is-wrapped .chat-session-block-text,
+.chat-session-block.is-wrapped .chat-session-resolution-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-session-block.is-unwrapped .chat-session-block-text,
+.chat-session-block.is-unwrapped .chat-session-resolution-text {
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.chat-session-resolution-text {
+  border-top: 1px solid rgb(255 255 255 / 0.12);
+  padding-top: 0.45rem;
+  color: rgb(255 255 255 / 0.82);
+}
+
+.chat-session-tool-output {
+  border-top: 1px solid rgb(255 255 255 / 0.12);
+  padding-top: 0.45rem;
+}
+
+.chat-session-tool-events {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chat-session-tool-event {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgb(255 255 255 / 0.82);
+  font-family: var(--mm-font-mono);
+  font-size: 0.72rem;
+}
+
+.chat-session-tool-output summary,
+.raw-timeline-escape-hatch summary {
+  cursor: pointer;
+  color: rgb(232 234 240 / 0.86);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.chat-session-tool-output-body {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 0.45rem;
+}
+
+.chat-session-tool-output pre {
+  margin: 0;
+  overflow-x: auto;
+  border-radius: 0.45rem;
+  padding: 0.55rem;
+  background: rgb(0 0 0 / 0.28);
+  color: rgb(232 234 240 / 0.9);
+  font-family: var(--mm-font-mono);
+  font-size: 0.72rem;
+  white-space: pre-wrap;
+}
+
+.raw-timeline-escape-hatch {
+  border-top: 1px solid rgb(255 255 255 / 0.12);
+  padding-top: 0.65rem;
+}
+
+.raw-timeline-escape-hatch .live-logs-viewer {
+  margin-top: 0.55rem;
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
 .live-logs-legacy-viewer {
   max-height: 400px;
   overflow-y: auto;


### PR DESCRIPTION
Issue reference: MM-1014

Summary:
- Adds a chat session projection to the workflow detail Live Logs surface using the existing observability summary/events, SSE stream, and merged-log fallback inputs.
- Renders user and assistant messages as chat bubbles, tool calls and paired outputs as tool cards, approvals with resolved state, and reset/status events as explicit session boundaries/status rows.
- Keeps the raw Live Logs timeline available as the chronological/debug escape hatch.

Tests run:
- PASS: from /tmp/mmrepo-copy, `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx` (151 tests passed).
- NOTE: in the managed workspace path, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` failed before UI tests because Python pytest is not installed; direct npm/Vitest initially hit the workspace path colon resolution issue, so the same checkout contents were verified from a colon-free temporary copy.

Remaining risks:
- Local verification required the colon-free temporary copy because Vitest resolved the managed workspace path incorrectly under `/work/agent_jobs/mm:...`.
