### PR TITLE
MM-1031 Implement approval elicitation resolution

### DIFF
--- a/api_service/api/routers/sessions.py
+++ b/api_service/api/routers/sessions.py
@@ -341,11 +341,6 @@ async def resolve_session_elicitation(
                 ),
             ) from exc
         raise
-    if record.status in agent_runs_router._MANAGED_SESSION_TERMINAL_STATUSES:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="This managed session is not available for elicitation resolution.",
-        )
     control = ArtifactSessionControlRequest(
         action="send_follow_up",
         message=_ELICITATION_DECISION_MESSAGES[decision],

--- a/api_service/api/routers/sessions.py
+++ b/api_service/api/routers/sessions.py
@@ -94,6 +94,30 @@ def _artifact_refs_from_projection(projection: object) -> dict[str, Any]:
     }
 
 
+_SUPPORTED_ELICITATION_DECISIONS = {"approve", "reject"}
+
+_ELICITATION_DECISION_MESSAGES = {
+    "approve": "Approved.",
+    "reject": "Rejected.",
+}
+
+
+def _elicitation_resolution_decision(payload: dict[str, Any]) -> str:
+    decision = str(payload.get("decision") or "").strip().lower()
+    if decision not in _SUPPORTED_ELICITATION_DECISIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported_elicitation_resolution",
+                "message": (
+                    "Supported elicitation resolution decisions are approve "
+                    "and reject."
+                ),
+            },
+        )
+    return decision
+
+
 def _event_item(event: dict[str, Any]) -> dict[str, Any]:
     sequence = event.get("sequence")
     kind = str(event.get("kind") or event.get("stream") or "event")
@@ -231,7 +255,9 @@ async def post_session_event(
     payload: dict[str, Any],
     _enabled: None = Depends(_require_session_api_compat_enabled),
     _user: User = Depends(get_current_user()),
-    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+    artifact_service: TemporalArtifactService = Depends(
+        _get_temporal_artifact_service
+    ),
 ) -> dict[str, Any]:
     record = await _load_authorized_session_record(session_id, _user)
     event_type = str(payload.get("type") or "").strip()
@@ -295,22 +321,47 @@ async def resolve_session_elicitation(
     payload: dict[str, Any],
     _enabled: None = Depends(_require_session_api_compat_enabled),
     _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
 ) -> dict[str, Any]:
     record = await _load_authorized_session_record(session_id, _user)
+    decision = _elicitation_resolution_decision(payload)
     capabilities = agent_runs_router._build_intervention_capabilities(record)
-    if not any(capabilities.values()):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="This managed session is not available for elicitation resolution.",
+    try:
+        agent_runs_router._require_session_control_capability(
+            action="send_follow_up",
+            capabilities=capabilities,
         )
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_409_CONFLICT:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "This managed session is not available for elicitation "
+                    "resolution."
+                ),
+            ) from exc
+        raise
     if record.status in agent_runs_router._MANAGED_SESSION_TERMINAL_STATUSES:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="This managed session is not available for elicitation resolution.",
         )
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail=(
-            "Session elicitation resolution is not implemented for managed sessions."
-        ),
+    control = ArtifactSessionControlRequest(
+        action="send_follow_up",
+        message=_ELICITATION_DECISION_MESSAGES[decision],
+        reason=f"session_elicitation:{elicitation_id}:{decision}",
     )
+    response = await control_agent_run_artifact_session(
+        agent_run_id=record.agent_run_id,
+        session_id=record.session_id,
+        payload=control,
+        _user=_user,
+        artifact_service=artifact_service,
+    )
+    return {
+        "type": "elicitation_resolution",
+        "elicitationId": elicitation_id,
+        "decision": decision,
+        "action": response.action,
+        "projection": jsonable_encoder(response.projection),
+    }

