### PR TITLE
[codex] Fix Jira integration workflow routing

### DIFF
--- a/docs/Temporal/ActivityCatalogAndWorkerTopology.md
+++ b/docs/Temporal/ActivityCatalogAndWorkerTopology.md
@@ -389,6 +389,12 @@ Purpose: external provider interaction and delegated agent execution.
 - `integration.openclaw.execute`
 - `integration.omnigent.execute`
 
+Capability labels and execution visibility metadata are not provider activity
+families by themselves. For example, Jira is available as the
+`integration:jira` capability through trusted Jira tool surfaces and
+merge-automation activities, but there is no `integration.jira.start` /
+`integration.jira.status` external monitor family.
+
 ### Jules and Codex Cloud contract pattern
 
 Current canonical pattern:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -264,6 +264,7 @@ _PR_OPTIONAL_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _PR_OPTIONAL_TASK_SKILLS = frozenset(
     {"jira-implement", *_PR_OPTIONAL_AGENT_SKILLS}
 )
+_EXTERNAL_INTEGRATION_MONITOR_IDS = frozenset({"codex_cloud", "jules"})
 _PUBLISH_NOT_REQUIRED_STATUSES = frozenset(
     {
         "not_required",
@@ -872,6 +873,7 @@ class MoonMindRunWorkflow:
         self._workflow_type: Optional[str] = None
         self._entry: Optional[str] = None
         self._repo: Optional[str] = None
+        self._integration_label: Optional[str] = None
         self._integration: Optional[str] = None
         self._target_runtime: Optional[str] = None
         self._target_skill: Optional[str] = None
@@ -5963,7 +5965,7 @@ class MoonMindRunWorkflow:
             or self._string_from_mapping(ws, "repo")
             or self._string_from_mapping(ws, "repository")
         )
-        self._integration = self._string_from_mapping(parameters, "integration")
+        self._record_integration_from_parameters(parameters)
 
         input_ref = self._optional_string(
             input_payload,
@@ -5997,6 +5999,20 @@ class MoonMindRunWorkflow:
             self._scheduled_for = scheduled_for
 
         return workflow_type, parameters, input_ref, plan_ref, scheduled_for
+
+    def _record_integration_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> None:
+        integration = self._string_from_mapping(parameters, "integration")
+        if integration:
+            integration = integration.strip().lower()
+        self._integration_label = integration
+        self._integration = (
+            integration
+            if integration in _EXTERNAL_INTEGRATION_MONITOR_IDS
+            else None
+        )
 
     def _record_remediation_context(
         self,
@@ -14277,11 +14293,12 @@ class MoonMindRunWorkflow:
                     self._repo,
                 )
             )
-        if self._integration:
+        integration_label = self._integration_label or self._integration
+        if integration_label:
             pairs.append(
                 SearchAttributePair(
                     SearchAttributeKey.for_keyword("mm_integration"),
-                    self._integration,
+                    integration_label,
                 )
             )
         if self._scheduled_for:

--- a/scripts/create_issue_implement_preset_workflows.py
+++ b/scripts/create_issue_implement_preset_workflows.py
@@ -107,7 +107,7 @@ def build_payload(*, provider: str, issue_ref: str, repository: str, runtime: st
             "publishMode": "pr",
             "mergeAutomation": {"enabled": True},
             "idempotencyKey": build_idempotency_key(provider=provider, issue_ref=issue_ref, repository=repository, runtime=runtime, model=model, effort=effort),
-            "integration": provider,
+            "metadata": {"integration": provider},
             "task": task,
         },
     }

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -997,6 +997,42 @@ def test_list_executions_passes_temporal_filters_for_admin() -> None:
     assert kwargs["page_size"] == 25
     assert kwargs["next_page_token"] == "token-123"
 
+
+def test_create_task_shaped_execution_keeps_integration_as_metadata(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "integration": "jira",
+                "targetRuntime": "codex_cli",
+                "task": {
+                    "title": "Run Jira Implement for MM-770",
+                    "instructions": "Complete Jira issue MM-770.",
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "title": "Implement",
+                            "instructions": "Implement MM-770.",
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    kwargs = service.create_execution.await_args.kwargs
+    assert kwargs["integration"] == "jira"
+    assert "integration" not in kwargs["initial_parameters"]
+
+
 def test_list_executions_temporal_query_includes_target_runtime_filter() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/scripts/test_create_issue_implement_preset_workflows.py
+++ b/tests/unit/scripts/test_create_issue_implement_preset_workflows.py
@@ -54,6 +54,8 @@ def test_build_payload_uses_jira_implement_pr_with_merge_automation() -> None:
     assert request_payload["targetRuntime"] == "codex_cli"
     assert request_payload["publishMode"] == "pr"
     assert request_payload["mergeAutomation"] == {"enabled": True}
+    assert "integration" not in request_payload
+    assert request_payload["metadata"] == {"integration": "jira"}
     assert request_payload["idempotencyKey"] == (
         "jira-implement:MM-770:MoonLadderStudios/MoonMind:codex_cli:"
         "pr-merge-automation-expanded-steps"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -168,6 +168,25 @@ def test_run_workflow_skill_context_includes_remediation_policy() -> None:
     }
 
 
+def test_jira_integration_parameter_is_visibility_only() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    workflow._record_integration_from_parameters({"integration": "jira"})
+
+    assert workflow._integration_label == "jira"
+    assert workflow._integration is None
+
+
+def test_jules_integration_parameter_enables_external_monitor() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    workflow._record_integration_from_parameters({"integration": "JULES"})
+
+    assert workflow._integration_label == "jules"
+    assert workflow._integration == "jules"
+    assert workflow._integration_activity_type("start") == "integration.jules.start"
+
+
 @pytest.fixture
 def mock_run_workflow(monkeypatch: pytest.MonkeyPatch) -> MoonMindRunWorkflow:
     workflow = MoonMindRunWorkflow()


### PR DESCRIPTION
## Summary

Fixes the workflow failure seen in `mm:b4d93be2-52c8-4057-a857-6a3e7e47fc63`, where a Jira implementation run reached the parent workflow's legacy external-integration stage and tried to resolve the nonexistent `integration.jira.start` activity.

## Root Cause

`initialParameters.integration = "jira"` was being treated as an external provider monitor selector. Jira is a searchable integration/capability label and trusted tool surface, not a `integration.<provider>.start/status` activity family.

## Changes

- Split workflow integration visibility from legacy external-monitor routing.
- Only `jules` and `codex_cloud` can enable the parent workflow external monitor path.
- Keep Jira integration metadata available for `mm_integration` search attributes.
- Update the batch issue implementation helper to submit provider metadata under `payload.metadata.integration` instead of workflow parameters.
- Document the Jira capability vs provider activity family distinction.

## Validation

- `git diff --check`
- `MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=0 MOONMIND_FORCE_LOCAL_TESTS=1 .venv/bin/python -m pytest -q tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/scripts/test_create_issue_implement_preset_workflows.py tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_keeps_integration_as_metadata`

Note: `./tools/test_unit.sh ...` was attempted first, but its pre-pytest static scanner hit a local permission error on `deploy/state/desired-state.json`; the focused pytest targets above passed.