### PR TITLE
MM-1010 Add workspace-specific regression and boundary tests

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -636,6 +636,42 @@ describe('Workflow Detail Entrypoint', () => {
     });
   }
 
+  function mockWorkflowWorkspaceDetailFailure() {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/executions?')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                workflowId: 'test-123',
+                taskId: 'test-123',
+                source: 'temporal',
+                title: 'MM-1010 sidebar remains loaded',
+                status: 'running',
+                state: 'executing',
+                rawState: 'executing',
+                createdAt: '2026-04-09T00:00:00Z',
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        statusText: 'Forbidden',
+        json: async () => ({}),
+      } as Response);
+    });
+  }
+
   function mockDesktopViewport(matches = true) {
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
@@ -706,16 +742,51 @@ describe('Workflow Detail Entrypoint', () => {
     );
   });
 
+  it('MM-1010 keeps an empty filtered sidebar state, pinned current workflow, and detail content independent (MM-975)', async () => {
+    window.history.pushState({}, 'Workspace Empty Filter Test', '/workflows/test-123?source=temporal&stateIn=failed');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceFetches({ rows: [] });
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    expect(await within(sidebar).findByText('No workflows match the current list filters.')).toBeTruthy();
+    const pinnedGroup = within(sidebar).getByRole('list', { name: 'Current workflow' });
+    const pinned = within(pinnedGroup).getByRole('link', { name: /MM-997 selected workflow/i });
+    expect(pinned.getAttribute('aria-current')).toBe('page');
+    expect(pinned.getAttribute('data-pinned')).toBe('true');
+    expect(within(sidebar).getByRole('link', { name: 'Expand to full list' }).getAttribute('href')).toBe(
+      '/workflows?stateIn=failed&returnFromWorkflowDetail=1',
+    );
+    expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(lastFetchUrl(fetchSpy, '/api/executions?')).toBe('/api/executions?source=temporal&stateIn=failed&pageSize=25');
+  });
+
   it('MM-999 keeps detail visible and retries only sidebar data after a recoverable sidebar error', async () => {
     window.history.pushState({}, 'Workspace Sidebar Error Test', '/workflows/test-123?source=temporal');
     mockDesktopViewport(true);
     mockWorkflowWorkspaceSidebarFailure();
 
-    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+    renderWithClient(
+      <WorkflowDetailEntrypoint
+        payload={{
+          ...stepsPayload,
+          initialData: {
+            dashboardConfig: {
+              ...((stepsPayload.initialData as { dashboardConfig: Record<string, unknown> }).dashboardConfig),
+              pollIntervalsMs: { detail: 60000, list: 60000 },
+            },
+          },
+        }}
+      />,
+    );
 
     const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
     expect(await within(sidebar).findByText('Workflow navigation is unavailable.')).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    const detailCallsBeforeRetry = fetchSpy.mock.calls.filter(
+      ([input]) => String(input) === '/api/executions/test-123?source=temporal',
+    ).length;
 
     fireEvent.click(within(sidebar).getByRole('button', { name: 'Retry' }));
 
@@ -724,6 +795,26 @@ describe('Workflow Detail Entrypoint', () => {
       expect(sidebarFetches.length).toBeGreaterThanOrEqual(2);
     });
     expect(screen.getByRole('heading', { name: 'Workflow Detail' })).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.filter(
+        ([input]) => String(input) === '/api/executions/test-123?source=temporal',
+      ).length,
+    ).toBe(detailCallsBeforeRetry);
+  });
+
+  it('MM-1010 keeps a loaded desktop sidebar visible when the selected detail request fails (MM-975)', async () => {
+    window.history.pushState({}, 'Workspace Detail Failure Test', '/workflows/test-123?source=temporal');
+    mockDesktopViewport(true);
+    mockWorkflowWorkspaceDetailFailure();
+
+    renderWithClient(<WorkflowDetailEntrypoint payload={stepsPayload} />);
+
+    const sidebar = await screen.findByRole('complementary', { name: 'Workflow navigation' });
+    const active = await within(sidebar).findByRole('link', { name: /MM-1010 sidebar remains loaded/i });
+    expect(active.getAttribute('aria-current')).toBe('page');
+    expect(screen.getByRole('main', { name: 'Workflow detail' })).toBeTruthy();
+    expect(await screen.findByText('Failed to fetch workflow: Forbidden')).toBeTruthy();
+    expect(within(sidebar).queryByText('Workflow navigation is unavailable.')).toBeNull();
   });
 
   it('MM-997 translates workspace sidebar limit state to the executions API page size', async () => {

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1652,6 +1652,35 @@ describe('Workflows Entrypoint', () => {
     expect(screen.getByRole('button', { name: 'Filters' })).toBeTruthy();
   }, 10000);
 
+  it('MM-1010 keeps desktop workspace sidebar controls out of mobile workflow list accessibility', async () => {
+    renderWithClient(
+      <WorkflowListPage
+        payload={{
+          ...mockPayload,
+          initialData: {
+            dashboardConfig: {
+              features: {
+                temporalDashboard: {
+                  workspaceShellEnabled: true,
+                },
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    await screen.findAllByText('Example task');
+    const cardList = document.querySelector('.queue-card-list') as HTMLElement | null;
+    expect(cardList).toBeTruthy();
+    expect(within(cardList as HTMLElement).getByRole('link', { name: 'Example task' })).toBeTruthy();
+    expect(screen.queryByRole('complementary', { name: 'Workflow navigation' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Close sidebar' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Open workflow sidebar' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Expand to full list' })).toBeNull();
+    expect(document.querySelector('.workflow-workspace-shell')).toBeNull();
+  });
+
   it('keeps mobile task cards constrained to the viewport width', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);
 

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -403,6 +403,25 @@ def test_detail_sub_routes_render_dashboard_shell(client: TestClient) -> None:
         assert 'type="module"' in response.text
         assert "/static/workflow_console/dist/assets/" in response.text
 
+def test_detail_shell_boot_payload_keeps_workspace_query_state_browser_only(
+    client: TestClient,
+) -> None:
+    """MM-1010 / MM-975: shell routing authorizes the path without embedding URL secrets."""
+    token_param = "token" + "=redacted-fixture"
+    password_param = "password" + "=redacted-fixture"
+    response = client.get(
+        "/workflows/mm:workflow-123/steps"
+        f"?source=temporal&stateIn=completed&{token_param}&{password_param}"
+    )
+
+    assert response.status_code == 200
+    boot_payload = _extract_boot_payload(response.text)
+    dashboard_config = boot_payload["initialData"]["dashboardConfig"]
+    assert dashboard_config["initialPath"] == "/workflows/mm:workflow-123/steps"
+    serialized_boot_payload = json.dumps(boot_payload)
+    assert token_param not in serialized_boot_payload
+    assert password_param not in serialized_boot_payload
+
 def test_data_wide_panel_on_selected_react_routes(client: TestClient) -> None:
     for path in (
         "/workflows",


### PR DESCRIPTION
Issue reference: MM-1010

Summary:
- Adds desktop workflow workspace tests for empty filtered sidebar state, pinned current workflow behavior, sidebar retry isolation, and detail failure resilience.
- Adds mobile regression coverage proving desktop sidebar controls are absent from mobile list rendering.
- Adds API shell routing coverage for authorized detail subroutes while keeping sensitive query state browser-only.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_workflow_console.py
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/workflow-list.test.tsx

Remaining risks:
- Full unit suite was not run; verification was targeted to the changed API and dashboard test areas.