### PR TITLE
When you add an image or capability to a step in Start Workflow, the X buttons that appear next to the text are too big. The outer border of the X in…

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16624,7 +16624,8 @@ describe("Task Create governed Tool authoring", () => {
     const derivedChip = (
       await within(step).findByText("GitHub CLI / PRs")
     ).closest("li") as HTMLElement;
-    expect(within(derivedChip).getByText("· from publish mode")).toBeTruthy();
+    expect(within(derivedChip).queryByText("· from publish mode")).toBeNull();
+    expect(derivedChip.getAttribute("title")).toContain("from publish mode");
     fireEvent.focus(
       within(derivedChip).getByRole("button", {
         name: "GitHub CLI / PRs capability provenance",

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16503,11 +16503,14 @@ describe("Task Create governed Tool authoring", () => {
     expect(within(menu).getByText("Capabilities")).toBeTruthy();
     fireEvent.click(within(step).getByRole("menuitem", { name: /^Docker/ }));
 
-    const chip = await within(step).findByText("Docker");
+    const chip = (await within(step).findByText("Docker")).closest(
+      "li",
+    ) as HTMLElement;
     expect(chip).toBeTruthy();
-    expect(
-      within(step).getByText("· docker", { exact: false }),
-    ).toBeTruthy();
+    expect(chip.getAttribute("title")).toBe(
+      "Docker: Allow container builds and Docker operations for this step.",
+    );
+    expect(within(step).queryByText("· docker", { exact: false })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
     await waitFor(() => {
@@ -16757,7 +16760,8 @@ describe("Task Create governed Tool authoring", () => {
     const chip = (await within(step).findByText("Jira")).closest(
       "li",
     ) as HTMLElement;
-    expect(within(chip).getByText("· from preset")).toBeTruthy();
+    expect(chip.getAttribute("title")).toBe("Jira: from preset");
+    expect(within(chip).queryByText("· from preset")).toBeNull();
     expect(
       within(chip).queryByRole("button", {
         name: "Remove Jira capability from Step 1",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4957,11 +4957,14 @@ function derivedCapabilityExplanation(chip: StepCapabilityChip): string {
 function CapabilityChip({ chip, stepNumber, onRemove }: CapabilityChipProps) {
   const [showExplanation, setShowExplanation] = useState(false);
   const provenance = capabilityChipProvenanceLabel(chip);
-  const detailText = chip.removable ? chip.token : provenance || chip.token;
   const explanation = chip.removable ? chip.description : derivedCapabilityExplanation(chip);
+  const chipTitle = provenance
+    ? `${chip.label}: ${provenance}`
+    : `${chip.label}: ${chip.description}`;
   return (
     <li
       className={`queue-step-capability-chip${chip.removable ? "" : " is-derived"}`}
+      title={chipTitle}
       onClick={
         chip.removable
           ? undefined
@@ -4972,7 +4975,6 @@ function CapabilityChip({ chip, stepNumber, onRemove }: CapabilityChipProps) {
         {chip.icon}
       </span>
       <span className="queue-step-capability-chip-label">{chip.label}</span>
-      <span className="queue-step-capability-chip-detail">{`· ${detailText}`}</span>
       {chip.removable ? (
         <button
           type="button"

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -4960,7 +4960,9 @@ function CapabilityChip({ chip, stepNumber, onRemove }: CapabilityChipProps) {
   const explanation = chip.removable ? chip.description : derivedCapabilityExplanation(chip);
   const chipTitle = provenance
     ? `${chip.label}: ${provenance}`
-    : `${chip.label}: ${chip.description}`;
+    : chip.description
+      ? `${chip.label}: ${chip.description}`
+      : chip.label;
   return (
     <li
       className={`queue-step-capability-chip${chip.removable ? "" : " is-derived"}`}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4916,7 +4916,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   color: inherit;
   font-size: 0.96rem;
   line-height: 1;
-  cursor: help;
+  cursor: pointer;
 }
 
 .queue-step-capability-chip-lock:hover,

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4889,8 +4889,8 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.15rem 0.5rem;
+  gap: 0.25rem;
+  padding: 0.16rem 0.38rem 0.16rem 0.5rem;
   border: 1px solid rgb(var(--mm-accent) / 0.45);
   border-radius: 999px;
   background: rgb(var(--mm-accent) / 0.1);
@@ -4903,27 +4903,25 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   color: rgb(var(--mm-muted));
 }
 
-.queue-step-capability-chip-detail {
-  color: rgb(var(--mm-muted));
-  font-size: 0.76rem;
-}
-
 .queue-step-capability-chip-lock {
   display: inline-grid;
   place-items: center;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  margin-left: 0.05rem;
+  padding: 0;
   border: none;
-  border-radius: 999px;
+  border-radius: 0;
   background: transparent;
   color: inherit;
-  font-size: 0.72rem;
+  font-size: 0.96rem;
+  line-height: 1;
   cursor: help;
 }
 
 .queue-step-capability-chip-lock:hover,
 .queue-step-capability-chip-lock:focus-visible {
-  background: rgb(var(--mm-accent) / 0.14);
+  color: rgb(var(--mm-text));
   outline: none;
 }
 
@@ -5026,15 +5024,17 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 .queue-step-attachment-chip-remove {
-  width: 0.95rem;
-  height: 0.95rem;
+  width: 0.82rem;
+  height: 0.82rem;
+  min-width: 0.82rem;
+  padding: 0;
   border-radius: 999px;
   flex: 0 0 auto;
 }
 
 .queue-step-attachment-chip-remove svg {
-  width: 0.58rem;
-  height: 0.58rem;
+  width: 0.48rem;
+  height: 0.48rem;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) li {
@@ -5062,14 +5062,16 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-capability-chip-remove {
-  width: 0.95rem;
-  height: 0.95rem;
+  width: 0.82rem;
+  height: 0.82rem;
+  min-width: 0.82rem;
+  padding: 0;
   border-radius: 999px;
 }
 
 :is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-capability-chip-remove svg {
-  width: 0.58rem;
-  height: 0.58rem;
+  width: 0.48rem;
+  height: 0.48rem;
 }
 
 .queue-attachment-preview {


### PR DESCRIPTION
When you add an image or capability to a step in Start Workflow, the X buttons that appear next to the text are too big. The outer border of the X in particular is way too big. Additionally it says "Docker · docker" and "Git repository · git" and "Jira · jira". The dot and second part of this is unnecessary wasted space. This can be hidden information if desired, but I don't think it needs to be shown. When items are added from something like the publish mode and therefore cannot be X removed, I am fine with the lock icon being used and the tooltip, but I don't think we need to put the message as well next to it of "· from publish mode". We already see this information on tooltip hover, which is enough. The lock icon could be improved as it appears to be off the corner of a blank oval button. I'd rather just have the lock shown a bit larger without the oval included at all. We can keep the ability to click on the lock and see the pop up explanation without the oval.