### PR TITLE
MM-1015 Finish capability-gated chat composer behavior

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -7295,6 +7295,8 @@ describe('Workflow Detail Entrypoint', () => {
     };
     const executionDetailUrl = '/api/executions/test-123?source=temporal';
 
+    let resolveFollowUpControl: ((response: Response) => void) | null = null;
+
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes('/observability-summary')) {
@@ -7323,20 +7325,26 @@ describe('Workflow Detail Entrypoint', () => {
         } as Response);
       }
       if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
+        const action = JSON.parse(String(init?.body || '{}')).action;
+        if (action === 'send_follow_up') {
+          return new Promise((resolve) => {
+            resolveFollowUpControl = resolve;
+          });
+        }
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            action: JSON.parse(String(init?.body || '{}')).action,
+            action,
             projection: {
               agent_run_id: 'wf-task-1',
               session_id: 'sess:wf-task-1:codex_cli',
-              session_epoch: JSON.parse(String(init?.body || '{}')).action === 'clear_session' ? 2 : 1,
+              session_epoch: action === 'clear_session' ? 2 : 1,
               grouped_artifacts: [],
               latest_summary_ref: { artifact_id: 'art-summary' },
               latest_checkpoint_ref: { artifact_id: 'art-checkpoint' },
               latest_control_event_ref: { artifact_id: 'art-control' },
               latest_reset_boundary_ref:
-                JSON.parse(String(init?.body || '{}')).action === 'clear_session'
+                action === 'clear_session'
                   ? { artifact_id: 'art-reset' }
                   : null,
             },
@@ -7383,6 +7391,14 @@ describe('Workflow Detail Entrypoint', () => {
     ).length;
     fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
 
+    const pendingMessages = await screen.findByLabelText('Pending session messages');
+    const optimisticBubble = within(pendingMessages).getByText('Continue with the existing session.');
+    const optimisticContainer = optimisticBubble.closest('.chat-session-message');
+    expect(optimisticContainer?.getAttribute('data-client-event-key')).toMatch(
+      /^MM-1015:MM-977:sess:wf-task-1:codex_cli:1:\d+$/,
+    );
+    expect(screen.getByText('Operator message · Sending')).toBeTruthy();
+
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
         '/api/agent-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
@@ -7394,6 +7410,29 @@ describe('Workflow Detail Entrypoint', () => {
           }),
         }),
       );
+    });
+    expect(resolveFollowUpControl).toBeTruthy();
+
+    act(() => {
+      resolveFollowUpControl?.({
+        ok: true,
+        json: async () => ({
+          action: 'send_follow_up',
+          projection: {
+            agent_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 1,
+            grouped_artifacts: [],
+            latest_summary_ref: { artifact_id: 'art-summary' },
+            latest_checkpoint_ref: { artifact_id: 'art-checkpoint' },
+            latest_control_event_ref: { artifact_id: 'art-control' },
+            latest_reset_boundary_ref: null,
+          },
+        }),
+      } as Response);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Operator message · Sending')).toBeNull();
     });
     await waitFor(() => {
       expect(
@@ -7419,6 +7458,105 @@ describe('Workflow Detail Entrypoint', () => {
         }),
       );
     });
