### PR TITLE
[codex] Fix batch resolver child workflow payloads

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -81,7 +81,7 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
 
 4. For each matched PR, submit a `pr-resolver` task with the canonical `batch-pr-resolver`
    payload (`repository`, `task.inputs = { repo, pr, branch, mergeMethod, maxIterations }`,
-   `task.git.startingBranch/targetBranch`, `task.skill.name = pr-resolver`,
+   `task.git.startingBranch/branch`, `task.skill.name = pr-resolver`,
    `task.publish.mode = none`, inherited runtime) and a stable idempotency key:
    `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`. Submit via
    `POST /api/executions` (`MOONMIND_URL` must point at the MoonMind API).
@@ -90,7 +90,8 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
    session artifact spool when available, otherwise the configured `--artifacts-dir`) listing
    discovered PRs, matched count, queued / would-queue resolver workflows, skipped PRs with
    reasons, and submission errors. A deliberate zero-match run also writes
-   `skill_outcome.json` with `status: "no_op"`.
+   `skill_outcome.json` with `status: "no_op"`. A run with submission errors writes
+   `skill_outcome.json` with `status: "failed"` and returns non-zero.
 
 6. Print a short summary to stdout (`matched`, `queued`, `would_queue`, `skipped`, `errors`).
 

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -621,7 +621,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -842,14 +842,35 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and any terminal skill outcome marker.
 
     ``skill_outcome.json`` with ``status: "no_op"`` is written only when the run
     queued zero executions, hit no submission errors, and was not a dry run —
     i.e. a deliberate "no matching Dependabot PRs" outcome.
+
+    ``skill_outcome.json`` with ``status: "failed"`` is written when child
+    workflow submission errors occur so the managed-session runtime cannot
+    mark the parent skill turn successful based only on assistant text.
     """
 
     _write_artifacts(artifacts_dir / "batch_dependabot_resolver_result.json", payload)
+    if payload.get("errors"):
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_submission_failed",
+                "failureClass": "execution_error",
+                "evidence": {
+                    "requested": payload.get("requested"),
+                    "matched": payload.get("matched"),
+                    "created": payload.get("created"),
+                    "errors": payload.get("errors"),
+                },
+            },
+        )
+        return
     if (
         payload.get("created") == 0
         and not payload.get("errors")

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -69,13 +69,15 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      - `payload.idempotencyKey`: stable per parent batch run and PR, hash-backed and capped to the execution persistence limit, so rerunning the same batch task does not create duplicate resolver workflows.
      - `payload.repository`: target repo
      - `payload.task.git.startingBranch`: PR head branch
+     - `payload.task.git.branch`: PR head branch
      - `payload.task.publish.mode`: `none`
      - `payload.task.skill.name`: `pr-resolver`
      - `payload.task.inputs`: `{ repo, pr, branch, mergeMethod, maxIterations }`
    - Submit via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
 4. Write one summary artifact at `batch_pr_resolver_result.json` under the managed session artifact spool path when available, otherwise under the configured `--artifacts-dir`.
-5. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
+5. If submission errors occur, write `skill_outcome.json` with `status: "failed"` and return non-zero so the parent managed run fails instead of being summarized as successful.
+6. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
 
 ## Safety constraints
 

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -515,7 +515,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -777,15 +777,35 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and any terminal skill outcome marker.
 
     A ``skill_outcome.json`` with ``status: "no_op"`` is written only when the
     run produced zero queued executions AND encountered no errors — i.e. the
     run is a deliberate no-op, not a failed-to-do-anything case. The runtime
     treats this artifact as a positive intentional-no-op signal and records
     the run as succeeded with a ``no_op`` disposition.
+
+    A ``skill_outcome.json`` with ``status: "failed"`` is written when child
+    workflow submission errors occur so the managed-session runtime cannot
+    mark the parent skill turn successful based only on assistant text.
     """
     _write_artifacts(artifacts_dir / "batch_pr_resolver_result.json", payload)
