### PR TITLE
MM-1035 implement workflow status color semantics

### DIFF
--- a/frontend/src/components/ExecutionStatusPill.tsx
+++ b/frontend/src/components/ExecutionStatusPill.tsx
@@ -33,9 +33,15 @@ function visibleStatusLabel(status: string | null | undefined): string {
   return formatStatusLabel(status);
 }
 
-export function ExecutionStatusPill({ status }: { status: string | null | undefined }) {
+export function ExecutionStatusPill({
+  status,
+  enableMotion = true,
+}: {
+  status: string | null | undefined;
+  enableMotion?: boolean;
+}) {
   const label = visibleStatusLabel(status);
-  const pillProps = executionStatusPillProps(status);
+  const pillProps = executionStatusPillProps(status, { enableMotion });
   const hasShimmerSweep = pillProps['data-effect'] === 'shimmer-sweep';
   const glyphs = useMemo(() => splitGraphemes(label), [label]);
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -824,22 +824,26 @@ describe('Dashboard shared entry', () => {
       dashboardCss,
       '.status-queued, .status-scheduled, .status-awaiting-slot',
     ).join('\n');
-    expect(queueBlock).toContain('color: #8248F6');
-    expect(queueBlock).toContain('rgb(130 72 246 / 0.14)');
+    expect(queueBlock).toContain('color: rgb(var(--mm-status-queued, 130 72 246))');
+    expect(queueBlock).toContain('rgb(var(--mm-status-queued, 130 72 246) / 0.14)');
 
     const waitBlock = cssRuleBlocks(
       dashboardCss,
       '.status-waiting, .status-awaiting-dependencies, .status-awaiting-external',
     ).join('\n');
-    expect(waitBlock).toContain('color: #EC4899');
-    expect(waitBlock).toContain('rgb(236 72 153 / 0.14)');
+    expect(waitBlock).toContain('color: rgb(var(--mm-status-waiting, 236 72 153))');
+    expect(waitBlock).toContain('rgb(var(--mm-status-waiting, 236 72 153) / 0.14)');
 
     const setupBlock = cssRuleBlocks(dashboardCss, '.status-initializing, .status-planning').join('\n');
-    expect(setupBlock).toContain('color: #6366F1');
-    expect(setupBlock).toContain('rgb(99 102 241 / 0.14)');
+    expect(setupBlock).toContain('color: rgb(var(--mm-status-setup, 99 102 241))');
+    expect(setupBlock).toContain('rgb(var(--mm-status-setup, 99 102 241) / 0.14)');
 
-    expect(cssRuleBlock(dashboardCss, '.status-finalizing')).toContain('color: #64748B');
-    expect(cssRuleBlock(dashboardCss, '.status-canceled')).toContain('color: #F97316');
+    expect(cssRuleBlock(dashboardCss, '.status-finalizing')).toContain(
+      'color: rgb(var(--mm-status-finalizing, 100 116 139))',
+    );
+    expect(cssRuleBlock(dashboardCss, '.status-canceled')).toContain(
+      'color: rgb(var(--mm-status-canceled, 249 115 22))',
+    );
     expect(cssRuleBlock(dashboardCss, '.status-no-commit')).toContain('color: #159376');
     expect(cssRuleBlock(dashboardCss, '.status-running, .status-running.is-executing')).toContain(
       'color: rgb(var(--mm-accent-2))',

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -791,6 +791,14 @@ describe('Dashboard shared entry', () => {
       '.card',
       '.toolbar',
       '.status-queued',
+      '.status-scheduled',
+      '.status-awaiting-slot',
+      '.status-awaiting-dependencies',
+      '.status-awaiting-external',
+      '.status-initializing',
+      '.status-planning',
+      '.status-finalizing',
+      '.status-canceled',
       '.status-running',
       '.queue-submit-form',
     ]) {
@@ -809,6 +817,33 @@ describe('Dashboard shared entry', () => {
     expect(dashboardTemplate).toContain('<span class="masthead-brand-mind">Mind</span>');
     expect(cssRuleBlock(dashboardCss, '.masthead-brand-moon')).toContain('color: rgb(255 255 255)');
     expect(cssRuleBlock(dashboardCss, '.masthead-brand-mind')).toContain('color: inherit');
+  });
+
+  it('defines MM-1035 exact workflow status color roles', async () => {
+    const queueBlock = cssRuleBlocks(
+      dashboardCss,
+      '.status-queued, .status-scheduled, .status-awaiting-slot',
+    ).join('\n');
+    expect(queueBlock).toContain('color: #8248F6');
+    expect(queueBlock).toContain('rgb(130 72 246 / 0.14)');
+
+    const waitBlock = cssRuleBlocks(
+      dashboardCss,
+      '.status-waiting, .status-awaiting-dependencies, .status-awaiting-external',
+    ).join('\n');
+    expect(waitBlock).toContain('color: #EC4899');
+    expect(waitBlock).toContain('rgb(236 72 153 / 0.14)');
+
+    const setupBlock = cssRuleBlocks(dashboardCss, '.status-initializing, .status-planning').join('\n');
+    expect(setupBlock).toContain('color: #6366F1');
+    expect(setupBlock).toContain('rgb(99 102 241 / 0.14)');
+
+    expect(cssRuleBlock(dashboardCss, '.status-finalizing')).toContain('color: #64748B');
+    expect(cssRuleBlock(dashboardCss, '.status-canceled')).toContain('color: #F97316');
+    expect(cssRuleBlock(dashboardCss, '.status-no-commit')).toContain('color: #159376');
+    expect(cssRuleBlock(dashboardCss, '.status-running, .status-running.is-executing')).toContain(
+      'color: rgb(var(--mm-accent-2))',
+    );
   });
 
 
@@ -839,7 +874,7 @@ describe('Dashboard shared entry', () => {
 
     const shimmerBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"], .status-running.is-executing, .status-running.is-planning',
+      '.status-running[data-effect="shimmer-sweep"], .status-running.is-executing',
     ).join('\n');
     expect(shimmerBlock).toContain('background-color: rgb(var(--mm-accent-2) / 0.14)');
     expect(shimmerBlock).toContain('overflow: hidden');
@@ -867,21 +902,21 @@ describe('Dashboard shared entry', () => {
     expect(dashboardCss).not.toMatch(/@keyframes mm-status-pill-shimmer\s*\{[\s\S]*?52%\s*\{/);
     expect(dashboardCss).toMatch(/@keyframes mm-status-pill-shimmer\s*\{[\s\S]*?0%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-start-x\)\s*var\(--mm-executing-sweep-start-y\),[\s\S]*?100%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-end-x\)\s*var\(--mm-executing-sweep-end-y\),[\s\S]*?background-size:\s*calc\(var\(--mm-executing-sweep-band-width\)\s*\*\s*var\(--mm-executing-sweep-halo-width-multiplier\)\)\s*var\(--mm-executing-sweep-band-height\),[\s\S]*?calc\(var\(--mm-executing-sweep-band-width\)\s*\*\s*var\(--mm-executing-sweep-core-width-multiplier\)\)\s*var\(--mm-executing-sweep-band-height\);/);
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\],\s*\.status-running\.is-executing,\s*\.status-running\.is-planning[\s\S]*?animation: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\],\s*\.status-running\.is-executing[\s\S]*?animation: none;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?background-position:\s*50% 50%,[\s\S]*?calc\(50% \+ \(var\(--mm-executing-sweep-layer-offset-x\) \/ 2\)\)\s*calc\(50% \+ \(var\(--mm-executing-sweep-layer-offset-y\) \/ 2\)\);[\s\S]*?background-size:\s*160% var\(--mm-executing-sweep-band-height\),\s*140% var\(--mm-executing-sweep-band-height\);/,
     );
     const shimmerBeforeSelector = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"]::before, .status-running.is-executing::before, .status-running.is-planning::before',
+      '.status-running[data-effect="shimmer-sweep"]::before, .status-running.is-executing::before',
     ).join('\n');
     expect(shimmerBeforeSelector).toContain('opacity: 0.62');
     expect(shimmerBeforeSelector).toContain('z-index: 1');
 
     const shimmerAfterBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"]::after, .status-running.is-executing::after, .status-running.is-planning::after',
+      '.status-running[data-effect="shimmer-sweep"]::after, .status-running.is-executing::after',
     ).join('\n');
     expect(shimmerAfterBlock).toContain('mask-composite: exclude');
     expect(shimmerAfterBlock).toContain('-webkit-mask-composite: xor');
@@ -923,7 +958,7 @@ describe('Dashboard shared entry', () => {
 
     const activeLetterWaveBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave, .status-running.is-executing .status-letter-wave, .status-running.is-planning .status-letter-wave',
+      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave, .status-running.is-executing .status-letter-wave',
     ).join('\n');
     expect(activeLetterWaveBlock).toContain('color: inherit');
     expect(activeLetterWaveBlock).not.toContain('color: var(--mm-executing-letter-bright)');
@@ -932,7 +967,7 @@ describe('Dashboard shared entry', () => {
     expect(activeLetterWaveBlock).not.toContain('white 50%');
     const activeGlyphBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph, .status-running.is-executing .status-letter-wave__glyph, .status-running.is-planning .status-letter-wave__glyph',
+      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph, .status-running.is-executing .status-letter-wave__glyph',
     ).join('\n');
     expect(activeGlyphBlock).toContain('animation: none');
     expect(activeGlyphBlock).toContain('animation-name: mm-executing-letter-brighten');
@@ -947,10 +982,10 @@ describe('Dashboard shared entry', () => {
       /@keyframes mm-executing-letter-brighten\s*\{[\s\S]*?color:\s*var\(--mm-executing-letter-bright\);[\s\S]*?text-shadow:\s*0 0 10px var\(--mm-executing-letter-halo\);/,
     );
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\] \.status-letter-wave,\s*\.status-running\.is-executing \.status-letter-wave,\s*\.status-running\.is-planning \.status-letter-wave[\s\S]*?text-shadow: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\] \.status-letter-wave,\s*\.status-running\.is-executing \.status-letter-wave[\s\S]*?text-shadow: none;/,
     );
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\]::before,[\s\S]*?\.status-running\.is-planning \.status-letter-wave::after[\s\S]*?animation: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\]::before,[\s\S]*?\.status-running\.is-executing \.status-letter-wave::after[\s\S]*?animation: none;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-letter-wave__glyph\s*\{[\s\S]*?animation:\s*none !important;[\s\S]*?text-shadow:\s*none !important;[\s\S]*?filter:\s*none !important;/,

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2519,7 +2519,7 @@ describe('Workflow Detail Entrypoint', () => {
   });
 
 
-  it('renders planning detail pills with the shared shimmer selector contract and keeps dependency pills inactive when appropriate', async () => {
+  it('renders planning detail pills with setup coloring and keeps dependency pills inactive when appropriate', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-123?source=temporal');
     const mockExecution = {
       taskId: 'test-123',
@@ -2565,21 +2565,19 @@ describe('Workflow Detail Entrypoint', () => {
     renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
 
     await screen.findByText('Planning detail task');
-    const toolbarStatus = document.querySelector<HTMLElement>('.toolbar-identity-row [data-effect="shimmer-sweep"]');
-    expect(toolbarStatus?.dataset.state).toBe('planning');
-    expect(toolbarStatus?.dataset.effect).toBe('shimmer-sweep');
-    expect(toolbarStatus?.className).toContain('is-planning');
-    expect(toolbarStatus?.className).toContain('status-running');
-    expect(toolbarStatus?.dataset.shimmerLabel).toBe('planning');
-    expect(toolbarStatus?.getAttribute('aria-label')).toBe('planning');
-    expect(toolbarStatus?.querySelector('.status-letter-wave')?.getAttribute('aria-hidden')).toBe('true');
-    const glyphs = Array.from(toolbarStatus?.querySelectorAll<HTMLElement>('.status-letter-wave__glyph') || []);
-    expect(glyphs).toHaveLength('planning'.length);
-    expect(glyphs.map((glyph) => glyph.textContent).join('')).toBe('planning');
+    const toolbarStatus = document.querySelector<HTMLElement>('.toolbar-identity-row span.status');
+    expect(toolbarStatus?.dataset.effect).toBeUndefined();
+    expect(toolbarStatus?.className).toContain('status-planning');
+    expect(toolbarStatus?.className).not.toContain('status-running');
+    expect(toolbarStatus?.className).not.toContain('is-planning');
+    expect(toolbarStatus?.dataset.shimmerLabel).toBeUndefined();
+    expect(toolbarStatus?.getAttribute('aria-label')).toBeNull();
+    expect(toolbarStatus?.querySelector('.status-letter-wave')).toBeNull();
     expect(toolbarStatus?.textContent).toBe('planning');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-489');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1035');
 
     const waitingPill = await screen.findByText('AWAITING DEP');
     expect(waitingPill.closest('span')?.dataset.effect).toBeUndefined();

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1174,19 +1174,17 @@ describe('Workflows Entrypoint', () => {
         document.querySelectorAll(
           '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
         ),
-      ).toHaveLength(6);
+      ).toHaveLength(2);
     });
 
     const activePills = document.querySelectorAll<HTMLElement>(
       '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
     );
-    expect(activePills).toHaveLength(6);
-    expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'planning')).toHaveLength(2);
+    expect(activePills).toHaveLength(2);
     expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'executing')).toHaveLength(2);
-    expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'finalizing')).toHaveLength(2);
     for (const pill of activePills) {
       const label = pill.dataset.state;
-      if (label !== 'planning' && label !== 'executing' && label !== 'finalizing') {
+      if (label !== 'executing') {
         throw new Error(`Unexpected active status pill state: ${label}`);
       }
       expect(pill.dataset.state).toBe(label);
@@ -1208,11 +1206,27 @@ describe('Workflows Entrypoint', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-489');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1035');
+
+    const planningPills = screen.getAllByText('planning');
+    expect(planningPills.length).toBeGreaterThan(0);
+    for (const pill of planningPills) {
+      expect(pill.closest('span')?.dataset.effect).toBeUndefined();
+      expect(pill.closest('span')?.className).toContain('status-planning');
+    }
+
+    const finalizingPills = screen.getAllByText('finalizing');
+    expect(finalizingPills.length).toBeGreaterThan(0);
+    for (const pill of finalizingPills) {
+      expect(pill.closest('span')?.dataset.effect).toBeUndefined();
+      expect(pill.closest('span')?.className).toContain('status-finalizing');
+    }
 
     const waitingPills = screen.getAllByText('AWAITING DEP');
     expect(waitingPills.length).toBeGreaterThan(0);
     for (const pill of waitingPills) {
       expect(pill.closest('span')?.dataset.effect).toBeUndefined();
+      expect(pill.closest('span')?.className).toContain('status-awaiting-dependencies');
     }
 
     const nonExecutingStatusPills = Array.from(
@@ -1223,6 +1237,7 @@ describe('Workflows Entrypoint', () => {
     expect(awaitingPills.length).toBeGreaterThan(0);
     for (const pill of awaitingPills) {
       expect(pill.dataset.effect).toBeUndefined();
+      expect(pill.className).toContain('status-awaiting-external');
     }
 
   });
@@ -1478,6 +1493,8 @@ describe('Workflows Entrypoint', () => {
     const pillList = screen.getByLabelText('Selected status filters');
     expect(pillList.textContent).toContain('completed');
     expect(pillList.textContent).toContain('failed');
+    expect(pillList.querySelector('.status-completed')).toBeTruthy();
+    expect(pillList.querySelector('.status-failed')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove completed' }));
     expect(pillList.textContent).not.toContain('completed');
@@ -1491,6 +1508,41 @@ describe('Workflows Entrypoint', () => {
       );
     });
   }, 10000);
+
+  it('renders selected status filters with the shared execution status pill colors', async () => {
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    openFilterDrawer();
+    const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
+
+    for (const value of [
+      'scheduled',
+      'awaiting_slot',
+      'waiting_on_dependencies',
+      'awaiting_external',
+      'initializing',
+      'planning',
+      'finalizing',
+      'canceled',
+      'no_commit',
+    ]) {
+      fireEvent.change(statusFilter, { target: { value } });
+    }
+
+    const pillList = screen.getByLabelText('Selected status filters');
+    expect(pillList.querySelector('.status-scheduled')).toBeTruthy();
+    expect(pillList.querySelector('.status-awaiting-slot')).toBeTruthy();
+    expect(pillList.querySelector('.status-awaiting-dependencies')).toBeTruthy();
+    expect(pillList.querySelector('.status-awaiting-external')).toBeTruthy();
+    expect(pillList.querySelector('.status-initializing')).toBeTruthy();
+    expect(pillList.querySelector('.status-planning')).toBeTruthy();
+    expect(pillList.querySelector('.status-finalizing')).toBeTruthy();
+    expect(pillList.querySelector('.status-canceled')).toBeTruthy();
+    expect(pillList.querySelector('.status-no-commit')).toBeTruthy();
+    expect(pillList.querySelector('[data-effect="shimmer-sweep"]')).toBeNull();
+  });
 
   it('stages status changes until Apply and discards them on cancel, Escape, or outside click', async () => {
     renderWithClient(<WorkflowListPage payload={mockPayload} />);

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1519,7 +1519,6 @@ describe('Workflows Entrypoint', () => {
 
     for (const value of [
       'executing',
-      'running',
       'scheduled',
       'awaiting_slot',
       'waiting_on_dependencies',
@@ -1534,7 +1533,7 @@ describe('Workflows Entrypoint', () => {
     }
 
     const pillList = screen.getByLabelText('Selected status filters');
-    expect(pillList.querySelectorAll('.status-running')).toHaveLength(2);
+    expect(pillList.querySelector('.status-running')).toBeTruthy();
     expect(pillList.querySelector('.status-scheduled')).toBeTruthy();
     expect(pillList.querySelector('.status-awaiting-slot')).toBeTruthy();
     expect(pillList.querySelector('.status-awaiting-dependencies')).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1518,6 +1518,8 @@ describe('Workflows Entrypoint', () => {
     const statusFilter = (await screen.findByLabelText('Status filter value')) as HTMLSelectElement;
 
     for (const value of [
+      'executing',
+      'running',
       'scheduled',
       'awaiting_slot',
       'waiting_on_dependencies',
@@ -1532,6 +1534,7 @@ describe('Workflows Entrypoint', () => {
     }
 
     const pillList = screen.getByLabelText('Selected status filters');
+    expect(pillList.querySelectorAll('.status-running')).toHaveLength(2);
     expect(pillList.querySelector('.status-scheduled')).toBeTruthy();
     expect(pillList.querySelector('.status-awaiting-slot')).toBeTruthy();
     expect(pillList.querySelector('.status-awaiting-dependencies')).toBeTruthy();

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1721,7 +1721,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             values={draft.values}
             options={[...TEMPORAL_STATUSES]}
             formatValue={formatStatusLabel}
-            renderValue={(value) => <ExecutionStatusPill status={value} />}
+            renderValue={(value) => <ExecutionStatusPill status={value} enableMotion={false} />}
             disabled={!listEnabled}
             ariaLabelAdd="Status filter value"
             ariaLabelSelected="Selected status filters"

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
@@ -885,6 +885,7 @@ type PillMultiSelectProps = {
   values: string[];
   options: string[];
   formatValue?: (value: string) => string;
+  renderValue?: (value: string) => ReactNode;
   disabled?: boolean;
   ariaLabelAdd: string;
   ariaLabelSelected: string;
@@ -898,6 +899,7 @@ function FilterPillMultiSelect({
   values,
   options,
   formatValue,
+  renderValue,
   disabled,
   ariaLabelAdd,
   ariaLabelSelected,
@@ -919,7 +921,7 @@ function FilterPillMultiSelect({
         ) : (
           values.map((value) => (
             <li key={value} className="workflow-list-pill">
-              <span className="workflow-list-pill-label">{fmt(value)}</span>
+              <span className="workflow-list-pill-label">{renderValue ? renderValue(value) : fmt(value)}</span>
               <button
                 type="button"
                 className="workflow-list-pill-remove"
@@ -1719,6 +1721,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
             values={draft.values}
             options={[...TEMPORAL_STATUSES]}
             formatValue={formatStatusLabel}
+            renderValue={(value) => <ExecutionStatusPill status={value} />}
             disabled={!listEnabled}
             ariaLabelAdd="Status filter value"
             ariaLabelSelected="Selected status filters"

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2720,9 +2720,9 @@ tr[data-proposal-id].proposal-consuming td {
 .status-queued,
 .status-scheduled,
 .status-awaiting-slot {
-  color: #8248F6;
-  background: rgb(130 72 246 / 0.14);
-  border-color: rgb(130 72 246 / 0.62);
+  color: rgb(var(--mm-status-queued, 130 72 246));
+  background: rgb(var(--mm-status-queued, 130 72 246) / 0.14);
+  border-color: rgb(var(--mm-status-queued, 130 72 246) / 0.62);
 }
 
 .status-awaiting_action {
@@ -2734,22 +2734,22 @@ tr[data-proposal-id].proposal-consuming td {
 .status-waiting,
 .status-awaiting-dependencies,
 .status-awaiting-external {
-  color: #EC4899;
-  background: rgb(236 72 153 / 0.14);
-  border-color: rgb(236 72 153 / 0.62);
+  color: rgb(var(--mm-status-waiting, 236 72 153));
+  background: rgb(var(--mm-status-waiting, 236 72 153) / 0.14);
+  border-color: rgb(var(--mm-status-waiting, 236 72 153) / 0.62);
 }
 
 .status-initializing,
 .status-planning {
-  color: #6366F1;
-  background: rgb(99 102 241 / 0.14);
-  border-color: rgb(99 102 241 / 0.62);
+  color: rgb(var(--mm-status-setup, 99 102 241));
+  background: rgb(var(--mm-status-setup, 99 102 241) / 0.14);
+  border-color: rgb(var(--mm-status-setup, 99 102 241) / 0.62);
 }
 
 .status-finalizing {
-  color: #64748B;
-  background: rgb(100 116 139 / 0.14);
-  border-color: rgb(100 116 139 / 0.62);
+  color: rgb(var(--mm-status-finalizing, 100 116 139));
+  background: rgb(var(--mm-status-finalizing, 100 116 139) / 0.14);
+  border-color: rgb(var(--mm-status-finalizing, 100 116 139) / 0.62);
 }
 
 .status-succeeded,
@@ -2772,9 +2772,9 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-canceled {
-  color: #F97316;
-  background: rgb(249 115 22 / 0.14);
-  border-color: rgb(249 115 22 / 0.62);
+  color: rgb(var(--mm-status-canceled, 249 115 22));
+  background: rgb(var(--mm-status-canceled, 249 115 22) / 0.14);
+  border-color: rgb(var(--mm-status-canceled, 249 115 22) / 0.62);
 }
 
 .status-neutral {

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2710,16 +2710,19 @@ tr[data-proposal-id].proposal-consuming td {
   letter-spacing: 0.03em;
 }
 
-.status-queued {
-  color: rgb(var(--mm-warn));
-  background: rgb(var(--mm-warn) / 0.14);
-  border-color: rgb(var(--mm-warn) / 0.55);
-}
-
-.status-running {
+.status-running,
+.status-running.is-executing {
   color: rgb(var(--mm-accent-2));
   background: rgb(var(--mm-accent-2) / 0.14);
   border-color: rgb(var(--mm-accent-2) / 0.55);
+}
+
+.status-queued,
+.status-scheduled,
+.status-awaiting-slot {
+  color: #8248F6;
+  background: rgb(130 72 246 / 0.14);
+  border-color: rgb(130 72 246 / 0.62);
 }
 
 .status-awaiting_action {
@@ -2728,10 +2731,25 @@ tr[data-proposal-id].proposal-consuming td {
   border-color: rgb(var(--mm-accent) / 0.55);
 }
 
-.status-waiting {
-  color: rgb(var(--mm-warning-ink, var(--mm-warn)));
-  background: rgb(var(--mm-warn) / 0.18);
-  border-color: rgb(var(--mm-warn) / 0.7);
+.status-waiting,
+.status-awaiting-dependencies,
+.status-awaiting-external {
+  color: #EC4899;
+  background: rgb(236 72 153 / 0.14);
+  border-color: rgb(236 72 153 / 0.62);
+}
+
+.status-initializing,
+.status-planning {
+  color: #6366F1;
+  background: rgb(99 102 241 / 0.14);
+  border-color: rgb(99 102 241 / 0.62);
+}
+
+.status-finalizing {
+  color: #64748B;
+  background: rgb(100 116 139 / 0.14);
+  border-color: rgb(100 116 139 / 0.62);
 }
 
 .status-succeeded,
@@ -2747,11 +2765,16 @@ tr[data-proposal-id].proposal-consuming td {
   border-color: rgb(26 153 123 / 0.62);
 }
 
-.status-failed,
-.status-cancelled {
+.status-failed {
   color: rgb(var(--mm-danger));
   background: rgb(var(--mm-danger) / 0.14);
   border-color: rgb(var(--mm-danger) / 0.55);
+}
+
+.status-canceled {
+  color: #F97316;
+  background: rgb(249 115 22 / 0.14);
+  border-color: rgb(249 115 22 / 0.62);
 }
 
 .status-neutral {
@@ -2761,8 +2784,7 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-running[data-effect="shimmer-sweep"],
-.status-running.is-executing,
-.status-running.is-planning {
+.status-running.is-executing {
   position: relative;
   overflow: hidden;
   isolation: isolate;
@@ -2771,10 +2793,8 @@ tr[data-proposal-id].proposal-consuming td {
 
 .status-running[data-effect="shimmer-sweep"]::before,
 .status-running.is-executing::before,
-.status-running.is-planning::before,
 .status-running[data-effect="shimmer-sweep"]::after,
-.status-running.is-executing::after,
-.status-running.is-planning::after {
+.status-running.is-executing::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -2792,15 +2812,13 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-running[data-effect="shimmer-sweep"]::before,
-.status-running.is-executing::before,
-.status-running.is-planning::before {
+.status-running.is-executing::before {
   z-index: 1;
   opacity: 0.62;
 }
 
 .status-running[data-effect="shimmer-sweep"]::after,
-.status-running.is-executing::after,
-.status-running.is-planning::after {
+.status-running.is-executing::after {
   z-index: 2;
   inset: calc(-1 * var(--mm-executing-border-glint-outset));
   border-radius: inherit;
@@ -2819,10 +2837,8 @@ tr[data-proposal-id].proposal-consuming td {
 @supports not (mix-blend-mode: plus-lighter) {
   .status-running[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running.is-planning::before,
   .status-running[data-effect="shimmer-sweep"]::after,
-  .status-running.is-executing::after,
-  .status-running.is-planning::after {
+  .status-running.is-executing::after {
     mix-blend-mode: screen;
   }
 }
@@ -2857,14 +2873,12 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-running[data-effect="shimmer-sweep"] .status-letter-wave,
-.status-running.is-executing .status-letter-wave,
-.status-running.is-planning .status-letter-wave {
+.status-running.is-executing .status-letter-wave {
   color: inherit;
 }
 
 .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
-.status-running.is-executing .status-letter-wave::after,
-.status-running.is-planning .status-letter-wave::after {
+.status-running.is-executing .status-letter-wave::after {
   content: attr(data-label);
   position: absolute;
   inset: 0;
@@ -2888,14 +2902,12 @@ tr[data-proposal-id].proposal-consuming td {
 
 @supports not ((background-clip: text) or (-webkit-background-clip: text)) {
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
-  .status-running.is-executing .status-letter-wave::after,
-  .status-running.is-planning .status-letter-wave::after {
+  .status-running.is-executing .status-letter-wave::after {
     content: none;
   }
 
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
-  .status-running.is-executing .status-letter-wave__glyph,
-  .status-running.is-planning .status-letter-wave__glyph {
+  .status-running.is-executing .status-letter-wave__glyph {
     animation-name: mm-executing-letter-brighten;
     animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms));
     animation-timing-function: linear;
@@ -2929,8 +2941,7 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 .status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
-.status-running.is-executing .status-letter-wave__glyph,
-.status-running.is-planning .status-letter-wave__glyph {
+.status-running.is-executing .status-letter-wave__glyph {
   animation: none;
 }
 
@@ -2959,8 +2970,7 @@ tr[data-proposal-id].proposal-consuming td {
 
 @media (prefers-reduced-motion: reduce) {
   .status-running[data-effect="shimmer-sweep"],
-  .status-running.is-executing,
-  .status-running.is-planning {
+  .status-running.is-executing {
     background-image: var(--mm-executing-moving-light-gradient);
     background-repeat: no-repeat;
     background-position:
@@ -2971,13 +2981,10 @@ tr[data-proposal-id].proposal-consuming td {
 
   .status-running[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running.is-planning::before,
   .status-running[data-effect="shimmer-sweep"]::after,
   .status-running.is-executing::after,
-  .status-running.is-planning::after,
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
-  .status-running.is-executing .status-letter-wave::after,
-  .status-running.is-planning .status-letter-wave::after {
+  .status-running.is-executing .status-letter-wave::after {
     animation: none;
   }
 
@@ -2988,42 +2995,35 @@ tr[data-proposal-id].proposal-consuming td {
   }
 
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave,
-  .status-running.is-executing .status-letter-wave,
-  .status-running.is-planning .status-letter-wave {
+  .status-running.is-executing .status-letter-wave {
     text-shadow: none;
   }
 
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
-  .status-running.is-executing .status-letter-wave::after,
-  .status-running.is-planning .status-letter-wave::after {
+  .status-running.is-executing .status-letter-wave::after {
     content: none;
   }
 }
 
 @media (forced-colors: active) {
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave,
-  .status-running.is-executing .status-letter-wave,
-  .status-running.is-planning .status-letter-wave {
+  .status-running.is-executing .status-letter-wave {
     color: ButtonText;
     background-image: none;
   }
 
   .status-running[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running.is-planning::before,
   .status-running[data-effect="shimmer-sweep"]::after,
   .status-running.is-executing::after,
-  .status-running.is-planning::after,
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
-  .status-running.is-executing .status-letter-wave::after,
-  .status-running.is-planning .status-letter-wave::after {
+  .status-running.is-executing .status-letter-wave::after {
     animation: none;
     content: none;
   }
 
   .status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
-  .status-running.is-executing .status-letter-wave__glyph,
-  .status-running.is-planning .status-letter-wave__glyph {
+  .status-running.is-executing .status-letter-wave__glyph {
     animation: none;
   }
 }

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -6,19 +6,12 @@ import {
 } from './executionStatusPillClasses';
 
 describe('executionStatusPillProps', () => {
-  it('adds shimmer selector metadata for blue running status pills', () => {
+  it('adds shimmer selector metadata only for active executing status pills', () => {
     expect(executionStatusPillProps('executing')).toMatchObject({
       className: 'status status-running is-executing',
       'data-state': 'executing',
       'data-effect': 'shimmer-sweep',
       'data-shimmer-label': 'executing',
-    });
-
-    expect(executionStatusPillProps('planning')).toMatchObject({
-      className: 'status status-running is-planning',
-      'data-state': 'planning',
-      'data-effect': 'shimmer-sweep',
-      'data-shimmer-label': 'planning',
     });
 
     expect(executionStatusPillProps('running')).toMatchObject({
@@ -28,19 +21,6 @@ describe('executionStatusPillProps', () => {
       'data-shimmer-label': 'running',
     });
 
-    expect(executionStatusPillProps('initializing')).toMatchObject({
-      className: 'status status-running is-initializing',
-      'data-state': 'initializing',
-      'data-effect': 'shimmer-sweep',
-      'data-shimmer-label': 'initializing',
-    });
-
-    expect(executionStatusPillProps('finalizing')).toMatchObject({
-      className: 'status status-running is-finalizing',
-      'data-state': 'finalizing',
-      'data-effect': 'shimmer-sweep',
-      'data-shimmer-label': 'finalizing',
-    });
     expect(executionStatusPillProps('waiting')).toEqual({
       className: 'status status-waiting',
     });
@@ -50,17 +30,32 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('completed')).toEqual({ className: 'status status-completed' });
     expect(executionStatusPillProps('failed')).toEqual({ className: 'status status-failed' });
     expect(executionStatusPillProps('executing').className).toBe('status status-running is-executing');
-    expect(executionStatusPillProps('planning').className).toBe('status status-running is-planning');
+    expect(executionStatusPillProps('planning').className).toBe('status status-planning');
     expect(executionStatusPillProps('proposals')).toEqual({ className: 'status status-running' });
 
     expect(executionStatusPillProps('waiting_on_dependencies')).toEqual({
-      className: 'status status-waiting',
+      className: 'status status-awaiting-dependencies',
     });
     expect(executionStatusPillProps('awaiting_external')).toEqual({
-      className: 'status status-awaiting_action',
+      className: 'status status-awaiting-external',
     });
     expect(executionStatusPillProps('paused')).toEqual({ className: 'status status-neutral' });
-    expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-cancelled' });
+    expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-canceled' });
+  });
+
+  it('maps MM-1035 exact workflow states to their status color classes without shimmer', () => {
+    expect(executionStatusPillProps('scheduled')).toEqual({ className: 'status status-scheduled' });
+    expect(executionStatusPillProps('awaiting_slot')).toEqual({ className: 'status status-awaiting-slot' });
+    expect(executionStatusPillProps('waiting_on_dependencies')).toEqual({
+      className: 'status status-awaiting-dependencies',
+    });
+    expect(executionStatusPillProps('awaiting_external')).toEqual({
+      className: 'status status-awaiting-external',
+    });
+    expect(executionStatusPillProps('initializing')).toEqual({ className: 'status status-initializing' });
+    expect(executionStatusPillProps('planning')).toEqual({ className: 'status status-planning' });
+    expect(executionStatusPillProps('finalizing')).toEqual({ className: 'status status-finalizing' });
+    expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-canceled' });
   });
 
   it('uses the no-commit teal pill class for canonical and legacy no-commit statuses', () => {
@@ -86,5 +81,6 @@ describe('executionStatusPillProps', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-704');
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1035');
   });
 });

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -26,6 +26,15 @@ describe('executionStatusPillProps', () => {
     });
   });
 
+  it('can render active status colors without shimmer metadata for passive contexts', () => {
+    expect(executionStatusPillProps('executing', { enableMotion: false })).toEqual({
+      className: 'status status-running',
+    });
+    expect(executionStatusPillProps('running', { enableMotion: false })).toEqual({
+      className: 'status status-running',
+    });
+  });
+
   it('keeps the existing class helper output for non-executing states across the MM-491 state matrix', () => {
     expect(executionStatusPillProps('completed')).toEqual({ className: 'status status-completed' });
     expect(executionStatusPillProps('failed')).toEqual({ className: 'status status-failed' });

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -24,6 +24,10 @@ export type ExecutionStatusPillProps = Readonly<{
   'data-shimmer-label'?: string;
 }>;
 
+export type ExecutionStatusPillOptions = Readonly<{
+  enableMotion?: boolean;
+}>;
+
 function normalizedExecutionStatusKey(status: string | null | undefined): string {
   return String(status || '')
     .toLowerCase()
@@ -66,11 +70,14 @@ function isShimmerSweepStatusKey(key: string): key is ShimmerSweepStatusKey {
   return SHIMMER_SWEEP_STATUS_KEYS.has(key);
 }
 
-export function executionStatusPillProps(status: string | null | undefined): ExecutionStatusPillProps {
+export function executionStatusPillProps(
+  status: string | null | undefined,
+  options: ExecutionStatusPillOptions = {},
+): ExecutionStatusPillProps {
   const key = normalizedExecutionStatusKey(status);
   const className = executionStatusBaseClasses(key);
 
-  if (isShimmerSweepStatusKey(key)) {
+  if (options.enableMotion !== false && isShimmerSweepStatusKey(key)) {
     return {
       className: `${className} is-${key}`,
       'data-state': key,

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -2,7 +2,7 @@ import { formatStatusLabel } from './formatters';
 
 export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   jiraIssue: 'MM-488',
-  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491', 'MM-704'],
+  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491', 'MM-704', 'MM-1035'],
   designRequirements: [
     'DESIGN-REQ-001',
     'DESIGN-REQ-002',
@@ -14,7 +14,7 @@ export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   ],
 });
 
-const SHIMMER_SWEEP_KEYS = ['executing', 'planning', 'running', 'initializing', 'finalizing'] as const;
+const SHIMMER_SWEEP_KEYS = ['executing', 'running'] as const;
 type ShimmerSweepStatusKey = (typeof SHIMMER_SWEEP_KEYS)[number];
 
 export type ExecutionStatusPillProps = Readonly<{
@@ -35,20 +35,24 @@ function executionStatusBaseClasses(key: string): string {
   if (key === 'no_commit' || key === 'no_changes') return 'status status-no-commit';
   if (key === 'succeeded' || key === 'completed') return 'status status-completed';
   if (key === 'failed') return 'status status-failed';
-  if (key === 'canceled' || key === 'cancelled') return 'status status-cancelled';
+  if (key === 'canceled') return 'status status-canceled';
+  if (key === 'scheduled') return 'status status-scheduled';
+  if (key === 'awaiting_slot') return 'status status-awaiting-slot';
+  if (key === 'waiting_on_dependencies') return 'status status-awaiting-dependencies';
+  if (key === 'awaiting_external') return 'status status-awaiting-external';
+  if (key === 'initializing') return 'status status-initializing';
+  if (key === 'planning') return 'status status-planning';
+  if (key === 'finalizing') return 'status status-finalizing';
   if (key === 'queued' || key === 'scheduling') return 'status status-queued';
   if (
     key === 'running' ||
     key === 'executing' ||
-    key === 'proposals' ||
-    key === 'planning' ||
-    key === 'initializing' ||
-    key === 'finalizing'
+    key === 'proposals'
   ) {
     return 'status status-running';
   }
-  if (key === 'awaiting_action' || key === 'awaiting_external') return 'status status-awaiting_action';
-  if (key === 'waiting' || key === 'waiting_on_dependencies') return 'status status-waiting';
+  if (key === 'awaiting_action') return 'status status-awaiting_action';
+  if (key === 'waiting') return 'status status-waiting';
   return 'status status-neutral';
 }
 


### PR DESCRIPTION
Issue reference: MM-1035

Summary:
- Implements explicit workflow status pill classes for queued, waiting, setup, finalizing, canceled, no-commit, completed, failed, and executing states.
- Restricts executing shimmer motion to actively executing/running states.
- Reuses the shared ExecutionStatusPill in workflow status filter chips so filters match list/detail pill colors.
- Updates frontend tests for the status color matrix and filter rendering behavior.

Tests run:
- `./tools/test_unit.sh --ui-args frontend/src/utils/executionStatusPillClasses.test.ts frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/workflow-detail.test.tsx frontend/src/entrypoints/dashboard.test.tsx` (blocked: container Python environment has no pytest module).
- `npm ci --no-fund --no-audit`
- `npm run ui:test -- ...` (blocked: npm script could not resolve local vitest binary in this environment).
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts` (blocked: Vitest resolved frontend test modules as `/frontend/...` paths and failed before running assertions).

Remaining risks:
- Local frontend test execution is blocked by the managed container test runner/module resolution environment, so CI should provide the authoritative test result.
- Visual color confirmation was not performed in a browser during this publication step.