### PR TITLE
MM-996 implement checkpoint resume hardening

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3127,12 +3127,22 @@ def _recovery_manifest_ref_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})
     search_attributes = dict(getattr(record, "search_attributes", None) or {})
     params = dict(getattr(record, "parameters", None) or {})
+    finish_summary = dict(getattr(record, "finish_summary_json", None) or {})
+    recovery_manifest = finish_summary.get("recoveryManifest")
+    if not isinstance(recovery_manifest, Mapping):
+        recovery_manifest = finish_summary.get("recovery_manifest")
+    if not isinstance(recovery_manifest, Mapping):
+        recovery_manifest = {}
     recovery_block = params.get("recoverySource")
     if not isinstance(recovery_block, Mapping):
         recovery_block = params.get("recovery_source")
     if not isinstance(recovery_block, Mapping):
         recovery_block = {}
     for value in (
+        recovery_manifest.get("manifestRef"),
+        recovery_manifest.get("manifest_ref"),
+        recovery_manifest.get("failedRunRecoveryManifestRef"),
+        recovery_manifest.get("failed_run_recovery_manifest_ref"),
         memo.get("failed_run_recovery_manifest_ref"),
         memo.get("failedRunRecoveryManifestRef"),
         memo.get("recovery_manifest_ref"),
@@ -3145,6 +3155,25 @@ def _recovery_manifest_ref_from_record(record) -> str | None:
         if candidate:
             return candidate
     return None
+
+
+def _canonical_recovery_manifest_ref(
+    request: RecoverFromFailedStepRequest | RecoverFromSelectedStepRequest,
+    canonical: TemporalExecutionCanonicalRecord,
+) -> str | None:
+    manifest_ref = _recovery_manifest_ref_from_record(canonical)
+    requested_ref = str(request.failed_run_recovery_manifest_ref or "").strip()
+    if requested_ref and manifest_ref and requested_ref != manifest_ref:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Recovery request fields do not match recovery manifest evidence.",
+                "reason": "recovery_manifest_inconsistent",
+                "fields": ["failedRunRecoveryManifestRef"],
+            },
+        )
+    return manifest_ref
 
 
 def _recovery_failed_step_id_from_record(record) -> str | None:
@@ -7477,7 +7506,7 @@ async def _hydrate_failed_run_recovery_manifest_payload(
 
 
 def _reject_recovery_manifest_mismatch(
-    request: RecoverFromFailedStepRequest,
+    request: RecoverFromFailedStepRequest | RecoverFromSelectedStepRequest,
     *,
     canonical: TemporalExecutionCanonicalRecord,
     manifest_payload: Mapping[str, Any],
@@ -7492,11 +7521,13 @@ def _reject_recovery_manifest_mismatch(
         mismatches.append("sourceRunId")
     if manifest.validation.checkpoint_ref != checkpoint_ref:
         mismatches.append("recoveryCheckpointRef")
-    if request.logical_step_id and request.logical_step_id != manifest.failed_logical_step_id:
+    logical_step_id = getattr(request, "logical_step_id", None)
+    if logical_step_id and logical_step_id != manifest.failed_logical_step_id:
         mismatches.append("logicalStepId")
+    source_execution_ordinal = getattr(request, "source_execution_ordinal", None)
     if (
-        request.source_execution_ordinal is not None
-        and request.source_execution_ordinal != manifest.failed_execution_ordinal
+        source_execution_ordinal is not None
+        and source_execution_ordinal != manifest.failed_execution_ordinal
     ):
         mismatches.append("sourceExecutionOrdinal")
     if mismatches:
@@ -10905,10 +10936,7 @@ async def recover_execution_from_failed_step(
     checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
         canonical
     )
-    manifest_ref = (
-        request.failed_run_recovery_manifest_ref
-        or _recovery_manifest_ref_from_record(canonical)
-    )
+    manifest_ref = _canonical_recovery_manifest_ref(request, canonical)
     if _recovery_evidence_marked_stale(canonical):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -11009,10 +11037,7 @@ async def recover_execution_from_selected_step(
     checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
         canonical
     )
-    manifest_ref = (
-        request.failed_run_recovery_manifest_ref
-        or _recovery_manifest_ref_from_record(canonical)
-    )
+    manifest_ref = _canonical_recovery_manifest_ref(request, canonical)
     if not checkpoint_ref:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -79,6 +79,7 @@ from moonmind.schemas.temporal_models import (
     ExecutionSkillLifecycleIntentModel,
     ExecutionSkillProvenanceModel,
     ExecutionSkillRuntimeModel,
+    FailedRunRecoveryManifestModel,
     RecoverFromFailedStepRequest,
     RecoverFromFailedStepResponse,
     RecoverFromSelectedStepRequest,
@@ -3120,6 +3121,31 @@ def _recovery_checkpoint_ref_from_record(record) -> str | None:
         if candidate:
             return candidate
     return None
+
+
+def _recovery_manifest_ref_from_record(record) -> str | None:
+    memo = dict(getattr(record, "memo", None) or {})
+    search_attributes = dict(getattr(record, "search_attributes", None) or {})
+    params = dict(getattr(record, "parameters", None) or {})
+    recovery_block = params.get("recoverySource")
+    if not isinstance(recovery_block, Mapping):
+        recovery_block = params.get("recovery_source")
+    if not isinstance(recovery_block, Mapping):
+        recovery_block = {}
+    for value in (
+        memo.get("failed_run_recovery_manifest_ref"),
+        memo.get("failedRunRecoveryManifestRef"),
+        memo.get("recovery_manifest_ref"),
+        memo.get("recoveryManifestRef"),
+        search_attributes.get("mm_failed_run_recovery_manifest_ref"),
+        recovery_block.get("failedRunRecoveryManifestRef"),
+        recovery_block.get("failed_run_recovery_manifest_ref"),
+    ):
+        candidate = str(value or "").strip()
+        if candidate:
+            return candidate
+    return None
+
 
 def _recovery_failed_step_id_from_record(record) -> str | None:
     memo = dict(getattr(record, "memo", None) or {})
@@ -7352,6 +7378,139 @@ async def _hydrate_recovery_checkpoint_payload(
     return decoded
 
 
+async def _hydrate_failed_run_recovery_manifest_payload(
+    *,
+    session: AsyncSession,
+    user: User,
+    manifest_ref: str | None,
+) -> Mapping[str, Any]:
+    artifact_id = _artifact_id_from_ref(manifest_ref)
+    if not artifact_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is required.",
+                "reason": "recovery_manifest_missing",
+            },
+        )
+    try:
+        artifact_service = get_temporal_artifact_service(session)
+        _artifact, body = await artifact_service.read(
+            artifact_id=artifact_id,
+            principal=str(getattr(user, "id", "") or "system"),
+            allow_restricted_raw=True,
+        )
+        decoded = json.loads(body.decode("utf-8"))
+    except (PermissionError, TemporalArtifactAuthorizationError) as exc:
+        logger.warning(
+            "Failed to hydrate failed-run recovery manifest artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is not readable.",
+                "reason": "recovery_manifest_unauthorized",
+            },
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        logger.warning(
+            "Failed to hydrate failed-run recovery manifest artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is invalid.",
+                "reason": "recovery_manifest_corrupted",
+            },
+        ) from exc
+    except Exception as exc:
+        logger.warning(
+            "Failed to hydrate failed-run recovery manifest artifact %s: %s",
+            artifact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is not readable.",
+                "reason": "recovery_manifest_missing",
+            },
+        ) from exc
+    if not isinstance(decoded, Mapping):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is invalid.",
+                "reason": "recovery_manifest_corrupted",
+            },
+        )
+    try:
+        manifest = FailedRunRecoveryManifestModel.model_validate(decoded)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest is invalid.",
+                "reason": "recovery_manifest_corrupted",
+            },
+        ) from exc
+    if not manifest.resume_allowed:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Failed-step recovery manifest blocks resume.",
+                "reason": manifest.blocked_reason or "recovery_manifest_blocks_resume",
+            },
+        )
+    return decoded
+
+
+def _reject_recovery_manifest_mismatch(
+    request: RecoverFromFailedStepRequest,
+    *,
+    canonical: TemporalExecutionCanonicalRecord,
+    manifest_payload: Mapping[str, Any],
+    checkpoint_ref: str,
+) -> None:
+    manifest = FailedRunRecoveryManifestModel.model_validate(manifest_payload)
+    expected_run_id = str(canonical.run_id or "")
+    mismatches: list[str] = []
+    if manifest.workflow_id != canonical.workflow_id:
+        mismatches.append("sourceWorkflowId")
+    if manifest.run_id != expected_run_id:
+        mismatches.append("sourceRunId")
+    if manifest.validation.checkpoint_ref != checkpoint_ref:
+        mismatches.append("recoveryCheckpointRef")
+    if request.logical_step_id and request.logical_step_id != manifest.failed_logical_step_id:
+        mismatches.append("logicalStepId")
+    if (
+        request.source_execution_ordinal is not None
+        and request.source_execution_ordinal != manifest.failed_execution_ordinal
+    ):
+        mismatches.append("sourceExecutionOrdinal")
+    if mismatches:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "resume_not_available",
+                "message": "Recovery request fields do not match recovery manifest evidence.",
+                "reason": "recovery_manifest_inconsistent",
+                "fields": sorted(set(mismatches)),
+            },
+        )
+
+
 def _recovery_not_available_reason(exc: Exception) -> str:
     message = str(exc).lower()
     if "selected start step" in message:
