### PR TITLE
[codex] Fix step checkpoint replay compatibility

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -501,6 +501,9 @@ RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
 RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
 RUN_CANONICAL_STEP_CHECKPOINTS_PATCH = "run-canonical-step-checkpoints-v1"
+RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH = (
+    "run-skip-ephemeral-step-checkpoints-v1"
+)
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
@@ -3938,7 +3941,20 @@ class MoonMindRunWorkflow:
             self._step_workspace_capture_inputs.get(logical_step_id) or {}
         )
         if not capture_input:
-            return None
+            if workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH):
+                return None
+            workspace_ref = self._step_checkpoint_refs.get(logical_step_id) or (
+                f"temporal://{identity.workflow_id}/{identity.run_id}/"
+                f"{identity.logical_step_id}/{boundary}"
+            )
+            return {
+                "workspace": {
+                    "kind": "ephemeral_workspace_ref",
+                    "workspaceRef": workspace_ref,
+                    "createdAt": workflow.now().isoformat(),
+                },
+                "diagnosticRefs": [],
+            }
 
         route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "workspace.capture_checkpoint"
@@ -3970,7 +3986,10 @@ class MoonMindRunWorkflow:
         workspace_evidence = result.get("workspace")
         if not isinstance(workspace_evidence, Mapping):
             return None
