### PR TITLE
[codex] fix execution list queued timestamp

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2233,6 +2233,7 @@ def _serialize_execution_list_item(record) -> ExecutionListItemModel:
     started_at = getattr(record, "started_at", None)
     updated_at = getattr(record, "updated_at", None) or started_at or datetime.now(UTC)
     created_at = getattr(record, "created_at", None) or started_at or updated_at
+    queued_at = getattr(record, "queued_at", None) or created_at
     scheduled_for = getattr(record, "scheduled_for", None)
     workflow_id = str(getattr(record, "workflow_id", "") or "").strip()
     dashboard_status = _DASHBOARD_STATUS_BY_STATE.get(
@@ -2265,6 +2266,7 @@ def _serialize_execution_list_item(record) -> ExecutionListItemModel:
         scheduled_for=scheduled_for,
         created_at=created_at,
         started_at=started_at,
+        queued_at=queued_at,
         updated_at=updated_at,
         closed_at=getattr(record, "closed_at", None),
         depends_on=depends_on,

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4665,6 +4665,8 @@ export interface components {
             createdAt: string;
             /** Startedat */
             startedAt?: string | null;
+            /** Queuedat */
+            queuedAt?: string | null;
             /**
              * Updatedat
              * Format: date-time

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -3322,6 +3322,7 @@ class ExecutionListItemModel(BaseModel):
     scheduled_for: Optional[datetime] = Field(None, alias="scheduledFor")
     created_at: datetime = Field(..., alias="createdAt")
     started_at: datetime | None = Field(None, alias="startedAt")
+    queued_at: datetime | None = Field(None, alias="queuedAt")
     updated_at: datetime = Field(..., alias="updatedAt")
     closed_at: datetime | None = Field(None, alias="closedAt")
     depends_on: list[str] = Field(default_factory=list, alias="dependsOn")


### PR DESCRIPTION
## Summary
- Add queuedAt to compact execution list rows.
- Populate queuedAt from the record queued timestamp or createdAt fallback before server-side list sorting.

## Root Cause
The Temporal list endpoint serialized rows as ExecutionListItemModel and then sorted them with _execution_queued_sort_timestamp. That helper reads queued_at, but the compact list model did not define queued_at, so list polling raised AttributeError and returned 500.

## Validation
- .venv/bin/python -m pytest tests/unit/api/test_executions_temporal.py::test_list_executions_source_temporal_bypasses_db_and_queries_temporal tests/unit/api/test_executions_temporal.py::test_list_executions_source_temporal_orders_immediate_runs_by_updated_at tests/unit/api/test_executions_temporal.py::test_list_executions_source_temporal_issue_2807_buckets_updated_at_then_queued_order tests/unit/api/routers/test_executions.py::test_list_executions_source_temporal_hydrates_live_progress -q
- curl -i http://localhost:7000/api/executions?source=temporal\&pageSize=50 returned 200 OK after restarting moonmind-api-1

## Notes
- ./tools/test_unit.sh tests/unit/api/test_executions_temporal.py -q did not reach pytest because deploy/state/desired-state.json is root-owned and unreadable in this checkout.