### PR TITLE
[codex] Handle Codex missing-turn visibility race

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -95,6 +95,23 @@ _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
 )
 
+
+def _redact_text(value: Any, *, max_chars: int) -> str:
+    text = str(value) if value is not None else ""
+    for pattern in _SECRET_REDACTION_PATTERNS:
+        text = pattern.sub(
+            lambda match: (
+                f"{match.group(1)}{match.group(2)}[REDACTED]"
+                if match.lastindex and match.lastindex >= 2
+                else "[REDACTED]"
+            ),
+            text,
+        )
+    if len(text) > max_chars:
+        return text[:max_chars] + "...[truncated]"
+    return text
+
+
 @dataclass(frozen=True)
 class _RolloutTurnScan:
     references_turn: bool = False
@@ -208,19 +225,7 @@ class CodexAppServerRpcClient:
 
     @staticmethod
     def _redact_trace_text(value: Any, *, max_chars: int = 500) -> str:
-        text = str(value or "")
-        for pattern in _SECRET_REDACTION_PATTERNS:
-            text = pattern.sub(
-                lambda match: (
-                    f"{match.group(1)}{match.group(2)}[REDACTED]"
-                    if match.lastindex and match.lastindex >= 2
-                    else "[REDACTED]"
-                ),
-                text,
-            )
-        if len(text) > max_chars:
-            return text[:max_chars] + "...[truncated]"
-        return text
+        return _redact_text(value, max_chars=max_chars)
 
     @classmethod
     def _trace_error_text(cls, value: Any) -> str | None:
@@ -871,19 +876,7 @@ class CodexManagedSessionRuntime:
 
     @staticmethod
     def _redact_diagnostic_text(value: Any, *, max_chars: int = _DIAGNOSTIC_TEXT_MAX_CHARS) -> str:
-        text = str(value or "")
-        for pattern in _SECRET_REDACTION_PATTERNS:
-            text = pattern.sub(
-                lambda match: (
-                    f"{match.group(1)}{match.group(2)}[REDACTED]"
-                    if match.lastindex and match.lastindex >= 2
-                    else "[REDACTED]"
-                ),
-                text,
-            )
-        if len(text) > max_chars:
-            return text[:max_chars] + "...[truncated]"
-        return text
+        return _redact_text(value, max_chars=max_chars)
 
     @classmethod
     def _diagnostic_value(cls, value: Any) -> Any:
@@ -2193,9 +2186,10 @@ class CodexManagedSessionRuntime:
                                     remaining,
                                 ),
                             )
+                            continue
                         except TimeoutError:
-                            pass
-                        continue
+                            # Expected during grace-period polling; retry until the deadline.
+                            continue
                 outcome = self._missing_turn_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -77,10 +77,13 @@ _TURN_ITEMS_PAGE_LIMIT = 200
 _TURN_ITEMS_MAX_PAGES = 20
 _EMPTY_ROLLOUT_READ_GRACE_SECONDS = 1.0
 _EMPTY_ROLLOUT_READ_RETRY_SECONDS = 0.1
+_MISSING_TURN_VISIBILITY_GRACE_SECONDS = 5.0
+_MISSING_TURN_VISIBILITY_RETRY_SECONDS = 1.0
 _SQLITE_STATE_RUNTIME_FAILURE_MARKERS: tuple[str, ...] = (
     "failed to initialize sqlite state runtime",
     "failed to initialize state runtime",
 )
+_MISSING_TURN_IDLE_EMPTY_ROLLOUT_SUBTYPE = "missing_turn_idle_empty_rollout"
 _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
@@ -125,6 +128,11 @@ class _TurnTerminalOutcome:
     error_text: str | None = None
     failure_class: str | None = None
     disposition: str | None = None
+
+@dataclass(frozen=True)
+class _ThreadRecoveryResult:
+    vendor_thread_id: str
+    fallback_started: bool = False
 
 _SKILL_OUTCOME_FILENAME = "skill_outcome.json"
 _SKILL_OUTCOME_SCHEMA_VERSION = 1
@@ -199,7 +207,40 @@ class CodexAppServerRpcClient:
         return list(self._trace)
 
     @staticmethod
