### PR TITLE
I do not want the X button to wrap to its own line for dependencies as seen in the image. I want the X button to remain to the right of the item. To m

### DIFF
--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5049,6 +5049,15 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
   overflow-wrap: anywhere;
 }
 
+#queue-dependency-list li {
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+#queue-dependency-list li > span:first-child {
+  flex: 1 1 auto;
+}
+
 :is(.queue-step-attachments-list, #queue-dependency-list) .queue-step-icon-button {
   width: 1.85rem;
   height: 1.85rem;

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -5050,7 +5050,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 }
 
 #queue-dependency-list li {
-  align-items: center;
   flex-wrap: nowrap;
 }
 


### PR DESCRIPTION
I do not want the X button to wrap to its own line for dependencies as seen in the image. I want the X button to remain to the right of the item. To make this work, I'd prefer to have the text wrap and the X button always be positioned to the right and centered vertically compared to the dependency text.