### PR TITLE
[codex] Fix pr-resolver gate continuation handling

### DIFF
--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -93,9 +93,10 @@ Continuation blockers use `reenter_gate`, not generic failure. This includes
 resolver-owned remediation steps (`run_fix_comments_skill`, `run_fix_ci_skill`,
 `run_fix_merge_conflicts_skill`) and transient finalize-only waits
 (`retry_finalize_after_backoff`, `wait_for_ci_and_retry_finalize`). Managed
-runtime adapters preserve that disposition even when the resolver command exits
-non-zero, so `MoonMind.MergeAutomation` can re-enter the gate instead of failing
-the parent workflow.
+runtime adapters preserve that disposition only when the resolver run carries a
+`mergeGate` owner from `MoonMind.MergeAutomation`. In that gate-owned case, the
+adapter must not turn a non-zero resolver exit such as `attempts_exhausted` into
+an agent failure, because merge automation owns the next gate cycle.
 
 During long waits, especially `ci_running`, the resolver emits concise progress
 lines before sleeping. These lines are part of the operational contract: they keep
@@ -112,7 +113,10 @@ while CI is still running abandons the merge and leaves the PR unresolved.
 A standalone `pr-resolver` run (one not launched by `MoonMind.MergeAutomation`)
 that ends in the continuation state `reenter_gate` has no gate to re-enter, so it
 is not a successful PR resolution; the owning workflow fails such a run terminally
-rather than reporting success. See `docs/Workflows/PrMergeAutomation.md` §13.4.
+rather than reporting success. Managed-runtime adapters suppress ungated
+continuation disposition metadata and surface the resolver's terminal blocker
+summary as a normal failed/blocked PR-resolution result. See
+`docs/Workflows/PrMergeAutomation.md` §13.4.
 
 ---
 

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -542,10 +542,11 @@ older artifacts encode the same intent through a continuation `next_step` such
 as `run_fix_comments_skill`, `run_fix_ci_skill`,
 `run_fix_merge_conflicts_skill`, `retry_finalize_after_backoff`, or
 `wait_for_ci_and_retry_finalize`, the managed-agent adapter returns a successful
-child result carrying `mergeAutomationDisposition = "reenter_gate"`. It MUST NOT
-convert that state into an agent failure merely because the resolver process used
-a non-zero exit code such as `attempts_exhausted`; merge automation owns the next
-gate cycle.
+child result carrying `mergeAutomationDisposition = "reenter_gate"` only when
+the resolver run carries the `mergeGate` owner injected by
+`MoonMind.MergeAutomation`. It MUST NOT convert that gate-owned state into an
+agent failure merely because the resolver process used a non-zero exit code such
+as `attempts_exhausted`; merge automation owns the next gate cycle.
 
 Long resolver waits also remain observable. While polling transient states such
 as `ci_running`, resolver tooling SHOULD emit periodic progress output before
@@ -569,8 +570,10 @@ run that ends with `mergeAutomationDisposition = "reenter_gate"` in that case ha
 workflow MUST NOT report `status: success`. It MUST fail the run terminally with
 an actionable summary directing the operator to re-submit under merge automation
 or finalize manually. This prevents a false-green completion where the PR is left
-open and unmerged. Terminal dispositions (`merged`, `already_merged`) and
-gated continuation runs are unaffected.
+open and unmerged. Managed-runtime adapters suppress ungated continuation
+disposition metadata and surface the resolver's terminal blocker summary as a
+normal failed/blocked PR-resolution result. Terminal dispositions (`merged`,
+`already_merged`) and gated continuation runs are unaffected.
 
 ---
 

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -261,6 +261,14 @@ class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
         alias="prResolverExpected",
         validation_alias=AliasChoices("prResolverExpected", "pr_resolver_expected"),
     )
+    pr_resolver_merge_gate_owned: bool = Field(
+        default=False,
+        alias="prResolverMergeGateOwned",
+        validation_alias=AliasChoices(
+            "prResolverMergeGateOwned",
+            "pr_resolver_merge_gate_owned",
+        ),
+    )
 
     @model_validator(mode="after")
     def _normalize_fetch(self) -> "AgentRuntimeFetchResultInput":

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1103,6 +1103,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         run_id: str,
         *,
         pr_resolver_expected: bool = False,
