### PR TITLE
[codex] Remove workflow action confirmations

### DIFF
--- a/docs/UI/WorkflowDetailsPage.md
+++ b/docs/UI/WorkflowDetailsPage.md
@@ -268,15 +268,7 @@ Rerun behavior:
 - Links the new run back to the original Workflow Execution as a rerun.
 - Leaves the original failed Workflow unchanged.
 
-Optional confirmation copy:
-
-```text
-Rerun workflow?
-
-This will run the workflow again with the exact same steps, choices, and settings.
-
-[Cancel] [Rerun workflow]
-```
+Rerun executes directly from the capability-gated action control without collecting extra operator input.
 
 After a successful rerun request, the user is taken to the new Workflow Execution details page or shown a success toast with a link to the new run.
 
@@ -314,15 +306,7 @@ Resume behavior:
 - Starts new execution work at the failed step.
 - Leaves the original failed Workflow unchanged.
 
-Optional confirmation copy:
-
-```text
-Resume from failed step?
-
-MoonMind will reuse the completed work before the failed step and retry the failed step. The original failed run will remain unchanged.
-
-[Cancel] [Resume]
-```
+Resume executes directly from the capability-gated action control without collecting extra operator input.
 
 After a successful Resume request, the user is taken to the resumed Workflow Execution details page or shown a success toast with a link to the resumed run.
 
@@ -371,7 +355,7 @@ Possible menu items:
 - Archive workflow, if supported
 - Delete workflow, if supported
 
-Destructive actions are visually separated and require confirmation.
+Destructive Workflow lifecycle actions are visually separated, clearly labeled, and capability-gated by the backend.
 
 ## Action visibility by status
 
@@ -807,9 +791,9 @@ Required accessibility behavior:
 - All buttons have clear accessible names.
 - Status is exposed to assistive technology.
 - Failure messages are announced when they load.
-- Toasts and confirmation dialogs use accessible live regions.
-- Confirmation dialogs trap focus while open.
-- Focus returns to the triggering action after a dialog is closed.
+- Toasts and action result messages use accessible live regions.
+- Text-entry dialogs, where an action inherently requires text input, trap focus while open.
+- Focus returns to the triggering action after a text-entry dialog is closed.
 - Copy actions provide accessible success feedback.
 
 Button accessible names:
@@ -863,21 +847,6 @@ Resume
 You are editing a failed workflow. Your changes will create a new run. The original failed run will remain unchanged.
 ```
 
-### Rerun confirmation
-
-```text
-Rerun workflow?
-
-This will run the workflow again with the exact same steps, choices, and settings.
-```
-
-Confirmation actions:
-
-```text
-Cancel
-Rerun workflow
-```
-
 ### Rerun success toast
 
 ```text
@@ -888,21 +857,6 @@ Toast action:
 
 ```text
 View new run
-```
-
-### Resume confirmation
-
-```text
-Resume from failed step?
-
-MoonMind will reuse the completed work before the failed step and retry the failed step. The original failed run will remain unchanged.
-```
-
-Confirmation actions:
-
-```text
-Cancel
-Resume
 ```
 
 ### Resume success toast
@@ -1051,26 +1005,24 @@ When the user clicks **Edit Workflow** on a failed Workflow:
 
 When the user clicks **Rerun** on a failed Workflow:
 
-1. The user confirms the rerun, if confirmation is enabled.
-2. The system creates a new run using the original submission draft.
-3. The new run preserves the original steps, choices, instructions, inputs, and advanced settings.
-4. The original failed execution is not modified.
-5. The user receives a success toast or is routed to the new run.
-6. The new run is linked to the original execution as a rerun.
+1. The system creates a new run using the original submission draft.
+2. The new run preserves the original steps, choices, instructions, inputs, and advanced settings.
+3. The original failed execution is not modified.
+4. The user receives a success toast or is routed to the new run.
+5. The new run is linked to the original execution as a rerun.
 
 ### Clicking Resume on a failed Workflow
 
 When the user clicks **Resume** on a failed Workflow:
 
