### PR TITLE
MM-1008 Add workflow sidebar controls

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -898,6 +898,30 @@ describe('Workflow Detail Entrypoint', () => {
     expect(expand.getAttribute('href')).not.toContain('selectedWorkflowId=');
     expect(expand.getAttribute('href')).not.toContain('unsafe=');
     expect(expand.getAttribute('class') || '').toContain('button');
+    expect(expand.getAttribute('class') || '').toContain('workflow-workspace-expand-list');
+    expect(within(sidebar).getByRole('button', { name: 'Close sidebar' }).getAttribute('class') || '').toContain(
+      'workflow-workspace-close-sidebar',
+    );
+  });
+
+  it('MM-1008 keeps close-sidebar and expand-list controls visually distinct', async () => {
+    window.history.pushState({}, 'Workspace Controls Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(within(sidebar).getByRole('button', { name: 'Close sidebar' }).getAttribute('class') || '').toContain(
+      'workflow-workspace-close-sidebar',
+    );
+    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('class') || '').toContain(
+      'workflow-workspace-expand-list',
+    );
+
+    const dashboardCss = await readDashboardCss();
+    expect(dashboardCss).toMatch(/\.workflow-workspace-close-sidebar\s*\{[\s\S]*border-style:\s*dashed;/);
+    expect(dashboardCss).toMatch(/\.workflow-workspace-expand-list\s*\{[\s\S]*background:\s*rgb\(var\(--mm-accent\)/);
   });
 
   it('MM-1002 renders sidebar titles, repositories, runtimes, and statuses as React text', async () => {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -23,6 +23,7 @@ import {
   readDashboardPreferences,
   updateDashboardPreferences,
 } from '../utils/dashboardPreferences';
+import { WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY } from '../lib/workflowListContext';
 
 declare const __dirname: string;
 
@@ -962,9 +963,11 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
-    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe(
-      '/workflows',
-    );
+    const expandLink = within(sidebar).getByRole('link', { name: 'Expand to full list' });
+    expect(expandLink.getAttribute('href')).toBe('/workflows');
+
+    fireEvent.click(expandLink);
+    expect(window.sessionStorage.getItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY)).toBe('1');
   });
 
   it('MM-1000 uses a single-column collapsed workspace layout and reduced-motion guard', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -304,12 +304,12 @@ function WorkflowSidebarControls({
       <button
         ref={closeButtonRef}
         type="button"
-        className="secondary"
+        className="secondary workflow-workspace-close-sidebar"
         onClick={onClose}
       >
         Close sidebar
       </button>
-      <a className="button secondary" href={fullListHref}>
+      <a className="button workflow-workspace-expand-list" href={fullListHref}>
         Expand to full list
       </a>
     </div>
@@ -466,7 +466,7 @@ function WorkflowWorkspaceShell({
     <div
       className="workflow-workspace-shell"
       data-sidebar-collapsed={sidebarOpen ? 'false' : 'true'}
-      data-jira-issue="MM-997 MM-999 MM-1000 MM-1002 MM-1005"
+      data-jira-issue="MM-997 MM-999 MM-1000 MM-1002 MM-1005 MM-1008"
       data-source-issue="MM-975"
     >
       {sidebarOpen ? (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -21,6 +21,7 @@ import {
   taskEditHref,
 } from '../lib/temporalTaskEditing';
 import {
+  markWorkflowListReturnFocusIntent,
   workflowDetailHref,
   workflowListContextParams,
   workflowListHrefFromContext,
@@ -309,7 +310,11 @@ function WorkflowSidebarControls({
       >
         Close sidebar
       </button>
-      <a className="button workflow-workspace-expand-list" href={fullListHref}>
+      <a
+        className="button workflow-workspace-expand-list"
+        href={fullListHref}
+        onClick={markWorkflowListReturnFocusIntent}
+      >
         Expand to full list
       </a>
     </div>
@@ -6157,7 +6162,11 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         </div>
         <div className="toolbar-controls">
           {showExpandToFullList ? (
-            <a className="button secondary" href={expandToFullListHref}>
+            <a
+              className="button secondary"
+              href={expandToFullListHref}
+              onClick={markWorkflowListReturnFocusIntent}
+            >
               Expand to full list
             </a>
           ) : null}

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1302,6 +1302,30 @@ describe('Workflows Entrypoint', () => {
     ).toBeNull();
   });
 
+  it('MM-1008 focuses the workflow list region when expanded from workspace detail', async () => {
+    window.history.pushState(
+      {},
+      'Workspace return focus',
+      '/workflows?stateIn=completed&limit=50&returnFromWorkflowDetail=1',
+    );
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const listRegion = screen.getByRole('region', { name: 'Workflow list' });
+    await waitFor(() => expect(document.activeElement).toBe(listRegion));
+    expect(listRegion.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('MM-1008 does not make the workflow list region focusable on normal list visits', async () => {
+    window.history.pushState({}, 'Normal workflows', '/workflows?stateIn=completed&limit=50');
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    expect(screen.getByRole('region', { name: 'Workflow list' }).getAttribute('tabindex')).toBeNull();
+  });
+
   it('supports skill and date filter chips with blank semantics', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
 import { EXECUTING_STATUS_PILL_TRACEABILITY } from '../utils/executionStatusPillClasses';
+import { markWorkflowListReturnFocusIntent } from '../lib/workflowListContext';
 import { WorkflowListPage } from './workflow-list';
 import '../styles/dashboard.css';
 
@@ -1324,6 +1325,19 @@ describe('Workflows Entrypoint', () => {
 
     await screen.findAllByText('Example task');
     expect(screen.getByRole('region', { name: 'Workflow list' }).getAttribute('tabindex')).toBeNull();
+  });
+
+  it('MM-1008 focuses the workflow list region on a plain expand return intent', async () => {
+    markWorkflowListReturnFocusIntent();
+    window.history.pushState({}, 'Plain workspace return focus', '/workflows');
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+    const listRegion = screen.getByRole('region', { name: 'Workflow list' });
+    await waitFor(() => expect(document.activeElement).toBe(listRegion));
+    expect(listRegion.getAttribute('tabindex')).toBe('-1');
+    expect(window.sessionStorage.getItem('moonmind.workflowList.returnFocusIntent')).toBeNull();
   });
 
   it('supports skill and date filter chips with blank semantics', async () => {

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -788,6 +788,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const initial = useMemo(() => new URLSearchParams(window.location.search), []);
 
   const initialFilterValidationErrors = useMemo(() => validateInitialFilterParams(initial), [initial]);
+  const focusListOnWorkspaceReturn = useMemo(
+    () => initial.get(WORKFLOW_LIST_CONTEXT_RETURN_PARAM) === '1',
+    [initial],
+  );
   const [workspaceCursorResetNotice, setWorkspaceCursorResetNotice] = useState(false);
   const [workspaceReturnFromDetail, setWorkspaceReturnFromDetail] = useState(() =>
     initial.get(WORKFLOW_LIST_CONTEXT_RETURN_PARAM) === '1',
@@ -801,6 +805,8 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const drawerToggleRef = useRef<HTMLButtonElement | null>(null);
   const desktopFilterRef = useRef<HTMLDivElement | null>(null);
+  const workflowListRegionRef = useRef<HTMLElement | null>(null);
+  const didFocusWorkspaceReturnRef = useRef(false);
   // The element that opened the drawer (the Filters trigger or a chip). Focus is
   // returned here when the drawer closes so keyboard users keep their place.
   const filterTriggerRef = useRef<HTMLElement | null>(null);
@@ -959,6 +965,15 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
     resetToFirstPage,
     workspaceReturnFromDetail,
   ]);
+
+  useEffect(() => {
+    if (!focusListOnWorkspaceReturn || didFocusWorkspaceReturnRef.current) return;
+    didFocusWorkspaceReturnRef.current = true;
+    const frame = window.requestAnimationFrame(() => {
+      workflowListRegionRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusListOnWorkspaceReturn]);
 
   // MM-964: column visibility. The workflow title column is the primary anchor
   // and is always shown; every other column honors the stored preference.
@@ -1913,8 +1928,10 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
       ) : null}
 
       <section
+        ref={workflowListRegionRef}
         className="queue-layouts panel--data workflow-list-data-slab"
         aria-label="Workflow list"
+        tabIndex={focusListOnWorkspaceReturn ? -1 : undefined}
       >
         {showResultsHeader ? (
         <header className="workflow-list-results-header">

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -9,6 +9,7 @@ import { PageSizeSelector, parsePageSize } from '../components/PageSizeSelector'
 import { WorkflowRowActionsMenu } from '../components/WorkflowRowActionsMenu';
 import {
   WORKFLOW_LIST_CONTEXT_RETURN_PARAM,
+  consumeWorkflowListReturnFocusIntent,
   workflowDetailHref,
 } from '../lib/workflowListContext';
 import {
@@ -789,7 +790,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
 
   const initialFilterValidationErrors = useMemo(() => validateInitialFilterParams(initial), [initial]);
   const focusListOnWorkspaceReturn = useMemo(
-    () => initial.get(WORKFLOW_LIST_CONTEXT_RETURN_PARAM) === '1',
+    () => consumeWorkflowListReturnFocusIntent(initial),
     [initial],
   );
   const [workspaceCursorResetNotice, setWorkspaceCursorResetNotice] = useState(false);

--- a/frontend/src/lib/workflowListContext.ts
+++ b/frontend/src/lib/workflowListContext.ts
@@ -1,4 +1,26 @@
 export const WORKFLOW_LIST_CONTEXT_RETURN_PARAM = 'returnFromWorkflowDetail';
+export const WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY = 'moonmind.workflowList.returnFocusIntent';
+
+export function markWorkflowListReturnFocusIntent(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY, '1');
+  } catch {
+    // Ignore storage failures; query-marked returns still focus the list.
+  }
+}
+
+export function consumeWorkflowListReturnFocusIntent(source: URLSearchParams): boolean {
+  const hasReturnParam = source.get(WORKFLOW_LIST_CONTEXT_RETURN_PARAM) === '1';
+  if (typeof window === 'undefined') return hasReturnParam;
+  try {
+    const hasStoredIntent = window.sessionStorage.getItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY) === '1';
+    window.sessionStorage.removeItem(WORKFLOW_LIST_RETURN_FOCUS_INTENT_KEY);
+    return hasReturnParam || hasStoredIntent;
+  } catch {
+    return hasReturnParam;
+  }
+}
 
 const WORKFLOW_LIST_CONTEXT_ALLOWLIST = new Set([
   'source',

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6514,6 +6514,23 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   white-space: nowrap;
 }
 
+.workflow-workspace-close-sidebar {
+  border-style: dashed;
+}
+
+.workflow-workspace-expand-list {
+  background: rgb(var(--mm-accent) / 0.16);
+  border-color: rgb(var(--mm-accent) / 0.55);
+  color: rgb(var(--mm-ink));
+  font-weight: 800;
+}
+
+.workflow-workspace-expand-list:hover,
+.workflow-workspace-expand-list:focus-visible {
+  background: rgb(var(--mm-accent) / 0.24);
+  border-color: rgb(var(--mm-accent) / 0.82);
+}
+
 .workflow-workspace-sidebar-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Issue reference: MM-1008

Summary:
- Adds distinct visual treatments for Close sidebar and Expand to full list controls in the workflow workspace.
- Adds deterministic focus to the workflow list region when returning from an expanded workspace detail view.
- Tags the workspace shell with MM-1008 traceability and covers the behavior with focused frontend tests.

Tests run:
- ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx (blocked: container Python environment is missing pytest before UI tests run)
- npm run ui:test -- frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx (blocked: npm wrapper could not resolve vitest despite lockfile install)
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx (blocked: Vitest resolves test modules to /frontend/... in this managed workspace)

Remaining risks:
- Focus and styling changes are covered by committed tests, but local execution was blocked by the managed workspace test environment described above.