### PR TITLE
[codex] compact workflow list responses

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -65,6 +65,7 @@ from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProjectionDiagnosticModel,
     ExecutionListResponse,
+    ExecutionListItemModel,
     ExecutionMetricsCostModel,
     ExecutionMetricsDurationModel,
     ExecutionMetricsResponse,
@@ -1793,6 +1794,211 @@ def _bounded_execution_progress_from_sources(
                 exc_info=True,
             )
     return None
+
+
+def _serialize_execution_list_item(record) -> ExecutionListItemModel:
+    close_status = _enum_value(getattr(record, "close_status", None))
+    if close_status == TemporalExecutionCloseStatus.COMPLETED.value:
+        temporal_status = "completed"
+    elif close_status == TemporalExecutionCloseStatus.CANCELED.value:
+        temporal_status = "canceled"
+    elif close_status in {
+        TemporalExecutionCloseStatus.FAILED.value,
+        TemporalExecutionCloseStatus.TERMINATED.value,
+        TemporalExecutionCloseStatus.TIMED_OUT.value,
+    }:
+        temporal_status = "failed"
+    else:
+        temporal_status = "running"
+
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    state_value = _enum_value(getattr(record, "state", None)) or ""
+    workflow_type_value = _enum_value(getattr(record, "workflow_type", None)) or ""
+    continue_as_new_cause = memo.get("continue_as_new_cause") or search_attributes.get(
+        "mm_continue_as_new_cause"
+    )
+    raw_state = state_value
+    owner_type = _normalize_owner_type(record, search_attributes)
+    owner_id = str(
+        search_attributes.get("mm_owner_id")
+        or getattr(record, "owner_id", None)
+        or "system"
+    )
+    title = str(memo.get("title") or "").strip() or workflow_type_value
+
+    waiting_reason = (
+        str(getattr(record, "waiting_reason", "") or "").strip()
+        or str(memo.get("waiting_reason") or "").strip()
+        or (
+            str(memo.get("summary") or "").strip()
+            if raw_state == "awaiting_external"
+            else ""
+        )
+    )
+    attention_required = bool(
+        getattr(record, "attention_required", False)
+        or memo.get("attention_required")
+        or False
+    )
+    if raw_state == "awaiting_external":
+        attention_required = True
+    if (
+        raw_state
+        not in {"awaiting_slot", "awaiting_external", "waiting_on_dependencies"}
+        and not bool(getattr(record, "paused", False))
+        and not attention_required
+    ):
+        waiting_reason = None
+
+    params_raw = getattr(record, "parameters", None)
+    params = dict(params_raw) if isinstance(params_raw, Mapping) else {}
+    target_runtime = _coerce_temporal_scalar(params.get("targetRuntime")) or None
+    if not target_runtime:
+        runtime_nested = params.get("runtime")
+        if isinstance(runtime_nested, Mapping):
+            target_runtime = _coerce_temporal_scalar(runtime_nested.get("mode")) or None
+    if not target_runtime:
+        target_runtime = (
+            _coerce_temporal_scalar(search_attributes.get("mm_target_runtime"))
+            or _coerce_temporal_scalar(search_attributes.get("mm_runtime"))
+            or _coerce_temporal_scalar(search_attributes.get("runtime"))
+            or _coerce_temporal_scalar(memo.get("targetRuntime"))
+            or _coerce_temporal_scalar(memo.get("target_runtime"))
+        ) or None
+
+    task_payload = _workflow_payload_from_parameters(params)
+    task_runtime_payload = task_payload.get("runtime")
+    if not isinstance(task_runtime_payload, Mapping):
+        task_runtime_payload = {}
+    if not target_runtime:
+        target_runtime = (
+            _coerce_temporal_scalar(task_runtime_payload.get("mode"))
+            or _coerce_temporal_scalar(task_runtime_payload.get("runtime"))
+        ) or None
+
+    tool_params = (
+        task_payload.get("tool") if isinstance(task_payload.get("tool"), Mapping) else {}
+    )
+    skill_params = (
+        task_payload.get("skill") if isinstance(task_payload.get("skill"), Mapping) else {}
+    )
+    target_skill = _preset_primary_skill_name(task_payload) or (
+        str(
+            tool_params.get("name")
+            or tool_params.get("id")
+            or skill_params.get("name")
+            or skill_params.get("id")
+            or ""
+        ).strip()
+        or None
+    )
+    if not target_skill:
+        target_skill = (
+            _coerce_temporal_scalar(params.get("targetSkill"))
+            or _coerce_temporal_scalar(params.get("target_skill"))
+            or _coerce_temporal_scalar(params.get("skillId"))
+            or _coerce_temporal_scalar(params.get("skill"))
+            or _coerce_temporal_scalar(params.get("selectedSkill"))
+            or _coerce_temporal_scalar(params.get("selected_skill"))
+            or _coerce_temporal_scalar(search_attributes.get("mm_target_skill"))
+            or _coerce_temporal_scalar(search_attributes.get("mm_skill_id"))
+            or _coerce_temporal_scalar(search_attributes.get("mm_skill"))
+            or _coerce_temporal_scalar(search_attributes.get("skillId"))
+            or _coerce_temporal_scalar(search_attributes.get("skill"))
+            or _coerce_temporal_scalar(memo.get("targetSkill"))
+            or _coerce_temporal_scalar(memo.get("target_skill"))
+            or _coerce_temporal_scalar(memo.get("skillId"))
+            or _coerce_temporal_scalar(memo.get("skill"))
+        ) or None
+
+    task_skills = _skill_selector_names(task_payload.get("skills"))
+    if task_skills is None:
+        template_primary_skill = _preset_primary_skill_name(task_payload)
+        if template_primary_skill:
+            task_skills = [template_primary_skill]
+
+    git_payload = task_payload.get("git")
+    if not isinstance(git_payload, Mapping):
+        git_payload = {}
+    repository = (
+        _coerce_temporal_scalar(git_payload.get("repository"))
+        or _coerce_temporal_scalar(task_payload.get("repository"))
+        or _coerce_temporal_scalar(params.get("repository"))
+        or _coerce_temporal_scalar(params.get("repo"))
+        or _coerce_temporal_scalar(task_payload.get("repo"))
+        or _coerce_temporal_scalar(search_attributes.get("mm_repository"))
+        or _coerce_temporal_scalar(search_attributes.get("mm_repo"))
+        or _coerce_temporal_scalar(search_attributes.get("repository"))
+        or _coerce_temporal_scalar(memo.get("repository"))
+    ) or None
+
+    dependencies_block = (
+        memo.get("dependencies")
+        if isinstance(memo.get("dependencies"), Mapping)
+        else {}
+    )
+    depends_on = normalize_dependency_ids(task_payload.get("dependsOn"))
+    if not depends_on:
+        depends_on = normalize_dependency_ids(
+            dependencies_block.get("declaredIds") or memo.get("depends_on")
+        )
+
+    finish_summary = _finish_summary_from_memo(memo)
+    progress = _bounded_execution_progress_from_sources(
+        record=record,
+        memo=memo,
+        finish_summary=finish_summary if isinstance(finish_summary, Mapping) else None,
+    )
+
+    started_at = getattr(record, "started_at", None)
+    updated_at = getattr(record, "updated_at", None) or started_at or datetime.now(UTC)
+    created_at = getattr(record, "created_at", None) or started_at or updated_at
+    scheduled_for = getattr(record, "scheduled_for", None)
+    workflow_id = str(getattr(record, "workflow_id", "") or "").strip()
+    dashboard_status = _DASHBOARD_STATUS_BY_STATE.get(
+        getattr(record, "state", None),
+        "queued",
+    )
+
+    return ExecutionListItemModel(
+        source=_TEMPORAL_SOURCE,
+        workflow_id=workflow_id,
+        run_id=str(getattr(record, "run_id", "") or ""),
+        workflow_type=workflow_type_value,
+        entry=_resolve_execution_entry(record, search_attributes),
+        owner_type=owner_type,
+        owner_id=owner_id,
+        title=title,
+        status=dashboard_status,
+        dashboard_status=dashboard_status,
+        state=state_value,
+        raw_state=raw_state,
+        temporal_status=temporal_status,
+        close_status=close_status,
+        waiting_reason=str(waiting_reason) if waiting_reason else None,
+        attention_required=attention_required,
+        target_runtime=target_runtime,
+        target_skill=target_skill,
+        task_skills=task_skills,
+        repository=repository,
+        progress=progress,
+        scheduled_for=scheduled_for,
+        created_at=created_at,
+        started_at=started_at,
+        updated_at=updated_at,
+        closed_at=getattr(record, "closed_at", None),
+        depends_on=depends_on,
+        blocked_on_dependencies=raw_state == "waiting_on_dependencies",
+        detail_href=f"/workflows/{workflow_id}",
+        redirect_path=f"/workflows/{workflow_id}?source=temporal",
+        latest_run_view=True,
+        continue_as_new_cause=_coerce_temporal_scalar(continue_as_new_cause) or None,
+        ui_query_model="compatibility_adapter",
+        stale_state=False,
+        refreshed_at=_compatibility_refreshed_at(record),
+    )
+
 
 def _serialize_execution(
     record, *, include_artifact_refs: bool = True, user: Optional["User"] = None
@@ -8523,11 +8729,7 @@ async def list_executions(
                         record_obj.updated_at = (
                             getattr(record_obj, "started_at", None) or datetime.now(UTC)
                         )
-                    execution = _serialize_execution(
-                        record_obj,
-                        include_artifact_refs=False,
-                        user=user,
-                    )
+                    execution = _serialize_execution_list_item(record_obj)
                     if _execution_uses_live_workflow_queries(execution):
                         progress, queried_run_id = await _load_execution_progress(
                             temporal_client=temporal_client,
@@ -8628,7 +8830,7 @@ async def list_executions(
     now = datetime.now(UTC)
     return ExecutionListResponse(
         items=[
-            _serialize_execution(item, include_artifact_refs=False, user=user)
+            _serialize_execution_list_item(item)
             for item in result.items
         ],
         next_page_token=result.next_page_token,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1944,7 +1944,13 @@ def _serialize_execution_list_item(record) -> ExecutionListItemModel:
             dependencies_block.get("declaredIds") or memo.get("depends_on")
         )
 
-    finish_summary = _finish_summary_from_memo(memo)
+    memo_finish_summary = _finish_summary_from_memo(memo)
+    finish_summary_json = getattr(record, "finish_summary_json", None)
+    finish_summary = (
+        dict(finish_summary_json)
+        if isinstance(finish_summary_json, Mapping)
+        else memo_finish_summary
+    )
     progress = _bounded_execution_progress_from_sources(
         record=record,
         memo=memo,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -82,7 +82,7 @@ const WorkflowWorkspaceRowSchema = z
     repository: z.string().nullable().optional(),
     targetRuntime: z.string().nullable().optional(),
   })
-  .passthrough();
+  .strip();
 
 const WorkflowWorkspaceListResponseSchema = z.object({
   items: z.array(WorkflowWorkspaceRowSchema),

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -222,7 +222,7 @@ const ExecutionRowSchema = z
       .nullable()
       .optional(),
   })
-  .passthrough();
+  .strip();
 
 const ExecutionListResponseSchema = z.object({
   items: z.array(ExecutionRowSchema),

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4585,12 +4585,132 @@ export interface components {
             createdAt: string;
         };
         /**
+         * ExecutionListItemModel
+         * @description Compact execution row returned by list APIs.
+         *
+         *     The detail endpoint returns ``ExecutionModel``. List views use this bounded
+         *     row model so high-cardinality dashboard polling does not ship memo,
+         *     parameters, summaries, debug fields, or other detail-only payloads.
+         */
+        ExecutionListItemModel: {
+            /**
+             * Source
+             * @default temporal
+             * @constant
+             */
+            source: "temporal";
+            /** Workflowid */
+            workflowId: string;
+            /** Runid */
+            runId: string;
+            /** Workflowtype */
+            workflowType: string;
+            /**
+             * Entry
+             * @enum {string}
+             */
+            entry: "user_workflow" | "manifest";
+            /**
+             * Ownertype
+             * @enum {string}
+             */
+            ownerType: "user" | "system" | "service";
+            /** Ownerid */
+            ownerId: string;
+            /** Title */
+            title: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "awaiting_action" | "waiting" | "completed" | "failed" | "canceled";
+            /**
+             * Dashboardstatus
+             * @enum {string}
+             */
+            dashboardStatus: "queued" | "running" | "awaiting_action" | "waiting" | "completed" | "failed" | "canceled";
+            /** State */
+            state: string;
+            /** Rawstate */
+            rawState: string;
+            /**
+             * Temporalstatus
+             * @enum {string}
+             */
+            temporalStatus: "running" | "completed" | "failed" | "canceled";
+            /** Closestatus */
+            closeStatus?: string | null;
+            /** Waitingreason */
+            waitingReason?: string | null;
+            /**
+             * Attentionrequired
+             * @default false
+             */
+            attentionRequired: boolean;
+            /** Targetruntime */
+            targetRuntime?: string | null;
+            /** Targetskill */
+            targetSkill?: string | null;
+            /** Taskskills */
+            taskSkills?: string[] | null;
+            /** Repository */
+            repository?: string | null;
+            progress?: components["schemas"]["ExecutionProgressModel"] | null;
+            /** Scheduledfor */
+            scheduledFor?: string | null;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /** Startedat */
+            startedAt?: string | null;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+            /** Closedat */
+            closedAt?: string | null;
+            /** Dependson */
+            dependsOn?: string[];
+            /**
+             * Blockedondependencies
+             * @default false
+             */
+            blockedOnDependencies: boolean;
+            /** Detailhref */
+            detailHref: string;
+            /** Redirectpath */
+            redirectPath?: string | null;
+            /**
+             * Latestrunview
+             * @default true
+             */
+            latestRunView: boolean;
+            /** Continueasnewcause */
+            continueAsNewCause?: string | null;
+            /**
+             * Uiquerymodel
+             * @default compatibility_adapter
+             * @constant
+             */
+            uiQueryModel: "compatibility_adapter";
+            /**
+             * Stalestate
+             * @default false
+             */
+            staleState: boolean;
+            /** Refreshedat */
+            refreshedAt?: string | null;
+        };
+        /**
          * ExecutionListResponse
          * @description Paginated list response for executions.
          */
         ExecutionListResponse: {
             /** Items */
-            items?: components["schemas"]["ExecutionModel"][];
+            items?: components["schemas"]["ExecutionListItemModel"][];
             /** Nextpagetoken */
             nextPageToken?: string | null;
             /** Count */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -3268,6 +3268,74 @@ class ExecutionModel(BaseModel):
     stale_state: bool = Field(False, alias="staleState")
     refreshed_at: datetime | None = Field(None, alias="refreshedAt")
 
+
+class ExecutionListItemModel(BaseModel):
+    """Compact execution row returned by list APIs.
+
+    The detail endpoint returns ``ExecutionModel``. List views use this bounded
+    row model so high-cardinality dashboard polling does not ship memo,
+    parameters, summaries, debug fields, or other detail-only payloads.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    source: Literal["temporal"] = Field("temporal", alias="source")
+    workflow_id: str = Field(..., alias="workflowId")
+    run_id: str = Field(..., alias="runId")
+    workflow_type: str = Field(..., alias="workflowType")
+    entry: Literal["user_workflow", "manifest"] = Field(..., alias="entry")
+    owner_type: Literal["user", "system", "service"] = Field(..., alias="ownerType")
+    owner_id: str = Field(..., alias="ownerId")
+    title: str = Field(..., alias="title")
+    status: Literal[
+        "queued",
+        "running",
+        "awaiting_action",
+        "waiting",
+        "completed",
+        "failed",
+        "canceled",
+    ] = Field(..., alias="status")
+    dashboard_status: Literal[
+        "queued",
+        "running",
+        "awaiting_action",
+        "waiting",
+        "completed",
+        "failed",
+        "canceled",
+    ] = Field(..., alias="dashboardStatus")
+    state: str = Field(..., alias="state")
+    raw_state: str = Field(..., alias="rawState")
+    temporal_status: Literal["running", "completed", "failed", "canceled"] = Field(
+        ..., alias="temporalStatus"
+    )
+    close_status: Optional[str] = Field(None, alias="closeStatus")
+    waiting_reason: Optional[str] = Field(None, alias="waitingReason")
+    attention_required: bool = Field(False, alias="attentionRequired")
+    target_runtime: Optional[str] = Field(None, alias="targetRuntime")
+    target_skill: Optional[str] = Field(None, alias="targetSkill")
+    task_skills: Optional[list[str]] = Field(None, alias="taskSkills")
+    repository: Optional[str] = Field(None, alias="repository")
+    progress: ExecutionProgressModel | None = Field(None, alias="progress")
+    scheduled_for: Optional[datetime] = Field(None, alias="scheduledFor")
+    created_at: datetime = Field(..., alias="createdAt")
+    started_at: datetime | None = Field(None, alias="startedAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+    closed_at: datetime | None = Field(None, alias="closedAt")
+    depends_on: list[str] = Field(default_factory=list, alias="dependsOn")
+    blocked_on_dependencies: bool = Field(False, alias="blockedOnDependencies")
+    detail_href: str = Field(..., alias="detailHref")
+    redirect_path: Optional[str] = Field(None, alias="redirectPath")
+    latest_run_view: bool = Field(True, alias="latestRunView")
+    continue_as_new_cause: Optional[str] = Field(None, alias="continueAsNewCause")
+    ui_query_model: Literal["compatibility_adapter"] = Field(
+        "compatibility_adapter", alias="uiQueryModel"
+    )
+    stale_state: bool = Field(False, alias="staleState")
+    refreshed_at: datetime | None = Field(None, alias="refreshedAt")
+
+
 class ExecutionRefreshEnvelope(BaseModel):
     """Compatibility metadata for patching one acted-on row and refetching lists."""
 
@@ -3313,7 +3381,7 @@ class ExecutionListResponse(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    items: list[ExecutionModel] = Field(default_factory=list, alias="items")
+    items: list[ExecutionListItemModel] = Field(default_factory=list, alias="items")
     next_page_token: Optional[str] = Field(None, alias="nextPageToken")
     count: Optional[int] = Field(None, alias="count")
     count_mode: Literal["exact", "estimated_or_unknown"] = Field(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10333,6 +10333,41 @@ def test_list_executions_preserves_logical_identity_fields() -> None:
         ):
             assert detail_only_key not in item
 
+
+def test_list_executions_reads_progress_from_persisted_finish_summary() -> None:
+    for test_client, service in _client_with_service():
+        record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)
+        record.close_status = TemporalExecutionCloseStatus.COMPLETED
+        record.finish_summary_json = {
+            "progress": {
+                "total": 4,
+                "pending": 0,
+                "ready": 0,
+                "running": 0,
+                "awaitingExternal": 0,
+                "reviewing": 0,
+                "succeeded": 4,
+                "failed": 0,
+                "skipped": 0,
+                "canceled": 0,
+                "currentStepTitle": "Verify compact response",
+            }
+        }
+        service.list_executions.return_value = SimpleNamespace(
+            items=[record],
+            next_page_token=None,
+            count=1,
+        )
+
+        response = test_client.get("/api/executions")
+
+        assert response.status_code == 200
+        progress = response.json()["items"][0]["progress"]
+        assert progress["total"] == 4
+        assert progress["succeeded"] == 4
+        assert progress["currentStepTitle"] == "Verify compact response"
+
+
 def test_describe_manifest_execution_exposes_bounded_manifest_fields() -> None:
     """Manifest ingest detail should expose refs, policy, and bounded counts."""
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10320,6 +10320,18 @@ def test_list_executions_preserves_logical_identity_fields() -> None:
         assert "temporalRunId" not in item
         assert item["latestRunView"] is True
         assert item["continueAsNewCause"] == "manual_rerun"
+        for detail_only_key in (
+            "memo",
+            "searchAttributes",
+            "inputParameters",
+            "taskInstructions",
+            "artifactRefs",
+            "finishSummary",
+            "debugFields",
+            "runMetrics",
+            "logContext",
+        ):
+            assert detail_only_key not in item
 
 def test_describe_manifest_execution_exposes_bounded_manifest_fields() -> None:
     """Manifest ingest detail should expose refs, policy, and bounded counts."""


### PR DESCRIPTION
## Summary
- Add a compact `ExecutionListItemModel` for `/api/executions` list responses while keeping detail endpoints on the full `ExecutionModel`.
- Switch list serialization to avoid computing and returning detail-only payloads such as memo, search attributes, input parameters, task instructions, summaries, debug fields, and run metrics.
- Strip unknown row fields in workflow list/sidebar clients and regenerate OpenAPI types.

## Why
The workflows list initial load was carrying detail-page data for every row. On a local 50-row sample, the table needed roughly 77 KB of row data while the full response was about 1.3 MB.

## Validation
- `./tools/test_unit.sh tests/unit/api/test_executions_temporal.py tests/unit/api/routers/test_executions.py -q`
- `npm run ui:test -- frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx`
- `npm run ui:typecheck`
- `npm run api:types:check`
- `git diff --check`