+        pr_resolver_merge_gate_owned: bool = False,
     ) -> AgentRunResult:
         state = self._load_run_state(run_id)
         if state is not None:
@@ -1113,9 +1114,17 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     failure_class = result.failure_class
                     summary = str(result.summary or "").strip()
                     metadata = dict(result.metadata)
-                    metadata.update(_derive_pr_resolver_metadata(record.workspace_path))
+                    metadata.update(
+                        _derive_pr_resolver_metadata(
+                            record.workspace_path,
+                            merge_gate_owned=pr_resolver_merge_gate_owned,
+                        )
+                    )
                     derived_failure_class, derived_summary = (
-                        _derive_pr_resolver_failure(record.workspace_path)
+                        _derive_pr_resolver_failure(
+                            record.workspace_path,
+                            merge_gate_owned=pr_resolver_merge_gate_owned,
+                        )
                     )
                     resolver_disposition = str(
                         metadata.get("mergeAutomationDisposition") or ""

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -231,7 +231,11 @@ def _pr_resolver_next_step(payload: dict[str, Any]) -> str:
     )
 
 
-def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
+def _pr_resolver_disposition(
+    payload: dict[str, Any],
+    *,
+    merge_gate_owned: bool = False,
+) -> str:
     """Return explicit or derived merge-automation disposition for a resolver result."""
 
     final = _pr_resolver_final_payload(payload)
@@ -242,7 +246,10 @@ def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
         final.get("merge_automation_disposition"),
     )
     if explicit:
-        return explicit.lower()
+        normalized = explicit.lower()
+        if normalized == "reenter_gate" and not merge_gate_owned:
+            return ""
+        return normalized
 
     status = _pr_resolver_status(payload)
     reason = _first_stripped_text(
@@ -255,7 +262,10 @@ def _pr_resolver_disposition(payload: dict[str, Any]) -> str:
         return "already_merged" if reason == "already_merged" else "merged"
 
     next_step = _pr_resolver_next_step(payload).lower()
-    if next_step in _PR_RESOLVER_REENTER_NEXT_STEPS or next_step.startswith("run_fix_"):
+    if merge_gate_owned and (
+        next_step in _PR_RESOLVER_REENTER_NEXT_STEPS
+        or next_step.startswith("run_fix_")
+    ):
         return "reenter_gate"
     return ""
 
@@ -465,6 +475,8 @@ LaunchContextBuilderFunc = Callable[..., Awaitable[ManagedProfileLaunchContext |
 
 def _derive_pr_resolver_failure(
     workspace_path: str | None,
+    *,
+    merge_gate_owned: bool = False,
 ) -> tuple[str | None, str | None]:
     """Return failure metadata from pr-resolver artifacts when present."""
     payload = _load_pr_resolver_result(workspace_path)
@@ -478,7 +490,10 @@ def _derive_pr_resolver_failure(
         )
 
     status = _pr_resolver_status(payload)
-    if _pr_resolver_disposition(payload) == "reenter_gate":
+    if (
+        _pr_resolver_disposition(payload, merge_gate_owned=merge_gate_owned)
+        == "reenter_gate"
+    ):
         return None, None
     if status not in _PR_RESOLVER_FAILURE_STATUSES:
         return None, None
@@ -495,7 +510,11 @@ def _derive_pr_resolver_failure(
     )
     return failure_class, "; ".join(summary_parts)
 
-def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
+def _derive_pr_resolver_metadata(
+    workspace_path: str | None,
+    *,
+    merge_gate_owned: bool = False,
+) -> dict[str, Any]:
     """Return compact metadata from pr-resolver artifacts for parent workflows."""
     payload = _load_pr_resolver_result(workspace_path)
     if payload is None:
@@ -504,7 +523,9 @@ def _derive_pr_resolver_metadata(workspace_path: str | None) -> dict[str, Any]:
     status = _pr_resolver_status(payload)
     reason = str(payload.get("final_reason") or payload.get("reason") or "").strip()
     metadata: dict[str, Any] = {}
-    disposition = _pr_resolver_disposition(payload)
+    disposition = _pr_resolver_disposition(
+        payload, merge_gate_owned=merge_gate_owned
+    )
     if disposition:
         metadata["mergeAutomationDisposition"] = disposition
     final = _pr_resolver_final_payload(payload)
@@ -767,6 +788,7 @@ class ManagedAgentAdapter:
         run_id: str,
         *,
         pr_resolver_expected: bool = False,
+        pr_resolver_merge_gate_owned: bool = False,
     ) -> AgentRunResult:
         """Return result from the run store, falling back to empty if no store.
 
@@ -779,6 +801,9 @@ class ManagedAgentAdapter:
             autonomous/incidental pr-resolver invocations (e.g. the agent
             deciding on its own to run the skill) do not override the
             actual task result.
+        pr_resolver_merge_gate_owned:
+            When ``True``, continuation dispositions such as ``reenter_gate``
+            are preserved for the owning ``MoonMind.MergeAutomation`` workflow.
         """
         if self._run_store is not None:
             record = self._run_store.load(run_id)
@@ -796,10 +821,14 @@ class ManagedAgentAdapter:
                         output_refs.append(ref)
                 summary = record.error_message or f"Completed with status {record.status}"
                 failure_class = record.failure_class
-                metadata = _derive_pr_resolver_metadata(record.workspace_path)
+                metadata = _derive_pr_resolver_metadata(
+                    record.workspace_path,
+                    merge_gate_owned=pr_resolver_merge_gate_owned,
+                )
                 if pr_resolver_expected:
                     derived_failure_class, derived_summary = _derive_pr_resolver_failure(
-                        record.workspace_path
+                        record.workspace_path,
+                        merge_gate_owned=pr_resolver_merge_gate_owned,
                     )
                     resolver_disposition = str(
                         metadata.get("mergeAutomationDisposition") or ""

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8644,6 +8644,11 @@ class TemporalAgentRuntimeActivities:
             if isinstance(request, AgentRuntimeFetchResultInput)
             else False
         )
+        pr_resolver_merge_gate_owned = (
+            request.pr_resolver_merge_gate_owned
+            if isinstance(request, AgentRuntimeFetchResultInput)
+            else False
+        )
 
         adapter = ManagedAgentAdapter(
             profile_fetcher=_unused_profile_fetcher,
@@ -8656,7 +8661,9 @@ class TemporalAgentRuntimeActivities:
         workspace_github_token: str | None = None
         try:
             result = await adapter.fetch_result(
-                run_id, pr_resolver_expected=pr_resolver_expected
+                run_id,
+                pr_resolver_expected=pr_resolver_expected,
+                pr_resolver_merge_gate_owned=pr_resolver_merge_gate_owned,
             )
             record = self._run_store.load(run_id)
             if record is not None:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8644,11 +8644,14 @@ class TemporalAgentRuntimeActivities:
             if isinstance(request, AgentRuntimeFetchResultInput)
             else False
         )
-        pr_resolver_merge_gate_owned = (
-            request.pr_resolver_merge_gate_owned
-            if isinstance(request, AgentRuntimeFetchResultInput)
-            else False
-        )
+        pr_resolver_merge_gate_owned = False
+        if isinstance(request, AgentRuntimeFetchResultInput):
+            pr_resolver_merge_gate_owned = request.pr_resolver_merge_gate_owned
+            if (
+                pr_resolver_expected
+                and "pr_resolver_merge_gate_owned" not in request.model_fields_set
+            ):
+                pr_resolver_merge_gate_owned = True
 
         adapter = ManagedAgentAdapter(
             profile_fetcher=_unused_profile_fetcher,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -145,6 +145,9 @@ MANAGED_SESSION_DEFER_TURN_INSTRUCTIONS_UNTIL_LAUNCH_PATCH_ID = (
 PR_RESOLVER_PAYLOAD_SKILL_DETECTION_PATCH_ID = (
     "agent-run-pr-resolver-payload-skill-detection-v1"
 )
+PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID = (
+    "agent-run-pr-resolver-merge-gate-ownership-v1"
+)
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
 SLOT_HANDOFF_PATCH_ID = "agent-run-slot-handoff-v1"
 SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
@@ -261,6 +264,24 @@ def _request_selected_skill(
         return None
     tool_name = str(tool.get("name") or tool.get("id") or "").strip()
     return tool_name or None
+
+def _request_pr_resolver_merge_gate_owned(
+    request: AgentExecutionRequest,
+) -> bool:
+    """Return whether a pr-resolver request carries a merge-automation gate owner."""
+
+    parameters = request.parameters if isinstance(request.parameters, Mapping) else {}
+    merge_gate = parameters.get("mergeGate")
+    if not isinstance(merge_gate, Mapping):
+        merge_gate = parameters.get("merge_gate")
+    if not isinstance(merge_gate, Mapping):
+        return False
+    parent_workflow_id = str(
+        merge_gate.get("parentWorkflowId")
+        or merge_gate.get("parent_workflow_id")
+        or ""
+    ).strip()
+    return bool(parent_workflow_id)
 
 def _request_step_ledger_context(
     request: AgentExecutionRequest,
@@ -1473,6 +1494,10 @@ class MoonMindAgentRun:
         )
         if selected_skill == "pr-resolver":
             activity_input["prResolverExpected"] = True
+            if workflow.patched(PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID):
+                activity_input["prResolverMergeGateOwned"] = (
+                    _request_pr_resolver_merge_gate_owned(request)
+                )
         return AgentRuntimeFetchResultInput.model_validate(activity_input)
 
     async def _fetch_managed_result(
@@ -1483,6 +1508,25 @@ class MoonMindAgentRun:
         uses_codex_session_adapter: bool,
         use_managed_status_activity: bool,
     ) -> AgentRunResult:
+        def _pr_resolver_fetch_flags() -> tuple[bool, bool]:
+            expected = (
+                _request_selected_skill(
+                    request,
+                    include_payload_contract=workflow.patched(
+                        PR_RESOLVER_PAYLOAD_SKILL_DETECTION_PATCH_ID
+                    ),
+                )
+                == "pr-resolver"
+            )
+            if not expected:
+                return False, False
+            gate_owned = (
+                _request_pr_resolver_merge_gate_owned(request)
+                if workflow.patched(PR_RESOLVER_MERGE_GATE_OWNERSHIP_PATCH_ID)
+                else False
+            )
+            return True, gate_owned
+
         if uses_codex_session_adapter:
             if workflow.patched(MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID):
                 result_payload = await self._execute_routed_activity(
@@ -1496,17 +1540,13 @@ class MoonMindAgentRun:
                     else result_payload
                 )
 
+            pr_resolver_expected, pr_resolver_merge_gate_owned = (
+                _pr_resolver_fetch_flags()
+            )
             return await adapter.fetch_result(
                 self.run_id,
-                pr_resolver_expected=(
-                    _request_selected_skill(
-                        request,
-                        include_payload_contract=workflow.patched(
-                            PR_RESOLVER_PAYLOAD_SKILL_DETECTION_PATCH_ID
-                        ),
-                    )
-                    == "pr-resolver"
-                ),
+                pr_resolver_expected=pr_resolver_expected,
+                pr_resolver_merge_gate_owned=pr_resolver_merge_gate_owned,
             )
 
         if use_managed_status_activity:
@@ -1521,17 +1561,11 @@ class MoonMindAgentRun:
                 else result_payload
             )
 
+        pr_resolver_expected, pr_resolver_merge_gate_owned = _pr_resolver_fetch_flags()
         return await adapter.fetch_result(
             self.run_id,
-            pr_resolver_expected=(
-                _request_selected_skill(
-                    request,
-                    include_payload_contract=workflow.patched(
-                        PR_RESOLVER_PAYLOAD_SKILL_DETECTION_PATCH_ID
-                    ),
-                )
-                == "pr-resolver"
-            ),
+            pr_resolver_expected=pr_resolver_expected,
+            pr_resolver_merge_gate_owned=pr_resolver_merge_gate_owned,
         )
 
     async def _poll_managed_status(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -4281,10 +4281,98 @@ async def test_fetch_result_treats_pr_resolver_reenter_gate_as_continuation(
         started_at=datetime.now(tz=UTC),
     )
 
-    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+    result = await adapter.fetch_result(
+        run_id,
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
+    )
 
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+
+async def test_fetch_result_reports_standalone_pr_resolver_reentry_as_failure(
+    tmp_path: Path,
+) -> None:
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "attempts_exhausted",\n'
+            '  "mergeAutomationDisposition": "reenter_gate",\n'
+            '  "final_reason": "ci_failures",\n'
+            '  "next_step": "run_fix_ci_skill"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    run_id = "run-result-pr-standalone-ci"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    run_store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=datetime.now(tz=UTC),
+            workspacePath=str(workspace_path),
+        )
+    )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_async_noop,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=run_id,
+        agent_id="codex_cli",
+        locator={
+            "sessionId": "sess:wf-task-1:codex_cli",
+            "sessionEpoch": 1,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Managed session turn completed.",
+            "metadata": {},
+        },
+        status="completed",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+
+    assert result.failure_class == "user_error"
+    assert result.summary is not None
+    assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
+    assert "ci_failures" in result.summary
+    assert "next_step=run_fix_ci_skill" in result.summary
+    assert "mergeAutomationDisposition" not in result.metadata
 
 async def test_fetch_result_clears_generic_failed_exit_for_pr_resolver_reentry(
     tmp_path: Path,
@@ -4363,7 +4451,11 @@ async def test_fetch_result_clears_generic_failed_exit_for_pr_resolver_reentry(
         started_at=datetime.now(tz=UTC),
     )
 
-    result = await adapter.fetch_result(run_id, pr_resolver_expected=True)
+    result = await adapter.fetch_result(
+        run_id,
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
+    )
 
     assert result.failure_class is None
     assert result.summary == "pr-resolver requested merge automation re-entry."

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1509,7 +1509,9 @@ async def test_fetch_result_treats_pr_resolver_reenter_gate_as_continuation(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-blocked", pr_resolver_expected=True
+        "run-result-pr-blocked",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
@@ -1558,10 +1560,68 @@ async def test_fetch_result_derives_pr_resolver_reenter_gate_from_next_step(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-ci-wait", pr_resolver_expected=True
+        "run-result-pr-ci-wait",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
+
+async def test_fetch_result_reports_standalone_pr_resolver_next_step_as_failure(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "attempts_exhausted",\n'
+            '  "mergeAutomationDisposition": "reenter_gate",\n'
+            '  "final_reason": "ci_failures",\n'
+            '  "next_step": "run_fix_ci_skill"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-standalone-ci",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-standalone-ci",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-standalone-ci",
+        pr_resolver_expected=True,
+    )
+
+    assert result.failure_class == "user_error"
+    assert result.summary is not None
+    assert "pr-resolver reported status 'attempts_exhausted'" in result.summary
+    assert "ci_failures" in result.summary
+    assert "next_step=run_fix_ci_skill" in result.summary
+    assert "mergeAutomationDisposition" not in result.metadata
 
 async def test_fetch_result_normalizes_pr_resolver_reenter_values(
     tmp_path: Path,
@@ -1610,7 +1670,9 @@ async def test_fetch_result_normalizes_pr_resolver_reenter_values(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-mixed-case", pr_resolver_expected=True
+        "run-result-pr-mixed-case",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
@@ -1660,7 +1722,9 @@ async def test_fetch_result_prefers_terminal_status_over_skipped_merge_outcome(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-blocked-skipped", pr_resolver_expected=True
+        "run-result-pr-blocked-skipped",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
@@ -1765,7 +1829,9 @@ async def test_fetch_result_clears_generic_failed_exit_for_reenter_gate(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-generic-reenter", pr_resolver_expected=True
+        "run-result-pr-generic-reenter",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.summary == "pr-resolver requested merge automation re-entry."
@@ -1828,7 +1894,9 @@ async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
     )
 
     result = await adapter.fetch_result(
-        "run-result-pr-latest-attempt", pr_resolver_expected=True
+        "run-result-pr-latest-attempt",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
     )
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -2973,6 +2973,35 @@ async def test_fetch_result_forwards_pr_resolver_expected_flag(tmp_path: Path) -
         assert result.failure_class == "user_error"
 
 
+async def test_fetch_result_preserves_legacy_pr_resolver_gate_ownership(
+    tmp_path: Path,
+) -> None:
+    """Missing ownership field keeps old scheduled fetch_result payload semantics."""
+    from unittest.mock import patch
+
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="fr-pr-legacy", status="completed")
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+        autospec=True,
+    ) as mock_adapter_cls:
+        adapter = mock_adapter_cls.return_value
+        adapter.fetch_result = AsyncMock(return_value=AgentRunResult(summary="ok"))
+
+        result = await activities.agent_runtime_fetch_result(
+            {"run_id": "fr-pr-legacy", "pr_resolver_expected": True}
+        )
+
+        adapter.fetch_result.assert_awaited_once_with(
+            "fr-pr-legacy",
+            pr_resolver_expected=True,
+            pr_resolver_merge_gate_owned=True,
+        )
+        assert result.summary == "ok"
+
+
 async def test_fetch_result_skips_infrastructure_push_for_jules_runtime(
     tmp_path: Path,
 ) -> None:
@@ -3646,7 +3675,7 @@ async def test_agent_runtime_fetch_result_temporal_boundary(tmp_path: Path) -> N
                 instance.fetch_result.assert_awaited_once_with(
                     "boundary-1",
                     pr_resolver_expected=True,
-                    pr_resolver_merge_gate_owned=False,
+                    pr_resolver_merge_gate_owned=True,
                 )
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -46,6 +46,7 @@ from moonmind.schemas.managed_session_models import (
 )
 from moonmind.schemas.temporal_activity_models import (
     AgentRuntimeCancelInput,
+    AgentRuntimeFetchResultInput,
     AgentRuntimeStatusInput,
 )
 from moonmind.workflows.temporal import client as temporal_client_module
@@ -1345,6 +1346,22 @@ async def test_fetch_result_validates_legacy_dict_to_typed_request(
     )
 
     assert isinstance(result, AgentRunResult)
+
+async def test_fetch_result_input_defaults_merge_gate_ownership_false() -> None:
+    legacy = AgentRuntimeFetchResultInput.model_validate(
+        {"run_id": "typed-fetch-legacy", "pr_resolver_expected": True}
+    )
+    gated = AgentRuntimeFetchResultInput.model_validate(
+        {
+            "runId": "typed-fetch-gated",
+            "prResolverExpected": True,
+            "prResolverMergeGateOwned": True,
+        }
+    )
+
+    assert legacy.pr_resolver_expected is True
+    assert legacy.pr_resolver_merge_gate_owned is False
+    assert gated.pr_resolver_merge_gate_owned is True
 
 async def test_cancel_accepts_typed_request_model() -> None:
     activities = TemporalAgentRuntimeActivities()
@@ -2941,11 +2958,17 @@ async def test_fetch_result_forwards_pr_resolver_expected_flag(tmp_path: Path) -
         )
 
         result = await activities.agent_runtime_fetch_result(
-            {"run_id": "fr-pr", "pr_resolver_expected": True}
+            {
+                "run_id": "fr-pr",
+                "pr_resolver_expected": True,
+                "pr_resolver_merge_gate_owned": True,
+            }
         )
 
         adapter.fetch_result.assert_awaited_once_with(
-            "fr-pr", pr_resolver_expected=True
+            "fr-pr",
+            pr_resolver_expected=True,
+            pr_resolver_merge_gate_owned=True,
         )
         assert result.failure_class == "user_error"
 
@@ -3354,7 +3377,9 @@ async def test_fetch_result_string_request_defaults_pr_resolver_expected_false(
         result = await activities.agent_runtime_fetch_result("fr-string")
 
         adapter.fetch_result.assert_awaited_once_with(
-            "fr-string", pr_resolver_expected=False
+            "fr-string",
+            pr_resolver_expected=False,
+            pr_resolver_merge_gate_owned=False,
         )
         assert result.summary == "ok"
 
@@ -3619,7 +3644,9 @@ async def test_agent_runtime_fetch_result_temporal_boundary(tmp_path: Path) -> N
                 assert isinstance(result, AgentRunResult)
                 assert result.summary == "ok"
                 instance.fetch_result.assert_awaited_once_with(
-                    "boundary-1", pr_resolver_expected=True
+                    "boundary-1",
+                    pr_resolver_expected=True,
+                    pr_resolver_merge_gate_owned=False,
                 )
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -162,7 +162,30 @@ async def test_managed_fetch_result_marks_pr_resolver_from_task_tool_contract(
 
     assert isinstance(activity_input, AgentRuntimeFetchResultInput)
     assert activity_input.pr_resolver_expected is True
+    assert activity_input.pr_resolver_merge_gate_owned is True
     assert activity_input.head_branch == "feature/pr-1671"
+
+async def test_managed_fetch_result_marks_standalone_pr_resolver_as_not_gate_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={
+            "publishMode": "none",
+            "metadata": {"moonmind": {"selectedSkill": "pr-resolver"}},
+            "workflow": {
+                "tool": {"type": "skill", "name": "pr-resolver"},
+                "skill": {"name": "pr-resolver"},
+            },
+        },
+        workspace_spec={"branch": "codex/example-pr"},
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert activity_input.pr_resolver_expected is True
+    assert activity_input.pr_resolver_merge_gate_owned is False
 
 async def test_parent_child_state_signal_failure_is_logged_not_raised(
     monkeypatch: pytest.MonkeyPatch,
@@ -1509,9 +1532,11 @@ async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
             run_id: str,
             *,
             pr_resolver_expected: bool = False,
+            pr_resolver_merge_gate_owned: bool = False,
         ) -> AgentRunResult:
             assert run_id == "managed-session-run-legacy"
             assert pr_resolver_expected is False
+            assert pr_resolver_merge_gate_owned is False
             return AgentRunResult(summary="Legacy managed-session fetch path.")
 
     class _FakeManagerHandle:
@@ -1609,9 +1634,11 @@ async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_hist
             run_id: str,
             *,
             pr_resolver_expected: bool = False,
+            pr_resolver_merge_gate_owned: bool = False,
         ) -> AgentRunResult:
             assert run_id == "managed-session-run-legacy-prepare"
             assert pr_resolver_expected is False
+            assert pr_resolver_merge_gate_owned is False
             return AgentRunResult(summary="Legacy instruction preparation path.")
 
     class _FakeManagerHandle:
@@ -1708,9 +1735,11 @@ async def test_agent_run_preserves_pre_launch_instruction_order_for_pre_defer_hi
             run_id: str,
             *,
             pr_resolver_expected: bool = False,
+            pr_resolver_merge_gate_owned: bool = False,
         ) -> AgentRunResult:
             assert run_id == "managed-session-run-pre-defer"
             assert pr_resolver_expected is False
+            assert pr_resolver_merge_gate_owned is False
             return AgentRunResult(summary="Pre-defer instruction order path.")
 
     class _FakeManagerHandle:


### PR DESCRIPTION
## Summary

- Add a gate-ownership flag to managed runtime fetch-result handling for pr-resolver runs.
- Preserve `mergeAutomationDisposition=reenter_gate` only for resolver children launched by `MoonMind.MergeAutomation`.
- Surface standalone pr-resolver continuation blockers as ordinary failed/blocked resolver results instead of confusing merge-gate continuation failures.
- Update pr-resolver and merge automation docs, plus adapter/activity/workflow tests.

## Root Cause

Standalone pr-resolver runs could produce resolver artifacts with `mergeAutomationDisposition=reenter_gate` or continuation `next_step` values. The managed runtime adapters normalized those artifacts as merge-gate continuations without knowing whether a merge gate actually owned the run.

## Validation

- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py`

Python targeted tests passed: 307 passed. UI phase passed: 704 passed, 236 skipped.