-    def _message_summary(message: Mapping[str, Any]) -> dict[str, Any]:
+    def _redact_trace_text(value: Any, *, max_chars: int = 500) -> str:
+        text = str(value or "")
+        for pattern in _SECRET_REDACTION_PATTERNS:
+            text = pattern.sub(
+                lambda match: (
+                    f"{match.group(1)}{match.group(2)}[REDACTED]"
+                    if match.lastindex and match.lastindex >= 2
+                    else "[REDACTED]"
+                ),
+                text,
+            )
+        if len(text) > max_chars:
+            return text[:max_chars] + "...[truncated]"
+        return text
+
+    @classmethod
+    def _trace_error_text(cls, value: Any) -> str | None:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return cls._redact_trace_text(normalized) if normalized else None
+        if isinstance(value, Mapping):
+            for field_name in ("message", "error", "reason", "detail"):
+                recovered = cls._trace_error_text(value.get(field_name))
+                if recovered:
+                    return recovered
+        if isinstance(value, list):
+            for item in value:
+                recovered = cls._trace_error_text(item)
+                if recovered:
+                    return recovered
+        return None
+
+    @classmethod
+    def _message_summary(cls, message: Mapping[str, Any]) -> dict[str, Any]:
         summary: dict[str, Any] = {}
         method = str(message.get("method") or "").strip()
         if method:
@@ -207,14 +248,22 @@ class CodexAppServerRpcClient:
         raw_id = message.get("id")
         if isinstance(raw_id, int):
             summary["id"] = raw_id
-        if "error" in message:
-            summary["hasError"] = True
         result = message.get("result")
         if isinstance(result, Mapping):
             summary["resultKeys"] = sorted(str(key) for key in result.keys())[:12]
         params = message.get("params")
         if isinstance(params, Mapping):
             summary["paramKeys"] = sorted(str(key) for key in params.keys())[:12]
+        if "error" in message:
+            error = message.get("error")
+            summary["hasError"] = True
+            if isinstance(error, Mapping):
+                code = error.get("code")
+                if isinstance(code, (int, float, str)):
+                    summary["errorCode"] = code
+            error_text = cls._trace_error_text(error)
+            if error_text:
+                summary["errorMessage"] = error_text
         return summary
 
     def _ensure_started(self) -> None:
@@ -458,6 +507,9 @@ class CodexManagedSessionRuntime:
         container_id: str,
         app_server_command: Sequence[str] = ("codex", "app-server"),
         turn_completion_timeout_seconds: float = _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS,
+        missing_turn_visibility_grace_seconds: float = (
+            _MISSING_TURN_VISIBILITY_GRACE_SECONDS
+        ),
     ) -> None:
         self._workspace_path = Path(workspace_path)
         self._session_workspace_path = Path(session_workspace_path)
@@ -471,6 +523,10 @@ class CodexManagedSessionRuntime:
         self._container_id = container_id
         self._app_server_command = tuple(app_server_command)
         self._turn_completion_timeout_seconds = turn_completion_timeout_seconds
+        self._missing_turn_visibility_grace_seconds = max(
+            0.0,
+            float(missing_turn_visibility_grace_seconds),
+        )
         self._client: CodexAppServerRpcClient | None = None
 
     @property
@@ -1976,25 +2032,51 @@ class CodexManagedSessionRuntime:
             return turn
         return None
 
