### PR TITLE
MM-1016 Add session compatibility facades

### DIFF
--- a/api_service/api/routers/sessions.py
+++ b/api_service/api/routers/sessions.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from api_service.api.routers import agent_runs as agent_runs_router
+from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
+from api_service.auth_providers import get_current_user
+from api_service.db.models import User
+from moonmind.config.settings import settings
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.schemas.temporal_artifact_models import ArtifactSessionControlRequest
+from moonmind.workflows.temporal.artifacts import TemporalArtifactService
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+ManagedRunStore = agent_runs_router.ManagedRunStore
+ManagedSessionStore = agent_runs_router.ManagedSessionStore
+_build_agent_run_artifact_session_projection = (
+    agent_runs_router._build_agent_run_artifact_session_projection
+)
+_load_agent_run_observability_events = agent_runs_router._load_agent_run_observability_events
+control_agent_run_artifact_session = agent_runs_router.control_agent_run_artifact_session
+get_temporal_client_adapter = agent_runs_router.get_temporal_client_adapter
+stream_agent_run_live_logs = agent_runs_router.stream_agent_run_live_logs
+
+
+def _require_session_api_compat_enabled() -> None:
+    if not settings.feature_flags.session_api_compat_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "session_api_compat_disabled",
+                "message": (
+                    "Session API aliases are disabled. Enable "
+                    "MOONMIND_SESSION_API_COMPAT_ENABLED or "
+                    "FEATURE_FLAGS__SESSION_API_COMPAT_ENABLED to use this surface."
+                ),
+            },
+        )
+
+
+async def _load_authorized_session_record(
+    session_id: str,
+    user: User,
+) -> CodexManagedSessionRecord:
+    store = ManagedSessionStore(
+        agent_runs_router._get_managed_session_store_root()
+    )
+    try:
+        record = await asyncio.to_thread(store.load, session_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid session id",
+        ) from exc
+    if record is None:
+        agent_runs_router._session_projection_not_found()
+    await agent_runs_router._require_agent_run_access(record.agent_run_id, user)
+    return record
+
+
+async def _load_agent_run_record(agent_run_id: str) -> object | None:
+    store = ManagedRunStore(
+        agent_runs_router._get_agent_runtime_store_root()
+    )
+    return await agent_runs_router._load_managed_run_record(store, agent_run_id)
+
+
+async def _session_projection(
+    record: CodexManagedSessionRecord,
+    artifact_service: TemporalArtifactService,
+):
+    projection = await _build_agent_run_artifact_session_projection(
+        agent_run_id=record.agent_run_id,
+        session_id=record.session_id,
+        service=artifact_service,
+    )
+    if projection is None:
+        agent_runs_router._session_projection_not_found()
+    return projection
+
+
+def _artifact_refs_from_projection(projection: object) -> dict[str, Any]:
+    return {
+        "latestSummaryRef": getattr(projection, "latest_summary_ref", None),
+        "latestCheckpointRef": getattr(projection, "latest_checkpoint_ref", None),
+        "latestControlEventRef": getattr(projection, "latest_control_event_ref", None),
+        "latestResetBoundaryRef": getattr(projection, "latest_reset_boundary_ref", None),
+        "groupedArtifacts": getattr(projection, "grouped_artifacts", []),
+    }
+
+
+def _event_item(event: dict[str, Any]) -> dict[str, Any]:
+    sequence = event.get("sequence")
+    kind = str(event.get("kind") or event.get("stream") or "event")
+    return {
+        "id": f"event:{sequence}" if isinstance(sequence, int) else f"event:{kind}",
+        "type": "event",
+        "kind": kind,
+        "sequence": sequence,
+        "timestamp": event.get("timestamp"),
+        "sessionEpoch": event.get("sessionEpoch"),
+        "threadId": event.get("threadId"),
+        "turnId": event.get("turnId"),
+        "event": event,
+    }
+
+
+def _artifact_items(projection: object) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for name, artifact_ref in (
+        ("latest_summary", getattr(projection, "latest_summary_ref", None)),
+        ("latest_checkpoint", getattr(projection, "latest_checkpoint_ref", None)),
+        ("latest_control_event", getattr(projection, "latest_control_event_ref", None)),
+        ("latest_reset_boundary", getattr(projection, "latest_reset_boundary_ref", None)),
+    ):
+        if artifact_ref is None:
+            continue
+        items.append(
+            {
+                "id": f"artifact:{name}",
+                "type": "artifact_ref",
+                "kind": name,
+                "artifactRef": artifact_ref,
+            }
+        )
+    return items
+
+
+@router.get("/{session_id}", response_model=dict)
+async def get_session_snapshot(
+    session_id: str,
+    _enabled: None = Depends(_require_session_api_compat_enabled),
+    _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+) -> dict[str, Any]:
+    record = await _load_authorized_session_record(session_id, _user)
+    projection = await _session_projection(record, artifact_service)
+    run_record = await _load_agent_run_record(record.agent_run_id)
+    return {
+        "id": record.session_id,
+        "agentRunId": record.agent_run_id,
+        "workflowId": getattr(run_record, "workflow_id", None),
+        "status": getattr(run_record, "status", None) or record.status,
+        "sessionEpoch": record.session_epoch,
+        "interventionCapabilities": agent_runs_router._build_intervention_capabilities(
+            record
+        ),
+        "artifactRefs": _artifact_refs_from_projection(projection),
+    }
+
+
+@router.get("/{session_id}/items", response_model=dict)
+async def get_session_items(
+    session_id: str,
+    since: int | None = Query(default=None, ge=0),
+    limit: int = Query(default=500, ge=1, le=5000),
+    _enabled: None = Depends(_require_session_api_compat_enabled),
+    _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+) -> dict[str, Any]:
+    record = await _load_authorized_session_record(session_id, _user)
+    run_record = await _load_agent_run_record(record.agent_run_id)
+    if run_record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Observability record not found for this session",
+        )
+    events, source = await asyncio.to_thread(
+        _load_agent_run_observability_events,
+        record=run_record,
+        session_record=record,
+        limit=limit,
+        since=since,
+        streams=set(),
+        kinds=set(),
+        session_epochs=set(),
+        thread_ids=set(),
+    )
+    events = agent_runs_router._filter_observability_events(
+        events,
+        since=since,
+        streams=set(),
+        kinds=set(),
+        session_epochs={record.session_epoch},
+        thread_ids=set(),
+    )
+    events.sort(key=agent_runs_router._event_sort_key)
+    truncated = len(events) > limit
+    if truncated:
+        events = events[:limit]
+    projection = await _session_projection(record, artifact_service)
+    return {
+        "items": [_event_item(event) for event in events] + _artifact_items(projection),
+        "truncated": truncated,
+        "source": source,
+        "sessionEpoch": record.session_epoch,
+    }
+
+
+@router.get("/{session_id}/stream")
+async def stream_session(
+    session_id: str,
+    request: Request,
+    since: int | None = Query(default=None, ge=0),
+    format: str = Query(default="sse"),
+    _enabled: None = Depends(_require_session_api_compat_enabled),
+    _user: User = Depends(get_current_user()),
+):
+    if format != "sse":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported session stream format. Supported formats: sse.",
+        )
+    record = await _load_authorized_session_record(session_id, _user)
+    return await stream_agent_run_live_logs(
+        id=record.agent_run_id,
+        request=request,
+        since=since,
+        _user=_user,
+    )
+
+
+@router.post("/{session_id}/events", response_model=dict)
+async def post_session_event(
+    session_id: str,
+    payload: dict[str, Any],
+    _enabled: None = Depends(_require_session_api_compat_enabled),
+    _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+) -> dict[str, Any]:
+    record = await _load_authorized_session_record(session_id, _user)
+    event_type = str(payload.get("type") or "").strip()
+    if event_type == "message":
+        try:
+            control = ArtifactSessionControlRequest(
+                action="send_follow_up",
+                message=payload.get("message"),
+                reason=payload.get("reason"),
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="message is required when type=message",
+            ) from exc
+    elif event_type == "interrupt":
+        try:
+            control = ArtifactSessionControlRequest(
+                action="interrupt_turn",
+                reason=payload.get("reason"),
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="Invalid interrupt event payload",
+            ) from exc
+    elif event_type == "clear_session":
+        try:
+            control = ArtifactSessionControlRequest(
+                action="clear_session",
+                reason=payload.get("reason"),
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="Invalid clear_session event payload",
+            ) from exc
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported session event type: {event_type or '<missing>'}",
+        )
+    response = await control_agent_run_artifact_session(
+        agent_run_id=record.agent_run_id,
+        session_id=record.session_id,
+        payload=control,
+        _user=_user,
+        artifact_service=artifact_service,
+    )
+    return {
+        "type": event_type,
+        "action": response.action,
+        "projection": jsonable_encoder(response.projection),
+    }
+
+
+@router.post("/{session_id}/elicitations/{elicitation_id}/resolve", response_model=dict)
+async def resolve_session_elicitation(
+    session_id: str,
+    elicitation_id: str,
+    payload: dict[str, Any],
+    _enabled: None = Depends(_require_session_api_compat_enabled),
+    _user: User = Depends(get_current_user()),
+) -> dict[str, Any]:
+    record = await _load_authorized_session_record(session_id, _user)
+    capabilities = agent_runs_router._build_intervention_capabilities(record)
+    if not any(capabilities.values()):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This managed session is not available for elicitation resolution.",
+        )
+    if record.status in agent_runs_router._MANAGED_SESSION_TERMINAL_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This managed session is not available for elicitation resolution.",
+        )
+    client = get_temporal_client_adapter()
+    workflow_id = agent_runs_router._agent_run_session_workflow_id(
+        agent_run_id=record.agent_run_id,
+        runtime_id=record.runtime_id,
+    )
+    update_payload = {
+        "elicitationId": elicitation_id,
+        "sessionEpoch": record.session_epoch,
+        "resolution": dict(payload),
+    }
+    result = await client.update_workflow(
+        workflow_id,
+        "ResolveElicitation",
+        update_payload,
+    )
+    return {
+        "elicitationId": elicitation_id,
+        "status": "resolved",
+        "result": result,
+    }