@@ -10746,6 +10905,10 @@ async def recover_execution_from_failed_step(
     checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
         canonical
     )
+    manifest_ref = (
+        request.failed_run_recovery_manifest_ref
+        or _recovery_manifest_ref_from_record(canonical)
+    )
     if _recovery_evidence_marked_stale(canonical):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -10755,6 +10918,17 @@ async def recover_execution_from_failed_step(
                 "reason": "stale_recovery_evidence",
             },
         )
+    manifest_payload = await _hydrate_failed_run_recovery_manifest_payload(
+        session=session,
+        user=user,
+        manifest_ref=manifest_ref,
+    )
+    _reject_recovery_manifest_mismatch(
+        request,
+        canonical=canonical,
+        manifest_payload=manifest_payload,
+        checkpoint_ref=str(checkpoint_ref or "").strip(),
+    )
     checkpoint_payload = await _hydrate_recovery_checkpoint_payload(
         session=session,
         user=user,
@@ -10771,6 +10945,8 @@ async def recover_execution_from_failed_step(
             recovery_checkpoint_ref=request.recovery_checkpoint_ref,
             idempotency_key=request.idempotency_key,
             checkpoint_payload=checkpoint_payload,
+            failed_run_recovery_manifest_ref=manifest_ref,
+            failed_run_recovery_manifest=manifest_payload,
         )
     except TemporalExecutionRecoveryCheckpointError as exc:
         raise HTTPException(
@@ -10833,6 +11009,10 @@ async def recover_execution_from_selected_step(
     checkpoint_ref = request.recovery_checkpoint_ref or _recovery_checkpoint_ref_from_record(
         canonical
     )
+    manifest_ref = (
+        request.failed_run_recovery_manifest_ref
+        or _recovery_manifest_ref_from_record(canonical)
+    )
     if not checkpoint_ref:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -10851,6 +11031,17 @@ async def recover_execution_from_selected_step(
                 "reason": "stale_recovery_evidence",
             },
         )
+    manifest_payload = await _hydrate_failed_run_recovery_manifest_payload(
+        session=session,
+        user=user,
+        manifest_ref=manifest_ref,
+    )
+    _reject_recovery_manifest_mismatch(
+        request,
+        canonical=canonical,
+        manifest_payload=manifest_payload,
+        checkpoint_ref=str(checkpoint_ref or "").strip(),
+    )
     checkpoint_payload = await _hydrate_recovery_checkpoint_payload(
         session=session,
         user=user,
@@ -10867,6 +11058,8 @@ async def recover_execution_from_selected_step(
             recovery_checkpoint_ref=checkpoint_ref,
             idempotency_key=request.idempotency_key,
             checkpoint_payload=checkpoint_payload,
+            failed_run_recovery_manifest_ref=manifest_ref,
+            failed_run_recovery_manifest=manifest_payload,
             selected_start_step_id=request.selected_start_step_id,
         )
     except TemporalExecutionRecoveryCheckpointError as exc:

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -7290,6 +7290,8 @@ export interface components {
             sourceExecutionOrdinal?: number | null;
             /** Recoverycheckpointref */
             recoveryCheckpointRef?: string | null;
+            /** Failedrunrecoverymanifestref */
+            failedRunRecoveryManifestRef?: string | null;
             /** Checkpointboundary */
             checkpointBoundary?: ("after_prepare" | "before_execution" | "after_execution" | "after_gate" | "before_publication" | "before_recovery_restoration") | null;
             /** Taskinputsnapshotref */
@@ -7356,6 +7358,8 @@ export interface components {
             sourceExecutionOrdinal?: number | null;
             /** Recoverycheckpointref */
             recoveryCheckpointRef?: string | null;
+            /** Failedrunrecoverymanifestref */
+            failedRunRecoveryManifestRef?: string | null;
             /** Checkpointboundary */
             checkpointBoundary?: ("after_prepare" | "before_execution" | "after_execution" | "after_gate" | "before_publication" | "before_recovery_restoration") | null;
             /** Taskinputsnapshotref */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -2001,6 +2001,9 @@ class RecoverFromFailedStepRequest(BaseModel):
         None, alias="sourceExecutionOrdinal", ge=1
     )
     recovery_checkpoint_ref: Optional[str] = Field(None, alias="recoveryCheckpointRef")
+    failed_run_recovery_manifest_ref: Optional[str] = Field(
+        None, alias="failedRunRecoveryManifestRef"
+    )
     checkpoint_boundary: Optional[StepExecutionCheckpointBoundary] = Field(
         None, alias="checkpointBoundary"
     )
@@ -2023,6 +2026,7 @@ class RecoverFromFailedStepRequest(BaseModel):
         "source_run_id",
         "logical_step_id",
         "recovery_checkpoint_ref",
+        "failed_run_recovery_manifest_ref",
         "task_input_snapshot_ref",
         "plan_ref",
         "plan_digest",
@@ -2223,6 +2227,12 @@ class RecoverySourceModel(BaseModel):
         None, alias="selectedStartStepExecution", ge=1
     )
     recovery_checkpoint_ref: str = Field(..., alias="recoveryCheckpointRef", min_length=1)
+    failed_run_recovery_manifest_ref: str | None = Field(
+        None, alias="failedRunRecoveryManifestRef"
+    )
+    selected_checkpoint_boundary: str | None = Field(
+        None, alias="selectedCheckpointBoundary"
+    )
     recovery_workspace: dict[str, Any] = Field(
         default_factory=dict, alias="recoveryWorkspace"
     )

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -46,7 +46,8 @@ def resolve_checkpoint_policy(
     """Return the shared policy used for capture, manifests, and recovery apply."""
 
     del runtime_kind
-    boundary_token = str(boundary or "").strip()
+    boundary_value = boundary.value if hasattr(boundary, "value") else boundary
+    boundary_token = str(boundary_value or "").strip()
     if boundary_token == "before_recovery_restoration":
         return ResolvedCheckpointPolicy(
             workspace_policy=_workspace_policy_from_recovery_source(recovery_source),

--- a/moonmind/workflows/temporal/checkpoint_policy.py
+++ b/moonmind/workflows/temporal/checkpoint_policy.py
@@ -1,0 +1,69 @@
+"""Shared checkpoint policy selection for MM-996 failed-step recovery."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from moonmind.schemas.temporal_models import WorkspacePolicy
+
+
+@dataclass(frozen=True)
+class ResolvedCheckpointPolicy:
+    workspace_policy: WorkspacePolicy
+    checkpoint_kind: str
+    resumable: bool
+    required_evidence: tuple[str, ...]
+
+
+def _workspace_policy_from_recovery_source(
+    recovery_source: Mapping[str, Any] | None,
+) -> WorkspacePolicy:
+    workspace = {}
+    if isinstance(recovery_source, Mapping):
+        candidate = recovery_source.get("recoveryWorkspace")
+        if not isinstance(candidate, Mapping):
+            candidate = recovery_source.get("recovery_workspace")
+        if isinstance(candidate, Mapping):
+            workspace = candidate
+    raw_policy = str(
+        workspace.get("workspacePolicy")
+        or workspace.get("workspace_policy")
+        or "restore_pre_execution"
+    ).strip()
+    if raw_policy == "start_from_last_passed_commit":
+        return "start_from_last_passed_commit"
+    return "restore_pre_execution"
+
+
+def resolve_checkpoint_policy(
+    *,
+    boundary: str,
+    recovery_source: Mapping[str, Any] | None = None,
+    runtime_kind: str | None = None,
+) -> ResolvedCheckpointPolicy:
+    """Return the shared policy used for capture, manifests, and recovery apply."""
+
+    del runtime_kind
+    boundary_token = str(boundary or "").strip()
+    if boundary_token == "before_recovery_restoration":
+        return ResolvedCheckpointPolicy(
+            workspace_policy=_workspace_policy_from_recovery_source(recovery_source),
+            checkpoint_kind="worktree_archive",
+            resumable=True,
+            required_evidence=("checkpointRef", "workspacePolicy"),
+        )
+    if boundary_token == "after_execution":
+        return ResolvedCheckpointPolicy(
+            workspace_policy="restore_pre_execution",
+            checkpoint_kind="git_patch",
+            resumable=True,
+            required_evidence=("patchRef", "manifestRef"),
+        )
+    return ResolvedCheckpointPolicy(
+        workspace_policy="restore_pre_execution",
+        checkpoint_kind="worktree_archive",
+        resumable=True,
+        required_evidence=("archiveRef", "manifestRef"),
+    )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -53,12 +53,14 @@ from moonmind.schemas.temporal_models import (
     AGENT_RUN_ID_MEMO_KEYS,
     AGENT_RUN_ID_PARAM_KEYS,
     AGENT_RUN_ID_SEARCH_ATTR_KEYS,
+    FailedRunRecoveryManifestModel,
     RecoveryCheckpointModel,
     RecoverySourceModel,
     has_user_workflow_plan_source,
 )
 from moonmind.security.outbound_scan import scan_outbound_text
 from moonmind.workflows.temporal.client import TemporalClientAdapter
+from moonmind.workflows.temporal.checkpoint_policy import resolve_checkpoint_policy
 from moonmind.workflows.temporal.hard_switch_cutover import (
     resolve_user_workflow_start_contract,
 )
@@ -3003,6 +3005,8 @@ class TemporalExecutionService:
         recovery_checkpoint_ref: str | None,
         idempotency_key: str,
         checkpoint_payload: Mapping[str, Any] | None = None,
+        failed_run_recovery_manifest_ref: str | None = None,
+        failed_run_recovery_manifest: Mapping[str, Any] | None = None,
         selected_start_step_id: str | None = None,
     ) -> dict[str, Any]:
         """Create a linked follow-up execution for failed-step recovery."""
@@ -3052,6 +3056,39 @@ class TemporalExecutionService:
         if checkpoint_payload is None:
             raise TemporalExecutionRecoveryCheckpointError(
                 "Recovery checkpoint payload is required."
+            )
+        manifest_ref = str(failed_run_recovery_manifest_ref or "").strip()
+        if not manifest_ref:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest ref is required."
+            )
+        if failed_run_recovery_manifest is None:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest is required."
+            )
+        try:
+            recovery_manifest = FailedRunRecoveryManifestModel.model_validate(
+                failed_run_recovery_manifest
+            )
+        except ValidationError as exc:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest is invalid."
+            ) from exc
+        if not recovery_manifest.resume_allowed:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest does not allow resume."
+            )
+        if recovery_manifest.workflow_id != record.workflow_id:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest workflowId does not match source execution."
+            )
+        if recovery_manifest.run_id != source_run_id:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest runId does not match source execution."
+            )
+        if recovery_manifest.validation.checkpoint_ref != checkpoint_ref:
+            raise TemporalExecutionRecoveryCheckpointError(
+                "Failed-run recovery manifest checkpoint ref does not match source execution."
             )
         try:
             checkpoint = RecoveryCheckpointModel.model_validate(checkpoint_payload)
@@ -3144,6 +3181,10 @@ class TemporalExecutionService:
             recoveryWorkspace=checkpoint.recovery_workspace,
             preservedSteps=preserved_steps,
         ).model_dump(by_alias=True, mode="json")
+        recovery_source_payload["failedRunRecoveryManifestRef"] = manifest_ref
+        recovery_source_payload["selectedCheckpointBoundary"] = (
+            recovery_manifest.validation.boundary
+        )
         if recovery_mode == "last_failed_step":
             recovery_source_payload.pop("recoveryMode", None)
             recovery_source_payload.pop("selectedStartStepId", None)
@@ -3175,13 +3216,10 @@ class TemporalExecutionService:
                 ):
                     preserved_step_refs.append(artifact_ref)
         recovery_workspace = checkpoint.recovery_workspace or {}
-        workspace_policy = str(
-            recovery_workspace.get("workspacePolicy")
-            or recovery_workspace.get("workspace_policy")
-            or "restore_pre_execution"
-        ).strip()
-        if not workspace_policy:
-            workspace_policy = "restore_pre_execution"
+        workspace_policy = resolve_checkpoint_policy(
+            boundary="before_recovery_restoration",
+            recovery_source=recovery_source_payload,
+        ).workspace_policy
         dependency_signatures = recovery_workspace.get("dependencySignatures")
         if not isinstance(dependency_signatures, dict):
             dependency_signatures = {}
@@ -3198,6 +3236,7 @@ class TemporalExecutionService:
             "dependencySignatures": dependency_signatures,
             "workspacePolicy": workspace_policy,
         }
+        recover_ref["failedRunRecoveryManifestRef"] = manifest_ref
         if recovery_mode == "selected_step":
             recover_ref["recoveryMode"] = recovery_mode
             recover_ref["selectedStartStepId"] = failed_step_id

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -95,6 +95,9 @@ with workflow.unsafe.imports_passed_through():
         StepExecutionCheckpointBoundary,
         build_step_checkpoint_id,
     )
+    from moonmind.workflows.temporal.checkpoint_policy import (
+        resolve_checkpoint_policy,
+    )
     from moonmind.workflows.temporal.managed_session_errors import (
         is_managed_session_locator_mismatch_error,
     )
@@ -1906,8 +1909,15 @@ class MoonMindRunWorkflow:
         source_execution_ordinal: Mapping[str, Any] | None,
     ) -> dict[str, Any]:
         if source_execution_ordinal and logical_step_id == self._recovery_failed_step_id:
+            resolved_policy = resolve_checkpoint_policy(
+                boundary="before_recovery_restoration",
+                recovery_source=self._recovery_source
+                if isinstance(self._recovery_source, Mapping)
+                else None,
+                runtime_kind=self._target_runtime,
+            )
             workspace = workspace_policy_metadata(
-                policy="start_from_last_passed_commit",
+                policy=resolved_policy.workspace_policy,
                 checkpoint_ref=self._recovery_workspace_restored_ref,
                 checkpoint_valid=bool(self._recovery_workspace_restored_ref),
             )
@@ -2602,6 +2612,13 @@ class MoonMindRunWorkflow:
         )
         if not checkpoint_ref:
             raise ValueError("Recovery source requires recovery checkpoint ref.")
+        manifest_ref = self._recovery_source_text(
+            recovery_source,
+            "failedRunRecoveryManifestRef",
+            "failed_run_recovery_manifest_ref",
+        )
+        if not manifest_ref:
+            raise ValueError("Recovery source requires failed-run recovery manifest ref.")
 
         plan_identity = self._recovery_source_text(
             recovery_source,
@@ -2622,6 +2639,11 @@ class MoonMindRunWorkflow:
             raise ValueError("Recovery source requires resume workspace checkpoint.")
         if not self._recovery_workspace_has_evidence(workspace):
             raise ValueError("Recovery source requires workspace evidence.")
+        workspace_checkpoint_ref = self._recovery_workspace_checkpoint_ref(workspace)
+        if workspace_checkpoint_ref and workspace_checkpoint_ref != checkpoint_ref:
+            raise ValueError(
+                "Recovery source checkpoint ref must match workspace evidence."
+            )
 
         preserved_steps = recovery_source.get("preservedSteps") or recovery_source.get(
             "preserved_steps"
@@ -2749,11 +2771,16 @@ class MoonMindRunWorkflow:
             "sourcePlanDigest",
             "source_plan_digest",
         )
+        resolved_policy = resolve_checkpoint_policy(
+            boundary="before_recovery_restoration",
+            recovery_source=self._recovery_source,
+            runtime_kind=self._target_runtime,
+        )
         workspace_policy = self._recovery_source_text(
             self._recovery_workspace,
             "workspacePolicy",
             "workspace_policy",
-        ) or "restore_pre_execution"
+        ) or resolved_policy.workspace_policy
 
         validate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "step_checkpoint.validate"
@@ -3968,37 +3995,24 @@ class MoonMindRunWorkflow:
         capture_input = dict(
             self._step_workspace_capture_inputs.get(logical_step_id) or {}
         )
-        emit_ephemeral_checkpoint = workflow.patched(
-            RUN_EMIT_EPHEMERAL_STEP_CHECKPOINTS_PATCH
-        )
         if not capture_input:
-            if not emit_ephemeral_checkpoint:
-                return None
-            workspace_ref = (
-                self._step_checkpoint_refs.get(logical_step_id)
-                or self._previous_step_checkpoint_refs.get(logical_step_id)
-                or (
-                    f"temporal://{identity.workflow_id}/{identity.run_id}/"
-                    f"{identity.logical_step_id}/{boundary}"
-                )
-            )
-            return {
-                "workspace": {
-                    "kind": "ephemeral_workspace_ref",
-                    "workspaceRef": workspace_ref,
-                    "createdAt": workflow.now().isoformat(),
-                },
-                "diagnosticRefs": [],
-            }
+            return None
 
         route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
             "workspace.capture_checkpoint"
         )
         checkpoint_id = build_step_checkpoint_id(identity, boundary)
+        resolved_policy = resolve_checkpoint_policy(
+            boundary=str(boundary),
+            recovery_source=self._recovery_source
+            if isinstance(self._recovery_source, Mapping)
+            else None,
+            runtime_kind=self._target_runtime,
+        )
         payload = {
             "identity": identity.model_dump(by_alias=True, mode="json"),
             "boundary": boundary,
-            "kind": capture_input.get("kind") or "worktree_archive",
+            "kind": capture_input.get("kind") or resolved_policy.checkpoint_kind,
             "artifactNamespace": f"step-checkpoints/{identity.logical_step_id}",
             "idempotencyKey": f"{checkpoint_id}:capture",
         }
@@ -4021,10 +4035,7 @@ class MoonMindRunWorkflow:
         workspace_evidence = result.get("workspace")
         if not isinstance(workspace_evidence, Mapping):
             return None
-        if (
-            workspace_evidence.get("kind") == "ephemeral_workspace_ref"
-            and not emit_ephemeral_checkpoint
-        ):
+        if workspace_evidence.get("kind") == "ephemeral_workspace_ref":
             return None
         return {
             "workspace": dict(workspace_evidence),

--- a/tests/integration/temporal/test_backend_resume_eligibility.py
+++ b/tests/integration/temporal/test_backend_resume_eligibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -16,6 +17,7 @@ from api_service.db.models import (
     MoonMindWorkflowState,
     TemporalExecutionCloseStatus,
 )
+from moonmind.schemas.temporal_models import FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE
 from moonmind.workflows.temporal.service import TemporalExecutionService
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
@@ -58,6 +60,30 @@ def _checkpoint_payload(*, workflow_id: str, run_id: str) -> dict[str, object]:
         ],
         "preparedArtifactRefs": ["artifact://prepared"],
         "recoveryWorkspace": {"branch": "feature", "commit": "abc123"},
+    }
+
+
+def _recovery_manifest_payload(*, workflow_id: str, run_id: str) -> dict[str, object]:
+    return {
+        "schemaVersion": "v1",
+        "contentType": FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+        "workflowId": workflow_id,
+        "runId": run_id,
+        "failedLogicalStepId": "implement",
+        "failedExecutionOrdinal": 1,
+        "validation": {
+            "result": "valid",
+            "checkpointRef": "artifact://checkpoint/source",
+            "boundary": "before_recovery_restoration",
+        },
+        "resumeAllowed": True,
+        "recoveryEligibility": {
+            "eligible": True,
+            "defaultAction": "resume_from_checkpoint",
+            "checkpointRef": "artifact://checkpoint/source",
+            "operatorGuidance": "resume",
+        },
+        "createdAt": datetime.now(UTC),
     }
 
 
@@ -108,6 +134,11 @@ async def test_accepted_recovery_carries_canonical_recovery_and_recovery_refs(
                     workflow_id=created.workflow_id,
                     run_id=created.run_id,
                 ),
+                failed_run_recovery_manifest_ref="artifact://manifest/source",
+                failed_run_recovery_manifest=_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
             )
             resumed = await service.describe_execution(result["execution"]["workflowId"])
 
@@ -124,6 +155,7 @@ async def test_accepted_recovery_carries_canonical_recovery_and_recovery_refs(
         "failedStepId": "implement",
         "failedStepExecution": 1,
         "recoveryCheckpointRef": "artifact://checkpoint/source",
+        "failedRunRecoveryManifestRef": "artifact://manifest/source",
         "checkpointBoundary": "before_recovery_restoration",
         "taskInputSnapshotRef": "artifact://snapshot/source",
         "planRef": "artifact://plan/source",

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -71,6 +71,7 @@ def _recovery_source_with_checkpoint_payload() -> dict[str, object]:
         "failedStepId": "implement",
         "failedStepExecution": 2,
         "recoveryCheckpointRef": "artifact-checkpoint",
+        "failedRunRecoveryManifestRef": "artifact-manifest",
         "recoveryWorkspace": {
             "checkpointRef": "artifact-checkpoint",
             "targetWorkspaceRef": "workspace-target",

--- a/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
+++ b/tests/integration/workflows/temporal/test_step_execution_manifest_evidence.py
@@ -131,9 +131,11 @@ async def test_recovery_step_execution_manifest_carries_lineage_without_large_pa
         "sourcePlanDigest": "sha256:source-plan",
         "failedStepId": "implement",
         "failedStepExecution": 2,
-        "recoveryCheckpointRef": "artifact://resume/checkpoint",
+        "recoveryCheckpointRef": "artifact://workspace/before-implement",
+        "failedRunRecoveryManifestRef": "artifact://resume/manifest",
         "recoveryWorkspace": {
             "checkpointRef": "artifact://workspace/before-implement",
+            "workspacePolicy": "start_from_last_passed_commit",
         },
         "preservedSteps": [],
     }
@@ -179,6 +181,9 @@ async def test_recovery_step_execution_manifest_carries_lineage_without_large_pa
     assert manifest["lineage"]["lineageExecutionOrdinal"] == 3
     assert manifest["recoverySource"]["sourceWorkflowId"] == "wf-source"
     assert manifest["recoverySource"]["sourceRunId"] == "run-source"
+    assert manifest["recoverySource"]["failedRunRecoveryManifestRef"] == (
+        "artifact://resume/manifest"
+    )
     assert manifest["recoverySource"]["preservedSteps"] == []
     assert manifest["workspace"]["policy"] == "start_from_last_passed_commit"
     assert manifest["workspace"]["checkpointRef"] == (

--- a/tests/integration/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -25,7 +25,8 @@ def _recovery_source(**overrides: object) -> dict[str, object]:
         "sourcePlanDigest": "sha256:source-plan",
         "failedStepId": "implement",
         "failedStepExecution": 1,
-        "recoveryCheckpointRef": "artifact://resume/checkpoint",
+        "recoveryCheckpointRef": "artifact://workspace/before-implement",
+        "failedRunRecoveryManifestRef": "artifact://recovery/manifest",
         "recoveryWorkspace": {
             "checkpointRef": "artifact://workspace/before-implement",
         },

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -72,6 +72,7 @@ from moonmind.workflows.temporal.artifacts import TemporalArtifactAuthorizationE
 from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProgressModel,
+    FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
     StepExecutionDetailModel,
     StepExecutionManifestModel,
     StepLedgerSnapshotModel,
@@ -11823,6 +11824,55 @@ async def test_mm773_skips_related_run_metadata_for_foreign_owner() -> None:
     assert related["model"] is None
 
 
+def _valid_failed_run_recovery_manifest_payload(
+    canonical,
+    *,
+    checkpoint_ref: str,
+    failed_step_id: str = "implement",
+) -> dict[str, Any]:
+    return {
+        "schemaVersion": "v1",
+        "contentType": FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+        "workflowId": canonical.workflow_id,
+        "runId": canonical.run_id,
+        "failedLogicalStepId": failed_step_id,
+        "failedExecutionOrdinal": 1,
+        "checkpointRefs": [
+            {
+                "category": "checkpoint",
+                "status": "available",
+                "artifactRef": checkpoint_ref,
+                "boundary": "before_recovery_restoration",
+            }
+        ],
+        "validation": {
+            "result": "valid",
+            "checkpointRef": checkpoint_ref,
+            "boundary": "before_recovery_restoration",
+        },
+        "sideEffectDispositions": [],
+        "resumeAllowed": True,
+        "recoveryEligibility": {
+            "eligible": True,
+            "defaultAction": "resume_from_checkpoint",
+            "requiredBoundary": "before_recovery_restoration",
+            "checkpointRef": checkpoint_ref,
+            "sourceWorkflowId": canonical.workflow_id,
+            "sourceRunId": canonical.run_id,
+            "operatorGuidance": "resume",
+            "evidence": [
+                {
+                    "category": "checkpoint",
+                    "status": "available",
+                    "artifactRef": checkpoint_ref,
+                    "boundary": "before_recovery_restoration",
+                }
+            ],
+        },
+        "createdAt": "2026-06-13T12:00:00+00:00",
+    }
+
+
 def test_failed_step_recovery_hydrates_checkpoint_artifact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -11833,6 +11883,7 @@ def test_failed_step_recovery_hydrates_checkpoint_artifact(
     canonical.memo = {
         **canonical.memo,
         "recovery_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+        "failed_run_recovery_manifest_ref": "artifact://recovery/manifest",
         "task_input_snapshot_ref": "artifact://snapshot/source",
     }
     mock_service.describe_execution.return_value = canonical
@@ -11873,12 +11924,19 @@ def test_failed_step_recovery_hydrates_checkpoint_artifact(
         "recoveryWorkspace": {
             "branch": "feature/resume",
             "commit": "abc123",
-            "checkpointRef": "artifact://workspace/before-implement",
+            "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1",
         },
     }
+    manifest_payload = _valid_failed_run_recovery_manifest_payload(
+        canonical,
+        checkpoint_ref="artifact://resume-checkpoints/source/checkpoint-v1",
+    )
     artifact_service = SimpleNamespace(
         read=AsyncMock(
-            return_value=(SimpleNamespace(), json.dumps(checkpoint_payload).encode())
+            side_effect=[
+                (SimpleNamespace(), json.dumps(manifest_payload).encode()),
+                (SimpleNamespace(), json.dumps(checkpoint_payload).encode()),
+            ]
         )
     )
 
@@ -11904,9 +11962,14 @@ def test_failed_step_recovery_hydrates_checkpoint_artifact(
         )
 
     assert response.status_code == 201
-    artifact_service.read.assert_awaited_once()
+    assert artifact_service.read.await_count == 2
     call_kwargs = mock_service.create_failed_step_recovery_execution.await_args.kwargs
     assert call_kwargs["checkpoint_payload"] == checkpoint_payload
+    assert call_kwargs["failed_run_recovery_manifest"] == manifest_payload
+    assert (
+        call_kwargs["failed_run_recovery_manifest_ref"]
+        == "artifact://recovery/manifest"
+    )
     assert call_kwargs["recovery_checkpoint_ref"] is None
 
 
@@ -11920,6 +11983,7 @@ def test_selected_step_recovery_pins_source_and_selected_step(
     canonical.memo = {
         **canonical.memo,
         "recovery_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+        "failed_run_recovery_manifest_ref": "artifact://recovery/manifest",
         "task_input_snapshot_ref": "artifact://snapshot/source",
     }
     mock_service.describe_execution.return_value = canonical
@@ -11955,11 +12019,20 @@ def test_selected_step_recovery_pins_source_and_selected_step(
                 "stateCheckpointRef": "artifact://workspace/before-plan",
             }
         ],
-        "recoveryWorkspace": {"checkpointRef": "artifact://workspace/source"},
+        "recoveryWorkspace": {
+            "checkpointRef": "artifact://resume-checkpoints/source/checkpoint-v1"
+        },
     }
+    manifest_payload = _valid_failed_run_recovery_manifest_payload(
+        canonical,
+        checkpoint_ref="artifact://resume-checkpoints/source/checkpoint-v1",
+    )
     artifact_service = SimpleNamespace(
         read=AsyncMock(
-            return_value=(SimpleNamespace(), json.dumps(checkpoint_payload).encode())
+            side_effect=[
+                (SimpleNamespace(), json.dumps(manifest_payload).encode()),
+                (SimpleNamespace(), json.dumps(checkpoint_payload).encode()),
+            ]
         )
     )
 
@@ -12096,11 +12169,21 @@ def test_failed_step_recovery_reports_checkpoint_authorization_error(
     canonical.memo = {
         **canonical.memo,
         "recovery_checkpoint_ref": "artifact://resume-checkpoints/source/checkpoint-v1",
+        "failed_run_recovery_manifest_ref": "artifact://recovery/manifest",
         "task_input_snapshot_ref": "artifact://snapshot/source",
     }
     mock_service.describe_execution.return_value = canonical
+    manifest_payload = _valid_failed_run_recovery_manifest_payload(
+        canonical,
+        checkpoint_ref="artifact://resume-checkpoints/source/checkpoint-v1",
+    )
     artifact_service = SimpleNamespace(
-        read=AsyncMock(side_effect=TemporalArtifactAuthorizationError("denied"))
+        read=AsyncMock(
+            side_effect=[
+                (SimpleNamespace(), json.dumps(manifest_payload).encode()),
+                TemporalArtifactAuthorizationError("denied"),
+            ]
+        )
     )
 
     class Session:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -32,7 +32,10 @@ from api_service.api.routers.executions import (
     _effective_user_roles,
     _hydrate_related_run_metadata,
     _merge_workflow_preserving_artifact_instructions,
+    _canonical_recovery_manifest_ref,
+    _recovery_manifest_ref_from_record,
     _recovery_not_available_reason,
+    _reject_recovery_manifest_mismatch,
     _reuse_original_task_input_snapshot_from_source,
     _workflow_input_snapshot_descriptor_from_record,
     _normalize_task_steps,
@@ -73,6 +76,8 @@ from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProgressModel,
     FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+    RecoverFromFailedStepRequest,
+    RecoverFromSelectedStepRequest,
     StepExecutionDetailModel,
     StepExecutionManifestModel,
     StepLedgerSnapshotModel,
@@ -848,6 +853,80 @@ def _build_execution_record(
         entry=entry,
         integration_state=None,
     )
+
+
+def _failed_run_manifest_payload() -> dict[str, Any]:
+    return {
+        "schemaVersion": "v1",
+        "contentType": FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+        "workflowId": "mm:wf-1",
+        "runId": "run-2",
+        "failedLogicalStepId": "step-2",
+        "failedExecutionOrdinal": 2,
+        "validation": {
+            "result": "valid",
+            "checkpointRef": "artifact://checkpoint/1",
+            "boundary": "before_recovery_restoration",
+        },
+        "resumeAllowed": True,
+        "recoveryEligibility": {
+            "eligible": True,
+            "defaultAction": "resume_from_checkpoint",
+            "checkpointRef": "artifact://checkpoint/1",
+            "operatorGuidance": "resume",
+        },
+        "createdAt": datetime.now(UTC),
+    }
+
+
+def test_recovery_manifest_ref_reads_finish_summary_manifest_ref() -> None:
+    record = _build_execution_record()
+    record.finish_summary_json = {
+        "recoveryManifest": {
+            "manifestRef": "artifact://recovery/manifest-1",
+        }
+    }
+
+    assert _recovery_manifest_ref_from_record(record) == "artifact://recovery/manifest-1"
+
+
+def test_canonical_recovery_manifest_ref_rejects_request_override() -> None:
+    record = _build_execution_record()
+    record.finish_summary_json = {
+        "recoveryManifest": {
+            "manifestRef": "artifact://recovery/emitted",
+        }
+    }
+    request = RecoverFromFailedStepRequest(
+        idempotencyKey="recover-1",
+        recoveryCheckpointRef="artifact://checkpoint/1",
+        failedRunRecoveryManifestRef="artifact://recovery/request",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        _canonical_recovery_manifest_ref(request, record)
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["reason"] == "recovery_manifest_inconsistent"
+    assert exc.value.detail["fields"] == ["failedRunRecoveryManifestRef"]
+
+
+def test_reject_recovery_manifest_mismatch_accepts_selected_step_request() -> None:
+    request = RecoverFromSelectedStepRequest(
+        idempotencyKey="recover-1",
+        sourceWorkflowId="mm:wf-1",
+        sourceRunId="run-2",
+        selectedStartStepId="step-1",
+        recoveryCheckpointRef="artifact://checkpoint/1",
+    )
+
+    _reject_recovery_manifest_mismatch(
+        request,
+        canonical=_build_execution_record(),
+        manifest_payload=_failed_run_manifest_payload(),
+        checkpoint_ref="artifact://checkpoint/1",
+    )
+
 
 def test_serialize_execution_includes_finish_summary_projection_fields():
     record = _build_execution_record(state=MoonMindWorkflowState.COMPLETED)

--- a/tests/unit/workflows/temporal/test_checkpoint_policy.py
+++ b/tests/unit/workflows/temporal/test_checkpoint_policy.py
@@ -1,0 +1,25 @@
+"""Unit tests for shared checkpoint policy resolution."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from moonmind.workflows.temporal.checkpoint_policy import resolve_checkpoint_policy
+
+
+class _Boundary(Enum):
+    BEFORE_RECOVERY_RESTORATION = "before_recovery_restoration"
+
+
+def test_resolve_checkpoint_policy_uses_enum_value() -> None:
+    policy = resolve_checkpoint_policy(
+        boundary=_Boundary.BEFORE_RECOVERY_RESTORATION,
+        recovery_source={
+            "recoveryWorkspace": {
+                "workspacePolicy": "start_from_last_passed_commit",
+            }
+        },
+    )
+
+    assert policy.checkpoint_kind == "worktree_archive"
+    assert policy.workspace_policy == "start_from_last_passed_commit"

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -46,6 +46,7 @@ from moonmind.workflows.temporal.service import (
 from moonmind.workflows.temporal.hard_switch_cutover import RENAMED_USER_WORKFLOW_TYPE
 from moonmind.schemas.temporal_models import (
     CreateExecutionRequest,
+    FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
     RecoveryCheckpointModel,
     has_user_workflow_plan_source,
 )
@@ -2857,8 +2858,64 @@ def _valid_recovery_checkpoint_payload(
             }
         ],
         "preparedArtifactRefs": ["artifact://prepared"],
-        "recoveryWorkspace": {"branch": "feature", "commit": "abc123"},
+        "recoveryWorkspace": {
+            "branch": "feature",
+            "commit": "abc123",
+            "checkpointRef": "artifact://checkpoint/source",
+        },
     }
+
+
+def _valid_failed_run_recovery_manifest_payload(
+    *,
+    workflow_id: str,
+    run_id: str,
+    checkpoint_ref: str = "artifact://checkpoint/source",
+    failed_step_id: str = "implement",
+    failed_execution_ordinal: int = 1,
+) -> dict[str, object]:
+    return {
+        "schemaVersion": "v1",
+        "contentType": FAILED_RUN_RECOVERY_MANIFEST_CONTENT_TYPE,
+        "workflowId": workflow_id,
+        "runId": run_id,
+        "failedLogicalStepId": failed_step_id,
+        "failedExecutionOrdinal": failed_execution_ordinal,
+        "checkpointRefs": [
+            {
+                "category": "checkpoint",
+                "status": "available",
+                "artifactRef": checkpoint_ref,
+                "boundary": "before_recovery_restoration",
+            }
+        ],
+        "validation": {
+            "result": "valid",
+            "checkpointRef": checkpoint_ref,
+            "boundary": "before_recovery_restoration",
+        },
+        "sideEffectDispositions": [],
+        "resumeAllowed": True,
+        "recoveryEligibility": {
+            "eligible": True,
+            "defaultAction": "resume_from_checkpoint",
+            "requiredBoundary": "before_recovery_restoration",
+            "checkpointRef": checkpoint_ref,
+            "sourceWorkflowId": workflow_id,
+            "sourceRunId": run_id,
+            "operatorGuidance": "resume",
+            "evidence": [
+                {
+                    "category": "checkpoint",
+                    "status": "available",
+                    "artifactRef": checkpoint_ref,
+                    "boundary": "before_recovery_restoration",
+                }
+            ],
+        },
+        "createdAt": "2026-06-13T12:00:00+00:00",
+    }
+
 
 def test_recovery_checkpoint_model_requires_plan_identity() -> None:
     with pytest.raises(ValidationError, match="plan identity"):
@@ -3017,6 +3074,11 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
                 run_id=created.run_id,
                 snapshot_ref="artifact://snapshot/source",
             ),
+            failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+            failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                workflow_id=created.workflow_id,
+                run_id=created.run_id,
+            ),
         )
 
         resumed = await service.describe_execution(result["execution"]["workflowId"])
@@ -3031,6 +3093,7 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
         assert resumed.parameters["recoverySource"]["recoveryWorkspace"] == {
             "branch": "feature",
             "commit": "abc123",
+            "checkpointRef": "artifact://checkpoint/source",
         }
         assert resumed.parameters["recoverySource"]["preservedSteps"][0][
             "logicalStepId"
@@ -3058,6 +3121,7 @@ async def test_failed_step_recovery_creates_linked_execution_with_source_identit
             ],
             "dependencySignatures": {},
             "workspacePolicy": "restore_pre_execution",
+            "failedRunRecoveryManifestRef": "artifact://recovery/manifest",
         }
         assert "agentRunId" not in resumed.parameters
 
