### PR TITLE
[codex] Preserve agent workspaces volume ownership

### DIFF
--- a/docs/ManagedAgents/DockerOutOfDocker.md
+++ b/docs/ManagedAgents/DockerOutOfDocker.md
@@ -508,6 +508,11 @@ The canonical shared workflow workspace remains a named volume such as:
 
 * `agent_workspaces` mounted at `/work/agent_jobs`
 
+`agent_workspaces` is a Docker-managed named volume. It does not use
+`driver_opts`, a bind-mounted `device`, or an externally precreated host path.
+Deployments that need this workspace on a dedicated data disk move Docker's
+daemon `data-root` to that disk so the volume remains under Docker ownership.
+
 Recommended layout:
 
 * `run_root = /work/agent_jobs/<agent_run_id>`

--- a/docs/ManagedAgents/DockerSidecarRuntime.md
+++ b/docs/ManagedAgents/DockerSidecarRuntime.md
@@ -135,6 +135,10 @@ MoonMind workspaces follow the canonical layout from `DockerOutOfDocker.md §10`
 - `/work/agent_jobs/<agent_run_id>/repo` is the checked-out repository.
 - `/work/agent_jobs/<agent_run_id>/artifacts/<step_id>` is the durable artifact area.
 
+`agent_workspaces` remains a Docker-managed named volume under the Docker
+daemon's data root. Do not materialize it as a bind-backed local volume; see
+`DockerOutOfDocker.md §10.1` for the storage ownership invariant.
+
 The sidecar runtime keeps this convention. The "workspace" mount in this document is `agent_workspaces` mounted at `/work/agent_jobs` in both containers; `/workspace` is shown in examples as a synonym for the per-run repo path made visible to the agent via `MOONMIND_REPO_DIR`. Deployments may choose to expose either the run root or the repo path as the agent's working directory; the invariant in §5.1 applies to whatever path is actually shared.
 
 ---

--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -102,6 +102,10 @@ The managed session container receives the shared workflow workspace volume:
 - configurable compose name: `MOONMIND_AGENT_WORKSPACES_VOLUME_NAME`
 - container mount root: `/work/agent_jobs`
 
+The backing volume is Docker-managed storage under the Docker daemon data root.
+It is not an external host bind path; data-disk deployments move Docker's
+`data-root` instead of overriding this volume with local driver bind options.
+
 The per-workflow layout under that root is:
 
 - `repo/` for the checked-out workflow repository

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -321,7 +321,7 @@ def test_agent_workspaces_volume_is_docker_managed_named_volume():
     assert volume_config.get("name") == (
         "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}"
     ), "agent_workspaces must remain the deployment-configurable named volume"
-    assert volume_config.get("external") is not True, (
+    assert not volume_config.get("external"), (
         "agent_workspaces must be created by the MoonMind compose project, not "
         "borrowed from an externally configured host path"
     )

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -309,6 +309,28 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"
 
 
+def test_agent_workspaces_volume_is_docker_managed_named_volume():
+    """agent_workspaces must stay under Docker's data root, not a host bind path."""
+    compose_data = _load_compose()
+    volumes = compose_data.get("volumes", {})
+    volume_config = volumes.get("agent_workspaces")
+    assert isinstance(
+        volume_config, dict
+    ), "agent_workspaces volume is missing from docker-compose.yaml"
+
+    assert volume_config.get("name") == (
+        "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}"
+    ), "agent_workspaces must remain the deployment-configurable named volume"
+    assert volume_config.get("external") is not True, (
+        "agent_workspaces must be created by the MoonMind compose project, not "
+        "borrowed from an externally configured host path"
+    )
+    assert "driver_opts" not in volume_config, (
+        "agent_workspaces must not configure local driver bind/device options; "
+        "place Docker on a data disk by configuring the daemon data-root"
+    )
+
+
 def test_moonmind_application_services_use_deployment_image_variable():
     """Deployment updates must be able to change the app image without YAML edits."""
     compose_path = Path("docker-compose.yaml")


### PR DESCRIPTION
## Summary

- Document that `agent_workspaces` is a Docker-managed named volume under the Docker daemon data root.
- Clarify that data-disk deployments should move Docker's `data-root` instead of binding `agent_workspaces` to a host path.
- Add a local-dev contract test that rejects external or bind-option-backed `agent_workspaces` Compose definitions.

## Why

The local deployment had drifted into a bind-backed `agent_workspaces` volume pointing outside `/mnt/data/docker`. That made `/mnt/data` partly Docker-owned and partly host-owned, which defeated the intended single Docker storage root. This PR preserves the target-state invariant in docs and tests so future changes do not recreate that shape.

## Validation

- `python3 -m pytest tests/test_local_dev.py -q --tb=short` passed.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/test_local_dev.py` was attempted, but the wrapper stopped before pytest because local deployment state `deploy/state/desired-state.json` is root-owned on this machine.