--- a/api_service/api/routers/sessions.py
+++ b/api_service/api/routers/sessions.py
@@ -25,7 +25,6 @@ _build_agent_run_artifact_session_projection = (
 )
 _load_agent_run_observability_events = agent_runs_router._load_agent_run_observability_events
 control_agent_run_artifact_session = agent_runs_router.control_agent_run_artifact_session
-get_temporal_client_adapter = agent_runs_router.get_temporal_client_adapter
 stream_agent_run_live_logs = agent_runs_router.stream_agent_run_live_logs
 
 
@@ -179,7 +178,7 @@ async def get_session_items(
         since=since,
         streams=set(),
         kinds=set(),
-        session_epochs=set(),
+        session_epochs={record.session_epoch},
         thread_ids=set(),
     )
     events = agent_runs_router._filter_observability_events(
@@ -309,23 +308,9 @@ async def resolve_session_elicitation(
             status_code=status.HTTP_409_CONFLICT,
             detail="This managed session is not available for elicitation resolution.",
         )
-    client = get_temporal_client_adapter()
-    workflow_id = agent_runs_router._agent_run_session_workflow_id(
-        agent_run_id=record.agent_run_id,
-        runtime_id=record.runtime_id,
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=(
+            "Session elicitation resolution is not implemented for managed sessions."
+        ),
     )
-    update_payload = {
-        "elicitationId": elicitation_id,
-        "sessionEpoch": record.session_epoch,
-        "resolution": dict(payload),
-    }
-    result = await client.update_workflow(
-        workflow_id,
-        "ResolveElicitation",
-        update_payload,
-    )
-    return {
-        "elicitationId": elicitation_id,
-        "status": "resolved",
-        "result": result,
-    }

--- a/api_service/config.template.toml
+++ b/api_service/config.template.toml
@@ -24,6 +24,8 @@ moonmind_severity_floor_default = "high"
 proposal_delivery_provider_default = "github"
 
 [feature_flags]
+# Enable /api/sessions compatibility facades over canonical AgentRun session APIs.
+session_api_compat_enabled = false
 # Disable the Preset Catalog (UI + API) when required.
 disable_preset_catalog = false
 # Rollout scope for the session-aware Live Logs timeline contract:

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -55,6 +55,7 @@ if _ENABLE_TEST_UI_ROUTE:
 
 from api_service.api.routers.workflow_console import router as workflow_console_router
 from api_service.api.routers.agent_runs import router as agent_runs_router
+from api_service.api.routers.sessions import router as sessions_router
 from api_service.api.routers.workflow_proposals import router as workflow_proposals_router
 from api_service.api.routers.presets import (
     router as presets_router,
@@ -458,6 +459,7 @@ app.include_router(automation_router)
 app.include_router(workflow_proposals_router)
 app.include_router(recurring_workflows_router)
 app.include_router(agent_runs_router, prefix="/api")
+app.include_router(sessions_router, prefix="/api")
 app.include_router(workflow_console_router)
 app.include_router(presets_router)
 app.include_router(temporal_artifacts_router)

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2176,6 +2176,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sessions/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Session Snapshot */
+        get: operations["get_session_snapshot_api_sessions__session_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Session Items */
+        get: operations["get_session_items_api_sessions__session_id__items_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream Session */
+        get: operations["stream_session_api_sessions__session_id__stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post Session Event */
+        post: operations["post_session_event_api_sessions__session_id__events_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/elicitations/{elicitation_id}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resolve Session Elicitation */
+        post: operations["resolve_session_elicitation_api_sessions__session_id__elicitations__elicitation_id__resolve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/secrets": {
         parameters: {
             query?: never;
@@ -13710,6 +13795,188 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_snapshot_api_sessions__session_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_items_api_sessions__session_id__items_get: {
+        parameters: {
+            query?: {
+                since?: number | null;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_session_api_sessions__session_id__stream_get: {
+        parameters: {
+            query?: {
+                since?: number | null;
+                format?: string;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_session_event_api_sessions__session_id__events_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    resolve_session_elicitation_api_sessions__session_id__elicitations__elicitation_id__resolve_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+                elicitation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
             };
             /** @description Validation Error */
             422: {

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2175,6 +2175,18 @@ class OIDCSettings(BaseSettings):
 class FeatureFlagsSettings(BaseSettings):
     """Feature flag toggles for runtime surfaces."""
 
+    session_api_compat_enabled: bool = Field(
+        False,
+        validation_alias=AliasChoices(
+            "MOONMIND_SESSION_API_COMPAT_ENABLED",
+            "FEATURE_FLAGS__SESSION_API_COMPAT_ENABLED",
+            "SESSION_API_COMPAT_ENABLED",
+        ),
+        description=(
+            "Enable /api/sessions compatibility facades over canonical "
+            "AgentRun managed-session APIs."
+        ),
+    )
     live_logs_session_timeline_rollout: Literal[
         "off",
         "internal",

--- a/tests/unit/api/routers/test_sessions.py
+++ b/tests/unit/api/routers/test_sessions.py
@@ -178,7 +178,7 @@ def test_get_session_items_maps_events_and_artifact_refs(
             with patch(
                 "api_service.api.routers.sessions._load_agent_run_observability_events",
                 return_value=(events, "artifacts"),
-            ):
+            ) as load_events:
                 with patch(
                     "api_service.api.routers.sessions._build_agent_run_artifact_session_projection",
                     new=AsyncMock(return_value=_projection()),
@@ -196,6 +196,7 @@ def test_get_session_items_maps_events_and_artifact_refs(
         "latest_control_event",
         "latest_reset_boundary",
     }
+    assert load_events.call_args.kwargs["session_epochs"] == {2}
 
 
 def test_session_stream_delegates_to_agent_run_live_logs(
@@ -286,37 +287,24 @@ def test_post_session_event_rejects_unknown_type(
     assert "Unsupported session event type" in response.json()["detail"]
 
 
-def test_resolve_elicitation_uses_session_workflow_update(
+def test_resolve_elicitation_rejects_unsupported_facade(
     client: tuple[TestClient, AsyncMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _enable_session_api(monkeypatch)
     test_client, _ = client
-    temporal_client = SimpleNamespace(update_workflow=AsyncMock(return_value={"ok": True}))
 
     with patch(
         "api_service.api.routers.sessions.ManagedSessionStore.load",
         return_value=_session_record(),
     ):
-        with patch(
-            "api_service.api.routers.sessions.get_temporal_client_adapter",
-            return_value=temporal_client,
-        ):
-            response = test_client.post(
-                "/api/sessions/sess-1/elicitations/el-1/resolve",
-                json={"decision": "approve"},
-            )
+        response = test_client.post(
+            "/api/sessions/sess-1/elicitations/el-1/resolve",
+            json={"decision": "approve"},
+        )
 
-    assert response.status_code == 200
-    temporal_client.update_workflow.assert_awaited_once_with(
-        "mm:run-1:session:codex_cli",
-        "ResolveElicitation",
-        {
-            "elicitationId": "el-1",
-            "sessionEpoch": 2,
-            "resolution": {"decision": "approve"},
-        },
-    )
+    assert response.status_code == 501
+    assert "not implemented" in response.json()["detail"]
 
 
 def test_terminal_session_suppresses_elicitation_resolution_capability(

--- a/tests/unit/api/routers/test_sessions.py
+++ b/tests/unit/api/routers/test_sessions.py
@@ -1,0 +1,339 @@
+"""Unit tests for MM-1016 /api/sessions compatibility facades.
+
+Source traceability: MM-977 chat-session API naming alignment.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+import pytest
+
+from api_service.api.routers import sessions as sessions_router
+from api_service.api.routers.sessions import router
+from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
+from api_service.auth_providers import get_current_user
+from api_service.db.models import User
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+
+
+@pytest.fixture
+def test_user() -> User:
+    return User(id=uuid4(), email="test@example.com", is_superuser=True)
+
+
+@pytest.fixture
+def client(test_user: User) -> Iterator[tuple[TestClient, AsyncMock]]:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    artifact_service = AsyncMock()
+
+    app.dependency_overrides[get_current_user()] = lambda: test_user
+    app.dependency_overrides[_get_temporal_artifact_service] = lambda: artifact_service
+
+    with TestClient(app) as test_client:
+        yield test_client, artifact_service
+
+    app.dependency_overrides.clear()
+
+
+def _enable_session_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sessions_router.settings.feature_flags,
+        "session_api_compat_enabled",
+        True,
+    )
+
+
+def _session_record(**overrides: object) -> CodexManagedSessionRecord:
+    values = {
+        "sessionId": "sess:mm:run-1:codex_cli",
+        "sessionEpoch": 2,
+        "agentRunId": "mm:run-1",
+        "containerId": "ctr-1",
+        "threadId": "thread-1",
+        "runtimeId": "codex_cli",
+        "imageRef": "ghcr.io/moonmind/session:latest",
+        "controlUrl": "http://session-control",
+        "status": "ready",
+        "workspacePath": "/tmp/workspace",
+        "sessionWorkspacePath": "/tmp/workspace/session",
+        "artifactSpoolPath": "/tmp/workspace/artifacts",
+        "latestSummaryRef": "artifact-summary",
+        "latestCheckpointRef": "artifact-checkpoint",
+        "latestControlEventRef": "artifact-control",
+        "latestResetBoundaryRef": "artifact-reset",
+        "startedAt": datetime(2026, 6, 1, tzinfo=UTC),
+        "updatedAt": datetime(2026, 6, 1, 0, 1, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return CodexManagedSessionRecord.model_validate(values)
+
+
+def _projection() -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_run_id="mm:run-1",
+        session_id="sess:mm:run-1:codex_cli",
+        session_epoch=2,
+        grouped_artifacts=[],
+        latest_summary_ref={"artifactId": "artifact-summary"},
+        latest_checkpoint_ref={"artifactId": "artifact-checkpoint"},
+        latest_control_event_ref={"artifactId": "artifact-control"},
+        latest_reset_boundary_ref={"artifactId": "artifact-reset"},
+    )
+
+
+def test_session_aliases_are_disabled_by_default(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sessions_router.settings.feature_flags,
+        "session_api_compat_enabled",
+        False,
+    )
+    test_client, _ = client
+
+    with patch("api_service.api.routers.sessions.ManagedSessionStore.load") as load:
+        response = test_client.get("/api/sessions/sess-1")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "session_api_compat_disabled"
+    load.assert_not_called()
+
+
+def test_get_session_snapshot_returns_bounded_alias_contract(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+    run_record = SimpleNamespace(workflow_id="mm:workflow-1", status="running")
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ) as load_session:
+        with patch(
+            "api_service.api.routers.sessions._build_agent_run_artifact_session_projection",
+            new=AsyncMock(return_value=_projection()),
+        ):
+            with patch(
+                "api_service.api.routers.sessions.ManagedRunStore.load",
+                return_value=run_record,
+            ):
+                response = test_client.get("/api/sessions/sess%3Amm%3Arun-1%3Acodex_cli")
+
+    assert response.status_code == 200
+    load_session.assert_called_once_with("sess:mm:run-1:codex_cli")
+    body = response.json()
+    assert body["id"] == "sess:mm:run-1:codex_cli"
+    assert body["agentRunId"] == "mm:run-1"
+    assert body["workflowId"] == "mm:workflow-1"
+    assert body["status"] == "running"
+    assert body["sessionEpoch"] == 2
+    assert body["interventionCapabilities"] == {
+        "sendFollowUp": True,
+        "clearSession": True,
+        "interruptTurn": False,
+        "cancelSession": False,
+    }
+    assert body["artifactRefs"]["latestSummaryRef"] == {
+        "artifactId": "artifact-summary"
+    }
+
+
+def test_get_session_items_maps_events_and_artifact_refs(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+    run_record = SimpleNamespace(workspace_path="/tmp/workspace")
+    events = [
+        {
+            "sequence": 3,
+            "kind": "assistant_message",
+            "timestamp": "2026-06-01T00:00:03Z",
+            "sessionEpoch": 2,
+            "threadId": "thread-1",
+            "text": "done",
+        }
+    ]
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.ManagedRunStore.load",
+            return_value=run_record,
+        ):
+            with patch(
+                "api_service.api.routers.sessions._load_agent_run_observability_events",
+                return_value=(events, "artifacts"),
+            ):
+                with patch(
+                    "api_service.api.routers.sessions._build_agent_run_artifact_session_projection",
+                    new=AsyncMock(return_value=_projection()),
+                ):
+                    response = test_client.get("/api/sessions/sess-1/items?since=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source"] == "artifacts"
+    assert body["items"][0]["id"] == "event:3"
+    assert body["items"][0]["kind"] == "assistant_message"
+    assert {item["kind"] for item in body["items"][1:]} == {
+        "latest_summary",
+        "latest_checkpoint",
+        "latest_control_event",
+        "latest_reset_boundary",
+    }
+
+
+def test_session_stream_delegates_to_agent_run_live_logs(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    async def _stream(**kwargs):
+        return Response("data: {}\n\n", media_type="text/event-stream")
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.stream_agent_run_live_logs",
+            new=AsyncMock(side_effect=_stream),
+        ) as stream:
+            response = test_client.get("/api/sessions/sess-1/stream?since=10")
+
+    assert response.status_code == 200
+    assert response.text == "data: {}\n\n"
+    assert stream.await_args.kwargs["id"] == "mm:run-1"
+    assert stream.await_args.kwargs["since"] == 10
+
+
+def test_session_stream_rejects_unsupported_format(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    response = test_client.get("/api/sessions/sess-1/stream?format=jsonl")
+
+    assert response.status_code == 400
+    assert "Unsupported session stream format" in response.json()["detail"]
+
+
+def test_post_session_message_event_maps_to_existing_control_path(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+    control_response = SimpleNamespace(action="send_follow_up", projection=_projection())
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.control_agent_run_artifact_session",
+            new=AsyncMock(return_value=control_response),
+        ) as control:
+            response = test_client.post(
+                "/api/sessions/sess-1/events",
+                json={"type": "message", "message": "continue", "reason": "operator"},
+            )
+
+    assert response.status_code == 200
+    assert response.json()["action"] == "send_follow_up"
+    control_payload = control.await_args.kwargs["payload"]
+    assert control.await_args.kwargs["agent_run_id"] == "mm:run-1"
+    assert control_payload.action == "send_follow_up"
+    assert control_payload.message == "continue"
+
+
+def test_post_session_event_rejects_unknown_type(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        response = test_client.post(
+            "/api/sessions/sess-1/events",
+            json={"type": "retry_everything"},
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported session event type" in response.json()["detail"]
+
+
+def test_resolve_elicitation_uses_session_workflow_update(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+    temporal_client = SimpleNamespace(update_workflow=AsyncMock(return_value={"ok": True}))
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.get_temporal_client_adapter",
+            return_value=temporal_client,
+        ):
+            response = test_client.post(
+                "/api/sessions/sess-1/elicitations/el-1/resolve",
+                json={"decision": "approve"},
+            )
+
+    assert response.status_code == 200
+    temporal_client.update_workflow.assert_awaited_once_with(
+        "mm:run-1:session:codex_cli",
+        "ResolveElicitation",
+        {
+            "elicitationId": "el-1",
+            "sessionEpoch": 2,
+            "resolution": {"decision": "approve"},
+        },
+    )
+
+
+def test_terminal_session_suppresses_elicitation_resolution_capability(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(status="terminated"),
+    ):
+        response = test_client.post(
+            "/api/sessions/sess-1/elicitations/el-1/resolve",
+            json={"decision": "approve"},
+        )
+
+    assert response.status_code == 409
+    assert "not available" in response.json()["detail"]

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -229,6 +229,40 @@ class TestFeatureFlagsSettings:
         assert settings.live_logs_session_timeline_rollout == "off"
         assert settings.live_logs_session_timeline_enabled is False
 
+    def test_session_api_compat_flag_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("MOONMIND_SESSION_API_COMPAT_ENABLED", raising=False)
+        monkeypatch.delenv(
+            "FEATURE_FLAGS__SESSION_API_COMPAT_ENABLED", raising=False
+        )
+        monkeypatch.delenv("SESSION_API_COMPAT_ENABLED", raising=False)
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.session_api_compat_enabled is False
+
+    @pytest.mark.parametrize(
+        "env_name",
+        [
+            "MOONMIND_SESSION_API_COMPAT_ENABLED",
+            "FEATURE_FLAGS__SESSION_API_COMPAT_ENABLED",
+        ],
+    )
+    def test_session_api_compat_flag_accepts_configured_env(
+        self,
+        monkeypatch,
+        env_name,
+    ):
+        monkeypatch.delenv("MOONMIND_SESSION_API_COMPAT_ENABLED", raising=False)
+        monkeypatch.delenv(
+            "FEATURE_FLAGS__SESSION_API_COMPAT_ENABLED", raising=False
+        )
+        monkeypatch.delenv("SESSION_API_COMPAT_ENABLED", raising=False)
+        monkeypatch.setenv(env_name, "true")
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.session_api_compat_enabled is True
+
     def test_live_logs_session_timeline_rollout_accepts_prefixed_env(
         self, monkeypatch
     ):


### PR DESCRIPTION
Issue reference
- MM-1016: https://moonladder.atlassian.net/browse/MM-1016

Summary
- Added feature-flagged `/api/sessions` compatibility facades over existing AgentRun/session artifact APIs.
- Added deterministic session-to-agent-run handling, authorization-preserving alias behavior, session snapshot/items/stream/event/elicitation routes, and generated OpenAPI updates.
- Added config support for `MOONMIND_SESSION_API_COMPAT_ENABLED` and template documentation.

Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_sessions.py tests/unit/config/test_settings.py`

Remaining risks
- Session alias behavior is intentionally thin over the existing AgentRun APIs; broader client adoption may surface additional compatibility expectations outside this issue scope.