### PR TITLE
MM-1011 Wire durable workspace checkpoint capture

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -970,6 +970,7 @@ class MoonMindRunWorkflow:
         self._step_checkpoint_refs: dict[str, str] = {}
         self._previous_step_checkpoint_refs: dict[str, str] = {}
         self._step_checkpoint_refs_by_boundary: dict[str, dict[str, str]] = {}
+        self._step_workspace_capture_inputs: dict[str, dict[str, Any]] = {}
         self._step_execution_launch_blocks: set[str] = set()
         self._step_dependency_effects: dict[str, dict[str, Any]] = {}
         self._step_terminal_dispositions: dict[str, str] = {}
@@ -3723,6 +3724,7 @@ class MoonMindRunWorkflow:
             workload=workload_metadata,
         ):
             return
+        self._record_step_workspace_capture_input(logical_step_id, outputs)
         if checkpoint_ref:
             try:
                 mark_step_checkpoint_evidence(
@@ -3839,25 +3841,136 @@ class MoonMindRunWorkflow:
             executionOrdinal=attempt,
         )
 
-    def _canonical_step_checkpoint_workspace(
+    @staticmethod
+    def _checkpoint_capture_text(
+        payload: Mapping[str, Any],
+        *keys: str,
+    ) -> str | None:
+        for key in keys:
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def _record_step_workspace_capture_input(
         self,
         logical_step_id: str,
+        outputs: Mapping[str, Any],
+    ) -> None:
+        candidates: list[Mapping[str, Any]] = [outputs]
+        workload_metadata = outputs.get("workloadMetadata") or outputs.get(
+            "workload_metadata"
+        )
+        if isinstance(workload_metadata, Mapping):
+            candidates.append(workload_metadata)
+        workload_result = outputs.get("workloadResult") or outputs.get(
+            "workload_result"
+        )
+        if isinstance(workload_result, Mapping):
+            metadata = workload_result.get("metadata")
+            if isinstance(metadata, Mapping):
+                candidates.append(metadata)
+                nested_workload = metadata.get("workload")
+                if isinstance(nested_workload, Mapping):
+                    candidates.append(nested_workload)
+
+        capture_input: dict[str, Any] = {}
+        for candidate in candidates:
+            workspace_path = self._checkpoint_capture_text(
+                candidate,
+                "workspacePath",
+                "workspace_path",
+            )
+            workspace_root_ref = self._checkpoint_capture_text(
+                candidate,
+                "workspaceRootRef",
+                "workspace_root_ref",
+            )
+            if workspace_path:
+                capture_input["workspacePath"] = workspace_path
+            elif workspace_root_ref:
+                capture_input["workspaceRootRef"] = workspace_root_ref
+            else:
+                continue
+
+            base_commit = self._checkpoint_capture_text(
+                candidate,
+                "baseCommit",
+                "base_commit",
+            )
+            if base_commit:
+                capture_input["baseCommit"] = base_commit
+
+            checkpoint_kind = self._checkpoint_capture_text(
+                candidate,
+                "checkpointKind",
+                "checkpoint_kind",
+                "workspaceCheckpointKind",
+                "workspace_checkpoint_kind",
+            )
+            if checkpoint_kind:
+                capture_input["kind"] = checkpoint_kind
+            elif base_commit:
+                capture_input["kind"] = "git_patch"
+            else:
+                capture_input["kind"] = "worktree_archive"
+            break
+
+        if capture_input:
+            self._step_workspace_capture_inputs[logical_step_id] = capture_input
+
+    async def _capture_canonical_step_checkpoint_workspace(
+        self,
+        logical_step_id: str,
+        *,
+        identity: StepExecutionIdentityModel,
         boundary: StepExecutionCheckpointBoundary,
-    ) -> dict[str, Any]:
-        checkpoint_ref = (
-            self._step_checkpoint_refs.get(logical_step_id)
-            or self._previous_step_checkpoint_refs.get(logical_step_id)
-            or getattr(self, "_recovery_workspace_restored_ref", None)
+    ) -> dict[str, Any] | None:
+        capture_input = dict(
+            self._step_workspace_capture_inputs.get(logical_step_id) or {}
         )
-        workspace_ref = checkpoint_ref or (
-            "temporal://"
-            f"{workflow.info().workflow_id}/{workflow.info().run_id}/"
-            f"{logical_step_id}/{boundary}"
+        if not capture_input:
+            return None
+
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+            "workspace.capture_checkpoint"
         )
+        checkpoint_id = build_step_checkpoint_id(identity, boundary)
+        payload = {
+            "identity": identity.model_dump(by_alias=True, mode="json"),
+            "boundary": boundary,
+            "kind": capture_input.get("kind") or "worktree_archive",
+            "artifactNamespace": f"step-checkpoints/{identity.logical_step_id}",
+            "idempotencyKey": f"{checkpoint_id}:capture",
+        }
+        if capture_input.get("workspacePath"):
+            payload["workspacePath"] = capture_input["workspacePath"]
+        if capture_input.get("workspaceRootRef"):
+            payload["workspaceRootRef"] = capture_input["workspaceRootRef"]
+        if capture_input.get("baseCommit"):
+            payload["baseCommit"] = capture_input["baseCommit"]
+
+        result = await workflow.execute_activity(
+            route.activity_type,
+            payload,
+            **self._execute_kwargs_for_route(route),
+        )
+        if not isinstance(result, Mapping):
+            return None
+        if result.get("status") != "captured":
+            return None
+        workspace_evidence = result.get("workspace")
+        if not isinstance(workspace_evidence, Mapping):
+            return None
+        if workspace_evidence.get("kind") == "ephemeral_workspace_ref":
+            return None
         return {
-            "kind": "ephemeral_workspace_ref",
-            "workspaceRef": workspace_ref,
-            "createdAt": workflow.now().isoformat(),
+            "workspace": dict(workspace_evidence),
+            "diagnosticRefs": [
+                str(ref).strip()
+                for ref in result.get("diagnosticRefs", [])
+                if str(ref).strip()
+            ],
         }
 
     async def _record_canonical_step_checkpoint(
@@ -3878,14 +3991,19 @@ class MoonMindRunWorkflow:
             self._input_ref
             or f"temporal://{identity.workflow_id}/{identity.run_id}/task-input"
         )
+        capture = await self._capture_canonical_step_checkpoint_workspace(
+            logical_step_id,
+            identity=identity,
+            boundary=boundary,
+        )
+        if capture is None:
+            return None
+        capture_diagnostics = list(capture.get("diagnosticRefs") or [])
         result = await self._create_step_checkpoint_via_activity(
             identity=identity,
             boundary=boundary,
             task_input_snapshot_ref=task_input_snapshot_ref,
-            workspace=self._canonical_step_checkpoint_workspace(
-                logical_step_id,
-                boundary,
-            ),
+            workspace=capture["workspace"],
             created_at=updated_at,
             plan_ref=self._plan_ref
             or f"temporal://{identity.workflow_id}/{identity.run_id}/plan",
@@ -3893,7 +4011,7 @@ class MoonMindRunWorkflow:
             step_outputs=step_outputs or self._step_execution_compact_output_refs(
                 logical_step_id
             ),
-            diagnostic_refs=diagnostic_refs,
+            diagnostic_refs=[*capture_diagnostics, *diagnostic_refs],
         )
         checkpoint_ref = str(result.get("checkpointRef") or "").strip()
         if checkpoint_ref:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3858,6 +3858,9 @@ class MoonMindRunWorkflow:
         outputs: Mapping[str, Any],
     ) -> None:
         candidates: list[Mapping[str, Any]] = [outputs]
