### PR TITLE
[codex] Fix batch resolver child workflow payloads

### DIFF
--- a/.agents/skills/batch-dependabot-resolver/SKILL.md
+++ b/.agents/skills/batch-dependabot-resolver/SKILL.md
@@ -81,7 +81,7 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
 
 4. For each matched PR, submit a `pr-resolver` task with the canonical `batch-pr-resolver`
    payload (`repository`, `task.inputs = { repo, pr, branch, mergeMethod, maxIterations }`,
-   `task.git.startingBranch/targetBranch`, `task.skill.name = pr-resolver`,
+   `task.git.startingBranch/branch`, `task.skill.name = pr-resolver`,
    `task.publish.mode = none`, inherited runtime) and a stable idempotency key:
    `batch-dependabot-resolver:{repo}:pr:{number}:head:{headSha}`. Submit via
    `POST /api/executions` (`MOONMIND_URL` must point at the MoonMind API).
@@ -90,7 +90,8 @@ python3 .agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.p
    session artifact spool when available, otherwise the configured `--artifacts-dir`) listing
    discovered PRs, matched count, queued / would-queue resolver workflows, skipped PRs with
    reasons, and submission errors. A deliberate zero-match run also writes
-   `skill_outcome.json` with `status: "no_op"`.
+   `skill_outcome.json` with `status: "no_op"`. A run with submission errors writes
+   `skill_outcome.json` with `status: "failed"` and returns non-zero.
 
 6. Print a short summary to stdout (`matched`, `queued`, `would_queue`, `skipped`, `errors`).
 

--- a/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
+++ b/.agents/skills/batch-dependabot-resolver/bin/batch_dependabot_resolver.py
@@ -621,7 +621,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -842,14 +842,35 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and any terminal skill outcome marker.
 
     ``skill_outcome.json`` with ``status: "no_op"`` is written only when the run
     queued zero executions, hit no submission errors, and was not a dry run —
     i.e. a deliberate "no matching Dependabot PRs" outcome.
+
+    ``skill_outcome.json`` with ``status: "failed"`` is written when child
+    workflow submission errors occur so the managed-session runtime cannot
+    mark the parent skill turn successful based only on assistant text.
     """
 
     _write_artifacts(artifacts_dir / "batch_dependabot_resolver_result.json", payload)
+    if payload.get("errors"):
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_submission_failed",
+                "failureClass": "execution_error",
+                "evidence": {
+                    "requested": payload.get("requested"),
+                    "matched": payload.get("matched"),
+                    "created": payload.get("created"),
+                    "errors": payload.get("errors"),
+                },
+            },
+        )
+        return
     if (
         payload.get("created") == 0
         and not payload.get("errors")

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -69,13 +69,15 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      - `payload.idempotencyKey`: stable per parent batch run and PR, hash-backed and capped to the execution persistence limit, so rerunning the same batch task does not create duplicate resolver workflows.
      - `payload.repository`: target repo
      - `payload.task.git.startingBranch`: PR head branch
+     - `payload.task.git.branch`: PR head branch
      - `payload.task.publish.mode`: `none`
      - `payload.task.skill.name`: `pr-resolver`
      - `payload.task.inputs`: `{ repo, pr, branch, mergeMethod, maxIterations }`
    - Submit via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
 4. Write one summary artifact at `batch_pr_resolver_result.json` under the managed session artifact spool path when available, otherwise under the configured `--artifacts-dir`.
-5. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
+5. If submission errors occur, write `skill_outcome.json` with `status: "failed"` and return non-zero so the parent managed run fails instead of being summarized as successful.
+6. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
 
 ## Safety constraints
 

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -515,7 +515,7 @@ def _build_queue_request(
             },
             "git": {
                 "startingBranch": branch,
-                "targetBranch": branch,
+                "branch": branch,
             },
             "publish": {"mode": publish_mode},
         },
@@ -777,15 +777,35 @@ def _write_artifacts(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 def _write_run_artifacts(artifacts_dir: Path, payload: dict[str, Any]) -> None:
-    """Write the result payload and (when applicable) the no-op outcome file.
+    """Write the result payload and any terminal skill outcome marker.
 
     A ``skill_outcome.json`` with ``status: "no_op"`` is written only when the
     run produced zero queued executions AND encountered no errors — i.e. the
     run is a deliberate no-op, not a failed-to-do-anything case. The runtime
     treats this artifact as a positive intentional-no-op signal and records
     the run as succeeded with a ``no_op`` disposition.
+
+    A ``skill_outcome.json`` with ``status: "failed"`` is written when child
+    workflow submission errors occur so the managed-session runtime cannot
+    mark the parent skill turn successful based only on assistant text.
     """
     _write_artifacts(artifacts_dir / "batch_pr_resolver_result.json", payload)