+    if payload["errors"]:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_submission_failed",
+                "failureClass": "execution_error",
+                "evidence": {
+                    "requested": payload["requested"],
+                    "created": payload["created"],
+                    "errors": payload["errors"],
+                },
+            },
+        )
+        return
     if payload["created"] == 0 and not payload["errors"]:
         _write_artifacts(
             artifacts_dir / "skill_outcome.json",

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -3,7 +3,7 @@
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
 
 Status: **Implemented** (runtime live; contract hardening in progress)
-Last updated: 2026-04-09
+Last updated: 2026-06-29
 Related:
 - [`docs/Steps/SkillSystem.md`](../Steps/SkillSystem.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
@@ -371,6 +371,24 @@ metadata:
 * `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
 * `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted
 * `metadata.attempts[]` may contain bounded attempt summaries, not raw logs
+
+### 4.4.1 Managed skill outcome markers
+
+Managed runtimes may emit a compact `skill_outcome.json` file in the current
+turn's artifact spool to make tool-like skill outcomes explicit to the runtime
+adapter. This file is local runtime evidence, not a Temporal payload; stale files
+from prior turns must be ignored.
+
+Supported schema version 1 statuses:
+
+* `no_op` declares an intentional no-op and may complete an otherwise empty
+  managed turn with `metadata.disposition = "no_op"`.
+* `failed` declares that the skill failed even if the agent later produced
+  assistant text. The adapter must return a failed `AgentRunResult`, preserving
+  the marker's `failureClass` when present and defaulting to `execution_error`.
+
+Malformed, unsupported, or stale markers must not upgrade a failed or empty
+managed turn to success.
 
 ## 4.5 Idempotency requirements
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -95,6 +95,23 @@ _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
 )
 
+
+def _redact_text(value: Any, *, max_chars: int) -> str:
+    text = str(value) if value is not None else ""
+    for pattern in _SECRET_REDACTION_PATTERNS:
+        text = pattern.sub(
+            lambda match: (
+                f"{match.group(1)}{match.group(2)}[REDACTED]"
+                if match.lastindex and match.lastindex >= 2
+                else "[REDACTED]"
+            ),
+            text,
+        )
+    if len(text) > max_chars:
+        return text[:max_chars] + "...[truncated]"
+    return text
+
+
 @dataclass(frozen=True)
 class _RolloutTurnScan:
     references_turn: bool = False
@@ -208,19 +225,7 @@ class CodexAppServerRpcClient:
 
     @staticmethod
     def _redact_trace_text(value: Any, *, max_chars: int = 500) -> str:
-        text = str(value or "")
-        for pattern in _SECRET_REDACTION_PATTERNS:
-            text = pattern.sub(
-                lambda match: (
-                    f"{match.group(1)}{match.group(2)}[REDACTED]"
-                    if match.lastindex and match.lastindex >= 2
-                    else "[REDACTED]"
-                ),
-                text,
-            )
-        if len(text) > max_chars:
-            return text[:max_chars] + "...[truncated]"
-        return text
+        return _redact_text(value, max_chars=max_chars)
 
     @classmethod
     def _trace_error_text(cls, value: Any) -> str | None:
@@ -871,19 +876,7 @@ class CodexManagedSessionRuntime:
 
     @staticmethod
     def _redact_diagnostic_text(value: Any, *, max_chars: int = _DIAGNOSTIC_TEXT_MAX_CHARS) -> str:
-        text = str(value or "")
-        for pattern in _SECRET_REDACTION_PATTERNS:
-            text = pattern.sub(
-                lambda match: (
-                    f"{match.group(1)}{match.group(2)}[REDACTED]"
-                    if match.lastindex and match.lastindex >= 2
-                    else "[REDACTED]"
-                ),
-                text,
-            )
-        if len(text) > max_chars:
-            return text[:max_chars] + "...[truncated]"
-        return text
+        return _redact_text(value, max_chars=max_chars)
 
     @classmethod
     def _diagnostic_value(cls, value: Any) -> Any:
@@ -2193,9 +2186,10 @@ class CodexManagedSessionRuntime:
                                     remaining,
                                 ),
                             )
+                            continue
                         except TimeoutError:
-                            pass
-                        continue
+                            # Expected during grace-period polling; retry until the deadline.
+                            continue
                 outcome = self._missing_turn_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -77,10 +77,13 @@ _TURN_ITEMS_PAGE_LIMIT = 200
 _TURN_ITEMS_MAX_PAGES = 20
 _EMPTY_ROLLOUT_READ_GRACE_SECONDS = 1.0
 _EMPTY_ROLLOUT_READ_RETRY_SECONDS = 0.1
+_MISSING_TURN_VISIBILITY_GRACE_SECONDS = 5.0
+_MISSING_TURN_VISIBILITY_RETRY_SECONDS = 1.0
 _SQLITE_STATE_RUNTIME_FAILURE_MARKERS: tuple[str, ...] = (
     "failed to initialize sqlite state runtime",
     "failed to initialize state runtime",
 )
+_MISSING_TURN_IDLE_EMPTY_ROLLOUT_SUBTYPE = "missing_turn_idle_empty_rollout"
 _SECRET_REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"ghp_[A-Za-z0-9_]{20,}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
@@ -125,6 +128,11 @@ class _TurnTerminalOutcome:
     error_text: str | None = None
     failure_class: str | None = None
     disposition: str | None = None
