### PR TITLE
Stabilize workflow list ordering for MoonLadderStudios/MoonMind#2807

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -231,6 +231,7 @@ _EXECUTION_SORT_FIELDS = {
     "createdAt": "StartTime",
     "closedAt": "CloseTime",
 }
+_EXECUTION_UPDATED_SORT_BUCKET_SECONDS = 60
 _EXECUTION_FACET_ATTRS = {
     "status": "mm_state",
     "targetRuntime": "mm_target_runtime",
@@ -2252,6 +2253,7 @@ def _serialize_execution(
         artifacts_count=len(record.artifact_refs or []),
         scheduled_for=scheduled_for,
         created_at=created_at,
+        queued_at=created_at,
         steps_href=steps_href,
         actions=actions,
         resume=resume_summary,
@@ -2803,6 +2805,21 @@ def _build_recovery_summary(
 
 def _related_run_href(workflow_id: str) -> str:
     return f"/workflows/{quote(workflow_id, safe='')}?source=temporal"
+
+
+def _execution_sort_timestamp(value: datetime | None) -> float:
+    return value.timestamp() if value is not None else 0
+
+
+def _execution_updated_sort_bucket(execution: ExecutionModel) -> int:
+    return int(
+        _execution_sort_timestamp(execution.updated_at)
+        // _EXECUTION_UPDATED_SORT_BUCKET_SECONDS
+    )
+
+
+def _execution_queued_sort_timestamp(execution: ExecutionModel) -> float:
+    return _execution_sort_timestamp(execution.queued_at or execution.created_at)
 
 
 def _build_related_runs(
@@ -8553,7 +8570,8 @@ async def list_executions(
                             and item.scheduled_for is not None
                             else float("inf")
                         ),
-                        -(item.updated_at.timestamp() if item.updated_at else 0),
+                        -_execution_updated_sort_bucket(item),
+                        -_execution_queued_sort_timestamp(item),
                         item.workflow_id,
                     )
                 )

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -227,6 +227,7 @@ The current allowed values for `state` are:
 | `memo` | object | yes | Small display-oriented metadata |
 | `artifactRefs` | string[] | yes | Artifact references linked to this execution |
 | `startedAt` | datetime | yes | Initial execution timestamp |
+| `queuedAt` | datetime or `null` | no | Queue-order timestamp used as the stable fallback within small updated-time buckets |
 | `updatedAt` | datetime | yes | Last meaningful lifecycle/progress update |
 | `closedAt` | datetime or `null` | no | Terminal close timestamp |
 
@@ -441,12 +442,13 @@ Example:
 
 ### 10.4 Ordering semantics
 
-The current ordering contract is:
+The current default ordering contract is:
 
-1. `updatedAt` descending
-2. `workflowId` descending as a deterministic tiebreaker
+1. `updatedAt` descending by one-minute stability bucket
+2. queued order descending (`queuedAt`, newest queued first) within the same updated-time bucket
+3. `workflowId` descending as a deterministic tiebreaker
 
-Clients must not assume queue semantics or FIFO ordering.
+Meaningfully newer `updatedAt` values still sort first. Small updated-time differences inside the same bucket do not reorder rows ahead of newer queued executions.
 
 ### 10.5 Pagination semantics
 

--- a/docs/UI/WorkflowsListPage.md
+++ b/docs/UI/WorkflowsListPage.md
@@ -202,11 +202,11 @@ The current desktop table columns are:
 Rules:
 
 1. Header sort buttons sort the current page only until server-authoritative sort is wired through the frontend.
-2. The current default frontend sort is `updatedAt` descending.
-3. Timestamp columns sort by parsed timestamp. `updatedAt` falls back to the best available execution timestamp.
+2. The current default frontend sort is `updatedAt` descending by one-minute stability bucket, then queued order descending (`queuedAt || createdAt`).
+3. Timestamp columns sort by parsed timestamp. `updatedAt` falls back to the best available execution timestamp before bucketing.
 4. Status sorting uses `rawState` or `state` when available.
 5. Non-timestamp string columns sort as lowercase strings.
-6. Ties sort by workflow identifier descending.
+6. Ties after updated bucket and queued order sort by workflow identifier descending.
 7. Each status cell renders an `ExecutionStatusPill` using `rawState || state || status`, followed by compact status supplement text when needed.
 8. Rows blocked on dependencies show dependency text under the status pill, for example `Blocked by 1 prerequisite`.
 9. Rows requiring intervention show `Intervention requested` under the status pill.

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -252,6 +252,64 @@ describe('Workflows Entrypoint', () => {
     }
   });
 
+  it('keeps issue #2807 updated-time jitter inside a bucket ordered by newest queued workflow', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            workflowId: 'mm:older-queued-slightly-newer-update',
+            source: 'temporal',
+            title: 'Older queued, slightly newer update',
+            status: 'queued',
+            state: 'awaiting_slot',
+            rawState: 'awaiting_slot',
+            createdAt: '2026-03-28T09:00:00Z',
+            queuedAt: '2026-03-28T09:00:00Z',
+            updatedAt: '2026-03-28T12:00:45Z',
+          },
+          {
+            workflowId: 'mm:newer-queued-same-update-bucket',
+            source: 'temporal',
+            title: 'Newer queued, same update bucket',
+            status: 'queued',
+            state: 'awaiting_slot',
+            rawState: 'awaiting_slot',
+            createdAt: '2026-03-28T10:00:00Z',
+            queuedAt: '2026-03-28T10:00:00Z',
+            updatedAt: '2026-03-28T12:00:05Z',
+          },
+          {
+            workflowId: 'mm:meaningfully-newer-update',
+            source: 'temporal',
+            title: 'Meaningfully newer update',
+            status: 'queued',
+            state: 'awaiting_slot',
+            rawState: 'awaiting_slot',
+            createdAt: '2026-03-28T08:00:00Z',
+            queuedAt: '2026-03-28T08:00:00Z',
+            updatedAt: '2026-03-28T12:02:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Meaningfully newer update');
+
+    const table = document.querySelector('.queue-table-wrapper table') as HTMLTableElement;
+    const titles = Array.from(table.querySelectorAll('tbody .workflow-list-row-title')).map(
+      (element) => element.textContent,
+    );
+
+    expect(titles).toEqual([
+      'Meaningfully newer update',
+      'Newer queued, same update bucket',
+      'Older queued, slightly newer update',
+    ]);
+  });
+
   it('preserves allowlisted list context on workflow detail links and keeps browser back target intact (MM-998, MM-975)', async () => {
     window.history.pushState(
       {},

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -73,6 +73,7 @@ const TASK_WORKFLOW_TYPE = 'MoonMind.UserWorkflow';
 const TASK_ENTRY = 'user_workflow';
 
 const TIMESTAMP_SORT_FIELDS = new Set(['updatedAt', 'scheduledFor', 'createdAt', 'closedAt']);
+const UPDATED_AT_SORT_BUCKET_MS = 60_000;
 type FilterField =
   | 'workflowId'
   | 'status'
@@ -199,6 +200,7 @@ const ExecutionRowSchema = z
     scheduledFor: z.string().nullable().optional(),
     closedAt: z.string().nullable().optional(),
     createdAt: z.string(),
+    queuedAt: z.string().nullable().optional(),
     updatedAt: z.string().nullable().optional(),
     entry: z.string().optional(),
     dependsOn: z.array(z.string()).optional(),
@@ -364,6 +366,10 @@ function rowUpdatedAt(row: ExecutionRow): string | null | undefined {
   return row.updatedAt || row.closedAt || row.scheduledFor || row.createdAt;
 }
 
+function rowQueuedAt(row: ExecutionRow): string {
+  return row.queuedAt || row.createdAt;
+}
+
 const RELATIVE_TIME_UNITS: Array<[string, number]> = [
   ['y', 31536000],
   ['mo', 2592000],
@@ -411,6 +417,14 @@ function sortRows(rows: ExecutionRow[], field: string, direction: 'asc' | 'desc'
       };
       leftVal = Date.parse(getTimestamp(left) || '') || 0;
       rightVal = Date.parse(getTimestamp(right) || '') || 0;
+      if (field === 'updatedAt') {
+        const leftBucket = Math.floor(leftVal / UPDATED_AT_SORT_BUCKET_MS);
+        const rightBucket = Math.floor(rightVal / UPDATED_AT_SORT_BUCKET_MS);
+        if (leftBucket !== rightBucket) return dir * (leftBucket - rightBucket);
+        const leftQueued = Date.parse(rowQueuedAt(left) || '') || 0;
+        const rightQueued = Date.parse(rowQueuedAt(right) || '') || 0;
+        if (leftQueued !== rightQueued) return dir * (leftQueued - rightQueued);
+      }
       if (leftVal !== rightVal) return dir * (leftVal - rightVal);
     } else if (field === 'status') {
       const leftStatus = (left.rawState || left.state || '').toLowerCase();

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5022,6 +5022,8 @@ export interface components {
             dependents?: components["schemas"]["ExecutionDependencySummaryModel"][];
             /** Startedat */
             startedAt?: string | null;
+            /** Queuedat */
+            queuedAt?: string | null;
             /**
              * Updatedat
              * Format: date-time

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -3259,6 +3259,7 @@ class ExecutionModel(BaseModel):
         default_factory=list, alias="dependents"
     )
     started_at: datetime | None = Field(None, alias="startedAt")
+    queued_at: datetime | None = Field(None, alias="queuedAt")
     updated_at: datetime = Field(..., alias="updatedAt")
     closed_at: datetime | None = Field(None, alias="closedAt")
     detail_href: str = Field(..., alias="detailHref")

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -803,6 +803,90 @@ def test_list_executions_source_temporal_orders_immediate_runs_by_updated_at(
     assert items[0]["scheduledFor"] is None
     assert items[1]["scheduledFor"] is None
 
+
+def test_list_executions_source_temporal_issue_2807_buckets_updated_at_then_queued_order(
+    client,
+) -> None:
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    test_client, _service, _user, _mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    async def _memo():
+        return {}
+
+    def _datetime_bytes(value: datetime) -> bytes:
+        return f'"{value.isoformat().replace("+00:00", "Z")}"'.encode("utf-8")
+
+    def _workflow(
+        workflow_id: str,
+        *,
+        created_at: datetime,
+        updated_at: datetime,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=workflow_id,
+            run_id=f"run-{workflow_id}",
+            namespace="moonmind",
+            workflow_type="MoonMind.UserWorkflow",
+            status=1,
+            memo=_memo,
+            search_attributes={
+                "mm_state": b'"awaiting_slot"',
+                "mm_entry": b'["user_workflow"]',
+                "mm_updated_at": _datetime_bytes(updated_at),
+            },
+            start_time=created_at,
+            execution_time=None,
+            close_time=None,
+        )
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = [
+            _workflow(
+                "mm:wf-older-queued-slightly-newer-update",
+                created_at=datetime(2026, 4, 15, 9, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 15, 12, 0, 45, tzinfo=UTC),
+            ),
+            _workflow(
+                "mm:wf-newer-queued-same-update-bucket",
+                created_at=datetime(2026, 4, 15, 10, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 15, 12, 0, 5, tzinfo=UTC),
+            ),
+            _workflow(
+                "mm:wf-meaningfully-newer-update",
+                created_at=datetime(2026, 4, 15, 8, 0, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 15, 12, 2, 0, tzinfo=UTC),
+            ),
+        ]
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = lambda **kwargs: mock_iterator
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=3))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "workflowType": "MoonMind.UserWorkflow"},
+        )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["workflowId"] for item in items] == [
+        "mm:wf-meaningfully-newer-update",
+        "mm:wf-newer-queued-same-update-bucket",
+        "mm:wf-older-queued-slightly-newer-update",
+    ]
+    assert items[1]["queuedAt"] == "2026-04-15T10:00:00Z"
+    assert items[2]["queuedAt"] == "2026-04-15T09:00:00Z"
+
 def test_describe_execution_source_temporal_syncs_projection(client) -> None:
     test_client, service, user, _mock_session = client
 


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#2807

Summary:
- Adds queuedAt to execution list rows so queue order is available to clients.
- Sorts default updatedAt ordering by one-minute stability buckets, then newest queued workflow first, then workflow ID.
- Mirrors the same bucketed ordering in the workflow list frontend and updates API/UI docs plus generated OpenAPI types.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_executions_temporal.py -k issue_2807
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-list.test.tsx --runInBand
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/workflow-list.test.tsx --runInBand also triggered the full Python unit suite in this environment: 2 failed, 7531 passed, 6 skipped, 1 xpassed. The failures are tests/unit/tools/test_sync_moonspec_submodule.py::{test_projection_plan_reads_moonspec_submodule_manifest,test_top_level_directory_projection_manages_target_directory}, both due to missing vendor/moonspec/bundle/moonspec.bundle.yaml in this checkout.

Remaining risks:
- Existing clients that do not consume queuedAt should continue to work, but the default ordering semantics intentionally change for workflows whose updatedAt values fall in the same one-minute bucket.
- The broader unit-suite failure should be rechecked in an environment with the MoonSpec submodule bundle materialized.