@@ -3100,6 +3164,11 @@ async def test_failed_step_recovery_accepts_legacy_checkpoint_memo_key(
                 workflow_id=created.workflow_id,
                 run_id=created.run_id,
                 snapshot_ref="artifact://snapshot/source",
+            ),
+            failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+            failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                workflow_id=created.workflow_id,
+                run_id=created.run_id,
             ),
         )
 
@@ -3170,6 +3239,11 @@ async def test_selected_step_recovery_starts_from_preserved_step(
             recovery_checkpoint_ref=None,
             idempotency_key="recover-selected",
             checkpoint_payload=checkpoint_payload,
+            failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+            failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                workflow_id=created.workflow_id,
+                run_id=created.run_id,
+            ),
             selected_start_step_id="design",
         )
 
@@ -3228,6 +3302,11 @@ async def test_selected_step_recovery_rejects_step_without_checkpoint_evidence(
                     run_id=created.run_id,
                     snapshot_ref="artifact://snapshot/source",
                 ),
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
                 selected_start_step_id="missing-step",
             )
 
@@ -3285,6 +3364,11 @@ async def test_selected_step_recovery_rejects_step_after_failed_step(
                 recovery_checkpoint_ref=None,
                 idempotency_key="recover-selected",
                 checkpoint_payload=checkpoint_payload,
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
                 selected_start_step_id="notify",
             )
 