+    @classmethod
+    def _is_missing_turn_idle_empty_rollout(
+        cls,
+        *,
+        thread_payload: Mapping[str, Any],
+        rollout_scan: _RolloutTurnScan,
+        vendor_turn_id: str,
+    ) -> bool:
+        if cls._find_turn_payload(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        ) is not None:
+            return False
+        thread_outcome = cls._terminal_thread_outcome(thread_payload)
+        if thread_outcome is None or thread_outcome.status != "completed":
+            return False
+        return (
+            rollout_scan.entries_scanned == 0
+            and not rollout_scan.references_turn
+            and not rollout_scan.saw_task_complete
+            and not rollout_scan.assistant_text
+            and not rollout_scan.error_text
+        )
+
     def _missing_turn_terminal_outcome(
         self,
         *,
         state: CodexSessionRuntimeState,
         thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
+        rollout_scan: _RolloutTurnScan | None = None,
     ) -> _TurnTerminalOutcome | None:
         thread_outcome = self._terminal_thread_outcome(thread_payload)
         if thread_outcome is not None and thread_outcome.status != "completed":
             return thread_outcome
 
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        rollout_scan = self._scan_rollout_for_turn(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-        )
+        if rollout_scan is None:
+            vendor_thread_path = self._resolved_rollout_path(
+                state=state,
+                thread_payload=thread_payload,
+            )
+            rollout_scan = self._scan_rollout_for_turn(
+                vendor_thread_path,
+                vendor_turn_id=vendor_turn_id,
+            )
         rollout_outcome = self._rollout_terminal_outcome_from_scan(
             rollout_scan,
             vendor_turn_id=vendor_turn_id,
@@ -2021,9 +2103,11 @@ class CodexManagedSessionRuntime:
         vendor_thread_id: str,
         vendor_turn_id: str,
         rollout_mirror: _RolloutLiveMirror,
+        thread_started_after_recovery_fallback: bool = False,
     ) -> tuple[Mapping[str, Any], _TurnTerminalOutcome]:
         deadline = time.monotonic() + self._turn_completion_timeout_seconds
         empty_rollout_first_seen_at: float | None = None
+        missing_turn_first_seen_at: float | None = None
         while True:
             try:
                 thread_payload = client.request(
@@ -2067,18 +2151,60 @@ class CodexManagedSessionRuntime:
                 vendor_turn_id=vendor_turn_id,
             )
             if isinstance(turn_payload, Mapping):
+                missing_turn_first_seen_at = None
                 outcome = self._terminal_turn_outcome(turn_payload)
                 if outcome is not None:
                     return thread_payload, outcome
             else:
                 state = self._load_state()
+                vendor_thread_path = self._resolved_rollout_path(
+                    state=state,
+                    thread_payload=thread_payload,
+                )
+                rollout_scan = self._scan_rollout_for_turn(
+                    vendor_thread_path,
+                    vendor_turn_id=vendor_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if (
+                    thread_started_after_recovery_fallback
+                    and self._missing_turn_visibility_grace_seconds > 0
+                    and self._is_missing_turn_idle_empty_rollout(
+                        thread_payload=thread_payload,
+                        rollout_scan=rollout_scan,
+                        vendor_turn_id=vendor_turn_id,
+                    )
+                ):
+                    now = time.monotonic()
+                    if missing_turn_first_seen_at is None:
+                        missing_turn_first_seen_at = now
+                    grace_remaining = (
+                        self._missing_turn_visibility_grace_seconds
+                        - (now - missing_turn_first_seen_at)
+                    )
+                    remaining = deadline - now
+                    if grace_remaining > 0 and remaining > 0:
+                        try:
+                            client.wait_for_notification(
+                                None,
+                                timeout_seconds=min(
+                                    _MISSING_TURN_VISIBILITY_RETRY_SECONDS,
+                                    grace_remaining,
+                                    remaining,
+                                ),
+                            )
+                        except TimeoutError:
+                            pass
+                        continue
                 outcome = self._missing_turn_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,
                     vendor_turn_id=vendor_turn_id,
+                    rollout_scan=rollout_scan,
                 )
                 if outcome is not None:
                     return thread_payload, outcome
+                missing_turn_first_seen_at = None
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -2130,13 +2256,13 @@ class CodexManagedSessionRuntime:
         normalized = message.lower()
         return "rollout at " in normalized and " is empty" in normalized
 
-    def _recovery_thread(
+    def _recovery_thread_result(
         self,
         *,
         client: CodexAppServerRpcClient,
         state: CodexSessionRuntimeState,
         allow_fallback_start: bool = True,
-    ) -> str:
+    ) -> _ThreadRecoveryResult:
         existing_thread_path = self._existing_thread_path(state.vendor_thread_path)
         discovered_thread_path = None
         if existing_thread_path is None:
@@ -2188,6 +2314,7 @@ class CodexManagedSessionRuntime:
                     {"cwd": str(self._workspace_path)},
                 )
                 thread_payload = started.get("thread")