-1. The user confirms Resume, if confirmation is enabled.
-2. The backend creates a linked follow-up execution using the original Workflow input snapshot unchanged.
-3. The backend pins the source by `workflowId` and `runId`.
-4. The backend restores completed prior work from durable step output refs and workspace, branch, commit, or equivalent checkpoints.
-5. The new execution marks prior completed steps as preserved from the source run.
-6. The new execution starts newly executed work at the last failed step.
-7. The original failed execution is not modified.
-8. The user receives a success toast or is routed to the resumed run.
-9. The new run is linked to the original execution as `Recovered from failed step`.
+1. The backend creates a linked follow-up execution using the original Workflow input snapshot unchanged.
+2. The backend pins the source by `workflowId` and `runId`.
+3. The backend restores completed prior work from durable step output refs and workspace, branch, commit, or equivalent checkpoints.
+4. The new execution marks prior completed steps as preserved from the source run.
+5. The new execution starts newly executed work at the last failed step.
+6. The original failed execution is not modified.
+7. The user receives a success toast or is routed to the resumed run.
+8. The new run is linked to the original execution as `Recovered from failed step`.
 
 ## Non-goals
 
@@ -1080,7 +1032,7 @@ The Workflow Details page does not hide valid failed-Workflow actions merely bec
 
 The Workflow Details page does not reconstruct edit-form state from display-only labels when a canonical submission draft is available.
 
-The Workflow Details page does not allow destructive actions without confirmation.
+The Workflow Details page does not collect extra operator input before invoking Workflow lifecycle actions.
 
 The Workflow Details page does not allow Workflow input editing as part of failed-step **Resume**. Editing instructions, steps, attachments, runtime, publish mode, branch, presets, or dependencies belongs to **Edit Workflow**.
 