@@ -3371,6 +3455,11 @@ async def test_failed_step_recovery_invalid_evidence_does_not_create_execution(
                 recovery_checkpoint_ref=None,
                 idempotency_key="recover-1",
                 checkpoint_payload=invalid_payload,
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
             )
 
         create_execution.assert_not_awaited()
@@ -3417,6 +3506,11 @@ async def test_failed_step_recovery_rejects_noncanonical_checkpoint_ref(
                     run_id=created.run_id,
                     snapshot_ref="artifact://snapshot/source",
                 ),
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
             )
 
 
@@ -3456,6 +3550,11 @@ async def test_failed_step_recovery_rejects_checkpoint_run_mismatch(
                     workflow_id=created.workflow_id,
                     run_id="stale-run-id",
                     snapshot_ref="artifact://snapshot/source",
+                ),
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
                 ),
             )
 
@@ -3500,6 +3599,11 @@ async def test_failed_step_recovery_rejects_checkpoint_plan_mismatch(
                 recovery_checkpoint_ref=None,
                 idempotency_key="recover-1",
                 checkpoint_payload=payload,
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
+                ),
             )
 
 
@@ -3543,6 +3647,11 @@ async def test_failed_step_recovery_rejects_checkpoint_plan_digest_mismatch(
                     workflow_id=created.workflow_id,
                     run_id=created.run_id,
                     snapshot_ref="artifact://snapshot/source",
+                ),
+                failed_run_recovery_manifest_ref="artifact://recovery/manifest",
+                failed_run_recovery_manifest=_valid_failed_run_recovery_manifest_payload(
+                    workflow_id=created.workflow_id,
+                    run_id=created.run_id,
                 ),
             )
 