+    if payload["errors"]:
+        _write_artifacts(
+            artifacts_dir / "skill_outcome.json",
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_submission_failed",
+                "failureClass": "execution_error",
+                "evidence": {
+                    "requested": payload["requested"],
+                    "created": payload["created"],
+                    "errors": payload["errors"],
+                },
+            },
+        )
+        return
     if payload["created"] == 0 and not payload["errors"]:
         _write_artifacts(
             artifacts_dir / "skill_outcome.json",

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -3,7 +3,7 @@
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
 
 Status: **Implemented** (runtime live; contract hardening in progress)
-Last updated: 2026-04-09
+Last updated: 2026-06-29
 Related:
 - [`docs/Steps/SkillSystem.md`](../Steps/SkillSystem.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
@@ -371,6 +371,24 @@ metadata:
 * `metadata.hitRateLimit = true` if any attempt hit a provider rate limit
 * `metadata.exhaustedRateLimitRetries = true` if backoff retries were exhausted
 * `metadata.attempts[]` may contain bounded attempt summaries, not raw logs
+
+### 4.4.1 Managed skill outcome markers
+
+Managed runtimes may emit a compact `skill_outcome.json` file in the current
+turn's artifact spool to make tool-like skill outcomes explicit to the runtime
+adapter. This file is local runtime evidence, not a Temporal payload; stale files
+from prior turns must be ignored.
+
+Supported schema version 1 statuses:
+
+* `no_op` declares an intentional no-op and may complete an otherwise empty
+  managed turn with `metadata.disposition = "no_op"`.
+* `failed` declares that the skill failed even if the agent later produced
+  assistant text. The adapter must return a failed `AgentRunResult`, preserving
+  the marker's `failureClass` when present and defaulting to `execution_error`.
+
+Malformed, unsupported, or stale markers must not upgrade a failed or empty
+managed turn to success.
 
 ## 4.5 Idempotency requirements
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -139,6 +139,7 @@ class _TurnTerminalOutcome:
     ``disposition`` carries a positive intentional-no-op signal from the
     skill. When set (currently only ``"no_op"``), ``status`` MUST be
     ``"completed"`` and ``error_text`` carries the skill-declared reason.
+    Failed skill outcomes use ``status="failed"`` and ``failure_class``.
     """
 
     status: str
@@ -1788,17 +1789,17 @@ class CodexManagedSessionRuntime:
     ) -> dict[str, Any] | None:
         """Read the optional skill-declared outcome file from the spool.
 
-        Returns the parsed object only when it is a valid no-op declaration
-        produced during the current turn: single JSON object,
-        ``schema_version == 1``, ``status == "no_op"``, and file ``mtime``
+        Returns the parsed object only when it is a valid declaration produced
+        during the current turn: single JSON object, ``schema_version == 1``,
+        supported ``status`` (``"no_op"`` or ``"failed"``), and file ``mtime``
         at or after ``turn_started_at`` (minus a small skew tolerance for
-        filesystem granularity). ``send_turn`` removes any pre-existing
-        marker at turn start; this freshness check is defense in depth.
+        filesystem granularity). ``send_turn`` removes any pre-existing marker
+        at turn start; this freshness check is defense in depth.
 
-        Any other shape (missing file, malformed JSON, wrong version, other
-        status, stale mtime, or no turn-start timestamp) returns ``None`` so
-        the caller falls back to default classification. A malformed or
-        stale declaration cannot upgrade a failure to a success.
+        Any other shape (missing file, malformed JSON, wrong version,
+        unsupported status, stale mtime, or no turn-start timestamp) returns
+        ``None`` so the caller falls back to default classification. A
+        malformed or stale declaration cannot upgrade a failure to a success.
         """
         if turn_started_at is None:
             return None
@@ -1824,9 +1825,23 @@ class CodexManagedSessionRuntime:
             return None
         if payload.get("schema_version") != _SKILL_OUTCOME_SCHEMA_VERSION:
             return None
-        if payload.get("status") != "no_op":
+        if payload.get("status") not in {"no_op", "failed"}:
             return None
         return payload
+
+    def _failed_skill_outcome_terminal(
+        self,
+        outcome: Mapping[str, Any] | None,
+    ) -> _TurnTerminalOutcome | None:
+        if outcome is None or outcome.get("status") != "failed":
+            return None
+        reason = str(outcome.get("reason") or "").strip()
+        failure_class = str(outcome.get("failureClass") or "").strip()
+        return _TurnTerminalOutcome(
+            status="failed",
+            error_text=reason or "skill declared failed",
+            failure_class=failure_class or "execution_error",
+        )
 
     def _rollout_terminal_outcome_from_scan(
         self,
@@ -1841,6 +1856,10 @@ class CodexManagedSessionRuntime:
                 error_text=scan.error_text,
                 failure_class="permanent",
             )
+        skill_outcome = self._read_skill_outcome(turn_started_at=turn_started_at)
+        failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+        if failed_outcome is not None:
+            return failed_outcome
         if scan.assistant_text:
             return _TurnTerminalOutcome(status="completed")
         if scan.saw_task_complete:
@@ -1854,11 +1873,10 @@ class CodexManagedSessionRuntime:
                     error_text=recovered_error,
                     failure_class="permanent",
                 )
-            no_op = self._read_skill_outcome(turn_started_at=turn_started_at)
-            if no_op is not None:
+            if skill_outcome is not None and skill_outcome.get("status") == "no_op":
                 return _TurnTerminalOutcome(
                     status="completed",
-                    error_text=str(no_op.get("reason") or "").strip() or None,
+                    error_text=str(skill_outcome.get("reason") or "").strip() or None,
                     disposition="no_op",
                 )
         return None
@@ -1888,11 +1906,14 @@ class CodexManagedSessionRuntime:
         )
         if rollout_outcome is not None:
             return rollout_outcome
-        no_op = self._read_skill_outcome(turn_started_at=state.last_control_at)
-        if no_op is not None:
+        skill_outcome = self._read_skill_outcome(turn_started_at=state.last_control_at)
+        failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+        if failed_outcome is not None:
+            return failed_outcome
+        if skill_outcome is not None and skill_outcome.get("status") == "no_op":
             return _TurnTerminalOutcome(
                 status="completed",
-                error_text=str(no_op.get("reason") or "").strip() or None,
+                error_text=str(skill_outcome.get("reason") or "").strip() or None,
                 disposition="no_op",
             )
         return _TurnTerminalOutcome(
@@ -2691,7 +2712,16 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
-            if not assistant_text:
+            skill_outcome = self._read_skill_outcome(
+                turn_started_at=state.last_control_at
+            )
+            failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+            if failed_outcome is not None:
+                status = failed_outcome.status
+                error_text = failed_outcome.error_text
+                failure_class = failed_outcome.failure_class
+                assistant_text = ""
+            elif not assistant_text:
                 empty_outcome = self._completed_turn_without_assistant_outcome(
                     state=state,
                     thread_payload=thread_payload,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -2510,21 +2510,27 @@ class CodexManagedSessionRuntime:
                 vendor_thread_id=state.vendor_thread_id,
             )
             assistant_text = completed_turn_inspection.assistant_text
-        if status == "completed" and not assistant_text:
-            empty_outcome = self._completed_turn_without_assistant_outcome(
-                state=state,
-                thread_payload=thread_payload,
-                vendor_turn_id=active_turn_id,
-                rollout_scan=(
-                    completed_turn_inspection.rollout_scan
-                    if completed_turn_inspection is not None
-                    else None
-                ),
+            disposition = None
+            skill_outcome = self._read_skill_outcome(
+                turn_started_at=state.last_control_at
             )
-            status = empty_outcome.status
-            error_text = empty_outcome.error_text
-            failure_class = empty_outcome.failure_class
-            disposition = empty_outcome.disposition
+            failed_outcome = self._failed_skill_outcome_terminal(skill_outcome)
+            if failed_outcome is not None:
+                status = failed_outcome.status
+                error_text = failed_outcome.error_text
+                failure_class = failed_outcome.failure_class
+                assistant_text = ""
+            elif not assistant_text:
+                empty_outcome = self._completed_turn_without_assistant_outcome(
+                    state=state,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=active_turn_id,
+                    rollout_scan=completed_turn_inspection.rollout_scan,
+                )
+                status = empty_outcome.status
+                error_text = empty_outcome.error_text
+                failure_class = empty_outcome.failure_class
+                disposition = empty_outcome.disposition
         else:
             disposition = None
         self._finalize_turn(

--- a/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
+++ b/tests/integration/skills/test_batch_dependabot_resolver_e2e.py
@@ -182,6 +182,8 @@ def test_end_to_end_mixed_pr_set(monkeypatch: Any, tmp_path: Path) -> None:
 
     # Each child carries publish.mode=none and a stable idempotency key.
     for body in _FakeAsyncClient.submissions:
+        assert body["payload"]["task"]["git"]["branch"].startswith("dependabot/")
+        assert "targetBranch" not in body["payload"]["task"]["git"]
         assert body["payload"]["task"]["publish"]["mode"] == "none"
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
         assert "version" not in body["payload"]["task"]["skill"]

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1184,6 +1184,49 @@ def test_runtime_no_op_signal_ignored_when_assistant_text_present(
     assert response.status == "completed"
     assert "disposition" not in response.metadata
 
+def test_runtime_failed_skill_outcome_overrides_assistant_text(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    script = write_fake_app_server(
+        tmp_path,
+        assistant_text="all done",
+        skill_outcome_path=_spool_skill_outcome_path(request),
+        skill_outcome_payload={
+            "schema_version": 1,
+            "status": "failed",
+            "reason": "child_workflow_submission_failed",
+            "failureClass": "execution_error",
+            "evidence": {"created": 0, "errors": [{"error": "422"}]},
+        },
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["failureClass"] == "execution_error"
+    assert response.metadata["reason"] == "child_workflow_submission_failed"
+    assert "disposition" not in response.metadata
+
 def test_runtime_no_op_signal_ignored_when_schema_version_wrong(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1227,6 +1227,69 @@ def test_runtime_failed_skill_outcome_overrides_assistant_text(
     assert response.metadata["reason"] == "child_workflow_submission_failed"
     assert "disposition" not in response.metadata
 
+def test_runtime_failed_skill_outcome_overrides_status_refresh_assistant_text(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    script = write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        omit_turns_on_initial_reads=2,
+        assistant_text="all done",
+        thread_status_type="running",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.0,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "running"
+    _spool_skill_outcome_path(request).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "reason": "child_workflow_submission_failed",
+                "failureClass": "execution_error",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert handle.status == "failed"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.metadata["failureClass"] == "execution_error"
+    assert handle.metadata["lastTurnError"] == "child_workflow_submission_failed"
+    assert "lastAssistantText" not in handle.metadata
+
 def test_runtime_no_op_signal_ignored_when_schema_version_wrong(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_batch_dependabot_resolver.py
+++ b/tests/unit/test_batch_dependabot_resolver.py
@@ -255,7 +255,8 @@ def test_build_queue_request_child_payload_shape() -> None:
         "maxIterations": 3,
     }
     assert task["git"]["startingBranch"] == "dependabot/pip/anthropic-0.107.1"
-    assert task["git"]["targetBranch"] == "dependabot/pip/anthropic-0.107.1"
+    assert task["git"]["branch"] == "dependabot/pip/anthropic-0.107.1"
+    assert "targetBranch" not in task["git"]
     assert task["publish"]["mode"] == "none"
     assert task["runtime"]["mode"] == "codex"
     assert payload["targetRuntime"] == "codex"
@@ -420,7 +421,7 @@ def test_write_run_artifacts_skips_no_op_on_dry_run(tmp_path: Path) -> None:
     assert not (tmp_path / "skill_outcome.json").exists()
 
 
-def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
+def test_write_run_artifacts_emits_failed_outcome_on_errors(tmp_path: Path) -> None:
     module = _load_module()
     payload = {
         "dryRun": False,
@@ -432,7 +433,12 @@ def test_write_run_artifacts_skips_no_op_on_errors(tmp_path: Path) -> None:
         "errors": [{"pr": 9, "branch": "dependabot/pip/x", "error": "boom"}],
     }
     module["_write_run_artifacts"](tmp_path, payload)
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_submission_failed"
+    assert outcome["failureClass"] == "execution_error"
+    assert outcome["evidence"]["matched"] is None
+    assert outcome["evidence"]["errors"] == payload["errors"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -106,7 +106,8 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["title"] == "feature/example"
     assert task["publish"]["mode"] == "none"
     assert git["startingBranch"] == "feature/example"
-    assert git["targetBranch"] == "feature/example"
+    assert git["branch"] == "feature/example"
+    assert "targetBranch" not in git
 
 def test_build_queue_request_adds_batch_scoped_idempotency_key() -> None:
     module = _load_module()
@@ -840,8 +841,8 @@ def test_write_run_artifacts_emits_no_op_when_zero_queued_no_errors(tmp_path: Pa
     assert outcome["evidence"]["requested"] == 3
     assert outcome["evidence"]["skipped"][0]["pr"] == 1
 
-def test_write_run_artifacts_skips_no_op_when_errors_present(tmp_path: Path) -> None:
-    """A run that hit submission errors must NOT declare itself a no-op."""
+def test_write_run_artifacts_emits_failed_outcome_when_errors_present(tmp_path: Path) -> None:
+    """A run that hit submission errors must declare a failed skill outcome."""
     module = _load_module()
     write = module["_write_run_artifacts"]
 
@@ -860,7 +861,12 @@ def test_write_run_artifacts_skips_no_op_when_errors_present(tmp_path: Path) -> 
     write(tmp_path, payload)
 
     assert (tmp_path / "batch_pr_resolver_result.json").exists()
-    assert not (tmp_path / "skill_outcome.json").exists()
+    outcome = json.loads((tmp_path / "skill_outcome.json").read_text())
+    assert outcome["status"] == "failed"
+    assert outcome["reason"] == "child_workflow_submission_failed"
+    assert outcome["failureClass"] == "execution_error"
+    assert outcome["evidence"]["created"] == 0
+    assert outcome["evidence"]["errors"] == payload["errors"]
 
 def test_write_run_artifacts_skips_no_op_when_executions_queued(tmp_path: Path) -> None:
     """When real work was queued, no skill_outcome.json is written."""

--- a/tests/unit/tools/test_check_removed_capability_semantics.py
+++ b/tests/unit/tools/test_check_removed_capability_semantics.py
@@ -112,6 +112,15 @@ def test_guard_excludes_transient_artifacts(tmp_path: Path) -> None:
     assert check_removed_capability_semantics(tmp_path) == []
 
 
+def test_guard_excludes_deploy_state_runtime_files(tmp_path: Path) -> None:
+    desired_state = tmp_path / "deploy" / "state" / "desired-state.json"
+    desired_state.parent.mkdir(parents=True)
+    desired_state.write_text(_old_camel(), encoding="utf-8")
+
+    assert list(iter_scanned_files(tmp_path)) == []
+    assert check_removed_capability_semantics(tmp_path) == []
+
+
 def test_guard_excludes_local_skill_overlay(tmp_path: Path) -> None:
     local_skill = tmp_path / ".agents" / "skills" / "local" / "private" / "SKILL.md"
     local_skill.parent.mkdir(parents=True)

--- a/tools/check_removed_capability_semantics.py
+++ b/tools/check_removed_capability_semantics.py
@@ -103,6 +103,10 @@ EXCLUDED_DIR_NAMES = {
     "var",
 }
 
+EXCLUDED_RELATIVE_PREFIXES = {
+    ("deploy", "state"),
+}
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -118,6 +122,8 @@ def _is_scanned_file(path: Path, root: Path) -> bool:
     except ValueError:
         return False
     if any(part in EXCLUDED_DIR_NAMES for part in relative.parts):
+        return False
+    if any(relative.parts[: len(prefix)] == prefix for prefix in EXCLUDED_RELATIVE_PREFIXES):
         return False
     if relative.parts[:3] == (".agents", "skills", "local"):
         return False


### PR DESCRIPTION
## Summary
- Emit child workflow payloads with the current `task.git.branch` field instead of legacy `targetBranch`.
- Write and enforce failed skill outcome markers when batch child workflow submission fails, so these runs do not get marked completed after bad payload generation.
- Exclude ignored local `deploy/state` runtime files from the removed-capability static guard so root-owned desired-state files do not disrupt workflow/test runs.

## Root Cause
The batch resolver skills were still generating legacy task-shaped payloads with `task.git.targetBranch`. Current `/api/executions` validation rejects that field, but the managed Codex runtime could still treat a run as completed if the agent produced assistant text after the failed submissions. Separately, `tools/check_removed_capability_semantics.py` walked the raw filesystem and attempted to read ignored local deployment state under `deploy/state`, including `desired-state.json`.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/test_batch_pr_resolver.py tests/unit/test_batch_dependabot_resolver.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/tools/test_check_removed_capability_semantics.py`
- `uv run python -m pytest tests/integration/skills/test_batch_dependabot_resolver_e2e.py -q --tb=short`
- `git diff --check`