### PR TITLE
The Actions menu button in the workflows list should be center aligned in that column and not right-aligned where it approaches the edge of the screen

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -76,6 +76,17 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
 });
 
 describe('Workflow list table dropdown overflow', () => {
+  it('centers the row actions trigger in the desktop actions column', () => {
+    const headerBlock = cssRuleBlock('.queue-table-actions-header-inner');
+    expect(headerBlock).toContain('justify-content: center;');
+
+    const cellBlock = cssRuleBlock('.queue-table-cell-actions');
+    expect(cellBlock).toContain('text-align: center;');
+
+    const rowActionsBlock = cssRuleBlock('.workflow-row-actions');
+    expect(rowActionsBlock).toContain('align-items: center;');
+  });
+
   it('lets row action popovers overflow the table edges instead of clipping them', () => {
     // `overflow-x: auto` on the wrapper is coerced to `overflow-y: auto` by the
     // browser, so the wrapper clips popovers. A highly restrictive filter leaves

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -7205,21 +7205,21 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-table-actions-header {
-  text-align: right;
+  text-align: center;
 }
 
 /* Keeps the "Actions" label and the small desktop "Advanced filters" + "View
- * options" icon buttons on one right-aligned row. */
+ * options" icon buttons centered within the actions column. */
 .queue-table-actions-header-inner {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 0.4rem;
   white-space: nowrap;
 }
 
 .queue-table-cell-actions {
-  text-align: right;
+  text-align: center;
   white-space: nowrap;
 }
 
@@ -7227,7 +7227,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   position: relative;
   display: inline-flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   gap: 0.25rem;
 }
 
@@ -7259,7 +7259,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   font-size: 0.74rem;
   font-weight: 500;
   line-height: 1.3;
-  text-align: right;
+  text-align: center;
 }
 
 .td-evidence-slab {


### PR DESCRIPTION
The Actions menu button in the workflows list should be center aligned in that column and not right-aligned where it approaches the edge of the screen