--- a/tests/unit/api/routers/test_sessions.py
+++ b/tests/unit/api/routers/test_sessions.py
@@ -1,6 +1,7 @@
 """Unit tests for MM-1016 /api/sessions compatibility facades.
 
 Source traceability: MM-977 chat-session API naming alignment.
+Implementation traceability: MM-1031 approval elicitation resolution facade.
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ from typing import Iterator
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
 import pytest
 
@@ -287,7 +288,43 @@ def test_post_session_event_rejects_unknown_type(
     assert "Unsupported session event type" in response.json()["detail"]
 
 
-def test_resolve_elicitation_rejects_unsupported_facade(
+def test_resolve_elicitation_maps_approval_to_existing_control_path(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+    control_response = SimpleNamespace(action="send_follow_up", projection=_projection())
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.control_agent_run_artifact_session",
+            new=AsyncMock(return_value=control_response),
+        ) as control:
+            response = test_client.post(
+                "/api/sessions/sess-1/elicitations/el-1/resolve",
+                json={"decision": "approve"},
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["type"] == "elicitation_resolution"
+    assert body["elicitationId"] == "el-1"
+    assert body["decision"] == "approve"
+    assert body["action"] == "send_follow_up"
+    assert body["projection"]["agent_run_id"] == "mm:run-1"
+    control_payload = control.await_args.kwargs["payload"]
+    assert control.await_args.kwargs["agent_run_id"] == "mm:run-1"
+    assert control.await_args.kwargs["session_id"] == "sess:mm:run-1:codex_cli"
+    assert control_payload.action == "send_follow_up"
+    assert control_payload.message == "Approved."
+    assert control_payload.reason == "session_elicitation:el-1:approve"
+
+
+def test_resolve_elicitation_preserves_session_authorization(
     client: tuple[TestClient, AsyncMock],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -298,13 +335,21 @@ def test_resolve_elicitation_rejects_unsupported_facade(
         "api_service.api.routers.sessions.ManagedSessionStore.load",
         return_value=_session_record(),
     ):
-        response = test_client.post(
-            "/api/sessions/sess-1/elicitations/el-1/resolve",
-            json={"decision": "approve"},
-        )
+        with patch(
+            "api_service.api.routers.agent_runs._require_agent_run_access",
+            new=AsyncMock(side_effect=HTTPException(status_code=403, detail="no")),
+        ):
+            with patch(
+                "api_service.api.routers.sessions.control_agent_run_artifact_session",
+                new=AsyncMock(),
+            ) as control:
+                response = test_client.post(
+                    "/api/sessions/sess-1/elicitations/el-1/resolve",
+                    json={"decision": "approve"},
+                )
 
-    assert response.status_code == 501
-    assert "not implemented" in response.json()["detail"]
+    assert response.status_code == 403
+    control.assert_not_awaited()
 
 
 def test_terminal_session_suppresses_elicitation_resolution_capability(
@@ -325,3 +370,53 @@ def test_terminal_session_suppresses_elicitation_resolution_capability(
 
     assert response.status_code == 409
     assert "not available" in response.json()["detail"]
+
+
+def test_resolve_elicitation_rejects_unsupported_capability(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(status="busy", activeTurnId="turn-1"),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.control_agent_run_artifact_session",
+            new=AsyncMock(),
+        ) as control:
+            response = test_client.post(
+                "/api/sessions/sess-1/elicitations/el-1/resolve",
+                json={"decision": "approve"},
+            )
+
+    assert response.status_code == 409
+    assert "not available" in response.json()["detail"]
+    control.assert_not_awaited()
+
+
+def test_resolve_elicitation_rejects_unsupported_decision(
+    client: tuple[TestClient, AsyncMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_session_api(monkeypatch)
+    test_client, _ = client
+
+    with patch(
+        "api_service.api.routers.sessions.ManagedSessionStore.load",
+        return_value=_session_record(),
+    ):
+        with patch(
+            "api_service.api.routers.sessions.control_agent_run_artifact_session",
+            new=AsyncMock(),
+        ) as control:
+            response = test_client.post(
+                "/api/sessions/sess-1/elicitations/el-1/resolve",
+                json={"decision": "maybe"},
+            )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "unsupported_elicitation_resolution"
+    control.assert_not_awaited()


### PR DESCRIPTION
Issue reference: MM-1031

Summary:
- Implements the session elicitation resolve facade for approve/reject decisions behind the existing session compatibility gate.
- Routes approval resolution through the existing managed session control path using `send_follow_up` so authorization and capability checks stay centralized.
- Adds unit coverage for successful approval resolution, preserved authorization, terminal-session rejection, unsupported capability rejection, and unsupported decisions.

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_sessions.py`

Remaining risks:
- The facade currently supports only explicit `approve` and `reject` decisions; additional elicitation shapes will need separate API behavior if introduced.