--- a/frontend/src/components/DashboardActionDialog.test.tsx
+++ b/frontend/src/components/DashboardActionDialog.test.tsx
@@ -48,30 +48,29 @@ describe('DashboardActionDialog', () => {
     render(
       <DashboardActionDialog
         open
-        title="Force cancel workflow"
-        subject="Workflow title"
-        compactId="wf-1"
-        consequence="Force cancel this workflow."
-        valueLabel="Reason"
-        confirmLabel="Force cancel workflow"
+        title="Delete schedule"
+        subject="Nightly maintenance"
+        compactId="schedule-1"
+        consequence="Delete this recurring schedule."
+        confirmLabel="Delete schedule"
         destructive
-        confirmationText="FORCE CANCEL"
+        confirmationText="DELETE"
         onCancel={vi.fn()}
         onConfirm={onConfirm}
       />,
     );
 
-    const dialog = screen.getByRole('dialog', { name: 'Force cancel workflow' });
-    const closeButton = screen.getByRole('button', { name: 'Close Force cancel workflow' });
-    const confirmButton = screen.getByRole('button', { name: 'Force cancel workflow' }) as HTMLButtonElement;
+    const dialog = screen.getByRole('dialog', { name: 'Delete schedule' });
+    const closeButton = screen.getByRole('button', { name: 'Close Delete schedule' });
+    const confirmButton = screen.getByRole('button', { name: 'Delete schedule' }) as HTMLButtonElement;
     expect(confirmButton.disabled).toBe(true);
 
     closeButton.focus();
     fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
 
-    fireEvent.change(screen.getByLabelText('Type FORCE CANCEL to confirm'), {
-      target: { value: 'FORCE CANCEL' },
+    fireEvent.change(screen.getByLabelText('Type DELETE to confirm'), {
+      target: { value: 'DELETE' },
     });
     expect(confirmButton.disabled).toBe(false);
     confirmButton.focus();
@@ -86,18 +85,18 @@ describe('DashboardActionDialog', () => {
     render(
       <DashboardActionDialog
         open
-        title="Cancel workflow"
-        subject="Workflow title"
-        compactId="wf-1"
-        consequence="Cancel this workflow."
-        confirmLabel="Cancelling"
+        title="Archive report"
+        subject="Daily report"
+        compactId="report-1"
+        consequence="Archive this report."
+        confirmLabel="Archiving"
         confirmPending
         onCancel={vi.fn()}
         onConfirm={onConfirm}
       />,
     );
 
-    const confirmButton = screen.getByRole('button', { name: 'Cancelling' }) as HTMLButtonElement;
+    const confirmButton = screen.getByRole('button', { name: 'Archiving' }) as HTMLButtonElement;
     expect(confirmButton.disabled).toBe(true);
     expect(confirmButton.getAttribute('aria-busy')).toBe('true');
 

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -136,7 +136,7 @@ describe('WorkflowRowActionsMenu', () => {
     });
   });
 
-  it('bypasses dependencies directly without opening a confirmation dialog', async () => {
+  it('bypasses dependencies directly without opening a dialog', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/executions/wf-123?source=temporal') {
@@ -210,38 +210,33 @@ describe('WorkflowRowActionsMenu', () => {
     expect(screen.getByRole('status').className).toContain('ok');
   });
 
-  it('opens a cancel dialog and posts to the cancel endpoint after confirmation', async () => {
+  it('posts a graceful cancel request directly from the row menu', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
     await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Cancel' }));
-    expect(screen.getByRole('dialog', { name: 'Cancel workflow' })).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel workflow' }));
+    expect(screen.queryByRole('dialog')).toBeNull();
 
     await waitFor(() => {
       const cancelCall = fetchSpy.mock.calls.find(
         ([url]) => String(url) === '/api/executions/wf-123/cancel',
       );
       expect(cancelCall).toBeTruthy();
-      expect(JSON.parse(String((cancelCall?.[1] as RequestInit).body))).toMatchObject({
+      const body = JSON.parse(String((cancelCall?.[1] as RequestInit).body));
+      expect(body).toMatchObject({
         action: 'cancel',
         graceful: true,
       });
+      expect(body).not.toHaveProperty('reason');
     });
   });
 
-  it('requires typed confirmation before posting a forced cancel request', async () => {
+  it('posts a forced cancel request directly from the row menu', async () => {
     renderMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
     await waitForActionAvailability();
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Force cancel' }));
-    const confirmButton = screen.getByRole('button', { name: 'Force cancel workflow' }) as HTMLButtonElement;
-    expect(confirmButton.disabled).toBe(true);
-    fireEvent.change(screen.getByLabelText('Type FORCE CANCEL to confirm'), {
-      target: { value: 'FORCE CANCEL' },
-    });
-    expect(confirmButton.disabled).toBe(false);
-    fireEvent.click(confirmButton);
+    expect(screen.queryByRole('dialog')).toBeNull();
 
     await waitFor(() => {
       const cancelCall = fetchSpy.mock.calls.find(([url, init]) => {
@@ -250,11 +245,12 @@ describe('WorkflowRowActionsMenu', () => {
         return body.graceful === false;
       });
       expect(cancelCall).toBeTruthy();
-      expect(JSON.parse(String((cancelCall?.[1] as RequestInit).body))).toMatchObject({
+      const body = JSON.parse(String((cancelCall?.[1] as RequestInit).body));
+      expect(body).toMatchObject({
         action: 'cancel',
         graceful: false,
-        reason: 'Force canceled by operator from the dashboard.',
       });
+      expect(body).not.toHaveProperty('reason');
     });
   });
 });

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -59,10 +59,6 @@ const RowActionsExecutionSchema = z
 type RowActionsExecution = z.infer<typeof RowActionsExecutionSchema>;
 type RowActionDialogKind =
   | 'rename'
-  | 'resume-from-failed-step'
-  | 'cancel'
-  | 'force-cancel'
-  | 'reject'
   | 'send-message';
 
 const KEBAB_ICON = (
@@ -192,16 +188,14 @@ export function WorkflowRowActionsMenu({
     mutationFn: async ({
       action = 'cancel',
       graceful = true,
-      reason,
     }: {
       action?: 'cancel' | 'reject';
       graceful?: boolean;
-      reason?: string;
     }) => {
       const response = await fetch(`${apiBase}/executions/${encodeURIComponent(workflowId)}/cancel`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({ action, graceful, ...(reason ? { reason } : {}) }),
+        body: JSON.stringify({ action, graceful }),
       });
       if (!response.ok) {
         const text = await response.text();
@@ -352,7 +346,7 @@ export function WorkflowRowActionsMenu({
         },
         onResumeFromFailedStep: () => {
           setActionError(null);
-          setActiveDialog('resume-from-failed-step');
+          failedStepResumeMutation.mutate();
         },
         onRecoverFromSelectedStep: () => {},
         onPause: () => {
@@ -369,15 +363,15 @@ export function WorkflowRowActionsMenu({
         },
         onReject: () => {
           setActionError(null);
-          setActiveDialog('reject');
+          cancelMutation.mutate({ action: 'reject', graceful: true });
         },
         onCancel: () => {
           setActionError(null);
-          setActiveDialog('cancel');
+          cancelMutation.mutate({ action: 'cancel', graceful: true });
         },
         onForceCancel: () => {
           setActionError(null);
-          setActiveDialog('force-cancel');
+          cancelMutation.mutate({ action: 'cancel', graceful: false });
         },
         onSendMessage: () => {
           setActionError(null);
@@ -442,31 +436,6 @@ export function WorkflowRowActionsMenu({
       case 'rename':
         updateMutation.mutate({ updateName: 'SetTitle', title: value }, closeOnSuccess);
         break;
-      case 'resume-from-failed-step':
-        failedStepResumeMutation.mutate(undefined, closeOnSuccess);
-        break;
-      case 'cancel':
-        cancelMutation.mutate(
-          { action: 'cancel', graceful: true, ...(value ? { reason: value } : {}) },
-          closeOnSuccess,
-        );
-        break;
-      case 'force-cancel':
-        cancelMutation.mutate(
-          {
-            action: 'cancel',
-            graceful: false,
-            reason: value || 'Force canceled by operator from the dashboard.',
-          },
-          closeOnSuccess,
-        );
-        break;
-      case 'reject':
-        cancelMutation.mutate(
-          { action: 'reject', graceful: true, reason: value || 'Rejected by operator.' },
-          closeOnSuccess,
-        );
-        break;
       case 'send-message':
         signalMutation.mutate(
           { signalName: 'SendMessage', payload: { message: value } },
@@ -504,74 +473,6 @@ export function WorkflowRowActionsMenu({
         confirmPending={updateMutation.isPending}
         disabledReason={disabledReason('canSetTitle')}
         error={activeDialog === 'rename' ? actionError : null}
-        onCancel={closeDialog}
-        onConfirm={confirmDialog}
-      />
-      <DashboardActionDialog
-        open={activeDialog === 'resume-from-failed-step'}
-        title="Resume from failed step"
-        subject={subject}
-        compactId={workflowId}
-        consequence="Resume from the failed step using the original workflow input snapshot."
-        confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
-        confirmPending={failedStepResumeMutation.isPending}
-        disabledReason={disabledReason('canResumeFromFailedStep')}
-        error={activeDialog === 'resume-from-failed-step' ? actionError : null}
-        onCancel={closeDialog}
-        onConfirm={confirmDialog}
-      />
-      <DashboardActionDialog
-        open={activeDialog === 'cancel'}
-        title="Cancel workflow"
-        subject={subject}
-        compactId={workflowId}
-        consequence="Request a graceful workflow cancellation. Running work may stop at the next cancellation boundary."
-        valueLabel="Reason"
-        valuePlaceholder="Optional operator reason"
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        disabledReason={disabledReason('canCancel')}
-        error={activeDialog === 'cancel' ? actionError : null}
-        onCancel={closeDialog}
-        onConfirm={confirmDialog}
-      />
-      <DashboardActionDialog
-        open={activeDialog === 'force-cancel'}
-        title="Force cancel workflow"
-        subject={subject}
-        compactId={workflowId}
-        consequence="Terminate the Temporal workflow immediately. This is a high-risk operator action and may skip graceful cleanup."
-        valueLabel="Reason"
-        valuePlaceholder="Force canceled by operator from the dashboard."
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        destructive
-        confirmationText="FORCE CANCEL"
-        disabledReason={disabledReason('canCancel')}
-        error={activeDialog === 'force-cancel' ? actionError : null}
-        onCancel={closeDialog}
-        onConfirm={confirmDialog}
-      />
-      <DashboardActionDialog
-        open={activeDialog === 'reject'}
-        title="Reject workflow"
-        subject={subject}
-        compactId={workflowId}
-        consequence="Reject the workflow and record an operator rejection outcome."
-        valueLabel="Reason"
-        valuePlaceholder="Rejected by operator."
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        destructive
-        confirmationText="REJECT"
-        disabledReason={disabledReason('canReject')}
-        error={activeDialog === 'reject' ? actionError : null}
         onCancel={closeDialog}
         onConfirm={confirmDialog}
       />

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -357,12 +357,6 @@ describe('Workflow Detail Entrypoint', () => {
     fireEvent.click(screen.getByRole('button', { name }));
   }
 
-  function typeWorkflowConfirmation(text: string) {
-    fireEvent.change(screen.getByLabelText(`Type ${text} to confirm`), {
-      target: { value: text },
-    });
-  }
-
   function mockWorkflowDetailSubrouteFetch() {
     const mockExecution = {
       taskId: 'test-123',
@@ -3574,7 +3568,7 @@ describe('Workflow Detail Entrypoint', () => {
     expect(within(menu).queryByRole('menuitem', { name: 'Remediate' })).toBeNull();
   });
 
-  it('routes menu selections through existing handlers and preserves destructive confirmations', async () => {
+  it('routes menu selections through direct lifecycle handlers', async () => {
     const mockExecution = {
       taskId: 'test-123',
       workflowId: 'test-123',
@@ -3640,10 +3634,27 @@ describe('Workflow Detail Entrypoint', () => {
 
     menu = await openWorkflowActionsMenu('Cancel');
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Cancel' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(
-      fetchSpy.mock.calls.some(([url, init]) => String(url).includes('/cancel') && init?.method === 'POST'),
-    ).toBe(false);
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/executions/test-123/cancel',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ action: 'cancel', graceful: true }),
+        }),
+      );
+    });
+
+    menu = await openWorkflowActionsMenu('Force cancel');
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Force cancel' }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/executions/test-123/cancel',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ action: 'cancel', graceful: false }),
+        }),
+      );
+    });
   });
 
   it('dismisses the Workflow actions menu without side effects and supports keyboard selection', async () => {
@@ -4186,7 +4197,7 @@ describe('Workflow Detail Entrypoint', () => {
     const resumeButton = within(menu).getByRole('menuitem', { name: 'Resume from failed step' });
     expect(screen.queryByRole('button', { name: 'Resume' })).toBeNull();
     fireEvent.click(resumeButton);
-    confirmWorkflowDialog('Resume workflow');
+    expect(screen.queryByRole('dialog', { name: 'Resume from failed step' })).toBeNull();
 
     await waitFor(() => {
       expect(calls.some((call) => call.url.includes('/recover-from-failed-step'))).toBe(true);
@@ -4323,7 +4334,7 @@ describe('Workflow Detail Entrypoint', () => {
     ).toBe(true);
     const menu = await openWorkflowActionsMenu('Recover from selected step');
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Recover from selected step' }));
-    confirmWorkflowDialog('Recover workflow');
+    expect(screen.queryByRole('dialog', { name: 'Recover from selected step' })).toBeNull();
 
     await waitFor(() => {
       expect(calls.some((call) => call.url.includes('/recover-from-selected-step'))).toBe(true);
@@ -7015,8 +7026,7 @@ describe('Workflow Detail Entrypoint', () => {
 
     menu = await openWorkflowActionsMenu('Reject');
     fireEvent.click(within(menu).getByRole('menuitem', { name: 'Reject' }));
-    typeWorkflowConfirmation('REJECT');
-    confirmWorkflowDialog('Reject workflow');
+    expect(screen.queryByRole('dialog')).toBeNull();
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -7026,7 +7036,6 @@ describe('Workflow Detail Entrypoint', () => {
           body: JSON.stringify({
             action: 'reject',
             graceful: true,
-            reason: 'Rejected by operator.',
           }),
         }),
       );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -223,11 +223,6 @@ type SegmentedNavItem<T extends string> = {
 };
 type WorkflowDialogKind =
   | 'rename'
-  | 'resume-from-failed-step'
-  | 'recover-from-selected-step'
-  | 'cancel'
-  | 'force-cancel'
-  | 'reject'
   | 'send-message';
 
 function workflowDetailSubrouteFromPath(pathname: string): WorkflowDetailSubroute {
@@ -6536,11 +6531,9 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
     mutationFn: async ({
       action = 'cancel',
       graceful = true,
-      reason,
     }: {
       action?: 'cancel' | 'reject';
       graceful?: boolean;
-      reason?: string;
     }) => {
       const response = await fetch(`${payload.apiBase}/executions/${encodeURIComponent(workflowId)}/cancel`, {
         method: 'POST',
@@ -6548,7 +6541,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         body: JSON.stringify({
           action,
           graceful,
-          ...(reason ? { reason } : {}),
         }),
       });
       if (!response.ok) {
@@ -6713,12 +6705,12 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onResumeFromFailedStep = () => {
     setActionError(null);
-    setActiveWorkflowDialog('resume-from-failed-step');
+    failedStepResumeMutation.mutate();
   };
 
   const onRecoverFromSelectedStep = () => {
     setActionError(null);
-    setActiveWorkflowDialog('recover-from-selected-step');
+    selectedStepRecoveryMutation.mutate();
   };
 
   const onApprove = () => {
@@ -6744,17 +6736,17 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
 
   const onCancel = () => {
     setActionError(null);
-    setActiveWorkflowDialog('cancel');
+    cancelMutation.mutate({ action: 'cancel', graceful: true });
   };
 
   const onForceCancel = () => {
     setActionError(null);
-    setActiveWorkflowDialog('force-cancel');
+    cancelMutation.mutate({ action: 'cancel', graceful: false });
   };
 
   const onReject = () => {
     setActionError(null);
-    setActiveWorkflowDialog('reject');
+    cancelMutation.mutate({ action: 'reject', graceful: true });
   };
 
   const actions = execution?.actions;
@@ -6903,8 +6895,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
   };
   const workflowDialogSubject = execution?.title?.trim() || taskId || 'Workflow';
   const workflowDialogId = taskId || workflowId || '';
-  const selectedRecoveryStepLabel =
-    selectedRecoveryStep?.title || selectedRecoveryStep?.logicalStepId || 'the selected step';
   const closeWorkflowDialog = () => {
     setActiveWorkflowDialog(null);
     setActionError(null);
@@ -6915,34 +6905,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
       case 'rename':
         updateMutation.mutate(
           { updateName: 'SetTitle', title: value },
-          closeOnSuccess,
-        );
-        break;
-      case 'resume-from-failed-step':
-        failedStepResumeMutation.mutate(undefined, closeOnSuccess);
-        break;
-      case 'recover-from-selected-step':
-        selectedStepRecoveryMutation.mutate(undefined, closeOnSuccess);
-        break;
-      case 'cancel':
-        cancelMutation.mutate(
-          { action: 'cancel', graceful: true, ...(value ? { reason: value } : {}) },
-          closeOnSuccess,
-        );
-        break;
-      case 'force-cancel':
-        cancelMutation.mutate(
-          {
-            action: 'cancel',
-            graceful: false,
-            reason: value || 'Force canceled by operator from the dashboard.',
-          },
-          closeOnSuccess,
-        );
-        break;
-      case 'reject':
-        cancelMutation.mutate(
-          { action: 'reject', graceful: true, reason: value || 'Rejected by operator.' },
           closeOnSuccess,
         );
         break;
@@ -7047,93 +7009,6 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
         confirmPending={updateMutation.isPending}
         disabledReason={actionDisabledReason('canSetTitle')}
         error={activeWorkflowDialog === 'rename' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'resume-from-failed-step'}
-        title="Resume from failed step"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence="Resume from the failed step using the original workflow input snapshot."
-        confirmLabel={failedStepResumeMutation.isPending ? 'Resuming' : 'Resume workflow'}
-        confirmPending={failedStepResumeMutation.isPending}
-        disabledReason={actionDisabledReason('canResumeFromFailedStep')}
-        error={activeWorkflowDialog === 'resume-from-failed-step' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'recover-from-selected-step'}
-        title="Recover from selected step"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence={`Recover from ${selectedRecoveryStepLabel} using checkpoint evidence from the source run.`}
-        confirmLabel={selectedStepRecoveryMutation.isPending ? 'Recovering' : 'Recover workflow'}
-        confirmPending={selectedStepRecoveryMutation.isPending}
-        disabledReason={
-          selectedRecoveryStep?.eligible
-            ? null
-            : selectedRecoveryStep?.reason
-              ? formatStatusLabel(selectedRecoveryStep.reason)
-              : 'selected step is not eligible'
-        }
-        error={activeWorkflowDialog === 'recover-from-selected-step' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'cancel'}
-        title="Cancel workflow"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence="Request a graceful workflow cancellation. Running work may stop at the next cancellation boundary."
-        valueLabel="Reason"
-        valuePlaceholder="Optional operator reason"
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Cancelling' : 'Cancel workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        disabledReason={actionDisabledReason('canCancel')}
-        error={activeWorkflowDialog === 'cancel' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'force-cancel'}
-        title="Force cancel workflow"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence="Terminate the Temporal workflow immediately. This is a high-risk operator action and may skip graceful cleanup."
-        valueLabel="Reason"
-        valuePlaceholder="Force canceled by operator from the dashboard."
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Force cancelling' : 'Force cancel workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        destructive
-        confirmationText="FORCE CANCEL"
-        disabledReason={actionDisabledReason('canCancel')}
-        error={activeWorkflowDialog === 'force-cancel' ? actionError : null}
-        onCancel={closeWorkflowDialog}
-        onConfirm={confirmWorkflowDialog}
-      />
-      <DashboardActionDialog
-        open={activeWorkflowDialog === 'reject'}
-        title="Reject workflow"
-        subject={workflowDialogSubject}
-        compactId={workflowDialogId}
-        consequence="Reject the workflow and record an operator rejection outcome."
-        valueLabel="Reason"
-        valuePlaceholder="Rejected by operator."
-        valueMultiline
-        confirmLabel={cancelMutation.isPending ? 'Rejecting' : 'Reject workflow'}
-        confirmPending={cancelMutation.isPending}
-        danger
-        destructive
-        confirmationText="REJECT"
-        disabledReason={actionDisabledReason('canReject')}
-        error={activeWorkflowDialog === 'reject' ? actionError : null}
         onCancel={closeWorkflowDialog}
         onConfirm={confirmWorkflowDialog}
       />

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2150,9 +2150,12 @@ class TemporalExecutionService:
         record = await self._require_cancel_target_execution(workflow_id)
 
         action_name = "reject" if action == "reject" else "cancel"
-        default_reason = (
-            "Rejected by operator." if action_name == "reject" else "Canceled by user."
-        )
+        if action_name == "reject":
+            default_reason = "Rejected by operator."
+        elif graceful:
+            default_reason = "Canceled by user."
+        else:
+            default_reason = "Force canceled by operator."
         reason_text = (reason or default_reason).strip() or default_reason
 
         if record.state in TERMINAL_STATES:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -4890,6 +4890,45 @@ async def test_forced_cancel_marks_failed_with_terminated_close_status(
         assert terminated.memo["summary"] == "forced_termination: ops kill"
 
 @pytest.mark.asyncio
+async def test_forced_cancel_without_reason_uses_force_specific_audit_summary(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+
+        terminated = await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason=None,
+            graceful=False,
+        )
+
+        assert terminated.state is MoonMindWorkflowState.FAILED
+        assert terminated.close_status is TemporalExecutionCloseStatus.TERMINATED
+        assert terminated.memo["summary"] == (
+            "forced_termination: Force canceled by operator."
+        )
+        assert terminated.memo["intervention_audit"][-1]["summary"] == (
+            "Force canceled by operator."
+        )
+        mock_client_adapter.terminate_workflow.assert_called_once_with(
+            created.workflow_id,
+            reason="Force canceled by operator.",
+        )
+
+@pytest.mark.asyncio
 async def test_request_rerun_can_override_inputs_and_parameters(
     tmp_path, mock_client_adapter
 ):


### PR DESCRIPTION
## Summary
- Removes Workflow Details design guidance that called for rerun/resume/destructive workflow action confirmations.
- Makes workflow row and detail lifecycle actions execute directly for cancel, force cancel, reject, failed-step resume, and selected-step recovery.
- Updates frontend tests so cancel, force cancel, and reject send no dashboard-generated reason payload, and removes workflow-specific typed-confirmation examples.

## Validation
- `npm run ui:test -- frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/components/DashboardActionDialog.test.tsx frontend/src/lib/workflowActions.test.ts`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/components/WorkflowRowActionsMenu.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/components/DashboardActionDialog.test.tsx frontend/src/lib/workflowActions.test.ts`

Note: `./tools/test_unit.sh --ui-args ...` without `--dashboard-only` did not reach tests because the Python precheck hit a local permission error reading `deploy/state/desired-state.json`, which is root-owned in this workspace.