+                fallback_started = True
                 if not isinstance(thread_payload, Mapping):
                     raise RuntimeError(
                         "codex app-server thread/start did not return a thread"
@@ -2202,7 +2329,23 @@ class CodexManagedSessionRuntime:
         state.vendor_thread_path = self._normalized_thread_path(
             recovered_thread_path or thread_payload.get("path")
         )
-        return vendor_thread_id
+        return _ThreadRecoveryResult(
+            vendor_thread_id=vendor_thread_id,
+            fallback_started=fallback_started,
+        )
+
+    def _recovery_thread(
+        self,
+        *,
+        client: CodexAppServerRpcClient,
+        state: CodexSessionRuntimeState,
+        allow_fallback_start: bool = True,
+    ) -> str:
+        return self._recovery_thread_result(
+            client=client,
+            state=state,
+            allow_fallback_start=allow_fallback_start,
+        ).vendor_thread_id
 
     @classmethod
     def _terminal_turn_outcome(
@@ -2447,7 +2590,8 @@ class CodexManagedSessionRuntime:
     ) -> CodexManagedSessionTurnResponse:
         state = self._validate_locator(request)
         client = self._initialized_app_server_client()
-        vendor_thread_id = self._recovery_thread(client=client, state=state)
+        thread_recovery = self._recovery_thread_result(client=client, state=state)
+        vendor_thread_id = thread_recovery.vendor_thread_id
         rollout_mirror = self._new_rollout_live_mirror(state)
 
         started = client.request(
@@ -2488,6 +2632,9 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=vendor_thread_id,
                 vendor_turn_id=vendor_turn_id,
                 rollout_mirror=rollout_mirror,
+                thread_started_after_recovery_fallback=(
+                    thread_recovery.fallback_started
+                ),
             )
             status = outcome.status
             error_text = outcome.error_text
@@ -2584,6 +2731,14 @@ class CodexManagedSessionRuntime:
                     )
                 metadata["failureCause"] = EMPTY_ASSISTANT_FAILURE_CAUSE
                 metadata["retryRecommendedAction"] = "clear_session"