+
+@dataclass(frozen=True)
+class _ThreadRecoveryResult:
+    vendor_thread_id: str
+    fallback_started: bool = False
 
 _SKILL_OUTCOME_FILENAME = "skill_outcome.json"
 _SKILL_OUTCOME_SCHEMA_VERSION = 1
@@ -199,7 +207,40 @@ class CodexAppServerRpcClient:
         return list(self._trace)
 
     @staticmethod
-    def _message_summary(message: Mapping[str, Any]) -> dict[str, Any]:
+    def _redact_trace_text(value: Any, *, max_chars: int = 500) -> str:
+        text = str(value or "")
+        for pattern in _SECRET_REDACTION_PATTERNS:
+            text = pattern.sub(
+                lambda match: (
+                    f"{match.group(1)}{match.group(2)}[REDACTED]"
+                    if match.lastindex and match.lastindex >= 2
+                    else "[REDACTED]"
+                ),
+                text,
+            )
+        if len(text) > max_chars:
+            return text[:max_chars] + "...[truncated]"
+        return text
+
+    @classmethod
+    def _trace_error_text(cls, value: Any) -> str | None:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return cls._redact_trace_text(normalized) if normalized else None
+        if isinstance(value, Mapping):
+            for field_name in ("message", "error", "reason", "detail"):
+                recovered = cls._trace_error_text(value.get(field_name))
+                if recovered:
+                    return recovered
+        if isinstance(value, list):
+            for item in value:
+                recovered = cls._trace_error_text(item)
+                if recovered:
+                    return recovered
+        return None
+
+    @classmethod
+    def _message_summary(cls, message: Mapping[str, Any]) -> dict[str, Any]:
         summary: dict[str, Any] = {}
         method = str(message.get("method") or "").strip()
         if method:
@@ -207,14 +248,22 @@ class CodexAppServerRpcClient:
         raw_id = message.get("id")
         if isinstance(raw_id, int):
             summary["id"] = raw_id
-        if "error" in message:
-            summary["hasError"] = True
         result = message.get("result")
         if isinstance(result, Mapping):
             summary["resultKeys"] = sorted(str(key) for key in result.keys())[:12]
         params = message.get("params")
         if isinstance(params, Mapping):
             summary["paramKeys"] = sorted(str(key) for key in params.keys())[:12]
+        if "error" in message:
+            error = message.get("error")
+            summary["hasError"] = True
+            if isinstance(error, Mapping):
+                code = error.get("code")
+                if isinstance(code, (int, float, str)):
+                    summary["errorCode"] = code
+            error_text = cls._trace_error_text(error)
+            if error_text:
+                summary["errorMessage"] = error_text
         return summary
 
     def _ensure_started(self) -> None:
@@ -458,6 +507,9 @@ class CodexManagedSessionRuntime:
         container_id: str,
         app_server_command: Sequence[str] = ("codex", "app-server"),
         turn_completion_timeout_seconds: float = _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS,
+        missing_turn_visibility_grace_seconds: float = (
+            _MISSING_TURN_VISIBILITY_GRACE_SECONDS
+        ),
     ) -> None:
         self._workspace_path = Path(workspace_path)
         self._session_workspace_path = Path(session_workspace_path)
@@ -471,6 +523,10 @@ class CodexManagedSessionRuntime:
         self._container_id = container_id
         self._app_server_command = tuple(app_server_command)
         self._turn_completion_timeout_seconds = turn_completion_timeout_seconds
+        self._missing_turn_visibility_grace_seconds = max(
+            0.0,
+            float(missing_turn_visibility_grace_seconds),
+        )
         self._client: CodexAppServerRpcClient | None = None
 
     @property
@@ -1976,25 +2032,51 @@ class CodexManagedSessionRuntime:
             return turn
         return None
 
+    @classmethod
+    def _is_missing_turn_idle_empty_rollout(
+        cls,
+        *,
+        thread_payload: Mapping[str, Any],
+        rollout_scan: _RolloutTurnScan,
+        vendor_turn_id: str,
+    ) -> bool:
+        if cls._find_turn_payload(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        ) is not None:
+            return False
+        thread_outcome = cls._terminal_thread_outcome(thread_payload)
+        if thread_outcome is None or thread_outcome.status != "completed":
+            return False
+        return (
+            rollout_scan.entries_scanned == 0
+            and not rollout_scan.references_turn
+            and not rollout_scan.saw_task_complete
+            and not rollout_scan.assistant_text
+            and not rollout_scan.error_text
+        )
+
     def _missing_turn_terminal_outcome(
         self,
         *,
         state: CodexSessionRuntimeState,
         thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
+        rollout_scan: _RolloutTurnScan | None = None,
     ) -> _TurnTerminalOutcome | None:
         thread_outcome = self._terminal_thread_outcome(thread_payload)
         if thread_outcome is not None and thread_outcome.status != "completed":
             return thread_outcome
 
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        rollout_scan = self._scan_rollout_for_turn(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-        )
+        if rollout_scan is None:
+            vendor_thread_path = self._resolved_rollout_path(
+                state=state,
+                thread_payload=thread_payload,
+            )
+            rollout_scan = self._scan_rollout_for_turn(
+                vendor_thread_path,
+                vendor_turn_id=vendor_turn_id,
+            )
         rollout_outcome = self._rollout_terminal_outcome_from_scan(
             rollout_scan,
             vendor_turn_id=vendor_turn_id,
@@ -2021,9 +2103,11 @@ class CodexManagedSessionRuntime:
         vendor_thread_id: str,
         vendor_turn_id: str,
         rollout_mirror: _RolloutLiveMirror,
+        thread_started_after_recovery_fallback: bool = False,
     ) -> tuple[Mapping[str, Any], _TurnTerminalOutcome]:
         deadline = time.monotonic() + self._turn_completion_timeout_seconds
         empty_rollout_first_seen_at: float | None = None
