### PR TITLE
MM-1017 Expose session resource artifact aliases

### DIFF
--- a/api_service/api/routers/agent_runs.py
+++ b/api_service/api/routers/agent_runs.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
 from fastapi.responses import FileResponse, StreamingResponse
@@ -373,6 +374,15 @@ def _safe_session_resource_metadata(metadata: dict[str, object]) -> dict[str, ob
         safe[str(key)] = value
     return safe
 
+
+def _session_resource_url(session_id: str, artifact_id: str, suffix: str) -> str:
+    encoded_session_id = quote(str(session_id), safe="")
+    encoded_artifact_id = quote(str(artifact_id), safe="")
+    return (
+        f"/api/sessions/{encoded_session_id}/resources/"
+        f"{encoded_artifact_id}/{suffix}"
+    )
+
 def _build_session_resource_list(
     projection: ArtifactSessionProjectionModel,
 ) -> SessionResourceListResponse:
@@ -399,13 +409,15 @@ def _build_session_resource_list(
                     default_read_ref=artifact.default_read_ref,
                     preview_artifact_ref=artifact.preview_artifact_ref,
                     metadata=metadata,
-                    content_url=(
-                        f"/api/sessions/{projection.session_id}/resources/"
-                        f"{artifact.artifact_id}/content"
+                    content_url=_session_resource_url(
+                        projection.session_id,
+                        artifact.artifact_id,
+                        "content",
                     ),
-                    download_url=(
-                        f"/api/sessions/{projection.session_id}/resources/"
-                        f"{artifact.artifact_id}/download"
+                    download_url=_session_resource_url(
+                        projection.session_id,
+                        artifact.artifact_id,
+                        "download",
                     ),
                 )
             )
@@ -433,6 +445,14 @@ def _require_session_resource(
         },
     )
 
+
+def _session_resource_filename(artifact: object) -> str:
+    artifact_id = str(getattr(artifact, "artifact_id", "") or "")
+    content_type = str(getattr(artifact, "content_type", "") or "")
+    is_json = content_type.split(";", 1)[0].strip().lower() == "application/json"
+    return f"{artifact_id}.json" if is_json else artifact_id
+
+
 async def _read_session_resource_artifact(
     *,
     session_id: str,
@@ -440,6 +460,7 @@ async def _read_session_resource_artifact(
     user: User,
     principal: str,
     service: TemporalArtifactService,
+    as_attachment: bool,
 ):
     projection = await _load_session_projection_for_alias(
         session_id=session_id,
@@ -455,15 +476,11 @@ async def _read_session_resource_artifact(
             artifact_id=artifact_id,
             principal=principal,
         )
-        is_json = (
-            (artifact.content_type or "").split(";", 1)[0].strip().lower()
-            == "application/json"
-        )
-        filename = f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
         return FileResponse(
             path,
-            filename=filename,
+            filename=_session_resource_filename(artifact),
             media_type=artifact.content_type or "application/octet-stream",
+            content_disposition_type="attachment" if as_attachment else "inline",
         )
     except Exception as exc:
         if not isinstance(exc, TemporalArtifactValidationError):
@@ -479,15 +496,16 @@ async def _read_session_resource_artifact(
         _raise_temporal_artifact_http(exc)
         raise
 
-    is_json = (
-        (artifact.content_type or "").split(";", 1)[0].strip().lower()
-        == "application/json"
-    )
-    filename = f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
+    content_disposition_type = "attachment" if as_attachment else "inline"
+    filename = _session_resource_filename(artifact)
     return StreamingResponse(
         chunks,
         media_type=artifact.content_type or "application/octet-stream",
-        headers={"content-disposition": f'attachment; filename="{filename}"'},
+        headers={
+            "content-disposition": (
+                f'{content_disposition_type}; filename="{filename}"'
+            )
+        },
     )
 
 def _agent_run_session_workflow_id(*, agent_run_id: str, runtime_id: str) -> str:
@@ -1500,6 +1518,7 @@ async def get_session_resource_content(
         user=_user,
         principal=principal,
         service=artifact_service,
+        as_attachment=False,
     )
 
 @sessions_router.get(
@@ -1522,6 +1541,7 @@ async def download_session_resource(
         user=_user,
         principal=principal,
         service=artifact_service,
+        as_attachment=True,
     )
 
 @router.post(

--- a/api_service/api/routers/agent_runs.py
+++ b/api_service/api/routers/agent_runs.py
@@ -14,6 +14,8 @@ from fastapi.responses import FileResponse, StreamingResponse
 
 from api_service.api.routers.temporal_artifacts import (
     _get_temporal_artifact_service,
+    _raise_temporal_artifact_http,
+    _resolve_principal,
     _serialize_metadata,
 )
 from api_service.auth_providers import get_current_user
@@ -25,6 +27,8 @@ from moonmind.schemas.temporal_artifact_models import (
     ArtifactSessionControlResponse,
     ArtifactSessionGroupModel,
     ArtifactSessionProjectionModel,
+    SessionResourceListResponse,
+    SessionResourceModel,
 )
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
@@ -37,12 +41,14 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactNotFoundError,
     TemporalArtifactService,
     TemporalArtifactStateError,
+    TemporalArtifactValidationError,
 )
 from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.schemas.agent_runtime_models import is_terminal_agent_run_state
 from moonmind.observability.transport import SpoolLogReader
 
 router = APIRouter(prefix="/agent-runs", tags=["agent_runs"])
+sessions_router = APIRouter(prefix="/sessions", tags=["session_resources"])
 
 _HISTORICAL_EVENT_CHUNK_SIZE = 65536
 _OBSERVABILITY_TERMINAL_STATUSES = frozenset(
@@ -200,6 +206,7 @@ async def _resolve_projection_artifact(
     *,
     artifact_id: str | None,
     service: TemporalArtifactService,
+    principal: str = "service:agent_runs",
 ) -> ArtifactMetadataModel | None:
     normalized = str(artifact_id or "").strip()
     if not normalized:
@@ -207,7 +214,7 @@ async def _resolve_projection_artifact(
     try:
         artifact, links, pinned, read_policy = await service.get_metadata(
             artifact_id=normalized,
-            principal="service:agent_runs",
+            principal=principal,
         )
     except (
         TemporalArtifactAuthorizationError,
@@ -227,6 +234,7 @@ async def _build_agent_run_artifact_session_projection(
     agent_run_id: str,
     session_id: str,
     service: TemporalArtifactService,
+    principal: str = "service:agent_runs",
 ) -> ArtifactSessionProjectionModel | None:
     store = ManagedSessionStore(_get_managed_session_store_root())
     try:
@@ -246,6 +254,7 @@ async def _build_agent_run_artifact_session_projection(
             cache[normalized] = await _resolve_projection_artifact(
                 artifact_id=normalized,
                 service=service,
+                principal=principal,
             )
         return cache[normalized]
 
@@ -307,6 +316,178 @@ async def _build_agent_run_artifact_session_projection(
         latest_checkpoint_ref=await _artifact_ref(record.latest_checkpoint_ref),
         latest_control_event_ref=await _artifact_ref(record.latest_control_event_ref),
         latest_reset_boundary_ref=await _artifact_ref(record.latest_reset_boundary_ref),
+    )
+
+async def _load_session_projection_for_alias(
+    *,
+    session_id: str,
+    user: User,
+    principal: str,
+    service: TemporalArtifactService,
+) -> ArtifactSessionProjectionModel | None:
+    store = ManagedSessionStore(_get_managed_session_store_root())
+    try:
+        record = await asyncio.to_thread(store.load, session_id)
+    except ValueError:
+        return None
+    if record is None:
+        return None
+
+    await _require_agent_run_access(record.agent_run_id, user)
+    return await _build_agent_run_artifact_session_projection(
+        agent_run_id=record.agent_run_id,
+        session_id=record.session_id,
+        service=service,
+        principal=principal,
+    )
+
+_SECRET_METADATA_FRAGMENTS = frozenset(
+    {
+        "apikey",
+        "api_key",
+        "authorization",
+        "auth",
+        "bearer",
+        "cookie",
+        "credential",
+        "password",
+        "privatekey",
+        "private_key",
+        "secret",
+        "session",
+        "token",
+    }
+)
+
+def _is_secret_like_metadata_key(key: object) -> bool:
+    normalized = "".join(
+        char.lower() for char in str(key or "").strip() if char.isalnum() or char == "_"
+    )
+    return any(fragment in normalized for fragment in _SECRET_METADATA_FRAGMENTS)
+
+def _safe_session_resource_metadata(metadata: dict[str, object]) -> dict[str, object]:
+    safe: dict[str, object] = {}
+    for key, value in metadata.items():
+        if _is_secret_like_metadata_key(key):
+            continue
+        safe[str(key)] = value
+    return safe
+
+def _build_session_resource_list(
+    projection: ArtifactSessionProjectionModel,
+) -> SessionResourceListResponse:
+    resources: list[SessionResourceModel] = []
+    for group in projection.grouped_artifacts:
+        for artifact in group.artifacts:
+            metadata = _safe_session_resource_metadata(dict(artifact.metadata or {}))
+            label = (
+                str(metadata.get("label") or metadata.get("filename") or "").strip()
+                or None
+            )
+            resource_id = artifact.artifact_id
+            resources.append(
+                SessionResourceModel(
+                    resource_id=resource_id,
+                    artifact_id=artifact.artifact_id,
+                    group_key=group.group_key,
+                    group_title=group.title,
+                    label=label,
+                    content_type=artifact.content_type,
+                    size_bytes=artifact.size_bytes,
+                    status=artifact.status,
+                    artifact_ref=artifact.artifact_ref,
+                    default_read_ref=artifact.default_read_ref,
+                    preview_artifact_ref=artifact.preview_artifact_ref,
+                    metadata=metadata,
+                    content_url=(
+                        f"/api/sessions/{projection.session_id}/resources/"
+                        f"{artifact.artifact_id}/content"
+                    ),
+                    download_url=(
+                        f"/api/sessions/{projection.session_id}/resources/"
+                        f"{artifact.artifact_id}/download"
+                    ),
+                )
+            )
+    return SessionResourceListResponse(
+        agent_run_id=projection.agent_run_id,
+        session_id=projection.session_id,
+        session_epoch=projection.session_epoch,
+        resources=resources,
+    )
+
+def _require_session_resource(
+    projection: ArtifactSessionProjectionModel,
+    artifact_id: str,
+) -> None:
+    normalized = str(artifact_id or "").strip()
+    for group in projection.grouped_artifacts:
+        for artifact in group.artifacts:
+            if artifact.artifact_id == normalized:
+                return
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "session_resource_not_found",
+            "message": "Session resource was not found for the requested session.",
+        },
+    )
+
+async def _read_session_resource_artifact(
+    *,
+    session_id: str,
+    artifact_id: str,
+    user: User,
+    principal: str,
+    service: TemporalArtifactService,
+):
+    projection = await _load_session_projection_for_alias(
+        session_id=session_id,
+        user=user,
+        principal=principal,
+        service=service,
+    )
+    if projection is None:
+        _session_projection_not_found()
+    _require_session_resource(projection, artifact_id)
+    try:
+        artifact, path = await service.read_path(
+            artifact_id=artifact_id,
+            principal=principal,
+        )
+        is_json = (
+            (artifact.content_type or "").split(";", 1)[0].strip().lower()
+            == "application/json"
+        )
+        filename = f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
+        return FileResponse(
+            path,
+            filename=filename,
+            media_type=artifact.content_type or "application/octet-stream",
+        )
+    except Exception as exc:
+        if not isinstance(exc, TemporalArtifactValidationError):
+            _raise_temporal_artifact_http(exc)
+            raise
+
+    try:
+        artifact, chunks = await service.read_chunks(
+            artifact_id=artifact_id,
+            principal=principal,
+        )
+    except Exception as exc:
+        _raise_temporal_artifact_http(exc)
+        raise
+
+    is_json = (
+        (artifact.content_type or "").split(";", 1)[0].strip().lower()
+        == "application/json"
+    )
+    filename = f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
+    return StreamingResponse(
+        chunks,
+        media_type=artifact.content_type or "application/octet-stream",
+        headers={"content-disposition": f'attachment; filename="{filename}"'},
     )
 
 def _agent_run_session_workflow_id(*, agent_run_id: str, runtime_id: str) -> str:
@@ -1234,7 +1415,9 @@ async def get_agent_run_artifact_session(
     agent_run_id: str,
     session_id: str,
     _user: User = Depends(get_current_user()),
-    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+    artifact_service: TemporalArtifactService = Depends(
+        _get_temporal_artifact_service
+    ),
 ) -> ArtifactSessionProjectionModel:
     await _require_agent_run_access(agent_run_id, _user)
     projection = await _build_agent_run_artifact_session_projection(
@@ -1245,6 +1428,101 @@ async def get_agent_run_artifact_session(
     if projection is None:
         _session_projection_not_found()
     return projection
+
+@sessions_router.get(
+    "/{session_id}/resources",
+    response_model=SessionResourceListResponse,
+    responses={
+        403: {"description": "You do not have permission to access this session"},
+        404: {"description": "Session projection not found"},
+    },
+)
+async def list_session_resources(
+    session_id: str,
+    _user: User = Depends(get_current_user()),
+    principal: str = Depends(_resolve_principal),
+    artifact_service: TemporalArtifactService = Depends(
+        _get_temporal_artifact_service
+    ),
+) -> SessionResourceListResponse:
+    projection = await _load_session_projection_for_alias(
+        session_id=session_id,
+        user=_user,
+        principal=principal,
+        service=artifact_service,
+    )
+    if projection is None:
+        _session_projection_not_found()
+    return _build_session_resource_list(projection)
+
+@sessions_router.get(
+    "/{session_id}/resources/files",
+    response_model=SessionResourceListResponse,
+    responses={
+        403: {"description": "You do not have permission to access this session"},
+        404: {"description": "Session projection not found"},
+    },
+)
+async def list_session_resource_files(
+    session_id: str,
+    _user: User = Depends(get_current_user()),
+    principal: str = Depends(_resolve_principal),
+    artifact_service: TemporalArtifactService = Depends(
+        _get_temporal_artifact_service
+    ),
+) -> SessionResourceListResponse:
+    return await list_session_resources(
+        session_id=session_id,
+        _user=_user,
+        principal=principal,
+        artifact_service=artifact_service,
+    )
+
+@sessions_router.get(
+    "/{session_id}/resources/{artifact_id}/content",
+    responses={
+        403: {"description": "You do not have permission to access this resource"},
+        404: {"description": "Session resource not found"},
+    },
+)
+async def get_session_resource_content(
+    session_id: str,
+    artifact_id: str,
+    _user: User = Depends(get_current_user()),
+    principal: str = Depends(_resolve_principal),
+    artifact_service: TemporalArtifactService = Depends(
+        _get_temporal_artifact_service
+    ),
+):
+    return await _read_session_resource_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+        user=_user,
+        principal=principal,
+        service=artifact_service,
+    )
+
+@sessions_router.get(
+    "/{session_id}/resources/{artifact_id}/download",
+    responses={
+        403: {"description": "You do not have permission to access this resource"},
+        404: {"description": "Session resource not found"},
+    },
+)
+async def download_session_resource(
+    session_id: str,
+    artifact_id: str,
+    _user: User = Depends(get_current_user()),
+    principal: str = Depends(_resolve_principal),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+):
+    return await _read_session_resource_artifact(
+        session_id=session_id,
+        artifact_id=artifact_id,
+        user=_user,
+        principal=principal,
+        service=artifact_service,
+    )
 
 @router.post(
     "/{agent_run_id}/artifact-sessions/{session_id}/control",

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -727,6 +727,7 @@ def build_runtime_config(
                 "diagnostics": "/api/agent-runs/{agentRunId}/diagnostics",
                 "artifactSession": "/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}",
                 "artifactSessionControl": "/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}/control",
+                "sessionResources": "/api/sessions/{sessionId}/resources",
             },
             **jira_sources,
             "github": {

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -55,6 +55,7 @@ if _ENABLE_TEST_UI_ROUTE:
 
 from api_service.api.routers.workflow_console import router as workflow_console_router
 from api_service.api.routers.agent_runs import router as agent_runs_router
+from api_service.api.routers.agent_runs import sessions_router
 from api_service.api.routers.workflow_proposals import router as workflow_proposals_router
 from api_service.api.routers.presets import (
     router as presets_router,
@@ -458,6 +459,7 @@ app.include_router(automation_router)
 app.include_router(workflow_proposals_router)
 app.include_router(recurring_workflows_router)
 app.include_router(agent_runs_router, prefix="/api")
+app.include_router(sessions_router, prefix="/api")
 app.include_router(workflow_console_router)
 app.include_router(presets_router)
 app.include_router(temporal_artifacts_router)

--- a/docs/Artifacts/ArtifactPresentationContract.md
+++ b/docs/Artifacts/ArtifactPresentationContract.md
@@ -510,14 +510,38 @@ Future extension rule:
 
 - If query filters such as `session_epoch`, `link_type`, or `latest_only` are added later, the server must define their scope. Clients must not re-derive canonical “latest” locally.
 
-### 7.11 Pin / unpin
+### 7.11 List session resource aliases
+
+- `GET /api/sessions/{session_id}/resources`
+- `GET /api/sessions/{session_id}/resources/files`
+
+Response:
+
+- `SessionResourceList`
+
+Rules:
+
+- Session resources are read-only projections over authorized artifact refs from the durable managed-session projection.
+- The aliases must not create blob storage, upload flows, or a second file/resource browser source of truth.
+- The server must enforce the same artifact authorization boundary for listing, content, and download paths.
+- Secret-like metadata keys must be dropped from resource summaries before they are returned to clients.
+- Ended, degraded, or otherwise non-live sessions may still return resource references from durable artifact state.
+
+Initial content aliases:
+
+- `GET /api/sessions/{session_id}/resources/{artifact_id}/content`
+- `GET /api/sessions/{session_id}/resources/{artifact_id}/download`
+
+These aliases may only serve artifacts that belong to the requested session projection. A request for another artifact id must fail with `session_resource_not_found` even when the artifact exists elsewhere.
+
+### 7.12 Pin / unpin
 
 - `POST /api/artifacts/{artifact_id}/pin`
 - `DELETE /api/artifacts/{artifact_id}/pin`
 
 Pin request includes optional `reason`.
 
-### 7.12 Delete
+### 7.13 Delete
 
 `DELETE /api/artifacts/{artifact_id}`
 
@@ -544,6 +568,7 @@ Common codes:
 - `artifact_too_large` 413
 - `session_projection_not_found` 404
 - `session_projection_unavailable` 409
+- `session_resource_not_found` 404
 
 Client rules:
 
@@ -589,6 +614,12 @@ Common session-continuity modes:
 Default session view call:
 
 - `GET /api/agent-runs/{agent_run_id}/artifact-sessions/{session_id}`
+
+Default session resource call:
+
+- `GET /api/sessions/{session_id}/resources`
+
+The session resource response may be used to render compact evidence cards or links, but it must not replace the existing artifact detail, execution artifacts, diagnostics, or log surfaces.
 
 Artifact detail drawer/page should:
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -176,6 +176,7 @@ describe('Workflow Detail Entrypoint', () => {
             diagnostics: '/api/agent-runs/{agentRunId}/diagnostics',
             artifactSession: '/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}',
             artifactSessionControl: '/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}/control',
+            sessionResources: '/api/sessions/{sessionId}/resources',
           },
         },
       },
@@ -7037,6 +7038,28 @@ describe('Workflow Detail Entrypoint', () => {
           }),
         } as Response);
       }
+      if (url.includes('/sessions/sess%3Awf-task-1%3Acodex_cli/resources')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            agent_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 2,
+            resources: [
+              {
+                resource_id: 'art-summary',
+                artifact_id: 'art-summary',
+                group_key: 'continuity',
+                group_title: 'Continuity',
+                label: 'summary.json',
+                content_url: '/api/sessions/sess:wf-task-1:codex_cli/resources/art-summary/content',
+                download_url: '/api/sessions/sess:wf-task-1:codex_cli/resources/art-summary/download',
+                metadata: { filename: 'summary.json' },
+              },
+            ],
+          }),
+        } as Response);
+      }
       if (url.includes('/artifacts?link_type=report.primary&latest_only=true')) {
         return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
       }
@@ -7061,6 +7084,8 @@ describe('Workflow Detail Entrypoint', () => {
       expect(screen.getAllByText('art-checkpoint').length).toBeGreaterThan(0);
       expect(screen.getAllByText('art-control').length).toBeGreaterThan(0);
       expect(screen.getAllByText('art-reset').length).toBeGreaterThan(0);
+      expect(screen.getByText('Resource Evidence')).toBeTruthy();
+      expect(screen.getByText('summary.json')).toBeTruthy();
       expect(screen.getByText('Live Logs')).toBeTruthy();
       expect(screen.getByText('Diagnostics')).toBeTruthy();
     });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1284,6 +1284,48 @@ const ArtifactSessionControlResponseSchema = z.object({
   projection: ArtifactSessionProjectionSchema,
 });
 
+const SessionResourceSchema = z
+  .object({
+    resource_id: z.string().optional(),
+    resourceId: z.string().optional(),
+    artifact_id: z.string().optional(),
+    artifactId: z.string().optional(),
+    group_key: z.string().optional(),
+    groupKey: z.string().optional(),
+    group_title: z.string().optional(),
+    groupTitle: z.string().optional(),
+    label: z.string().nullable().optional(),
+    content_type: z.string().nullable().optional(),
+    contentType: z.string().nullable().optional(),
+    size_bytes: z.number().nullable().optional(),
+    sizeBytes: z.number().nullable().optional(),
+    content_url: z.string().optional(),
+    contentUrl: z.string().optional(),
+    download_url: z.string().optional(),
+    downloadUrl: z.string().optional(),
+    metadata: z.record(z.string(), z.unknown()).default({}),
+  })
+  .passthrough()
+  .transform((resource) => ({
+    resourceId: resource.resourceId ?? resource.resource_id ?? resource.artifactId ?? resource.artifact_id ?? '',
+    artifactId: resource.artifactId ?? resource.artifact_id ?? '',
+    groupKey: resource.groupKey ?? resource.group_key ?? '',
+    groupTitle: resource.groupTitle ?? resource.group_title ?? 'Resources',
+    label: resource.label ?? null,
+    contentType: resource.contentType ?? resource.content_type ?? null,
+    sizeBytes: resource.sizeBytes ?? resource.size_bytes ?? null,
+    contentUrl: resource.contentUrl ?? resource.content_url ?? null,
+    downloadUrl: resource.downloadUrl ?? resource.download_url ?? null,
+    metadata: resource.metadata ?? {},
+  }));
+
+const SessionResourceListSchema = z.object({
+  agent_run_id: z.string(),
+  session_id: z.string(),
+  session_epoch: z.number(),
+  resources: z.array(SessionResourceSchema).default([]),
+});
+
 const InterventionCapabilitiesSchema = z
   .object({
     sendFollowUp: z.boolean().default(false),
@@ -2141,6 +2183,28 @@ async function fetchArtifactSessionProjection(
     throw new Error(`Session continuity: ${resp.status}`);
   }
   return ArtifactSessionProjectionSchema.parse(await resp.json());
+}
+
+async function fetchSessionResources(
+  apiBase: string,
+  agentRunId: string,
+  sessionId: string,
+  routeTemplate?: string | null,
+): Promise<z.infer<typeof SessionResourceListSchema> | null> {
+  const resp = await fetch(
+    agentRunRoute(
+      apiBase,
+      routeTemplate,
+      `/sessions/${encodeURIComponent(sessionId)}/resources`,
+      agentRunRouteParams(agentRunId, { sessionId }),
+    ),
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw new Error(`Session resources: ${resp.status}`);
+  }
+  return SessionResourceListSchema.parse(await resp.json());
 }
 
 async function controlArtifactSession(
@@ -3010,6 +3074,7 @@ type AgentRunRouteTemplates = {
   diagnostics?: string | undefined;
   artifactSession?: string | undefined;
   artifactSessionControl?: string | undefined;
+  sessionResources?: string | undefined;
 };
 
 function readAgentRunRouteTemplates(config: DashboardConfig | undefined): AgentRunRouteTemplates {
@@ -3024,6 +3089,7 @@ function readAgentRunRouteTemplates(config: DashboardConfig | undefined): AgentR
     diagnostics: sourceRoutes?.diagnostics,
     artifactSession: sourceRoutes?.artifactSession,
     artifactSessionControl: sourceRoutes?.artifactSessionControl,
+    sessionResources: sourceRoutes?.sessionResources,
   };
 }
 
@@ -4476,6 +4542,23 @@ function SessionContinuityPanel({
     retry: false,
   });
 
+  const resourcesQuery = useQuery({
+    queryKey: ['session-resources', sessionId],
+    queryFn: () => {
+      if (!sessionId) return Promise.resolve(null);
+      return fetchSessionResources(apiBase, agentRunId, sessionId, routes.sessionResources);
+    },
+    enabled: Boolean(agentRunId && sessionId && summaryQuery.isSuccess),
+    refetchInterval: (query) => {
+      return getSessionProjectionRefetchInterval(
+        isTerminal,
+        Boolean(query.state.data),
+        Boolean(query.state.error),
+      );
+    },
+    retry: false,
+  });
+
   const controlMutation = useMutation({
     mutationFn: async (body: { action: 'send_follow_up' | 'clear_session' | 'interrupt_turn' | 'cancel_session'; message?: string; reason?: string }) => {
       if (!sessionId) throw new Error('Managed session is unavailable.');
@@ -4539,6 +4622,7 @@ function SessionContinuityPanel({
   }
 
   const projection = projectionQuery.data;
+  const sessionResources = resourcesQuery.data?.resources ?? [];
   const latestBadges = [
     ['Latest Summary', projection.latest_summary_ref?.artifact_id ?? null],
     ['Latest Checkpoint', projection.latest_checkpoint_ref?.artifact_id ?? null],
@@ -4610,6 +4694,38 @@ function SessionContinuityPanel({
               <strong>{label}:</strong> <code className="text-xs">{artifactId}</code>
             </span>
           ))}
+        </div>
+      ) : null}
+
+      {sessionResources.length > 0 ? (
+        <div className="stack">
+          <h4>Resource Evidence</h4>
+          <div className="grid-2">
+            {sessionResources.map((resource) => {
+              const label = resource.label || resource.artifactId;
+              const contentHref = resource.contentUrl
+                ? resolveApiBaseTemplate(apiBase, resource.contentUrl)
+                : buildArtifactDownloadHref(apiBase, resource.artifactId);
+              const downloadHref = resource.downloadUrl
+                ? resolveApiBaseTemplate(apiBase, resource.downloadUrl)
+                : buildArtifactDownloadHref(apiBase, resource.artifactId);
+              return (
+                <div key={resource.resourceId || resource.artifactId} className="card">
+                  <strong>{label}</strong>
+                  <div className="small">{resource.groupTitle}</div>
+                  <code className="text-xs break-all">{resource.artifactId}</code>
+                  <div className="actions" style={{ marginTop: '0.5rem' }}>
+                    <a className="button secondary small" href={contentHref} target="_blank" rel="noreferrer">
+                      Open
+                    </a>
+                    <a className="button secondary small" href={downloadHref} target="_blank" rel="noreferrer">
+                      Download
+                    </a>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       ) : null}
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2176,6 +2176,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sessions/{session_id}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Session Resources */
+        get: operations["list_session_resources_api_sessions__session_id__resources_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/resources/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Session Resource Files */
+        get: operations["list_session_resource_files_api_sessions__session_id__resources_files_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/resources/{artifact_id}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Session Resource Content */
+        get: operations["get_session_resource_content_api_sessions__session_id__resources__artifact_id__content_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sessions/{session_id}/resources/{artifact_id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download Session Resource */
+        get: operations["download_session_resource_api_sessions__session_id__resources__artifact_id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/secrets": {
         parameters: {
             query?: never;
@@ -7683,6 +7751,52 @@ export interface components {
             usages?: components["schemas"]["SecretUsageItemResponse"][];
             /** Diagnostics */
             diagnostics?: components["schemas"]["SecretUsageDiagnosticResponse"][];
+        };
+        /**
+         * SessionResourceListResponse
+         * @description Session-scoped read-only resource aliases backed by ArtifactRefs.
+         */
+        SessionResourceListResponse: {
+            /** Agent Run Id */
+            agent_run_id: string;
+            /** Session Id */
+            session_id: string;
+            /** Session Epoch */
+            session_epoch: number;
+            /** Resources */
+            resources?: components["schemas"]["SessionResourceModel"][];
+        };
+        /**
+         * SessionResourceModel
+         * @description Read-only session resource projection over an authorized artifact.
+         */
+        SessionResourceModel: {
+            /** Resource Id */
+            resource_id: string;
+            /** Artifact Id */
+            artifact_id: string;
+            /** Group Key */
+            group_key: string;
+            /** Group Title */
+            group_title: string;
+            /** Label */
+            label?: string | null;
+            /** Content Type */
+            content_type?: string | null;
+            /** Size Bytes */
+            size_bytes?: number | null;
+            status: components["schemas"]["TemporalArtifactStatus"];
+            artifact_ref: components["schemas"]["ArtifactRefModel"];
+            default_read_ref?: components["schemas"]["ArtifactRefModel"] | null;
+            preview_artifact_ref?: components["schemas"]["ArtifactRefModel"] | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /** Content Url */
+            content_url: string;
+            /** Download Url */
+            download_url: string;
         };
         /** SettingsPatchRequest */
         SettingsPatchRequest: {
@@ -13705,6 +13819,188 @@ export interface operations {
                 };
             };
             /** @description Diagnostics artifact not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_session_resources_api_sessions__session_id__resources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResourceListResponse"];
+                };
+            };
+            /** @description You do not have permission to access this session */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session projection not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_session_resource_files_api_sessions__session_id__resources_files_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResourceListResponse"];
+                };
+            };
+            /** @description You do not have permission to access this session */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session projection not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_resource_content_api_sessions__session_id__resources__artifact_id__content_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+                artifact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description You do not have permission to access this resource */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_session_resource_api_sessions__session_id__resources__artifact_id__download_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+                artifact_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description You do not have permission to access this resource */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session resource not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -220,6 +220,36 @@ class ArtifactSessionProjectionModel(BaseModel):
     latest_control_event_ref: Optional[ArtifactRefModel] = None
     latest_reset_boundary_ref: Optional[ArtifactRefModel] = None
 
+class SessionResourceModel(BaseModel):
+    """Read-only session resource projection over an authorized artifact."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resource_id: str
+    artifact_id: str
+    group_key: str
+    group_title: str
+    label: Optional[str] = None
+    content_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+    status: TemporalArtifactStatus
+    artifact_ref: ArtifactRefModel
+    default_read_ref: Optional[ArtifactRefModel] = None
+    preview_artifact_ref: Optional[ArtifactRefModel] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    content_url: str
+    download_url: str
+
+class SessionResourceListResponse(BaseModel):
+    """Session-scoped read-only resource aliases backed by ArtifactRefs."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_run_id: str
+    session_id: str
+    session_epoch: int
+    resources: list[SessionResourceModel] = Field(default_factory=list)
+
 class ArtifactSessionControlRequest(BaseModel):
     """Operator control request for one workflow-scoped artifact session."""
 

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -3157,6 +3157,45 @@ def test_session_resource_content_requires_artifact_in_session_projection() -> N
     assert response.json()["detail"]["code"] == "session_resource_not_found"
     artifact_service.read_path.assert_not_called()
 
+def test_session_resource_content_reads_authorized_artifact_with_principal(tmp_path) -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+    artifact_path = tmp_path / "summary.json"
+    artifact_path.write_text('{"summary":"done"}', encoding="utf-8")
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        if artifact_id != "art_summary":
+            raise TemporalArtifactAuthorizationError("not authorized")
+        return _build_artifact(artifact_id, "session.summary", label=artifact_id)
+
+    async def _read_path(*, artifact_id: str, principal: str):
+        assert artifact_id == "art_summary"
+        assert principal == str(user_id)
+        return _build_artifact(artifact_id, "session.summary", label=artifact_id)[0], artifact_path
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+    artifact_service.read_path.side_effect = _read_path
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.agent_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources/art_summary/content"
+                )
+
+    assert response.status_code == 200
+    assert response.json() == {"summary": "done"}
+    artifact_service.read_path.assert_awaited_once()
+
 def test_get_agent_run_artifact_session_projection_returns_404_when_missing(
     client: tuple[TestClient, AsyncMock],
 ) -> None:

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -3078,6 +3078,47 @@ def test_list_session_resources_returns_authorized_redacted_artifact_projection(
     assert "secret-token" not in json.dumps(body)
     assert "secret-password" not in json.dumps(body)
 
+
+def test_list_session_resources_encodes_advertised_resource_urls() -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+    record = _build_session_record().model_copy(
+        update={"session_id": "sess?foo#bar", "latest_summary_ref": "art?summary#1"}
+    )
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        if artifact_id != "art?summary#1":
+            raise TemporalArtifactAuthorizationError("not authorized")
+        return _build_artifact(artifact_id, "session.summary", label="summary")
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.agent_runs.ManagedSessionStore.load",
+            return_value=record,
+        ):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    f"/api/sessions/{quote('sess?foo#bar', safe='')}/resources"
+                )
+
+    assert response.status_code == 200
+    resources = response.json()["resources"]
+    assert len(resources) == 1
+    assert resources[0]["content_url"] == (
+        "/api/sessions/sess%3Ffoo%23bar/resources/art%3Fsummary%231/content"
+    )
+    assert resources[0]["download_url"] == (
+        "/api/sessions/sess%3Ffoo%23bar/resources/art%3Fsummary%231/download"
+    )
+
 def test_list_session_resource_files_alias_reads_durable_degraded_session() -> None:
     user_id = uuid4()
     user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
@@ -3194,6 +3235,51 @@ def test_session_resource_content_reads_authorized_artifact_with_principal(tmp_p
 
     assert response.status_code == 200
     assert response.json() == {"summary": "done"}
+    assert response.headers["content-disposition"].startswith("inline;")
+    artifact_service.read_path.assert_awaited_once()
+
+
+def test_session_resource_download_returns_attachment(tmp_path) -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+    artifact_path = tmp_path / "summary.json"
+    artifact_path.write_text('{"summary":"done"}', encoding="utf-8")
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        if artifact_id != "art_summary":
+            raise TemporalArtifactAuthorizationError("not authorized")
+        return _build_artifact(artifact_id, "session.summary", label=artifact_id)
+
+    async def _read_path(*, artifact_id: str, principal: str):
+        assert artifact_id == "art_summary"
+        assert principal == str(user_id)
+        return (
+            _build_artifact(artifact_id, "session.summary", label=artifact_id)[0],
+            artifact_path,
+        )
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+    artifact_service.read_path.side_effect = _read_path
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.agent_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources/art_summary/download"
+                )
+
+    assert response.status_code == 200
+    assert response.json() == {"summary": "done"}
+    assert response.headers["content-disposition"].startswith("attachment;")
     artifact_service.read_path.assert_awaited_once()
 
 def test_get_agent_run_artifact_session_projection_returns_404_when_missing(

--- a/tests/unit/api/routers/test_agent_runs.py
+++ b/tests/unit/api/routers/test_agent_runs.py
@@ -26,6 +26,7 @@ from moonmind.schemas.agent_runtime_models import (
     RunObservabilityEvent,
 )
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.artifacts import TemporalArtifactAuthorizationError
 
 @pytest.fixture
 def test_user() -> User:
@@ -2938,6 +2939,15 @@ def _build_artifact(artifact_id: str, link_type: str, *, label: str) -> tuple[Si
     )
     return artifact, links, False, read_policy
 
+def _app_with_agent_and_session_routers(user: object, artifact_service: AsyncMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.include_router(agent_runs_router.sessions_router, prefix="/api")
+    app.dependency_overrides[get_current_user()] = lambda: user
+    app.dependency_overrides[_get_temporal_artifact_service] = lambda: artifact_service
+    app.dependency_overrides[agent_runs_router._resolve_principal] = lambda: str(user.id)
+    return app
+
 def test_get_agent_run_artifact_session_projection_returns_grouped_projection(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -3017,6 +3027,135 @@ def test_get_agent_run_artifact_session_projection_reads_durable_state_only(
 
     assert response.status_code == 200
     assert response.json()["session_epoch"] == 2
+
+def test_list_session_resources_returns_authorized_redacted_artifact_projection() -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+    record = _build_session_record()
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+    }
+    artifact_payloads["art_summary"][0].metadata_json = {
+        "label": "summary",
+        "filename": "summary.json",
+        "apiToken": "secret-token",
+        "password": "secret-password",
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        if artifact_id in {"art_stderr", "art_diag", "art_checkpoint", "art_control", "art_reset"}:
+            raise TemporalArtifactAuthorizationError("not authorized")
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with TestClient(app) as test_client:
+        with patch("api_service.api.routers.agent_runs.ManagedSessionStore.load", return_value=record):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources"
+                )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_run_id"] == "wf-task-1"
+    assert body["session_id"] == "sess:wf-task-1:codex_cli"
+    assert [resource["artifact_id"] for resource in body["resources"]] == [
+        "art_stdout",
+        "art_summary",
+    ]
+    summary = body["resources"][1]
+    assert summary["metadata"] == {"label": "summary", "filename": "summary.json"}
+    assert summary["content_url"].endswith("/art_summary/content")
+    assert summary["download_url"].endswith("/art_summary/download")
+    assert "secret-token" not in json.dumps(body)
+    assert "secret-password" not in json.dumps(body)
+
+def test_list_session_resource_files_alias_reads_durable_degraded_session() -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+    record = _build_session_record().model_copy(update={"status": "degraded"})
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        return _build_artifact(artifact_id, "session.summary", label=artifact_id)
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with TestClient(app) as test_client:
+        with patch("api_service.api.routers.agent_runs.ManagedSessionStore.load", return_value=record):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources/files"
+                )
+
+    assert response.status_code == 200
+    assert response.json()["session_epoch"] == 2
+    assert len(response.json()["resources"]) == 7
+
+def test_list_session_resources_forbids_cross_owner_access() -> None:
+    owner_id = uuid4()
+    other_id = uuid4()
+    user = SimpleNamespace(id=other_id, email="other@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.agent_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(owner_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources"
+                )
+
+    assert response.status_code == 403
+    artifact_service.get_metadata.assert_not_called()
+
+def test_session_resource_content_requires_artifact_in_session_projection() -> None:
+    user_id = uuid4()
+    user = SimpleNamespace(id=user_id, email="owner@example.com", is_superuser=False)
+    artifact_service = AsyncMock()
+    app = _app_with_agent_and_session_routers(user, artifact_service)
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == str(user_id)
+        return _build_artifact(artifact_id, "session.summary", label=artifact_id)
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.agent_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.agent_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(user_id))),
+            ):
+                response = test_client.get(
+                    "/api/sessions/sess:wf-task-1:codex_cli/resources/art_outside/content"
+                )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "session_resource_not_found"
+    artifact_service.read_path.assert_not_called()
 
 def test_get_agent_run_artifact_session_projection_returns_404_when_missing(
     client: tuple[TestClient, AsyncMock],

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -112,6 +112,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     assert config["sources"]["agentRuns"]["diagnostics"] == "/api/agent-runs/{agentRunId}/diagnostics"
     assert config["sources"]["agentRuns"]["artifactSession"] == "/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}"
     assert config["sources"]["agentRuns"]["artifactSessionControl"] == "/api/agent-runs/{agentRunId}/artifact-sessions/{sessionId}/control"
+    assert config["sources"]["agentRuns"]["sessionResources"] == "/api/sessions/{sessionId}/resources"
     assert "proposals" not in config["sources"]
     assert "speckit" not in config["sources"]
     assert "orchestrator" not in config["sources"]


### PR DESCRIPTION
Issue: MM-1017

Summary:
- Adds read-only /api/sessions/{session_id}/resources aliases over existing session artifact projections.
- Adds resource content/file alias handling that reads authorized ArtifactRefs rather than duplicating blob storage.
- Redacts secret-like metadata in session resource summaries and renders resource evidence in Workflow Detail while preserving existing artifact views.
- Updates generated OpenAPI types and the artifact presentation contract.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_agent_runs.py tests/unit/api/routers/test_workflow_console_view_model.py --ui-args frontend/src/entrypoints/workflow-detail.test.tsx

Remaining risks:
- Full unit and integration suites were not run; verification was targeted to the changed API/router/view-model and Workflow Detail UI areas.
- Provider or live artifact-backend behavior was not exercised beyond unit coverage.