+  });
+
+  it('marks optimistic follow-up bubbles failed when durable control confirmation fails', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'wf-session-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex session task',
+      summary: 'Session-backed work',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      targetRuntime: 'codex_cli',
+      agentRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 1,
+                containerId: 'ctr-1',
+                threadId: 'thread-1',
+                activeTurnId: null,
+              },
+              interventionCapabilities: {
+                sendFollowUp: true,
+                clearSession: false,
+                interruptTurn: false,
+                cancelSession: false,
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: async () => ({ detail: 'Follow-up is not supported for this session.' }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            agent_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 1,
+            grouped_artifacts: [],
+            latest_summary_ref: null,
+            latest_checkpoint_ref: null,
+            latest_control_event_ref: null,
+            latest_reset_boundary_ref: null,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={codexPayload} />);
+
+    fireEvent.change(await screen.findByLabelText('Follow-up message'), {
+      target: { value: 'Try the next turn.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
+
+    const pendingMessages = await screen.findByLabelText('Pending session messages');
+    expect(within(pendingMessages).getByText('Try the next turn.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText('Operator message · Failed')).toBeTruthy();
+    });
+    expect(screen.getAllByText('Follow-up is not supported for this session.').length).toBeGreaterThan(0);
   });
 
   it('routes active-turn interrupt and cancel controls through the agent-run session control API', async () => {

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1284,6 +1284,27 @@ const ArtifactSessionControlResponseSchema = z.object({
   projection: ArtifactSessionProjectionSchema,
 });
 
+type ArtifactSessionControlAction = z.infer<typeof ArtifactSessionControlResponseSchema>['action'];
+
+type ArtifactSessionControlRequest = {
+  action: ArtifactSessionControlAction;
+  message?: string;
+  reason?: string;
+};
+
+type ChatSessionMessageEvent = {
+  type: 'chat_session.message_submitted';
+  clientEventKey: string;
+  sessionId: string;
+  sessionEpoch: number;
+  message: string;
+};
+
+type OptimisticChatSessionMessage = ChatSessionMessageEvent & {
+  status: 'pending' | 'failed';
+  error?: string;
+};
+
 const InterventionCapabilitiesSchema = z
   .object({
     sendFollowUp: z.boolean().default(false),
@@ -2147,7 +2168,7 @@ async function controlArtifactSession(
   apiBase: string,
   agentRunId: string,
   sessionId: string,
-  body: { action: 'send_follow_up' | 'clear_session' | 'interrupt_turn' | 'cancel_session'; message?: string; reason?: string },
+  body: ArtifactSessionControlRequest,
   routeTemplate?: string | null,
 ): Promise<z.infer<typeof ArtifactSessionControlResponseSchema>> {
   const resp = await fetch(
@@ -2177,6 +2198,15 @@ async function controlArtifactSession(
     throw new Error(detail);
   }
   return ArtifactSessionControlResponseSchema.parse(await resp.json());
+}
+
+function chatSessionMessageEventToControlRequest(
+  event: ChatSessionMessageEvent,
+): ArtifactSessionControlRequest {
+  return {
+    action: 'send_follow_up',
+    message: event.message,
+  };
 }
 
 /** Fetch the observability summary for a agent run. */
@@ -4458,6 +4488,8 @@ function SessionContinuityPanel({
   const sessionId = sessionSnapshot?.sessionId ?? null;
   const [followUpMessage, setFollowUpMessage] = useState('');
   const [panelError, setPanelError] = useState<string | null>(null);
+  const [optimisticMessages, setOptimisticMessages] = useState<OptimisticChatSessionMessage[]>([]);
+  const optimisticMessageSequenceRef = useRef(0);
 
   const projectionQuery = useQuery({
     queryKey: ['agent-run-session-projection', agentRunId, sessionId],
@@ -4477,7 +4509,7 @@ function SessionContinuityPanel({
   });
 
   const controlMutation = useMutation({
-    mutationFn: async (body: { action: 'send_follow_up' | 'clear_session' | 'interrupt_turn' | 'cancel_session'; message?: string; reason?: string }) => {
+    mutationFn: async (body: ArtifactSessionControlRequest) => {
       if (!sessionId) throw new Error('Managed session is unavailable.');
       return controlArtifactSession(apiBase, agentRunId, sessionId, body, routes.artifactSessionControl);
     },
@@ -4494,6 +4526,42 @@ function SessionContinuityPanel({
       }
     },
     onError: (error: Error) => setPanelError(error.message),
+  });
+
+  const followUpMutation = useMutation({
+    mutationFn: async (event: ChatSessionMessageEvent) => {
+      if (!sessionId) throw new Error('Managed session is unavailable.');
+      return controlArtifactSession(
+        apiBase,
+        agentRunId,
+        sessionId,
+        chatSessionMessageEventToControlRequest(event),
+        routes.artifactSessionControl,
+      );
+    },
+    onSuccess: (result, event) => {
+      setPanelError(null);
+      setOptimisticMessages((messages) =>
+        messages.filter((message) => message.clientEventKey !== event.clientEventKey),
+      );
+      void queryClient.setQueryData(
+        ['agent-run-session-projection', agentRunId, sessionId],
+        result.projection,
+      );
+      void queryClient.invalidateQueries({ queryKey: ['observability-summary', agentRunId] });
+      invalidateWorkflowDetail();
+      setFollowUpMessage('');
+    },
+    onError: (error: Error, event) => {
+      setPanelError(error.message);
+      setOptimisticMessages((messages) =>
+        messages.map((message) =>
+          message.clientEventKey === event.clientEventKey
+            ? { ...message, status: 'failed', error: error.message }
+            : message,
+        ),
+      );
+    },
   });
 
   if (summaryQuery.isLoading) {
@@ -4545,7 +4613,7 @@ function SessionContinuityPanel({
     ['Latest Control', projection.latest_control_event_ref?.artifact_id ?? null],
     ['Latest Reset', projection.latest_reset_boundary_ref?.artifact_id ?? null],
   ].filter(([, artifactId]) => artifactId !== null) as Array<[string, string]>;
-  const busy = controlMutation.isPending;
+  const busy = controlMutation.isPending || followUpMutation.isPending;
   const canSendFollowUp = Boolean(sessionId && interventionCapabilities.sendFollowUp && !isTerminal);
   const canClearSession = Boolean(sessionId && interventionCapabilities.clearSession && !isTerminal);
   const canInterruptTurn = Boolean(sessionId && interventionCapabilities.interruptTurn && !isTerminal);
@@ -4553,12 +4621,20 @@ function SessionContinuityPanel({
 
   const submitFollowUp = () => {
     const message = followUpMessage.trim();
-    if (!message) return;
-    setPanelError(null);
-    controlMutation.mutate({
-      action: 'send_follow_up',
+    if (!message || !sessionId) return;
+    const event: ChatSessionMessageEvent = {
+      type: 'chat_session.message_submitted',
+      clientEventKey: `MM-1015:MM-977:${sessionId}:${sessionSnapshot?.sessionEpoch ?? projection.session_epoch}:${optimisticMessageSequenceRef.current++}`,
+      sessionId,
+      sessionEpoch: sessionSnapshot?.sessionEpoch ?? projection.session_epoch,
       message,
-    });
+    };
+    setPanelError(null);
+    setOptimisticMessages((messages) => [
+      ...messages.filter((pending) => pending.clientEventKey !== event.clientEventKey),
+      { ...event, status: 'pending' },
+    ]);
+    followUpMutation.mutate(event);
   };
 
   const clearSession = () => {
@@ -4633,6 +4709,25 @@ function SessionContinuityPanel({
       </div>
 
       <div className="stack">
+        {optimisticMessages.length > 0 ? (
+          <div className="chat-session-message-list" aria-label="Pending session messages">
+            {optimisticMessages.map((message) => (
+              <div
+                key={message.clientEventKey}
+                className={`chat-session-message chat-session-message-${message.status}`}
+                data-client-event-key={message.clientEventKey}
+              >
+                <div className="chat-session-message-meta">
+                  Operator message · {message.status === 'pending' ? 'Sending' : 'Failed'}
+                </div>
+                <div className="chat-session-message-text">{message.message}</div>
+                {message.error ? (
+                  <div className="chat-session-message-error">{message.error}</div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
         <label htmlFor="session-follow-up">Follow-up message</label>
         <textarea
           id="session-follow-up"

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -6081,6 +6081,45 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   flex-wrap: wrap;
 }
 
+.chat-session-message-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.chat-session-message {
+  border: 1px solid rgb(var(--mm-border));
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.72rem;
+  background: rgb(var(--mm-panel) / 0.72);
+}
+
+.chat-session-message-pending {
+  border-color: rgb(var(--mm-accent) / 0.45);
+}
+
+.chat-session-message-failed {
+  border-color: rgb(var(--mm-danger) / 0.5);
+  background: rgb(var(--mm-danger) / 0.08);
+}
+
+.chat-session-message-meta {
+  color: rgb(var(--mm-muted));
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.chat-session-message-text {
+  margin-top: 0.25rem;
+  white-space: pre-wrap;
+}
+
+.chat-session-message-error {
+  margin-top: 0.35rem;
+  color: rgb(var(--mm-danger));
+  font-size: 0.84rem;
+}
+
 .queue-template-actions {
   justify-content: flex-end;
 }


### PR DESCRIPTION
Issue reference: MM-1015

Summary:
- Adds an event-shaped internal chat-session message payload that translates to the existing send_follow_up session control action.
- Inserts optimistic operator message bubbles with stable client event keys while durable follow-up confirmation is pending.
- Reconciles optimistic bubbles on success and marks them failed with the control-route error on durable failure.
- Adds styling for pending and failed chat-session message bubbles.

Tests run:
- `vitest run --config frontend/vite.config.ts frontend/src/entrypoints/workflow-detail.test.tsx` -> 153 passed.
- `npm run ui:typecheck` -> passed.
- `npm run ui:lint` -> passed.
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-detail.test.tsx` could not run in the implementation environment because `pytest` was missing; the focused Vitest file was run directly afterward.

Remaining risks:
- The UI still translates event-shaped follow-up messages to the existing action-shaped control route until a dedicated API alias is available.