+                if self._is_missing_turn_idle_empty_rollout(
+                    thread_payload=thread_payload,
+                    rollout_scan=evidence_rollout_scan,
+                    vendor_turn_id=vendor_turn_id,
+                ):
+                    metadata["failureSubtype"] = (
+                        _MISSING_TURN_IDLE_EMPTY_ROLLOUT_SUBTYPE
+                    )
                 metadata["turnFailureEvidence"] = self._turn_failure_evidence(
                     reason=error_text,
                     state=state,

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -11,6 +11,7 @@ def write_fake_app_server(
     completion_notification_method: str | None = "turn/completed",
     complete_turn_on_read: bool = True,
     omit_turns_on_read: bool = False,
+    omit_turns_on_initial_reads: int = 0,
     omit_turns_when_incomplete: bool = False,
     assistant_text: str = "OK",
     thread_status_type: str = "idle",
@@ -65,6 +66,7 @@ START_THREAD_PATH = __START_THREAD_PATH__
 COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
 COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
 OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
+OMIT_TURNS_ON_INITIAL_READS = __OMIT_TURNS_ON_INITIAL_READS__
 OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
@@ -296,7 +298,10 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
-        should_omit_turns = OMIT_TURNS_ON_READ and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
+        should_omit_turns = (
+            (OMIT_TURNS_ON_READ or thread_read_attempts <= OMIT_TURNS_ON_INITIAL_READS)
+            and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
+        )
         turns = []
         preview = ""
         if not should_omit_turns:
@@ -375,6 +380,7 @@ __COMPLETION_BLOCK__
             "True" if complete_turn_on_read else "False",
         )
         .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
+        .replace("__OMIT_TURNS_ON_INITIAL_READS__", repr(omit_turns_on_initial_reads))
         .replace(
             "__OMIT_TURNS_WHEN_INCOMPLETE__",
             "True" if omit_turns_when_incomplete else "False",

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -338,6 +338,24 @@ def test_runtime_send_turn_returns_terminal_completed_response(
     assert handle.session_state.active_turn_id is None
     assert handle.metadata["lastAssistantText"] == "OK"
 
+
+def test_app_server_rpc_trace_summary_includes_redacted_error_message() -> None:
+    summary = CodexAppServerRpcClient._message_summary(
+        {
+            "id": 6,
+            "error": {
+                "code": -32600,
+                "message": "failed to read rollout with token=supersecret",
+            },
+        }
+    )
+
+    assert summary["hasError"] is True
+    assert summary["errorCode"] == -32600
+    assert summary["errorMessage"] == "failed to read rollout with token=[REDACTED]"
+    assert "supersecret" not in summary["errorMessage"]
+
+
 def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     tmp_path: Path,
 ) -> None:
@@ -2682,6 +2700,121 @@ def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_n
     )
     assert updated_state["vendorThreadId"] == "vendor-thread-2"
     assert "vendorThreadPath" not in updated_state
+
+
+def test_runtime_send_turn_waits_for_fallback_started_turn_visibility(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "06"
+        / "28"
+        / "rollout-2026-06-28T13-46-25-vendor-thread-2.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=str(transcript_path),
+        omit_turns_on_initial_reads=1,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        missing_turn_visibility_grace_seconds=1.0,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata["assistantText"] == "OK"
+    state_payload = json.loads(
+        (
+            Path(request.session_workspace_path)
+            / ".moonmind-codex-session-state.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert state_payload["vendorThreadId"] == "vendor-thread-2"
+    assert state_payload["lastTurnStatus"] == "completed"
+    stderr_path = Path(request.artifact_spool_path) / "stderr.log"
+    assert not stderr_path.exists() or "turn failed:" not in stderr_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_runtime_send_turn_marks_missing_fallback_turn_subtype_after_grace(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "06"
+        / "28"
+        / "rollout-2026-06-28T13-46-25-vendor-thread-2.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=str(transcript_path),
+        omit_turns_on_read=True,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        missing_turn_visibility_grace_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["failureCause"] == "app_server_protocol_empty_turn"
+    assert (
+        response.metadata["failureSubtype"]
+        == "missing_turn_idle_empty_rollout"
+    )
+    evidence = response.metadata["turnFailureEvidence"]
+    assert evidence["threadPayloadSummary"]["turnCount"] == 0
+    assert evidence["rolloutScan"]["entriesScanned"] == 0
 
 
 def test_runtime_send_turn_starts_new_thread_when_rollout_recovery_file_is_empty(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -356,6 +356,13 @@ def test_app_server_rpc_trace_summary_includes_redacted_error_message() -> None:
     assert "supersecret" not in summary["errorMessage"]
 
 
+def test_redaction_preserves_falsy_non_none_values() -> None:
+    assert CodexAppServerRpcClient._redact_trace_text(0) == "0"
+    assert CodexAppServerRpcClient._redact_trace_text(False) == "False"
+    assert CodexManagedSessionRuntime._redact_diagnostic_text(0) == "0"
+    assert CodexManagedSessionRuntime._redact_diagnostic_text(False) == "False"
+
+
 def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add a bounded visibility grace for Codex turns that were started after a thread recovery fallback but are not yet visible in `thread/read` or rollout state.
- Preserve the existing clear-and-retry self-heal path when the turn still never appears, but tag that case with `failureSubtype=missing_turn_idle_empty_rollout`.
- Include short redacted App Server error messages and codes in JSON-RPC trace summaries so future empty-turn diagnostics show why `thread/resume` or `thread/turns/items/list` failed.

## Root Cause

Recent failures showed `thread/resume` failing, fallback `thread/start` succeeding, `turn/start` returning a turn id, then immediate `thread/read` reporting an idle thread with zero turns while the rollout file was still empty. The runtime treated that as terminal empty assistant output right away, causing a clear-and-resend even though it may be a short App Server state visibility race.

## Validation

- `python3 -m pytest tests/unit/services/temporal/runtime/test_codex_session_runtime.py -q` -> 75 passed
- `python3 -m pytest tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py -q` -> 280 passed, 15 existing warnings
- `git diff --check` -> passed
- `python3 -c 'import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding="utf-8"), filename=p) for p in ("moonmind/workflows/temporal/runtime/codex_session_runtime.py", "tests/helpers/codex_session_runtime.py", "tests/unit/services/temporal/runtime/test_codex_session_runtime.py")]'` -> passed

Note: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py` failed before pytest because local `deploy/state/desired-state.json` is root-owned and unreadable to the current user. `ruff` is not installed in the local Python/uv environment, so ruff checks could not be run locally.