### PR TITLE
MM-1036 Add shimmer to transition status pills

### DIFF
--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -878,17 +878,21 @@ describe('Dashboard shared entry', () => {
 
     const shimmerBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"], .status-running.is-executing',
+      '.status[data-effect="shimmer-sweep"], .status-running.is-executing',
     ).join('\n');
-    expect(shimmerBlock).toContain('background-color: rgb(var(--mm-accent-2) / 0.14)');
     expect(shimmerBlock).toContain('overflow: hidden');
     expect(shimmerBlock).toContain('isolation: isolate');
     expect(shimmerBlock).not.toContain('animation-delay:');
+    const runningBackgroundBlock = cssRuleBlocks(
+      dashboardCss,
+      '.status-running[data-effect="shimmer-sweep"], .status-running.is-executing',
+    ).join('\n');
+    expect(runningBackgroundBlock).toContain('background-color: rgb(var(--mm-accent-2) / 0.14)');
 
     const sharedLightMaskBlock = cssRuleBlockMatching(
       dashboardCss,
       (rule) =>
-        rule.selector.includes('status-running') &&
+        rule.selector.includes('status') &&
         rule.selector.includes('shimmer-sweep') &&
         rule.selector.includes('::before') &&
         rule.selector.includes('::after'),
@@ -906,21 +910,21 @@ describe('Dashboard shared entry', () => {
     expect(dashboardCss).not.toMatch(/@keyframes mm-status-pill-shimmer\s*\{[\s\S]*?52%\s*\{/);
     expect(dashboardCss).toMatch(/@keyframes mm-status-pill-shimmer\s*\{[\s\S]*?0%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-start-x\)\s*var\(--mm-executing-sweep-start-y\),[\s\S]*?100%\s*\{[\s\S]*?background-position:\s*var\(--mm-executing-sweep-end-x\)\s*var\(--mm-executing-sweep-end-y\),[\s\S]*?background-size:\s*calc\(var\(--mm-executing-sweep-band-width\)\s*\*\s*var\(--mm-executing-sweep-halo-width-multiplier\)\)\s*var\(--mm-executing-sweep-band-height\),[\s\S]*?calc\(var\(--mm-executing-sweep-band-width\)\s*\*\s*var\(--mm-executing-sweep-core-width-multiplier\)\)\s*var\(--mm-executing-sweep-band-height\);/);
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\],\s*\.status-running\.is-executing[\s\S]*?animation: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status\[data-effect="shimmer-sweep"\],\s*\.status-running\.is-executing[\s\S]*?animation: none;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?background-position:\s*50% 50%,[\s\S]*?calc\(50% \+ \(var\(--mm-executing-sweep-layer-offset-x\) \/ 2\)\)\s*calc\(50% \+ \(var\(--mm-executing-sweep-layer-offset-y\) \/ 2\)\);[\s\S]*?background-size:\s*160% var\(--mm-executing-sweep-band-height\),\s*140% var\(--mm-executing-sweep-band-height\);/,
     );
     const shimmerBeforeSelector = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"]::before, .status-running.is-executing::before',
+      '.status[data-effect="shimmer-sweep"]::before, .status-running.is-executing::before',
     ).join('\n');
     expect(shimmerBeforeSelector).toContain('opacity: 0.62');
     expect(shimmerBeforeSelector).toContain('z-index: 1');
 
     const shimmerAfterBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"]::after, .status-running.is-executing::after',
+      '.status[data-effect="shimmer-sweep"]::after, .status-running.is-executing::after',
     ).join('\n');
     expect(shimmerAfterBlock).toContain('mask-composite: exclude');
     expect(shimmerAfterBlock).toContain('-webkit-mask-composite: xor');
@@ -948,7 +952,7 @@ describe('Dashboard shared entry', () => {
     const textMaskBlock = cssRuleBlockMatching(
       dashboardCss,
       (rule) =>
-        rule.selector.includes('status-running') &&
+        rule.selector.includes('status') &&
         rule.selector.includes('shimmer-sweep') &&
         rule.selector.includes('.status-letter-wave::after'),
     );
@@ -962,7 +966,7 @@ describe('Dashboard shared entry', () => {
 
     const activeLetterWaveBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave, .status-running.is-executing .status-letter-wave',
+      '.status[data-effect="shimmer-sweep"] .status-letter-wave, .status-running.is-executing .status-letter-wave',
     ).join('\n');
     expect(activeLetterWaveBlock).toContain('color: inherit');
     expect(activeLetterWaveBlock).not.toContain('color: var(--mm-executing-letter-bright)');
@@ -971,7 +975,7 @@ describe('Dashboard shared entry', () => {
     expect(activeLetterWaveBlock).not.toContain('white 50%');
     const activeGlyphBlock = cssRuleBlocks(
       dashboardCss,
-      '.status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph, .status-running.is-executing .status-letter-wave__glyph',
+      '.status[data-effect="shimmer-sweep"] .status-letter-wave__glyph, .status-running.is-executing .status-letter-wave__glyph',
     ).join('\n');
     expect(activeGlyphBlock).toContain('animation: none');
     expect(activeGlyphBlock).toContain('animation-name: mm-executing-letter-brighten');
@@ -986,10 +990,10 @@ describe('Dashboard shared entry', () => {
       /@keyframes mm-executing-letter-brighten\s*\{[\s\S]*?color:\s*var\(--mm-executing-letter-bright\);[\s\S]*?text-shadow:\s*0 0 10px var\(--mm-executing-letter-halo\);/,
     );
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\] \.status-letter-wave,\s*\.status-running\.is-executing \.status-letter-wave[\s\S]*?text-shadow: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status\[data-effect="shimmer-sweep"\] \.status-letter-wave,\s*\.status-running\.is-executing \.status-letter-wave[\s\S]*?text-shadow: none;/,
     );
     expect(dashboardCss).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-running\[data-effect="shimmer-sweep"\]::before,[\s\S]*?\.status-running\.is-executing \.status-letter-wave::after[\s\S]*?animation: none;/,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status\[data-effect="shimmer-sweep"\]::before,[\s\S]*?\.status-running\.is-executing \.status-letter-wave::after[\s\S]*?animation: none;/,
     );
     expect(dashboardCss).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.status-letter-wave__glyph\s*\{[\s\S]*?animation:\s*none !important;[\s\S]*?text-shadow:\s*none !important;[\s\S]*?filter:\s*none !important;/,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -6939,7 +6939,7 @@ export function WorkflowDetailPage({ payload }: { payload: BootPayload }) {
           <div className="toolbar-identity-row">
             <p className="page-meta">Workflow {taskId || '—'}</p>
             {execution ? (
-              <ExecutionStatusPill status={execution.rawState || execution.state || execution.status} />
+              <ExecutionStatusPill status={execution.rawState || execution.state || execution.status} enableMotion={false} />
             ) : null}
           </div>
         </div>

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -1174,22 +1174,24 @@ describe('Workflows Entrypoint', () => {
         document.querySelectorAll(
           '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
         ),
-      ).toHaveLength(2);
+      ).toHaveLength(6);
     });
 
     const activePills = document.querySelectorAll<HTMLElement>(
       '.queue-table-cell-status [data-effect="shimmer-sweep"], .queue-card-status [data-effect="shimmer-sweep"]',
     );
-    expect(activePills).toHaveLength(2);
+    expect(activePills).toHaveLength(6);
     expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'executing')).toHaveLength(2);
+    expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'planning')).toHaveLength(2);
+    expect(Array.from(activePills).filter((pill) => pill.dataset.state === 'finalizing')).toHaveLength(2);
     for (const pill of activePills) {
       const label = pill.dataset.state;
-      if (label !== 'executing') {
+      if (label !== 'executing' && label !== 'planning' && label !== 'finalizing') {
         throw new Error(`Unexpected active status pill state: ${label}`);
       }
       expect(pill.dataset.state).toBe(label);
       expect(pill.className).toContain(`is-${label}`);
-      expect(pill.className).toContain('status-running');
+      expect(pill.className).toContain(`status-${label === 'executing' ? 'running' : label}`);
       expect(pill.dataset.shimmerLabel).toBe(label);
       expect(pill.getAttribute('aria-label')).toBe(label);
       expect(pill.textContent).toBe(label);
@@ -1207,20 +1209,7 @@ describe('Workflows Entrypoint', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-490');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1035');
-
-    const planningPills = screen.getAllByText('planning');
-    expect(planningPills.length).toBeGreaterThan(0);
-    for (const pill of planningPills) {
-      expect(pill.closest('span')?.dataset.effect).toBeUndefined();
-      expect(pill.closest('span')?.className).toContain('status-planning');
-    }
-
-    const finalizingPills = screen.getAllByText('finalizing');
-    expect(finalizingPills.length).toBeGreaterThan(0);
-    for (const pill of finalizingPills) {
-      expect(pill.closest('span')?.dataset.effect).toBeUndefined();
-      expect(pill.closest('span')?.className).toContain('status-finalizing');
-    }
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1036');
 
     const waitingPills = screen.getAllByText('AWAITING DEP');
     expect(waitingPills.length).toBeGreaterThan(0);

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -2783,17 +2783,21 @@ tr[data-proposal-id].proposal-consuming td {
   border-color: rgb(var(--mm-border) / 0.75);
 }
 
-.status-running[data-effect="shimmer-sweep"],
+.status[data-effect="shimmer-sweep"],
 .status-running.is-executing {
   position: relative;
   overflow: hidden;
   isolation: isolate;
+}
+
+.status-running[data-effect="shimmer-sweep"],
+.status-running.is-executing {
   background-color: rgb(var(--mm-accent-2) / 0.14);
 }
 
-.status-running[data-effect="shimmer-sweep"]::before,
+.status[data-effect="shimmer-sweep"]::before,
 .status-running.is-executing::before,
-.status-running[data-effect="shimmer-sweep"]::after,
+.status[data-effect="shimmer-sweep"]::after,
 .status-running.is-executing::after {
   content: "";
   position: absolute;
@@ -2811,13 +2815,13 @@ tr[data-proposal-id].proposal-consuming td {
   mix-blend-mode: plus-lighter;
 }
 
-.status-running[data-effect="shimmer-sweep"]::before,
+.status[data-effect="shimmer-sweep"]::before,
 .status-running.is-executing::before {
   z-index: 1;
   opacity: 0.62;
 }
 
-.status-running[data-effect="shimmer-sweep"]::after,
+.status[data-effect="shimmer-sweep"]::after,
 .status-running.is-executing::after {
   z-index: 2;
   inset: calc(-1 * var(--mm-executing-border-glint-outset));
@@ -2835,9 +2839,9 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 @supports not (mix-blend-mode: plus-lighter) {
-  .status-running[data-effect="shimmer-sweep"]::before,
+  .status[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running[data-effect="shimmer-sweep"]::after,
+  .status[data-effect="shimmer-sweep"]::after,
   .status-running.is-executing::after {
     mix-blend-mode: screen;
   }
@@ -2872,12 +2876,12 @@ tr[data-proposal-id].proposal-consuming td {
   white-space: pre;
 }
 
-.status-running[data-effect="shimmer-sweep"] .status-letter-wave,
+.status[data-effect="shimmer-sweep"] .status-letter-wave,
 .status-running.is-executing .status-letter-wave {
   color: inherit;
 }
 
-.status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
+.status[data-effect="shimmer-sweep"] .status-letter-wave::after,
 .status-running.is-executing .status-letter-wave::after {
   content: attr(data-label);
   position: absolute;
@@ -2901,12 +2905,12 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 @supports not ((background-clip: text) or (-webkit-background-clip: text)) {
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave::after,
   .status-running.is-executing .status-letter-wave::after {
     content: none;
   }
 
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
   .status-running.is-executing .status-letter-wave__glyph {
     animation-name: mm-executing-letter-brighten;
     animation-duration: var(--mm-executing-letter-cycle-duration, var(--mm-executing-sweep-cycle-duration, 2200ms));
@@ -2940,7 +2944,7 @@ tr[data-proposal-id].proposal-consuming td {
   color: inherit;
 }
 
-.status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
+.status[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
 .status-running.is-executing .status-letter-wave__glyph {
   animation: none;
 }
@@ -2969,7 +2973,7 @@ tr[data-proposal-id].proposal-consuming td {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .status-running[data-effect="shimmer-sweep"],
+  .status[data-effect="shimmer-sweep"],
   .status-running.is-executing {
     background-image: var(--mm-executing-moving-light-gradient);
     background-repeat: no-repeat;
@@ -2979,11 +2983,11 @@ tr[data-proposal-id].proposal-consuming td {
     background-size: 160% var(--mm-executing-sweep-band-height), 140% var(--mm-executing-sweep-band-height);
   }
 
-  .status-running[data-effect="shimmer-sweep"]::before,
+  .status[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running[data-effect="shimmer-sweep"]::after,
+  .status[data-effect="shimmer-sweep"]::after,
   .status-running.is-executing::after,
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave::after,
   .status-running.is-executing .status-letter-wave::after {
     animation: none;
   }
@@ -2994,35 +2998,35 @@ tr[data-proposal-id].proposal-consuming td {
     filter: none !important;
   }
 
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave,
   .status-running.is-executing .status-letter-wave {
     text-shadow: none;
   }
 
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave::after,
   .status-running.is-executing .status-letter-wave::after {
     content: none;
   }
 }
 
 @media (forced-colors: active) {
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave,
   .status-running.is-executing .status-letter-wave {
     color: ButtonText;
     background-image: none;
   }
 
-  .status-running[data-effect="shimmer-sweep"]::before,
+  .status[data-effect="shimmer-sweep"]::before,
   .status-running.is-executing::before,
-  .status-running[data-effect="shimmer-sweep"]::after,
+  .status[data-effect="shimmer-sweep"]::after,
   .status-running.is-executing::after,
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave::after,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave::after,
   .status-running.is-executing .status-letter-wave::after {
     animation: none;
     content: none;
   }
 
-  .status-running[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
+  .status[data-effect="shimmer-sweep"] .status-letter-wave__glyph,
   .status-running.is-executing .status-letter-wave__glyph {
     animation: none;
   }

--- a/frontend/src/utils/executionStatusPillClasses.test.ts
+++ b/frontend/src/utils/executionStatusPillClasses.test.ts
@@ -6,7 +6,7 @@ import {
 } from './executionStatusPillClasses';
 
 describe('executionStatusPillProps', () => {
-  it('adds shimmer selector metadata only for active executing status pills', () => {
+  it('adds shimmer selector metadata for active executing and transition status pills', () => {
     expect(executionStatusPillProps('executing')).toMatchObject({
       className: 'status status-running is-executing',
       'data-state': 'executing',
@@ -21,6 +21,15 @@ describe('executionStatusPillProps', () => {
       'data-shimmer-label': 'running',
     });
 
+    for (const key of ['initializing', 'planning', 'finalizing'] as const) {
+      expect(executionStatusPillProps(key)).toMatchObject({
+        className: `status status-${key} is-${key}`,
+        'data-state': key,
+        'data-effect': 'shimmer-sweep',
+        'data-shimmer-label': key,
+      });
+    }
+
     expect(executionStatusPillProps('waiting')).toEqual({
       className: 'status status-waiting',
     });
@@ -33,13 +42,22 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('running', { enableMotion: false })).toEqual({
       className: 'status status-running',
     });
+    expect(executionStatusPillProps('initializing', { enableMotion: false })).toEqual({
+      className: 'status status-initializing',
+    });
+    expect(executionStatusPillProps('planning', { enableMotion: false })).toEqual({
+      className: 'status status-planning',
+    });
+    expect(executionStatusPillProps('finalizing', { enableMotion: false })).toEqual({
+      className: 'status status-finalizing',
+    });
   });
 
   it('keeps the existing class helper output for non-executing states across the MM-491 state matrix', () => {
     expect(executionStatusPillProps('completed')).toEqual({ className: 'status status-completed' });
     expect(executionStatusPillProps('failed')).toEqual({ className: 'status status-failed' });
     expect(executionStatusPillProps('executing').className).toBe('status status-running is-executing');
-    expect(executionStatusPillProps('planning').className).toBe('status status-planning');
+    expect(executionStatusPillProps('planning').className).toBe('status status-planning is-planning');
     expect(executionStatusPillProps('proposals')).toEqual({ className: 'status status-running' });
 
     expect(executionStatusPillProps('waiting_on_dependencies')).toEqual({
@@ -52,7 +70,7 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-canceled' });
   });
 
-  it('maps MM-1035 exact workflow states to their status color classes without shimmer', () => {
+  it('maps MM-1035 exact workflow states to their status color classes and MM-1036 shimmer metadata', () => {
     expect(executionStatusPillProps('scheduled')).toEqual({ className: 'status status-scheduled' });
     expect(executionStatusPillProps('awaiting_slot')).toEqual({ className: 'status status-awaiting-slot' });
     expect(executionStatusPillProps('waiting_on_dependencies')).toEqual({
@@ -61,9 +79,18 @@ describe('executionStatusPillProps', () => {
     expect(executionStatusPillProps('awaiting_external')).toEqual({
       className: 'status status-awaiting-external',
     });
-    expect(executionStatusPillProps('initializing')).toEqual({ className: 'status status-initializing' });
-    expect(executionStatusPillProps('planning')).toEqual({ className: 'status status-planning' });
-    expect(executionStatusPillProps('finalizing')).toEqual({ className: 'status status-finalizing' });
+    expect(executionStatusPillProps('initializing')).toMatchObject({
+      className: 'status status-initializing is-initializing',
+      'data-effect': 'shimmer-sweep',
+    });
+    expect(executionStatusPillProps('planning')).toMatchObject({
+      className: 'status status-planning is-planning',
+      'data-effect': 'shimmer-sweep',
+    });
+    expect(executionStatusPillProps('finalizing')).toMatchObject({
+      className: 'status status-finalizing is-finalizing',
+      'data-effect': 'shimmer-sweep',
+    });
     expect(executionStatusPillProps('canceled')).toEqual({ className: 'status status-canceled' });
   });
 
@@ -91,5 +118,6 @@ describe('executionStatusPillProps', () => {
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-491');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-704');
     expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1035');
+    expect(EXECUTING_STATUS_PILL_TRACEABILITY.relatedJiraIssues).toContain('MM-1036');
   });
 });

--- a/frontend/src/utils/executionStatusPillClasses.ts
+++ b/frontend/src/utils/executionStatusPillClasses.ts
@@ -2,7 +2,7 @@ import { formatStatusLabel } from './formatters';
 
 export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   jiraIssue: 'MM-488',
-  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491', 'MM-704', 'MM-1035'],
+  relatedJiraIssues: ['MM-489', 'MM-490', 'MM-491', 'MM-704', 'MM-1035', 'MM-1036'],
   designRequirements: [
     'DESIGN-REQ-001',
     'DESIGN-REQ-002',
@@ -14,7 +14,7 @@ export const EXECUTING_STATUS_PILL_TRACEABILITY = Object.freeze({
   ],
 });
 
-const SHIMMER_SWEEP_KEYS = ['executing', 'running'] as const;
+const SHIMMER_SWEEP_KEYS = ['executing', 'running', 'initializing', 'planning', 'finalizing'] as const;
 type ShimmerSweepStatusKey = (typeof SHIMMER_SWEEP_KEYS)[number];
 
 export type ExecutionStatusPillProps = Readonly<{


### PR DESCRIPTION
Issue reference: MM-1036

Summary:
- Extends shimmer-sweep metadata to initializing, planning, and finalizing status pills.
- Generalizes the shared shimmer CSS selector so non-running transition statuses receive the same shimmer treatment as executing.
- Updates status utility and dashboard/workflow-list tests for the new shimmer states.

Tests run:
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/utils/executionStatusPillClasses.test.ts frontend/src/entrypoints/workflow-list.test.tsx frontend/src/entrypoints/dashboard.test.tsx

Remaining risks:
- Unit test wrapper Python phase could not run in this container because pytest is missing; the frontend-only targeted suite passed.