+        workspace_spec = outputs.get("workspaceSpec") or outputs.get("workspace_spec")
+        if isinstance(workspace_spec, Mapping):
+            candidates.append(workspace_spec)
         workload_metadata = outputs.get("workloadMetadata") or outputs.get(
             "workload_metadata"
         )
@@ -3880,6 +3883,8 @@ class MoonMindRunWorkflow:
                 candidate,
                 "workspacePath",
                 "workspace_path",
+                "workspaceRoot",
+                "workspace_root",
             )
             workspace_root_ref = self._checkpoint_capture_text(
                 candidate,
@@ -6453,6 +6458,7 @@ class MoonMindRunWorkflow:
                     updated_at=workflow.now(),
                     summary=self._summary,
                 )
+                self._record_step_workspace_capture_input(node_id, node_inputs)
                 current_step_execution = self._step_execution_for(node_id) or 1
                 attempt_reason = (
                     "quality_gate_failed"

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2503,7 +2503,9 @@ async def test_run_blocks_canonical_checkpoint_create_when_capture_is_not_durabl
     assert result is None
     assert captured == ["workspace.capture_checkpoint"]
     step = workflow.get_step_ledger()["steps"][0]
-    assert "stepCheckpointRef" not in step
+    assert step.get("stepCheckpointRef") is None
+    assert step["refs"]["stepExecutionCheckpointRefs"] == []
+    assert step["refs"]["checkpointRefsByBoundary"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2445,6 +2445,85 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
 
 
 @pytest.mark.asyncio
+async def test_run_records_pre_execution_checkpoint_from_node_workspace_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+    workflow._record_step_workspace_capture_input(
+        "implement",
+        {
+            "workspaceRoot": "/work/agent_jobs/run-1/repo",
+            "baseCommit": "abc123",
+        },
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "git_patch",
+                    "baseCommit": payload["baseCommit"],
+                    "patchRef": "artifact://patch/before_execution",
+                    "manifestRef": "artifact://patch-manifest/before_execution",
+                    "createdAt": "2026-06-13T12:00:00+00:00",
+                },
+                "diagnosticRefs": ["artifact://patch-manifest/before_execution"],
+            }
+        assert activity == "step_checkpoint.create"
+        return {
+            "checkpointRef": "artifact://checkpoint/before_execution",
+            "checkpointId": payload["idempotencyKey"],
+            "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+            "workspaceKind": payload["workspace"]["kind"],
+            "diagnosticRefs": [],
+            "idempotencyKey": payload["idempotencyKey"],
+        }
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    assert result == "artifact://checkpoint/before_execution"
+    assert [(call["activity"], call["payload"]["boundary"]) for call in captured] == [
+        ("workspace.capture_checkpoint", "before_execution"),
+        ("step_checkpoint.create", "before_execution"),
+    ]
+    assert captured[0]["payload"]["workspacePath"] == "/work/agent_jobs/run-1/repo"
+    assert captured[1]["payload"]["workspace"]["patchRef"] == (
+        "artifact://patch/before_execution"
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_blocks_canonical_checkpoint_create_when_capture_is_not_durable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2309,6 +2309,11 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
     workflow._input_ref = "artifact://task-input"
     workflow._plan_ref = "artifact://plan"
     workflow._prepared_artifact_refs = ["artifact://prepared"]
+    workflow._step_workspace_capture_inputs["implement"] = {
+        "workspacePath": "/work/agent_jobs/run-1/repo",
+        "baseCommit": "abc123",
+        "kind": "git_patch",
+    }
     captured: list[dict[str, Any]] = []
     manifest_writes: list[dict[str, Any]] = []
 
@@ -2329,6 +2334,20 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
         **kwargs: Any,
     ) -> dict[str, Any]:
         captured.append({"activity": activity, "payload": payload, "kwargs": kwargs})
+        if activity == "workspace.capture_checkpoint":
+            boundary = payload["boundary"]
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "git_patch",
+                    "baseCommit": payload["baseCommit"],
+                    "patchRef": f"artifact://patch/{boundary}",
+                    "manifestRef": f"artifact://patch-manifest/{boundary}",
+                    "createdAt": "2026-06-13T12:00:00+00:00",
+                },
+                "diagnosticRefs": [f"artifact://patch-manifest/{boundary}"],
+            }
+        assert activity == "step_checkpoint.create"
         boundary = payload["boundary"]
         return {
             "checkpointRef": f"artifact://checkpoint/{boundary}",
@@ -2377,14 +2396,31 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
         reason="initial_execution",
     )
 