--- a/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py
@@ -45,7 +45,8 @@ def _recovery_source(**overrides: object) -> dict[str, object]:
         "sourcePlanDigest": "sha256:source-plan",
         "failedStepId": "implement",
         "failedStepExecution": 1,
-        "recoveryCheckpointRef": "artifact://recover/checkpoint",
+        "recoveryCheckpointRef": "artifact://workspace/before-implement",
+        "failedRunRecoveryManifestRef": "artifact://recovery/manifest",
         "recoveryWorkspace": {
             "checkpointRef": "artifact://workspace/before-implement",
         },
@@ -374,7 +375,7 @@ async def test_recover_step_execution_manifest_preserves_source_lineage(
         "relationship": "recover_from_failed_step",
         "lineageExecutionOrdinal": 2,
     }
-    assert manifest["workspace"]["policy"] == "start_from_last_passed_commit"
+    assert manifest["workspace"]["policy"] == "restore_pre_execution"
     assert manifest["workspace"]["checkpointRef"] == (
         "artifact://workspace/before-implement"
     )
@@ -417,6 +418,7 @@ def test_recovery_source_accepts_branch_commit_workspace_evidence() -> None:
 def test_recovery_source_accepts_checkpoint_payload_ref_workspace_evidence() -> None:
     now = datetime.now(UTC)
     source = _recovery_source(
+        recoveryCheckpointRef="artifact://checkpoint/payload",
         recoveryWorkspace={
             "checkpoint_payload_ref": "artifact://checkpoint/payload",
             "inline_checkpoint_metadata": "artifact://checkpoint/metadata",

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -2573,7 +2573,7 @@ async def test_run_skips_no_capture_ephemeral_checkpoint_for_pre_emit_histories(
 
 
 @pytest.mark.asyncio
-async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_retry_ref_for_replay(
+async def test_run_no_capture_ephemeral_checkpoint_skips_previous_retry_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2612,8 +2612,7 @@ async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_retry_ref_for
         **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.append({"activity": activity, "payload": payload})
-        assert activity == "step_checkpoint.create"
-        return _checkpoint_create_result(payload)
+        raise AssertionError(f"unexpected activity: {activity}")
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
@@ -2623,14 +2622,12 @@ async def test_run_no_capture_ephemeral_checkpoint_reuses_previous_retry_ref_for
         updated_at=now,
     )
 
-    assert result == "artifact://checkpoint/before_execution"
-    assert captured[0]["payload"]["workspace"]["workspaceRef"] == (
-        "artifact://checkpoint/after_prepare"
-    )
+    assert result is None
+    assert captured == []
 
 
 @pytest.mark.asyncio
-async def test_run_emits_no_capture_ephemeral_checkpoint_when_emit_patch_enabled(
+async def test_run_skips_no_capture_ephemeral_checkpoint_when_emit_patch_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2666,8 +2663,7 @@ async def test_run_emits_no_capture_ephemeral_checkpoint_when_emit_patch_enabled
         **_kwargs: Any,
     ) -> dict[str, Any]:
         captured.append({"activity": activity, "payload": payload})
-        assert activity == "step_checkpoint.create"
-        return _checkpoint_create_result(payload)
+        raise AssertionError(f"unexpected activity: {activity}")
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
@@ -2677,13 +2673,8 @@ async def test_run_emits_no_capture_ephemeral_checkpoint_when_emit_patch_enabled
         updated_at=now,
     )
 
-    assert result == "artifact://checkpoint/after_prepare"
-    assert [call["activity"] for call in captured] == ["step_checkpoint.create"]
-    assert captured[0]["payload"]["workspace"] == {
-        "kind": "ephemeral_workspace_ref",
-        "workspaceRef": "temporal://wf-run-1/run-1/implement/after_prepare",
-        "createdAt": "2026-04-07T12:00:00+00:00",
-    }
+    assert result is None
+    assert captured == []
 
 
 @pytest.mark.asyncio
@@ -2751,7 +2742,7 @@ async def test_run_skips_captured_ephemeral_checkpoint_for_pre_emit_histories(
 
 
 @pytest.mark.asyncio
-async def test_run_emits_captured_ephemeral_checkpoint_when_emit_patch_enabled(
+async def test_run_skips_captured_ephemeral_checkpoint_when_emit_patch_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
@@ -2800,15 +2791,7 @@ async def test_run_emits_captured_ephemeral_checkpoint_when_emit_patch_enabled(
                 },
                 "diagnosticRefs": ["artifact://diagnostic/ephemeral"],
             }
-        assert activity == "step_checkpoint.create"
-        return {
-            "checkpointRef": "artifact://checkpoint/after_execution",
-            "checkpointId": payload["idempotencyKey"],
-            "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
-            "workspaceKind": payload["workspace"]["kind"],
-            "diagnosticRefs": [],
-            "idempotencyKey": payload["idempotencyKey"],
-        }
+        raise AssertionError(f"unexpected activity: {activity}")
 
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
@@ -2818,20 +2801,12 @@ async def test_run_emits_captured_ephemeral_checkpoint_when_emit_patch_enabled(
         updated_at=now,
     )
 
-    assert result == "artifact://checkpoint/after_execution"
-    assert [call["activity"] for call in captured] == [
-        "workspace.capture_checkpoint",
-        "step_checkpoint.create",
-    ]
-    assert captured[1]["payload"]["workspace"]["kind"] == "ephemeral_workspace_ref"
+    assert result is None
+    assert [call["activity"] for call in captured] == ["workspace.capture_checkpoint"]
     step = workflow.get_step_ledger()["steps"][0]
-    assert step["stepCheckpointRef"] == "artifact://checkpoint/after_execution"
-    assert step["refs"]["stepExecutionCheckpointRefs"] == [
-        "artifact://checkpoint/after_execution"
-    ]
-    assert step["refs"]["checkpointRefsByBoundary"] == {
-        "after_execution": "artifact://checkpoint/after_execution"
-    }
+    assert step.get("stepCheckpointRef") is None
+    assert step["refs"]["stepExecutionCheckpointRefs"] == []
+    assert step["refs"]["checkpointRefsByBoundary"] == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue: MM-996

Summary:
- Adds a shared checkpoint policy resolver and uses it across canonical checkpoint capture, recovery workspace metadata, and recovery preparation.
- Threads failedRunRecoveryManifestRef through API/service/workflow recovery inputs so resume can be driven by recovery manifest artifacts.
- Rejects ephemeral workspace evidence for canonical resumable checkpoint creation and updates recovery/checkpoint tests around the workflow boundary.

Tests run:
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py tests/unit/workflows/temporal/workflows/test_run_recover_from_failed_step.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
- Result: 534 Python tests passed; 43 frontend test files passed with 695 tests passed and 236 skipped.

Remaining risks:
- Full unit and integration_ci suites were not run; verification was targeted to the changed API, service, and Temporal workflow areas.
- Checkpoint resume behavior remains sensitive to already-running workflow histories and should be watched during review/rollout.