+        missing_turn_first_seen_at: float | None = None
         while True:
             try:
                 thread_payload = client.request(
@@ -2067,18 +2151,60 @@ class CodexManagedSessionRuntime:
                 vendor_turn_id=vendor_turn_id,
             )
             if isinstance(turn_payload, Mapping):
+                missing_turn_first_seen_at = None
                 outcome = self._terminal_turn_outcome(turn_payload)
                 if outcome is not None:
                     return thread_payload, outcome
             else:
                 state = self._load_state()
+                vendor_thread_path = self._resolved_rollout_path(
+                    state=state,
+                    thread_payload=thread_payload,
+                )
+                rollout_scan = self._scan_rollout_for_turn(
+                    vendor_thread_path,
+                    vendor_turn_id=vendor_turn_id,
+                    turn_started_at=state.last_control_at,
+                )
+                if (
+                    thread_started_after_recovery_fallback
+                    and self._missing_turn_visibility_grace_seconds > 0
+                    and self._is_missing_turn_idle_empty_rollout(
+                        thread_payload=thread_payload,
+                        rollout_scan=rollout_scan,
+                        vendor_turn_id=vendor_turn_id,
+                    )
+                ):
+                    now = time.monotonic()
+                    if missing_turn_first_seen_at is None:
+                        missing_turn_first_seen_at = now
+                    grace_remaining = (
+                        self._missing_turn_visibility_grace_seconds
+                        - (now - missing_turn_first_seen_at)
+                    )
+                    remaining = deadline - now
+                    if grace_remaining > 0 and remaining > 0:
+                        try:
+                            client.wait_for_notification(
+                                None,
+                                timeout_seconds=min(
+                                    _MISSING_TURN_VISIBILITY_RETRY_SECONDS,
+                                    grace_remaining,
+                                    remaining,
+                                ),
+                            )
+                        except TimeoutError:
+                            pass
+                        continue
                 outcome = self._missing_turn_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,
                     vendor_turn_id=vendor_turn_id,
+                    rollout_scan=rollout_scan,
                 )
                 if outcome is not None:
                     return thread_payload, outcome
+                missing_turn_first_seen_at = None
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -2130,13 +2256,13 @@ class CodexManagedSessionRuntime:
         normalized = message.lower()
         return "rollout at " in normalized and " is empty" in normalized
 
-    def _recovery_thread(
+    def _recovery_thread_result(
         self,
         *,
         client: CodexAppServerRpcClient,
         state: CodexSessionRuntimeState,
         allow_fallback_start: bool = True,
-    ) -> str:
+    ) -> _ThreadRecoveryResult:
         existing_thread_path = self._existing_thread_path(state.vendor_thread_path)
         discovered_thread_path = None
         if existing_thread_path is None:
@@ -2188,6 +2314,7 @@ class CodexManagedSessionRuntime:
                     {"cwd": str(self._workspace_path)},
                 )
                 thread_payload = started.get("thread")