-    assert [call["payload"]["boundary"] for call in captured] == [
-        "before_execution",
-        "after_execution",
+    assert [(call["activity"], call["payload"]["boundary"]) for call in captured] == [
+        ("workspace.capture_checkpoint", "before_execution"),
+        ("step_checkpoint.create", "before_execution"),
+        ("workspace.capture_checkpoint", "after_execution"),
+        ("step_checkpoint.create", "after_execution"),
     ]
-    assert captured[0]["payload"]["taskInputSnapshotRef"] == "artifact://task-input"
-    assert captured[0]["payload"]["planRef"] == "artifact://plan"
-    assert captured[0]["payload"]["preparedInputRefs"] == ["artifact://prepared"]
-    assert captured[0]["payload"]["workspace"]["kind"] == "ephemeral_workspace_ref"
+    create_calls = [
+        call for call in captured if call["activity"] == "step_checkpoint.create"
+    ]
+    assert create_calls[0]["payload"]["taskInputSnapshotRef"] == "artifact://task-input"
+    assert create_calls[0]["payload"]["planRef"] == "artifact://plan"
+    assert create_calls[0]["payload"]["preparedInputRefs"] == ["artifact://prepared"]
+    assert create_calls[0]["payload"]["workspace"] == {
+        "kind": "git_patch",
+        "baseCommit": "abc123",
+        "patchRef": "artifact://patch/before_execution",
+        "manifestRef": "artifact://patch-manifest/before_execution",
+        "createdAt": "2026-06-13T12:00:00+00:00",
+    }
+    assert create_calls[1]["payload"]["workspace"]["patchRef"] == (
+        "artifact://patch/after_execution"
+    )
+    assert create_calls[1]["payload"]["diagnosticRefs"] == [
+        "artifact://patch-manifest/after_execution"
+    ]
     step = workflow.get_step_ledger()["steps"][0]
     assert step["refs"]["latestStepExecutionCheckpointRef"] == (
         "artifact://checkpoint/after_execution"
@@ -2406,6 +2442,68 @@ async def test_run_records_canonical_boundary_checkpoint_and_manifest_refs(
         [call["payload"] for call in captured],
         sort_keys=True,
     ).lower()
+
+
+@pytest.mark.asyncio
+async def test_run_blocks_canonical_checkpoint_create_when_capture_is_not_durable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    workflow._step_workspace_capture_inputs["implement"] = {
+        "workspacePath": "/work/agent_jobs/run-1/repo",
+        "kind": "worktree_archive",
+    }
+    captured: list[str] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append(activity)
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "ephemeral_workspace_ref",
+                    "workspaceRef": "artifact://diagnostic/ephemeral",
+                },
+                "diagnosticRefs": ["artifact://diagnostic/ephemeral"],
+            }
+        raise AssertionError(f"unexpected activity: {activity}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_execution",
+        updated_at=now,
+    )
+
+    assert result is None
+    assert captured == ["workspace.capture_checkpoint"]
+    step = workflow.get_step_ledger()["steps"][0]
+    assert "stepCheckpointRef" not in step
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue reference: MM-1011

Summary:
- Capture durable workspace checkpoint evidence through `workspace.capture_checkpoint` before creating canonical Step Execution checkpoints.
- Pass only captured, policy-compatible workspace evidence into `step_checkpoint.create` and reject diagnostic-only ephemeral workspace refs.
- Extend workflow-boundary unit coverage for the capture -> create path and non-durable capture blocking.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_step_checkpoints.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` -> 69 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 python -m pytest tests/integration/workflows/temporal/test_step_checkpoint_activities.py -q --tb=short` -> 19 passed

Remaining risks:
- Broader Temporal replay coverage was not rerun in this handoff step; validation is based on the targeted workflow and checkpoint activity suites recorded for MM-1011.
