### PR TITLE
MM-1041 Shift status-pill shimmer to travel more horizontally

### DIFF
--- a/docs/UI/EffectShimmerSweep.md
+++ b/docs/UI/EffectShimmerSweep.md
@@ -161,7 +161,7 @@ layers:
     keyframes: mm-status-pill-shimmer
     shape: two layered soft-edged linear gradients
     travel: top-left-to-bottom-right visual sweep using inverse background-position endpoints
-    angle_deg: -18
+    angle_deg: -24
     blend_mode:
       preferred: plus-lighter
       fallback: screen
@@ -217,11 +217,12 @@ motion:
 
   path:
     start_x_pct: 135
-    start_y_pct: 160
+    start_y_pct: 128
     end_x_pct: -135
-    end_y_pct: -160
+    end_y_pct: -128
     y_behavior: diagonal_travel
-    angle_deg: -18
+    horizontal_bias: horizontal travel delta (270%) exceeds vertical travel delta (256%)
+    angle_deg: -24
     keyframes: mm-status-pill-shimmer
 
   band:
@@ -525,7 +526,7 @@ tone:
 ```yaml
 effect_tokens:
   --mm-executing-sweep-cycle-duration: 2600ms
-  --mm-executing-sweep-angle: -18deg
+  --mm-executing-sweep-angle: -24deg
   --mm-executing-sweep-band-width: 24%
   --mm-executing-sweep-band-height: 180%
   --mm-executing-sweep-halo-width-multiplier: 10
@@ -533,9 +534,9 @@ effect_tokens:
   --mm-executing-sweep-core-opacity: 0.34
   --mm-executing-sweep-halo-opacity: 0.14
   --mm-executing-sweep-start-x: 135%
-  --mm-executing-sweep-start-y: 160%
+  --mm-executing-sweep-start-y: 128%
   --mm-executing-sweep-end-x: -135%
-  --mm-executing-sweep-end-y: -160%
+  --mm-executing-sweep-end-y: -128%
   --mm-executing-sweep-layer-offset-x: -12%
   --mm-executing-sweep-layer-offset-y: -10%
   --mm-executing-border-glint-outset: 1px

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -853,16 +853,20 @@ describe('Dashboard shared entry', () => {
 
   it('defines the shared MM-488 executing shimmer modifier contract', async () => {
     expect(dashboardCss).toMatch(/--mm-executing-sweep-cycle-duration:\s*2600ms/);
+    // MM-1041: steeper band angle pairs with the flatter, more horizontal travel path.
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-angle:\s*-24deg/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-width:\s*24%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-band-height:\s*180%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-halo-width-multiplier:\s*10/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-core-width-multiplier:\s*9\.1667/);
     expect(dashboardCss).not.toContain('--mm-executing-sweep-halo-peak-width-multiplier');
     expect(dashboardCss).not.toContain('--mm-executing-sweep-core-peak-width-multiplier');
+    // MM-1041: vertical travel reduced (160% -> 128%) so the horizontal delta
+    // exceeds the vertical delta and the sweep travels more horizontally.
     expect(dashboardCss).toMatch(/--mm-executing-sweep-start-x:\s*135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*160%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-start-y:\s*128%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-end-x:\s*-135%/);
-    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-160%/);
+    expect(dashboardCss).toMatch(/--mm-executing-sweep-end-y:\s*-128%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-x:\s*-12%/);
     expect(dashboardCss).toMatch(/--mm-executing-sweep-layer-offset-y:\s*-10%/);
     expect(dashboardCss).toContain('--mm-executing-letter-cycle-duration: var(--mm-executing-sweep-cycle-duration)');

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -51,15 +51,19 @@
   --mm-mobile-nav-active-edge: rgb(var(--mm-accent) / 0.88);
   --mm-font-sans: "IBM Plex Sans", system-ui, sans-serif;
   --mm-executing-sweep-cycle-duration: 2600ms;
-  --mm-executing-sweep-angle: -18deg;
+  /* MM-1041: flatter, more horizontal sweep. Steeper band angle (-24deg) keeps
+     the luminous stripe near-perpendicular to the reduced vertical travel. */
+  --mm-executing-sweep-angle: -24deg;
   --mm-executing-sweep-band-width: 24%;
   --mm-executing-sweep-band-height: 180%;
   --mm-executing-sweep-halo-width-multiplier: 10;
   --mm-executing-sweep-core-width-multiplier: 9.1667;
+  /* MM-1041: horizontal travel delta (270%) now exceeds the vertical delta
+     (256%) so the sweep reads as traveling slightly more horizontally. */
   --mm-executing-sweep-start-x: 135%;
-  --mm-executing-sweep-start-y: 160%;
+  --mm-executing-sweep-start-y: 128%;
   --mm-executing-sweep-end-x: -135%;
-  --mm-executing-sweep-end-y: -160%;
+  --mm-executing-sweep-end-y: -128%;
   --mm-executing-sweep-layer-offset-x: -12%;
   --mm-executing-sweep-layer-offset-y: -10%;
   --mm-executing-sweep-core-opacity: 0.34;


### PR DESCRIPTION
## Issue

[MM-1041](https://moonladder.atlassian.net/browse/MM-1041): "I'd like the shimmer's angle to be shifted so it travels slightly more horizontally than it does now."

## Summary

Shifts the executing status-pill shimmer sweep so it reads as traveling slightly more horizontally than the MM-1036 baseline, while preserving the original sheared look.

- Reduced the sweep's vertical travel: `--mm-executing-sweep-start-y` `160% → 128%` and `--mm-executing-sweep-end-y` `-160% → -128%`. The horizontal travel delta (270%) now exceeds the vertical travel delta (256%), whereas previously the vertical delta (320%) dominated. The horizontal endpoints (`±135%`) are unchanged.
- Steepened the band gradient angle `--mm-executing-sweep-angle` `-18deg → -24deg` so the luminous stripe stays near-perpendicular to the flatter travel path, keeping the sheared appearance intact.
- Updated the dashboard CSS contract test (`frontend/src/entrypoints/dashboard.test.tsx`) to lock in the new angle and travel values.
- Updated the `docs/UI/EffectShimmerSweep.md` design doc (angle, path endpoints, and effect-token reference) to match the new declared state, including the horizontal-bias note.

Files changed:
- `frontend/src/styles/dashboard.css`
- `frontend/src/entrypoints/dashboard.test.tsx`
- `docs/UI/EffectShimmerSweep.md`

## Tests run

- Frontend unit/contract suite for the changed file via vitest:
  `vitest run --config frontend/vite.config.ts src/entrypoints/dashboard.test.tsx` → **1 file passed, 50 tests passed**. This includes the updated `MM-488 executing shimmer modifier contract` test that now asserts the MM-1041 angle (`-24deg`) and reduced vertical travel (`128% / -128%`).

(Run via the documented colon-path workaround: the workspace path contains a colon that breaks vitest/npm PATH resolution, so the tree was copied to a colon-free path before running.)

## Remaining risks

- The change is purely visual (CSS custom properties) plus the matching contract test and design doc; no runtime/behavioral logic is affected. The exact perceived "more horizontal" feel is subjective — final tuning may want a human visual check in the running dashboard.
- This is a CSS-token-only adjustment; no Temporal/workflow/payload contracts are touched, so no in-flight or replay compatibility concerns apply.


[MM-1041]: https://moonladder.atlassian.net/browse/MM-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