+                fallback_started = True
                 if not isinstance(thread_payload, Mapping):
                     raise RuntimeError(
                         "codex app-server thread/start did not return a thread"
@@ -2202,7 +2329,23 @@ class CodexManagedSessionRuntime:
         state.vendor_thread_path = self._normalized_thread_path(
             recovered_thread_path or thread_payload.get("path")
         )
-        return vendor_thread_id
+        return _ThreadRecoveryResult(
+            vendor_thread_id=vendor_thread_id,
+            fallback_started=fallback_started,
+        )
+
+    def _recovery_thread(
+        self,
+        *,
+        client: CodexAppServerRpcClient,
+        state: CodexSessionRuntimeState,
+        allow_fallback_start: bool = True,
+    ) -> str:
+        return self._recovery_thread_result(
+            client=client,
+            state=state,
+            allow_fallback_start=allow_fallback_start,
+        ).vendor_thread_id
 
     @classmethod
     def _terminal_turn_outcome(
@@ -2447,7 +2590,8 @@ class CodexManagedSessionRuntime:
     ) -> CodexManagedSessionTurnResponse:
         state = self._validate_locator(request)
         client = self._initialized_app_server_client()
-        vendor_thread_id = self._recovery_thread(client=client, state=state)
+        thread_recovery = self._recovery_thread_result(client=client, state=state)
+        vendor_thread_id = thread_recovery.vendor_thread_id
         rollout_mirror = self._new_rollout_live_mirror(state)
 
         started = client.request(
@@ -2488,6 +2632,9 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=vendor_thread_id,
                 vendor_turn_id=vendor_turn_id,
                 rollout_mirror=rollout_mirror,
+                thread_started_after_recovery_fallback=(
+                    thread_recovery.fallback_started
+                ),
             )
             status = outcome.status
             error_text = outcome.error_text
@@ -2584,6 +2731,14 @@ class CodexManagedSessionRuntime:
                     )
                 metadata["failureCause"] = EMPTY_ASSISTANT_FAILURE_CAUSE
                 metadata["retryRecommendedAction"] = "clear_session"
+                if self._is_missing_turn_idle_empty_rollout(
+                    thread_payload=thread_payload,
+                    rollout_scan=evidence_rollout_scan,
+                    vendor_turn_id=vendor_turn_id,
+                ):
+                    metadata["failureSubtype"] = (
+                        _MISSING_TURN_IDLE_EMPTY_ROLLOUT_SUBTYPE
+                    )
                 metadata["turnFailureEvidence"] = self._turn_failure_evidence(
                     reason=error_text,
                     state=state,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -139,6 +139,7 @@ class _TurnTerminalOutcome:
     ``disposition`` carries a positive intentional-no-op signal from the
     skill. When set (currently only ``"no_op"``), ``status`` MUST be
     ``"completed"`` and ``error_text`` carries the skill-declared reason.
+    Failed skill outcomes use ``status="failed"`` and ``failure_class``.
     """
 
     status: str
@@ -1788,17 +1789,17 @@ class CodexManagedSessionRuntime:
     ) -> dict[str, Any] | None:
         """Read the optional skill-declared outcome file from the spool.
 
-        Returns the parsed object only when it is a valid no-op declaration
-        produced during the current turn: single JSON object,
-        ``schema_version == 1``, ``status == "no_op"``, and file ``mtime``
+        Returns the parsed object only when it is a valid declaration produced
+        during the current turn: single JSON object, ``schema_version == 1``,
+        supported ``status`` (``"no_op"`` or ``"failed"``), and file ``mtime``
         at or after ``turn_started_at`` (minus a small skew tolerance for
-        filesystem granularity). ``send_turn`` removes any pre-existing
-        marker at turn start; this freshness check is defense in depth.
+        filesystem granularity). ``send_turn`` removes any pre-existing marker
+        at turn start; this freshness check is defense in depth.
 