-        if workspace_evidence.get("kind") == "ephemeral_workspace_ref":
+        if (
+            workspace_evidence.get("kind") == "ephemeral_workspace_ref"
+            and workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH)
+        ):
             return None
         return {
             "workspace": dict(workspace_evidence),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -501,8 +501,8 @@ RUN_PAUSE_SAFE_BOUNDARIES_PATCH = "run-pause-safe-boundaries-v1"
 RUN_REAL_STARTED_AT_PATCH = "run-real-started-at-v1"
 RUN_STEP_EXECUTION_MANIFEST_PATCH = "run-step-" + "attempt-manifest-v1"
 RUN_CANONICAL_STEP_CHECKPOINTS_PATCH = "run-canonical-step-checkpoints-v1"
-RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH = (
-    "run-skip-ephemeral-step-checkpoints-v1"
+RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH = (
+    "run-emit-ephemeral-step-checkpoints-v1"
 )
 RUN_STEP_EXECUTION_NAMING_PATCH = "run-step-execution-naming-v1"
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
@@ -3940,12 +3940,19 @@ class MoonMindRunWorkflow:
         capture_input = dict(
             self._step_workspace_capture_inputs.get(logical_step_id) or {}
         )
+        emit_ephemeral_checkpoint = workflow.patched(
+            RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH
+        )
         if not capture_input:
-            if workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH):
+            if not emit_ephemeral_checkpoint:
                 return None
-            workspace_ref = self._step_checkpoint_refs.get(logical_step_id) or (
-                f"temporal://{identity.workflow_id}/{identity.run_id}/"
-                f"{identity.logical_step_id}/{boundary}"
+            workspace_ref = (
+                self._step_checkpoint_refs.get(logical_step_id)
+                or self._previous_step_checkpoint_refs.get(logical_step_id)
+                or (
+                    f"temporal://{identity.workflow_id}/{identity.run_id}/"
+                    f"{identity.logical_step_id}/{boundary}"
+                )
             )
             return {
                 "workspace": {
@@ -3988,7 +3995,7 @@ class MoonMindRunWorkflow:
             return None
         if (
             workspace_evidence.get("kind") == "ephemeral_workspace_ref"
-            and workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH)
+            and not emit_ephemeral_checkpoint
         ):
             return None
         return {

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -721,10 +721,15 @@ def test_canonical_step_checkpoint_writes_keep_replay_patch_guard() -> None:
     assert run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH == (
         "run-canonical-step-checkpoints-v1"
     )
+    assert run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH == (
+        "run-skip-ephemeral-step-checkpoints-v1"
+    )
     guard = "if not workflow.patched(RUN_CANONICAL_STEP_CHECKPOINTS_PATCH):"
+    ephemeral_guard = "workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH)"
     activity_call = "result = await self._create_step_checkpoint_via_activity("
 
     assert source.index(guard) < source.index(activity_call)
+    assert source.index(ephemeral_guard) < source.index(activity_call)
 
 
 def test_recovery_workspace_prepares_before_marking_failed_step_running() -> None:
@@ -2524,7 +2529,7 @@ async def test_run_records_pre_execution_checkpoint_from_node_workspace_inputs(
 
 
 @pytest.mark.asyncio
-async def test_run_blocks_canonical_checkpoint_create_when_capture_is_not_durable(
+async def test_run_preserves_no_capture_ephemeral_checkpoint_for_pre_patch_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2532,6 +2537,240 @@ async def test_run_blocks_canonical_checkpoint_create_when_capture_is_not_durabl
         run_module.workflow,
         "patched",
         lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_prepare",
+        updated_at=now,
+    )
+
+    assert result == "artifact://checkpoint/after_prepare"
+    assert [call["activity"] for call in captured] == ["step_checkpoint.create"]
+    assert captured[0]["payload"]["workspace"] == {
+        "kind": "ephemeral_workspace_ref",
+        "workspaceRef": "temporal://wf-run-1/run-1/implement/after_prepare",
+        "createdAt": "2026-04-07T12:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_ref_for_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+    workflow._step_checkpoint_refs["implement"] = "artifact://checkpoint/after_prepare"
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    assert result == "artifact://checkpoint/before_execution"
+    assert captured[0]["payload"]["workspace"]["workspaceRef"] == (
+        "artifact://checkpoint/after_prepare"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_skips_no_capture_ephemeral_checkpoint_when_skip_patch_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
+        },
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        raise AssertionError(f"unexpected activity: {activity} {payload}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_prepare",
+        updated_at=now,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_ephemeral_checkpoint_create_for_pre_patch_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    workflow._step_workspace_capture_inputs["implement"] = {
+        "workspacePath": "/work/agent_jobs/run-1/repo",
+        "kind": "worktree_archive",
+    }
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "ephemeral_workspace_ref",
+                    "workspaceRef": "artifact://diagnostic/ephemeral",
+                },
+                "diagnosticRefs": ["artifact://diagnostic/ephemeral"],
+            }
+        assert activity == "step_checkpoint.create"
+        return {
+            "checkpointRef": "artifact://checkpoint/after_execution",
+            "checkpointId": payload["idempotencyKey"],
+            "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+            "workspaceKind": payload["workspace"]["kind"],
+            "diagnosticRefs": [],
+            "idempotencyKey": payload["idempotencyKey"],
+        }
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_execution",
+        updated_at=now,
+    )
+
+    assert result == "artifact://checkpoint/after_execution"
+    assert [call["activity"] for call in captured] == [
+        "workspace.capture_checkpoint",
+        "step_checkpoint.create",
+    ]
+    assert captured[1]["payload"]["workspace"]["kind"] == "ephemeral_workspace_ref"
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["stepCheckpointRef"] == "artifact://checkpoint/after_execution"
+    assert step["refs"]["stepExecutionCheckpointRefs"] == [
+        "artifact://checkpoint/after_execution"
+    ]
+    assert step["refs"]["checkpointRefsByBoundary"] == {
+        "after_execution": "artifact://checkpoint/after_execution"
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_blocks_canonical_checkpoint_create_when_ephemeral_skip_patch_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
+        },
     )
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -721,11 +721,11 @@ def test_canonical_step_checkpoint_writes_keep_replay_patch_guard() -> None:
     assert run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH == (
         "run-canonical-step-checkpoints-v1"
     )
-    assert run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH == (
-        "run-skip-ephemeral-step-checkpoints-v1"
+    assert run_module.RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH == (
+        "run-emit-ephemeral-step-checkpoints-v1"
     )
     guard = "if not workflow.patched(RUN_CANONICAL_STEP_CHECKPOINTS_PATCH):"
-    ephemeral_guard = "workflow.patched(RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH)"
+    ephemeral_guard = "RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH"
     activity_call = "result = await self._create_step_checkpoint_via_activity("
 
     assert source.index(guard) < source.index(activity_call)
@@ -2529,7 +2529,7 @@ async def test_run_records_pre_execution_checkpoint_from_node_workspace_inputs(
 
 
 @pytest.mark.asyncio
-async def test_run_preserves_no_capture_ephemeral_checkpoint_for_pre_patch_histories(
+async def test_run_skips_no_capture_ephemeral_checkpoint_for_pre_emit_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2537,6 +2537,111 @@ async def test_run_preserves_no_capture_ephemeral_checkpoint_for_pre_patch_histo
         run_module.workflow,
         "patched",
         lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        raise AssertionError(f"unexpected activity: {activity} {payload}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="after_prepare",
+        updated_at=now,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_retry_ref_for_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
+        },
+    )
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+    workflow._input_ref = "artifact://task-input"
+    workflow._plan_ref = "artifact://plan"
+    captured: list[dict[str, Any]] = []
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
+        dependency_map={"implement": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "implement",
+        updated_at=now,
+        summary="Implementing",
+    )
+    workflow._previous_step_checkpoint_refs["implement"] = (
+        "artifact://checkpoint/after_prepare"
+    )
+
+    async def fake_execute_activity(
+        activity: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        captured.append({"activity": activity, "payload": payload})
+        assert activity == "step_checkpoint.create"
+        return _checkpoint_create_result(payload)
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    result = await workflow._record_canonical_step_checkpoint(
+        "implement",
+        boundary="before_execution",
+        updated_at=now,
+    )
+
+    assert result == "artifact://checkpoint/before_execution"
+    assert captured[0]["payload"]["workspace"]["workspaceRef"] == (
+        "artifact://checkpoint/after_prepare"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_emits_no_capture_ephemeral_checkpoint_when_emit_patch_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
+        },
     )
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
@@ -2582,7 +2687,7 @@ async def test_run_preserves_no_capture_ephemeral_checkpoint_for_pre_patch_histo
 
 
 @pytest.mark.asyncio
-async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_ref_for_replay(
+async def test_run_skips_captured_ephemeral_checkpoint_for_pre_emit_histories(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2595,6 +2700,10 @@ async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_ref_for_repla
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
     workflow._input_ref = "artifact://task-input"
     workflow._plan_ref = "artifact://plan"
+    workflow._step_workspace_capture_inputs["implement"] = {
+        "workspacePath": "/work/agent_jobs/run-1/repo",
+        "kind": "worktree_archive",
+    }
     captured: list[dict[str, Any]] = []
 
     workflow._initialize_step_ledger(
@@ -2607,7 +2716,6 @@ async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_ref_for_repla
         updated_at=now,
         summary="Implementing",
     )
-    workflow._step_checkpoint_refs["implement"] = "artifact://checkpoint/after_prepare"
 
     async def fake_execute_activity(
         activity: str,
@@ -2615,25 +2723,35 @@ async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_ref_for_repla
         **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.append({"activity": activity, "payload": payload})
-        assert activity == "step_checkpoint.create"
-        return _checkpoint_create_result(payload)
+        if activity == "workspace.capture_checkpoint":
+            return {
+                "status": "captured",
+                "workspace": {
+                    "kind": "ephemeral_workspace_ref",
+                    "workspaceRef": "artifact://diagnostic/ephemeral",
+                },
+                "diagnosticRefs": ["artifact://diagnostic/ephemeral"],
+            }
+        raise AssertionError(f"unexpected activity: {activity}")
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
     result = await workflow._record_canonical_step_checkpoint(
         "implement",
-        boundary="before_execution",
+        boundary="after_execution",
         updated_at=now,
     )
 
-    assert result == "artifact://checkpoint/before_execution"
-    assert captured[0]["payload"]["workspace"]["workspaceRef"] == (
-        "artifact://checkpoint/after_prepare"
-    )
+    assert result is None
+    assert [call["activity"] for call in captured] == ["workspace.capture_checkpoint"]
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step.get("stepCheckpointRef") is None
+    assert step["refs"]["stepExecutionCheckpointRefs"] == []
+    assert step["refs"]["checkpointRefsByBoundary"] == {}
 
 
 @pytest.mark.asyncio
-async def test_run_skips_no_capture_ephemeral_checkpoint_when_skip_patch_enabled(
+async def test_run_emits_captured_ephemeral_checkpoint_when_emit_patch_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2643,50 +2761,8 @@ async def test_run_skips_no_capture_ephemeral_checkpoint_when_skip_patch_enabled
         lambda patch_id: patch_id
         in {
             run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
-            run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
+            run_module.RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
         },
-    )
-    workflow = MoonMindRunWorkflow()
-    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
-
-    workflow._initialize_step_ledger(
-        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
-        dependency_map={"implement": []},
-        updated_at=now,
-    )
-    workflow._mark_step_running(
-        "implement",
-        updated_at=now,
-        summary="Implementing",
-    )
-
-    async def fake_execute_activity(
-        activity: str,
-        payload: dict[str, Any],
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        raise AssertionError(f"unexpected activity: {activity} {payload}")
-
-    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
-
-    result = await workflow._record_canonical_step_checkpoint(
-        "implement",
-        boundary="after_prepare",
-        updated_at=now,
-    )
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_run_preserves_ephemeral_checkpoint_create_for_pre_patch_histories(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _configure_workflow_runtime(monkeypatch)
-    monkeypatch.setattr(
-        run_module.workflow,
-        "patched",
-        lambda patch_id: patch_id == run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
     )
     workflow = MoonMindRunWorkflow()
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
@@ -2756,74 +2832,6 @@ async def test_run_preserves_ephemeral_checkpoint_create_for_pre_patch_histories
     assert step["refs"]["checkpointRefsByBoundary"] == {
         "after_execution": "artifact://checkpoint/after_execution"
     }
-
-
-@pytest.mark.asyncio
-async def test_run_blocks_canonical_checkpoint_create_when_ephemeral_skip_patch_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _configure_workflow_runtime(monkeypatch)
-    monkeypatch.setattr(
-        run_module.workflow,
-        "patched",
-        lambda patch_id: patch_id
-        in {
-            run_module.RUN_CANONICAL_STEP_CHECKPOINTS_PATCH,
-            run_module.RUN_SKIP_EPHEMERAL_STEP_CHECKPOINTS_PATCH,
-        },
-    )
-    workflow = MoonMindRunWorkflow()
-    now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
-    workflow._input_ref = "artifact://task-input"
-    workflow._plan_ref = "artifact://plan"
-    workflow._step_workspace_capture_inputs["implement"] = {
-        "workspacePath": "/work/agent_jobs/run-1/repo",
-        "kind": "worktree_archive",
-    }
-    captured: list[str] = []
-
-    workflow._initialize_step_ledger(
-        ordered_nodes=[{"id": "implement", "inputs": {"title": "Implement"}}],
-        dependency_map={"implement": []},
-        updated_at=now,
-    )
-    workflow._mark_step_running(
-        "implement",
-        updated_at=now,
-        summary="Implementing",
-    )
-
-    async def fake_execute_activity(
-        activity: str,
-        payload: dict[str, Any],
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        captured.append(activity)
-        if activity == "workspace.capture_checkpoint":
-            return {
-                "status": "captured",
-                "workspace": {
-                    "kind": "ephemeral_workspace_ref",
-                    "workspaceRef": "artifact://diagnostic/ephemeral",
-                },
-                "diagnosticRefs": ["artifact://diagnostic/ephemeral"],
-            }
-        raise AssertionError(f"unexpected activity: {activity}")
-
-    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
-
-    result = await workflow._record_canonical_step_checkpoint(
-        "implement",
-        boundary="after_execution",
-        updated_at=now,
-    )
-
-    assert result is None
-    assert captured == ["workspace.capture_checkpoint"]
-    step = workflow.get_step_ledger()["steps"][0]
-    assert step.get("stepCheckpointRef") is None
-    assert step["refs"]["stepExecutionCheckpointRefs"] == []
-    assert step["refs"]["checkpointRefsByBoundary"] == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve pre-patch `step_checkpoint.create` commands for ephemeral checkpoint histories when no workspace capture input exists.
- Gate the newer ephemeral-checkpoint skip behavior behind a Temporal patch marker.
- Add replay-focused unit coverage for old no-capture/captured ephemeral checkpoints and the new skip path.

## Root Cause
Existing Temporal histories recorded `step_checkpoint.create` for ephemeral workspace refs. Current workflow code skipped those checkpoints, so replay tried to schedule the next tool activity where history expected a checkpoint activity, producing nondeterminism.

## Validation
- Not run as part of this publish request; user requested no further local testing.
