### PR TITLE
[codex] Fix Temporal target search attributes

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -369,9 +369,11 @@ async def _detect_optional_temporal_search_attributes(
         if _search_attribute_type_value(attrs.get(name)) == int(expected_type):
             usable.add(name)
         elif name in attrs:
+            expected_type_name = getattr(expected_type, "name", str(expected_type))
             logger.error(
-                "Temporal Search Attribute %s has unexpected type; expected KeywordList.",
+                "Temporal Search Attribute %s has unexpected type; expected %s.",
                 name,
+                expected_type_name,
             )
     logger.info(
         "Temporal optional Search Attributes usable: %s",

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -245,9 +245,15 @@ _EXECUTION_FACET_ATTRS = {
     "integration": "mm_integration",
 }
 _OPTIONAL_TEMPORAL_SEARCH_ATTRIBUTES = {
-    "mm_target_runtime": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-    "mm_target_skill": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+    "mm_target_runtime": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+    "mm_target_skill": IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 }
+_UNSORTABLE_TEMPORAL_SEARCH_ATTRIBUTES = frozenset(
+    {
+        "mm_target_runtime",
+        "mm_target_skill",
+    }
+)
 _OPTIONAL_TEMPORAL_SEARCH_ATTRIBUTES_CACHE_TTL_SECONDS = 300.0
 _optional_temporal_search_attributes_cache: dict[
     tuple[str, int], tuple[float, frozenset[str]]
@@ -324,6 +330,8 @@ def _search_attribute_type_value(raw: object) -> int | None:
         normalized = raw.strip().lower()
         if normalized == "keyword":
             return int(IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD)
+        if normalized in {"keywordlist", "keyword_list", "keyword list"}:
+            return int(IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST)
     return None
 
 
@@ -362,7 +370,7 @@ async def _detect_optional_temporal_search_attributes(
             usable.add(name)
         elif name in attrs:
             logger.error(
-                "Temporal Search Attribute %s has unexpected type; expected Keyword.",
+                "Temporal Search Attribute %s has unexpected type; expected KeywordList.",
                 name,
             )
     logger.info(
@@ -1385,6 +1393,8 @@ def _build_temporal_execution_query(
             raise TemporalExecutionValidationError(
                 "sort must be one of: " + ", ".join(sorted(_EXECUTION_SORT_FIELDS)) + "."
             )
+        if sort_attr in _UNSORTABLE_TEMPORAL_SEARCH_ATTRIBUTES:
+            return count_query, list_query
         if sort_attr in _OPTIONAL_TEMPORAL_SEARCH_ATTRIBUTES and sort_attr not in usable_attrs:
             return count_query, list_query
         direction = str(sort_dir or "desc").strip().lower()

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -281,7 +281,7 @@ Optional bounded keys may include values such as:
 - `mm_target_skill`
 
 `mm_target_runtime` and `mm_target_skill` are authoritative filter/facet fields
-only after the Temporal namespace reports them registered as `Keyword` Search
+only after the Temporal namespace reports them registered as `KeywordList` Search
 Attributes. Before registration, requests that depend on those fields degrade
 without issuing invalid Temporal Visibility queries. Unknown values are omitted
 rather than serialized as blank strings.
@@ -450,7 +450,8 @@ Example:
 - `ownerType`, `entry`, `repo`, and `integration` are supported exact-match filters.
 - Runtime and skill filters use `mm_target_runtime` and the singular primary
   `mm_target_skill` Search Attribute only when the registry capability check
-  succeeds.
+  succeeds. They are one-item `KeywordList` values and are filterable through
+  membership queries, not sortable through Temporal Visibility.
 - `ownerId` is optional for admins.
 - Non-admin callers are implicitly scoped to themselves when `ownerId` is omitted.
 

--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -593,6 +593,8 @@ MoonMind uses PostgreSQL Visibility. Custom Search Attribute count, type, and si
 | `mm_entry` | Yes | keyword | set at start; immutable |
 | `mm_repo` | Optional | keyword | set when repo filtering is required |
 | `mm_integration` | Optional | keyword | set when integration filtering is required |
+| `mm_target_runtime` | Optional | keyword_list | one-item runtime facet; not sortable |
+| `mm_target_skill` | Optional | keyword_list | one-item primary skill facet; not sortable |
 | `mm_scheduled_for` | Optional | datetime | deferred/scheduled execution metadata |
 
 `mm_updated_at` is allowed, but it must not become a high-churn telemetry feed. It should move on meaningful user-visible mutations such as domain-state transitions, accepted Updates, visible Signal handling, terminal transitions, bounded progress checkpoints, and title/summary changes. It must not move on every heartbeat, log line, polling tick, low-level retry, or internal backoff detail.

--- a/docs/Temporal/TemporalPlatformFoundation.md
+++ b/docs/Temporal/TemporalPlatformFoundation.md
@@ -155,8 +155,8 @@ Because we're using SQL Advanced Visibility (Postgres 12+), we rely on:
 | `mm_state` | keyword | Workflow lifecycle logic | Exact MoonMind lifecycle state |
 | `mm_updated_at` | datetime | Workflow lifecycle logic | Default recency/sort key |
 | `mm_entry` | keyword | Workflow start path | Execution category for UI/query surfaces |
-| `mm_target_runtime` | keyword | API/workflow start path; workflow lifecycle repair | Optional canonical runtime dimension for filtering/facets |
-| `mm_target_skill` | keyword | API/workflow start path; workflow lifecycle repair | Optional singular primary skill dimension for filtering/facets |
+| `mm_target_runtime` | keyword_list | API/workflow start path; workflow lifecycle repair | Optional one-item canonical runtime dimension for filtering/facets; not sortable |
+| `mm_target_skill` | keyword_list | API/workflow start path; workflow lifecycle repair | Optional one-item singular primary skill dimension for filtering/facets; not sortable |
 
 ### 8.3 Foundation contract
 

--- a/docs/Temporal/VisibilityAndUiQueryModel.md
+++ b/docs/Temporal/VisibilityAndUiQueryModel.md
@@ -219,15 +219,19 @@ All MoonMind-owned Search Attributes for this query model follow these rules:
 | --- | --- | --- | --- | --- |
 | `mm_repo` | keyword | No | Repo-scoped executions when filtering is needed | Stable bounded repo identifier |
 | `mm_integration` | keyword | No | Integration-centric execution where filtering is useful | Examples: `jules`, `github`, `openclaw` |
-| `mm_target_runtime` | keyword | No | Workflow start path when the canonical runtime is known; workflow lifecycle logic if it resolves later | Canonical runtime ID such as `codex_cli`, `claude_code`, `gemini_cli`, `codex_cloud`, or `jules`; never a display label, model, profile name, prompt, or free text |
-| `mm_target_skill` | keyword | No | Workflow start path when the primary skill is known; workflow lifecycle logic if it resolves later | Singular primary skill slug/name/id used by `targetSkill`; future multi-skill faceting requires a separate explicitly documented attribute |
+| `mm_target_runtime` | keyword_list | No | Workflow start path when the canonical runtime is known; workflow lifecycle logic if it resolves later | One-item list containing the canonical runtime ID such as `codex_cli`, `claude_code`, `gemini_cli`, `codex_cloud`, or `jules`; never a display label, model, profile name, prompt, or free text |
+| `mm_target_skill` | keyword_list | No | Workflow start path when the primary skill is known; workflow lifecycle logic if it resolves later | One-item list containing the singular primary skill slug/name/id used by `targetSkill`; future multi-skill faceting requires a separate explicitly documented attribute |
 | `mm_scheduled_for` | datetime | No | Delayed start / schedule-backed execution | Queryable expected start time |
 
 Runtime and skill Search Attributes are optional during migration. The API must
 confirm that `mm_target_runtime` and `mm_target_skill` are registered as
-`Keyword` before issuing Temporal Visibility queries that reference them. When
+`KeywordList` before issuing Temporal Visibility queries that reference them. When
 they are unavailable, runtime/skill filters are not authoritative and facets
 return degraded metadata rather than failing the list page.
+
+Runtime/skill filters use Temporal KeywordList membership queries
+(`mm_target_runtime = "codex_cli"`). They are not sortable through Temporal
+Visibility because SQL Visibility rejects `ORDER BY` for KeywordList fields.
 
 Blank or unknown runtime/skill values are omitted, not written as empty strings
 or placeholders. Existing executions that cannot be updated in Temporal

--- a/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
@@ -216,8 +216,8 @@ Use only when product filtering requires them:
 
 - `mm_repo` (keyword)
 - `mm_integration` (keyword)
-- `mm_target_runtime` (keyword): canonical runtime ID, omitted when unknown
-- `mm_target_skill` (keyword): singular primary skill identifier, omitted when unknown
+- `mm_target_runtime` (keyword_list): one-item canonical runtime ID list, omitted when unknown
+- `mm_target_skill` (keyword_list): one-item singular primary skill identifier list, omitted when unknown
 
 Runtime and primary skill attributes must be registered before API filters or
 facets query them. Existing closed executions without these values remain

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -60,6 +60,12 @@ MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE = (
 )
 ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
 _WORKFLOW_UPDATE_ACCEPTED_TIMEOUT = timedelta(seconds=10)
+_SINGLE_VALUE_KEYWORD_LIST_SEARCH_ATTRIBUTES = frozenset(
+    {
+        "mm_target_runtime",
+        "mm_target_skill",
+    }
+)
 
 def _is_rpc_status(exc: BaseException, status_name: str) -> bool:
     """Check whether *exc* is a Temporal ``RPCError`` with the given gRPC status.
@@ -100,7 +106,10 @@ def _build_typed_search_attributes(
 
         # Temporal only supports lists for KeywordList. All other types must be unwrapped.
         if all(isinstance(v, str) for v in values):
-            if len(values) > 1:
+            if key in _SINGLE_VALUE_KEYWORD_LIST_SEARCH_ATTRIBUTES:
+                key_type = SearchAttributeKey.for_keyword_list(key)
+                pairs.append(SearchAttributePair(key_type, values))
+            elif len(values) > 1:
                 key_type = SearchAttributeKey.for_keyword_list(key)
                 pairs.append(SearchAttributePair(key_type, values))
             else:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -14367,15 +14367,15 @@ class MoonMindRunWorkflow:
         if self._target_runtime:
             pairs.append(
                 SearchAttributePair(
-                    SearchAttributeKey.for_keyword("mm_target_runtime"),
-                    self._target_runtime,
+                    SearchAttributeKey.for_keyword_list("mm_target_runtime"),
+                    [self._target_runtime],
                 )
             )
         if self._target_skill:
             pairs.append(
                 SearchAttributePair(
-                    SearchAttributeKey.for_keyword("mm_target_skill"),
-                    self._target_skill,
+                    SearchAttributeKey.for_keyword_list("mm_target_skill"),
+                    [self._target_skill],
                 )
             )
         if self._scheduled_for:

--- a/services/temporal/scripts/bootstrap-namespace.sh
+++ b/services/temporal/scripts/bootstrap-namespace.sh
@@ -193,8 +193,8 @@ mm_updated_at:Datetime
 mm_started_at:Datetime
 mm_repo:Keyword
 mm_integration:Keyword
-mm_target_runtime:Keyword
-mm_target_skill:Keyword
+mm_target_runtime:KeywordList
+mm_target_skill:KeywordList
 mm_title:KeywordList
 mm_scheduled_for:Datetime
 mm_has_dependencies:Bool
@@ -320,10 +320,23 @@ while :; do
       attr_type=${spec#*:}
       if search_attribute_registered "$name" "$list_output"; then
         if ! search_attribute_type_matches "$name" "$attr_type" "$list_output"; then
-          log "Search attribute ${name} exists with the wrong type; expected ${attr_type}."
-          exit 1
+          case "$name" in
+            mm_target_runtime|mm_target_skill)
+              log "Search attribute ${name} exists with the wrong type; replacing with ${attr_type}."
+              if ! remove_search_attribute "$name"; then
+                log "Failed to remove search attribute ${name} for type replacement."
+                exit 1
+              fi
+              ;;
+            *)
+              log "Search attribute ${name} exists with the wrong type; expected ${attr_type}."
+              exit 1
+              ;;
+          esac
         fi
-        continue
+        if search_attribute_type_matches "$name" "$attr_type" "$list_output"; then
+          continue
+        fi
       fi
       all_registered=0
       if create_search_attribute "$name" "$attr_type"; then

--- a/tests/integration/temporal/test_namespace_retention.py
+++ b/tests/integration/temporal/test_namespace_retention.py
@@ -20,8 +20,8 @@ REQUIRED_SEARCH_ATTRIBUTES = {
     "mm_started_at": "Datetime",
     "mm_repo": "Keyword",
     "mm_integration": "Keyword",
-    "mm_target_runtime": "Keyword",
-    "mm_target_skill": "Keyword",
+    "mm_target_runtime": "KeywordList",
+    "mm_target_skill": "KeywordList",
     "mm_title": "KeywordList",
     "mm_scheduled_for": "Datetime",
     "mm_has_dependencies": "Bool",
@@ -351,6 +351,47 @@ def test_namespace_bootstrap_registers_missing_search_attributes_on_upgrade(
     for name, attr_type in REQUIRED_SEARCH_ATTRIBUTES.items():
         assert f"{name} {attr_type}" in registered
 
+def test_namespace_bootstrap_retypes_target_facets_to_keyword_lists(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "namespace.exists").touch()
+    _write_search_attributes(
+        state_dir,
+        {
+            **REQUIRED_SEARCH_ATTRIBUTES,
+            "mm_target_runtime": "Keyword",
+            "mm_target_skill": "Keyword",
+        },
+    )
+    _write_executable(fake_bin / "temporal", TEMPORAL_STUB)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAKE_TEMPORAL_STATE_DIR"] = str(state_dir)
+    env["TEMPORAL_ADDRESS"] = "temporal:7233"
+    env["TEMPORAL_NAMESPACE"] = "default"
+    env.pop("TEMPORAL_NAMESPACE_RETENTION_DAYS", None)
+
+    result = subprocess.run(
+        ["sh", str(BOOTSTRAP_SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "replacing with KeywordList" in result.stdout
+
+    registered = (state_dir / "search-attributes.txt").read_text(encoding="utf-8")
+    assert "mm_target_runtime KeywordList" in registered
+    assert "mm_target_skill KeywordList" in registered
+    assert "mm_target_runtime Keyword\n" not in registered
+    assert "mm_target_skill Keyword\n" not in registered
+
 def test_namespace_bootstrap_retire_old_keyword_attributes_before_sql_limit_upgrade(
     tmp_path: Path,
 ):
@@ -386,7 +427,7 @@ def test_namespace_bootstrap_retire_old_keyword_attributes_before_sql_limit_upgr
     env = os.environ.copy()
     env["PATH"] = f"{fake_bin}:{env['PATH']}"
     env["FAKE_TEMPORAL_STATE_DIR"] = str(state_dir)
-    env["FAKE_TEMPORAL_KEYWORD_LIMIT"] = "12"
+    env["FAKE_TEMPORAL_KEYWORD_LIMIT"] = "10"
     env["TEMPORAL_ADDRESS"] = "temporal:7233"
     env["TEMPORAL_NAMESPACE"] = "default"
     env.pop("TEMPORAL_NAMESPACE_RETENTION_DAYS", None)
@@ -419,4 +460,4 @@ def test_namespace_bootstrap_retire_old_keyword_attributes_before_sql_limit_upgr
     keyword_count = sum(
         1 for line in registered.splitlines() if line.endswith(" Keyword")
     )
-    assert keyword_count == 12
+    assert keyword_count == 10

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -18,6 +18,7 @@ from fastapi import FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
+from temporalio.api.enums.v1 import IndexedValueType
 from temporalio.service import RPCError, RPCStatusCode
 
 from api_service.api.routers.executions import (
@@ -87,6 +88,8 @@ from moonmind.schemas.temporal_models import (
     UpdateExecutionRequest,
 )
 from moonmind.workflows.temporal.service import TemporalExecutionService
+
+_TARGET_SEARCH_ATTRIBUTE_TYPE = int(IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 
 
 class _ScalarRows:
@@ -1151,7 +1154,7 @@ def test_list_executions_temporal_query_includes_target_runtime_filter() -> None
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1200,8 +1203,8 @@ def test_list_executions_temporal_query_includes_canonical_state_filters() -> No
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1260,7 +1263,7 @@ def test_list_executions_temporal_query_anchors_non_terminal_state_to_running_st
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1306,7 +1309,7 @@ def test_list_executions_temporal_query_mixes_terminal_and_non_terminal_state_fi
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1351,8 +1354,8 @@ def test_list_executions_temporal_query_supports_repeated_canonical_filters() ->
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1399,8 +1402,8 @@ def test_list_executions_temporal_query_ignores_empty_canonical_state_for_legacy
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1474,8 +1477,8 @@ def test_list_executions_temporal_query_includes_canonical_runtime_skill_and_rep
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1547,7 +1550,7 @@ async def test_optional_temporal_search_attribute_detection_rejects_wrong_type()
                 return_value=SimpleNamespace(
                     custom_attributes={
                         "mm_target_runtime": SimpleNamespace(type=1),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1567,8 +1570,8 @@ async def test_optional_temporal_search_attribute_detection_uses_fresh_cache() -
         list_search_attributes=AsyncMock(
             return_value=SimpleNamespace(
                 custom_attributes={
-                    "mm_target_runtime": SimpleNamespace(type=2),
-                    "mm_target_skill": SimpleNamespace(type=2),
+                    "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                    "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                 }
             )
         )
@@ -1628,8 +1631,8 @@ def test_list_executions_temporal_query_prefers_canonical_filters_over_legacy_ex
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
-                        "mm_target_skill": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
+                        "mm_target_skill": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )
@@ -1805,6 +1808,54 @@ def test_list_executions_temporal_query_supports_sort_and_text_filters() -> None
     assert 'mm_title = "release"' in count_query
     assert "ORDER BY" not in count_query
     assert list_query.endswith("ORDER BY StartTime ASC")
+
+
+def test_list_executions_temporal_query_omits_order_by_for_keyword_list_target_sort() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_user_dependencies(app, is_superuser=True)
+
+    class _WorkflowIterator:
+        current_page: list[object] = []
+        next_page_token: bytes | None = None
+
+        async def fetch_next_page(self) -> None:
+            return None
+
+    temporal_client = SimpleNamespace(
+        operator_service=SimpleNamespace(
+            list_search_attributes=AsyncMock(
+                return_value=SimpleNamespace(
+                    custom_attributes={
+                        "mm_target_runtime": SimpleNamespace(
+                            type=_TARGET_SEARCH_ATTRIBUTE_TYPE
+                        ),
+                    }
+                )
+            )
+        ),
+        count_workflows=AsyncMock(return_value=SimpleNamespace(count=0)),
+        list_workflows=Mock(return_value=_WorkflowIterator()),
+    )
+    app.dependency_overrides[get_temporal_client] = lambda: temporal_client
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "targetRuntime": "codex_cli",
+                "sort": "targetRuntime",
+                "sortDir": "asc",
+            },
+        )
+
+    assert response.status_code == 200
+    list_query = temporal_client.list_workflows.call_args.kwargs["query"]
+    assert 'mm_target_runtime="codex_cli"' in list_query
+    assert "ORDER BY" not in list_query
 
 
 def test_list_executions_temporal_query_title_filter_ands_word_tokens() -> None:
@@ -2283,7 +2334,7 @@ def test_execution_facets_exclude_requested_facet_filter_and_keep_workflow_scope
             list_search_attributes=AsyncMock(
                 return_value=SimpleNamespace(
                     custom_attributes={
-                        "mm_target_runtime": SimpleNamespace(type=2),
+                        "mm_target_runtime": SimpleNamespace(type=_TARGET_SEARCH_ATTRIBUTE_TYPE),
                     }
                 )
             )

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -23,6 +23,7 @@ from moonmind.workflows.temporal.client import (
     MANAGED_SESSION_RECONCILE_WORKFLOW_ID_BASE,
     ScheduleTriggerResult,
     TemporalClientAdapter,
+    _build_typed_search_attributes,
 )
 from moonmind.workflows.temporal.schedule_errors import (
     ScheduleAlreadyExistsError,
@@ -59,6 +60,24 @@ async def _run_schedule_update_callback(handle: MagicMock, update_input: Any) ->
     update = await update_callback(update_input)
     assert isinstance(update, ScheduleUpdate)
     return update.schedule
+
+
+def test_build_typed_search_attributes_encodes_target_facets_as_keyword_lists() -> None:
+    typed_search_attributes = _build_typed_search_attributes(
+        {
+            "mm_target_runtime": ["codex_cli"],
+            "mm_target_skill": ["pr-resolver"],
+        }
+    )
+
+    assert typed_search_attributes is not None
+    assert typed_search_attributes.get(
+        SearchAttributeKey.for_keyword_list("mm_target_runtime")
+    ) == ["codex_cli"]
+    assert typed_search_attributes.get(
+        SearchAttributeKey.for_keyword_list("mm_target_skill")
+    ) == ["pr-resolver"]
+
 
 # ---------------------------------------------------------------------------
 # T010: create_schedule

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1184,6 +1184,40 @@ def test_run_memo_surfaces_runtime_and_skill_visibility(
     assert memo_updates[-1]["targetRuntime"] == "codex_cli"
     assert memo_updates[-1]["targetSkill"] == "pr-resolver"
 
+
+def test_run_search_attributes_encode_runtime_and_skill_as_keyword_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    upserts: list[object] = []
+    monkeypatch.setattr(
+        run_module.workflow,
+        "upsert_search_attributes",
+        upserts.append,
+    )
+    workflow = MoonMindRunWorkflow()
+
+    workflow._title = "Resolve PR #1633"
+    workflow._target_runtime = "codex_cli"
+    workflow._target_skill = "pr-resolver"
+    workflow._update_search_attributes()
+
+    pairs_by_name = {
+        pair.key.name: pair
+        for pair in upserts[-1]
+    }
+    runtime_pair = pairs_by_name["mm_target_runtime"]
+    skill_pair = pairs_by_name["mm_target_skill"]
+    assert runtime_pair.key == run_module.SearchAttributeKey.for_keyword_list(
+        "mm_target_runtime"
+    )
+    assert runtime_pair.value == ["codex_cli"]
+    assert skill_pair.key == run_module.SearchAttributeKey.for_keyword_list(
+        "mm_target_skill"
+    )
+    assert skill_pair.value == ["pr-resolver"]
+
+
 def test_run_groups_child_lineage_and_evidence_into_step_row(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fix Temporal namespace bootstrap failure caused by trying to register more than 10 custom `Keyword` search attributes.

This keeps the existing 10 `Keyword` fields intact and registers `mm_target_runtime` and `mm_target_skill` as single-value `KeywordList` attributes instead. Runtime and skill filters continue to work through membership queries, while the API skips Temporal `ORDER BY` for those fields because SQL visibility does not support sorting on `KeywordList`.

## Why

Temporal SQL visibility enforces a hard limit of 10 custom `Keyword` fields. The namespace already had all 10 slots allocated, so adding target runtime and target skill as additional `Keyword` attributes caused `temporal-namespace-init` to fail during `docker compose up -d`.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_client_schedules.py tests/unit/api/routers/test_executions.py -k 'target_facets or target_runtime_filter or runtime_skill_filters_degrade or optional_temporal_search_attribute_detection or keyword_list_target_sort or canonical_runtime_skill_and_repo_filters or repeated_canonical_filters or prefers_canonical_filters'`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/integration/temporal/test_namespace_retention.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -k 'runtime_and_skill'`
- `git diff --check`