-        Any other shape (missing file, malformed JSON, wrong version, other
-        status, stale mtime, or no turn-start timestamp) returns ``None`` so
-        the caller falls back to default classification. A malformed or
-        stale declaration cannot upgrade a failure to a success.
+        Any other shape (missing file, malformed JSON, wrong version,
+        unsupported status, stale mtime, or no turn-start timestamp) returns
+        ``None`` so the caller falls back to default classification. A
+        malformed or stale declaration cannot upgrade a failure to a success.
         """
         if turn_started_at is None:
             return None
@@ -1824,9 +1825,23 @@ class CodexManagedSessionRuntime:
             return None
         if payload.get("schema_version") != _SKILL_OUTCOME_SCHEMA_VERSION:
             return None
-        if payload.get("status") != "no_op":
+        if payload.get("status") not in {"no_op", "failed"}:
             return None
         return payload
+
+    def _failed_skill_outcome_terminal(
+        self,
+        outcome: Mapping[str, Any] | None,
+    ) -> _TurnTerminalOutcome | None:
+        if outcome is None or outcome.get("status") != "failed":
+            return None
+        reason = str(outcome.get("reason") or "").strip()
+        failure_class = str(outcome.get("failureClass") or "").strip()
+        return _TurnTerminalOutcome(
+            status="failed",
+            error_text=reason or "skill declared failed",
+            failure_class=failure_class or "execution_error",
+        )
 
     def _rollout_terminal_outcome_from_scan(
         self,
@@ -1841,6 +1856,10 @@ class CodexManagedSessionRuntime:
                 error_text=scan.error_text,
                 failure_class="permanent",
             )
+        skill_outcome = self._read_skill_outcome(turn_started_at=turn_started_at)
+        failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+        if failed_outcome is not None:
+            return failed_outcome
         if scan.assistant_text:
             return _TurnTerminalOutcome(status="completed")
         if scan.saw_task_complete:
@@ -1854,11 +1873,10 @@ class CodexManagedSessionRuntime:
                     error_text=recovered_error,
                     failure_class="permanent",
                 )
-            no_op = self._read_skill_outcome(turn_started_at=turn_started_at)
-            if no_op is not None:
+            if skill_outcome is not None and skill_outcome.get("status") == "no_op":
                 return _TurnTerminalOutcome(
                     status="completed",
-                    error_text=str(no_op.get("reason") or "").strip() or None,
+                    error_text=str(skill_outcome.get("reason") or "").strip() or None,
                     disposition="no_op",
                 )
         return None
@@ -1888,11 +1906,14 @@ class CodexManagedSessionRuntime:
         )
         if rollout_outcome is not None:
             return rollout_outcome
-        no_op = self._read_skill_outcome(turn_started_at=state.last_control_at)
-        if no_op is not None:
+        skill_outcome = self._read_skill_outcome(turn_started_at=state.last_control_at)
+        failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+        if failed_outcome is not None:
+            return failed_outcome
+        if skill_outcome is not None and skill_outcome.get("status") == "no_op":
             return _TurnTerminalOutcome(
                 status="completed",
-                error_text=str(no_op.get("reason") or "").strip() or None,
+                error_text=str(skill_outcome.get("reason") or "").strip() or None,
                 disposition="no_op",
             )
         return _TurnTerminalOutcome(
@@ -2691,7 +2712,16 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
-            if not assistant_text:
+            skill_outcome = self._read_skill_outcome(
+                turn_started_at=state.last_control_at
+            )
+            failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+            if failed_outcome is not None:
+                status = failed_outcome.status
+                error_text = failed_outcome.error_text
+                failure_class = failed_outcome.failure_class
+                assistant_text = ""
+            elif not assistant_text:
                 empty_outcome = self._completed_turn_without_assistant_outcome(
                     state=state,
                     thread_payload=thread_payload,

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -11,6 +11,7 @@ def write_fake_app_server(
     completion_notification_method: str | None = "turn/completed",
     complete_turn_on_read: bool = True,
     omit_turns_on_read: bool = False,
+    omit_turns_on_initial_reads: int = 0,
     omit_turns_when_incomplete: bool = False,
     assistant_text: str = "OK",
     thread_status_type: str = "idle",
@@ -65,6 +66,7 @@ START_THREAD_PATH = __START_THREAD_PATH__
 COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
 COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
 OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
+OMIT_TURNS_ON_INITIAL_READS = __OMIT_TURNS_ON_INITIAL_READS__
 OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
@@ -296,7 +298,10 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
-        should_omit_turns = OMIT_TURNS_ON_READ and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
+        should_omit_turns = (
+            (OMIT_TURNS_ON_READ or thread_read_attempts <= OMIT_TURNS_ON_INITIAL_READS)
+            and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
+        )
         turns = []
         preview = ""
         if not should_omit_turns:
@@ -375,6 +380,7 @@ __COMPLETION_BLOCK__
             "True" if complete_turn_on_read else "False",
         )
         .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
+        .replace("__OMIT_TURNS_ON_INITIAL_READS__", repr(omit_turns_on_initial_reads))
         .replace(
             "__OMIT_TURNS_WHEN_INCOMPLETE__",
             "True" if omit_turns_when_incomplete else "False",

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -182,6 +182,8 @@ def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
 
     # Each child carries publish.mode=none and a stable idempotency key.
     for body in _FakeAsyncClient.submissions:
+        assert body["payload"]["task"]["git"]["branch"].startswith("dependabot/")
+        assert "targetBranch" not in body["payload"]["task"]["git"]
         assert body["payload"]["task"]["publish"]["mode"] == "none"
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
         assert "version" not in body["payload"]["task"]["skill"]

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1184,6 +1184,49 @@ def test_runtime_no_op_signal_ignored_when_assistant_text_present(
     assert response.status == "completed"
     assert "disposition" not in response.metadata
 
+def test_runtime_failed_skill_outcome_overrides_assistant_text(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="all done",
+        skill_outcome_path=_spool_skill_outcome_path(request),
+        skill_outcome_payload={
+            "schema_version": 1,
+            "status": "failed",
+            "reason": "child_workflow_submission_failed",
+            "failureClass": "execution_error",
+            "evidence": {"created": 0, "errors": [{"error": "422"}]},
+        },
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["failureClass"] == "execution_error"
+    assert response.metadata["reason"] == "child_workflow_submission_failed"
+    assert "disposition" not in response.metadata
+
 def test_runtime_no_op_signal_ignored_when_schema_version_wrong(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -338,6 +338,24 @@ def test_runtime_send_turn_returns_terminal_completed_response(
     assert handle.session_state.active_turn_id is None
     assert handle.metadata["lastAssistantText"] == "OK"
 
+
+def test_app_server_rpc_trace_summary_includes_redacted_error_message() -> None:
+    summary = CodexAppServerRpcClient._message_summary(
+        {
+            "id": 6,
+            "error": {
+                "code": -32600,
+                "message": "failed to read rollout with token=supersecret",
+            },
+        }
+    )
+
+    assert summary["hasError"] is True
+    assert summary["errorCode"] == -32600
+    assert summary["errorMessage"] == "failed to read rollout with token=[REDACTED]"
+    assert "supersecret" not in summary["errorMessage"]
+
+
 def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     tmp_path: Path,
 ) -> None:
@@ -2682,6 +2700,121 @@ def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_n
     )
     assert updated_state["vendorThreadId"] == "vendor-thread-2"
     assert "vendorThreadPath" not in updated_state
+
+
+def test_runtime_send_turn_waits_for_fallback_started_turn_visibility(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "06"
+        / "28"
+        / "rollout-2026-06-28T13-46-25-vendor-thread-2.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=str(transcript_path),
+        omit_turns_on_initial_reads=1,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        missing_turn_visibility_grace_seconds=1.0,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata["assistantText"] == "OK"
+    state_payload = json.loads(
+        (
+            Path(request.session_workspace_path)
+            / ".moonmind-codex-session-state.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert state_payload["vendorThreadId"] == "vendor-thread-2"
+    assert state_payload["lastTurnStatus"] == "completed"
+    stderr_path = Path(request.artifact_spool_path) / "stderr.log"
+    assert not stderr_path.exists() or "turn failed:" not in stderr_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_runtime_send_turn_marks_missing_fallback_turn_subtype_after_grace(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "06"
+        / "28"
+        / "rollout-2026-06-28T13-46-25-vendor-thread-2.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True)
+    transcript_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=str(transcript_path),
+        omit_turns_on_read=True,
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        missing_turn_visibility_grace_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["failureCause"] == "app_server_protocol_empty_turn"
+    assert (
+        response.metadata["failureSubtype"]
+        == "missing_turn_idle_empty_rollout"
+    )
+    evidence = response.metadata["turnFailureEvidence"]
+    assert evidence["threadPayloadSummary"]["turnCount"] == 0
+    assert evidence["rolloutScan"]["entriesScanned"] == 0
 
 
 def test_runtime_send_turn_starts_new_thread_when_rollout_recovery_file_is_empty(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -356,6 +356,13 @@ def test_app_server_rpc_trace_summary_includes_redacted_error_message() -> None:
     assert "supersecret" not in summary["errorMessage"]
 
 
+def test_redaction_preserves_falsy_non_none_values() -> None:
+    assert CodexAppServerRpcClient._redact_trace_text(0) == "0"
+    assert CodexAppServerRpcClient._redact_trace_text(False) == "False"
+    assert CodexManagedSessionRuntime._redact_diagnostic_text(0) == "0"
+    assert CodexManagedSessionRuntime._redact_diagnostic_text(False) == "False"
+
+
 def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -255,7 +255,8 @@ def test_build_queue_request_child_payload_shape() -> None:
         "maxIterations": 3,
     }
     assert task["git"]["startingBranch"] == "dependabot/pip/anthropic-0.107.1"
-    assert task["git"]["targetBranch"] == "dependabot/pip/anthropic-0.107.1"
+    assert task["git"]["branch"] == "dependabot/pip/anthropic-0.107.1"
+    assert "targetBranch" not in task["git"]
     assert task["publish"]["mode"] == "none"
     assert task["runtime"]["mode"] == "codex"
     assert payload["targetRuntime"] == "codex"
@@ -420,7 +421,7 @@ def test_write_run_artifacts_skips_no_op_on_dry_run(tmp_path: Path) -> None:
     assert not (tmp_path / "skill_outcome.json").exists()
 
 
-def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
+def test_write_run_artifacts_emits_failed_outcome_on_errors(tmp_path: Path) -> None:
     module = _load_module()
     payload = {
         "dryRun": False,
@@ -432,7 +433,12 @@ def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
         "errors": [{"pr": 9, "branch": "dependabot/pip/x", "error": "boom"}],
     }
     module["_write_run_artifacts"](tmp_path, payload)
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_submission_failed"
+    assert outcome["failureClass"] == "execution_error"
+    assert outcome["evidence"]["matched"] is None
+    assert outcome["evidence"]["errors"] == payload["errors"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -106,7 +106,8 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["title"] == "feature/example"
     assert task["publish"]["mode"] == "none"
     assert git["startingBranch"] == "feature/example"
-    assert git["targetBranch"] == "feature/example"
+    assert git["branch"] == "feature/example"
+    assert "targetBranch" not in git
 
 def test_build_queue_request_adds_batch_scoped_idempotency_key() -> None:
     module = _load_module()
@@ -840,8 +841,8 @@ def test_write_run_artifacts_emits_no_op_when_zero_queued_no_errors(tmp_path: Pa
     assert outcome["evidence"]["requested"] == 3
     assert outcome["evidence"]["skipped"][0]["pr"] == 1
 
-def test_write_run_artifacts_skips_no_op_when_errors_present(tmp_path: Path) -> None:
-    """A run that hit submission errors must NOT declare itself a no-op."""
+def test_write_run_artifacts_emits_failed_outcome_when_errors_present(tmp_path: Path) -> None:
+    """A run that hit submission errors must declare a failed skill outcome."""
     module = _load_module()
     write = module["_write_run_artifacts"]
 
@@ -860,7 +861,12 @@ def test_write_run_artifacts_skips_no_op_when_errors_present(tmp_path: Path) -> 
     write(tmp_path, payload)
 
     assert (tmp_path / "batch_pr_resolver_result.json").exists()
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_submission_failed"
+    assert outcome["failureClass"] == "execution_error"
+    assert outcome["evidence"]["created"] == 0
+    assert outcome["evidence"]["errors"] == payload["errors"]
 
 def test_write_run_artifacts_skips_no_op_when_executions_queued(tmp_path: Path) -> None:
     """When real work was queued, no skill_outcome.json is written."""

--- a/tests/unit/tools/test_check_removed_capability_semantics.py
+++ b/tests/unit/tools/test_check_removed_capability_semantics.py
@@ -112,6 +112,15 @@ def test_guard_excludes_transient_artifacts(tmp_path: Path) -> None:
     assert check_removed_capability_semantics(tmp_path) == []
 
 
+def test_guard_excludes_deploy_state_runtime_files(tmp_path: Path) -> None:
+    desired_state = tmp_path / "deploy" / "state" / "desired-state.json"
+    desired_state.parent.mkdir(parents=True)
+    desired_state.write_text(_old_camel(), encoding="utf-8")
+
+    assert list(iter_scanned_files(tmp_path)) == []
+    assert check_removed_capability_semantics(tmp_path) == []
+
+
 def test_guard_excludes_local_skill_overlay(tmp_path: Path) -> None:
     local_skill = tmp_path / ".agents" / "skills" / "local" / "private" / "SKILL.md"
     local_skill.parent.mkdir(parents=True)

--- a/tools/check_removed_capability_semantics.py
+++ b/tools/check_removed_capability_semantics.py
@@ -103,6 +103,10 @@ EXCLUDED_DIR_NAMES = {
     "var",
 }
 
+EXCLUDED_RELATIVE_PREFIXES = {
+    ("deploy", "state"),
+}
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -118,6 +122,8 @@ def _is_scanned_file(path: Path, root: Path) -> bool:
     except ValueError:
         return False
     if any(part in EXCLUDED_DIR_NAMES for part in relative.parts):
+        return False
+    if any(relative.parts[: len(prefix)] == prefix for prefix in EXCLUDED_RELATIVE_PREFIXES):
         return False
     if relative.parts[:3] == (".agents", "skills", "local"):
         return False


### PR DESCRIPTION
## Summary

- Update `batch-pr-resolver` and `batch-dependabot-resolver` to submit child workflow payloads with canonical `task.git.branch` instead of rejected legacy `targetBranch`.
- Emit failed `skill_outcome.json` markers when child workflow submission fails, and make Codex managed sessions treat those markers as terminal failures even if assistant text claims success.
- Exclude ignored `deploy/state` runtime files from the removed-capability static guard so root-owned local deployment state does not break unit-test workflows.

## Root Cause

The batch Dependabot run generated `pr-resolver` child submissions with `task.git.targetBranch`. The current `/api/executions` task-shaped contract rejects that field with 422, but the parent run could still be summarized as successful after later manual correction. The runtime did not have a failed skill outcome marker that could override assistant success text.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/test_batch_pr_resolver.py tests/unit/test_batch_dependabot_resolver.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/tools/test_check_removed_capability_semantics.py`
- `uv run python -m pytest tests/integration/skills/test_batch_dependabot_resolver_e2e.py -q --tb=short`
- `git diff --check`

## Notes

`deploy/state/desired-state.json` is already ignored by `.gitignore`; the disruption came from the static guard walking the raw filesystem instead of excluding that ignored runtime state path.