### PR TITLE
MM-982 Avoid waiting for workflow actions to load

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -42,20 +42,57 @@ describe('WorkflowRowActionsMenu', () => {
         taskEditingEnabled={false}
       />,
     );
+
+  const waitForActionAvailability = async (expectedActionName = 'Pause') => {
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(
+          ([url]) => String(url) === '/api/executions/wf-123?source=temporal',
+        ),
+      ).not.toHaveLength(0);
+      expect(screen.getByRole('menuitem', { name: expectedActionName })).toBeTruthy();
+      expect(screen.queryByRole('menuitem', { name: 'Remediate' })).toBeNull();
+      expect(screen.queryByText('Checking availability…')).toBeNull();
+    });
+  };
+
   it('renders an icon trigger labeled "Actions" and does not fetch until opened', () => {
     renderMenu();
     expect(screen.getByRole('button', { name: 'Actions' })).toBeTruthy();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('lazily loads action capabilities the first time the menu opens', async () => {
+  it('lists actions immediately while lazily loading capabilities the first time the menu opens', async () => {
+    let resolveDetail: (response: Response) => void = () => {};
+    const detailPromise = new Promise<Response>((resolve) => {
+      resolveDetail = resolve;
+    });
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions/wf-123?source=temporal') {
+        return detailPromise;
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
-    // While the detail request is in flight, a loading message is shown.
-    expect(screen.getByText('Loading actions…')).toBeTruthy();
+    // While the detail request is in flight, the menu already shows the stable
+    // action names and uses a disabled placeholder for workflow-specific state.
+    expect(screen.getByRole('menuitem', { name: 'Pause' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Cancel' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Force cancel' })).toBeTruthy();
+    expect(screen.getAllByText('Checking availability…').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Loading actions…')).toBeNull();
+
+    resolveDetail({
+      ok: true,
+      json: async () => detailResponse,
+    } as Response);
 
     expect(await screen.findByRole('menuitem', { name: 'Pause' })).toBeTruthy();
+    await waitForActionAvailability();
     expect(screen.getByRole('menuitem', { name: 'Cancel' })).toBeTruthy();
     expect(screen.getByRole('menuitem', { name: 'Force cancel' })).toBeTruthy();
     expect(
@@ -70,6 +107,7 @@ describe('WorkflowRowActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
     await screen.findByRole('menuitem', { name: 'Pause' });
+    await waitForActionAvailability();
     // Match only the detail request (path ends at wf-123, optionally followed by
     // a query string) and not nested action endpoints like /signal or /cancel.
     const detailUrls = fetchSpy.mock.calls
@@ -84,6 +122,7 @@ describe('WorkflowRowActionsMenu', () => {
   it('invokes the signal endpoint when a lifecycle action is selected', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Pause' }));
 
     await waitFor(() => {
@@ -114,6 +153,7 @@ describe('WorkflowRowActionsMenu', () => {
 
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability('Bypass Dependencies');
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Bypass Dependencies' }));
 
     expect(screen.queryByRole('dialog', { name: 'Bypass dependencies' })).toBeNull();
@@ -147,6 +187,7 @@ describe('WorkflowRowActionsMenu', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Rerun' }));
 
     await waitFor(() => {
@@ -172,6 +213,7 @@ describe('WorkflowRowActionsMenu', () => {
   it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Cancel' }));
     expect(screen.getByRole('dialog', { name: 'Cancel workflow' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Cancel workflow' }));
@@ -191,6 +233,7 @@ describe('WorkflowRowActionsMenu', () => {
   it('requires typed confirmation before posting a forced cancel request', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Force cancel' }));
     const confirmButton = screen.getByRole('button', { name: 'Force cancel workflow' }) as HTMLButtonElement;
     expect(confirmButton.disabled).toBe(true);

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -78,6 +78,23 @@ const KEBAB_ICON = (
   </svg>
 );
 
+const ACTION_AVAILABILITY_PENDING_REASON = 'Checking availability…';
+
+const PENDING_WORKFLOW_ACTION_CAPABILITIES = {
+  canSetTitle: true,
+  canUpdateInputs: true,
+  canEditForRerun: true,
+  canRerun: true,
+  canApprove: true,
+  canPause: true,
+  canResume: true,
+  canResumeFromFailedStep: true,
+  canCancel: true,
+  canReject: true,
+  canSendMessage: true,
+  canBypassDependencies: true,
+} satisfies RowActionsExecution['actions'];
+
 export type WorkflowRowActionsMenuProps = {
   workflowId: string;
   apiBase: string;
@@ -277,35 +294,42 @@ export function WorkflowRowActionsMenu({
       null;
   const rerunUnavailableReason = actions?.disabledReasons?.canRerun || null;
   const canCreateRemediation = Boolean(execution && isRemediationEligibleTarget(execution));
+  const actionAvailabilityPending = actionsEnabled && !actions && !detailQuery.isError;
   const disabledReason = useCallback(
     (key: string): string | null => {
+      if (actionAvailabilityPending) return ACTION_AVAILABILITY_PENDING_REASON;
       const reason = actions?.disabledReasons?.[key];
       return reason ? formatStatusLabel(reason) : null;
     },
-    [actions],
+    [actionAvailabilityPending, actions],
   );
 
   const items: WorkflowActionMenuItem[] = useMemo(() => {
-    if (!actionsEnabled || !actions) return [];
+    const menuActions = actionAvailabilityPending
+      ? PENDING_WORKFLOW_ACTION_CAPABILITIES
+      : actions;
+    if (!actionsEnabled || !menuActions) return [];
+    const pendingReason = actionAvailabilityPending ? ACTION_AVAILABILITY_PENDING_REASON : null;
     return buildWorkflowActionMenuItems({
       actionsOn: actionsEnabled,
-      actions,
-      busy,
+      actions: menuActions,
+      busy: busy || actionAvailabilityPending,
+      ...(pendingReason ? { busyDisabledReason: pendingReason } : {}),
       taskEditingOn: taskEditingEnabled,
       disabledReason,
-      editHref,
-      compareHref,
-      canShowEditWorkflow,
+      editHref: actionAvailabilityPending ? taskEditHref(workflowId) : editHref,
+      compareHref: actionAvailabilityPending ? taskCompareHref(workflowId) : compareHref,
+      canShowEditWorkflow: actionAvailabilityPending ? true : canShowEditWorkflow,
       editTaskDisabledReason: editTaskUnavailableReason
         ? formatStatusLabel(editTaskUnavailableReason)
-        : null,
+        : pendingReason,
       rerunDisabledReason: rerunUnavailableReason
         ? formatStatusLabel(rerunUnavailableReason)
-        : null,
+        : pendingReason,
       selectedRecoveryOptionCount: 0,
       selectedRecoveryStepEligible: false,
       selectedRecoveryStepDisabledReason: null,
-      canCreateRemediation,
+      canCreateRemediation: actionAvailabilityPending ? true : canCreateRemediation,
       handlers: {
         onRename: () => {
           setActionError(null);
@@ -381,6 +405,7 @@ export function WorkflowRowActionsMenu({
       },
     });
   }, [
+    actionAvailabilityPending,
     actions,
     actionsEnabled,
     busy,

--- a/frontend/src/lib/workflowActions.test.ts
+++ b/frontend/src/lib/workflowActions.test.ts
@@ -154,6 +154,19 @@ describe('buildWorkflowActionMenuItems', () => {
     );
     expect(items.find((item) => item.id === 'pause')?.disabledReason).toBe('action pending');
   });
+
+  it('uses a caller-provided pending reason for temporarily disabled actions', () => {
+    const items = buildWorkflowActionMenuItems(
+      buildParams({
+        busy: true,
+        busyDisabledReason: 'Checking availability…',
+        actions: { canPause: true },
+      }),
+    );
+    expect(items.find((item) => item.id === 'pause')?.disabledReason).toBe(
+      'Checking availability…',
+    );
+  });
 });
 
 describe('buildRemediationRuntimeRequestFields', () => {

--- a/frontend/src/lib/workflowActions.ts
+++ b/frontend/src/lib/workflowActions.ts
@@ -62,6 +62,8 @@ export type WorkflowActionMenuBuilderParams = {
   actionsOn: boolean;
   actions: ExecutionActionCapabilities | null | undefined;
   busy: boolean;
+  /** Display-ready reason for temporarily disabled actions while work is pending. */
+  busyDisabledReason?: string;
   taskEditingOn: boolean;
   /** Returns a display-ready disabled reason for a capability key, or null. */
   disabledReason: (key: string) => string | null;
@@ -99,6 +101,7 @@ export function buildWorkflowActionMenuItems(
     actionsOn,
     actions,
     busy,
+    busyDisabledReason = 'action pending',
     taskEditingOn,
     disabledReason,
     editHref,
@@ -115,7 +118,7 @@ export function buildWorkflowActionMenuItems(
 
   if (!actionsOn || !actions) return [];
   const items: WorkflowActionMenuItem[] = [];
-  const pendingActionReason = busy ? 'action pending' : null;
+  const pendingActionReason = busy ? busyDisabledReason : null;
   const addButton = ({
     id,
     label,


### PR DESCRIPTION
Issue reference: MM-982

Summary:
- Render the stable workflow action list immediately when the row actions menu opens.
- Show actions as temporarily disabled with a Checking availability placeholder while workflow-specific capabilities load.
- Update the menu to real enabled/disabled state once the lazy detail request completes.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/lib/workflowActions.test.ts` (blocked: container is missing pytest before Vitest starts)
- `npm ci --no-fund --no-audit`
- `npm run ui:test -- frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/lib/workflowActions.test.ts` (blocked: npm script could not resolve vitest from PATH in this runtime)
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/lib/workflowActions.test.ts` (blocked: Vitest resolves test module imports to `/frontend/...` in this managed workspace)

Remaining risks:
- Focused Vitest execution could not complete in this container because of local test-runner environment issues described above; the changed test coverage is included in the PR for CI to exercise.